### PR TITLE
fix(board): the cloud twin claims launches atomically, the reaper gives up on a pruned run, labels adjust relatively, GitHub claims bootstrap their label

### DIFF
--- a/bots/evolve/skills/backlog-handoff.md
+++ b/bots/evolve/skills/backlog-handoff.md
@@ -71,7 +71,8 @@ Call `create_issue` once per proposal with:
   `feature-dev` plus its `feature_prompt`). When no bot clearly fits, omit
   both and add `needs-manual-triage`.
 
-`set_bot` / `set_labels` remain available for correcting a ticket after
+`set_bot` / `add_labels` / `remove_labels` (or the absolute `set_labels`
+for a full rewrite) remain available for correcting a ticket after
 creation, but the create call accepts those typed fields directly.
 
 ### The body IS the dispatch prompt

--- a/bots/evolve/skills/iterion-board.md
+++ b/bots/evolve/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the kanban
+  workflow. Covers the seven board capabilities and twelve MCP tools, the kanban
   state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -26,6 +26,8 @@ The server exposes these tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue — the canonical dispatcher selector. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. NOT for bot selection (use set_bot). |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -98,7 +100,33 @@ typo'd bot fails loudly. Names are matched tolerantly (`feature_dev` ≡
 {"id": "native:abcd...", "labels": ["source:evolve", "kind:evolution", "horizon:next"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `list_issues` / `get_issue` / `list_labels` (board.read)
 

--- a/bots/issue-triage/README.md
+++ b/bots/issue-triage/README.md
@@ -2,8 +2,10 @@
 
 Triagy reads ONE native-kanban card, classifies it against the generated
 bot catalog's decision tree, and stamps **which bot will handle it**: the
-typed Bot field (`set_bot`), vocabulary-consistent labels (`set_labels`),
-and one paragraph of routing rationale (`comment_issue`). It never does
+typed Bot field (`set_bot`), vocabulary-consistent labels (`add_labels`,
+relative — never the absolute `set_labels`, which would re-arm the
+consumed trigger label), and one paragraph of routing rationale
+(`comment_issue`). It never does
 the work itself, never edits code, and never moves the card — the card
 stays in inbox, and launching remains the operator's drag to Ready, where
 the dispatcher claims the stamped bot. No confident fit → the Bot stays
@@ -36,9 +38,10 @@ triage  (agent · backend claw · model openai/gpt-5.5 · tools: [skill] · tool
   4. mcp__iterion_board__set_bot        technical dash-form name copied verbatim
                                         from the catalog persona table; skipped
                                         only on a no-fit
-  5. mcp__iterion_board__set_labels     pre-existing labels + source:issue-triage
-                                        (+ needs-manual-triage on a no-fit,
-                                        + at most one axis:<area>); ≤ 5 labels
+  5. mcp__iterion_board__add_labels     source:issue-triage (+ needs-manual-triage
+                                        on a no-fit, + at most one axis:<area>);
+                                        remove_labels for a lingering
+                                        needs:approval; ≤ 5 labels
   6. mcp__iterion_board__comment_issue  the one-paragraph routing rationale
   → triage_output { routed_bot: string, no_fit: bool, rationale: string }
 done
@@ -88,8 +91,8 @@ devbox run -- iterion run bots/issue-triage/main.bot --var issue_id=<card-id>
 
 The `triage` node declares
 `capabilities: [board.read, board.assign, board.label, board.comment]` —
-respectively `get_issue`/`list_labels`, `set_bot`, `set_labels` and
-`comment_issue`. Deliberately absent: `board.create`, `board.move` and
+respectively `get_issue`/`list_labels`, `set_bot`, `add_labels`/
+`remove_labels` and `comment_issue`. Deliberately absent: `board.create`, `board.move` and
 `board.close`, so the card's column and existence are not Triagy's to
 change (`transition_issue`, `create_issue` and `close_issue` are also
 forbidden by the prompt).

--- a/bots/issue-triage/main.bot
+++ b/bots/issue-triage/main.bot
@@ -4,7 +4,9 @@
 ## ONE cheap agent, no shell, no code edits: read the target card,
 ## classify it against the generated iterion-bot-catalog decision
 ## tree, stamp the handler bot (set_bot) + vocabulary-consistent
-## labels (set_labels), leave a one-paragraph routing comment, and
+## labels (add_labels — never set_labels: the absolute list would
+## re-arm the consumed trigger label), leave a one-paragraph routing
+## comment, and
 ## STOP. The card never changes column here — launching stays the
 ## operator's gesture (drag to Ready; the dispatcher claims the
 ## stamped bot).
@@ -49,20 +51,25 @@ prompt triage_system:
      (`assignee` column — dashes, e.g. `feature-dev`, never an
      invented spelling). A name you cannot see in that table is a
      no-fit.
-  5. MANDATORY: `mcp__iterion_board__set_labels` — keep the card's
-     existing labels, add `source:issue-triage`, add ONE `axis:<area>`
-     label when one area clearly dominates (reuse the board's
-     spelling). No confident bot fit → add `needs-manual-triage`
-     instead and leave the bot unset. Never exceed 5 labels; drop your
-     own optional additions first, never the pre-existing ones.
+  5. MANDATORY: `mcp__iterion_board__add_labels` — add
+     `source:issue-triage`, plus ONE `axis:<area>` label when one area
+     clearly dominates (reuse the board's spelling). No confident bot
+     fit → add `needs-manual-triage` instead and leave the bot unset.
+     If `needs:approval` is still on the card, remove it with
+     `mcp__iterion_board__remove_labels` (the operator's approval
+     superseded it). NEVER `set_labels`: it replaces the whole list
+     from your earlier read and re-adds the `triage:auto` trigger the
+     spine consumed to launch you — which launches you again. Keep the
+     card at 5 labels or fewer: add fewer of your own optional labels
+     rather than removing pre-existing ones.
   6. MANDATORY: `mcp__iterion_board__comment_issue` — ONE short
      paragraph: which bot you routed to (or why none), the decisive
      signal from the card, and what the operator should do next (drag
      to Ready to launch, or triage manually).
   Only return triage_output AFTER comment_issue has succeeded — a run
   that skips steps 3, 5 or 6 is a FAILED triage even if a bot got
-  stamped. The set_labels replacement MUST include `source:issue-triage`
-  alongside the preserved pre-existing labels.
+  stamped. The add_labels call MUST include `source:issue-triage`; the
+  pre-existing labels stay because add_labels never touches them.
 
   Hard rules: no `transition_issue`, no `create_issue`, no
   `close_issue`, no processing of any card other than "{{vars.issue_id}}".
@@ -83,9 +90,10 @@ prompt triage_user:
   3. mcp__iterion_board__list_labels.
   4. mcp__iterion_board__set_bot — verbatim dash-form name from the
      catalog's persona table. Skip ONLY on a no-fit.
-  5. mcp__iterion_board__set_labels — the card's pre-existing labels
-     plus "source:issue-triage" (plus "needs-manual-triage" on a
-     no-fit).
+  5. mcp__iterion_board__add_labels — "source:issue-triage" (plus
+     "needs-manual-triage" on a no-fit, plus at most one axis:<area>);
+     mcp__iterion_board__remove_labels for "needs:approval" if it is
+     still there. Never set_labels.
   6. mcp__iterion_board__comment_issue — your one-paragraph routing
      rationale.
   Return triage_output only after step 6 succeeded.

--- a/bots/issue-triage/manifest.yaml
+++ b/bots/issue-triage/manifest.yaml
@@ -1,7 +1,7 @@
 name: issue-triage
 display_name: Triagy
 icon: 🏷️
-version: 0.1.0
+version: 0.2.0
 description: |
   Lightweight single-shot card triage. ONE cheap read-classify-stamp
   agent: reads a fresh board card, classifies it against the generated

--- a/bots/issue-triage/skills/issue-triage.md
+++ b/bots/issue-triage/skills/issue-triage.md
@@ -6,8 +6,11 @@ description: Triagy's single-shot routing procedure — read one board card, sta
 # issue-triage — the routing contract
 
 You process exactly ONE card (vars.issue_id) and your only outputs are:
-a `set_bot` stamp (or none), a `set_labels` refresh, and one
-`comment_issue` paragraph. The card's COLUMN is not yours: launching is
+a `set_bot` stamp (or none), an `add_labels` stamp (and a
+`remove_labels` when `needs:approval` lingers), and one `comment_issue`
+paragraph. Never `set_labels`: it replaces the whole list from your
+earlier read and re-adds the consumed `triage:auto`, which launches you
+again. The card's COLUMN is not yours: launching is
 the operator's drag to Ready, where the dispatcher claims the stamped
 bot. You never `transition_issue`, never `create_issue`, never
 `close_issue`, never touch another card.
@@ -19,8 +22,8 @@ bot. You never `transition_issue`, never `create_issue`, never
   launching you (that label is already gone; do not re-add it).
 - An operator's "Approve & triage" on an external-author card — they
   swapped `needs:approval` for `triage:auto`. If `needs:approval` is
-  still present on the card, remove it in your `set_labels` (the
-  operator's approval superseded it).
+  still present on the card, `remove_labels` it (the operator's
+  approval superseded it).
 - A manual `triage:auto` label on any card — re-triage on demand. Your
   new comment supersedes your old one; re-stamp `set_bot` if your
   routing changed.

--- a/bots/rgaa-audit/skills/iterion-board.md
+++ b/bots/rgaa-audit/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/sec-audit-deps/skills/iterion-board.md
+++ b/bots/sec-audit-deps/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/sec-audit-source/skills/iterion-board.md
+++ b/bots/sec-audit-source/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/supply-shield-cve/skills/iterion-board.md
+++ b/bots/supply-shield-cve/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/supply-shield/skills/iterion-board.md
+++ b/bots/supply-shield/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/ultra11y/skills/iterion-board.md
+++ b/bots/ultra11y/skills/iterion-board.md
@@ -2,7 +2,7 @@
 name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
-  workflow. Covers the seven board capabilities and ten MCP tools, the
+  workflow. Covers the seven board capabilities and twelve MCP tools, the
   kanban state machine, the "move to eligible → dispatcher dispatch" pattern,
   and common error cases. Load this skill whenever a node has any
   `board.*` capability granted in the DSL.
@@ -12,7 +12,7 @@ description: |
 
 Iterion runtime registers an internal MCP server (`__mcp-board`) for any
 agent/judge node whose `capabilities:` list contains a `board.*` entry.
-The server exposes ten tools, each gated by a single capability:
+The server exposes twelve tools, each gated by a single capability:
 
 | Tool FQN | Capability | Purpose |
 |---|---|---|
@@ -21,6 +21,8 @@ The server exposes ten tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -83,7 +85,33 @@ human/team owner. Empty strings clear the corresponding value.
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/bots/whats-next/main.bot
+++ b/bots/whats-next/main.bot
@@ -206,7 +206,8 @@ prompt nexie_system:
   - The board tools are capability-gated MCP tools
     (mcp__iterion_board__*): list_issues, get_issue, list_labels,
     create_issue, transition_issue, set_bot, assign_issue (human
-    owner — NOT bot routing), set_labels, close_issue, comment_issue.
+    owner — NOT bot routing), add_labels / remove_labels (relative; prefer
+    them over the absolute set_labels), close_issue, comment_issue.
     There is NO body/title edit — for a body change, propose
     close + recreate and ask first. The `iterion-board` skill is the
     full reference.

--- a/bots/whats-next/skills/iterion-board.md
+++ b/bots/whats-next/skills/iterion-board.md
@@ -3,7 +3,7 @@ name: iterion-board
 description: |
   How to write to the iterion native kanban board from inside a `.bot`
   workflow. Covers the capability-gated MCP tools (seven `board.*`
-  capabilities, ten tools), the kanban state machine, the "move to
+  capabilities, twelve tools), the kanban state machine, the "move to
   eligible → dispatcher dispatch" pattern with the limited-ready-lot
   discipline, and common error cases. Load this skill whenever a node
   has any `board.*` capability granted in the DSL.
@@ -22,6 +22,8 @@ The server exposes these tools, each gated by a single capability:
 | `mcp__iterion_board__set_bot` | `board.assign` | Choose which bot runs the issue — the canonical dispatcher selector. |
 | `mcp__iterion_board__assign_issue` | `board.assign` | Set the human/team owner. NOT for bot selection (use set_bot). |
 | `mcp__iterion_board__set_labels` | `board.label` | Replace the issue's label list. |
+| `mcp__iterion_board__add_labels` | `board.label` | Add labels, keeping the ones already on the issue (relative, atomic). |
+| `mcp__iterion_board__remove_labels` | `board.label` | Remove labels, keeping the others (relative, atomic). |
 | `mcp__iterion_board__close_issue` | `board.close` | Move the issue to a terminal state. |
 | `mcp__iterion_board__comment_issue` | `board.comment` | Append a markdown comment to an issue. |
 | `mcp__iterion_board__list_issues` | `board.read` | List issues (optionally filtered). |
@@ -108,7 +110,33 @@ where there is no bot field, the assignee doubles as the routing key via
 {"id": "native:abcd...", "labels": ["chore", "blocked"]}
 ```
 
-Replaces — does not merge. Pass an empty array to clear.
+Replaces — does not merge. Pass an empty array to clear. **Absolute by
+design**: the list you pass is written as-is, so a list you composed from
+an earlier `get_issue` re-adds any label removed in between — including a
+one-shot trigger label (`triage:auto`) the trigger spine consumed to
+launch you, which re-launches the bot. Use it only for a deliberate full
+rewrite from a fresh read; for anything incremental use the two relative
+operations below.
+
+### `add_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["source:issue-triage", "axis:api"]}
+```
+
+Adds the given labels and keeps every label already on the issue.
+Idempotent (a label already present is left alone), applied atomically
+to the card as it is on both board backends — never to the snapshot you
+read. This is the call for stamping your own labels on a card.
+
+### `remove_labels` (board.label)
+
+```json
+{"id": "native:abcd...", "labels": ["needs:approval"]}
+```
+
+Removes the given labels and keeps the others; a label not present is
+ignored. Same atomic, relative semantics as `add_labels`.
 
 ### `close_issue` (board.close)
 

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -527,6 +527,15 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// The un-leased claim horizon is a startup dial: read it before the
+	// coordinator's sweeps run, refuse a bad value rather than start a
+	// watchdog measuring against a horizon nobody intended.
+	if horizon, err := boardmongo.ConfigureUnleasedClaimHorizonFromEnv(); err != nil {
+		return err
+	} else if horizon != boardmongo.DefaultUnleasedClaimHorizon {
+		logger.Info("board watchdog: un-leased claim horizon set to %s (%s)", horizon, boardmongo.UnleasedClaimHorizonEnv)
+	}
+
 	srv := server.New(server.Config{
 		Port:        serverOpts.port,
 		Bind:        serverOpts.bind,

--- a/docs/adr/096-board-claim-lease-and-watchdog.md
+++ b/docs/adr/096-board-claim-lease-and-watchdog.md
@@ -230,6 +230,23 @@ pre-watchdog state, which is what the rollback lever promises.
   historical same-host pid-probe sweep touches them. A deliberate long
   operator stop that wants the OFF-window claims left alone advances the
   lease; the reaper's transfer is fail-safe otherwise.
+- **A PRUNED pointer is a give-up, not a release.** "No run loaded" has
+  two causes the table keeps apart through `StuckCard.RecordedRunID`. No
+  run *recorded* is the claimant dying before launch — release-only, the
+  card is simply eligible again. A recorded run that is *gone* (pruned by
+  `iterion runs prune`, deleted behind a tombstone) means a run happened
+  and nobody can tell whether its work was delivered: released bare, the
+  card re-entered the pool (the running column is eligible locally; the
+  cloud repark writes it back to `ready`) and the launch path read the
+  absence as a legitimate fresh start — a NEW run minted on the
+  watchdog's authority for possibly-delivered work. Such a card is filed
+  into the failed column under MACHINE provenance (no downstream chain
+  fires) with a give-up stamp naming the gone run and the reason
+  (`GiveUp.Reason`, rendered in the pipeline board's Needs-attention
+  lane), and an operator decides: reopen or re-queue to run it again,
+  close to acknowledge. The stamp window is irrelevant to this row — the
+  pointer is the stamp. Under a disabled gate the un-leased sweep keeps
+  conserving it: it is a decision, and the gate stops decisions.
 
 ## Non-goals (slice 3/3)
 

--- a/docs/adr/096-board-claim-lease-and-watchdog.md
+++ b/docs/adr/096-board-claim-lease-and-watchdog.md
@@ -186,8 +186,11 @@ real same-version lost update, closed at the choke). What remains — on
 BOTH twins, deliberately — is intent: `set_labels` is an ABSOLUTE list,
 so a bot that composed its list from a read taken before the consume
 re-arms the trigger by stating it. That is the API's shape (one-shots
-are documented re-armable), not a lost update; an add/remove label
-operation is the follow-up that would remove the foot-gun.
+are documented re-armable), not a lost update. The relative
+`add_labels` / `remove_labels` operations (`BoardStore.AdjustLabels` — one
+critical section on the FS twin, one pipeline update on Mongo) are the
+incremental path that cannot re-arm anything, and the agents are pointed
+at them; `set_labels` stays absolute by contract.
 Release N+1, once no old binary can un-lease a claim, enables the
 reaper — and with it the full decision table over whatever the
 mixed-fleet window stranded. The other gate-independent releaser is the

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -695,8 +695,14 @@ tracker:
 ```
 
 The dispatcher's `Claim` adds `iterion-claimed`; `Release` removes it.
-`ListCandidates` filters via `gh issue list --search` so pagination
-and rate-limit handling come for free.
+`gh issue edit --add-label` refuses a label the repository does not
+carry, so the first claim **creates the label** when it is missing
+(`gh label list` then `gh label create`, once per dispatcher process,
+neutral grey — an existing label keeps the colour and description you
+gave it). A label deleted later is re-created on the next claim. The
+token therefore needs write access to the repository's labels (it
+already needs it for issues). `ListCandidates` filters via `gh issue
+list --search` so pagination and rate-limit handling come for free.
 
 **Environment hygiene.** When `tracker.github.token` is set, iterion
 exports it as `GH_TOKEN` / `GITHUB_TOKEN` only to the `gh` subprocess,

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -830,6 +830,16 @@ Three properties of that routing are easy to assume wrongly:
 - **A card in the running column with no run recorded is left alone.**
   The run stamp is best-effort and lands after the launch, so its absence
   proves nothing — freeing the card could double-launch a live worker.
+- **A card whose recorded run is GONE is filed, never re-dispatched.** A
+  pointer at a run that `iterion runs prune` removed (or that was deleted
+  behind a tombstone) means a run happened and its outcome is unknowable.
+  Freeing the card would mint a fresh run for work that may already be
+  delivered, so the watchdog files it into the failed column with a
+  give-up stamp naming the gone run and why (visible in the pipeline
+  board's *Needs attention* lane, "The dispatcher gave up … recorded run
+  … is gone"). Reopen or re-queue it to run it again; close it to
+  acknowledge. The filing carries machine provenance, so no trigger fires
+  on it.
 - **Returning a card to the pool is bounded in cloud** (`watchdogRunCeiling`,
   20 lifetime runs): the cloud launcher starts a fresh run rather than
   resuming the recorded one, so an always-failing card would otherwise be

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -812,11 +812,24 @@ error conserves. Roll it out in two releases: ship the lease fields +
 heartbeats first (reaper off), then enable the reaper once no pre-lease
 binary is left in the fleet.
 
-The gate takes **`on` or `off` only** (case-insensitive) — not the
-`1`/`true` spellings some other `ITERION_*` toggles accept. Anything else
-leaves the watchdog OFF and is logged once at startup on both surfaces,
-so a mistyped cutover shows up in the log rather than as cards that
-quietly stay stuck.
+The gate takes `on`/`off`, `1`/`0`, `true`/`false` or `yes`/`no`
+(case-insensitive) — the spellings the repo's other `ITERION_*` toggles
+accept. Anything else leaves the watchdog OFF and is logged once at
+startup on both surfaces, so a mistyped cutover shows up in the log
+rather than as cards that quietly stay stuck.
+
+**The un-leased horizon (cloud board).** A claim a mixed-fleet write
+stripped of its lease is only reclaimable once nothing has touched the
+card for `ITERION_BOARD_UNLEASED_CLAIM_HORIZON` (default `24h`): an
+expired lease is positive evidence a heartbeat stopped, a missing one is
+an absence — and during a rolling deploy an OLD binary strips leases as
+it writes and does not heartbeat, so a short horizon would release a card
+its old-binary holder is still working. The default is sized for a
+day-long mixed window; a deployment whose rolling window is minutes can
+lower it (a Go duration, at least one claim lease — `15m` — or the server
+refuses to start). Until the horizon elapses a stripped claim is
+unwritable by anybody (ADR-096 §6): that stuck window is the accepted
+cost of the mixed fleet, bounded by this dial.
 
 Three properties of that routing are easy to assume wrongly:
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -83,7 +83,7 @@ though read-only mode restricts it to GET.
 | `local_run` | write | **Launch a run** (see semantics below). |
 | `local_resume` | write | Resume a paused / `failed_resumable` / cancelled run (answers supported). |
 | `local_run_cancel` | write | Cancel a detached run — or explicitly repair a dead one (see below). |
-| `local_board_*` | read/write | The native kanban board of this store — the full boardops tool set (`create_issue`, `list_issues`, `get_issue`, `transition_issue`, `assign_issue`, `set_bot`, `set_labels`, `comment_issue`, `close_issue`, `list_labels`) under the `local_board_` prefix, all capabilities granted (the operator drives their own board). |
+| `local_board_*` | read/write | The native kanban board of this store — the full boardops tool set (`create_issue`, `list_issues`, `get_issue`, `transition_issue`, `assign_issue`, `set_bot`, `add_labels`, `remove_labels`, `set_labels`, `comment_issue`, `close_issue`, `list_labels`) under the `local_board_` prefix, all capabilities granted (the operator drives their own board). |
 
 **Launch semantics (`local_run`).** The workflow is validated
 synchronously (invalid → diagnostics, nothing launched), then executed
@@ -169,7 +169,7 @@ without a terminal status, `local_run_cancel` repairs it to
 > "Create a board issue for the flaky webhook test, label it `bug`,
 > route it to feature-dev."
 
-`local_board_create_issue` → `local_board_set_labels` →
+`local_board_create_issue` → `local_board_add_labels` →
 `local_board_set_bot` (the dispatcher picks it up from there — see
 [native-tracker.md](native-tracker.md)).
 

--- a/openapi.json
+++ b/openapi.json
@@ -800,6 +800,9 @@
           "attempts": {
             "type": "integer"
           },
+          "reason": {
+            "type": "string"
+          },
           "run_id": {
             "type": "string"
           },

--- a/pkg/backend/tool/catalog_conformance_test.go
+++ b/pkg/backend/tool/catalog_conformance_test.go
@@ -141,8 +141,8 @@ func TestInternalMCPShorthandsMatchRegistry(t *testing.T) {
 		live[bare] = true
 	}
 	for _, bare := range []string{
-		"assign_issue", "close_issue", "comment_issue", "create_issue",
-		"get_issue", "list_issues", "list_labels", "set_bot", "set_labels",
+		"add_labels", "assign_issue", "close_issue", "comment_issue", "create_issue",
+		"get_issue", "list_issues", "list_labels", "remove_labels", "set_bot", "set_labels",
 		"transition_issue", "subscribe", "unsubscribe",
 	} {
 		if !live[bare] {

--- a/pkg/backend/tool/claw_board_tools.go
+++ b/pkg/backend/tool/claw_board_tools.go
@@ -22,8 +22,9 @@ type BoardConfig struct {
 	SourceIssueID string
 }
 
-// RegisterClawBoardTools registers the seven board operations as
-// in-process claw tools, filtered by the granted capabilities. The
+// RegisterClawBoardTools registers the board operations (boardops'
+// registry, whatever it lists) as in-process claw tools, filtered by the
+// granted capabilities. The
 // `mcp__iterion_board__` FQN prefix mirrors the claude_code MCP path so a
 // workflow swapping backends doesn't need to rename tool references in
 // prompts.

--- a/pkg/backend/tool/claw_board_tools_test.go
+++ b/pkg/backend/tool/claw_board_tools_test.go
@@ -26,8 +26,8 @@ func TestRegisterClawBoardTools_AllCapabilitiesExposesEveryTool(t *testing.T) {
 		t.Fatalf("RegisterClawBoardTools: %v", err)
 	}
 	for _, name := range []string{
-		"assign_issue", "close_issue", "comment_issue", "create_issue",
-		"get_issue", "list_issues", "list_labels", "set_bot",
+		"add_labels", "assign_issue", "close_issue", "comment_issue", "create_issue",
+		"get_issue", "list_issues", "list_labels", "remove_labels", "set_bot",
 		"set_labels", "transition_issue",
 	} {
 		if _, err := reg.Resolve("mcp.iterion_board." + name); err != nil {

--- a/pkg/backend/toolcatalog/toolcatalog.go
+++ b/pkg/backend/toolcatalog/toolcatalog.go
@@ -137,6 +137,7 @@ func ResolvesViaShorthand(name string) bool {
 // registrar by the same conformance test that guards clawBuiltins.
 var internalMCPShorthands = map[string]bool{
 	// mcp.iterion_board.* — boardops.AllTools()
+	"add_labels":       true,
 	"assign_issue":     true,
 	"close_issue":      true,
 	"comment_issue":    true,
@@ -144,6 +145,7 @@ var internalMCPShorthands = map[string]bool{
 	"get_issue":        true,
 	"list_issues":      true,
 	"list_labels":      true,
+	"remove_labels":    true,
 	"set_bot":          true,
 	"set_labels":       true,
 	"transition_issue": true,

--- a/pkg/cli/runs_prune.go
+++ b/pkg/cli/runs_prune.go
@@ -21,6 +21,10 @@ type PruneOptions struct {
 	Statuses  []string
 	DryRun    bool
 	Now       func() time.Time // test seam; nil = time.Now
+	// beforeDelete is a test seam invoked with each run id right before
+	// its delete — the window between the scan and the delete, where a
+	// run's status can change under the sweep. Nil in production.
+	beforeDelete func(runID string)
 }
 
 // pruneAllowedStatuses is the closed set of statuses eligible for
@@ -64,6 +68,12 @@ type PruneResult struct {
 	// (partial delete, crash before the first write). They are never
 	// deleted — the operator inspects or removes them by hand.
 	Unreadable []string `json:"unreadable,omitempty"`
+	// Refused lists runs the scan selected but the delete declined: their
+	// status had left the terminal set by the time the delete re-read them
+	// (a failed_resumable run resumed in the window). A tombstone on a
+	// live run reads as proof of absence to every board launch authority,
+	// so the delete never trusts the scan's snapshot.
+	Refused []string `json:"refused,omitempty"`
 	// TombstonesReaped counts the deletion markers older than the
 	// retention horizon that this sweep removed for good.
 	TombstonesReaped int `json:"tombstones_reaped,omitempty"`
@@ -185,6 +195,7 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 	})
 
 	pruned := make([]PrunedRun, 0, len(candidates))
+	var refused []string
 	nowT := now()
 	for _, c := range candidates {
 		age := nowT.Sub(c.ts)
@@ -201,6 +212,23 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 			Timestamp:    c.ts,
 		}
 		if !opts.DryRun {
+			if opts.beforeDelete != nil {
+				opts.beforeDelete(c.run.ID)
+			}
+			// The scan is a snapshot; the delete crosses the same lifecycle
+			// guard as every other delete authority (store.RunDeletable)
+			// on a FRESH read. A failed_resumable run resumed in the window
+			// is running now, and its tombstone would be read as proof of
+			// absence by the board launch authorities.
+			cur, err := s.LoadRun(ctx, c.run.ID)
+			if err != nil {
+				return fmt.Errorf("re-read run %s before delete: %w", c.run.ID, err)
+			}
+			if err := store.RunDeletable(cur); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: not pruning run %s: %v\n", c.run.ID, err)
+				refused = append(refused, c.run.ID)
+				continue
+			}
 			if err := s.DeleteRun(ctx, c.run.ID); err != nil {
 				return fmt.Errorf("delete run %s: %w", c.run.ID, err)
 			}
@@ -251,6 +279,7 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 		PrunedCount:             len(pruned),
 		SkippedCount:            scanned - len(pruned),
 		Unreadable:              unreadable,
+		Refused:                 refused,
 		TombstonesReaped:        tombstonesReaped,
 		WorkspaceObjectsPruned:  wsObjects,
 		WorkspaceBytesReclaimed: wsBytes,

--- a/pkg/cli/runs_prune_guard_test.go
+++ b/pkg/cli/runs_prune_guard_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestRunPrune_EveryPrunableStatusIsTerminal: prune's closed --status set
+// IS its lifecycle guard — the reason `prune --status paused_waiting_human`
+// cannot mint a tombstone on a live run is that the flag refuses it. Pin
+// the property so a status added to the set without being terminal fails
+// here rather than in production (a tombstone on a live run is read as
+// proof of absence by every board launch authority).
+func TestRunPrune_EveryPrunableStatusIsTerminal(t *testing.T) {
+	for name, st := range pruneAllowedStatuses {
+		if !st.IsTerminal() {
+			t.Fatalf("--status %q (%s) is prunable but not terminal — prune would tombstone a live run", name, st)
+		}
+	}
+	for _, live := range []string{"running", "queued", "paused_waiting_human", "paused_operator"} {
+		if _, err := validatePruneStatuses([]string{live}); err == nil {
+			t.Fatalf("--status %q must be refused: a live run's tombstone reads as proof of absence", live)
+		}
+	}
+}
+
+// TestRunPrune_RefusesARunResumedSinceTheScan: the scan is a snapshot.
+// A failed_resumable run (opt-in prunable) resumed between the scan and
+// the delete is RUNNING when the tombstone lands — and that tombstone is
+// read as proof of absence by the board launch authorities, which then
+// admit a fresh run on the same work while the resumed engine dies on
+// typed refusals. The delete re-reads the run and refuses a non-terminal
+// one, the same guard runview.DeleteRunCtx applies to the HTTP and MCP
+// deletes.
+func TestRunPrune_RefusesARunResumedSinceTheScan(t *testing.T) {
+	f := newPruneFixture(t)
+	f.seedRun(t, "resumed", store.RunStatusFailedResumable, 48*time.Hour)
+	f.seedRun(t, "old", store.RunStatusFinished, 48*time.Hour)
+	ctx := context.Background()
+
+	buf := &bytes.Buffer{}
+	p := &Printer{W: buf, Format: OutputJSON}
+	err := RunPrune(PruneOptions{
+		StoreDir:  f.dir,
+		OlderThan: 24 * time.Hour,
+		Statuses:  []string{"finished", "failed_resumable"},
+		Now:       func() time.Time { return f.now },
+		beforeDelete: func(id string) {
+			if id == "resumed" {
+				// The operator (or the usage-window retry) resumes it in
+				// the window.
+				if err := f.store.UpdateRunStatus(ctx, id, store.RunStatusRunning, ""); err != nil {
+					t.Fatal(err)
+				}
+			}
+		},
+	}, p)
+	if err != nil {
+		t.Fatalf("RunPrune: %v", err)
+	}
+
+	r, lerr := f.store.LoadRun(ctx, "resumed")
+	if lerr != nil || r.Status != store.RunStatusRunning {
+		t.Fatalf("REPRODUCED: the run resumed since the scan was tombstoned (LoadRun: %v) — its absence now reads as "+
+			"proof nothing is alive while the engine keeps running", lerr)
+	}
+	if _, lerr := f.store.LoadRun(ctx, "old"); !errors.Is(lerr, store.ErrRunDeleted) {
+		t.Fatalf("the terminal run must still be pruned, got %v", lerr)
+	}
+	var res PruneResult
+	if err := json.Unmarshal(buf.Bytes(), &res); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, buf.String())
+	}
+	if len(res.Refused) != 1 || res.Refused[0] != "resumed" {
+		t.Fatalf("the refusal must be reported, got refused=%v", res.Refused)
+	}
+	if res.PrunedCount != 1 {
+		t.Fatalf("pruned count = %d, want 1 (only the terminal run)", res.PrunedCount)
+	}
+}

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -1068,6 +1068,12 @@ func TestNativeStore_Conformance(t *testing.T) {
 		t.Fatalf("native.NewStore (admin): %v", err)
 	}
 	runBoardAdminSuite(t, admin, admin)
+
+	launch, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("native.NewStore (launch): %v", err)
+	}
+	runLaunchClaimSuite(t, launch)
 }
 
 // TestMongoStore_Conformance runs the same suite against the Mongo store.
@@ -1109,6 +1115,11 @@ func TestMongoStore_Conformance(t *testing.T) {
 	// The Mongo store must also drive the dispatcher as a tracker.Tracker via
 	// the shared native.Adapter (eligible + unclaimed + blocker-free filtering).
 	runTrackerSuite(t, boardmongo.New(db, "tracker-tenant"))
+
+	// The admission loop's atomic launch claim must exist on the cloud
+	// twin too — its own tenant, so the ready/held cards it seeds never
+	// enter the coordinator listing below.
+	runLaunchClaimSuite(t, boardmongo.New(db, "launch-tenant"))
 
 	// The Coordinator's cross-tenant ListEligible must find ready+unclaimed
 	// cards across tenants (verifies the issue.state / issue.claim BSON paths).

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -232,11 +232,19 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	if err != nil {
 		t.Fatalf("Claim give-up probe: %v", err)
 	}
-	if err := store.SetGaveUpOwned(gu.ID, &native.GiveUp{RunID: "run-gu", Attempts: 3}, guTok); err != nil {
+	if err := store.SetGaveUpOwned(gu.ID, &native.GiveUp{RunID: "run-gu", Attempts: 3, Reason: "recorded run gone"}, guTok); err != nil {
 		t.Fatalf("SetGaveUpOwned: %v", err)
 	}
-	if cur, _ := store.Get(gu.ID); cur.GaveUp == nil {
-		t.Fatalf("the give-up stamp must land: %+v", cur)
+	if cur, _ := store.Get(gu.ID); cur.GaveUp == nil || cur.GaveUp.Reason != "recorded run gone" {
+		t.Fatalf("the give-up stamp must land with its reason: %+v", cur.GaveUp)
+	}
+	// A re-stamp that only changes the REASON is a real change, not a
+	// no-op: the reason is what the operator reads.
+	if err := store.SetGaveUpOwned(gu.ID, &native.GiveUp{RunID: "run-gu", Attempts: 3, Reason: "still gone"}, guTok); err != nil {
+		t.Fatalf("SetGaveUpOwned (reason change): %v", err)
+	}
+	if cur, _ := store.Get(gu.ID); cur.GaveUp == nil || cur.GaveUp.Reason != "still gone" {
+		t.Fatalf("a changed reason must be written: %+v", cur.GaveUp)
 	}
 	if _, err := store.SetStateOwned(gu.ID, native.StateInProgress, guTok); err != nil {
 		t.Fatalf("SetStateOwned after give-up: %v", err)

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -1074,6 +1074,12 @@ func TestNativeStore_Conformance(t *testing.T) {
 		t.Fatalf("native.NewStore (launch): %v", err)
 	}
 	runLaunchClaimSuite(t, launch)
+
+	ownedFrom, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("native.NewStore (owned-from): %v", err)
+	}
+	runOwnedFromSuite(t, ownedFrom)
 }
 
 // TestMongoStore_Conformance runs the same suite against the Mongo store.
@@ -1120,6 +1126,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 	// twin too — its own tenant, so the ready/held cards it seeds never
 	// enter the coordinator listing below.
 	runLaunchClaimSuite(t, boardmongo.New(db, "launch-tenant"))
+	runOwnedFromSuite(t, boardmongo.New(db, "owned-from-tenant"))
 
 	// The Coordinator's cross-tenant ListEligible must find ready+unclaimed
 	// cards across tenants (verifies the issue.state / issue.claim BSON paths).

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -1088,6 +1088,12 @@ func TestNativeStore_Conformance(t *testing.T) {
 		t.Fatalf("native.NewStore (owned-from): %v", err)
 	}
 	runOwnedFromSuite(t, ownedFrom)
+
+	lateRenew, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("native.NewStore (late-renew): %v", err)
+	}
+	runRenewAfterReleaseSuite(t, lateRenew)
 }
 
 // TestMongoStore_Conformance runs the same suite against the Mongo store.
@@ -1135,6 +1141,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 	// enter the coordinator listing below.
 	runLaunchClaimSuite(t, boardmongo.New(db, "launch-tenant"))
 	runOwnedFromSuite(t, boardmongo.New(db, "owned-from-tenant"))
+	runRenewAfterReleaseSuite(t, boardmongo.New(db, "late-renew-tenant"))
 
 	// The Coordinator's cross-tenant ListEligible must find ready+unclaimed
 	// cards across tenants (verifies the issue.state / issue.claim BSON paths).

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -1094,6 +1094,12 @@ func TestNativeStore_Conformance(t *testing.T) {
 		t.Fatalf("native.NewStore (late-renew): %v", err)
 	}
 	runRenewAfterReleaseSuite(t, lateRenew)
+
+	adjust, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("native.NewStore (adjust-labels): %v", err)
+	}
+	runAdjustLabelsSuite(t, adjust)
 }
 
 // TestMongoStore_Conformance runs the same suite against the Mongo store.
@@ -1142,6 +1148,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 	runLaunchClaimSuite(t, boardmongo.New(db, "launch-tenant"))
 	runOwnedFromSuite(t, boardmongo.New(db, "owned-from-tenant"))
 	runRenewAfterReleaseSuite(t, boardmongo.New(db, "late-renew-tenant"))
+	runAdjustLabelsSuite(t, boardmongo.New(db, "adjust-labels-tenant"))
 
 	// The Coordinator's cross-tenant ListEligible must find ready+unclaimed
 	// cards across tenants (verifies the issue.state / issue.claim BSON paths).

--- a/pkg/dispatcher/boardmongo/coordinator.go
+++ b/pkg/dispatcher/boardmongo/coordinator.go
@@ -162,6 +162,12 @@ func (c *Coordinator) ReleaseOwned(_ context.Context, tenant, id string, tok tra
 	return c.StoreFor(tenant).ReleaseOwned(id, tok)
 }
 
+// SetGaveUpOwned is the fenced give-up stamp — the watchdog's record that
+// a filing was ITS decision (a pruned pointer), not a human's.
+func (c *Coordinator) SetGaveUpOwned(_ context.Context, tenant, id string, g *native.GiveUp, tok tracker.ClaimToken) error {
+	return c.StoreFor(tenant).SetGaveUpOwned(id, g, tok)
+}
+
 // ExpiredCandidate is one cross-tenant reap candidate.
 type ExpiredCandidate struct {
 	Tenant string

--- a/pkg/dispatcher/boardmongo/labels_adjust_conformance_test.go
+++ b/pkg/dispatcher/boardmongo/labels_adjust_conformance_test.go
@@ -1,0 +1,138 @@
+package boardmongo_test
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// countUpdatedEvents counts EvtIssueUpdated records for id.
+func countUpdatedEvents(t *testing.T, s native.BoardStore, id string) int {
+	t.Helper()
+	n := 0
+	if err := s.ScanEvents(func(e *native.Event) bool {
+		if e.Type == native.EvtIssueUpdated && e.IssueID == id {
+			n++
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("ScanEvents: %v", err)
+	}
+	return n
+}
+
+// runAdjustLabelsSuite pins BoardStore.AdjustLabels on both twins: the
+// RELATIVE label operations behind add_labels / remove_labels. Their
+// whole point is atomicity against the card as it is — a consumed
+// one-shot must not come back, and concurrent adds must not lose each
+// other — which is why the Mongo twin is one conditional write and the
+// FS twin one critical section, and why the suite runs on both.
+func runAdjustLabelsSuite(t *testing.T, store native.BoardStore) {
+	t.Helper()
+	iss, err := store.Create(native.Issue{Title: "labels", State: native.StateInbox, Labels: []string{"a", "b"}})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Add: existing kept in order, new appended, duplicates collapsed,
+	// blanks ignored, present ones not re-added.
+	got, changed, err := store.AdjustLabels(iss.ID, []string{"b", "c", "c", " d ", ""}, nil)
+	if err != nil || !changed {
+		t.Fatalf("AdjustLabels(add): changed=%v err=%v", changed, err)
+	}
+	want := []string{"a", "b", "c", "d"}
+	if !slices.Equal(got.Labels, want) {
+		t.Fatalf("returned labels = %v, want %v", got.Labels, want)
+	}
+	if cur, _ := store.Get(iss.ID); !slices.Equal(cur.Labels, want) || !cur.UpdatedAt.After(iss.UpdatedAt) {
+		t.Fatalf("stored labels = %v (updated %s vs created %s), want %v and a bumped UpdatedAt", cur.Labels, cur.UpdatedAt, iss.UpdatedAt, want)
+	}
+	events := countUpdatedEvents(t, store, iss.ID)
+
+	// A no-op add writes nothing: no event, no UpdatedAt churn.
+	before, _ := store.Get(iss.ID)
+	if got, changed, err := store.AdjustLabels(iss.ID, []string{"a", "b"}, nil); err != nil || changed || !slices.Equal(got.Labels, want) {
+		t.Fatalf("no-op add: changed=%v err=%v labels=%v", changed, err, got.Labels)
+	}
+	if after, _ := store.Get(iss.ID); !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Fatalf("a no-op add bumped UpdatedAt: %s → %s", before.UpdatedAt, after.UpdatedAt)
+	}
+	if n := countUpdatedEvents(t, store, iss.ID); n != events {
+		t.Fatalf("a no-op add emitted %d event(s)", n-events)
+	}
+
+	// Remove: the rest stays in place; an absent label is a no-op.
+	got, changed, err = store.AdjustLabels(iss.ID, nil, []string{"a", "zzz"})
+	if err != nil || !changed || !slices.Equal(got.Labels, []string{"b", "c", "d"}) {
+		t.Fatalf("AdjustLabels(remove): changed=%v err=%v labels=%v", changed, err, got.Labels)
+	}
+	// Overlap: a label named in both is removed, not added.
+	got, changed, err = store.AdjustLabels(iss.ID, []string{"e", "b"}, []string{"b"})
+	if err != nil || !changed || !slices.Equal(got.Labels, []string{"c", "d", "e"}) {
+		t.Fatalf("AdjustLabels(overlap): changed=%v err=%v labels=%v", changed, err, got.Labels)
+	}
+	// The event carries the delta the audit tail wants, under the same
+	// type set_labels emits (the trigger spine's card.updated).
+	var last map[string]any
+	if err := store.ScanEvents(func(e *native.Event) bool {
+		if e.Type == native.EvtIssueUpdated && e.IssueID == iss.ID {
+			last = e.Payload
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if fmt.Sprint(last["labels_added"]) != "[e]" || fmt.Sprint(last["labels_removed"]) != "[b]" {
+		t.Fatalf("event payload = %v, want labels_added=[e] labels_removed=[b]", last)
+	}
+
+	// A missing card is an error, never a silent no-op.
+	if _, _, err := store.AdjustLabels("native:00000000-0000-0000-0000-000000000000", []string{"x"}, nil); !errors.Is(err, tracker.ErrNotFound) {
+		t.Fatalf("missing card: err=%v, want ErrNotFound", err)
+	}
+
+	// The defect that motivated the op: a one-shot consumed between a
+	// bot's read and its write must NOT come back through a relative add.
+	shot, err := store.Create(native.Issue{Title: "one-shot", State: native.StateInbox, Labels: []string{"triage:auto", "kind:bug"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumed := []string{"kind:bug"} // the spine's consume (Update on FS, ConsumeLabels on Mongo)
+	if _, err := store.Update(shot.ID, native.Patch{Labels: &consumed}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _, err := store.AdjustLabels(shot.ID, []string{"source:issue-triage"}, nil); err != nil || slices.Contains(got.Labels, "triage:auto") {
+		t.Fatalf("a relative add re-armed a consumed one-shot: labels=%v err=%v", got.Labels, err)
+	}
+
+	// No lost update: N concurrent adds of distinct labels all land.
+	race, err := store.Create(native.Issue{Title: "concurrent", State: native.StateInbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, _, err := store.AdjustLabels(race.ID, []string{fmt.Sprintf("l%02d", i)}, nil); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent AdjustLabels: %v", err)
+	}
+	final, _ := store.Get(race.ID)
+	if len(final.Labels) != n {
+		t.Fatalf("concurrent adds lost updates: %d of %d labels landed: %v", len(final.Labels), n, final.Labels)
+	}
+}

--- a/pkg/dispatcher/boardmongo/launch_claim_conformance_test.go
+++ b/pkg/dispatcher/boardmongo/launch_claim_conformance_test.go
@@ -1,0 +1,101 @@
+package boardmongo_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// runLaunchClaimSuite pins the native.LaunchClaimer contract on BOTH
+// twins. The studio admission loop's ClaimForLaunch is a CAS StateReady →
+// StateInProgress that must ALSO read the claim family: the dispatcher
+// wins a card with the CLAIM and moves it to in_progress afterwards, off
+// the actor, so a claimed card can legally sit in Ready while its run is
+// already launching. A launcher that reads the state alone starts a
+// second run on it — and a backend without the method degrades the
+// admission loop to exactly that launcher (a best-effort SetState), which
+// on a multi-replica board is a cross-replica double-launch.
+func runLaunchClaimSuite(t *testing.T, store native.BoardStore) {
+	t.Helper()
+	claimer := native.AsLaunchClaimer(store)
+	if claimer == nil {
+		t.Fatalf("%T does not implement native.LaunchClaimer — the pipeline admission loop degrades to a "+
+			"best-effort SetState on this backend, a second launch authority that never reads the claim", store)
+	}
+
+	// A card outside StateReady is never won, whatever it carries.
+	inbox, err := store.Create(native.Issue{Title: "inbox card", State: native.StateInbox})
+	if err != nil {
+		t.Fatalf("Create inbox: %v", err)
+	}
+	if _, won, err := claimer.ClaimForLaunch(inbox.ID); err != nil || won {
+		t.Fatalf("ClaimForLaunch on an inbox card: won=%v err=%v, want a clean refusal", won, err)
+	}
+	if cur, _ := store.Get(inbox.ID); cur.State != native.StateInbox {
+		t.Fatalf("a refused launch claim must leave the card untouched, state now %q", cur.State)
+	}
+
+	// Ready + unclaimed: won, moved, and the move is on the event log with
+	// the same descriptive payload the FS twin writes.
+	ready, err := store.Create(native.Issue{Title: "ready card", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("Create ready: %v", err)
+	}
+	got, won, err := claimer.ClaimForLaunch(ready.ID)
+	if err != nil || !won || got == nil {
+		t.Fatalf("ClaimForLaunch on a free ready card: got=%v won=%v err=%v, want won", got, won, err)
+	}
+	if got.State != native.StateInProgress {
+		t.Fatalf("the returned issue must describe what was written: state %q, want %q", got.State, native.StateInProgress)
+	}
+	if cur, _ := store.Get(ready.ID); cur.State != native.StateInProgress {
+		t.Fatalf("stored state %q after a won launch claim, want %q", cur.State, native.StateInProgress)
+	}
+	if p := lastStatePayload(t, store, ready.ID); p["from"] != native.StateReady || p["to"] != native.StateInProgress {
+		t.Fatalf("launch claim event payload = %v, want from=ready to=in_progress", p)
+	}
+	// The same card cannot be won twice: the CAS is the mutual exclusion
+	// between two admission ticks (or two replicas).
+	if _, won, err := claimer.ClaimForLaunch(ready.ID); err != nil || won {
+		t.Fatalf("a second ClaimForLaunch on the same card: won=%v err=%v, want refused", won, err)
+	}
+
+	// Ready under a LIVE lease: the dispatcher already owns this card and
+	// its in_progress move is merely in flight. Refused, and nothing about
+	// the claim family may move.
+	held, err := store.Create(native.Issue{Title: "held card", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("Create held: %v", err)
+	}
+	tok, err := store.Claim(held.ID, "dispatcher-host-a")
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if _, won, err := claimer.ClaimForLaunch(held.ID); err != nil || won {
+		after, _ := store.Get(held.ID)
+		t.Fatalf("ClaimForLaunch won a Ready card held under a LIVE lease by %q (epoch %d) — two launchers now own it "+
+			"(state %q, claim %q); err=%v", tok.Marker, tok.Epoch, after.State, after.Claim, err)
+	}
+	cur, err := store.Get(held.ID)
+	if err != nil {
+		t.Fatalf("Get held: %v", err)
+	}
+	if cur.State != native.StateReady || cur.Claim != "dispatcher-host-a" || cur.ClaimEpoch != tok.Epoch || cur.ClaimLeaseUntil.IsZero() {
+		t.Fatalf("a refused launch claim must leave the holder's claim intact: state=%q claim=%q epoch=%d lease=%s",
+			cur.State, cur.Claim, cur.ClaimEpoch, cur.ClaimLeaseUntil)
+	}
+	// Once the holder releases, the card is free for the admission loop.
+	if err := store.Release(held.ID, "dispatcher-host-a"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if _, won, err := claimer.ClaimForLaunch(held.ID); err != nil || !won {
+		t.Fatalf("ClaimForLaunch after the holder released: won=%v err=%v, want won", won, err)
+	}
+
+	// A missing card is an error, never a silent "not won".
+	if _, won, err := claimer.ClaimForLaunch("native:00000000-0000-0000-0000-000000000000"); !errors.Is(err, tracker.ErrNotFound) || won {
+		t.Fatalf("ClaimForLaunch on a missing card: won=%v err=%v, want ErrNotFound", won, err)
+	}
+}

--- a/pkg/dispatcher/boardmongo/owned_from_conformance_test.go
+++ b/pkg/dispatcher/boardmongo/owned_from_conformance_test.go
@@ -1,0 +1,113 @@
+package boardmongo_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// countStateEvents counts EvtIssueState records for id — the oracle for
+// "nothing was written" on a drifted CAS.
+func countStateEvents(t *testing.T, s native.BoardStore, id string) int {
+	t.Helper()
+	n := 0
+	if err := s.ScanEvents(func(e *native.Event) bool {
+		if e.Type == native.EvtIssueState && e.IssueID == id {
+			n++
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("ScanEvents: %v", err)
+	}
+	return n
+}
+
+// runOwnedFromSuite pins BoardStore.SetStateOwnedFrom on both twins: ONE
+// CAS carrying the fence AND the source state. It is what the finish
+// worker's auto-transition writes through — a state probe followed by a
+// fenced overwrite lost an operator move that landed in between, while
+// the watchdog (which judges on the CAS-observed state) honoured it.
+func runOwnedFromSuite(t *testing.T, store native.BoardStore) {
+	t.Helper()
+	iss, err := store.Create(native.Issue{Title: "owned-from card", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	tok, err := store.Claim(iss.ID, "worker-a")
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	// Lands when the card is exactly where the owner believes it is.
+	got, changed, err := store.SetStateOwnedFrom(iss.ID, native.StateReady, native.StateInProgress, tok)
+	if err != nil || !changed || got == nil || got.State != native.StateInProgress {
+		t.Fatalf("SetStateOwnedFrom(ready→in_progress): got=%v changed=%v err=%v, want the move", got, changed, err)
+	}
+	if p := lastStatePayload(t, store, iss.ID); p["from"] != native.StateReady || p["to"] != native.StateInProgress {
+		t.Fatalf("event payload = %v, want from=ready to=in_progress", p)
+	}
+	events := countStateEvents(t, store, iss.ID)
+
+	// Drifted: the owner still believes "ready" but the card moved on —
+	// nothing is written, no event, no error, changed=false.
+	got, changed, err = store.SetStateOwnedFrom(iss.ID, native.StateReady, native.StateDone, tok)
+	if err != nil || changed {
+		t.Fatalf("drifted CAS: changed=%v err=%v, want changed=false and no error", changed, err)
+	}
+	if got == nil || got.State != native.StateInProgress {
+		t.Fatalf("drifted CAS must return the card as it stands (in_progress), got %+v", got)
+	}
+	if cur, _ := store.Get(iss.ID); cur.State != native.StateInProgress {
+		t.Fatalf("a drifted CAS wrote anyway: state now %q", cur.State)
+	}
+	if n := countStateEvents(t, store, iss.ID); n != events {
+		t.Fatalf("a drifted CAS emitted %d state event(s)", n-events)
+	}
+
+	// Same source and target: nothing to perform, changed=false — but the
+	// fence still speaks.
+	if _, changed, err := store.SetStateOwnedFrom(iss.ID, native.StateInProgress, native.StateInProgress, tok); err != nil || changed {
+		t.Fatalf("no-op CAS: changed=%v err=%v, want changed=false and no error", changed, err)
+	}
+
+	// Stolen: the claim moved to another holder, so the old token is
+	// refused with the typed conflict — never reported as a drift.
+	if err := store.Release(iss.ID, "worker-a"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	tok2, err := store.Claim(iss.ID, "worker-b")
+	if err != nil {
+		t.Fatalf("Claim (b): %v", err)
+	}
+	if _, _, err := store.SetStateOwnedFrom(iss.ID, native.StateInProgress, native.StateDone, tok); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("stale token on a matching state: err=%v, want ErrClaimConflict", err)
+	}
+	if _, _, err := store.SetStateOwnedFrom(iss.ID, native.StateInProgress, native.StateInProgress, tok); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("stale token on a no-op: err=%v, want ErrClaimConflict (an idempotent no-op must not mask a stolen claim)", err)
+	}
+	if cur, _ := store.Get(iss.ID); cur.State != native.StateInProgress || cur.Claim != "worker-b" {
+		t.Fatalf("a refused CAS wrote anyway: state=%q claim=%q", cur.State, cur.Claim)
+	}
+
+	// The terminal sink binds the owned family too: a declared terminal
+	// source is refused before the card is even read.
+	if _, _, err := store.SetStateOwnedFrom(iss.ID, native.StateDone, native.StateReady, tok2); !errors.Is(err, tracker.ErrTransitionRejected) {
+		t.Fatalf("terminal source: err=%v, want ErrTransitionRejected (wrapped ErrTerminalStateExit)", err)
+	}
+	if _, _, err := store.SetStateOwnedFrom(iss.ID, native.StateInProgress, "does-not-exist", tok2); !errors.Is(err, tracker.ErrTransitionRejected) {
+		t.Fatalf("unknown target: err=%v, want ErrTransitionRejected", err)
+	}
+
+	// The new holder's move lands, and a done filing cascades like every
+	// other done write.
+	if _, changed, err := store.SetStateOwnedFrom(iss.ID, native.StateInProgress, native.StateDone, tok2); err != nil || !changed {
+		t.Fatalf("holder's CAS: changed=%v err=%v, want the move", changed, err)
+	}
+
+	// A missing card is an error, never a silent drift.
+	if _, _, err := store.SetStateOwnedFrom("native:00000000-0000-0000-0000-000000000000", native.StateReady, native.StateDone, tok2); !errors.Is(err, tracker.ErrNotFound) {
+		t.Fatalf("missing card: err=%v, want ErrNotFound", err)
+	}
+}

--- a/pkg/dispatcher/boardmongo/renew_after_release_conformance_test.go
+++ b/pkg/dispatcher/boardmongo/renew_after_release_conformance_test.go
@@ -1,0 +1,70 @@
+package boardmongo_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// runRenewAfterReleaseSuite answers, on BOTH twins, whether a renewal that
+// lands AFTER the owner's release can re-stamp a lease on a card the
+// dispatcher no longer owns. native.Adapter.RenewClaim detaches the
+// store call from the caller's cancel, so a renewal can outlive Stop()
+// and land after the release that follows it — the detached call IS
+// Store.RenewClaim, and this suite pins what that write does then.
+func runRenewAfterReleaseSuite(t *testing.T, store native.BoardStore) {
+	t.Helper()
+	iss, err := store.Create(native.Issue{Title: "late renewal", State: native.StateInProgress})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	old, err := store.Claim(iss.ID, "host-a")
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := store.ReleaseOwned(iss.ID, old); err != nil {
+		t.Fatalf("ReleaseOwned: %v", err)
+	}
+	// 1. Released card: the stale token renews nothing — no lease comes
+	// back on an unclaimed card.
+	if err := store.RenewClaim(iss.ID, old); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("renew after release: err=%v, want ErrClaimConflict", err)
+	}
+	if cur, _ := store.Get(iss.ID); cur.Claim != "" || !cur.ClaimLeaseUntil.IsZero() {
+		t.Fatalf("a late renewal re-stamped a released card: claim=%q lease=%s", cur.Claim, cur.ClaimLeaseUntil)
+	}
+	// 2. Re-claimed by another owner: the stale token is refused and the
+	// new owner's lease is untouched.
+	other, err := store.Claim(iss.ID, "host-b")
+	if err != nil {
+		t.Fatalf("Claim (b): %v", err)
+	}
+	before, _ := store.Get(iss.ID)
+	if err := store.RenewClaim(iss.ID, old); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("stale renew against a new owner: err=%v, want ErrClaimConflict", err)
+	}
+	if cur, _ := store.Get(iss.ID); cur.Claim != "host-b" || !cur.ClaimLeaseUntil.Equal(before.ClaimLeaseUntil) || cur.ClaimEpoch != other.Epoch {
+		t.Fatalf("a stale renewal touched the new owner's claim: %+v vs %+v", cur.ClaimLeaseUntil, before.ClaimLeaseUntil)
+	}
+	// 3. Re-claimed by the SAME marker (a fresh hold of the same worker):
+	// the epoch moved, so the OLD token — the one a late renewal carries
+	// — is refused; only the new token renews.
+	if err := store.ReleaseOwned(iss.ID, other); err != nil {
+		t.Fatalf("ReleaseOwned (b): %v", err)
+	}
+	fresh, err := store.Claim(iss.ID, "host-a")
+	if err != nil {
+		t.Fatalf("Claim (a again): %v", err)
+	}
+	if fresh.Epoch <= old.Epoch {
+		t.Fatalf("a fresh hold must carry a newer epoch: old %d, fresh %d", old.Epoch, fresh.Epoch)
+	}
+	if err := store.RenewClaim(iss.ID, old); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("the previous generation's token renewed a fresh hold of the same marker: err=%v", err)
+	}
+	if err := store.RenewClaim(iss.ID, fresh); err != nil {
+		t.Fatalf("the live token must still renew: %v", err)
+	}
+}

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -858,6 +858,9 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 		// record exists to reconstruct what actually happened.
 		payload["state"] = stamped.State
 		payload["attempts"] = stamped.Attempts
+		if stamped.Reason != "" {
+			payload["reason"] = stamped.Reason
+		}
 	}
 	return s.emit(native.Event{Type: native.EvtIssueGaveUp, IssueID: id, Payload: payload})
 }

--- a/pkg/dispatcher/boardmongo/store_labels_adjust.go
+++ b/pkg/dispatcher/boardmongo/store_labels_adjust.go
@@ -1,0 +1,96 @@
+package boardmongo
+
+import (
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// AdjustLabels is the relative label write (see native.BoardStore) as ONE
+// pipeline update: the delta is computed by the server against the
+// document as it is, so two replicas' adds cannot lose each other and a
+// one-shot label the trigger spine consumed in between stays consumed.
+// The pipeline mirrors native.AdjustLabelList exactly (existing order
+// kept, missing adds appended in order, removes applied last), and the
+// returned issue is described from the pre-write document with the same
+// Go function — one definition of the delta on both twins.
+func (s *Store) AdjustLabels(id string, add, remove []string) (*native.Issue, bool, error) {
+	ctx, cancel := ctxWithTimeout()
+	defer cancel()
+	add, remove = native.CleanLabels(add), native.CleanLabels(remove)
+	if len(add) == 0 && len(remove) == 0 {
+		iss, err := s.get(ctx, id)
+		return iss, false, err
+	}
+	// $literal: pipeline $set evaluates values as EXPRESSIONS, and labels
+	// are operator/bot text — a "$"-leading one would be read as a field
+	// path (the AddComment lesson).
+	cur := bson.M{"$ifNull": bson.A{"$issue.labels", bson.A{}}}
+	next := bson.M{"$filter": bson.M{
+		"input": bson.M{"$concatArrays": bson.A{
+			cur,
+			bson.M{"$filter": bson.M{
+				"input": bson.M{"$literal": toBSONArray(add)},
+				"as":    "candidate",
+				"cond":  bson.M{"$not": bson.A{bson.M{"$in": bson.A{"$$candidate", cur}}}},
+			}},
+		}},
+		"as":   "label",
+		"cond": bson.M{"$not": bson.A{bson.M{"$in": bson.A{"$$label", bson.M{"$literal": toBSONArray(remove)}}}}},
+	}}
+	now := time.Now().UTC()
+	res := s.issues.FindOneAndUpdate(ctx,
+		bson.M{"_id": id, "tenant_id": s.tenant},
+		setPipeline(bson.M{
+			"issue.labels": next,
+			// UpdatedAt moves only when the labels do — the sweeps and the
+			// board_events tail order on it, and a no-op must not churn it.
+			"issue.updatedat": bson.M{"$cond": bson.A{bson.M{"$eq": bson.A{next, cur}}, "$issue.updatedat", now}},
+		}),
+		options.FindOneAndUpdate().SetReturnDocument(options.Before))
+	if res.Err() != nil {
+		if !isNoDocuments(res.Err()) {
+			return nil, false, fmt.Errorf("boardmongo: adjust labels: %w", res.Err())
+		}
+		_, gerr := s.get(ctx, id)
+		if gerr != nil {
+			return nil, false, gerr
+		}
+		return nil, false, fmt.Errorf("boardmongo: adjust labels: %s vanished mid-write", id)
+	}
+	var before issueDoc
+	if err := res.Decode(&before); err != nil {
+		return nil, false, fmt.Errorf("boardmongo: adjust labels decode: %w", err)
+	}
+	out, added, removed := native.AdjustLabelList(before.Issue.Labels, add, remove)
+	after := before.Issue
+	after.Labels = out
+	if len(added) == 0 && len(removed) == 0 {
+		return &after, false, nil
+	}
+	after.UpdatedAt = now
+	if err := s.emit(native.Event{Type: native.EvtIssueUpdated, IssueID: id,
+		Payload: native.LabelsAdjustedPayload(added, removed)}); err != nil {
+		return nil, false, err
+	}
+	return &after, true, nil
+}
+
+func toBSONArray(ss []string) bson.A {
+	out := make(bson.A, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s)
+	}
+	return out
+}
+
+// setPipeline wraps a $set document as an update pipeline (the form that
+// makes expressions legal), like leaseStampPipeline.
+func setPipeline(set bson.M) mongo.Pipeline {
+	return mongo.Pipeline{{{Key: "$set", Value: set}}}
+}

--- a/pkg/dispatcher/boardmongo/store_launch.go
+++ b/pkg/dispatcher/boardmongo/store_launch.go
@@ -1,0 +1,68 @@
+package boardmongo
+
+import (
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// The admission loop's atomic launch claim (native.LaunchClaimer), Mongo
+// twin of native.Store.ClaimForLaunch.
+
+// Compile-time assertion: the cloud board carries the launch CAS. The
+// interface is optional by design (native.AsLaunchClaimer), which is
+// exactly why this pin exists — a backend that loses the method degrades
+// the studio's pipeline admission to a best-effort SetState, a second
+// launch authority that never reads the claim.
+var _ native.LaunchClaimer = (*Store)(nil)
+
+// ClaimForLaunch moves a Ready ticket to in_progress for the caller that
+// wins it, reporting whether THIS caller won. ONE conditional write
+// carries the whole precondition: the card is still in StateReady AND
+// carries no claim. The claim half is what makes it safe under the claim
+// lease: the dispatcher wins a card with the CLAIM and moves it to
+// in_progress afterwards, off the actor, so a claimed card can legally
+// sit in Ready while its run is already launching — a launcher reading
+// the state alone starts a second run on it. "Unclaimed" includes an
+// ABSENT claim field, like Claim: a document that lost the field to an
+// out-of-band write must stay launchable.
+//
+// Not won is (nil, false, nil) — the FS twin's answer for both "not
+// ready" and "held"; a missing card is ErrNotFound.
+func (s *Store) ClaimForLaunch(id string) (*native.Issue, bool, error) {
+	ctx, cancel := ctxWithTimeout()
+	defer cancel()
+	res := s.issues.FindOneAndUpdate(ctx,
+		bson.M{
+			"_id":         id,
+			"tenant_id":   s.tenant,
+			"issue.state": native.StateReady,
+			"issue.claim": bson.M{"$in": bson.A{"", nil}},
+		},
+		bson.M{"$set": stateSetAt(native.StateInProgress, time.Now().UTC())},
+		options.FindOneAndUpdate().SetReturnDocument(options.After))
+	if res.Err() != nil {
+		if !isNoDocuments(res.Err()) {
+			return nil, false, fmt.Errorf("boardmongo: claim for launch: %w", res.Err())
+		}
+		// Zero match: not ready, or somebody holds it — either way not
+		// ours. A missing card must still surface as ErrNotFound.
+		if _, gerr := s.get(ctx, id); gerr != nil {
+			return nil, false, gerr
+		}
+		return nil, false, nil
+	}
+	var doc issueDoc
+	if err := res.Decode(&doc); err != nil {
+		return nil, false, fmt.Errorf("boardmongo: claim for launch decode: %w", err)
+	}
+	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: id,
+		Payload: map[string]any{"from": native.StateReady, "to": native.StateInProgress}}); err != nil {
+		return nil, false, err
+	}
+	return &doc.Issue, true, nil
+}

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -444,6 +444,9 @@ func (s *Store) SetGaveUpOwned(id string, g *native.GiveUp, tok tracker.ClaimTok
 		payload["run_id"] = stamped.RunID
 		payload["state"] = stamped.State
 		payload["attempts"] = stamped.Attempts
+		if stamped.Reason != "" {
+			payload["reason"] = stamped.Reason
+		}
 	}
 	return s.emit(native.Event{Type: native.EvtIssueGaveUp, IssueID: id, Payload: payload})
 }

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -259,6 +259,75 @@ func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 	return &updated, nil
 }
 
+// SetStateOwnedFrom is SetStateOwned with a source-state precondition
+// (see native.BoardStore): the fencing filter and `issue.state == from`
+// ride in ONE FindOneAndUpdate. On a zero match ownership is qualified
+// FIRST (the FS twin's order) — a stolen claim reported as "drifted"
+// would be swallowed by the caller as an ordinary operator move.
+func (s *Store) SetStateOwnedFrom(id, from, to string, tok tracker.ClaimToken) (*native.Issue, bool, error) {
+	ctx, cancel := ctxWithTimeout()
+	defer cancel()
+	board := s.Board()
+	if board.StateByName(to) == nil {
+		return nil, false, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, to)
+	}
+	if from != to {
+		if err := native.ValidateStateExit(board, from, to); err != nil {
+			return nil, false, err
+		}
+	}
+	if from == to {
+		// Nothing to perform, so nothing is CHANGED (the FS twin's answer)
+		// — but an idempotent no-op must not mask a stolen claim from a
+		// caller about to keep writing.
+		n, cerr := s.issues.CountDocuments(ctx, s.ownedFilter(id, tok))
+		if cerr != nil {
+			return nil, false, fmt.Errorf("boardmongo: verify claim ownership: %w", cerr)
+		}
+		if n == 0 {
+			return nil, false, s.ownedRefused(ctx, id, tok)
+		}
+		iss, err := s.get(ctx, id)
+		return iss, false, err
+	}
+	filter := s.ownedFilter(id, tok)
+	filter["issue.state"] = from
+	writtenAt := time.Now().UTC()
+	res := s.issues.FindOneAndUpdate(ctx, filter,
+		bson.M{"$set": stateSetAt(to, writtenAt)},
+		options.FindOneAndUpdate().SetReturnDocument(options.After))
+	if res.Err() != nil {
+		if !isNoDocuments(res.Err()) {
+			return nil, false, fmt.Errorf("boardmongo: set state owned from: %w", res.Err())
+		}
+		n, cerr := s.issues.CountDocuments(ctx, s.ownedFilter(id, tok))
+		if cerr != nil {
+			return nil, false, fmt.Errorf("boardmongo: verify claim ownership: %w", cerr)
+		}
+		if n == 0 {
+			return nil, false, s.ownedRefused(ctx, id, tok)
+		}
+		iss, gerr := s.get(ctx, id)
+		if gerr != nil {
+			return nil, false, gerr
+		}
+		return iss, false, nil
+	}
+	var doc issueDoc
+	if err := res.Decode(&doc); err != nil {
+		return nil, false, fmt.Errorf("boardmongo: set state owned from decode: %w", err)
+	}
+	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: id,
+		Payload: native.StateChangePayload(from, to, tok.Marker)}); err != nil {
+		return nil, false, err
+	}
+	if to == native.StateDone {
+		// Best-effort: do not roll back a successful done transition.
+		_ = native.PromoteUnblockedDependents(s, id)
+	}
+	return &doc.Issue, true, nil
+}
+
 // SetLastRunOwned is SetLastRun fenced on the claim token. The run-ref
 // history merge needs the current value, so this is read-then-CAS: the
 // write still only lands while the token owns the claim.

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -458,8 +460,56 @@ func isNoDocuments(err error) bool { return errors.Is(err, mongo.ErrNoDocuments)
 // lease: an expired lease is positive evidence a heartbeat stopped,
 // while a missing one is only an absence — so the bar is "nothing has
 // touched this card in a very long time" rather than "a beat was
-// missed".
-const unleasedClaimHorizon = 24 * time.Hour
+// missed". The default is the trade-off for a mixed fleet: during a
+// rolling deploy an OLD binary strips leases as it writes and does not
+// heartbeat, so a short horizon would release a card its old-binary
+// holder is still working. Tunable per deployment through
+// UnleasedClaimHorizonEnv (see SetUnleasedClaimHorizon) — set BEFORE the
+// coordinator runs; the queries read it unguarded.
+var unleasedClaimHorizon = DefaultUnleasedClaimHorizon
+
+// DefaultUnleasedClaimHorizon is the shipped horizon.
+const DefaultUnleasedClaimHorizon = 24 * time.Hour
+
+// UnleasedClaimHorizonEnv overrides the un-leased horizon (a Go duration,
+// e.g. "2h"). It must be at least one claim lease: below that, a claim
+// with NO lease would be reclaimable sooner than one whose lease merely
+// expired, inverting the evidence ordering the arms are built on.
+const UnleasedClaimHorizonEnv = "ITERION_BOARD_UNLEASED_CLAIM_HORIZON"
+
+// UnleasedClaimHorizon reports the horizon in force.
+func UnleasedClaimHorizon() time.Duration { return unleasedClaimHorizon }
+
+// SetUnleasedClaimHorizon installs the horizon. Refused loudly below one
+// lease (see UnleasedClaimHorizonEnv) — never silently clamped.
+func SetUnleasedClaimHorizon(d time.Duration) error {
+	if d < native.ClaimLeaseDuration {
+		return fmt.Errorf("%s: %s is below one claim lease (%s) — an un-leased claim would be reclaimable sooner than an expired one",
+			UnleasedClaimHorizonEnv, d, native.ClaimLeaseDuration)
+	}
+	unleasedClaimHorizon = d
+	return nil
+}
+
+// ConfigureUnleasedClaimHorizonFromEnv applies UnleasedClaimHorizonEnv
+// when set and reports the horizon in force. An unparsable or too-short
+// value is an error the caller surfaces at startup: a watchdog measuring
+// against a horizon nobody intended is worse than one that refuses to
+// start.
+func ConfigureUnleasedClaimHorizonFromEnv() (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv(UnleasedClaimHorizonEnv))
+	if raw == "" {
+		return unleasedClaimHorizon, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s=%q: %w", UnleasedClaimHorizonEnv, raw, err)
+	}
+	if err := SetUnleasedClaimHorizon(d); err != nil {
+		return 0, err
+	}
+	return d, nil
+}
 
 // reclaimableLease is the ONE definition of "this claim may be taken":
 // an expired lease, or none at all past a much longer horizon. The

--- a/pkg/dispatcher/boardmongo/unleased_horizon_test.go
+++ b/pkg/dispatcher/boardmongo/unleased_horizon_test.go
@@ -1,0 +1,51 @@
+package boardmongo
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// TestUnleasedClaimHorizon_FromEnv: the horizon is an operator dial with
+// a floor, not a constant — a deployment whose rolling window is minutes
+// should not wait a day for a stripped claim, and one that sets it below
+// a lease must be refused rather than silently clamped.
+func TestUnleasedClaimHorizon_FromEnv(t *testing.T) {
+	prev := UnleasedClaimHorizon()
+	t.Cleanup(func() { unleasedClaimHorizon = prev })
+
+	t.Setenv(UnleasedClaimHorizonEnv, "")
+	if d, err := ConfigureUnleasedClaimHorizonFromEnv(); err != nil || d != DefaultUnleasedClaimHorizon {
+		t.Fatalf("unset: d=%s err=%v, want the %s default", d, err, DefaultUnleasedClaimHorizon)
+	}
+
+	t.Setenv(UnleasedClaimHorizonEnv, "2h")
+	d, err := ConfigureUnleasedClaimHorizonFromEnv()
+	if err != nil || d != 2*time.Hour || UnleasedClaimHorizon() != 2*time.Hour {
+		t.Fatalf("2h: d=%s err=%v in force=%s", d, err, UnleasedClaimHorizon())
+	}
+	// The arm reads the value in force: a claim untouched for 3h is now a
+	// candidate, one untouched for 1h is not.
+	cutoff := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	arm := UnleasedArm(cutoff)
+	bound := arm["issue.updatedat"].(bson.M)["$lt"].(time.Time)
+	if !bound.Equal(cutoff.Add(-2 * time.Hour)) {
+		t.Fatalf("UnleasedArm bound = %s, want cutoff-2h", bound)
+	}
+
+	for _, bad := range []string{"abc", "0", "-1h", (native.ClaimLeaseDuration - time.Second).String()} {
+		t.Setenv(UnleasedClaimHorizonEnv, bad)
+		if _, err := ConfigureUnleasedClaimHorizonFromEnv(); err == nil {
+			t.Fatalf("%q must be refused, not clamped", bad)
+		} else if !strings.Contains(err.Error(), UnleasedClaimHorizonEnv) {
+			t.Fatalf("the error must name the variable: %v", err)
+		}
+		if UnleasedClaimHorizon() != 2*time.Hour {
+			t.Fatalf("a refused value must not change the horizon in force: %s", UnleasedClaimHorizon())
+		}
+	}
+}

--- a/pkg/dispatcher/claimsession.go
+++ b/pkg/dispatcher/claimsession.go
@@ -54,18 +54,31 @@ type claimSession struct {
 	done      chan struct{}
 }
 
-// StartClaimSession begins heartbeating. leaser must be non-nil; the
-// caller decides what "no lease backend" means (it logs once and runs
-// legacy, per the ClaimLeaser contract).
+// StartClaimSession begins heartbeating at the production cadence (a
+// third of the lease). leaser must be non-nil; the caller decides what
+// "no lease backend" means (it logs once and runs legacy, per the
+// ClaimLeaser contract).
 func StartClaimSession(leaser tracker.ClaimLeaser, issueID string, tok tracker.ClaimToken,
 	warn func(string, ...any), onLost func(error)) *claimSession {
+	return StartClaimSessionEvery(leaser, issueID, tok, warn, onLost, native.ClaimLeaseDuration/3)
+}
+
+// StartClaimSessionEvery is StartClaimSession with the heartbeat cadence
+// supplied — the seam a caller outside this package uses to drive a beat
+// into a window it wants to prove (the cloud dispatcher's release). A
+// non-positive interval means the production cadence.
+func StartClaimSessionEvery(leaser tracker.ClaimLeaser, issueID string, tok tracker.ClaimToken,
+	warn func(string, ...any), onLost func(error), interval time.Duration) *claimSession {
+	if interval <= 0 {
+		interval = native.ClaimLeaseDuration / 3
+	}
 	s := &claimSession{
 		issueID:  issueID,
 		tok:      tok,
 		leaser:   leaser,
 		warn:     warn,
 		onLost:   onLost,
-		interval: native.ClaimLeaseDuration / 3,
+		interval: interval,
 		stop:     make(chan struct{}),
 		done:     make(chan struct{}),
 	}

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -932,9 +932,7 @@ func (c *Dispatcher) stampGiveUp(plan finishPlan) {
 		At:       time.Now().UTC(),
 	}
 	if plan.session != nil {
-		if owned, ok := c.tracker.(interface {
-			SetGaveUpOwned(id string, g *native.GiveUp, tok tracker.ClaimToken) error
-		}); ok {
+		if owned, ok := c.tracker.(ownedGiveUpStamper); ok {
 			if err := owned.SetGaveUpOwned(plan.issueID, stamp, plan.session.Token()); err != nil {
 				c.logger.Warn("dispatcher: stamp give-up on %s: %v", plan.identifier, err)
 			}

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -788,6 +788,14 @@ func (c *Dispatcher) dropJournalAfterRelease(issueID, identifier string, err err
 	c.claims.Remove(issueID)
 }
 
+// ownedFromUpdater is the fenced CAS-from-state write a lease backend
+// offers (native.Adapter does, over BoardStore.SetStateOwnedFrom). It is
+// what lets the finish worker's auto-transition be ONE write instead of
+// a state probe followed by a fenced overwrite.
+type ownedFromUpdater interface {
+	UpdateStateOwnedFrom(ctx context.Context, id, from, to string, tok tracker.ClaimToken) (bool, error)
+}
+
 // fencedUpdateState routes a state move through the claim fence when a
 // session token is available (UpdateStateOwned), else the legacy path.
 // The fence is what makes a superseded holder's late move a typed
@@ -972,6 +980,32 @@ func (c *Dispatcher) maybeTransitionToCompleted(ctx context.Context, issueID, id
 	if completed == "" || completed == runningTarget {
 		return
 	}
+	if sess != nil && c.leaser != nil {
+		if fu, ok := c.leaser.(ownedFromUpdater); ok {
+			// ONE fenced CAS: "still in the running column" and the move
+			// are the same write. A probe followed by a fenced overwrite
+			// lost an operator move that landed in between — while the
+			// watchdog, judging on the CAS-observed state, honoured it.
+			changed, err := fu.UpdateStateOwnedFrom(ctx, issueID, runningTarget, completed, sess.Token())
+			switch {
+			case errors.Is(err, tracker.ErrNotFound):
+				// Issue disappeared from the tracker — refreshRunningStates'
+				// tombstone path already handled its cleanup.
+			case errors.Is(err, tracker.ErrTransitionRejected) || errors.Is(err, tracker.ErrNotSupported):
+				c.logger.Info("dispatcher: %s stayed in %s (tracker rejected move to %q): %v", identifier, runningTarget, completed, err)
+			case err != nil:
+				c.logger.Warn("dispatcher: completed-state move %s → %s: %v", identifier, completed, err)
+			case !changed:
+				// Workflow (or operator) already moved the state. Honor it.
+				c.logger.Info("dispatcher: %s already left %s before the auto-transition — leaving it where it was moved", identifier, runningTarget)
+			default:
+				c.logger.Info("dispatcher: %s moved %s → %s (workflow didn't change state, default auto-transition)", identifier, runningTarget, completed)
+			}
+			return
+		}
+	}
+	// Tokenless trackers (forge labels) carry no CAS: probe, then write —
+	// the window stays open exactly where no store can close it.
 	states, err := c.tracker.RefreshStates(ctx, []string{issueID})
 	if err != nil {
 		c.logger.Debug("dispatcher: completed-state probe %s: %v", identifier, err)

--- a/pkg/dispatcher/completed_transition_cas_test.go
+++ b/pkg/dispatcher/completed_transition_cas_test.go
@@ -1,0 +1,143 @@
+package dispatcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// probeTrapTracker records whether the finish worker PROBED the card's
+// state before its fenced write, and reproduces the window that probe
+// opens: the operator re-queues the card the instant the probe returns.
+// A probe-then-write worker then overwrites that move with its default
+// filing — while the watchdog, which judges on the CAS-observed state,
+// would have honoured it (the two authorities disagreeing on one card).
+type probeTrapTracker struct {
+	tracker.Tracker
+	board  *native.Store
+	id     string
+	moveTo string // the operator's destination; "" = re-queue to ready
+	probed bool
+}
+
+func (p *probeTrapTracker) RefreshStates(ctx context.Context, ids []string) (map[string]string, error) {
+	states, err := p.Tracker.RefreshStates(ctx, ids)
+	p.probed = true
+	// The operator's move lands between the probe and the write.
+	to := p.moveTo
+	if to == "" {
+		to = native.StateReady
+	}
+	if _, serr := p.board.SetState(p.id, to); serr != nil {
+		return nil, serr
+	}
+	return states, err
+}
+
+// TestMaybeTransitionToCompleted_IsOneFencedCAS: with a lease backend the
+// auto-transition is ONE CAS on (claim, epoch, state == running) — no
+// state probe, so there is no window for an operator move to be lost in.
+func TestMaybeTransitionToCompleted_IsOneFencedCAS(t *testing.T) {
+	c, board, _ := newReaperHarness(t)
+	iss, err := board.Create(native.Issue{Title: "finishing", State: native.StateReady})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := board.Claim(iss.ID, c.hostMarker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := board.SetStateOwned(iss.ID, native.StateInProgress, tok); err != nil {
+		t.Fatal(err)
+	}
+	trap := &probeTrapTracker{Tracker: c.tracker, board: board, id: iss.ID}
+	c.tracker = trap
+	sess := StartClaimSession(c.leaser, iss.ID, tok, func(string, ...any) {}, nil)
+	defer sess.Stop()
+
+	c.maybeTransitionToCompleted(context.Background(), iss.ID, "i1", native.StateInProgress, native.StateDone, sess)
+
+	got, err := board.Get(iss.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trap.probed {
+		t.Fatalf("the finish worker probed the state before its fenced write; the operator's re-queue that landed "+
+			"in that window now reads %q (a lost update the watchdog would not have made) — the auto-transition "+
+			"must be ONE fenced CAS on the running state", got.State)
+	}
+	if got.State != native.StateDone {
+		t.Fatalf("with nobody moving the card, the CAS must file it: state %q, want %q", got.State, native.StateDone)
+	}
+}
+
+// TestMaybeTransitionToCompleted_HonoursAMoveThatLandedFirst: an operator
+// (or the bot itself, via board.move) who moved the card out of the
+// running column before the worker's write keeps it there — the CAS
+// reports drift and nothing is written.
+func TestMaybeTransitionToCompleted_HonoursAMoveThatLandedFirst(t *testing.T) {
+	c, board, _ := newReaperHarness(t)
+	iss, err := board.Create(native.Issue{Title: "moved by hand", State: native.StateReady})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := board.Claim(iss.ID, c.hostMarker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := board.SetStateOwned(iss.ID, native.StateInProgress, tok); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := board.SetState(iss.ID, native.StateReview); err != nil {
+		t.Fatal(err)
+	}
+	sess := StartClaimSession(c.leaser, iss.ID, tok, func(string, ...any) {}, nil)
+	defer sess.Stop()
+
+	c.maybeTransitionToCompleted(context.Background(), iss.ID, "i1", native.StateInProgress, native.StateDone, sess)
+
+	if got, _ := board.Get(iss.ID); got.State != native.StateReview {
+		t.Fatalf("a move that landed before the auto-transition must stand: state %q, want %q", got.State, native.StateReview)
+	}
+}
+
+// TestRevertTransition_IsOneFencedCAS: the revert (a failed launch, a
+// cancel, a shutdown) is the same class as the auto-transition — its
+// "still in the running column" safety check must ride in the CAS, not
+// precede a fenced overwrite.
+func TestRevertTransition_IsOneFencedCAS(t *testing.T) {
+	c, board, _ := newReaperHarness(t)
+	iss, err := board.Create(native.Issue{Title: "reverting", State: native.StateReady})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := board.Claim(iss.ID, c.hostMarker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := board.SetStateOwned(iss.ID, native.StateInProgress, tok); err != nil {
+		t.Fatal(err)
+	}
+	// The trap parks the card in REVIEW (an operator's decision) the
+	// instant the probe returns in_progress.
+	trap := &probeTrapTracker{Tracker: c.tracker, board: board, id: iss.ID, moveTo: native.StateReview}
+	c.tracker = trap
+	sess := StartClaimSession(c.leaser, iss.ID, tok, func(string, ...any) {}, nil)
+	defer sess.Stop()
+
+	c.revertTransition(context.Background(), iss.ID, "i1", native.StateReady, native.StateInProgress, sess)
+
+	got, err := board.Get(iss.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if trap.probed {
+		t.Fatalf("revertTransition probed the state before its fenced write; the operator's move that landed in "+
+			"that window now reads %q — the safety check must ride in ONE fenced CAS", got.State)
+	}
+	if got.State != native.StateReady {
+		t.Fatalf("with nobody moving the card, the revert must land: state %q, want %q", got.State, native.StateReady)
+	}
+}

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -1326,7 +1326,28 @@ func (c *Dispatcher) revertTransition(ctx context.Context, issueID, identifier, 
 	// running state. If the workflow already moved it (typical clean
 	// finish path; the docs-refresh bot does this explicitly) or the
 	// operator dragged it on the kanban, leave the new state alone.
-	// RefreshStates is the cheapest read on the Tracker interface.
+	if currentTarget != "" && sess != nil && c.leaser != nil {
+		if fu, ok := c.leaser.(ownedFromUpdater); ok {
+			// ONE fenced CAS carries the safety check: a probe followed by
+			// a fenced write overwrote a move that landed in between (the
+			// maybeTransitionToCompleted class).
+			changed, err := fu.UpdateStateOwnedFrom(ctx, issueID, currentTarget, sourceState, sess.Token())
+			switch {
+			case errors.Is(err, tracker.ErrNotFound):
+				// Issue disappeared from the tracker — nothing to do.
+			case err != nil:
+				if !errors.Is(err, tracker.ErrTransitionRejected) && !errors.Is(err, tracker.ErrNotSupported) {
+					c.logger.Warn("dispatcher: revert state %s → %s: %v", identifier, sourceState, err)
+				}
+			case !changed:
+				c.logger.Debug("dispatcher: %s already left %s, skipping revert to %s", identifier, currentTarget, sourceState)
+			}
+			return
+		}
+	}
+	// Tokenless trackers carry no CAS: RefreshStates is the cheapest read
+	// on the Tracker interface, and the window stays open exactly where
+	// no store can close it.
 	if currentTarget != "" {
 		if states, err := c.tracker.RefreshStates(ctx, []string{issueID}); err == nil {
 			cur, present := states[issueID]

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -172,6 +172,19 @@ func (a *Adapter) UpdateStateOwned(ctx context.Context, id, newState string, tok
 	return err
 }
 
+// UpdateStateOwnedFrom is the fenced CAS move with a source-state
+// precondition (BoardStore.SetStateOwnedFrom): the finish worker's
+// auto-transition is ONE write through it, never a state probe followed
+// by a fenced overwrite. changed=false means the card drifted and nothing
+// was written.
+func (a *Adapter) UpdateStateOwnedFrom(ctx context.Context, id, from, to string, tok tracker.ClaimToken) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	_, changed, err := a.store.SetStateOwnedFrom(id, from, to, tok)
+	return changed, err
+}
+
 // UpdateStateOwnedReason is the fenced state write carrying an explicit
 // provenance (the watchdog's terminal verdicts) — see
 // native.SetStateOwnedReason.

--- a/pkg/dispatcher/native/adapter_late_renew_test.go
+++ b/pkg/dispatcher/native/adapter_late_renew_test.go
@@ -1,0 +1,77 @@
+package native
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// TestAdapterRenewClaim_LateRenewalCannotReStampAReleasedCard: the
+// adapter detaches the store renewal from the caller's cancel (so Stop()
+// is not hostage to the store lock), which means a renewal can land AFTER
+// the release that follows Stop(). It cannot re-stamp anything: the
+// detached call is Store.RenewClaim, fenced on (claim, epoch), and the
+// release cleared the claim. Deterministic: the store lock is held while
+// the release lands, so the parked renewal provably runs after it.
+func TestAdapterRenewClaim_LateRenewalCannotReStampAReleasedCard(t *testing.T) {
+	st, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, err := st.Create(Issue{Title: "held", State: StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := st.Claim(iss.ID, "host-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := NewAdapter(st)
+
+	release, held := make(chan struct{}), make(chan struct{})
+	go func() {
+		st.mu.Lock()
+		close(held)
+		<-release
+		st.mu.Unlock()
+	}()
+	<-held
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- a.RenewClaim(ctx, iss.ID, tok) }()
+	time.Sleep(20 * time.Millisecond) // the renewal is parked on the lock
+	cancel()
+	if e := <-errc; !errors.Is(e, context.Canceled) {
+		t.Fatalf("renew returned %v, want context.Canceled", e)
+	}
+
+	// Stop() has returned to the caller; the owner now releases — under
+	// the lock the detached renewal is still waiting for.
+	cur := cloneIssue(st.index[iss.ID])
+	if err := st.releaseLocked(cur, tok.Marker); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+
+	// The parked renewal runs next. Whatever it does, the released card
+	// must stay released: probe the same fenced write it performs, then
+	// read the card back.
+	if err := st.RenewClaim(iss.ID, tok); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Fatalf("the late renewal's own write must be refused on a released card, got %v", err)
+	}
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		got, err := st.Get(iss.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Claim != "" || !got.ClaimLeaseUntil.IsZero() {
+			t.Fatalf("a late renewal re-stamped a released card: claim=%q lease=%s", got.Claim, got.ClaimLeaseUntil)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/pkg/dispatcher/native/boardops/labels_adjust_test.go
+++ b/pkg/dispatcher/native/boardops/labels_adjust_test.go
@@ -1,0 +1,157 @@
+package boardops
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// staleReadStore hands every reader a snapshot taken BEFORE a one-shot
+// trigger label was consumed — the shape of a bot that read the card,
+// then had the trigger spine strip `triage:auto` atomically before its
+// own label write landed. A label operation built from a read (Get →
+// merge → Update, or the agent composing an absolute list) re-arms the
+// one-shot; a relative operation never consults the read.
+type staleReadStore struct {
+	native.BoardStore
+	stale *native.Issue
+}
+
+func (s *staleReadStore) Get(id string) (*native.Issue, error) {
+	if id == s.stale.ID {
+		cp := *s.stale
+		cp.Labels = append([]string(nil), s.stale.Labels...)
+		return &cp, nil
+	}
+	return s.BoardStore.Get(id)
+}
+
+// TestAddLabels_DoesNotRearmAConsumedOneShot is the #666 defect as a
+// contract: an incremental label change must be RELATIVE to the card as
+// it is, never rebuilt from what the caller read earlier. set_labels is
+// absolute by design (its stale list re-arms `triage:auto` BY INTENT —
+// pinned below as the documented shape), which is exactly why agents
+// need add_labels / remove_labels for anything incremental.
+func TestAddLabels_DoesNotRearmAConsumedOneShot(t *testing.T) {
+	s := newStore(t)
+	caps := NewCapabilities("board.label,board.read")
+	created, err := s.Create(native.Issue{Title: "fresh issue", State: native.StateInbox, Labels: []string{"triage:auto", "kind:bug"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The bot's read happens here…
+	stale, _ := s.Get(created.ID)
+	// …then the trigger spine consumes the one-shot before the bot's
+	// label write (the local effect strips it through Update).
+	consumed := []string{"kind:bug"}
+	if _, err := s.Update(created.ID, native.Patch{Labels: &consumed}); err != nil {
+		t.Fatal(err)
+	}
+	wrapped := &staleReadStore{BoardStore: s, stale: stale}
+
+	args, _ := json.Marshal(map[string]any{"id": created.ID, "labels": []string{"source:issue-triage"}})
+	res, err := Call(wrapped, caps, "add_labels", args)
+	if err != nil {
+		t.Fatalf("add_labels: %v", err)
+	}
+	var got native.Issue
+	if err := json.Unmarshal(res, &got); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(got.Labels, "triage:auto") {
+		t.Fatalf("REPRODUCED: add_labels re-armed the consumed one-shot from a stale read: labels=%v", got.Labels)
+	}
+	want := []string{"kind:bug", "source:issue-triage"}
+	if !slices.Equal(got.Labels, want) {
+		t.Fatalf("labels = %v, want %v (existing kept in order, the new one appended)", got.Labels, want)
+	}
+	if cur, _ := s.Get(created.ID); !slices.Equal(cur.Labels, want) {
+		t.Fatalf("stored labels = %v, want %v", cur.Labels, want)
+	}
+
+	// The absolute op, fed the stale list, re-arms it — the API's shape,
+	// and the reason the relative ops exist.
+	args, _ = json.Marshal(map[string]any{"id": created.ID, "labels": append(stale.Labels, "source:issue-triage")})
+	if _, err := Call(s, caps, "set_labels", args); err != nil {
+		t.Fatalf("set_labels: %v", err)
+	}
+	if cur, _ := s.Get(created.ID); !slices.Contains(cur.Labels, "triage:auto") {
+		t.Fatalf("set_labels is documented as ABSOLUTE and must replay its list: %v", cur.Labels)
+	}
+}
+
+func TestAddRemoveLabels_RelativeSemantics(t *testing.T) {
+	s := newStore(t)
+	caps := NewCapabilities("board.label")
+	created, err := s.Create(native.Issue{Title: "labelled", State: native.StateBacklog, Labels: []string{"a", "b"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	call := func(tool string, labels []string) native.Issue {
+		t.Helper()
+		args, _ := json.Marshal(map[string]any{"id": created.ID, "labels": labels})
+		res, err := Call(s, caps, tool, args)
+		if err != nil {
+			t.Fatalf("%s(%v): %v", tool, labels, err)
+		}
+		var got native.Issue
+		if err := json.Unmarshal(res, &got); err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+	// Idempotent add: present labels are left alone, duplicates in the
+	// request collapse, order is existing-then-new.
+	if got := call("add_labels", []string{"b", "c", "c", " d "}); !slices.Equal(got.Labels, []string{"a", "b", "c", "d"}) {
+		t.Fatalf("add: %v", got.Labels)
+	}
+	// Remove leaves the rest in place; an absent label is a no-op.
+	if got := call("remove_labels", []string{"a", "zzz"}); !slices.Equal(got.Labels, []string{"b", "c", "d"}) {
+		t.Fatalf("remove: %v", got.Labels)
+	}
+	// Short id prefixes resolve like every other board op.
+	prefix := created.ID[len("native:") : len("native:")+8]
+	args, _ := json.Marshal(map[string]any{"id": prefix, "labels": []string{"e"}})
+	if _, err := Call(s, caps, "add_labels", args); err != nil {
+		t.Fatalf("add_labels by prefix: %v", err)
+	}
+	if cur, _ := s.Get(created.ID); !slices.Equal(cur.Labels, []string{"b", "c", "d", "e"}) {
+		t.Fatalf("after prefix add: %v", cur.Labels)
+	}
+	// An empty request is an error, never a silent no-op.
+	args, _ = json.Marshal(map[string]any{"id": created.ID, "labels": []string{" "}})
+	if _, err := Call(s, caps, "add_labels", args); err == nil || !strings.Contains(err.Error(), "labels") {
+		t.Fatalf("empty add_labels must be refused explicitly, got %v", err)
+	}
+	args, _ = json.Marshal(map[string]any{"id": created.ID})
+	if _, err := Call(s, caps, "remove_labels", args); err == nil {
+		t.Fatal("remove_labels without labels must be refused")
+	}
+}
+
+func TestAddRemoveLabels_RequireLabelCapability(t *testing.T) {
+	s := newStore(t)
+	created, err := s.Create(native.Issue{Title: "gated", State: native.StateBacklog})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]any{"id": created.ID, "labels": []string{"x"}})
+	for _, tool := range []string{"add_labels", "remove_labels"} {
+		if _, err := Call(s, NewCapabilities("board.read,board.assign"), tool, args); !errors.Is(err, ErrCapabilityDenied) {
+			t.Fatalf("%s without board.label: err=%v, want ErrCapabilityDenied", tool, err)
+		}
+	}
+	names := map[string]bool{}
+	for _, tl := range ToolsFor(NewCapabilities("board.label")) {
+		names[tl.Name] = true
+	}
+	for _, want := range []string{"add_labels", "remove_labels", "set_labels"} {
+		if !names[want] {
+			t.Fatalf("board.label must unlock %s, got %v", want, names)
+		}
+	}
+}

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -87,6 +87,21 @@ type Tool struct {
 // perform.
 var allTools = []Tool{
 	{
+		Name:       "add_labels",
+		Capability: CapBoardLabel,
+		Description: "Add labels to an issue, leaving every label already on it in place (idempotent: a label already present is left as is). " +
+			"PREFER this over set_labels for any incremental change — set_labels REPLACES the whole list, so a list composed from an " +
+			"earlier read re-arms one-shot trigger labels (e.g. triage:auto) that were consumed in between.",
+		InputSchema: json.RawMessage(`{
+          "type":"object",
+          "properties":{
+            "id":{"type":"string","description":"Issue ID or unambiguous prefix."},
+            "labels":{"type":"array","items":{"type":"string"},"description":"Labels to add. At least one."}
+          },
+          "required":["id","labels"]
+        }`),
+	},
+	{
 		Name:        "assign_issue",
 		Capability:  CapBoardAssign,
 		Description: "Set the human/ownership assignee on an issue. To choose which BOT processes an issue, use set_bot instead — the dispatcher routes by bot first, and an assignee is only used as a bot selector when no bot is set (the path external trackers like GitHub/Forgejo rely on).",
@@ -192,6 +207,20 @@ var allTools = []Tool{
         }`),
 	},
 	{
+		Name:       "remove_labels",
+		Capability: CapBoardLabel,
+		Description: "Remove the given labels from an issue, leaving every other label in place (a label not present is ignored). " +
+			"Prefer it over set_labels for incremental changes — see add_labels.",
+		InputSchema: json.RawMessage(`{
+          "type":"object",
+          "properties":{
+            "id":{"type":"string","description":"Issue ID or unambiguous prefix."},
+            "labels":{"type":"array","items":{"type":"string"},"description":"Labels to remove. At least one."}
+          },
+          "required":["id","labels"]
+        }`),
+	},
+	{
 		Name:        "set_bot",
 		Capability:  CapBoardAssign,
 		Description: "Set the explicit bot (dispatcher workflow) for an issue. This is the CANONICAL way to choose which bot runs an issue — prefer it over assign_issue, which sets the human/ownership assignee. The dispatcher routes by bot first, else assignee. Empty string clears it (falls back to assignee-based routing).",
@@ -205,9 +234,11 @@ var allTools = []Tool{
         }`),
 	},
 	{
-		Name:        "set_labels",
-		Capability:  CapBoardLabel,
-		Description: "Replace the label list on an issue.",
+		Name:       "set_labels",
+		Capability: CapBoardLabel,
+		Description: "Replace the label list on an issue (ABSOLUTE). Only for a full rewrite from a fresh read; to add or remove a few " +
+			"labels use add_labels / remove_labels — a replacement built from an earlier read re-arms one-shot trigger labels " +
+			"(e.g. triage:auto) consumed in between.",
 		InputSchema: json.RawMessage(`{
           "type":"object",
           "properties":{
@@ -250,6 +281,8 @@ var dispatchByName = map[string]func(native.BoardStore, json.RawMessage) (json.R
 	"assign_issue":     doAssign,
 	"set_bot":          doSetBot,
 	"set_labels":       doSetLabels,
+	"add_labels":       doAddLabels,
+	"remove_labels":    doRemoveLabels,
 	"close_issue":      doClose,
 	"list_issues":      doList,
 	"list_labels":      doListLabels,
@@ -483,6 +516,49 @@ func doSetLabels(store native.BoardStore, raw json.RawMessage) (json.RawMessage,
 		return nil, err
 	}
 	iss, err := store.Update(resolved, native.Patch{Labels: &args.Labels})
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(iss)
+}
+
+// doAddLabels / doRemoveLabels are the RELATIVE label writes: the delta
+// goes to the store's atomic AdjustLabels and is applied to the card as
+// it is — never composed from a read the agent took earlier, which is how
+// set_labels re-armed a consumed one-shot (issue #666).
+func doAddLabels(store native.BoardStore, raw json.RawMessage) (json.RawMessage, error) {
+	return adjustLabels(store, raw, true)
+}
+
+func doRemoveLabels(store native.BoardStore, raw json.RawMessage) (json.RawMessage, error) {
+	return adjustLabels(store, raw, false)
+}
+
+func adjustLabels(store native.BoardStore, raw json.RawMessage, add bool) (json.RawMessage, error) {
+	var args struct {
+		ID     string   `json:"id"`
+		Labels []string `json:"labels"`
+	}
+	if err := unmarshalArgs(raw, &args); err != nil {
+		return nil, err
+	}
+	if args.ID == "" {
+		return nil, errors.New("id is required")
+	}
+	labels := native.CleanLabels(args.Labels)
+	if len(labels) == 0 {
+		return nil, errors.New("labels is required: at least one non-empty label")
+	}
+	resolved, err := store.Resolve(args.ID)
+	if err != nil {
+		return nil, err
+	}
+	var iss *native.Issue
+	if add {
+		iss, _, err = store.AdjustLabels(resolved, labels, nil)
+	} else {
+		iss, _, err = store.AdjustLabels(resolved, nil, labels)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -32,6 +32,15 @@ type BoardStore interface {
 	SetStateFrom(id, from, to string) (*Issue, bool, error)
 	Reopen(id, toState string) (*Issue, error)
 	Delete(id string) error
+	// AdjustLabels is the RELATIVE label write (add_labels /
+	// remove_labels): the delta applies to the card as it is, atomically
+	// — one critical section on the FS twin, one conditional write on the
+	// Mongo one. Update's absolute label list is the caller's intent and
+	// re-arms a one-shot trigger label consumed after the caller's read;
+	// this cannot. changed=false when nothing moved (no write, no event).
+	// Mandatory, not optional: a backend without it would degrade the
+	// board ops to the read-modify-write this exists to remove.
+	AdjustLabels(id string, add, remove []string) (*Issue, bool, error)
 
 	// Claim/Release are the dispatcher's per-issue claim (marker = the
 	// dispatcher instance id). Claim stamps a persisted LEASE and returns

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -51,6 +51,15 @@ type BoardStore interface {
 	// of clobbering the new owner's state.
 	ReleaseOwned(id string, tok tracker.ClaimToken) error
 	SetStateOwned(id, newState string, tok tracker.ClaimToken) (*Issue, error)
+	// SetStateOwnedFrom is SetStateOwned with a source-state precondition:
+	// ONE CAS on (claim, claim_epoch, state == from). changed=false when
+	// the state drifted (somebody moved the card while its owner was
+	// deciding — nothing is written); ErrClaimConflict when the token no
+	// longer owns the card. The finish worker's auto-transition needs both
+	// halves in one write: fenced alone it overwrote an operator move that
+	// landed between its state probe and its write, while the watchdog —
+	// which judges on the CAS-observed state — would have honoured it.
+	SetStateOwnedFrom(id, from, to string, tok tracker.ClaimToken) (*Issue, bool, error)
 	SetLastRunOwned(id, runID, workdir string, tok tracker.ClaimToken) error
 	SetAwaitingInputOwned(id string, v bool, tok tracker.ClaimToken) error
 	SetGaveUpOwned(id string, g *GiveUp, tok tracker.ClaimToken) error

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -122,9 +122,13 @@ type StateReasoner interface {
 // atomically claim a Ready ticket for launch — a CAS StateReady →
 // StateInProgress that reports whether THIS caller won (PR #193 M2). It
 // closes the check-then-act window where a live dispatcher and the studio
-// admission loop both pick the same Ready ticket. The filesystem store
-// implements it; a backend that does not cleanly degrades to the caller's
-// best-effort SetState (the documented V1 window).
+// admission loop both pick the same Ready ticket, and it reads the CLAIM
+// family too: the dispatcher wins a card with the claim and moves it to
+// in_progress afterwards, so a claimed card can legally sit in Ready while
+// its run is already launching. Both twins implement it (the filesystem
+// store here, boardmongo for the cloud — pinned by the shared conformance
+// suite); a backend without it degrades the caller to a best-effort
+// SetState, which under the claim lease is a second launch authority.
 type LaunchClaimer interface {
 	ClaimForLaunch(id string) (*Issue, bool, error)
 }

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -150,6 +150,11 @@ type GiveUp struct {
 	State string `json:"state,omitempty"`
 	// Attempts is how many attempts were made before giving up.
 	Attempts int `json:"attempts,omitempty"`
+	// Reason, when set, says WHY the dispatcher gave up when it was not a
+	// retry budget: the claim watchdog filing a card whose recorded run
+	// is gone. Operator-facing (rendered on the pipeline board); a
+	// retry-budget give-up leaves it empty and reads by Attempts.
+	Reason string `json:"reason,omitempty"`
 	// At is when the give-up was stamped (UTC).
 	At time.Time `json:"at"`
 }

--- a/pkg/dispatcher/native/labels_adjust.go
+++ b/pkg/dispatcher/native/labels_adjust.go
@@ -1,0 +1,104 @@
+package native
+
+import (
+	"slices"
+	"strings"
+	"time"
+)
+
+// AdjustLabelList is the ONE definition of a relative label change,
+// shared by the FS twin (in its critical section) and the Mongo twin
+// (which mirrors it in an aggregation pipeline and uses it to describe
+// what that pipeline wrote). Existing labels keep their order; adds not
+// already present are appended in request order, deduplicated; removes
+// are applied last, so a label named on both sides is removed. Blank
+// entries are ignored. added/removed report the actual delta — both
+// empty means nothing changed and nothing should be written.
+func AdjustLabelList(labels, add, remove []string) (out, added, removed []string) {
+	drop := map[string]bool{}
+	for _, l := range remove {
+		if l = strings.TrimSpace(l); l != "" {
+			drop[l] = true
+		}
+	}
+	out = make([]string, 0, len(labels)+len(add))
+	present := map[string]bool{}
+	for _, l := range labels {
+		if drop[l] {
+			removed = append(removed, l)
+			continue
+		}
+		out = append(out, l)
+		present[l] = true
+	}
+	for _, l := range add {
+		l = strings.TrimSpace(l)
+		if l == "" || present[l] || drop[l] {
+			continue
+		}
+		out = append(out, l)
+		added = append(added, l)
+		present[l] = true
+	}
+	return out, added, removed
+}
+
+// CleanLabels trims a request's labels and drops blanks and duplicates
+// (order kept) — the normalisation both twins apply to add/remove input.
+func CleanLabels(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, l := range in {
+		if l = strings.TrimSpace(l); l != "" && !slices.Contains(out, l) {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// AdjustLabels is the relative label write behind the add_labels /
+// remove_labels board operations (see BoardStore). One critical section:
+// the card as it IS is what the delta applies to, never a snapshot the
+// caller took earlier — a one-shot trigger label consumed between a
+// bot's read and its write stays consumed.
+func (s *Store) AdjustLabels(id string, add, remove []string) (updated *Issue, changed bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("AdjustLabels", &err)
+	iss, err := s.readIssueLocked(id)
+	if err != nil {
+		return nil, false, err
+	}
+	out, added, removed := AdjustLabelList(iss.Labels, add, remove)
+	if len(added) == 0 && len(removed) == 0 {
+		return iss, false, nil
+	}
+	iss.Labels = out
+	iss.UpdatedAt = time.Now().UTC()
+	if err := s.writeIssueLocked(iss); err != nil {
+		return nil, false, err
+	}
+	s.index[iss.ID] = cloneIssue(iss)
+	if err := s.emitPostCommitEvent(Event{
+		Type:    EvtIssueUpdated,
+		IssueID: iss.ID,
+		Payload: LabelsAdjustedPayload(added, removed),
+	}); err != nil {
+		return nil, false, err
+	}
+	return iss, true, nil
+}
+
+// LabelsAdjustedPayload is the event body a relative label change emits
+// on both twins: the same `changed: [labels]` shape Update emits (the
+// trigger spine's card.updated reads it the same way), plus the delta
+// for the audit tail.
+func LabelsAdjustedPayload(added, removed []string) map[string]any {
+	p := map[string]any{"changed": []string{"labels"}}
+	if len(added) > 0 {
+		p["labels_added"] = append([]string(nil), added...)
+	}
+	if len(removed) > 0 {
+		p["labels_removed"] = append([]string(nil), removed...)
+	}
+	return p
+}

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -438,6 +438,40 @@ func (s *Store) SetStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 	return s.setStateReasonLocked(iss, newState, "", reason)
 }
 
+// SetStateOwnedFrom is SetStateOwned with a source-state precondition —
+// ownership, the drift check and the move share ONE critical section
+// (see BoardStore). Ownership is judged first: a stolen claim reported
+// as "drifted" would be swallowed by the caller as an ordinary operator
+// move, losing the one signal the fence exists to surface.
+func (s *Store) SetStateOwnedFrom(id, from, to string, tok tracker.ClaimToken) (updated *Issue, changed bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("SetStateOwnedFrom", &err)
+	if s.board.StateByName(to) == nil {
+		return nil, false, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, to)
+	}
+	// Guard BEFORE the drift check (the SetStateFrom contract): an
+	// automated writer declaring a terminal source is a programming error
+	// and is refused loudly whatever the card currently reads.
+	if from != to {
+		if err := ValidateStateExit(s.board, from, to); err != nil {
+			return nil, false, err
+		}
+	}
+	iss, err := s.ownedIssueLocked(id, tok)
+	if err != nil {
+		return nil, false, err
+	}
+	if iss.State != from || from == to {
+		return cloneIssue(iss), false, nil
+	}
+	out, err := s.setStateLocked(iss, to, tok.Marker)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
 // Reopen is the ONE sanctioned exit from a terminal state — an
 // operator-surface op, refused when dependents were already promoted on
 // this card's completion (deterministic v1). It emits the ordinary

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -290,6 +290,9 @@ func (s *Store) setGaveUpLocked(iss *Issue, g *GiveUp) error {
 		// record exists to reconstruct what actually happened.
 		payload["state"] = stamped.State
 		payload["attempts"] = stamped.Attempts
+		if stamped.Reason != "" {
+			payload["reason"] = stamped.Reason
+		}
 	}
 	return s.emitPostCommitEvent(Event{
 		Type:    EvtIssueGaveUp,
@@ -331,7 +334,7 @@ func SameGiveUp(a, b *GiveUp) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
-	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts
+	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts && a.Reason == b.Reason
 }
 
 // AddComment appends a note to the issue's discussion thread and returns

--- a/pkg/dispatcher/reaper.go
+++ b/pkg/dispatcher/reaper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -82,34 +83,41 @@ func ClaimReaperEnabled() bool {
 }
 
 // ClaimReaperMisspelling returns a diagnostic when the gate is set to a
-// value that is neither "on" nor "off", and "" otherwise. The var takes
-// exactly those two spellings, while this repo's other toggles accept
-// 1/true/0 — so an operator who reaches for a familiar one gets a
-// watchdog that is OFF, at the release N+1 cutover, with no feedback but
-// cards that stay stuck. That is precisely the failure mode this file's
-// own comment names ("a declared watchdog that silently isn't running").
-// Both surfaces log it once at startup.
+// value it does not understand, and "" otherwise. An unrecognised value
+// leaves the watchdog OFF — at the release N+1 cutover, where the
+// operator's only other feedback is cards that stay stuck — which is
+// precisely the failure mode this file's own comment names ("a declared
+// watchdog that silently isn't running"). Both surfaces log it once at
+// startup.
 func ClaimReaperMisspelling() string {
 	_, raw := claimReaperSetting()
 	if raw == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s=%q is not a value this gate understands — it takes %q or %q, so the claim watchdog stays OFF",
-		claimReaperEnv, raw, "on", "off")
+	return fmt.Sprintf("%s=%q is not a value this gate understands — it takes on/off, 1/0, true/false or yes/no, so the claim watchdog stays OFF",
+		claimReaperEnv, raw)
 }
 
 // claimReaperSetting resolves the gate, returning whether it is on and
-// the raw value when that value is unrecognised (empty otherwise).
+// the raw value when that value is unrecognised (empty otherwise). It
+// takes the spellings this repo's other toggles take (strconv.ParseBool's
+// 1/0/t/f/true/false) plus on/off and yes/no, case-insensitively.
 func claimReaperSetting() (on bool, unrecognised string) {
 	raw := strings.TrimSpace(os.Getenv(claimReaperEnv))
-	switch {
-	case strings.EqualFold(raw, "on"):
-		return true, ""
-	case raw == "" || strings.EqualFold(raw, "off"):
+	if raw == "" {
 		return false, ""
-	default:
+	}
+	switch strings.ToLower(raw) {
+	case "on", "yes":
+		return true, ""
+	case "off", "no":
+		return false, ""
+	}
+	b, err := strconv.ParseBool(raw)
+	if err != nil {
 		return false, raw
 	}
+	return b, ""
 }
 
 // startClaimReaper launches the periodic reaper when the gate is on and

--- a/pkg/dispatcher/reaper.go
+++ b/pkg/dispatcher/reaper.go
@@ -198,6 +198,7 @@ func (c *Dispatcher) reapOne(ctx context.Context, reaper tracker.ClaimReaper, ru
 	card := StuckCard{
 		State: cand.State, RunningState: cfg.Agent.RunningState, LaunchStates: c.launchStates(),
 		StampWindowOpen: StampWindowOpen(cand.ClaimedAt, now),
+		RecordedRunID:   cand.LastRunID,
 	}
 	// PRE-transfer: only the rows that protect a live owner. The parked
 	// row is deliberately not consulted here — refusing the transfer would
@@ -242,6 +243,8 @@ func (c *Dispatcher) reapOne(ctx context.Context, reaper tracker.ClaimReaper, ru
 		filed = c.fileStuckCard(ctx, cand, card, cfg.Agent.CompletedState, tok, tracker.ReasonRunFinished)
 	case StuckFail:
 		filed = c.fileStuckCard(ctx, cand, card, cfg.Agent.FailedState, tok, tracker.ReasonRunFailed)
+	case StuckGiveUp:
+		filed = c.giveUpStuckCard(ctx, cand, card, cfg.Agent.FailedState, tok, dec.Reason)
 	case StuckRepark, StuckReleaseOnly:
 		// The release below is the whole action: the card re-enters the
 		// eligible pool, and for Repark the retry machinery resumes the
@@ -317,6 +320,50 @@ func (c *Dispatcher) fileStuckCard(ctx context.Context, cand tracker.ExpiredClai
 	}
 	if err := c.leaser.UpdateStateOwned(ctx, cand.IssueID, target, tok); err != nil {
 		c.logger.Warn("dispatcher: claim watchdog file %s → %s: %v", cand.Identifier, target, err)
+		return false
+	}
+	return true
+}
+
+// ownedGiveUpStamper is the FENCED give-up stamp a lease backend offers
+// (native.Adapter does) — the owner-scoped twin of giveUpStamper, named
+// for the same reason (an assertion on an anonymous interface fails
+// silently). The watchdog's give-up filing is NOT complete without it: a
+// card filed as failed with no stamp reads as a human's decision, which
+// is the misreport the stamp exists to prevent.
+type ownedGiveUpStamper interface {
+	SetGaveUpOwned(id string, g *native.GiveUp, tok tracker.ClaimToken) error
+}
+
+// giveUpStuckCard performs the StuckGiveUp disposition: file the card into
+// the failed column under MACHINE provenance (the watchdog decided this by
+// itself — no downstream chain may fire as if a run had failed), then
+// stamp the give-up naming the gone run and why, so the pipeline board's
+// Needs-attention lane shows it as the watchdog's own filing. Both halves
+// are the disposition: a failed stamp keeps the recovery claim, and the
+// next lease retries — loudly.
+func (c *Dispatcher) giveUpStuckCard(ctx context.Context, cand tracker.ExpiredClaim, card StuckCard, target string, tok tracker.ClaimToken, reason string) bool {
+	if target == "" {
+		c.logger.Warn("dispatcher: claim watchdog cannot file %s (recorded run %s is gone): no failed_state is configured, "+
+			"and releasing it would re-dispatch work that may already be delivered — keeping the recovery claim",
+			cand.Identifier, cand.LastRunID)
+		return false
+	}
+	stamper, ok := c.leaser.(ownedGiveUpStamper)
+	if !ok {
+		c.logger.Warn("dispatcher: claim watchdog cannot stamp a give-up on %s (leaser %T has no SetGaveUpOwned) — "+
+			"keeping the recovery claim rather than filing a card that would read as a human's decision",
+			cand.Identifier, c.leaser)
+		return false
+	}
+	if !c.fileStuckCard(ctx, cand, card, target, tok, "") {
+		return false
+	}
+	// GiveUpToRecord makes the stamp a no-op when the card is not in the
+	// stamped state (the guard declined the filing: an operator moved the
+	// card first, and their intent stands unannotated).
+	if err := stamper.SetGaveUpOwned(cand.IssueID, &native.GiveUp{RunID: cand.LastRunID, State: target, Reason: reason}, tok); err != nil {
+		c.logger.Warn("dispatcher: claim watchdog give-up stamp on %s: %v", cand.Identifier, err)
 		return false
 	}
 	return true
@@ -400,8 +447,10 @@ func (c *Dispatcher) loadRunForReap(ctx context.Context, runs *store.FilesystemR
 	if err != nil {
 		if store.RunAbsent(err) {
 			// A recorded run whose document is gone — pruned, or deleted
-			// with a tombstone — proves nothing is alive: same disposition
-			// as "no run". Reading a tombstone as a transient read failure
+			// with a tombstone — proves nothing is alive. It is NOT the
+			// "no run" row: the table tells the two apart through
+			// StuckCard.RecordedRunID and files the gone pointer as a
+			// give-up. Reading a tombstone as a transient read failure
 			// instead would conserve the card for ever (DecideStuckCard
 			// returns StuckKeep on any read error, and reapOne returns
 			// before the transfer, so keepAfterTransfer's "conserved once"

--- a/pkg/dispatcher/reaper.go
+++ b/pkg/dispatcher/reaper.go
@@ -42,6 +42,11 @@ const (
 	reaperMarkerPrefix = tracker.ReaperMarkerPrefix
 )
 
+// claimReaperTick is the cadence the local reaper goroutine actually
+// ticks on — the production constant, injectable so a pass can be driven
+// under test without waiting a real minute.
+var claimReaperTick = claimReaperInterval
+
 // ClaimReaperInterval is the watchdog's cadence, exported so the cloud
 // board dispatcher paces its own pass by the SAME constant instead of
 // inheriting whatever its dispatch tick happens to be.
@@ -124,15 +129,33 @@ func (c *Dispatcher) startClaimReaper() {
 		return
 	}
 	c.logger.Info("dispatcher: claim watchdog active (every %s — expired leases are reclaimed and routed by the decision table)", claimReaperInterval)
+	// Tracked by workersWG and cancelled by c.stop: Stop() promises that
+	// nothing of this dispatcher keeps writing once it returns
+	// (Manager.Stop tears the EngineRunner down right after; the studio
+	// rebuilds the dispatcher on a project switch). A pass on
+	// context.Background() outside the WaitGroup kept transferring
+	// claims, filing cards and writing run statuses under a config the
+	// operator had already replaced.
+	c.workersWG.Add(1)
 	errtrack.Go("dispatcher.claimReaper", func() {
-		t := time.NewTicker(claimReaperInterval)
+		defer c.workersWG.Done()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			select {
+			case <-c.stop:
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+		t := time.NewTicker(claimReaperTick)
 		defer t.Stop()
 		for {
 			select {
 			case <-c.stop:
 				return
 			case <-t.C:
-				c.reapExpiredClaims(context.Background(), reaper, time.Now().UTC())
+				c.reapExpiredClaims(ctx, reaper, time.Now().UTC())
 			}
 		}
 	})

--- a/pkg/dispatcher/reaper_pruned_test.go
+++ b/pkg/dispatcher/reaper_pruned_test.go
@@ -1,0 +1,74 @@
+package dispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// TestReapOne_PrunedRunIsAGiveUpNotARelaunch: a card whose RECORDED run is
+// gone (pruned by `iterion runs prune`, or deleted behind a tombstone) is
+// not "died pre-launch" — a stamp landed, so a run happened, and nobody
+// can tell any more whether its work was delivered. Released bare, the
+// card sat in the eligible running column, the next tick re-dispatched
+// it, and lastRunHoldBeforeClaim read the absence as a legitimate fresh
+// start: a NEW run minted on the watchdog's authority for work that may
+// already be delivered. The disposition is a distinct give-up — filed
+// out of the pool, stamped with why — that an operator decides on.
+func TestReapOne_PrunedRunIsAGiveUpNotARelaunch(t *testing.T) {
+	c, board, runs := newReaperHarness(t)
+	ctx := context.Background()
+	if _, err := runs.CreateRun(ctx, "run-pruned", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := runs.DeleteRun(ctx, "run-pruned"); err != nil {
+		t.Fatal(err)
+	}
+	cand := seedClaimedCard(t, board, "run-pruned")
+
+	c.reapOne(ctx, c.tracker.(tracker.ClaimReaper), runsFor(c), cand, time.Now().Add(2*native.ClaimLeaseDuration))
+
+	got, err := board.Get(cand.IssueID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Claim != "" {
+		t.Fatalf("the recovery claim must come off once the disposition landed, claim = %q", got.Claim)
+	}
+	if got.State != native.StateBlocked {
+		t.Fatalf("REPRODUCED: the pruned pointer left the card in %q — an eligible column, so the next tick mints a "+
+			"fresh run for work that may already be delivered; want %q with a give-up stamp", got.State, native.StateBlocked)
+	}
+	if got.GaveUp == nil || got.GaveUp.RunID != "run-pruned" || got.GaveUp.State != native.StateBlocked || got.GaveUp.Reason == "" {
+		t.Fatalf("give-up stamp = %+v, want the pruned run named, the filed state, and a reason", got.GaveUp)
+	}
+	if !got.GaveUp.Current(got.State, got.LastRunID) {
+		t.Fatalf("the stamp must read as CURRENT for the card's own pointer (the Needs-attention predicate): %+v vs state %q run %q",
+			got.GaveUp, got.State, got.LastRunID)
+	}
+	// Machine provenance: the watchdog decided this by itself, so the
+	// card's downstream chain must not fire as if a run had failed.
+	if p := lastStatePayloadFS(t, board, cand.IssueID); p["reason"] != tracker.ReasonWatchdog {
+		t.Fatalf("give-up filing provenance = %v, want reason=%q", p, tracker.ReasonWatchdog)
+	}
+}
+
+func lastStatePayloadFS(t *testing.T, s *native.Store, id string) map[string]any {
+	t.Helper()
+	var last map[string]any
+	if err := s.ScanEvents(func(e *native.Event) bool {
+		if e.Type == native.EvtIssueState && e.IssueID == id {
+			last = e.Payload
+		}
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if last == nil {
+		t.Fatal("no state event")
+	}
+	return last
+}

--- a/pkg/dispatcher/reaper_stop_test.go
+++ b/pkg/dispatcher/reaper_stop_test.go
@@ -1,0 +1,93 @@
+package dispatcher
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// blockingReaperTracker is a lease-capable tracker whose expired-claim
+// listing parks until released, recording the context the pass runs on.
+type blockingReaperTracker struct {
+	*native.Adapter
+	entered chan context.Context
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingReaperTracker) ListExpiredClaimCandidates(ctx context.Context, _ time.Time, _ int) ([]tracker.ExpiredClaim, error) {
+	b.once.Do(func() { b.entered <- ctx })
+	<-b.release
+	return nil, nil
+}
+
+// TestClaimReaper_StopInterruptsAndDrainsThePass: Stop() promises that
+// nothing of this dispatcher keeps writing once it returns — Manager.Stop
+// tears the EngineRunner down right after, and the studio rebuilds the
+// dispatcher on a project switch. The reaper pass ran on
+// context.Background(), outside every WaitGroup Stop waits on, so a pass
+// mid-flight kept transferring claims, filing cards and writing run
+// statuses under a config the operator had already replaced. The pass
+// must be interruptible (its context dies with c.stop) and awaited.
+func TestClaimReaper_StopInterruptsAndDrainsThePass(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := native.NewAdapter(board)
+	trk := &blockingReaperTracker{Adapter: adapter, entered: make(chan context.Context, 1), release: make(chan struct{})}
+	c := &Dispatcher{
+		tracker: trk, leaser: adapter, logger: iterlog.Nop(), hostMarker: "host-1",
+		state: newState(), stop: make(chan struct{}), done: make(chan struct{}),
+	}
+	c.cfg.Store(&Config{Agent: AgentConfig{RunningState: native.StateInProgress}})
+	// No actor runs in this harness: Stop's <-c.done wait is satisfied up
+	// front, so what it measures below is ONLY the reaper's drain.
+	close(c.done)
+
+	t.Setenv(claimReaperEnv, "on")
+	prevTick := claimReaperTick
+	claimReaperTick = time.Millisecond
+	t.Cleanup(func() { claimReaperTick = prevTick })
+
+	c.startClaimReaper()
+
+	var passCtx context.Context
+	select {
+	case passCtx = <-trk.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the reaper never ticked")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		c.Stop()
+		close(stopped)
+	}()
+
+	// 1. Interruptible: the pass's context dies with the stop.
+	select {
+	case <-passCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("REPRODUCED: Stop() did not cancel the reaper pass — it runs on context.Background(), so a pass " +
+			"mid-flight keeps transferring claims and filing cards after the dispatcher is declared stopped")
+	}
+	// 2. Awaited: Stop() must not return while the pass is still running.
+	select {
+	case <-stopped:
+		t.Fatal("REPRODUCED: Stop() returned while a reaper pass was still in flight — the pass is not tracked by " +
+			"any WaitGroup Stop waits on")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(trk.release)
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return once the pass ended")
+	}
+}

--- a/pkg/dispatcher/reaper_test.go
+++ b/pkg/dispatcher/reaper_test.go
@@ -1336,26 +1336,37 @@ func TestReapOne_FailedFilingKeepsTheClaim(t *testing.T) {
 // stay stuck. That is the failure mode reaper.go's own comment says this
 // whole chantier exists to end.
 func TestClaimReaperGate_UnrecognisedValueIsLoud(t *testing.T) {
-	for _, v := range []string{"1", "true", "yes", "enabled"} {
+	// The spellings the repo's other toggles accept enable the gate — an
+	// operator reaching for ITERION_OPENAI_USE_OAUTH=1's shape must not
+	// get a watchdog that is OFF.
+	for _, v := range []string{"on", "ON", "On", "1", "true", "TRUE", "yes", "t"} {
 		t.Setenv(claimReaperEnv, v)
-		if ClaimReaperEnabled() {
-			t.Fatalf("%s=%q must not enable the gate — only %q does", claimReaperEnv, v, "on")
+		if !ClaimReaperEnabled() {
+			t.Fatalf("%s=%q must enable the gate", claimReaperEnv, v)
 		}
-		if msg := ClaimReaperMisspelling(); msg == "" {
-			t.Fatalf("%s=%q disabled the watchdog with no diagnostic — a declared watchdog that silently "+
-				"isn't running is exactly what this must not do", claimReaperEnv, v)
-		}
-	}
-	// The two spellings it DOES understand say nothing.
-	for _, v := range []string{"", "off", "OFF", "on", "On"} {
-		t.Setenv(claimReaperEnv, v)
 		if msg := ClaimReaperMisspelling(); msg != "" {
 			t.Fatalf("%s=%q is a valid spelling but warned: %s", claimReaperEnv, v, msg)
 		}
 	}
-	t.Setenv(claimReaperEnv, "ON")
-	if !ClaimReaperEnabled() {
-		t.Fatal("the gate must stay case-insensitive on its own spelling")
+	for _, v := range []string{"", "off", "OFF", "0", "false", "no", "f"} {
+		t.Setenv(claimReaperEnv, v)
+		if ClaimReaperEnabled() {
+			t.Fatalf("%s=%q must leave the gate off", claimReaperEnv, v)
+		}
+		if msg := ClaimReaperMisspelling(); msg != "" {
+			t.Fatalf("%s=%q is a valid spelling but warned: %s", claimReaperEnv, v, msg)
+		}
+	}
+	// Anything else still leaves it OFF and says so — a declared watchdog
+	// that silently isn't running is exactly what this must not do.
+	for _, v := range []string{"enabled", "oui", "2", "y", "n"} {
+		t.Setenv(claimReaperEnv, v)
+		if ClaimReaperEnabled() {
+			t.Fatalf("%s=%q must not enable the gate", claimReaperEnv, v)
+		}
+		if msg := ClaimReaperMisspelling(); msg == "" {
+			t.Fatalf("%s=%q disabled the watchdog with no diagnostic", claimReaperEnv, v)
+		}
 	}
 }
 

--- a/pkg/dispatcher/stuckcard.go
+++ b/pkg/dispatcher/stuckcard.go
@@ -34,6 +34,15 @@ const (
 	// StuckReleaseOnly: the claimant died before leaving any run — free
 	// the claim so the card is simply eligible again.
 	StuckReleaseOnly
+	// StuckGiveUp: the card RECORDS a run whose document is gone (pruned
+	// by the retention command, or deleted behind a tombstone). A run
+	// happened and nobody can tell any more whether its work was
+	// delivered — so the watchdog neither re-dispatches it (a fresh run
+	// on possibly-delivered work) nor files it as a plain failure (a
+	// terminal state that reads as a human's decision): it files the
+	// card as failed WITH a give-up stamp naming why, and an operator
+	// decides.
+	StuckGiveUp
 )
 
 func (a StuckAction) String() string {
@@ -46,6 +55,8 @@ func (a StuckAction) String() string {
 		return "repark"
 	case StuckReleaseOnly:
 		return "release"
+	case StuckGiveUp:
+		return "give_up"
 	default:
 		return "keep"
 	}
@@ -113,6 +124,10 @@ func ShouldFileStuckCard(cardState, runningState, target string, launchStates []
 // The table, in precedence order — every arm is a test:
 //
 //	run load error        → Keep      (a read error conserves — ADR-070)
+//	recorded run is GONE  → GiveUp    (pruned/tombstoned pointer: a run
+//	                                   happened, its outcome is unknowable —
+//	                                   filed as failed with a give-up stamp
+//	                                   for an operator, never re-dispatched)
 //	no run at all         → Release   (died pre-launch; card re-eligible)
 //	running / queued      → Keep      (liveness-first — a live run is
 //	                                   never stolen from; the caller's
@@ -136,6 +151,21 @@ func DecideStuckCard(run *store.Run, runErr error, card StuckCard) StuckDecision
 		return StuckDecision{StuckKeep, fmt.Sprintf("run unreadable (%v) — a read error conserves", runErr)}
 	}
 	if run == nil {
+		if card.RecordedRunID != "" {
+			// The card RECORDS a run and that run is gone: pruned by the
+			// retention command, or deleted behind a tombstone. This is
+			// not the no-run row — a stamp landed, so a run happened, and
+			// nobody can tell any more whether its work was delivered.
+			// Freeing the card re-dispatches it (the running column is
+			// eligible locally; the cloud repark writes it back into the
+			// pool) and the launch path reads the absence as a legitimate
+			// fresh start: a NEW run, on the watchdog's own authority, for
+			// work that may already be delivered. The stamp window does
+			// not apply either — the pointer IS the stamp.
+			return StuckDecision{StuckGiveUp, fmt.Sprintf(
+				"recorded run %s is gone (pruned or deleted) — a run happened and nobody can tell whether its work was delivered; filed for an operator rather than re-dispatched",
+				card.RecordedRunID)}
+		}
 		// "No run recorded" only means "died pre-launch" if the card never
 		// reached the running column. Stamping the run onto the card is
 		// BEST-EFFORT on both launch paths and happens AFTER the launch, so
@@ -235,10 +265,12 @@ func RecoveryHoldExpired(run *store.Run, runErr error, card StuckCard, prev trac
 
 // stampMayStillLand: the card is in the running column and was claimed
 // recently enough that its run stamp — written after the launch, and
-// best-effort — could still be on its way. ONE definition, read by both
-// the table and the pre-transfer decision.
+// best-effort — could still be on its way. A card that RECORDS a run has
+// its stamp: nothing is in flight, whatever the window says. ONE
+// definition, read by the table, the pre-transfer decision and the
+// recovery-hold bound.
 func stampMayStillLand(card StuckCard) bool {
-	return card.RunningState != "" && card.State == card.RunningState && card.StampWindowOpen
+	return card.RecordedRunID == "" && card.RunningState != "" && card.State == card.RunningState && card.StampWindowOpen
 }
 
 // parkedOutOfPool: the card is neither running nor in a column it would
@@ -255,6 +287,13 @@ type StuckCard struct {
 	State        string
 	RunningState string
 	LaunchStates []string
+	// RecordedRunID is the run the card's pointer names (LastRunID). It
+	// is what tells "no run was ever recorded" (the claimant died before
+	// launching) from "the recorded run is GONE" (pruned or tombstoned):
+	// the caller loads nil in both cases, and the two must not share a
+	// disposition — freeing the second re-dispatches work that may have
+	// been delivered.
+	RecordedRunID string
 	// StampWindowOpen says a run stamp could still plausibly be in
 	// flight for this card — the claim was taken moments ago. The stamp
 	// is written AFTER the launch and best-effort, so its absence means

--- a/pkg/dispatcher/stuckcard_test.go
+++ b/pkg/dispatcher/stuckcard_test.go
@@ -108,6 +108,44 @@ func TestDecideStuckCard_CardContext(t *testing.T) {
 // PROCESS_ORPHANED, redelivery_pending — is about to be resumed by the very
 // delivery that wrote it. The pre-transfer decision must keep the card:
 // a transfer would re-park it into a duplicate run on cloud.
+// TestDecideStuckCard_PrunedPointerIsAGiveUp: "no run loaded" has two
+// causes and they must not share a disposition. No run RECORDED is the
+// claimant dying before launch (release-only: the card is simply eligible
+// again). A recorded run that is GONE — pruned by the retention command,
+// deleted behind a tombstone — means a run happened and nobody can tell
+// whether its work was delivered: freeing the card re-dispatches it
+// (locally the running column is eligible; in cloud the repark writes it
+// back into the pool), minting a fresh run on the watchdog's authority.
+// That row is a give-up an operator decides on, whatever the stamp window
+// says (the pointer IS the stamp, so nothing is still in flight).
+func TestDecideStuckCard_PrunedPointerIsAGiveUp(t *testing.T) {
+	pruned := StuckCard{
+		State: "in_progress", RunningState: "in_progress", LaunchStates: []string{"ready"},
+		RecordedRunID: "run-gone", StampWindowOpen: true,
+	}
+	if got := DecideStuckCard(nil, nil, pruned); got.Action != StuckGiveUp {
+		t.Fatalf("pruned pointer: action = %s (%s), want give_up", got.Action, got.Reason)
+	}
+	if got := DecideTransfer(nil, nil, pruned); got.Action == StuckKeep {
+		t.Fatalf("a pruned pointer protects no live owner — the transfer must proceed, got keep (%s)", got.Reason)
+	}
+	// In a launch column too: the card was never moved by its launch, and
+	// its pointer is still gone.
+	pruned.State, pruned.StampWindowOpen = "ready", false
+	if got := DecideStuckCard(nil, nil, pruned); got.Action != StuckGiveUp {
+		t.Fatalf("pruned pointer in a launch column: action = %s, want give_up", got.Action)
+	}
+	// A read error still conserves — absence must be PROVEN, never inferred
+	// from a store blip.
+	if got := DecideStuckCard(nil, errors.New("store down"), pruned); got.Action != StuckKeep {
+		t.Fatalf("read error with a recorded run: action = %s, want keep", got.Action)
+	}
+	// And the genuine no-run shape keeps its release-only row.
+	if got := DecideStuckCard(nil, nil, StuckCard{State: "ready", RunningState: "in_progress", LaunchStates: []string{"ready"}}); got.Action != StuckReleaseOnly {
+		t.Fatalf("no run recorded: action = %s, want release", got.Action)
+	}
+}
+
 func TestDecideTransfer_KeepsAnAdoptedOrphan(t *testing.T) {
 	adopted := &store.Run{
 		ID: "r1", Status: store.RunStatusFailedResumable,

--- a/pkg/dispatcher/tracker/github.go
+++ b/pkg/dispatcher/tracker/github.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -70,6 +71,15 @@ type LabelSelector struct {
 // pagination come for free from gh; iterion only deals with JSON.
 type GitHubAdapter struct {
 	opts GitHubOptions
+
+	// claimedLabelEnsured memoises, per adapter, that the repository
+	// carries ClaimedLabel: `gh issue edit --add-label` refuses a label
+	// the repo does not have, so the first claim bootstraps it (the
+	// Forgejo twin's resolveLabelID). Dropped when a claim finds the
+	// label gone again, so an operator deleting it does not put the repo
+	// back into the every-tick claim failure.
+	labelMu             sync.Mutex
+	claimedLabelEnsured bool
 }
 
 // NewGitHub returns a configured adapter. Returns an error if the
@@ -295,16 +305,88 @@ func (a *GitHubAdapter) Comment(ctx context.Context, id, body string) error {
 // the issue (labels carry no host/pid — see the Tracker interface note),
 // which is why the boot journal is this adapter's only claim-recovery
 // path.
+//
+// The label is created on first use when the repository lacks it: `gh
+// issue edit --add-label` refuses an unknown label ('<label>' not
+// found), which on a fresh repo failed every issue's claim at every
+// tick, for ever. A refusal of that exact shape on a later claim means
+// the label was deleted behind the adapter's back: the memo is dropped,
+// the label re-created, the claim retried once.
 func (a *GitHubAdapter) Claim(ctx context.Context, id, marker string) error {
 	num, ok := parseGitHubID(a.opts.Repo, id)
 	if !ok {
 		return ErrNotFound
 	}
+	if err := a.ensureClaimedLabel(ctx); err != nil {
+		return err
+	}
 	args := []string{"issue", "edit", fmt.Sprintf("%d", num), "--repo", a.opts.Repo, "--add-label", a.opts.ClaimedLabel}
-	if _, err := a.opts.Command(ctx, args, a.env()); err != nil {
+	_, err := a.opts.Command(ctx, args, a.env())
+	if err != nil && a.ghClaimedLabelMissing(err) {
+		a.labelMu.Lock()
+		a.claimedLabelEnsured = false
+		a.labelMu.Unlock()
+		if err := a.ensureClaimedLabel(ctx); err != nil {
+			return err
+		}
+		_, err = a.opts.Command(ctx, args, a.env())
+	}
+	if err != nil {
 		return fmt.Errorf("gh issue edit (claim): %w", err)
 	}
 	return nil
+}
+
+// ensureClaimedLabel makes sure the repository carries ClaimedLabel,
+// creating it when absent — once per adapter. Listing first and creating
+// only on absence (never `--force`) keeps an operator's own colour and
+// description on a label that already exists; the created one takes the
+// neutral grey the Forgejo twin uses. A failure here is the claim's
+// failure: it surfaces with the label and the cause, and nothing is
+// memoised, so the next claim tries again.
+func (a *GitHubAdapter) ensureClaimedLabel(ctx context.Context) error {
+	a.labelMu.Lock()
+	defer a.labelMu.Unlock()
+	if a.claimedLabelEnsured {
+		return nil
+	}
+	list := []string{"label", "list", "--repo", a.opts.Repo, "--search", a.opts.ClaimedLabel, "--json", "name", "--limit", "100"}
+	out, err := a.opts.Command(ctx, list, a.env())
+	if err != nil {
+		return fmt.Errorf("gh label list (ensure claim label %q): %w", a.opts.ClaimedLabel, err)
+	}
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if len(bytes.TrimSpace(out)) > 0 {
+		if err := json.Unmarshal(out, &labels); err != nil {
+			return fmt.Errorf("gh label list (ensure claim label %q): decode: %w", a.opts.ClaimedLabel, err)
+		}
+	}
+	for _, l := range labels {
+		if l.Name == a.opts.ClaimedLabel {
+			a.claimedLabelEnsured = true
+			return nil
+		}
+	}
+	create := []string{"label", "create", a.opts.ClaimedLabel, "--repo", a.opts.Repo,
+		"--color", "888888", "--description", "Claimed by an iterion dispatcher"}
+	if _, err := a.opts.Command(ctx, create, a.env()); err != nil {
+		return fmt.Errorf("gh label create %q (the dispatcher's claim label is missing from %s and could not be created): %w",
+			a.opts.ClaimedLabel, a.opts.Repo, err)
+	}
+	a.claimedLabelEnsured = true
+	return nil
+}
+
+// ghClaimedLabelMissing recognises gh 2.x's refusal of an --add-label for
+// a label the repository does not carry, anchored on the exact configured
+// label name so an unrelated not-found cannot match.
+func (a *GitHubAdapter) ghClaimedLabelMissing(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), strings.ToLower("'"+a.opts.ClaimedLabel+"' not found"))
 }
 
 // Release removes the ClaimedLabel. Idempotent — gh ignores
@@ -350,7 +432,7 @@ func (a *GitHubAdapter) ghReleaseGone(err error, num int) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "could not resolve to an issue") ||
 		ghIssueScoped404(msg, num) ||
-		strings.Contains(msg, strings.ToLower("'"+a.opts.ClaimedLabel+"' not found"))
+		a.ghClaimedLabelMissing(err)
 }
 
 // ghIssueScoped404 matches gh's REST failure form (`HTTP 404: Not Found

--- a/pkg/dispatcher/tracker/github.go
+++ b/pkg/dispatcher/tracker/github.go
@@ -320,7 +320,7 @@ func (a *GitHubAdapter) Release(ctx context.Context, id, marker string) error {
 	}
 	args := []string{"issue", "edit", fmt.Sprintf("%d", num), "--repo", a.opts.Repo, "--remove-label", a.opts.ClaimedLabel}
 	if _, err := a.opts.Command(ctx, args, a.env()); err != nil {
-		if a.ghReleaseGone(err) {
+		if a.ghReleaseGone(err, num) {
 			return ErrNotFound
 		}
 		return fmt.Errorf("gh issue edit (release): %w", err)
@@ -330,21 +330,53 @@ func (a *GitHubAdapter) Release(ctx context.Context, id, marker string) error {
 
 // ghReleaseGone recognises the gh CLI error texts that mean the release
 // target is PERMANENTLY absent: the issue itself (GraphQL resolve
-// failure, REST 404), or the claim LABEL deleted from the repo — the
-// second member of the same class: either way the claim cannot exist
-// any more, and a non-benign error would keep the journal entry retried
-// and warned at every boot, for ever. The label form is anchored on the
-// exact configured label name (gh 2.x prints `'<label>' not found`), so
-// an unrelated not-found in the message cannot match. Text matching is
+// failure, or a REST 404 whose URL names THIS issue), or the claim LABEL
+// deleted from the repo — the second member of the same class: either
+// way the claim cannot exist any more, and a non-benign error would keep
+// the journal entry retried and warned at every boot, for ever.
+//
+// Both absence arms are scoped to the issue on purpose. GitHub answers
+// 404 (not 403) for a repository a token can no longer see, so a bare
+// "404" would read a permission regression as a gone issue and drop the
+// journal entry — this adapter's only recovery path — while the claim
+// label stayed on the issue. The label form is anchored on the exact
+// configured label name (gh 2.x prints `'<label>' not found`), so an
+// unrelated not-found in the message cannot match. Text matching is
 // brittle but the CLI offers no typed channel.
-func (a *GitHubAdapter) ghReleaseGone(err error) bool {
+func (a *GitHubAdapter) ghReleaseGone(err error, num int) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "could not resolve to an issue") ||
-		strings.Contains(msg, "not found (http 404)") ||
+		ghIssueScoped404(msg, num) ||
 		strings.Contains(msg, strings.ToLower("'"+a.opts.ClaimedLabel+"' not found"))
+}
+
+// ghIssueScoped404 matches gh's REST failure form (`HTTP 404: Not Found
+// (<url>)`) only when the URL's path names issue `num` — `/issues/638`
+// followed by a path or query separator, or the closing parenthesis, so
+// issue 6380 never matches 638.
+func ghIssueScoped404(lowerMsg string, num int) bool {
+	if !strings.Contains(lowerMsg, "http 404") {
+		return false
+	}
+	needle := fmt.Sprintf("/issues/%d", num)
+	for start := 0; ; {
+		i := strings.Index(lowerMsg[start:], needle)
+		if i < 0 {
+			return false
+		}
+		end := start + i + len(needle)
+		if end == len(lowerMsg) {
+			return true
+		}
+		switch lowerMsg[end] {
+		case '/', ')', '?', ' ', '\n':
+			return true
+		}
+		start = end
+	}
 }
 
 // HasLinkedPR reports whether an OPEN pull request already references this

--- a/pkg/dispatcher/tracker/github_claim_label_test.go
+++ b/pkg/dispatcher/tracker/github_claim_label_test.go
@@ -1,0 +1,130 @@
+package tracker_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+func ghCallsOf(fake *fakeGH, first, second string) [][]string {
+	var out [][]string
+	for _, c := range fake.calls {
+		if len(c) > 1 && c[0] == first && c[1] == second {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// TestGitHubClaim_CreatesTheClaimedLabelOnAFreshRepo: `gh issue edit
+// --add-label` REFUSES a label the repository does not carry ('<label>'
+// not found), so on a fresh repo EVERY issue failed its claim at every
+// tick, for ever — warned each time, repaired never. The Forgejo twin
+// creates the missing label (resolveLabelID, "so a fresh repository can
+// be dispatched without manual label setup"); the GitHub adapter must
+// too, once per adapter, and only when the repo lacks it (never
+// --force: an operator's colour on an existing label is theirs).
+func TestGitHubClaim_CreatesTheClaimedLabelOnAFreshRepo(t *testing.T) {
+	fake := &fakeGH{} // an empty repository: `gh label list` answers []
+	a := newGHAdapter(t, fake, nil)
+	if err := a.Claim(context.Background(), "github:owner/repo#5", "h-1"); err != nil {
+		t.Fatalf("Claim on a fresh repo: %v", err)
+	}
+	creates := ghCallsOf(fake, "label", "create")
+	if len(creates) != 1 || !contains(creates[0], "iterion-claimed") {
+		t.Fatalf("REPRODUCED: the claim never created the missing label (label create calls: %v) — every "+
+			"claim on this repo fails at every tick", creates)
+	}
+	if contains(creates[0], "--force") {
+		t.Fatalf("label create must not --force: it would overwrite an operator's colour/description on an existing label: %v", creates[0])
+	}
+	// Ordering: the label exists BEFORE the first --add-label.
+	var sawCreate bool
+	for _, c := range fake.calls {
+		if len(c) > 1 && c[0] == "label" && c[1] == "create" {
+			sawCreate = true
+		}
+		if len(c) > 1 && c[0] == "issue" && c[1] == "edit" && contains(c, "--add-label") && !sawCreate {
+			t.Fatalf("--add-label ran before the label was created: %v", fake.calls)
+		}
+	}
+	// Memoised: a second claim neither lists nor creates again.
+	if err := a.Claim(context.Background(), "github:owner/repo#6", "h-1"); err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if n := len(ghCallsOf(fake, "label", "create")); n != 1 {
+		t.Fatalf("label create ran %d times across two claims, want 1 (memoised per adapter)", n)
+	}
+	if n := len(ghCallsOf(fake, "label", "list")); n != 1 {
+		t.Fatalf("label list ran %d times across two claims, want 1 (memoised per adapter)", n)
+	}
+}
+
+// A repository that already carries the label is left alone: no create.
+func TestGitHubClaim_DoesNotRecreateAnExistingLabel(t *testing.T) {
+	fake := &fakeGH{labelListOut: []byte(`[{"name":"bug"},{"name":"iterion-claimed"}]`)}
+	a := newGHAdapter(t, fake, nil)
+	if err := a.Claim(context.Background(), "github:owner/repo#5", "h-1"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if n := len(ghCallsOf(fake, "label", "create")); n != 0 {
+		t.Fatalf("label create ran %d times on a repo that has the label", n)
+	}
+}
+
+// A label the adapter cannot create is a claim that cannot happen: the
+// error surfaces (loudly, typed by text) instead of an --add-label that
+// would fail with a less useful message.
+func TestGitHubClaim_LabelCreateFailureIsLoud(t *testing.T) {
+	fake := &fakeGH{labelCreateErr: errors.New("HTTP 403: Resource not accessible by integration")}
+	a := newGHAdapter(t, fake, nil)
+	err := a.Claim(context.Background(), "github:owner/repo#5", "h-1")
+	if err == nil || !strings.Contains(err.Error(), "iterion-claimed") || !strings.Contains(err.Error(), "403") {
+		t.Fatalf("a failed label bootstrap must surface with the label and the cause, got %v", err)
+	}
+	if n := len(ghCallsOf(fake, "issue", "edit")); n != 0 {
+		t.Fatalf("no --add-label may be attempted when the label could not be ensured, got %d edits", n)
+	}
+	// Not memoised as ensured: the next claim tries again.
+	fake.labelCreateErr = nil
+	if err := a.Claim(context.Background(), "github:owner/repo#5", "h-1"); err != nil {
+		t.Fatalf("Claim after the bootstrap recovers: %v", err)
+	}
+}
+
+// The label deleted behind the adapter's back (an operator tidying the
+// repo's labels) must not put the repo back into the every-tick failure:
+// the memo is dropped, the label re-created, the claim retried once.
+func TestGitHubClaim_RecreatesALabelDeletedMidLife(t *testing.T) {
+	fake := &fakeGH{labelListOut: []byte(`[{"name":"iterion-claimed"}]`)}
+	a := newGHAdapter(t, fake, nil)
+	if err := a.Claim(context.Background(), "github:owner/repo#1", "h-1"); err != nil {
+		t.Fatalf("first Claim: %v", err)
+	}
+	// Someone deletes the label; gh 2.x refuses the next --add-label.
+	fake.labelListOut = []byte(`[]`)
+	fake.editErrOnce = errors.New("failed to update https://github.com/owner/repo/issues/2: 'iterion-claimed' not found\nfailed to update 1 issue")
+	if err := a.Claim(context.Background(), "github:owner/repo#2", "h-1"); err != nil {
+		t.Fatalf("Claim after the label vanished: %v", err)
+	}
+	if n := len(ghCallsOf(fake, "label", "create")); n != 1 {
+		t.Fatalf("the vanished label must be re-created exactly once, got %d creates", n)
+	}
+	if n := len(ghCallsOf(fake, "issue", "edit")); n != 3 {
+		t.Fatalf("want 3 edits (first claim, refused claim, retried claim), got %d: %v", n, fake.calls)
+	}
+	// An unrelated edit failure is NOT a missing-label signal: no retry,
+	// no create, the error surfaces.
+	fake.editErrOnce = errors.New("HTTP 502: bad gateway")
+	if err := a.Claim(context.Background(), "github:owner/repo#3", "h-1"); err == nil || !strings.Contains(err.Error(), "502") {
+		t.Fatalf("an unrelated failure must surface unchanged, got %v", err)
+	}
+	if n := len(ghCallsOf(fake, "label", "create")); n != 1 {
+		t.Fatalf("an unrelated failure must not re-create the label, got %d creates", n)
+	}
+}
+
+var _ tracker.Tracker = (*tracker.GitHubAdapter)(nil)

--- a/pkg/dispatcher/tracker/github_test.go
+++ b/pkg/dispatcher/tracker/github_test.go
@@ -21,6 +21,14 @@ type fakeGH struct {
 	calls        [][]string
 	failNum      int
 	editErr      error
+	// labelListOut is the canned `gh label list --json name` answer
+	// (nil = an empty repository: no labels at all).
+	labelListOut []byte
+	// labelCreateErr fails `gh label create`.
+	labelCreateErr error
+	// editErrOnce fails the FIRST `issue edit` only, then clears — the
+	// shape of a label deleted behind the adapter's back.
+	editErrOnce error
 }
 
 func (f *fakeGH) cmd(_ context.Context, args []string, _ []string) ([]byte, error) {
@@ -47,7 +55,22 @@ func (f *fakeGH) cmd(_ context.Context, args []string, _ []string) ([]byte, erro
 			return nil, fmt.Errorf("no canned response for path %q", path)
 		}
 		return f.apiOut, nil
+	case args[0] == "label" && args[1] == "list":
+		if f.labelListOut == nil {
+			return []byte("[]"), nil
+		}
+		return f.labelListOut, nil
+	case args[0] == "label" && args[1] == "create":
+		if f.labelCreateErr != nil {
+			return nil, f.labelCreateErr
+		}
+		return nil, nil
 	case args[0] == "issue" && (args[1] == "edit" || args[1] == "comment"):
+		if f.editErrOnce != nil {
+			err := f.editErrOnce
+			f.editErrOnce = nil
+			return nil, err
+		}
 		if f.editErr != nil {
 			return nil, f.editErr
 		}
@@ -225,8 +248,15 @@ func TestGitHubClaimAndRelease(t *testing.T) {
 	if err := a.Release(context.Background(), "github:owner/repo#5", "h-1"); err != nil {
 		t.Fatalf("Release: %v", err)
 	}
-	// Last two calls should be edit --add-label, edit --remove-label.
-	if !contains(fake.calls[0], "--add-label") || !contains(fake.calls[1], "--remove-label") {
+	// The last two ISSUE edits are --add-label then --remove-label (the
+	// claim may be preceded by the label bootstrap).
+	var edits [][]string
+	for _, c := range fake.calls {
+		if len(c) > 1 && c[0] == "issue" && c[1] == "edit" {
+			edits = append(edits, c)
+		}
+	}
+	if len(edits) != 2 || !contains(edits[0], "--add-label") || !contains(edits[1], "--remove-label") {
 		t.Fatalf("unexpected calls: %v", fake.calls)
 	}
 }

--- a/pkg/dispatcher/tracker/github_test.go
+++ b/pkg/dispatcher/tracker/github_test.go
@@ -343,6 +343,31 @@ func TestGitHubReleaseMapsMissingIssueToNotFound(t *testing.T) {
 	}
 }
 
+// TestGitHubReleaseNarrowsRest404ToTheIssue: GitHub answers 404 (not 403)
+// for a repository a token can no longer see, so a REST 404 that names
+// only the REPO is a permission regression, not a gone issue — mapping it
+// to ErrNotFound drops the claim-journal entry (this adapter's only
+// recovery path) while the claim label stays on the issue. Only a 404
+// whose URL names THIS issue is the permanent shape.
+func TestGitHubReleaseNarrowsRest404ToTheIssue(t *testing.T) {
+	fake := &fakeGH{}
+	a := newGHAdapter(t, fake, nil)
+	fake.editErr = errors.New("HTTP 404: Not Found (https://api.github.com/repos/owner/repo/issues/638/labels/iterion-claimed)")
+	if err := a.Release(context.Background(), "github:owner/repo#638", "m"); !errors.Is(err, tracker.ErrNotFound) {
+		t.Fatalf("an issue-scoped REST 404 = %v, want ErrNotFound (the issue is gone; the entry would be retried at every boot)", err)
+	}
+	for _, msg := range []string{
+		"HTTP 404: Not Found (https://api.github.com/repos/owner/repo)",
+		"HTTP 404: Not Found (https://api.github.com/repos/owner/repo/issues/6380)",
+		"GraphQL: Could not resolve to a Repository with the name 'owner/repo'. (repository)",
+	} {
+		fake.editErr = errors.New(msg)
+		if err := a.Release(context.Background(), "github:owner/repo#638", "m"); err == nil || errors.Is(err, tracker.ErrNotFound) {
+			t.Fatalf("%q must stay a real error (the journal entry is the only recovery path), got %v", msg, err)
+		}
+	}
+}
+
 // The claim LABEL deleted from the repo is the same permanent shape the
 // missing-ISSUE mapping closed: gh refuses the remove, and a non-benign
 // error kept the journal entry retried + warned at every boot for ever.

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -3,7 +3,6 @@ package runview
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -65,30 +64,31 @@ func (s *Service) RenameRunCtx(ctx context.Context, runID, name string) (*store.
 	return r, nil
 }
 
-// ErrRunNotDeletable marks a delete refused on lifecycle grounds — the
-// run exists and is ALIVE. Typed so the HTTP layer can answer 409
-// instead of 404: a refusal made in the name of "the tombstone is proof
-// of absence" must not itself answer with the HTTP proof of absence.
-var ErrRunNotDeletable = errors.New("run is not deletable")
+// ErrRunNotDeletable is store.ErrRunNotDeletable, re-exported for the HTTP
+// layer's 409 mapping — the guard itself lives in the store package so
+// every delete authority (this service, `iterion runs prune`) crosses the
+// same one.
+var ErrRunNotDeletable = store.ErrRunNotDeletable
 
 // DeleteRunCtx permanently removes a run and all of its data. It LoadRuns
 // first so a run outside the caller's tenant scope surfaces as not-found
 // (a tenant can only delete its own runs); the actual delete is then
 // tenant-scoped by the store as well. Idempotent at the store layer.
 //
-// A run that is not TERMINAL is refused: the delete tombstone is read
-// everywhere as PROOF the run is gone (the board launch authorities
-// admit a fresh run on it), so deleting a running/queued/paused run
-// would mint a live sibling while the engine goroutine keeps burning.
-// The studio already disables delete on those; this is the choke both
-// the HTTP handler and the MCP/CLI escape hatch cross.
+// A run that is not TERMINAL is refused (store.RunDeletable): the delete
+// tombstone is read everywhere as PROOF the run is gone (the board launch
+// authorities admit a fresh run on it), so deleting a running/queued/
+// paused run would mint a live sibling while the engine goroutine keeps
+// burning. The studio already disables delete on those; this is the
+// choke the HTTP handler and the MCP escape hatch cross, and prune
+// crosses the same guard at its own delete.
 func (s *Service) DeleteRunCtx(ctx context.Context, runID string) error {
 	r, err := s.store.LoadRun(ctx, runID)
 	if err != nil {
 		return err
 	}
-	if !r.Status.IsTerminal() {
-		return fmt.Errorf("%w: run %s is %s — cancel it first: a delete tombstone reads as proof of absence and would let a second run launch on the same work", ErrRunNotDeletable, runID, r.Status)
+	if err := store.RunDeletable(r); err != nil {
+		return err
 	}
 	return s.store.DeleteRun(ctx, runID)
 }

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -43,6 +43,9 @@ type boardCoordinator interface {
 	SetStateOwned(ctx context.Context, tenant, id, state string, tok tracker.ClaimToken) error
 	SetStateOwnedReason(ctx context.Context, tenant, id, state string, tok tracker.ClaimToken, reason string) error
 	ReleaseOwned(ctx context.Context, tenant, id string, tok tracker.ClaimToken) error
+	// SetGaveUpOwned stamps the watchdog's give-up on a card it filed on
+	// its own authority (a pruned pointer) — fenced like every owner write.
+	SetGaveUpOwned(ctx context.Context, tenant, id string, g *native.GiveUp, tok tracker.ClaimToken) error
 	// The reaper pair (the cloud half of the claim watchdog — the hole
 	// boarddispatch itself documented as R5ceb26: "no TTL and no reaper
 	// exists yet"). List is cross-tenant; Reclaim is a CAS TRANSFER.
@@ -724,9 +727,10 @@ func (d *boardDispatcher) sweepUnleasedClaims(ctx context.Context, now time.Time
 		// ListEligible and therefore from that reconciler, for ever,
 		// under a disabled gate. Still conserved: StuckKeep (paused
 		// parking brake, operator cancel, armed continuation — those
-		// claims are load-bearing or owned) and StuckReleaseOnly (a
-		// PRUNED pointer the reconciler cannot read — released bare it
-		// would sit unclaimed and unfiled in the running column).
+		// claims are load-bearing or owned), StuckReleaseOnly (no run
+		// was ever recorded) and StuckGiveUp (a PRUNED pointer — a
+		// decision, which waits for the gate; released bare it would sit
+		// unclaimed and unfiled in the running column).
 		switch dec := dispatcher.DecideStuckCard(run, runErr, card); dec.Action {
 		case dispatcher.StuckComplete, dispatcher.StuckFail, dispatcher.StuckRepark:
 		default:
@@ -1088,6 +1092,7 @@ func (d *boardDispatcher) reapOne(ctx context.Context, cand boardmongo.ExpiredCa
 	card := dispatcher.StuckCard{
 		State: cand.Claim.State, RunningState: d.inProgressState, LaunchStates: d.eligible,
 		StampWindowOpen: dispatcher.StampWindowOpen(cand.Claim.ClaimedAt, now),
+		RecordedRunID:   cand.Claim.LastRunID,
 	}
 	// PRE-transfer: only the rows that protect a live owner (see
 	// DecideTransfer). Refusing the transfer on the parked row would make
@@ -1138,6 +1143,8 @@ func (d *boardDispatcher) reapOne(ctx context.Context, cand boardmongo.ExpiredCa
 		filed = d.fileReapedCard(ctx, cand, card, d.doneState, tok, tracker.ReasonRunFinished)
 	case dispatcher.StuckFail:
 		filed = d.fileReapedCard(ctx, cand, card, d.blockedState, tok, tracker.ReasonRunFailed)
+	case dispatcher.StuckGiveUp:
+		filed = d.giveUpReapedCard(ctx, cand, card, tok, dec.Reason)
 	case dispatcher.StuckRepark, dispatcher.StuckReleaseOnly:
 		// Unlike the local dispatcher — where the running column is itself
 		// eligible, so a bare release re-arms the card — this tick only
@@ -1156,9 +1163,9 @@ func (d *boardDispatcher) reapOne(ctx context.Context, cand boardmongo.ExpiredCa
 		switch {
 		case dec.Action == dispatcher.StuckRepark && cand.Claim.LifetimeRuns >= watchdogRunCeiling:
 			// Only a REPARK spends a fresh run here. A release-only card
-			// (the claimant died before recording anything, or its run was
-			// pruned by the documented retention command) has failed at
-			// nothing and must never be filed as failed.
+			// (the claimant died before recording anything) has failed at
+			// nothing and must never be filed as failed; a PRUNED pointer
+			// is its own row (StuckGiveUp) and never reaches this arm.
 			d.warn("claim watchdog stops returning %s/%s to the pool: it has already carried %d runs — "+
 				"filing it as %s rather than paying for another",
 				cand.Tenant, cand.Claim.IssueID, cand.Claim.LifetimeRuns, d.blockedState)
@@ -1194,6 +1201,28 @@ func (d *boardDispatcher) reapOne(ctx context.Context, cand boardmongo.ExpiredCa
 		cand.Tenant, cand.Claim.IssueID, cand.Claim.Prev.Marker, cand.Claim.State, dec.Action, dec.Reason)
 	acted = true
 	return
+}
+
+// giveUpReapedCard performs the StuckGiveUp disposition (the cloud twin of
+// the local giveUpStuckCard): file the card as failed under MACHINE
+// provenance — the watchdog decided this by itself, so no downstream chain
+// may fire as if a run had failed — then stamp the give-up naming the gone
+// run and why, so the Needs-attention lane shows it as the watchdog's own
+// filing rather than a human's. Both halves are the disposition: a failed
+// stamp keeps the recovery claim and the next lease retries, loudly.
+func (d *boardDispatcher) giveUpReapedCard(ctx context.Context, cand boardmongo.ExpiredCandidate, card dispatcher.StuckCard, tok tracker.ClaimToken, reason string) bool {
+	if !d.fileReapedCard(ctx, cand, card, d.blockedState, tok, "") {
+		return false
+	}
+	// The store's GiveUpToRecord makes the stamp a no-op when the card is
+	// not in the stamped state (the guard declined the filing because an
+	// operator moved the card first — their intent stands unannotated).
+	g := &native.GiveUp{RunID: cand.Claim.LastRunID, State: d.blockedState, Reason: reason}
+	if err := d.coord.SetGaveUpOwned(ctx, cand.Tenant, cand.Claim.IssueID, g, tok); err != nil {
+		d.warn("claim watchdog give-up stamp on %s/%s: %v", cand.Tenant, cand.Claim.IssueID, err)
+		return false
+	}
+	return true
 }
 
 // fileReapedCard writes a reaped card's disposition under the recovery

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -150,9 +150,9 @@ type boardDispatcher struct {
 	// driven into the release window and the announce/release order
 	// proven, rather than waited five minutes for.
 	sessionInterval time.Duration
-	sem       chan struct{}
-	logger    *iterlog.Logger
-	wg        sync.WaitGroup // tracks in-flight processCard goroutines (for tests + drain)
+	sem             chan struct{}
+	logger          *iterlog.Logger
+	wg              sync.WaitGroup // tracks in-flight processCard goroutines (for tests + drain)
 	// clockFallbackReason latches WHICH degradation was last reported, so
 	// the notice stays edge-triggered (a per-pass warn is a log storm at
 	// the watchdog's cadence) without a change of cause going unsaid —
@@ -1189,6 +1189,15 @@ func (d *boardDispatcher) reapOne(ctx context.Context, cand boardmongo.ExpiredCa
 			filed = d.fileReapedCard(ctx, cand, card, d.blockedState, tok, "")
 		case len(d.eligible) > 0:
 			filed = d.fileReapedCard(ctx, cand, card, d.eligible[0], tok, "")
+		default:
+			// No eligible column: there is nowhere to WRITE the return to
+			// the pool, and a bare release would strand the card exactly
+			// as the arm's contract forbids. Keep the recovery claim
+			// (retried, loudly, at the next lease) rather than free it
+			// unfiled.
+			d.warn("claim watchdog cannot return %s/%s to the pool: no eligible column is configured — keeping the recovery claim",
+				cand.Tenant, cand.Claim.IssueID)
+			filed = false
 		}
 	}
 	if !filed {

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -145,6 +145,11 @@ type boardDispatcher struct {
 	// sweeps) inside the run loop; injectable so the periodicity is
 	// provable without waiting a real minute.
 	reapEvery time.Duration
+	// sessionInterval is the claim heartbeat cadence processCard runs;
+	// zero = the production third-of-a-lease. Injectable so a beat can be
+	// driven into the release window and the announce/release order
+	// proven, rather than waited five minutes for.
+	sessionInterval time.Duration
 	sem       chan struct{}
 	logger    *iterlog.Logger
 	wg        sync.WaitGroup // tracks in-flight processCard goroutines (for tests + drain)
@@ -220,9 +225,9 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	// poll, since the fenced writes below are refused already and the
 	// cancel just stops this replica working a card it no longer owns.
 	cardCtx, cancelCard := context.WithCancel(ctx)
-	sess := dispatcher.StartClaimSession(
+	sess := dispatcher.StartClaimSessionEvery(
 		coordLeaser{coord: d.coord, tenant: c.Tenant},
-		c.Issue.ID, tok, d.warn, func(error) { cancelCard() })
+		c.Issue.ID, tok, d.warn, func(error) { cancelCard() }, d.sessionInterval)
 	defer func() { cancelCard(); sess.Stop() }()
 
 	// Move to in-progress for board visibility (best-effort, fenced) —
@@ -284,6 +289,12 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 			d.warn("card %s/%s → %s: %v", c.Tenant, c.Issue.ID, final, err)
 		}
 	}
+	// Announce the release BEFORE it lands (the local twin's rule, see
+	// releaseClaimSess): a heartbeat already in flight reads our OWN
+	// release as ErrClaimConflict, which without this latches `lost`,
+	// warns "claim lost — stopping the worker" on an ordinary finish, and
+	// fires the cancel path for a card whose work is already over.
+	sess.Releasing()
 	if err := d.coord.ReleaseOwned(finCtx, c.Tenant, c.Issue.ID, tok); err != nil {
 		d.warn("card %s/%s release: %v", c.Tenant, c.Issue.ID, err)
 	}

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -730,6 +730,7 @@ func (d *boardDispatcher) sweepUnleasedClaims(ctx context.Context, now time.Time
 		card := dispatcher.StuckCard{
 			State: cand.Claim.State, RunningState: d.inProgressState, LaunchStates: d.eligible,
 			StampWindowOpen: dispatcher.StampWindowOpen(cand.Claim.ClaimedAt, now),
+			RecordedRunID:   cand.Claim.LastRunID,
 		}
 		// Release for every disposition the RECONCILER can then file, not
 		// only finished: a released card is exactly what the
@@ -844,6 +845,7 @@ func (d *boardDispatcher) sweepClaims(ctx context.Context, label string, cands [
 		card := dispatcher.StuckCard{
 			State: cand.Claim.State, RunningState: d.inProgressState, LaunchStates: d.eligible,
 			StampWindowOpen: dispatcher.StampWindowOpen(cand.Claim.ClaimedAt, now),
+			RecordedRunID:   cand.Claim.LastRunID,
 		}
 		if pre := dispatcher.DecideTransfer(run, runErr, card); pre.Action == dispatcher.StuckKeep &&
 			!dispatcher.RecoveryHoldExpired(run, runErr, card, cand.Claim.Prev) {

--- a/pkg/server/boarddispatch_release_test.go
+++ b/pkg/server/boarddispatch_release_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// TestBoardDispatcher_ReleaseAnnouncesItselfToTheHeartbeat: processCard's
+// final ReleaseOwned lands while its claim session is still beating
+// (Stop runs in the deferred teardown, after the last write). A beat in
+// flight across that release comes back ErrClaimConflict — and without
+// the owner announcing the release first (claimSession.Releasing, the
+// local twin's rule in releaseClaimSess) the session reads its OWN
+// release as a supersession: "claim lost (lease superseded) — stopping
+// the worker" at WARN on an ordinary, successful finish, plus the cancel
+// path fired on a card whose work is over. That line is the one signal an
+// operator has to diagnose a stolen claim; a false one on every finish
+// that straddles a beat buries the real ones.
+func TestBoardDispatcher_ReleaseAnnouncesItselfToTheHeartbeat(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	beatInFlight := make(chan struct{})
+	beatRelease := make(chan struct{})
+	released := make(chan struct{})
+	var once, onceRel sync.Once
+	f.renewHook = func(string) {
+		once.Do(func() { close(beatInFlight) })
+		<-beatRelease
+	}
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		// The run finishes only once a heartbeat is parked in flight, so
+		// the release below lands UNDER that beat.
+		select {
+		case <-beatInFlight:
+		case <-time.After(5 * time.Second):
+			t.Error("no heartbeat reached the coordinator — the probe cannot straddle the release")
+		}
+		return nil
+	}, "replica-A", 1, iterlog.New(iterlog.LevelWarn, &buf))
+	d.sessionInterval = time.Millisecond
+	// The parked beat is let through the instant the owner's release has
+	// landed: it then reads the card as no longer ours.
+	f.releaseHook = func(string) { onceRel.Do(func() { close(released) }) }
+	go func() {
+		<-released
+		close(beatRelease)
+	}()
+
+	d.tick(context.Background())
+	d.wg.Wait()
+
+	if got := f.states["native:1"]; got != native.StateDone {
+		t.Fatalf("card state = %q, want done", got)
+	}
+	if len(f.claimed) != 0 {
+		t.Fatalf("card must be released: %v", f.claimed)
+	}
+	if log := buf.String(); strings.Contains(log, "was lost (lease superseded)") {
+		t.Fatalf("REPRODUCED: the owner's OWN release was reported as a stolen claim on an ordinary finish:\n%s", log)
+	}
+}

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -46,6 +46,13 @@ type fakeBoardCoord struct {
 	reasons map[string]string
 	// gaveUps records the fenced give-up stamps, keyed by issue id.
 	gaveUps map[string]*native.GiveUp
+	// renewHook, when set, runs at the start of RenewClaim OUTSIDE the
+	// lock — a test parks a heartbeat in flight with it while the owner's
+	// own release lands.
+	renewHook func(id string)
+	// releaseHook, when set, runs after a successful Release, outside the
+	// lock — the signal that the owner's release has landed.
+	releaseHook func(id string)
 }
 
 func newFakeBoardCoord(cands ...boardmongo.Candidate) *fakeBoardCoord {
@@ -158,7 +165,17 @@ func (f *fakeBoardCoord) SetStateFromReason(ctx context.Context, tenant, id, fro
 	return true, nil
 }
 
-func (f *fakeBoardCoord) Release(ctx context.Context, _, id, _ string) error {
+func (f *fakeBoardCoord) Release(ctx context.Context, tenant, id, marker string) error {
+	if err := f.release(ctx, tenant, id, marker); err != nil {
+		return err
+	}
+	if f.releaseHook != nil {
+		f.releaseHook(id)
+	}
+	return nil
+}
+
+func (f *fakeBoardCoord) release(ctx context.Context, _, id, _ string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -173,6 +190,9 @@ func (f *fakeBoardCoord) Release(ctx context.Context, _, id, _ string) error {
 // gets tracker.ErrClaimConflict. renews counts heartbeats for the
 // heartbeat test.
 func (f *fakeBoardCoord) RenewClaim(_ context.Context, _, id string, tok tracker.ClaimToken) error {
+	if f.renewHook != nil {
+		f.renewHook(id)
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.renews[id]++

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -44,6 +44,8 @@ type fakeBoardCoord struct {
 	recoveryListErr error
 	// reasons records the explicit provenance of reasoned owned writes.
 	reasons map[string]string
+	// gaveUps records the fenced give-up stamps, keyed by issue id.
+	gaveUps map[string]*native.GiveUp
 }
 
 func newFakeBoardCoord(cands ...boardmongo.Candidate) *fakeBoardCoord {
@@ -207,6 +209,28 @@ func (f *fakeBoardCoord) SetStateOwnedReason(ctx context.Context, tenant, id, st
 	}
 	f.reasons[id] = reason
 	f.mu.Unlock()
+	return nil
+}
+
+// SetGaveUpOwned honours the fence like the real coordinator and, like the
+// twins' GiveUpToRecord, only lands when the card sits in the stamped
+// state — a stamp naming a state the card left is superseded, not written.
+func (f *fakeBoardCoord) SetGaveUpOwned(ctx context.Context, _, id string, g *native.GiveUp, tok tracker.ClaimToken) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.claimed[id] != tok.Marker {
+		return tracker.ErrClaimConflict
+	}
+	if g != nil && g.State != "" && f.states[id] != g.State {
+		return nil
+	}
+	if f.gaveUps == nil {
+		f.gaveUps = map[string]*native.GiveUp{}
+	}
+	f.gaveUps[id] = g
 	return nil
 }
 
@@ -1394,9 +1418,8 @@ func TestCloudReaper_CeilingSparesAHealthyCard(t *testing.T) {
 }
 
 // TestCloudReaper_ReleaseOnlyIsNeverFiledAsFailed: a release-only card
-// failed at nothing — its claimant died before recording a run, or the
-// run was removed by the documented retention command. Filing it as
-// failed reports a failure that never happened.
+// failed at nothing — its claimant died before recording any run. Filing
+// it as failed (the ceiling arm) reports a failure that never happened.
 func TestCloudReaper_ReleaseOnlyIsNeverFiledAsFailed(t *testing.T) {
 	f := newFakeBoardCoord()
 	f.claimed["c-nofail"] = "dead-owner"
@@ -1405,7 +1428,37 @@ func TestCloudReaper_ReleaseOnlyIsNeverFiledAsFailed(t *testing.T) {
 	f.expired = []boardmongo.ExpiredCandidate{{
 		Tenant: "t1",
 		Claim: tracker.ExpiredClaim{
-			IssueID: "c-nofail", LastRunID: "run-pruned", LifetimeRuns: watchdogRunCeiling + 5,
+			IssueID: "c-nofail", LifetimeRuns: watchdogRunCeiling + 5,
+			Prev: tracker.ClaimToken{Marker: "dead-owner", Epoch: 1},
+		},
+	}}
+	d := newBoardDispatcher(f, nil, "replica-A", 1, iterlog.Nop())
+
+	d.reapExpiredClaims(context.Background(), time.Now(), nil)
+
+	if got := f.states["c-nofail"]; got == native.StateBlocked {
+		t.Fatalf("a card whose claimant never recorded a run failed at nothing — it must not be filed as %q", got)
+	}
+	if _, still := f.claimed["c-nofail"]; still {
+		t.Fatal("a release-only card must be released")
+	}
+}
+
+// TestCloudReaper_PrunedRunIsAGiveUp: the cloud twin of the local
+// give-up. A card whose RECORDED run is gone is not release-only: the
+// repark arm wrote it back into the pool, and the pool launched a fresh
+// run for work that may already be delivered. It is filed as failed with
+// a give-up stamp naming why — under MACHINE provenance, since the
+// watchdog decided this by itself and no downstream chain may fire.
+func TestCloudReaper_PrunedRunIsAGiveUp(t *testing.T) {
+	f := newFakeBoardCoord()
+	f.claimed["c-pruned"] = "dead-owner"
+	f.epochs["c-pruned"] = 1
+	f.states["c-pruned"] = native.StateInProgress
+	f.expired = []boardmongo.ExpiredCandidate{{
+		Tenant: "t1",
+		Claim: tracker.ExpiredClaim{
+			IssueID: "c-pruned", LastRunID: "run-pruned",
 			Prev: tracker.ClaimToken{Marker: "dead-owner", Epoch: 1},
 		},
 	}}
@@ -1416,8 +1469,19 @@ func TestCloudReaper_ReleaseOnlyIsNeverFiledAsFailed(t *testing.T) {
 
 	d.reapExpiredClaims(context.Background(), time.Now(), nil)
 
-	if got := f.states["c-nofail"]; got == native.StateBlocked {
-		t.Fatalf("a card whose run was pruned failed at nothing — it must not be filed as %q", got)
+	if got := f.states["c-pruned"]; got != native.StateBlocked {
+		t.Fatalf("REPRODUCED: a pruned pointer left the card in %q — returned to the pool, a fresh run is minted for "+
+			"work that may already be delivered; want %q with a give-up stamp", got, native.StateBlocked)
+	}
+	g := f.gaveUps["c-pruned"]
+	if g == nil || g.RunID != "run-pruned" || g.State != native.StateBlocked || g.Reason == "" {
+		t.Fatalf("give-up stamp = %+v, want the pruned run named, the filed state, and a reason", g)
+	}
+	if reason := f.reasons["c-pruned"]; reason != "" {
+		t.Fatalf("a give-up filing must stay under machine provenance (no downstream chain), got reason %q", reason)
+	}
+	if _, still := f.claimed["c-pruned"]; still {
+		t.Fatal("the recovery claim must come off once the disposition landed")
 	}
 }
 

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -1464,6 +1464,45 @@ func TestCloudReaper_ReleaseOnlyIsNeverFiledAsFailed(t *testing.T) {
 	}
 }
 
+// TestCloudReaper_ReparkFailsClosedWithoutAnEligibleColumn: the repark
+// arm's own comment says the return to the pool must be WRITTEN before
+// the release — a card released in in_progress is reachable by no cloud
+// net. With no eligible column configured there is nowhere to write it,
+// and the arm must keep the recovery claim (retried, loudly, next lease)
+// rather than fall through to a bare release with `filed` still true.
+func TestCloudReaper_ReparkFailsClosedWithoutAnEligibleColumn(t *testing.T) {
+	f := newFakeBoardCoord()
+	f.claimed["c-noeligible"] = "dead-owner"
+	f.epochs["c-noeligible"] = 1
+	f.states["c-noeligible"] = native.StateInProgress
+	f.expired = []boardmongo.ExpiredCandidate{{
+		Tenant: "t1",
+		Claim: tracker.ExpiredClaim{
+			IssueID: "c-noeligible", LastRunID: "run-resumable",
+			Prev: tracker.ClaimToken{Marker: "dead-owner", Epoch: 1},
+		},
+	}}
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, nil, "replica-A", 1, iterlog.New(iterlog.LevelWarn, &buf))
+	d.eligible = nil
+	d.runFor = func(_ context.Context, _, id string) (*store.Run, error) {
+		return &store.Run{ID: id, Status: store.RunStatusFailedResumable}, nil
+	}
+
+	d.reapExpiredClaims(context.Background(), time.Now(), nil)
+
+	if _, still := f.claimed["c-noeligible"]; !still {
+		t.Fatalf("REPRODUCED: with no eligible column the repark released the card UNFILED in %q — unclaimed, "+
+			"listed by nothing, reachable by no cloud sweep", f.states["c-noeligible"])
+	}
+	if got := f.states["c-noeligible"]; got != native.StateInProgress {
+		t.Fatalf("state = %q, want untouched in_progress", got)
+	}
+	if !strings.Contains(buf.String(), "no eligible column") {
+		t.Fatalf("the refusal must be said out loud, log:\n%s", buf.String())
+	}
+}
+
 // TestCloudReaper_PrunedRunIsAGiveUp: the cloud twin of the local
 // give-up. A card whose RECORDED run is gone is not release-only: the
 // repark arm wrote it back into the pool, and the pool launched a fresh

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -287,8 +287,17 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 // parent iss.LastRunID still names (the board mutates its own copy of
 // the issue on SetLastRun).
 func (s *Server) fileFinishedTicket(board native.BoardStore, iss *native.Issue, runID string) {
-	if _, _, err := board.SetStateFrom(iss.ID, iss.State, native.StateDone); err != nil {
+	_, changed, err := board.SetStateFrom(iss.ID, iss.State, native.StateDone)
+	if err != nil {
 		s.logger.Warn("pipeline admission: file finished ticket %s (run %s): %v", iss.ID, runID, err)
+		return
+	}
+	if !changed {
+		// The CAS found the card already moved out of the state the sweep
+		// saw — an operator's (or the bot's) decision that predates this
+		// filing. Say THAT: an operator debugging a ticket that never
+		// reached done must not read a filing that did not happen.
+		s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) but already left %s — leaving it where it was moved", iss.ID, runID, iss.State)
 		return
 	}
 	s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) — filed as done", iss.ID, runID)

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -384,10 +384,13 @@ func (s *Server) warnAdmissionSkipOnce(ticketID, bot string, found bool) {
 func (s *Server) launchReadyTicket(runs *runview.Service, board native.BoardStore, iss *native.Issue) {
 	// Atomically claim the Ready ticket before launching so a live dispatcher
 	// and this admission loop can't both win the same one in the check-then-act
-	// window (PR #193 M2). On backends without the CAS we degrade to the
-	// best-effort SetState claim inside launchTicketNow (the documented V1
-	// window). When the CAS wins, launchTicketNow's own SetState(InProgress) is
-	// an idempotent no-op (already in that state).
+	// window (PR #193 M2). The CAS also refuses a card under a live claim —
+	// the dispatcher's own in_progress move lands after its claim, so state
+	// alone never proves a Ready card is free. Both board twins implement
+	// it; a backend without it degrades to the best-effort SetState claim
+	// inside launchTicketNow, which is exactly the double-launch window.
+	// When the CAS wins, launchTicketNow's own SetState(InProgress) is an
+	// idempotent no-op (already in that state).
 	if claimer := native.AsLaunchClaimer(board); claimer != nil {
 		_, won, err := claimer.ClaimForLaunch(iss.ID)
 		if err != nil {

--- a/pkg/server/pipeline_admission_filed_test.go
+++ b/pkg/server/pipeline_admission_filed_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// TestFileFinishedTicket_SaysWhenTheCardAlreadyMoved: the filing is a CAS
+// on the state the sweep saw. When it finds the card already moved (an
+// operator parked it in review while the run finished), nothing was
+// written — and the log must say THAT, not "filed as done": an operator
+// debugging a ticket that never reached done reads the old line as a
+// filing that happened.
+func TestFileFinishedTicket_SaysWhenTheCardAlreadyMoved(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, err := board.Create(native.Issue{Title: "finished run", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := *iss // the sweep's view: still in_progress
+	if _, err := board.SetState(iss.ID, native.StateReview); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	s := &Server{logger: iterlog.New(iterlog.LevelInfo, &buf)}
+
+	s.fileFinishedTicket(board, &snapshot, "run-1")
+
+	if cur, _ := board.Get(iss.ID); cur.State != native.StateReview {
+		t.Fatalf("the operator's move must stand: state %q", cur.State)
+	}
+	log := buf.String()
+	if strings.Contains(log, "filed as done") {
+		t.Fatalf("REPRODUCED: the log claims a filing that never happened:\n%s", log)
+	}
+	if !strings.Contains(log, "already left") {
+		t.Fatalf("the drift must be named distinctly, log:\n%s", log)
+	}
+}

--- a/pkg/server/stuckcard_sites_test.go
+++ b/pkg/server/stuckcard_sites_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// TestEveryStuckCardSiteNamesTheRecordedRun: the decision table tells a
+// pruned pointer (StuckGiveUp) from a card that never recorded a run
+// (StuckReleaseOnly) through StuckCard.RecordedRunID. A construction
+// site that leaves it empty silently demotes every pruned pointer it
+// judges to the release-only row — the gate-off sweeps did exactly that
+// while the gated reap did not, two authorities judging one card
+// differently. Pin every literal in this file.
+func TestEveryStuckCardSiteNamesTheRecordedRun(t *testing.T) {
+	src, err := os.ReadFile("boarddispatch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	literal := regexp.MustCompile(`(?s)dispatcher\.StuckCard\{.*?\n\t*\}`)
+	sites := literal.FindAll(src, -1)
+	if len(sites) < 3 {
+		t.Fatalf("expected the three StuckCard sites (reap, un-leased sweep, recovery sweep), found %d", len(sites))
+	}
+	for _, site := range sites {
+		if !regexp.MustCompile(`RecordedRunID:\s*cand\.Claim\.LastRunID`).Match(site) {
+			t.Fatalf("a StuckCard site does not name the recorded run — a pruned pointer there reads as \"no run\":\n%s", site)
+		}
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -49,6 +49,29 @@ func RunAbsent(err error) bool {
 	return errors.Is(err, ErrRunNotFound) || errors.Is(err, ErrRunDeleted)
 }
 
+// ErrRunNotDeletable marks a delete refused on lifecycle grounds — the
+// run exists and is ALIVE. Typed so the HTTP layer can answer 409
+// instead of 404: a refusal made in the name of "the tombstone is proof
+// of absence" must not itself answer with the HTTP proof of absence.
+var ErrRunNotDeletable = errors.New("run is not deletable")
+
+// RunDeletable is the ONE lifecycle guard on deleting a run, crossed by
+// every delete authority (runview.DeleteRunCtx behind the HTTP handler
+// and the MCP tool, `iterion runs prune`). A run that is not TERMINAL is
+// refused: the delete tombstone is read everywhere as PROOF the run is
+// gone (the board launch authorities admit a fresh run on it), so
+// deleting a running/queued/paused run would mint a live sibling while
+// the engine goroutine keeps burning.
+func RunDeletable(r *Run) error {
+	if r == nil {
+		return fmt.Errorf("%w: no run record", ErrRunNotDeletable)
+	}
+	if !r.Status.IsTerminal() {
+		return fmt.Errorf("%w: run %s is %s — cancel it first: a delete tombstone reads as proof of absence and would let a second run launch on the same work", ErrRunNotDeletable, r.ID, r.Status)
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // RunStatus — lifecycle state of a run
 // ---------------------------------------------------------------------------

--- a/studio/src/api/pipelineBoards.test.ts
+++ b/studio/src/api/pipelineBoards.test.ts
@@ -246,6 +246,19 @@ describe("normalizePipelineBoard", () => {
           title: "Unattributable",
           gave_up: { state: "blocked", attempts: 2 },
         },
+        {
+          // The watchdog's own verdict carries a reason instead of an
+          // attempt count — it must survive normalisation, it is what the
+          // operator reads.
+          id: "run:c",
+          column_id: "needs_attention",
+          title: "Pruned pointer",
+          gave_up: {
+            run_id: "run-pruned",
+            state: "blocked",
+            reason: "recorded run run-pruned is gone (pruned or deleted)",
+          },
+        },
       ],
     });
     expect(board.cards[0]?.gave_up).toEqual({
@@ -255,6 +268,11 @@ describe("normalizePipelineBoard", () => {
       at: "2026-08-23T09:00:00Z",
     });
     expect(board.cards[1]?.gave_up).toBeUndefined();
+    expect(board.cards[2]?.gave_up).toEqual({
+      run_id: "run-pruned",
+      state: "blocked",
+      reason: "recorded run run-pruned is gone (pruned or deleted)",
+    });
   });
 
   it("omits planner provenance when the server sends none", () => {

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -75,6 +75,12 @@ export interface PipelineBoardGiveUp {
   state?: string;
   /** How many attempts were burned before giving up. */
   attempts?: number;
+  /**
+   * Why the dispatcher gave up when it was not a retry budget — the claim
+   * watchdog filing a card whose recorded run is gone. Empty for a
+   * retry-budget give-up, which reads by `attempts`.
+   */
+  reason?: string;
   /** When the give-up happened (RFC 3339). */
   at?: string;
 }
@@ -276,6 +282,8 @@ function normalizeGiveUp(value: unknown): PipelineBoardGiveUp | undefined {
   if (state) out.state = state;
   const attempts = numberValue(source.attempts);
   if (attempts !== undefined) out.attempts = attempts;
+  const reason = text(source.reason);
+  if (reason) out.reason = reason;
   const at = text(source.at);
   if (at) out.at = at;
   return out;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5558,6 +5558,7 @@ export interface components {
             /** Format: date-time */
             at: string;
             attempts?: number;
+            reason?: string;
             run_id?: string;
             state?: string;
         };

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -387,13 +387,18 @@ function SpawnTreeSection({ card }: { card: PipelineBoardCard }) {
 function giveUpSentence(
   giveUp: NonNullable<PipelineBoardCard["gave_up"]>,
 ): string {
+  const filed = giveUp.state
+    ? ` and filed this ticket as "${giveUp.state}"`
+    : "";
+  // A reasoned give-up is the watchdog's own verdict (a recorded run that
+  // is gone), not a retry budget: the reason replaces the attempt count.
+  if (giveUp.reason) {
+    return `The dispatcher gave up${filed}: ${giveUp.reason}`;
+  }
   const attempts =
     giveUp.attempts && giveUp.attempts > 0
       ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
       : "after exhausting its attempts";
-  const filed = giveUp.state
-    ? ` and filed this ticket as "${giveUp.state}"`
-    : "";
   return `The dispatcher gave up ${attempts}${filed}.`;
 }
 

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -1301,11 +1301,16 @@ function ClosedStatus({ card }: { card: PipelineBoardCardDTO }) {
 function giveUpTitle(
   giveUp: NonNullable<PipelineBoardCardDTO["gave_up"]>,
 ): string {
+  const filed = giveUp.state ? ` and filed the ticket as "${giveUp.state}"` : "";
+  // A reasoned give-up is the watchdog's own verdict (a recorded run that
+  // is gone), not a retry budget: say the reason, not an attempt count.
+  if (giveUp.reason) {
+    return `The dispatcher gave up${filed}: ${giveUp.reason} Nobody decided this — retry it, or close the card to acknowledge it.`;
+  }
   const attempts =
     giveUp.attempts && giveUp.attempts > 0
       ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
       : "after exhausting its attempts";
-  const filed = giveUp.state ? ` and filed the ticket as "${giveUp.state}"` : "";
   return `The dispatcher gave up ${attempts}${filed}. Nobody decided this — retry it, or close the card to acknowledge it.`;
 }
 


### PR DESCRIPTION
Wave 2 of the board-203 triage, cluster D — C1 slice 3/3 of the reliability program (#623): the board twins after the claim-lease watchdog (ADR-096, PR #646).

Closes #665
Closes #660
Closes #666
Closes #667

## What was wrong, and the fix

**#665 — the Mongo board did not implement `LaunchClaimer`**, so the cloud pipeline admission degraded to a best-effort `SetState` — a cross-replica double-launch under a live lease. The cloud twin now carries `ClaimForLaunch` as ONE `FindOneAndUpdate` filtered `{state: ready, claim ∈ {"", null}}` → in_progress, same event payload as the FS twin, with a shared launch-claim conformance suite on both twins (ready under a live lease is refused with claim/epoch/lease intact). Same ticket: `maybeTransitionToCompleted` was probe-then-fenced-write (an operator move in the window was overwritten while the watchdog would have honoured it) → `SetStateOwnedFrom(id, from, to, tok)`, ONE CAS on (claim, epoch, state==from) on both twins; `revertTransition` was the same class and is fixed too. **Q6 decided and implemented:** a recorded run that is GONE (pruned) is a distinct **give-up**, never a release/relaunch — `StuckCard.RecordedRunID`, action `StuckGiveUp`, the card is filed failed under machine provenance with a `GiveUp{RunID, State, Reason}` stamp the pipelines "needs attention" banner renders; a source pin (`TestEveryStuckCardSiteNamesTheRecordedRun`) keeps all 4 `StuckCard{` sites honest.

**#660 — Revi round-2 leftovers, all settled with proof.** Rf238b1: cloud `processCard` calls `sess.Releasing()` before its final `ReleaseOwned` (reproduced the false "claim lost" alarm with a beat parked in flight; class grep: 2 sites hold a live heartbeat, both announce now). R3c7198: the claim-reaper pass runs on a ctx cancelled by `Stop()` and is drained by `workersWG`. The 7 questions: (1) `runs prune` — the prunable set was already a closed terminal set; the real hole was the scan-to-delete window, so the lifecycle guard moved to the store (`store.RunDeletable`, one definition) and both `DeleteRunCtx` and prune cross it at delete time — no `--force` (a bypass writes exactly the tombstone four authorities misread; `cancel first` is the path); (2) `ghReleaseGone` narrowed to a REST 404 whose URL names THIS issue — and the old literal never matched gh's actual `HTTP 404: Not Found (<url>)` shape, so the issue-scoped case was retried forever; (3) the 24h un-leased horizon is documented and an operator dial (`ITERION_BOARD_UNLEASED_CLAIM_HORIZON`, floor one lease, invalid refuses to start); (4) a late lease renewal cannot re-stamp a released card — proven on both twins + a deterministic FS test (the detached call IS the fenced `RenewClaim`); (5) `ITERION_BOARD_CLAIM_REAPER` accepts the repo's toggle spellings (`1/true/yes/on`), misspellings still warn; (6) the cloud repark arm fails closed without an eligible column; (7) `fileFinishedTicket` says when the card had already moved.

**#666 — `set_labels` is absolute and re-armed consumed one-shots (Triagy relaunched twice).** New relative `add_labels` / `remove_labels`: `BoardStore.AdjustLabels` — one critical section on FS, one pipeline `FindOneAndUpdate` on Mongo (server-side delta, `updated_at` only when changed, no-op = no write/no event), event `issue_updated {labels_added, labels_removed}`; exposed unchanged on all four transports (`__mcp-board`, `/api/v1/mcp/board`, claw `mcp.iterion_board.*`, operator `local_board_*`). All 8 `iterion-board.md` skill copies, `issue-triage` (0.1.0 → 0.2.0, never `set_labels` for increments), `whats-next`, `evolve`'s hand-off skill, `docs/mcp-server.md`, ADR-096 §9 updated. Mutation proof: a read-modify-write Mongo variant lost 1 of 16 concurrent adds.

**#667 — `GitHubAdapter.Claim` never created the claimed label**, so a fresh GitHub repo was undispatchable forever (`'iterion-claimed' not found` on every tick). `ensureClaimedLabel`: `gh label list --search --json name`, `gh label create` only when absent (no `--force`, keeps an operator's colour), memoised per adapter; a later "not found" on `--add-label` drops the memo, re-creates, retries once; a failed bootstrap surfaces loudly. Parity with `forgejo.go`'s `resolveLabelID`. `docs/dispatcher.md` documents it (+ the token needs label write).

## Tests (each seen red first; excerpts in the branch's report)
Shared conformance suites on BOTH twins: `runLaunchClaimSuite`, `runOwnedFromSuite`, `runRenewAfterReleaseSuite`, adjust-labels · `TestMaybeTransitionToCompleted_IsOneFencedCAS` · `TestReapOne_PrunedRunIsAGiveUpNotARelaunch`, `TestCloudReaper_PrunedRunIsAGiveUp`, `TestDecideStuckCard_PrunedPointerIsAGiveUp` · `TestBoardDispatcher_ReleaseAnnouncesItselfToTheHeartbeat` · `TestClaimReaper_StopInterruptsAndDrainsThePass` · `TestRunPrune_EveryPrunableStatusIsTerminal` + the resumed-since-scan refusal · `TestGitHubReleaseNarrowsRest404ToTheIssue` · `TestUnleasedClaimHorizon_FromEnv` · `TestCloudReaper_ReparkFailsClosedWithoutAnEligibleColumn` · `TestFileFinishedTicket_SaysWhenTheCardAlreadyMoved` · `TestAddLabels_DoesNotRearmAConsumedOneShot` · the fake-gh label bootstrap cases.

`task check` green (135 packages, studio 1308 tests, goldens, pi-ext); `-race` green on `pkg/dispatcher/...`, `pkg/server/...`, `pkg/backend/tool/...`; the whole `boardmongo` package green against a real `mongo:8.3` replica set. `GiveUp.Reason` is a new persisted field (both twins, OpenAPI + studio types regenerated).

## Follow-ups (evidence in the code, to file)
- cloud `processCard` writes its `final` state under the fence with no from-state precondition — the cloud twin of the class fixed here; `SetStateOwnedFrom` now exists for it;
- FS `NativeBoardEffect.ConsumeMatchLabels` is Get → filter → Update across two lock acquisitions — a concurrent `AdjustLabels` between them is lost (`AdjustLabels(remove)` could make it atomic once the `$all` delta is exposed);
- `bots/evolve/main.bot` still words fresh-ticket labels as `set_labels` (not the one-shot class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)