### PR TITLE
fix(modernize): the contract is not the worker's to rewrite — typed only_lot refusal, done written by the gate, rewrites refused before the gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,19 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # The modernize bot-level tests execute the bot's real plan_read /
+      # lot_verify / mark_done scripts, which read the programme contract
+      # through yq. Without it on PATH they SKIP — and a skipped guard test is
+      # a green no-op, the very class those guards refuse. Pinned by version
+      # and digest (mikefarah/yq, the same implementation the bundles pin).
+      - name: Install yq (pinned)
+        run: |
+          set -eu
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -152,6 +165,19 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
+
+      # The modernize bot-level tests execute the bot's real plan_read /
+      # lot_verify / mark_done scripts, which read the programme contract
+      # through yq. Without it on PATH they SKIP — and a skipped guard test is
+      # a green no-op, the very class those guards refuse. Pinned by version
+      # and digest (mikefarah/yq, the same implementation the bundles pin).
+      - name: Install yq (pinned)
+        run: |
+          set -eu
+          curl -fsSL -o /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64
+          echo "0c4d965ea944b64b8fddaf7f27779ee3034e5693263786506ccd1c120f184e8c  /tmp/yq" | sha256sum -c -
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
 
       - name: Race tests (unit + e2e)
         # 900s, not the plain job's 600s: -race runs the e2e package 2-3x

--- a/bots/modernize/README.md
+++ b/bots/modernize/README.md
@@ -62,11 +62,30 @@ A self-reported status and a verified one are different kinds of claim, and a
 programme that conflates them eventually reports a milestone that never
 happened.
 
+Who may write which word is part of the contract, and it is enforced in git:
+
+| word | written by | believed as |
+|---|---|---|
+| `blocked` | the worker, with the reason committed | a STOP — a claim of failure cannot cheat toward green |
+| `done` | the **gate** (`mark_done`, after `gate ∧ oracle ∧ refs` went green), one line in a commit of its own | the programme's "accepted" — a landing has exactly one commit to check for it |
+
+A `done` the worker wrote is refused by `lot_verify` **before any gate
+command runs** (the revert costs seconds, the gate an hour), because a run
+interrupted after such a write relaunches as a green no-op. Measured: four
+`finished` runs in 24 h that crossed no gate, every one a relaunch from a
+banked branch carrying a completion nobody had proven.
+
 ## Running
 
 ```sh
 iterion run bots/modernize/main.bot --var only_lot=L1
 ```
+
+An explicit `only_lot` is answered explicitly: a lot the contract carries as
+`done` or `blocked`, does not declare, or holds behind an unmet dependency is
+**refused, typed** (`LOT_NOT_ACTIONABLE`, run failed), never reported as a
+green no-op. The unfiltered mode keeps its legitimate no-op on an exhausted
+programme.
 
 Prerequisite: a behavioural net in the target repo. Build it with the
 `golden-master` bot first.

--- a/bots/modernize/README.md
+++ b/bots/modernize/README.md
@@ -82,10 +82,11 @@ iterion run bots/modernize/main.bot --var only_lot=L1
 ```
 
 An explicit `only_lot` is answered explicitly: a lot the contract carries as
-`done` or `blocked`, does not declare, or holds behind an unmet dependency is
-**refused, typed** (`LOT_NOT_ACTIONABLE`, run failed), never reported as a
-green no-op. The unfiltered mode keeps its legitimate no-op on an exhausted
-programme.
+`done` or `blocked`, does not declare, holds behind an unmet dependency, or
+declares no `exit_gate` is a **typed verdict** (`lot_not_actionable` with its
+`lot_status`) that `work_gate` routes to `fail` — run failed, never a green
+no-op, never a tool error the engine would retry. The unfiltered mode keeps
+its legitimate no-op on an exhausted programme.
 
 Prerequisite: a behavioural net in the target repo. Build it with the
 `golden-master` bot first.

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -438,21 +438,11 @@ tool plan_read:
         # every one a relaunch from a banked branch whose contract carried a
         # `done` no gate had proven.
         target = next((l for l in lots if l.get("id") == only), None)
-        if target is None:
-            refuse("LOT_NOT_ACTIONABLE: no lot %r in the contract — the request "
-                   "names a lot the programme does not declare." % only)
-        st = target.get("status")
-        if st in ("done", "blocked"):
-            refuse("LOT_NOT_ACTIONABLE: lot %s is `%s` at HEAD — an explicit "
-                   "request on a lot the contract carries as landed is refused "
-                   "rather than reported as a green no-op. If the work is real "
-                   "but its gate never ran, flip the lot back to `todo` on the "
-                   "branch you relaunch from and let the gate decide."
-                   % (only, st))
+        # done / blocked / absent were resolved above, by not_actionable().
         missing = [d for d in (target.get("depends_on") or []) if d not in done_ids]
-        refuse("LOT_NOT_ACTIONABLE: lot %s waits on %s — an explicit request "
-               "cannot skip the contract's order."
-               % (only, ", ".join(missing) or "an unmet dependency"))
+        not_actionable("waiting",
+            "only_lot %r is not actionable: it waits on %s — an explicit request "
+            "cannot skip the contract's order." % (only, ", ".join(missing) or "an unmet dependency"))
 
     if chosen is None:
         if waiting:
@@ -500,9 +490,10 @@ tool plan_read:
                "and invoke it." % chosen.get("id"))
     if not gate:
         if only:
-            refuse("LOT_NOT_ACTIONABLE: lot %s declares no exit_gate — an "
-                   "explicit request on a lot that cannot be verified is refused, "
-                   "not answered with a green no-op." % chosen.get("id"))
+            not_actionable("no_gate",
+                "only_lot %r is not actionable: it declares no exit_gate — an "
+                "explicit request on a lot that cannot be verified is refused, "
+                "not answered with a green no-op." % chosen.get("id"))
         emit("lot %s declares no exit_gate. A lot with no gate cannot be "
              "verified, and an unverifiable lot is indistinguishable from one "
              "that was never done." % chosen.get("id"))

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -56,7 +56,7 @@ prompt campaign_system:
   Read the bundled skills before acting: `modernize-lots` for what a lot is and
   how one goes wrong, `plan-contract` for the contract you are working from.
 
-  Three rules override any instinct to make the gate pass:
+  Four rules override any instinct to make the gate pass:
 
   1. Stay inside the lot. The lot's intent says what may change. A change that
      reaches beyond it is not initiative, it is an unreviewable diff — and the
@@ -70,6 +70,11 @@ prompt campaign_system:
   3. Never weaken the gate. Skipping a check, loosening a version constraint to
      dodge a conflict, or excluding a failing module are all ways of passing
      without having done the work.
+  4. Never write `status: done`. That word is the gate's: a tool node writes it
+     after the gate has proven the lot, in a commit of its own. Write
+     `status: blocked` — with the reason committed — when you must stop. A
+     claim of failure cannot cheat toward green; a claim of completion can,
+     and a run interrupted after one relaunches as a green no-op.
 
   Commit as you go, so an interrupted run leaves landed work.
 
@@ -160,6 +165,15 @@ schema lot_report:
   ## harness's own code, and routed to the net's extension subbot. A lot may
   ## ASK for a new observation point; it may never write one.
   extension_pending: json
+  ## The worker wrote `done` into the contract. `done` is the gate's word: this
+  ## verdict is refused BEFORE any gate command runs, so the revert costs the
+  ## worker seconds, never the hour a full gate would spend confirming a
+  ## completion it had already written for itself.
+  done_self_written: bool
+  ## The contract was rewritten during the lot: an existing lot's normative
+  ## fields changed, a lot disappeared, or another lot's status moved. One
+  ## entry per rewrite. Refused before any gate command runs, like `done`.
+  contract_rewritten: string[]
   log_tail: string
 
 schema gate_state:
@@ -176,6 +190,18 @@ schema verify_input:
   base_sha: string
   refs_dir: string
   exit_gate: string
+
+schema mark_input:
+  lot_id: string
+  plan_path: string
+  base_sha: string
+
+## What the gate wrote, and where. `marked` is false on the idempotent path
+## (the contract already read `done`) — nothing was written, nothing committed.
+schema mark_state:
+  marked: bool
+  commit: string
+  notice: string
 
 ## ─── Nodes ─────────────────────────────────────────────────────────
 
@@ -367,6 +393,31 @@ tool plan_read:
         chosen = lot
         break
 
+    if chosen is None and only:
+        # An EXPLICIT request is answered explicitly. The unfiltered mode may
+        # legitimately find nothing to do; a launch that NAMES a lot which
+        # cannot be carried out is refused, typed, rather than reported as a
+        # green no-op — a `finished` run that crossed no gate reads as
+        # convergence. Measured on a live campaign: four such greens in 24 h,
+        # every one a relaunch from a banked branch whose contract carried a
+        # `done` no gate had proven.
+        target = next((l for l in lots if l.get("id") == only), None)
+        if target is None:
+            refuse("LOT_NOT_ACTIONABLE: no lot %r in the contract — the request "
+                   "names a lot the programme does not declare." % only)
+        st = target.get("status")
+        if st in ("done", "blocked"):
+            refuse("LOT_NOT_ACTIONABLE: lot %s is `%s` at HEAD — an explicit "
+                   "request on a lot the contract carries as landed is refused "
+                   "rather than reported as a green no-op. If the work is real "
+                   "but its gate never ran, flip the lot back to `todo` on the "
+                   "branch you relaunch from and let the gate decide."
+                   % (only, st))
+        missing = [d for d in (target.get("depends_on") or []) if d not in done_ids]
+        refuse("LOT_NOT_ACTIONABLE: lot %s waits on %s — an explicit request "
+               "cannot skip the contract's order."
+               % (only, ", ".join(missing) or "an unmet dependency"))
+
     if chosen is None:
         if waiting:
             emit("no lot is ready: %s. Finish an upstream lot first." % "; ".join(waiting))
@@ -471,22 +522,118 @@ tool lot_verify:
 
     report = {"gate_passed": False, "oracle_passed": False, "refs_untouched": False,
               "refs_changed": [], "lot_blocked": False, "block_reason": "", "log_tail": "",
-              "oracle_invalid": [], "extension_pending": []}
+              "oracle_invalid": [], "extension_pending": [], "done_self_written": False,
+              "contract_rewritten": []}
     problems = []
 
-    # Did the campaign declare this lot blocked? Read from the contract, which
-    # it had to commit to say so — a claim in a control-plane message would be
-    # cheaper to make and impossible to review.
+    # 0. Who wrote the status? The contract is read at HEAD and at the run's
+    #    base, and the two claims it can carry are believed asymmetrically.
+    #    `blocked` is believed as a STOP: it had to be committed to be said, and
+    #    a claim of failure cannot cheat its way to green. `done` is the GATE's
+    #    word — a tool node writes it after this verdict, in a commit of its
+    #    own — so a `done` the worker wrote is refused HERE, before a single
+    #    gate command runs: the revert costs seconds, the gate costs an hour,
+    #    and a run interrupted after such a write relaunches as a green no-op.
+    def plan_lots(text):
+        if text is None:
+            return None
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+            tf.write(text)
+            tmp = tf.name
+        try:
+            raw = subprocess.run(["yq", "-o=json", tmp], capture_output=True,
+                                 text=True, timeout=60)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        finally:
+            os.unlink(tmp)
+        if raw.returncode != 0:
+            return None
+        try:
+            return json.loads(raw.stdout).get("lots") or []
+        except ValueError:
+            return None
+
+    def lot_of(lots, lot_id):
+        for lot in lots or []:
+            if lot.get("id") == lot_id:
+                return lot
+        return None
+
+    plan_rel = {{input.plan_path}}
     try:
-        raw = subprocess.run(["yq", "-o=json", os.path.join(ws, {{input.plan_path}})],
-                             capture_output=True, text=True, timeout=60)
-        if raw.returncode == 0:
-            for lot in (json.loads(raw.stdout).get("lots") or []):
-                if lot.get("id") == {{input.lot_id}} and lot.get("status") == "blocked":
-                    report["lot_blocked"] = True
-                    report["block_reason"] = (lot.get("title") or "") + " -- see the committed report"
-    except (OSError, ValueError, subprocess.SubprocessError):
-        pass
+        head_text = open(os.path.join(ws, plan_rel), encoding="utf-8").read()
+    except OSError:
+        head_text = None
+    base_show = subprocess.run(["git", "-C", ws, "show", "%s:%s" % (base, plan_rel)],
+                               capture_output=True, text=True, timeout=60)
+    head_lot = lot_of(plan_lots(head_text), {{input.lot_id}})
+    base_lot = lot_of(plan_lots(base_show.stdout if base_show.returncode == 0 else None),
+                      {{input.lot_id}})
+    head_status = (head_lot or {}).get("status")
+    if head_status == "blocked":
+        report["lot_blocked"] = True
+        report["block_reason"] = ((head_lot or {}).get("title") or "") + " -- see the committed report"
+    if head_status == "done" and (base_lot or {}).get("status") != "done":
+        report["done_self_written"] = True
+        problems.append(
+            "the contract marks lot %s `done` at HEAD while it was `%s` at base "
+            "%s: the worker wrote the verdict. `done` is the gate's word — a "
+            "tool node writes it after the gate has proven the lot. Revert that "
+            "status line (nothing else) and let the gate decide; this verdict "
+            "ran no command."
+            % ({{input.lot_id}}, (base_lot or {}).get("status") or "absent", base[:12]))
+        report["log_tail"] = "\n".join(problems)[-6000:]
+        print(json.dumps(report))
+        raise SystemExit(0)
+
+    # 0b. The contract is read-only inside a lot — and that is checked in git,
+    #     not asked nicely. Existing lots keep their normative fields (title,
+    #     intent, exit_gate, depends_on, rebaseline_allowed, crosses_major),
+    #     no lot disappears, and no OTHER lot's status moves; the worker may
+    #     flip its own status to `blocked` and may ADD lots — an addition is a
+    #     proposal the programme's owner re-takes at the handoff. A gate
+    #     loosened, an intent rewritten or a lot dropped mid-run is the
+    #     contract rewritten by the party it binds: refused here, before any
+    #     gate command runs, with the rewrites named.
+    def gate_list(v):
+        if isinstance(v, str):
+            v = [v]
+        if not isinstance(v, list):
+            return v
+        return [c.strip() for c in v if isinstance(c, str) and c.strip()]
+    base_lots = plan_lots(base_show.stdout if base_show.returncode == 0 else None)
+    head_lots = plan_lots(head_text)
+    if base_lots is not None and head_lots is not None:
+        head_by = {l.get("id"): l for l in head_lots}
+        rewritten = []
+        for bl in base_lots:
+            hl = head_by.get(bl.get("id"))
+            if hl is None:
+                rewritten.append("lot %s was REMOVED" % bl.get("id"))
+                continue
+            for k in ("title", "intent", "depends_on", "rebaseline_allowed", "crosses_major"):
+                if bl.get(k) != hl.get(k):
+                    rewritten.append("%s.%s changed" % (bl.get("id"), k))
+            if gate_list(bl.get("exit_gate")) != gate_list(hl.get("exit_gate")):
+                rewritten.append("%s.exit_gate changed" % bl.get("id"))
+            if bl.get("id") != {{input.lot_id}} and bl.get("status") != hl.get("status"):
+                rewritten.append("%s.status moved from %r to %r"
+                                 % (bl.get("id"), bl.get("status"), hl.get("status")))
+        if rewritten:
+            report["contract_rewritten"] = rewritten
+            problems.append(
+                "the contract was rewritten during lot %s (%s). The plan is "
+                "read-only inside a lot: existing lots keep their gates, intents "
+                "and dependencies, no lot disappears, no other lot's status "
+                "moves. Revert those lines (nothing else); ADD a lot if the "
+                "programme needs one, never reshape or drop the ones it has. "
+                "This verdict ran no command."
+                % ({{input.lot_id}}, "; ".join(rewritten)[:1500]))
+            report["log_tail"] = "\n".join(problems)[-6000:]
+            print(json.dumps(report))
+            raise SystemExit(0)
 
     def run(cmd, timeout=3600):
         p = subprocess.run(cmd, shell=True, cwd=ws, capture_output=True,
@@ -788,6 +935,128 @@ schema extend_result:
   extended: int
   notice: string
 
+## mark_done — `done` is the GATE's word, and this is where it is written.
+##
+## The worker reads `status` to know what to skip and may declare `blocked`;
+## it never writes `done`. A converged verdict lands here, and this node flips
+## the ONE line, verifies it changed nothing else, and commits it alone — so a
+## landing has exactly one commit to check for "what did the programme accept",
+## and a bank taken before the verdict can never carry a completion nobody
+## proved. Idempotent: a contract that already reads `done` is left as it is,
+## with nothing committed.
+tool mark_done:
+  input: mark_input
+  output: mark_state
+  language: py
+  script: |
+    import json
+    import os
+    import re
+    import shutil
+    import subprocess
+    import sys
+
+    ws = {{vars.workspace_dir}}
+    plan_rel = {{input.plan_path}}
+    lot_id = {{input.lot_id}}
+    base = {{input.base_sha}}
+
+    out = {"marked": False, "commit": "", "notice": ""}
+
+    def refuse(notice):
+        out["notice"] = notice
+        print(json.dumps(out))
+        sys.stderr.write("modernize: %s\n" % notice)
+        raise SystemExit(1)
+
+    def finish(notice):
+        out["notice"] = notice
+        print(json.dumps(out))
+        raise SystemExit(0)
+
+    # Same lookup as plan_read: yq is sought on PATH, then in the target's
+    # devbox profile — declared is not realised.
+    def find_yq():
+        found = shutil.which("yq")
+        if found:
+            return found
+        cand = os.path.join(ws, ".devbox", "nix", "profile", "default", "bin", "yq")
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+        return ""
+
+    def lots_json(path):
+        yq = find_yq()
+        if not yq:
+            refuse("yq is not on PATH and was not found in the target's devbox "
+                   "profile, so the contract cannot be re-read after the write.")
+        raw = subprocess.run([yq, "-o=json", path], capture_output=True, text=True, timeout=60)
+        if raw.returncode != 0:
+            refuse("the contract at %s does not parse: %s" % (path, raw.stderr[-400:]))
+        return json.loads(raw.stdout).get("lots") or []
+
+    plan_path = os.path.join(ws, plan_rel)
+    try:
+        text = open(plan_path, encoding="utf-8").read()
+    except OSError as e:
+        refuse("cannot read the contract at %s: %s" % (plan_path, e))
+
+    before = lots_json(plan_path)
+    idx = next((i for i, l in enumerate(before) if l.get("id") == lot_id), None)
+    if idx is None:
+        refuse("lot %s is not in the contract at HEAD — nothing to mark." % lot_id)
+    if before[idx].get("status") == "done":
+        finish("lot %s already reads `done` at HEAD — nothing written, nothing committed." % lot_id)
+
+    # The one line, edited in place: locate the lot's block by its `- id:` line
+    # and the first `status:` line inside it. A structural rewrite of the file
+    # (yq -i) would reflow a contract humans read and diff; a line edit keeps
+    # the diff to the word that changed.
+    lines = text.splitlines(keepends=True)
+    id_re = re.compile(r"^\s*-\s+id:\s*['\"]?%s['\"]?\s*(#.*)?$" % re.escape(lot_id))
+    any_id_re = re.compile(r"^\s*-\s+id:")
+    start = next((i for i, l in enumerate(lines) if id_re.match(l)), None)
+    if start is None:
+        refuse("lot %s: its `- id:` line was not found in %s — the contract's "
+               "shape is not one this node knows how to edit." % (lot_id, plan_rel))
+    end = next((i for i in range(start + 1, len(lines)) if any_id_re.match(lines[i])), len(lines))
+    status_re = re.compile(r"^(\s*)status:\s*\S+(\s*#.*)?(\r?\n?)$")
+    hit = next((i for i in range(start, end) if status_re.match(lines[i])), None)
+    if hit is None:
+        refuse("lot %s: no `status:` line inside its block — the contract's "
+               "shape is not one this node knows how to edit." % lot_id)
+    m = status_re.match(lines[hit])
+    lines[hit] = "%sstatus: done%s%s" % (m.group(1), m.group(2) or "", m.group(3) or "")
+    with open(plan_path, "w", encoding="utf-8") as f:
+        f.write("".join(lines))
+
+    # Verified, not trusted: the only difference between the two parses is this
+    # lot's status. Anything else is a rewrite, and the write is undone.
+    after = lots_json(plan_path)
+    expect = [dict(l) for l in before]
+    expect[idx]["status"] = "done"
+    if after != expect:
+        with open(plan_path, "w", encoding="utf-8") as f:
+            f.write(text)
+        refuse("the status edit changed more than lot %s's status — reverted, "
+               "the contract is not one this node knows how to edit." % lot_id)
+
+    def git(*args):
+        return subprocess.run(["git", "-C", ws] + list(args), capture_output=True,
+                              text=True, timeout=120)
+
+    subject = "%s: done — gate, oracle and references green at %s" % (lot_id, base[:12])
+    if git("add", "--", plan_rel).returncode != 0:
+        refuse("git add %s failed" % plan_rel)
+    c = git("-c", "user.name=iterion-modernize", "-c", "user.email=modernize@iterion.local",
+            "commit", "-q", "--only", "-m", subject, "--", plan_rel)
+    if c.returncode != 0:
+        refuse("committing the status failed: %s" % (c.stdout + c.stderr)[-600:])
+    sha = git("rev-parse", "HEAD").stdout.strip()
+    out["marked"] = True
+    out["commit"] = sha
+    finish("lot %s marked `done` by the gate in %s" % (lot_id, sha[:12]))
+
 workflow modernize:
   entry: plan_read
 
@@ -876,9 +1145,16 @@ workflow modernize:
     exit_gate: "{{outputs.work_gate.exit_gate}}"
   }
 
-  ## Converged, or declared blocked with a committed reason. Both end the run;
-  ## looping against a wall the agent has already described and proven costs
-  ## money and produces nothing.
+  ## Converged: the gate writes `done` — one line, one commit — then the run
+  ## ends. Declared blocked with a committed reason: the run ends as it is.
+  ## Both end the run; looping against a wall the agent has already described
+  ## and proven costs money and produces nothing.
+  lot_gate -> mark_done when converged with {
+    lot_id:    "{{outputs.work_gate.lot_id}}",
+    plan_path: "{{vars.plan_path}}",
+    base_sha:  "{{outputs.work_gate.base_sha}}"
+  }
+  mark_done -> done
   lot_gate -> done when stop
 
   ## Not converged → another pass on the SAME lot, carrying the deterministic

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -187,6 +187,11 @@ schema gate_state:
   converged: bool
   ## Converged OR declared blocked — both end the run, for opposite reasons.
   stop: bool
+  ## The verifier REFUSED to judge: a worker-written `done`, a rewritten
+  ## contract. Sent back to the worker while the repair loop lasts; past it,
+  ## the run fails — it never leaves through the exhaustion edge as
+  ## `finished` with the forged word still in the contract.
+  refused: bool
   fail_log: string
   needs_reanchor: bool
   needs_extend: bool
@@ -517,7 +522,7 @@ tool plan_read:
         key_col = dash_indent + 1 + len(m0.group(2))
         same_level = re.compile(r"^\s{%d}-\s+id:" % dash_indent)
         end = next((i for i in range(start + 1, len(lines)) if same_level.match(lines[i])), len(lines))
-        status_re = re.compile(r"^\s{%d}status:\s*\S+" % key_col)
+        status_re = re.compile(r"^(\s{%d})status:\s*\S+(\s*#.*)?(\r?\n?)$" % key_col)
         if not any(status_re.match(lines[i]) for i in range(start, end)):
             return "no `status:` line at its key column inside its block"
         return ""
@@ -1059,6 +1064,7 @@ compute lot_gate:
   expr:
     converged: "outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched"
     stop: "(outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched) || outputs.lot_verify.lot_blocked"
+    refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0"
     fail_log: "outputs.lot_verify.log_tail"
     ## Read on EVERY outcome, including a converged one, and that is the point.
     ## An invalidated mutant does not fail the gate: its verdict is excluded
@@ -1169,15 +1175,29 @@ tool mark_done:
             return cand
         return ""
 
-    def lots_json(path):
+    def lots_json(path, what=None):
         yq = find_yq()
         if not yq:
             refuse("yq is not on PATH and was not found in the target's devbox "
                    "profile, so the contract cannot be re-read after the write.")
         raw = subprocess.run([yq, "-o=json", path], capture_output=True, text=True, timeout=60)
         if raw.returncode != 0:
-            refuse("the contract at %s does not parse: %s" % (path, raw.stderr[-400:]))
+            refuse("the contract %s does not parse: %s" % (what or ("at " + path), raw.stderr[-400:]))
         return json.loads(raw.stdout).get("lots") or []
+
+    def lots_json_text(text, what):
+        import tempfile
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+            tf.write(text)
+            tmp = tf.name
+        try:
+            return lots_json(tmp, what)
+        finally:
+            os.unlink(tmp)
+
+    def git(*args):
+        return subprocess.run(["git", "-C", ws] + list(args), capture_output=True,
+                              text=True, timeout=120)
 
     plan_path = os.path.join(ws, plan_rel)
     try:
@@ -1185,18 +1205,33 @@ tool mark_done:
     except OSError as e:
         refuse("cannot read the contract at %s: %s" % (plan_path, e))
 
-    before = lots_json(plan_path)
+    # Idempotence is judged at HEAD, never in the working tree: an attempt
+    # killed between the write and the commit leaves `done` on disk and
+    # nothing in git, and a re-execution that read the tree would skip the
+    # commit and let the run end green with the gate's word uncommitted.
+    head = git("show", "HEAD:%s" % plan_rel)
+    if head.returncode != 0:
+        refuse("the contract is not committed at HEAD (%s): %s" % (plan_rel, head.stderr[-300:]))
+    head_lots = lots_json_text(head.stdout, "at HEAD")
+    hidx = next((i for i, l in enumerate(head_lots) if l.get("id") == lot_id), None)
+    if hidx is None:
+        refuse("lot %s is not in the contract at HEAD — nothing to mark." % lot_id)
+    if head_lots[hidx].get("status") == "done":
+        finish("lot %s already reads `done` at HEAD — nothing written, nothing committed." % lot_id)
+
+    before = lots_json(plan_path, "in the working tree")
     idx = next((i for i, l in enumerate(before) if l.get("id") == lot_id), None)
     if idx is None:
-        refuse("lot %s is not in the contract at HEAD — nothing to mark." % lot_id)
-    if before[idx].get("status") == "done":
-        finish("lot %s already reads `done` at HEAD — nothing written, nothing committed." % lot_id)
+        refuse("lot %s is in the contract at HEAD but not in the working tree — "
+               "the tree is not one this node writes into." % lot_id)
 
     # The one line, edited in place: locate the lot's block by its `- id:` line
     # and the first `status:` line inside it. A structural rewrite of the file
     # (yq -i) would reflow a contract humans read and diff; a line edit keeps
-    # the diff to the word that changed.
+    # the diff to the word that changed. A tree that already reads `done` is
+    # an interrupted attempt: nothing to write, the commit is what is owed.
     lines = text.splitlines(keepends=True)
+    already_written = before[idx].get("status") == "done"
     # Anchored on INDENTATION, not on the first line that looks right: the
     # block ends at the next `- id:` at the SAME list level, and the status
     # line is the one at the item's key column — so a `status:` or `- id:`
@@ -1220,10 +1255,11 @@ tool mark_done:
     if hit is None:
         refuse("lot %s: no `status:` line inside its block — the contract's "
                "shape is not one this node knows how to edit." % lot_id)
-    m = status_re.match(lines[hit])
-    lines[hit] = "%sstatus: done%s%s" % (m.group(1), m.group(2) or "", m.group(3) or "")
-    with open(plan_path, "w", encoding="utf-8") as f:
-        f.write("".join(lines))
+    if not already_written:
+        m = status_re.match(lines[hit])
+        lines[hit] = "%sstatus: done%s%s" % (m.group(1), m.group(2) or "", m.group(3) or "")
+        with open(plan_path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
 
     # Verified, not trusted: the only difference between the two parses is this
     # lot's status. Anything else is a rewrite, and the write is undone.
@@ -1236,15 +1272,16 @@ tool mark_done:
         refuse("the status edit changed more than lot %s's status — reverted, "
                "the contract is not one this node knows how to edit." % lot_id)
 
-    def git(*args):
-        return subprocess.run(["git", "-C", ws] + list(args), capture_output=True,
-                              text=True, timeout=120)
-
+    # The gate's bookkeeping commit bypasses the target's hooks: a pre-commit
+    # that reformats YAML would commit a contract other than the one just
+    # verified, and one that rejects would fail a converged lot at its last
+    # node. The lot's own commits went through them; this one line is the
+    # gate's.
     subject = "%s: done — gate, oracle and references green at %s" % (lot_id, base[:12])
     if git("add", "--", plan_rel).returncode != 0:
         refuse("git add %s failed" % plan_rel)
     c = git("-c", "user.name=iterion-modernize", "-c", "user.email=modernize@iterion.local",
-            "commit", "-q", "--only", "-m", subject, "--", plan_rel)
+            "commit", "-q", "--only", "--no-verify", "-m", subject, "--", plan_rel)
     if c.returncode != 0:
         refuse("committing the status failed: %s" % (c.stdout + c.stderr)[-600:])
     sha = git("rev-parse", "HEAD").stdout.strip()
@@ -1354,13 +1391,26 @@ workflow modernize:
 
   ## Not converged → another pass on the SAME lot, carrying the deterministic
   ## failure back so the agent fixes the cause rather than re-deriving it.
-  lot_gate -> upgrade_campaign as repair_loop("{{vars.max_passes}}") with {
+  ## Conditional on purpose: a bare `when` edge is taken in declaration order
+  ## as soon as it holds, while an unconditional edge is only the fallback —
+  ## so the loop, while it lasts, must beat the `fail when refused` edge below,
+  ## and only an EXHAUSTED loop (skipped by the engine) lets that edge fire.
+  lot_gate -> upgrade_campaign when not stop as repair_loop("{{vars.max_passes}}") with {
     lot_id:     "{{outputs.work_gate.lot_id}}",
     lot_title:  "{{outputs.work_gate.lot_title}}",
     lot_intent: "{{outputs.work_gate.lot_intent}}",
     exit_gate:  "{{outputs.work_gate.exit_gate}}",
     fail_log:   "{{outputs.lot_gate.fail_log}}"
   }
+
+  ## A refusal that outlived the loop — the worker kept its `done`, or its
+  ## rewrite, through every pass — must not exit through the green door: the
+  ## forged word is still in the contract, a merge of a `finished` run would
+  ## land it, and the lot would vanish from the programme (an only_lot
+  ## relaunch is refused as not actionable, a free relaunch skips it as
+  ## landed). The run FAILS, in words, with the work banked — after the loop
+  ## above has been exhausted, never instead of it.
+  lot_gate -> fail when refused
 
   ## Loop exhausted → stop and leave the committed work in place. A lot that
   ## will not converge in max_passes is a finding about the lot, not a reason

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -216,6 +216,7 @@ tool plan_read:
   script: |
     import json
     import os
+    import re
     import subprocess
     import sys
 
@@ -331,10 +332,27 @@ tool plan_read:
     rev = subprocess.run(["git", "-C", ws, "rev-parse", "HEAD"],
                          capture_output=True, text=True, timeout=30)
     if rev.returncode != 0:
-        emit("cannot read HEAD in %s: %s" % (ws, rev.stderr[-400:]))
+        # A failure to LOOK, never a no-op: refs_immutable_gate compares
+        # against this commit, and a run that cannot read it has nothing to
+        # judge against.
+        refuse("CONTRACT_UNREADABLE: cannot read HEAD in %s: %s" % (ws, rev.stderr[-400:]))
     out["base_sha"] = rev.stdout.strip()
 
     lots = plan.get("lots") or []
+    # An id is a KEY. A contract declaring one twice is not one this bot can
+    # read: the reader would take the first, the verifier the last, and a
+    # worker could add a homonym ahead of its lot, carrying the gate of its
+    # choice (adversarial finding, executed). Refused here — the single point
+    # every later node relies on — for both launch modes.
+    ids = [l.get("id") for l in lots]
+    if any(not isinstance(i, str) or not i for i in ids):
+        refuse("CONTRACT_UNREADABLE: every lot needs a non-empty string id; "
+               "got %r" % [i for i in ids if not isinstance(i, str) or not i][:5])
+    dupes = sorted({i for i in ids if ids.count(i) > 1})
+    if dupes:
+        refuse("CONTRACT_UNREADABLE: duplicate lot id(s) %s — an id is a key, "
+               "and a contract that declares one twice is not readable."
+               % ", ".join(dupes))
 
     # only_lot is an EXPLICIT request for one lot, not a scope filter over
     # an otherwise-normal scan. Resolve its actual status FIRST: a lot
@@ -463,9 +481,48 @@ tool plan_read:
                "must be a single line; put multi-line logic in a script file "
                "and invoke it." % chosen.get("id"))
     if not gate:
+        if only:
+            refuse("LOT_NOT_ACTIONABLE: lot %s declares no exit_gate — an "
+                   "explicit request on a lot that cannot be verified is refused, "
+                   "not answered with a green no-op." % chosen.get("id"))
         emit("lot %s declares no exit_gate. A lot with no gate cannot be "
              "verified, and an unverifiable lot is indistinguishable from one "
              "that was never done." % chosen.get("id"))
+
+    # The gate writes `done` by editing ONE line of this file (mark_done), and
+    # it must be able to. A lot whose block the editor cannot locate — flow
+    # mapping, `- id:` not opening the item, no `status:` at the item's key
+    # column — would be refused AFTER convergence, when the work is done and
+    # the campaign has no way to mark it: check the shape now, before a token
+    # is spent. Same regexes as mark_done, on purpose.
+    def block_shape_ok(text, lot_id):
+        lines = text.splitlines()
+        id_re = re.compile(r"^(\s*)-(\s+)id:\s*['\"]?%s['\"]?\s*(#.*)?$" % re.escape(lot_id))
+        start = m0 = None
+        for i, l in enumerate(lines):
+            m0 = id_re.match(l)
+            if m0:
+                start = i
+                break
+        if start is None:
+            return "its `- id:` line was not found (only `- id: <id>` opening a block item is edited)"
+        dash_indent = len(m0.group(1))
+        key_col = dash_indent + 1 + len(m0.group(2))
+        same_level = re.compile(r"^\s{%d}-\s+id:" % dash_indent)
+        end = next((i for i in range(start + 1, len(lines)) if same_level.match(lines[i])), len(lines))
+        status_re = re.compile(r"^\s{%d}status:\s*\S+" % key_col)
+        if not any(status_re.match(lines[i]) for i in range(start, end)):
+            return "no `status:` line at its key column inside its block"
+        return ""
+    try:
+        with open(plan_path, encoding="utf-8") as f:
+            shape = block_shape_ok(f.read(), chosen.get("id"))
+    except OSError as e:
+        refuse("CONTRACT_UNREADABLE: %s" % e)
+    if shape:
+        refuse("LOT_UNEDITABLE: lot %s — %s; the gate could never write its "
+               "`done`. Write the lot as a block item (`- id: %s` then its keys "
+               "at one column) before running it." % (chosen.get("id"), shape, chosen.get("id")))
 
     out["nothing_to_do"] = False
     out["lot_id"] = chosen.get("id") or ""
@@ -514,6 +571,7 @@ tool lot_verify:
     import os
     import shlex
     import subprocess
+    import sys
 
     ws = {{vars.workspace_dir}}
     base = {{input.base_sha}}
@@ -534,26 +592,52 @@ tool lot_verify:
     #    own — so a `done` the worker wrote is refused HERE, before a single
     #    gate command runs: the revert costs seconds, the gate costs an hour,
     #    and a run interrupted after such a write relaunches as a green no-op.
-    def plan_lots(text):
-        if text is None:
-            return None
+    # Same lookup as plan_read and mark_done: yq on PATH, then the TARGET's
+    # devbox profile — declared is not realised, and a verifier that cannot
+    # find its parser must say so, never fall through to a verdict that skips
+    # the checks it could not make (adversarial finding, executed: with yq
+    # off PATH, a worker-written `done` and an amputated gate converged green).
+    def find_yq():
+        import shutil
+        found = shutil.which("yq")
+        if found:
+            return found
+        cand = os.path.join(ws, ".devbox", "nix", "profile", "default", "bin", "yq")
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+        return ""
+
+    def unreadable(why):
+        """A failure to LOOK is refused, never turned into a verdict: a verdict
+        over a contract this node could not read would skip exactly the checks
+        that exist to catch a rewritten one."""
+        sys.stderr.write("modernize: CONTRACT_UNREADABLE: %s\n" % why)
+        report["log_tail"] = "CONTRACT_UNREADABLE: %s" % why
+        print(json.dumps(report))
+        raise SystemExit(1)
+
+    def plan_lots(text, what):
         import tempfile
+        yq = find_yq()
+        if not yq:
+            unreadable("yq is not on PATH and was not found in the target's devbox "
+                       "profile, so the contract cannot be read (%s)" % what)
         with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
             tf.write(text)
             tmp = tf.name
         try:
-            raw = subprocess.run(["yq", "-o=json", tmp], capture_output=True,
+            raw = subprocess.run([yq, "-o=json", tmp], capture_output=True,
                                  text=True, timeout=60)
-        except (OSError, subprocess.SubprocessError):
-            return None
+        except (OSError, subprocess.SubprocessError) as e:
+            unreadable("cannot run yq on the contract (%s): %s" % (what, e))
         finally:
             os.unlink(tmp)
         if raw.returncode != 0:
-            return None
+            unreadable("the contract does not parse (%s): %s" % (what, raw.stderr[-400:]))
         try:
             return json.loads(raw.stdout).get("lots") or []
-        except ValueError:
-            return None
+        except ValueError as e:
+            unreadable("yq produced no JSON for the contract (%s): %s" % (what, e))
 
     def lot_of(lots, lot_id):
         for lot in lots or []:
@@ -564,19 +648,28 @@ tool lot_verify:
     plan_rel = {{input.plan_path}}
     try:
         head_text = open(os.path.join(ws, plan_rel), encoding="utf-8").read()
-    except OSError:
-        head_text = None
+    except OSError as e:
+        unreadable("the contract is missing from the tree at HEAD (%s): %s" % (plan_rel, e))
     base_show = subprocess.run(["git", "-C", ws, "show", "%s:%s" % (base, plan_rel)],
                                capture_output=True, text=True, timeout=60)
-    head_lot = lot_of(plan_lots(head_text), {{input.lot_id}})
-    base_lot = lot_of(plan_lots(base_show.stdout if base_show.returncode == 0 else None),
-                      {{input.lot_id}})
+    if base_show.returncode != 0:
+        unreadable("the contract is not committed at the run's base %s — a programme "
+                   "that lives only in the working tree cannot be judged: %s"
+                   % (base[:12], base_show.stderr[-300:]))
+    head_lots = plan_lots(head_text, "HEAD")
+    base_lots = plan_lots(base_show.stdout, "base %s" % base[:12])
+    head_lot = lot_of(head_lots, {{input.lot_id}})
+    base_lot = lot_of(base_lots, {{input.lot_id}})
     head_status = (head_lot or {}).get("status")
     if head_status == "blocked":
         report["lot_blocked"] = True
         report["block_reason"] = ((head_lot or {}).get("title") or "") + " -- see the committed report"
     if head_status == "done" and (base_lot or {}).get("status") != "done":
         report["done_self_written"] = True
+        # Not a stop: a self-written verdict goes back to the worker with the
+        # refusal in fail_log, whatever else the contract says.
+        report["lot_blocked"] = False
+        report["block_reason"] = ""
         problems.append(
             "the contract marks lot %s `done` at HEAD while it was `%s` at base "
             "%s: the worker wrote the verdict. `done` is the gate's word — a "
@@ -603,11 +696,11 @@ tool lot_verify:
         if not isinstance(v, list):
             return v
         return [c.strip() for c in v if isinstance(c, str) and c.strip()]
-    base_lots = plan_lots(base_show.stdout if base_show.returncode == 0 else None)
-    head_lots = plan_lots(head_text)
-    if base_lots is not None and head_lots is not None:
+    if True:
+        head_ids = [l.get("id") for l in head_lots]
         head_by = {l.get("id"): l for l in head_lots}
-        rewritten = []
+        rewritten = ["duplicate lot id %s at HEAD" % i
+                     for i in sorted({i for i in head_ids if head_ids.count(i) > 1})]
         for bl in base_lots:
             hl = head_by.get(bl.get("id"))
             if hl is None:
@@ -623,6 +716,12 @@ tool lot_verify:
                                  % (bl.get("id"), bl.get("status"), hl.get("status")))
         if rewritten:
             report["contract_rewritten"] = rewritten
+            # A rewritten contract is never a clean stop, even under a lot the
+            # worker declared blocked: `stop` would end the run with the rewrite
+            # landed (adversarial finding, executed). It goes back to the
+            # worker with the refusal in fail_log.
+            report["lot_blocked"] = False
+            report["block_reason"] = ""
             problems.append(
                 "the contract was rewritten during lot %s (%s). The plan is "
                 "read-only inside a lot: existing lots keep their gates, intents "
@@ -1013,14 +1112,25 @@ tool mark_done:
     # (yq -i) would reflow a contract humans read and diff; a line edit keeps
     # the diff to the word that changed.
     lines = text.splitlines(keepends=True)
-    id_re = re.compile(r"^\s*-\s+id:\s*['\"]?%s['\"]?\s*(#.*)?$" % re.escape(lot_id))
-    any_id_re = re.compile(r"^\s*-\s+id:")
-    start = next((i for i, l in enumerate(lines) if id_re.match(l)), None)
+    # Anchored on INDENTATION, not on the first line that looks right: the
+    # block ends at the next `- id:` at the SAME list level, and the status
+    # line is the one at the item's key column — so a `status:` or `- id:`
+    # written inside an `intent: |` block scalar (deeper) is text, not a key.
+    id_re = re.compile(r"^(\s*)-(\s+)id:\s*['\"]?%s['\"]?\s*(#.*)?$" % re.escape(lot_id))
+    start = m0 = None
+    for i, l in enumerate(lines):
+        m0 = id_re.match(l)
+        if m0:
+            start = i
+            break
     if start is None:
         refuse("lot %s: its `- id:` line was not found in %s — the contract's "
                "shape is not one this node knows how to edit." % (lot_id, plan_rel))
-    end = next((i for i in range(start + 1, len(lines)) if any_id_re.match(lines[i])), len(lines))
-    status_re = re.compile(r"^(\s*)status:\s*\S+(\s*#.*)?(\r?\n?)$")
+    dash_indent = len(m0.group(1))
+    key_col = dash_indent + 1 + len(m0.group(2))
+    same_level = re.compile(r"^\s{%d}-\s+id:" % dash_indent)
+    end = next((i for i in range(start + 1, len(lines)) if same_level.match(lines[i])), len(lines))
+    status_re = re.compile(r"^(\s{%d})status:\s*\S+(\s*#.*)?(\r?\n?)$" % key_col)
     hit = next((i for i in range(start, end) if status_re.match(lines[i])), None)
     if hit is None:
         refuse("lot %s: no `status:` line inside its block — the contract's "

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -173,9 +173,11 @@ schema lot_report:
   ## A gate command outlived `gate_timeout_s`. A VERDICT, not an execution
   ## failure: an expiry that surfaced as a tool error was retried once by the
   ## engine — the same hour replayed for nothing — then left the run
-  ## `failed_resumable` with no line to read. Read as a STOP (`lot_blocked`,
-  ## `block_reason` GATE_TIMEOUT): a wall the next pass would hit again is a
-  ## finding about the wall, not a reason to pay four passes for it.
+  ## `failed_resumable` with no line to read, and the engine's own auto-resume
+  ## replayed the same hour on a fresh pod until the budget. The gate ends the
+  ## run at `fail`, once, with `block_reason` naming the wall: a wall the next
+  ## pass would hit again is a finding about the wall, not a reason to pay
+  ## four passes for it — nor a stop that reads `finished`.
   gate_timed_out: bool
   ## The contract was rewritten during the lot: an existing lot's normative
   ## fields changed, a lot disappeared, or another lot's status moved. One
@@ -192,6 +194,10 @@ schema gate_state:
   ## the run fails — it never leaves through the exhaustion edge as
   ## `finished` with the forged word still in the contract.
   refused: bool
+  ## A gate command outlived the contract's wall. Ends the run at `fail` on
+  ## the first occurrence — never a repair pass against the same wall, never
+  ## a `finished` the programme would relaunch into the same wall.
+  timed_out: bool
   fail_log: string
   needs_reanchor: bool
   needs_extend: bool
@@ -738,7 +744,17 @@ tool lot_verify:
     if True:
         head_ids = [l.get("id") for l in head_lots]
         head_by = {l.get("id"): l for l in head_lots}
-        rewritten = ["duplicate lot id %s in the working tree" % i
+        # The normative keys the contract carries OUTSIDE `lots` — the wall
+        # every lot gets and where the net lives — are read from the NEXT
+        # run's base, which is this tree once landed: one committed line would
+        # disarm the wall for the rest of the programme (review finding,
+        # executed: top-level gate_timeout_s 3600 -> 1 converged unrefused).
+        head_doc = plan_doc(head_text, "the working tree")
+        rewritten = []
+        for k in ("gate_timeout_s", "oracle"):
+            if base_doc.get(k) != head_doc.get(k):
+                rewritten.append("top-level %s moved from %r to %r" % (k, base_doc.get(k), head_doc.get(k)))
+        rewritten += ["duplicate lot id %s in the working tree" % i
                      for i in sorted({i for i in head_ids if head_ids.count(i) > 1})]
         for bl in base_lots:
             hl = head_by.get(bl.get("id"))
@@ -790,8 +806,11 @@ tool lot_verify:
         return p.returncode, (p.stdout + p.stderr)[-4000:]
 
     def timed_out(what, cmd, log):
+        # Not a `lot_blocked` stop: that one ends the run `finished`, and a
+        # wall the run never crossed must not read as a stop the worker
+        # declared — the lot would stay `todo` and every relaunch would hit
+        # the wall and finish green again. The gate routes it to `fail`, once.
         report["gate_timed_out"] = True
-        report["lot_blocked"] = True
         report["block_reason"] = "GATE_TIMEOUT: %s `%s` %s" % (what, cmd, log.splitlines()[0] if log else "")
         problems.append("GATE_TIMEOUT: %s `%s` %s — a verdict, not a retry: raise "
                         "gate_timeout_s in the contract (lot or top level) if the "
@@ -965,12 +984,19 @@ tool lot_verify:
         # certificate (review finding, executed: additions-only committed,
         # entry deleted in the worktree, green). A dirty net voids the
         # certificate: commit, then verify.
+        # `net_dirty` is carried to the final assignment below: a refusal
+        # written into report["refs_untouched"] here was silently overwritten
+        # there by the diff's own result — a dirty net converged and the gate
+        # committed `done` (review finding, executed).
+        net_dirty = False
         code, log = run("git -c core.quotePath=false status --porcelain -- %s"
                         % shlex.quote(gm_dir))
         if code != 0:
             problems.append("cannot read the net's worktree state: %s" % log)
             exempt = set()
+            net_dirty = True
         elif log.strip():
+            net_dirty = True
             dirty = sorted(l[3:] for l in log.splitlines() if l.strip())
             problems.append("%d uncommitted path(s) under the net (%s) — the "
                             "extension certificate reads commits, the verdict "
@@ -1010,7 +1036,7 @@ tool lot_verify:
                 exempt = set()
             changed = [p for p in raw if p not in exempt]
             report["refs_changed"] = changed
-            report["refs_untouched"] = not changed and net_at_base
+            report["refs_untouched"] = not changed and net_at_base and not net_dirty
             if changed:
                 problems.append("%d oracle artefact(s) were MODIFIED during this "
                                 "lot: %s. Either the lot changed behaviour it was "
@@ -1065,6 +1091,7 @@ compute lot_gate:
     converged: "outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched"
     stop: "(outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched) || outputs.lot_verify.lot_blocked"
     refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0"
+    timed_out: "outputs.lot_verify.gate_timed_out"
     fail_log: "outputs.lot_verify.log_tail"
     ## Read on EVERY outcome, including a converged one, and that is the point.
     ## An invalidated mutant does not fail the gate: its verdict is excluded
@@ -1388,6 +1415,13 @@ workflow modernize:
   }
   mark_done -> done
   lot_gate -> done when stop
+
+  ## A wall the run never crossed: the verdict is in the tree (gate_timed_out,
+  ## block_reason GATE_TIMEOUT), the run fails at once — no repair pass
+  ## replays an hour against the same wall, and no `finished` invites a
+  ## relaunch into it. Raise `gate_timeout_s` in the contract, or shorten the
+  ## gate, then relaunch.
+  lot_gate -> fail when timed_out
 
   ## Not converged → another pass on the SAME lot, carrying the deterministic
   ## failure back so the agent fixes the cause rather than re-deriving it.

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -824,10 +824,18 @@ tool lot_verify:
         # additions are exempted from the immutability verdict below, and
         # ONLY those: an addition cannot mask an existing divergence, which
         # is the one property that makes the exemption safe to grant.
+        # A net materialised BEFORE the extension feature has no `extend-verify`
+        # mode: that is the legal state of an older net — no extension
+        # machinery, no exemption, the immutability diff alone judges (the
+        # pre-feature behaviour) — and it is NOT the same event as a certifier
+        # that exists and cannot answer, which is a refusal. Two sentinels,
+        # because conflating them refused every lot on every older net.
+        CAPABILITY_ABSENT = {"__capability_absent__": True}
+
         def harness_json(mode, **extra):
             hp = os.path.join(ws, gm_dir, "harness.py")
             if not os.path.isfile(hp):
-                return None
+                return CAPABILITY_ABSENT
             # A net materialised BEFORE this feature has no extension modes:
             # its main() would fall through to the FULL gate path — boot the
             # app, run the campaign — and die on this call's timeout (review
@@ -838,7 +846,7 @@ tool lot_verify:
             try:
                 with open(hp, encoding="utf-8") as f:
                     if 'mode == "extend-verify"' not in f.read():
-                        return None
+                        return CAPABILITY_ABSENT
             except OSError as e:
                 problems.append("cannot read %s to probe its capabilities: %s"
                                 % (hp, e))
@@ -862,11 +870,11 @@ tool lot_verify:
                 return None
 
         listing = harness_json("extensions")
-        if listing is not None:
+        if listing is not None and listing is not CAPABILITY_ABSENT:
             report["extension_pending"] = listing.get("pending") or []
         exempt = set()
         verdict = harness_json("extend-verify", GM_BASE=base)
-        if verdict is not None and not verdict.get("error"):
+        if verdict is not None and verdict is not CAPABILITY_ABSENT and not verdict.get("error"):
             exempt = set(verdict.get("ok_paths") or [])
 
         # The certifier is the TARGET's harness copy — a file the lot could
@@ -940,7 +948,11 @@ tool lot_verify:
         # a green — extension_verdict SEES both frauds and its verdict was
         # read for ok_paths only (consolidation finding, executed: emptied
         # ledger and act recording "peu-importe-quoi" both came out green).
-        if verdict is not None and not verdict.get("error"):
+        if verdict is CAPABILITY_ABSENT:
+            # Older net: nothing to certify and nothing to refuse. The
+            # references are still judged, in git, two blocks above.
+            pass
+        elif verdict is not None and not verdict.get("error"):
             bad = [r for r in (verdict.get("acted") or []) if not r.get("ok")]
             if verdict.get("problems") or bad \
                     or not verdict.get("ledger_append_only", True):

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -170,6 +170,13 @@ schema lot_report:
   ## worker seconds, never the hour a full gate would spend confirming a
   ## completion it had already written for itself.
   done_self_written: bool
+  ## A gate command outlived `gate_timeout_s`. A VERDICT, not an execution
+  ## failure: an expiry that surfaced as a tool error was retried once by the
+  ## engine — the same hour replayed for nothing — then left the run
+  ## `failed_resumable` with no line to read. Read as a STOP (`lot_blocked`,
+  ## `block_reason` GATE_TIMEOUT): a wall the next pass would hit again is a
+  ## finding about the wall, not a reason to pay four passes for it.
+  gate_timed_out: bool
   ## The contract was rewritten during the lot: an existing lot's normative
   ## fields changed, a lot disappeared, or another lot's status moved. One
   ## entry per rewrite. Refused before any gate command runs, like `done`.
@@ -571,6 +578,7 @@ tool lot_verify:
     import os
     import shlex
     import subprocess
+    import time
     import sys
 
     ws = {{vars.workspace_dir}}
@@ -579,6 +587,7 @@ tool lot_verify:
     gate_cmds = [c for c in {{input.exit_gate}}.split("\n") if c.strip()]
 
     report = {"gate_passed": False, "oracle_passed": False, "refs_untouched": False,
+              "gate_timed_out": False,
               "refs_changed": [], "lot_blocked": False, "block_reason": "", "log_tail": "",
               "oracle_invalid": [], "extension_pending": [], "done_self_written": False,
               "contract_rewritten": []}
@@ -616,7 +625,8 @@ tool lot_verify:
         print(json.dumps(report))
         raise SystemExit(1)
 
-    def plan_lots(text, what):
+    def plan_doc(text, what):
+        """The whole contract as JSON — `lots` and the top-level keys."""
         import tempfile
         yq = find_yq()
         if not yq:
@@ -635,9 +645,13 @@ tool lot_verify:
         if raw.returncode != 0:
             unreadable("the contract does not parse (%s): %s" % (what, raw.stderr[-400:]))
         try:
-            return json.loads(raw.stdout).get("lots") or []
+            doc = json.loads(raw.stdout)
         except ValueError as e:
             unreadable("yq produced no JSON for the contract (%s): %s" % (what, e))
+        return doc if isinstance(doc, dict) else {}
+
+    def plan_lots(text, what):
+        return plan_doc(text, what).get("lots") or []
 
     def lot_of(lots, lot_id):
         for lot in lots or []:
@@ -649,17 +663,37 @@ tool lot_verify:
     try:
         head_text = open(os.path.join(ws, plan_rel), encoding="utf-8").read()
     except OSError as e:
-        unreadable("the contract is missing from the tree at HEAD (%s): %s" % (plan_rel, e))
+        unreadable("the contract is missing from the working tree (%s): %s" % (plan_rel, e))
     base_show = subprocess.run(["git", "-C", ws, "show", "%s:%s" % (base, plan_rel)],
                                capture_output=True, text=True, timeout=60)
     if base_show.returncode != 0:
         unreadable("the contract is not committed at the run's base %s — a programme "
                    "that lives only in the working tree cannot be judged: %s"
                    % (base[:12], base_show.stderr[-300:]))
-    head_lots = plan_lots(head_text, "HEAD")
-    base_lots = plan_lots(base_show.stdout, "base %s" % base[:12])
+    head_lots = plan_lots(head_text, "the working tree")
+    base_doc = plan_doc(base_show.stdout, "base %s" % base[:12])
+    base_lots = base_doc.get("lots") or []
     head_lot = lot_of(head_lots, {{input.lot_id}})
     base_lot = lot_of(base_lots, {{input.lot_id}})
+
+    # The wall each gate command gets, from the contract the owner committed at
+    # the base: `gate_timeout_s` on the lot, else at the top level, else 3600.
+    # Bounded to a day, and an unreadable value is a refusal — a wall this
+    # node guessed would be a verdict nobody wrote.
+    def gate_timeout_from(doc, lot):
+        src, raw = None, None
+        if isinstance(lot, dict) and "gate_timeout_s" in lot:
+            src, raw = "lot %s" % {{input.lot_id}}, lot.get("gate_timeout_s")
+        elif isinstance(doc, dict) and "gate_timeout_s" in doc:
+            src, raw = "the top level", doc.get("gate_timeout_s")
+        if src is None:
+            return 3600
+        if isinstance(raw, bool) or not isinstance(raw, int) or not 1 <= raw <= 86400:
+            unreadable("gate_timeout_s at %s is %r — an integer number of seconds "
+                       "between 1 and 86400 is the only shape this node reads"
+                       % (src, raw))
+        return raw
+    gate_timeout = gate_timeout_from(base_doc, base_lot)
     head_status = (head_lot or {}).get("status")
     if head_status == "blocked":
         report["lot_blocked"] = True
@@ -671,7 +705,7 @@ tool lot_verify:
         report["lot_blocked"] = False
         report["block_reason"] = ""
         problems.append(
-            "the contract marks lot %s `done` at HEAD while it was `%s` at base "
+            "the contract marks lot %s `done` in the working tree while it was `%s` at base "
             "%s: the worker wrote the verdict. `done` is the gate's word — a "
             "tool node writes it after the gate has proven the lot. Revert that "
             "status line (nothing else) and let the gate decide; this verdict "
@@ -699,14 +733,14 @@ tool lot_verify:
     if True:
         head_ids = [l.get("id") for l in head_lots]
         head_by = {l.get("id"): l for l in head_lots}
-        rewritten = ["duplicate lot id %s at HEAD" % i
+        rewritten = ["duplicate lot id %s in the working tree" % i
                      for i in sorted({i for i in head_ids if head_ids.count(i) > 1})]
         for bl in base_lots:
             hl = head_by.get(bl.get("id"))
             if hl is None:
                 rewritten.append("lot %s was REMOVED" % bl.get("id"))
                 continue
-            for k in ("title", "intent", "depends_on", "rebaseline_allowed", "crosses_major"):
+            for k in ("title", "intent", "depends_on", "rebaseline_allowed", "crosses_major", "gate_timeout_s"):
                 if bl.get(k) != hl.get(k):
                     rewritten.append("%s.%s changed" % (bl.get("id"), k))
             if gate_list(bl.get("exit_gate")) != gate_list(hl.get("exit_gate")):
@@ -734,15 +768,39 @@ tool lot_verify:
             print(json.dumps(report))
             raise SystemExit(0)
 
-    def run(cmd, timeout=3600):
-        p = subprocess.run(cmd, shell=True, cwd=ws, capture_output=True,
-                           text=True, timeout=timeout)
+    def run(cmd, timeout=None):
+        """(exit code, tail). An expiry returns (None, tail) — the caller records
+        it as the GATE_TIMEOUT verdict; raised, it was a tool error the engine
+        retried once (the same hour replayed) before failed_resumable."""
+        started = time.monotonic()
+        try:
+            p = subprocess.run(cmd, shell=True, cwd=ws, capture_output=True,
+                               text=True, timeout=timeout or gate_timeout)
+        except subprocess.TimeoutExpired as e:
+            def text_of(v):
+                return v.decode("utf-8", "replace") if isinstance(v, bytes) else (v or "")
+            tail = (text_of(e.stdout) + text_of(e.stderr))[-4000:]
+            return None, "exceeded gate_timeout_s=%d after %ds; last output:\n%s" % (
+                timeout or gate_timeout, int(time.monotonic() - started), tail)
         return p.returncode, (p.stdout + p.stderr)[-4000:]
+
+    def timed_out(what, cmd, log):
+        report["gate_timed_out"] = True
+        report["lot_blocked"] = True
+        report["block_reason"] = "GATE_TIMEOUT: %s `%s` %s" % (what, cmd, log.splitlines()[0] if log else "")
+        problems.append("GATE_TIMEOUT: %s `%s` %s — a verdict, not a retry: raise "
+                        "gate_timeout_s in the contract (lot or top level) if the "
+                        "gate legitimately needs longer, or shorten the gate."
+                        % (what, cmd, log))
 
     # 1. The lot's own gate, every command, in order.
     report["gate_passed"] = True
     for cmd in gate_cmds:
         code, log = run(cmd)
+        if code is None:
+            report["gate_passed"] = False
+            timed_out("exit_gate command", cmd, log)
+            break
         if code != 0:
             report["gate_passed"] = False
             problems.append("exit_gate command failed (exit %d): %s\n%s" % (code, cmd, log))
@@ -759,7 +817,9 @@ tool lot_verify:
     else:
         code, log = run(verify)
         report["oracle_passed"] = code == 0
-        if code != 0:
+        if code is None:
+            timed_out("the behavioural oracle", verify, log)
+        elif code != 0:
             problems.append("the behavioural oracle went RED (exit %d):\n%s" % (code, log))
         # WHICH mutants the oracle could no longer apply, read rather than
         # guessed. A mutant goes invalid for two very different reasons: it
@@ -919,6 +979,19 @@ tool lot_verify:
             # finding, executed).
             report["refs_untouched"] = False
 
+        # The net must EXIST at the base to be judged: `refs_untouched` over
+        # an absent net would be true by absence, which is not a term (an
+        # absent oracle already reads red above; this keeps the second term
+        # honest on its own). The judged directory itself is probed — an
+        # older net has no harness, every net has the directory.
+        probe = subprocess.run(["git", "-C", ws, "cat-file", "-e", "%s:%s" % (base, gm_dir)],
+                               capture_output=True, text=True, timeout=60)
+        net_at_base = probe.returncode == 0
+        if not net_at_base:
+            problems.append("no net at the run's base %s (%s is not committed there): "
+                            "nothing to judge the references against — build and commit "
+                            "the net before modernising against it." % (base[:12], gm_dir))
+
         code, log = run("git -c core.quotePath=false diff --name-only %s -- %s"
                         % (base, " ".join(shlex.quote(p) for p in judged)))
         if code != 0:
@@ -932,7 +1005,7 @@ tool lot_verify:
                 exempt = set()
             changed = [p for p in raw if p not in exempt]
             report["refs_changed"] = changed
-            report["refs_untouched"] = not changed
+            report["refs_untouched"] = not changed and net_at_base
             if changed:
                 problems.append("%d oracle artefact(s) were MODIFIED during this "
                                 "lot: %s. Either the lot changed behaviour it was "

--- a/bots/modernize/skills/modernize-lots.md
+++ b/bots/modernize/skills/modernize-lots.md
@@ -237,6 +237,12 @@ diligence against exactly this, and its record belongs in the tree.
 Commit as you go. An interrupted run should leave landed work, not a worktree
 full of uncommitted changes that the next pass cannot tell apart from its own.
 
+Never write `status: done`. That word is the gate's — a tool node writes it
+after the verdict went green, in a commit of its own. Write `status: blocked`
+with the reason committed when you must stop. A run interrupted after a
+self-written `done` relaunches as a green no-op, and the verifier refuses the
+word before it runs a single gate command.
+
 Write the reasoning where a human will find it — in the commit message and, for
 anything longer, in a file you commit. A status field in a control-plane
 message is read by a machine that does not care, and by no one else.

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -74,9 +74,11 @@ bank taken before the verdict can never carry a completion nobody proved. A
 command; revert the line and let the gate decide.
 
 An explicit launch (`only_lot`) on a lot that cannot be carried out — already
-`done` or `blocked`, undeclared, or waiting on a dependency — is refused,
-typed (`LOT_NOT_ACTIONABLE`), never answered with a green no-op: a `finished`
-run that crossed no gate reads as convergence to whoever relaunched it.
+`done` or `blocked`, undeclared, waiting on a dependency, or declaring no
+`exit_gate` — is a typed verdict the graph reads (`lot_not_actionable`,
+`lot_status`: done / blocked / absent / waiting / no_gate) and the run fails on
+it, never a green no-op: a `finished` run that crossed no gate reads as
+convergence to whoever relaunched it.
 
 ## `exit_gate`
 

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -24,7 +24,7 @@ oracle:
 lots:
   - id: L1
     title: "one line, in the imperative"
-    status: todo                 # todo | blocked | done
+    status: todo                 # todo | blocked (worker) | done (the gate only)
     rebaseline_allowed: false
     crosses_major: false         # true -> the upgrade-archetypes sweep is due
     depends_on: []
@@ -61,6 +61,20 @@ This is not distrust of any particular agent. It is that a self-reported status
 and a verified one are different kinds of claim, and a programme that conflates
 them will, sooner or later, report a milestone that never happened. The field
 is a bookmark, not evidence.
+
+And the two words it can carry are not the worker's to write alike. `blocked`
+is yours: it had to be committed to be said, and a claim of failure cannot
+cheat its way to green. `done` is the gate's: the `mark_done` node writes it
+after the verdict went green, one line, in a commit of its own — so a landing
+has exactly one commit to check for "what did the programme accept", and a
+bank taken before the verdict can never carry a completion nobody proved. A
+`done` you wrote is refused by the verifier before it runs a single gate
+command; revert the line and let the gate decide.
+
+An explicit launch (`only_lot`) on a lot that cannot be carried out — already
+`done` or `blocked`, undeclared, or waiting on a dependency — is refused,
+typed (`LOT_NOT_ACTIONABLE`), never answered with a green no-op: a `finished`
+run that crossed no gate reads as convergence to whoever relaunched it.
 
 ## `exit_gate`
 

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -168,22 +168,34 @@ prove the sweep missed nothing it watches. A sweep record that says "class not
 instantiated in this stack, because X" is a legitimate record; an absent one is
 a lot that skipped a due diligence its own contract named.
 
+## The shape of a lot block is part of the contract
+
+A lot is a list item whose FIRST line is `- id: <id>` and whose `status:` key
+sits at the item's key column (the column right after `- `). The gate edits
+exactly one line when a lot converges — the status — by anchoring on that
+shape; a lot written as a flow mapping (`- {id: L1, …}`), or with `id:` below
+another key, cannot be edited by it. `plan_read` refuses such a lot as
+`LOT_UNEDITABLE` before any token is spent, never after the gate.
+
 ## `gate_timeout_s`
 
 The wall each gate command gets — every `exit_gate` entry and the oracle
 replay, one command at a time. Read from the contract **at the run's base**
 (a lot cannot move its own wall): on the lot first, else at the top level,
 else 3600 s. An integer number of seconds between 1 and 86400; anything else
-is a `CONTRACT_UNREADABLE` refusal before any command runs. On a lot it is a
-normative field: a worker who adds or changes it has rewritten the contract.
+is a `CONTRACT_UNREADABLE` refusal before any command runs. It is normative
+wherever it sits — on a lot or at the top level, like `oracle`: a worker who
+adds or changes it has rewritten the contract (the next run reads its wall from
+its base, which is this tree once landed).
 
 An expiry is a **verdict**, not a tool error: the report carries
-`gate_timed_out: true`, `lot_blocked: true` and a `block_reason` beginning
-`GATE_TIMEOUT:` naming the command, the wall and the time spent; the run stops
-non-converged with its work banked. A wall the next pass would hit again is a
-finding about the wall, not a reason to pay four passes for it — raise it here
-when the gate legitimately needs the time (a full oracle replay over ~150
-mutants can take an hour), or shorten the gate.
+`gate_timed_out: true` and a `block_reason` beginning `GATE_TIMEOUT:` naming
+the command, the wall and the time spent, and the run ends at `fail` on the
+first occurrence, its work banked — no repair pass replays an hour against the
+same wall, and no `finished` invites a relaunch into it. A wall the next pass
+would hit again is a finding about the wall: raise it here when the gate
+legitimately needs the time (a full oracle replay over ~150 mutants can take an
+hour), or shorten the gate, then relaunch.
 
 ```yaml
 gate_timeout_s: 7200        # top level: every lot of the programme

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -21,6 +21,8 @@ oracle:
   refs_dir: .golden-master/refs  # references — off-limits to this bot
   verify: .golden-master/verify-oracle.sh
 
+gate_timeout_s: 3600             # wall per gate command (optional; a lot may carry its own)
+
 lots:
   - id: L1
     title: "one line, in the imperative"
@@ -165,6 +167,30 @@ judges what it says, and the behavioural net remains the only party that can
 prove the sweep missed nothing it watches. A sweep record that says "class not
 instantiated in this stack, because X" is a legitimate record; an absent one is
 a lot that skipped a due diligence its own contract named.
+
+## `gate_timeout_s`
+
+The wall each gate command gets — every `exit_gate` entry and the oracle
+replay, one command at a time. Read from the contract **at the run's base**
+(a lot cannot move its own wall): on the lot first, else at the top level,
+else 3600 s. An integer number of seconds between 1 and 86400; anything else
+is a `CONTRACT_UNREADABLE` refusal before any command runs. On a lot it is a
+normative field: a worker who adds or changes it has rewritten the contract.
+
+An expiry is a **verdict**, not a tool error: the report carries
+`gate_timed_out: true`, `lot_blocked: true` and a `block_reason` beginning
+`GATE_TIMEOUT:` naming the command, the wall and the time spent; the run stops
+non-converged with its work banked. A wall the next pass would hit again is a
+finding about the wall, not a reason to pay four passes for it — raise it here
+when the gate legitimately needs the time (a full oracle replay over ~150
+mutants can take an hour), or shorten the gate.
+
+```yaml
+gate_timeout_s: 7200        # top level: every lot of the programme
+lots:
+  - id: L21
+    gate_timeout_s: 10800   # this lot's own wall
+```
 
 ## Re-anchoring a mutant is the NET's act, and this bot delegates it
 

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -125,11 +125,11 @@ lots:
 	const gate = "sh -c 'echo ran > gate.marker'"
 
 	t.Run("worker wrote done: refused before the gate runs", func(t *testing.T) {
-		ws, base, git := modernizeRepo(t, plan)
+		ws, _, git := modernizeRepo(t, plan)
 		modernizeNet(t, ws)
 		git("add", ".golden-master")
 		git("commit", "-qm", "net")
-		base = git("rev-parse", "HEAD")
+		base := git("rev-parse", "HEAD")
 		flipped := strings.Replace(plan, "status: todo", "status: done", 1)
 		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(flipped), 0o644); err != nil {
 			t.Fatal(err)

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -53,6 +53,18 @@ else:
 
 func modernizeLotVerify(t *testing.T, script, ws, lotID, base, exitGate string) modernizeLotVerifyOut {
 	t.Helper()
+	res, exit := modernizeLotVerifyEnv(t, script, ws, lotID, base, exitGate, nil)
+	if exit != 0 {
+		t.Fatalf("lot_verify exited %d, want a verdict (out %+v)", exit, res)
+	}
+	return res
+}
+
+// modernizeLotVerifyEnv runs lot_verify with an optional environment override
+// and returns the parsed report plus the exit code (1 = typed refusal, the
+// contract could not be read).
+func modernizeLotVerifyEnv(t *testing.T, script, ws, lotID, base, exitGate string, env []string) (modernizeLotVerifyOut, int) {
+	t.Helper()
 	body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
 	body = strings.ReplaceAll(body, "{{input.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
 	body = strings.ReplaceAll(body, "{{input.lot_id}}", strconv.Quote(lotID))
@@ -66,15 +78,24 @@ func modernizeLotVerify(t *testing.T, script, ws, lotID, base, exitGate string) 
 	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	out, err := exec.Command("python3", scriptPath).Output()
+	cmd := exec.Command("python3", scriptPath)
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.Output()
+	exit := 0
 	if err != nil {
-		t.Fatalf("lot_verify failed: %v (out %q)", err, out)
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("lot_verify failed to execute: %v (out %q)", err, out)
+		}
+		exit = ee.ExitCode()
 	}
 	var res modernizeLotVerifyOut
 	if uerr := json.Unmarshal(out, &res); uerr != nil {
 		t.Fatalf("lot_verify output is not JSON: %v (out %q)", uerr, out)
 	}
-	return res
+	return res, exit
 }
 
 // TestModernizeLotVerifyRefusesWorkerWrittenDone pins the asymmetry in how
@@ -88,11 +109,7 @@ func modernizeLotVerify(t *testing.T, script, ws, lotID, base, exitGate string) 
 // into a relaunch, which finished green at zero minutes having proven
 // nothing (measured, four times in 24 h on a live campaign).
 func TestModernizeLotVerifyRefusesWorkerWrittenDone(t *testing.T) {
-	for _, tool := range []string{"python3", "git", "yq"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not on PATH", tool)
-		}
-	}
+	requireModernizeTools(t)
 	script := toolScript(t, "modernize/main.bot", "lot_verify")
 	const plan = `version: 1
 oracle:
@@ -189,11 +206,7 @@ lots:
 // status moved is refused BEFORE any gate command runs, with the rewrites
 // named. Adding a lot is a proposal, not a rewrite, and passes.
 func TestModernizeLotVerifyRefusesContractRewrite(t *testing.T) {
-	for _, tool := range []string{"python3", "git", "yq"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not on PATH", tool)
-		}
-	}
+	requireModernizeTools(t)
 	script := toolScript(t, "modernize/main.bot", "lot_verify")
 	const plan = `version: 1
 oracle:
@@ -284,11 +297,135 @@ lots:
 	})
 	t.Run("scalar and list gates with the same command are the same gate", func(t *testing.T) {
 		ws, base, git := setup(t)
-		rewrite(t, ws, "    exit_gate:\n      - \"true\"\n", "    exit_gate: \"true\"\n")
+		rewrite(t, ws, "    depends_on: [L1]\n    exit_gate:\n      - \"true\"\n", "    depends_on: [L1]\n    exit_gate: \"true\"\n")
 		git("commit", "-qam", "reformat L2 gate")
 		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
 		if len(res.ContractRewrite) != 0 {
 			t.Fatalf("a reformatted, unchanged gate was flagged: %v", res.ContractRewrite)
+		}
+	})
+}
+
+// TestModernizeLotVerifyReadsTheContractOrRefuses pins the adversarial
+// finding that turned both guards into a silent no-op: lot_verify called `yq`
+// on the bare PATH and swallowed its absence, so a worker-written `done` and
+// an amputated gate converged green with an empty log_tail. The verifier now
+// finds yq where plan_read and mark_done do — the target's devbox profile —
+// and REFUSES, typed, when it cannot read the contract at all.
+func TestModernizeLotVerifyReadsTheContractOrRefuses(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	const gate = "sh -c 'echo ran > gate.marker'"
+	selfWrittenDone := func(t *testing.T) (string, string, func(args ...string) string) {
+		t.Helper()
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(strings.Replace(plan, "status: todo", "status: done", 1)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "worker writes done")
+		return ws, base, git
+	}
+	yqPath, _ := exec.LookPath("yq")
+
+	t.Run("yq off PATH but in the target's devbox profile: the guard still fires", func(t *testing.T) {
+		ws, base, _ := selfWrittenDone(t)
+		profile := filepath.Join(ws, ".devbox", "nix", "profile", "default", "bin")
+		if err := os.MkdirAll(profile, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(yqPath, filepath.Join(profile, "yq")); err != nil {
+			t.Fatal(err)
+		}
+		env := append(os.Environ(), "PATH="+restrictedPATH(t, "python3", "git", "sh"))
+		res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, gate, env)
+		if exit != 0 || !res.DoneSelfWritten {
+			t.Fatalf("exit=%d done_self_written=%v — with yq only in the devbox profile the guard must still fire (%s)", exit, res.DoneSelfWritten, res.LogTail)
+		}
+		if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err == nil {
+			t.Fatalf("the exit_gate ran: the refusal must come first")
+		}
+	})
+
+	t.Run("no yq anywhere: refused, typed — never a verdict that skipped its checks", func(t *testing.T) {
+		ws, base, _ := selfWrittenDone(t)
+		env := append(os.Environ(), "PATH="+restrictedPATH(t, "python3", "git", "sh"))
+		res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, gate, env)
+		if exit != 1 {
+			t.Fatalf("exit=%d, want 1 (typed refusal) — report %+v", exit, res)
+		}
+		if !strings.HasPrefix(res.LogTail, "CONTRACT_UNREADABLE") {
+			t.Fatalf("log_tail = %q, want CONTRACT_UNREADABLE", res.LogTail)
+		}
+		if res.GatePassed || res.OraclePassed || res.RefsUntouched {
+			t.Fatalf("a refusal must leave every conjunct false: %+v", res)
+		}
+	})
+
+	t.Run("contract not committed at base: refused, typed", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("rm", "-q", "--cached", ".modernize/plan.yaml")
+		git("commit", "-qm", "net, and the contract dropped from the tree")
+		base := git("rev-parse", "HEAD")
+		// the contract exists only in the working tree, never at base
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(plan), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, gate, nil)
+		if exit != 1 || !strings.Contains(res.LogTail, "not committed at the run's base") {
+			t.Fatalf("exit=%d log_tail=%q, want a typed refusal naming the uncommitted contract", exit, res.LogTail)
+		}
+	})
+
+	t.Run("blocked AND rewritten: the rewrite wins, the run does not stop", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan+"  - id: L2\n    title: next\n    status: todo\n    exit_gate: [ \"true\" ]\n")
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		rewritten := strings.Replace(plan, "status: todo", "status: blocked", 1) + "  - id: L2\n    title: next\n    status: done\n    exit_gate: [ \"true\" ]\n"
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(rewritten), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "L1 blocked, and L2 quietly done")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if len(res.ContractRewrite) == 0 || !strings.Contains(strings.Join(res.ContractRewrite, "|"), "L2.status moved") {
+			t.Fatalf("contract_rewritten = %v, want L2's move named", res.ContractRewrite)
+		}
+		if res.LotBlocked {
+			t.Fatalf("lot_blocked stayed true on a rewritten contract: lot_gate.stop would end the run with the rewrite landed")
+		}
+	})
+
+	t.Run("a homonym lot added ahead: named as a duplicate, refused", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		homonym := strings.Replace(plan, "lots:\n", "lots:\n  - id: L1\n    title: impostor\n    status: todo\n    exit_gate: [ \"true\" ]\n", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(homonym), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "a second L1")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !strings.Contains(strings.Join(res.ContractRewrite, "|"), "duplicate lot id L1") {
+			t.Fatalf("contract_rewritten = %v, want the duplicate named", res.ContractRewrite)
 		}
 	})
 }

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -534,8 +534,8 @@ lots:
 	t.Run("the oracle outlives the wall: a GATE_TIMEOUT verdict, not an exception", func(t *testing.T) {
 		ws, base, _ := netAndBase(t, plan, "#!/bin/sh\nsleep 3\nexit 0\n")
 		res := modernizeLotVerify(t, script, ws, "L1", base, "true")
-		if !res.GateTimedOut || !res.LotBlocked || !strings.HasPrefix(res.BlockReason, "GATE_TIMEOUT:") {
-			t.Fatalf("expiry not read as the GATE_TIMEOUT stop: %+v", res)
+		if !res.GateTimedOut || res.LotBlocked || !strings.HasPrefix(res.BlockReason, "GATE_TIMEOUT:") {
+			t.Fatalf("expiry not read as the GATE_TIMEOUT verdict (gate_timed_out, NOT a worker-declared block): %+v", res)
 		}
 		if !res.GatePassed || res.OraclePassed {
 			t.Fatalf("the exit gate ran green and the oracle never answered — want gate_passed=true oracle_passed=false, got %+v", res)
@@ -549,20 +549,25 @@ lots:
 		lotPlan = strings.Replace(lotPlan, "    status: todo\n", "    status: todo\n    gate_timeout_s: 1\n", 1)
 		ws, base, _ := netAndBase(t, lotPlan, "")
 		res := modernizeLotVerify(t, script, ws, "L1", base, "sleep 3")
-		if !res.GateTimedOut || res.GatePassed || !res.LotBlocked {
+		if !res.GateTimedOut || res.GatePassed || res.LotBlocked {
 			t.Fatalf("the lot's 1 s wall did not stop a 3 s exit_gate: %+v", res)
 		}
 	})
-	t.Run("the wall is read at the BASE: raising it in the tree changes nothing", func(t *testing.T) {
+	t.Run("a TOP-LEVEL wall the worker moved is a contract rewrite", func(t *testing.T) {
+		// The next run reads its wall from its base, which is this tree once
+		// landed: one committed line would disarm the wall for the rest of
+		// the programme (review finding, executed with 3600 -> 1).
 		ws, base, git := netAndBase(t, plan, "")
-		raised := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: 7200\n", 1)
-		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(raised), 0o644); err != nil {
+		moved := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: 86400\n", 1)
+		moved = strings.Replace(moved, "  refs_dir: .golden-master/refs\n", "  refs_dir: .elsewhere/refs\n", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(moved), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		git("commit", "-qam", "raise the wall")
-		res := modernizeLotVerify(t, script, ws, "L1", base, "sleep 3")
-		if !res.GateTimedOut {
-			t.Fatalf("the base's wall (1 s) must bind, not the tree's (7200): %+v", res)
+		git("commit", "-qam", "move the wall and the net")
+		res := modernizeLotVerify(t, script, ws, "L1", base, "true")
+		joined := strings.Join(res.ContractRewrite, "\n")
+		if !strings.Contains(joined, "top-level gate_timeout_s") || !strings.Contains(joined, "top-level oracle") {
+			t.Fatalf("top-level normative keys moved without a rewrite refusal: %+v", res)
 		}
 	})
 	t.Run("a lot-level wall the worker added is a contract rewrite", func(t *testing.T) {
@@ -616,5 +621,59 @@ lots:
 	}
 	if !strings.Contains(res.LogTail, "no net at the run's base") {
 		t.Fatalf("the verdict must say the net is absent at the base: %s", res.LogTail)
+	}
+}
+
+// TestModernizeLotVerifyDirtyNetVoidSurvives pins the refusal a dirty net
+// carries all the way to the verdict. The void was written into
+// refs_untouched when `git status` saw an uncommitted path under the net —
+// and the diff block below it REASSIGNED the same key from `git diff <base>`,
+// which cannot see an untracked file or an uncommitted edit to a ledger the
+// diff exempts. A dirty net converged and the gate committed `done` (review
+// finding, executed).
+func TestModernizeLotVerifyDirtyNetVoidSurvives(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	for _, tc := range []struct {
+		name string
+		mess func(ws string) error
+	}{
+		{"an uncommitted edit to the extension ledger (exempt from the diff)", func(ws string) error {
+			return os.WriteFile(filepath.Join(ws, ".golden-master", "EXTENSIONS.md"), []byte("# ledger\n- request: something\n"), 0o644)
+		}},
+		{"an untracked file dropped under the net", func(ws string) error {
+			return os.WriteFile(filepath.Join(ws, ".golden-master", "json.py"), []byte("# certifier hijack\n"), 0o644)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws, _, git := modernizeRepo(t, plan)
+			modernizeNet(t, ws)
+			if err := os.WriteFile(filepath.Join(ws, ".golden-master", "EXTENSIONS.md"), []byte("# ledger\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			git("add", ".golden-master")
+			git("commit", "-qm", "net")
+			base := git("rev-parse", "HEAD")
+			if err := tc.mess(ws); err != nil {
+				t.Fatal(err)
+			}
+			res := modernizeLotVerify(t, script, ws, "L1", base, "true")
+			if res.RefsUntouched {
+				t.Fatalf("refs_untouched=true on a dirty net — the void was overwritten by the diff's own result: %+v", res)
+			}
+			if !strings.Contains(res.LogTail, "uncommitted path") {
+				t.Fatalf("the verdict must name the dirty net: %s", res.LogTail)
+			}
+		})
 	}
 }

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -1,0 +1,294 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// modernizeLotVerifyOut is the subset of lot_verify's report the tests read.
+type modernizeLotVerifyOut struct {
+	GatePassed      bool     `json:"gate_passed"`
+	OraclePassed    bool     `json:"oracle_passed"`
+	RefsUntouched   bool     `json:"refs_untouched"`
+	LotBlocked      bool     `json:"lot_blocked"`
+	DoneSelfWritten bool     `json:"done_self_written"`
+	ContractRewrite []string `json:"contract_rewritten"`
+	LogTail         string   `json:"log_tail"`
+}
+
+// modernizeNet drops the smallest net lot_verify accepts into ws: a runner
+// that exits 0, a reference, and a harness stub answering the two extension
+// modes with empty verdicts — so the refs-immutability and extension
+// certification paths run for real without an application to boot.
+func modernizeNet(t *testing.T, ws string) {
+	t.Helper()
+	gm := filepath.Join(ws, ".golden-master")
+	if err := os.MkdirAll(filepath.Join(gm, "refs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"verify-oracle.sh": "#!/bin/sh\nexit 0\n",
+		"refs/001.txt":     "STATUS 200\n",
+		"harness.py": `import json, os, sys
+mode = os.environ.get("GM_MODE", "gate")
+if mode == "extend-verify":
+    print(json.dumps({"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`,
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(gm, name), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func modernizeLotVerify(t *testing.T, script, ws, lotID, base, exitGate string) modernizeLotVerifyOut {
+	t.Helper()
+	body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	body = strings.ReplaceAll(body, "{{input.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
+	body = strings.ReplaceAll(body, "{{input.lot_id}}", strconv.Quote(lotID))
+	body = strings.ReplaceAll(body, "{{input.base_sha}}", strconv.Quote(base))
+	body = strings.ReplaceAll(body, "{{input.refs_dir}}", strconv.Quote(".golden-master/refs"))
+	body = strings.ReplaceAll(body, "{{input.exit_gate}}", strconv.Quote(exitGate))
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in lot_verify near %q", body[i:min(i+40, len(body))])
+	}
+	scriptPath := filepath.Join(t.TempDir(), "lot_verify.py")
+	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", scriptPath).Output()
+	if err != nil {
+		t.Fatalf("lot_verify failed: %v (out %q)", err, out)
+	}
+	var res modernizeLotVerifyOut
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("lot_verify output is not JSON: %v (out %q)", uerr, out)
+	}
+	return res
+}
+
+// TestModernizeLotVerifyRefusesWorkerWrittenDone pins the asymmetry in how
+// the verifier believes the contract's status. `blocked` is a STOP the worker
+// may declare; `done` is the gate's word. A `done` the worker wrote is
+// refused BEFORE any gate command runs — the marker file proves the gate was
+// never reached — so the revert costs the worker seconds, never the hour a
+// full gate would spend confirming a verdict it had written for itself.
+//
+// The failure this guards: a bank taken after such a write carried `done`
+// into a relaunch, which finished green at zero minutes having proven
+// nothing (measured, four times in 24 h on a live campaign).
+func TestModernizeLotVerifyRefusesWorkerWrittenDone(t *testing.T) {
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	// The gate leaves a marker when it runs: its absence proves fail-fast.
+	const gate = "sh -c 'echo ran > gate.marker'"
+
+	t.Run("worker wrote done: refused before the gate runs", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base = git("rev-parse", "HEAD")
+		flipped := strings.Replace(plan, "status: todo", "status: done", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(flipped), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "chore(plan): L1 done — written by the worker")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.DoneSelfWritten {
+			t.Fatalf("done_self_written=false on a worker-written done (%s)", res.LogTail)
+		}
+		if res.GatePassed || res.OraclePassed || res.RefsUntouched {
+			t.Fatalf("a refused verdict must be red on every conjunct: %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "gate's word") || !strings.Contains(res.LogTail, "Revert that status line") {
+			t.Fatalf("log_tail = %q, want the cause and the way out named", res.LogTail)
+		}
+		if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err == nil {
+			t.Fatalf("the exit_gate ran: a worker-written done must be refused before any gate command")
+		}
+	})
+
+	t.Run("status untouched: the gate runs and the lot converges", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if res.DoneSelfWritten {
+			t.Fatalf("done_self_written=true on an untouched status (%s)", res.LogTail)
+		}
+		if !res.GatePassed || !res.OraclePassed || !res.RefsUntouched {
+			t.Fatalf("expected a green verdict on a clean tree, got %+v", res)
+		}
+		if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err != nil {
+			t.Fatalf("the exit_gate never ran on the happy path")
+		}
+	})
+
+	t.Run("done already at base is not the worker's word", func(t *testing.T) {
+		// A lot done at base is never selected by plan_read; if a verifier is
+		// nevertheless pointed at it, the status is the base's, not a
+		// self-report, and the verdict is taken on the tree.
+		ws, _, git := modernizeRepo(t, strings.Replace(plan, "status: todo", "status: done", 1))
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if res.DoneSelfWritten {
+			t.Fatalf("a done inherited from base was flagged as self-written")
+		}
+	})
+
+	t.Run("blocked is believed as a stop", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(strings.Replace(plan, "status: todo", "status: blocked", 1)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "L1 blocked, reason committed")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.LotBlocked || res.DoneSelfWritten {
+			t.Fatalf("blocked=%v self_written=%v, want the stop believed and no refusal", res.LotBlocked, res.DoneSelfWritten)
+		}
+	})
+}
+
+// TestModernizeLotVerifyRefusesContractRewrite pins the contract's read-only
+// rule inside a lot, enforced in git rather than asked nicely: an existing
+// lot's gate, intent or dependencies changed, a lot dropped, or another lot's
+// status moved is refused BEFORE any gate command runs, with the rewrites
+// named. Adding a lot is a proposal, not a rewrite, and passes.
+func TestModernizeLotVerifyRefusesContractRewrite(t *testing.T) {
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+      - "test -f build.gradle"
+  - id: L2
+    title: "raise the runtime"
+    status: todo
+    depends_on: [L1]
+    exit_gate:
+      - "true"
+`
+	const gate = "sh -c 'echo ran > gate.marker'"
+	setup := func(t *testing.T) (string, string, func(args ...string) string) {
+		t.Helper()
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		if err := os.WriteFile(filepath.Join(ws, "build.gradle"), []byte("// build\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("add", ".")
+		git("commit", "-qm", "net + build")
+		return ws, git("rev-parse", "HEAD"), git
+	}
+	rewrite := func(t *testing.T, ws string, from, to string) {
+		t.Helper()
+		if !strings.Contains(plan, from) {
+			t.Fatalf("fixture has no %q", from)
+		}
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(strings.Replace(plan, from, to, 1)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	refusedBeforeGate := func(t *testing.T, ws string, res modernizeLotVerifyOut, want string) {
+		t.Helper()
+		if len(res.ContractRewrite) == 0 || !strings.Contains(strings.Join(res.ContractRewrite, "|"), want) {
+			t.Fatalf("contract_rewritten = %v, want %q named (%s)", res.ContractRewrite, want, res.LogTail)
+		}
+		if res.GatePassed || res.OraclePassed || res.RefsUntouched {
+			t.Fatalf("a refused verdict must be red on every conjunct: %+v", res)
+		}
+		if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err == nil {
+			t.Fatalf("the exit_gate ran: a rewritten contract must be refused before any gate command")
+		}
+	}
+
+	t.Run("own gate loosened: refused, gate never ran", func(t *testing.T) {
+		ws, base, git := setup(t)
+		rewrite(t, ws, "      - \"test -f build.gradle\"\n", "")
+		git("commit", "-qam", "drop a gate command")
+		refusedBeforeGate(t, ws, modernizeLotVerify(t, script, ws, "L1", base, gate), "L1.exit_gate changed")
+	})
+	t.Run("another lot's status moved: refused", func(t *testing.T) {
+		ws, base, _ := setup(t)
+		rewrite(t, ws, "    status: todo\n    depends_on: [L1]", "    status: done\n    depends_on: [L1]")
+		// uncommitted on purpose: the tree the gate judges is what is read
+		refusedBeforeGate(t, ws, modernizeLotVerify(t, script, ws, "L1", base, gate), "L2.status moved")
+	})
+	t.Run("a lot removed: refused", func(t *testing.T) {
+		ws, base, git := setup(t)
+		short := plan[:strings.Index(plan, "  - id: L2")]
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(short), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "drop L2")
+		refusedBeforeGate(t, ws, modernizeLotVerify(t, script, ws, "L1", base, gate), "lot L2 was REMOVED")
+	})
+	t.Run("a lot added: a proposal, not a rewrite — the gate runs", func(t *testing.T) {
+		ws, base, git := setup(t)
+		added := plan + "  - id: L3\n    title: \"pin the locale\"\n    status: todo\n    exit_gate: [ \"true\" ]\n"
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(added), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "propose L3")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if len(res.ContractRewrite) != 0 || res.DoneSelfWritten {
+			t.Fatalf("an added lot was flagged: %v", res.ContractRewrite)
+		}
+		if !res.GatePassed || !res.OraclePassed || !res.RefsUntouched {
+			t.Fatalf("expected a green verdict, got %+v", res)
+		}
+	})
+	t.Run("scalar and list gates with the same command are the same gate", func(t *testing.T) {
+		ws, base, git := setup(t)
+		rewrite(t, ws, "    exit_gate:\n      - \"true\"\n", "    exit_gate: \"true\"\n")
+		git("commit", "-qam", "reformat L2 gate")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if len(res.ContractRewrite) != 0 {
+			t.Fatalf("a reformatted, unchanged gate was flagged: %v", res.ContractRewrite)
+		}
+	})
+}

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -429,3 +429,65 @@ lots:
 		}
 	})
 }
+
+// TestModernizeLotVerifyOlderNetIsNotRefused pins the pre-extension
+// behaviour for a net materialised before the extension feature: no
+// `extend-verify` mode means no certificate and no exemption — never "the
+// certifier returned no usable verdict", which refused every lot on every
+// older net. A certifier that EXISTS and cannot answer stays a refusal.
+func TestModernizeLotVerifyOlderNetIsNotRefused(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	const gate = "sh -c 'echo ran > gate.marker'"
+	setup := func(t *testing.T, harness string) (string, string) {
+		t.Helper()
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		hp := filepath.Join(ws, ".golden-master", "harness.py")
+		if harness == "" {
+			if err := os.Remove(hp); err != nil {
+				t.Fatal(err)
+			}
+		} else if err := os.WriteFile(hp, []byte(harness), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		git("add", "-A", ".golden-master")
+		git("commit", "-qm", "net")
+		return ws, git("rev-parse", "HEAD")
+	}
+
+	t.Run("no harness at all: the references are judged in git, nothing is refused", func(t *testing.T) {
+		ws, base := setup(t, "")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.GatePassed || !res.OraclePassed || !res.RefsUntouched {
+			t.Fatalf("an older net without a harness must not be refused: %+v", res)
+		}
+		if strings.Contains(res.LogTail, "no usable verdict") {
+			t.Fatalf("log_tail carries the certifier refusal on a net that has no certifier: %q", res.LogTail)
+		}
+	})
+	t.Run("a harness without the extend-verify mode: same, the older net's legal state", func(t *testing.T) {
+		ws, base := setup(t, "import json\nprint(json.dumps({\"mode\": \"gate\"}))\n")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.RefsUntouched || strings.Contains(res.LogTail, "no usable verdict") {
+			t.Fatalf("older-net harness refused: %+v", res)
+		}
+	})
+	t.Run("a certifier that exists and answers garbage is still a refusal", func(t *testing.T) {
+		ws, base := setup(t, "import os\nmode = os.environ.get(\"GM_MODE\")\nif mode == \"extend-verify\":\n    print(\"not json at all\")\nelse:\n    print(\"{}\")\n")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if res.RefsUntouched || !strings.Contains(res.LogTail, "no usable verdict") {
+			t.Fatalf("a mute certifier must refuse: %+v", res)
+		}
+	})
+}

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -18,6 +18,8 @@ type modernizeLotVerifyOut struct {
 	LotBlocked      bool     `json:"lot_blocked"`
 	DoneSelfWritten bool     `json:"done_self_written"`
 	ContractRewrite []string `json:"contract_rewritten"`
+	GateTimedOut    bool     `json:"gate_timed_out"`
+	BlockReason     string   `json:"block_reason"`
 	LogTail         string   `json:"log_tail"`
 }
 
@@ -490,4 +492,129 @@ lots:
 			t.Fatalf("a mute certifier must refuse: %+v", res)
 		}
 	})
+}
+
+// TestModernizeLotVerifyGateTimeoutIsAVerdict pins the wall each gate command
+// gets. Measured on a live campaign: a target whose full oracle gate replays
+// ~150 mutants in ~58 min hit the fixed 3600 s subprocess timeout at 3646 s —
+// a Python exception, which the engine read as a tool error, retried ONCE (the
+// same hour, replayed) and then left `failed_resumable` with no verdict line
+// to read. The wall is now the contract's (`gate_timeout_s`, lot over top
+// level, read at the BASE), and an expiry is a verdict: `gate_timed_out`,
+// `lot_blocked`, a GATE_TIMEOUT block_reason — the run stops with its work
+// banked instead of paying four passes against the same wall.
+func TestModernizeLotVerifyGateTimeoutIsAVerdict(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+gate_timeout_s: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	netAndBase := func(t *testing.T, planYAML, oracle string) (string, string, func(args ...string) string) {
+		t.Helper()
+		ws, _, git := modernizeRepo(t, planYAML)
+		modernizeNet(t, ws)
+		if oracle != "" {
+			if err := os.WriteFile(filepath.Join(ws, ".golden-master", "verify-oracle.sh"), []byte(oracle), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		git("add", ".golden-master")
+		git("commit", "-qm", "net")
+		return ws, git("rev-parse", "HEAD"), git
+	}
+
+	t.Run("the oracle outlives the wall: a GATE_TIMEOUT verdict, not an exception", func(t *testing.T) {
+		ws, base, _ := netAndBase(t, plan, "#!/bin/sh\nsleep 3\nexit 0\n")
+		res := modernizeLotVerify(t, script, ws, "L1", base, "true")
+		if !res.GateTimedOut || !res.LotBlocked || !strings.HasPrefix(res.BlockReason, "GATE_TIMEOUT:") {
+			t.Fatalf("expiry not read as the GATE_TIMEOUT stop: %+v", res)
+		}
+		if !res.GatePassed || res.OraclePassed {
+			t.Fatalf("the exit gate ran green and the oracle never answered — want gate_passed=true oracle_passed=false, got %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "gate_timeout_s=1") {
+			t.Fatalf("the verdict must name the wall it hit: %s", res.LogTail)
+		}
+	})
+	t.Run("the lot's own wall beats the top level, and an exit_gate command is stopped by it", func(t *testing.T) {
+		lotPlan := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: 3600\n", 1)
+		lotPlan = strings.Replace(lotPlan, "    status: todo\n", "    status: todo\n    gate_timeout_s: 1\n", 1)
+		ws, base, _ := netAndBase(t, lotPlan, "")
+		res := modernizeLotVerify(t, script, ws, "L1", base, "sleep 3")
+		if !res.GateTimedOut || res.GatePassed || !res.LotBlocked {
+			t.Fatalf("the lot's 1 s wall did not stop a 3 s exit_gate: %+v", res)
+		}
+	})
+	t.Run("the wall is read at the BASE: raising it in the tree changes nothing", func(t *testing.T) {
+		ws, base, git := netAndBase(t, plan, "")
+		raised := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: 7200\n", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(raised), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "raise the wall")
+		res := modernizeLotVerify(t, script, ws, "L1", base, "sleep 3")
+		if !res.GateTimedOut {
+			t.Fatalf("the base's wall (1 s) must bind, not the tree's (7200): %+v", res)
+		}
+	})
+	t.Run("a lot-level wall the worker added is a contract rewrite", func(t *testing.T) {
+		ws, base, git := netAndBase(t, plan, "")
+		moved := strings.Replace(plan, "    status: todo\n", "    status: todo\n    gate_timeout_s: 7200\n", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(moved), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "move the wall")
+		res := modernizeLotVerify(t, script, ws, "L1", base, "true")
+		if !strings.Contains(strings.Join(res.ContractRewrite, "\n"), "gate_timeout_s") {
+			t.Fatalf("a worker-added gate_timeout_s on the lot must read as a rewrite: %+v", res)
+		}
+	})
+	for _, bad := range []string{"soon", "0", "86401", "true", `"7200"`} {
+		t.Run("unreadable wall "+bad+" is refused before any command", func(t *testing.T) {
+			badPlan := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: "+bad+"\n", 1)
+			ws, base, _ := netAndBase(t, badPlan, "")
+			res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, "sh -c 'echo ran > gate.marker'", nil)
+			if exit != 1 || !strings.Contains(res.LogTail, "CONTRACT_UNREADABLE") || !strings.Contains(res.LogTail, "gate_timeout_s") {
+				t.Fatalf("exit %d, log %q — want the typed refusal naming gate_timeout_s", exit, res.LogTail)
+			}
+			if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err == nil {
+				t.Fatal("the gate ran under a wall the node could not read")
+			}
+		})
+	}
+}
+
+// TestModernizeLotVerifyRefsNeedANetAtBase: `refs_untouched` over a net that
+// does not exist at the run's base would be true by absence — nothing was
+// there to touch — which is not a term. The absent oracle already reads red;
+// this keeps the second conjunct honest on its own.
+func TestModernizeLotVerifyRefsNeedANetAtBase(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	ws, base, _ := modernizeRepo(t, plan) // the base carries NO net
+	res := modernizeLotVerify(t, script, ws, "L1", base, "true")
+	if res.RefsUntouched {
+		t.Fatalf("refs_untouched=true over an absent net — true by absence: %+v", res)
+	}
+	if !strings.Contains(res.LogTail, "no net at the run's base") {
+		t.Fatalf("the verdict must say the net is absent at the base: %s", res.LogTail)
+	}
 }

--- a/bots/modernize_mark_done_test.go
+++ b/bots/modernize_mark_done_test.go
@@ -148,6 +148,39 @@ lots:
 		}
 	})
 
+	t.Run("an interrupted attempt — done in the tree, not at HEAD — is committed, not skipped", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		written := strings.Replace(plan, "status: todo   # a bookmark, never evidence", "status: done   # a bookmark, never evidence", 1)
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(written), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if !res.Marked || res.Commit == "" {
+			t.Fatalf("marked=%v commit=%q — idempotence judged in the working tree skipped the commit the gate owes (%s)", res.Marked, res.Commit, res.Notice)
+		}
+		if head := git("rev-parse", "HEAD"); head == base || head != res.Commit {
+			t.Fatalf("HEAD=%s base=%s reported=%s, want the done commit at HEAD", head, base, res.Commit)
+		}
+		if dirty := git("status", "--porcelain"); dirty != "" {
+			t.Fatalf("the tree must be clean after the commit, got %q", dirty)
+		}
+	})
+
+	t.Run("a rejecting pre-commit hook does not stop the gate's commit", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		hooks := filepath.Join(ws, ".git", "hooks")
+		if err := os.MkdirAll(hooks, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(hooks, "pre-commit"), []byte("#!/bin/sh\necho rejected >&2\nexit 1\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if !res.Marked || git("rev-parse", "HEAD") != res.Commit {
+			t.Fatalf("the gate's bookkeeping commit must bypass the target's hooks: %+v", res)
+		}
+	})
+
 	t.Run("undeclared lot is refused", func(t *testing.T) {
 		ws, base, git := modernizeRepo(t, plan)
 		res := modernizeMarkDone(t, script, ws, "L9", base, 1)

--- a/bots/modernize_mark_done_test.go
+++ b/bots/modernize_mark_done_test.go
@@ -89,11 +89,7 @@ func modernizeMarkDone(t *testing.T, script, ws, lotID, base string, wantExit in
 // this node is the only place the programme's "accepted" ever gets written,
 // and a landing has exactly one commit to check for it.
 func TestModernizeMarkDone(t *testing.T) {
-	for _, tool := range []string{"python3", "git", "yq"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not on PATH", tool)
-		}
-	}
+	requireModernizeTools(t)
 	script := toolScript(t, "modernize/main.bot", "mark_done")
 	const plan = `version: 1
 # the programme, as a human wrote it
@@ -175,4 +171,44 @@ lots:
 			t.Fatalf("a refused edit must leave the contract byte-identical")
 		}
 	})
+}
+
+// TestModernizeMarkDoneAnchorsOnIndentation pins the editor against the two
+// look-alikes an intent can carry: a `status:` line and a `- id:` line written
+// INSIDE an `intent: |` block scalar. Both sit deeper than the item's key
+// column, so neither is the key the gate flips nor the boundary of the block.
+func TestModernizeMarkDoneAnchorsOnIndentation(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "mark_done")
+	const plan = `version: 1
+lots:
+  -   id: L1
+      title: "wide dash"
+      intent: |
+        the previous line said
+        status: done
+        - id: L9
+        but that is prose, not a key
+      status: todo
+      exit_gate:
+        - "true"
+  -   id: L2
+      title: "next"
+      status: todo
+      exit_gate:
+        - "true"
+`
+	ws, base, git := modernizeRepo(t, plan)
+	res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+	if !res.Marked {
+		t.Fatalf("not marked: %s", res.Notice)
+	}
+	got, _ := os.ReadFile(filepath.Join(ws, ".modernize", "plan.yaml"))
+	want := strings.Replace(plan, "      status: todo\n      exit_gate:\n        - \"true\"\n  -   id: L2", "      status: done\n      exit_gate:\n        - \"true\"\n  -   id: L2", 1)
+	if string(got) != want {
+		t.Fatalf("the wrong line was edited:\n%s", got)
+	}
+	if subj := git("log", "-1", "--format=%s"); !strings.HasPrefix(subj, "L1: done") {
+		t.Fatalf("commit subject = %q", subj)
+	}
 }

--- a/bots/modernize_mark_done_test.go
+++ b/bots/modernize_mark_done_test.go
@@ -1,0 +1,178 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// modernizeMarkDoneOut is the subset of mark_done's output the tests read.
+type modernizeMarkDoneOut struct {
+	Marked bool   `json:"marked"`
+	Commit string `json:"commit"`
+	Notice string `json:"notice"`
+}
+
+// modernizeRepo builds a throwaway git repository carrying one committed
+// contract and returns its path, the base commit, and a git runner bound to
+// it. Shared by the mark_done and lot_verify tests.
+func modernizeRepo(t *testing.T, planYAML string) (string, string, func(args ...string) string) {
+	t.Helper()
+	ws := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", ws}, args...)
+		cmd := exec.Command("git", full...)
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	if err := os.MkdirAll(filepath.Join(ws, ".modernize"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(planYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".modernize/plan.yaml")
+	git("commit", "-qm", "contract")
+	return ws, git("rev-parse", "HEAD"), git
+}
+
+func modernizeMarkDone(t *testing.T, script, ws, lotID, base string, wantExit int) modernizeMarkDoneOut {
+	t.Helper()
+	body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	body = strings.ReplaceAll(body, "{{input.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
+	body = strings.ReplaceAll(body, "{{input.lot_id}}", strconv.Quote(lotID))
+	body = strings.ReplaceAll(body, "{{input.base_sha}}", strconv.Quote(base))
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in mark_done near %q", body[i:min(i+40, len(body))])
+	}
+	scriptPath := filepath.Join(t.TempDir(), "mark_done.py")
+	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", scriptPath).Output()
+	exit := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("mark_done failed to execute: %v (out %q)", err, out)
+		}
+		exit = ee.ExitCode()
+	}
+	if exit != wantExit {
+		t.Fatalf("mark_done exited %d, want %d (out %q)", exit, wantExit, out)
+	}
+	var res modernizeMarkDoneOut
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("mark_done output is not JSON: %v (out %q)", uerr, out)
+	}
+	return res
+}
+
+// TestModernizeMarkDone pins the one write the gate makes to the contract:
+// the converged lot's status, one line, one commit, nothing else. `done` is
+// the gate's word — a worker that writes it is refused by lot_verify — so
+// this node is the only place the programme's "accepted" ever gets written,
+// and a landing has exactly one commit to check for it.
+func TestModernizeMarkDone(t *testing.T) {
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+	script := toolScript(t, "modernize/main.bot", "mark_done")
+	const plan = `version: 1
+# the programme, as a human wrote it
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo   # a bookmark, never evidence
+    rebaseline_allowed: false
+    intent: |
+      what may change, and what may not
+    exit_gate:
+      - "true"
+  - id: L2
+    title: "raise the runtime"
+    status: todo
+    depends_on: [L1]
+    exit_gate:
+      - "true"
+`
+
+	t.Run("converged lot: one line flipped, one commit, comments intact", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if !res.Marked || res.Commit == "" {
+			t.Fatalf("marked=%v commit=%q, want the status written and committed (%s)", res.Marked, res.Commit, res.Notice)
+		}
+		got, err := os.ReadFile(filepath.Join(ws, ".modernize", "plan.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := strings.Replace(plan, "status: todo   # a bookmark, never evidence", "status: done   # a bookmark, never evidence", 1)
+		if string(got) != want {
+			t.Fatalf("contract after mark_done:\n%s\nwant exactly one status line changed:\n%s", got, want)
+		}
+		if subj := git("log", "-1", "--format=%s"); subj != "L1: done — gate, oracle and references green at "+base[:12] {
+			t.Fatalf("commit subject = %q", subj)
+		}
+		if files := git("show", "--stat", "--format=", "HEAD"); !strings.Contains(files, "1 file changed") {
+			t.Fatalf("the done commit must carry the contract alone, got:\n%s", files)
+		}
+		if git("rev-parse", "HEAD") != res.Commit {
+			t.Fatalf("reported commit %s is not HEAD", res.Commit)
+		}
+	})
+
+	t.Run("idempotent: a contract already done is left alone, nothing committed", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, strings.Replace(plan, "status: todo   # a bookmark, never evidence", "status: done", 1))
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if res.Marked || res.Commit != "" {
+			t.Fatalf("marked=%v commit=%q on an already-done lot, want no write", res.Marked, res.Commit)
+		}
+		if head := git("rev-parse", "HEAD"); head != base {
+			t.Fatalf("HEAD moved to %s on the idempotent path", head)
+		}
+	})
+
+	t.Run("undeclared lot is refused", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		res := modernizeMarkDone(t, script, ws, "L9", base, 1)
+		if !strings.Contains(res.Notice, "not in the contract") {
+			t.Fatalf("notice = %q", res.Notice)
+		}
+		if head := git("rev-parse", "HEAD"); head != base {
+			t.Fatalf("HEAD moved to %s on a refusal", head)
+		}
+	})
+
+	t.Run("a block without a status line is refused, contract untouched", func(t *testing.T) {
+		noStatus := strings.Replace(plan, "    status: todo   # a bookmark, never evidence\n", "", 1)
+		ws, base, _ := modernizeRepo(t, noStatus)
+		res := modernizeMarkDone(t, script, ws, "L1", base, 1)
+		if !strings.Contains(res.Notice, "no `status:` line") {
+			t.Fatalf("notice = %q", res.Notice)
+		}
+		got, _ := os.ReadFile(filepath.Join(ws, ".modernize", "plan.yaml"))
+		if string(got) != noStatus {
+			t.Fatalf("a refused edit must leave the contract byte-identical")
+		}
+	})
+}

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -20,11 +20,7 @@ import (
 // (exit 127: `t: not found`) and the lot can never converge — a red verdict
 // manufactured by the reader, not earned by the tree.
 func TestModernizePlanReadExitGateForms(t *testing.T) {
-	for _, tool := range []string{"python3", "git", "yq"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not on PATH", tool)
-		}
-	}
+	requireModernizeTools(t)
 
 	script := toolScript(t, "modernize/main.bot", "plan_read")
 
@@ -193,11 +189,7 @@ func modernizePlanRead(t *testing.T, script, planYAML, onlyLot string, wantExit 
 // whose contract carried a `done` no gate had proven. An operator reading
 // convergence where nothing was measured.
 func TestModernizePlanReadOnlyLotRefusal(t *testing.T) {
-	for _, tool := range []string{"python3", "git", "yq"} {
-		if _, err := exec.LookPath(tool); err != nil {
-			t.Skipf("%s not on PATH", tool)
-		}
-	}
+	requireModernizeTools(t)
 	script := toolScript(t, "modernize/main.bot", "plan_read")
 	const plan = `version: 1
 lots:
@@ -271,6 +263,79 @@ lots:
 `, "", 0)
 		if !res.NothingToDo {
 			t.Fatalf("an exhausted programme without only_lot must stay a clean no-op, got %+v", res)
+		}
+	})
+}
+
+// TestModernizePlanReadContractShape pins what plan_read refuses BEFORE a
+// token is spent: duplicate or non-string ids (a key declared twice cannot be
+// read consistently by three nodes), an explicit request on a gate-less lot
+// (the green no-op the typed refusal exists to remove), and a lot block the
+// gate could never edit its `done` into.
+func TestModernizePlanReadContractShape(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "plan_read")
+
+	t.Run("duplicate ids are unreadable, in both modes", func(t *testing.T) {
+		dup := `version: 1
+lots:
+  - id: L1
+    title: first
+    status: todo
+    exit_gate: [ "true" ]
+  - id: L1
+    title: impostor
+    status: todo
+    exit_gate: [ "false" ]
+`
+		for _, only := range []string{"", "L1"} {
+			res := modernizePlanRead(t, script, dup, only, 1)
+			if !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE: duplicate lot id") {
+				t.Fatalf("only=%q notice = %q", only, res.Notice)
+			}
+		}
+	})
+	t.Run("a non-string id is unreadable", func(t *testing.T) {
+		res := modernizePlanRead(t, script, `version: 1
+lots:
+  - id: 1.0
+    title: numeric
+    status: todo
+    exit_gate: [ "true" ]
+`, "", 1)
+		if !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE") {
+			t.Fatalf("notice = %q", res.Notice)
+		}
+	})
+	t.Run("explicit request on a gate-less lot is refused, typed", func(t *testing.T) {
+		res := modernizePlanRead(t, script, `version: 1
+lots:
+  - id: L5
+    title: no gate
+    status: todo
+`, "L5", 1)
+		if !strings.HasPrefix(res.Notice, "LOT_NOT_ACTIONABLE") || !strings.Contains(res.Notice, "no exit_gate") {
+			t.Fatalf("notice = %q", res.Notice)
+		}
+	})
+	t.Run("unfiltered mode keeps the documented no-op on a gate-less lot", func(t *testing.T) {
+		res := modernizePlanRead(t, script, `version: 1
+lots:
+  - id: L5
+    title: no gate
+    status: todo
+`, "", 0)
+		if !res.NothingToDo {
+			t.Fatalf("expected the legitimate no-op, got %+v", res)
+		}
+	})
+	t.Run("a flow-mapping lot cannot be edited by the gate: refused before spend", func(t *testing.T) {
+		res := modernizePlanRead(t, script, `version: 1
+lots:
+  - {id: L1, title: flow, status: todo, exit_gate: ["true"]}
+`, "L1", 1)
+		if !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
+			t.Fatalf("notice = %q", res.Notice)
 		}
 	})
 }

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -28,70 +28,8 @@ func TestModernizePlanReadExitGateForms(t *testing.T) {
 
 	script := toolScript(t, "modernize/main.bot", "plan_read")
 
-	type planReadOut struct {
-		NothingToDo bool   `json:"nothing_to_do"`
-		LotID       string `json:"lot_id"`
-		ExitGate    string `json:"exit_gate"`
-		Notice      string `json:"notice"`
-	}
-
-	run := func(t *testing.T, planYAML string, wantExit int) planReadOut {
-		t.Helper()
-		ws := t.TempDir()
-		git := func(args ...string) {
-			t.Helper()
-			full := append([]string{"-C", ws}, args...)
-			cmd := exec.Command("git", full...)
-			// The throwaway repo must not inherit the operator's global or
-			// system config: a core.hooksPath or commit.gpgsign there fails
-			// `git commit` for reasons unrelated to what this test pins.
-			cmd.Env = append(os.Environ(),
-				"GIT_CONFIG_GLOBAL=/dev/null",
-				"GIT_CONFIG_SYSTEM=/dev/null",
-			)
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("git %v: %v (%s)", args, err, out)
-			}
-		}
-		git("init", "-q", "-b", "main")
-		git("config", "user.email", "t@example.com")
-		git("config", "user.name", "t")
-		if err := os.MkdirAll(filepath.Join(ws, ".modernize"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(planYAML), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		git("add", ".modernize/plan.yaml")
-		git("commit", "-qm", "contract")
-
-		body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
-		body = strings.ReplaceAll(body, "{{vars.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
-		body = strings.ReplaceAll(body, "{{vars.only_lot}}", strconv.Quote(""))
-		if i := strings.Index(body, "{{"); i >= 0 {
-			t.Fatalf("unresolved template ref in plan_read near %q", body[i:min(i+40, len(body))])
-		}
-		scriptPath := filepath.Join(t.TempDir(), "plan_read.py")
-		if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		out, err := exec.Command("python3", scriptPath).Output()
-		exit := 0
-		if err != nil {
-			ee, ok := err.(*exec.ExitError)
-			if !ok {
-				t.Fatalf("plan_read failed to execute: %v (out %q)", err, out)
-			}
-			exit = ee.ExitCode()
-		}
-		if exit != wantExit {
-			t.Fatalf("plan_read exited %d, want %d (out %q)", exit, wantExit, out)
-		}
-		var res planReadOut
-		if uerr := json.Unmarshal(out, &res); uerr != nil {
-			t.Fatalf("plan_read output is not JSON: %v (out %q)", uerr, out)
-		}
-		return res
+	run := func(t *testing.T, planYAML string, wantExit int) modernizePlanReadOut {
+		return modernizePlanRead(t, script, planYAML, "", wantExit)
 	}
 
 	t.Run("scalar gate reaches the verifier whole", func(t *testing.T) {
@@ -169,6 +107,170 @@ lots:
 `, 1)
 		if !strings.Contains(res.Notice, "unreadable shape") {
 			t.Fatalf("notice = %q, want an unreadable-shape refusal", res.Notice)
+		}
+	})
+}
+
+// modernizePlanReadOut is the subset of plan_read's output the tests read.
+type modernizePlanReadOut struct {
+	NothingToDo bool   `json:"nothing_to_do"`
+	LotID       string `json:"lot_id"`
+	ExitGate    string `json:"exit_gate"`
+	Notice      string `json:"notice"`
+}
+
+// modernizePlanRead executes the REAL plan_read script against a throwaway
+// contract, with `only_lot` bound to onlyLot, and pins the exit code. Shared
+// by every plan_read test so a change to the reader's contract surface is
+// measured in one place.
+func modernizePlanRead(t *testing.T, script, planYAML, onlyLot string, wantExit int) modernizePlanReadOut {
+	t.Helper()
+	ws := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", ws}, args...)
+		cmd := exec.Command("git", full...)
+		// The throwaway repo must not inherit the operator's global or
+		// system config: a core.hooksPath or commit.gpgsign there fails
+		// `git commit` for reasons unrelated to what this test pins.
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	if err := os.MkdirAll(filepath.Join(ws, ".modernize"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(planYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".modernize/plan.yaml")
+	git("commit", "-qm", "contract")
+
+	body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	body = strings.ReplaceAll(body, "{{vars.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
+	body = strings.ReplaceAll(body, "{{vars.only_lot}}", strconv.Quote(onlyLot))
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in plan_read near %q", body[i:min(i+40, len(body))])
+	}
+	scriptPath := filepath.Join(t.TempDir(), "plan_read.py")
+	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", scriptPath).Output()
+	exit := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("plan_read failed to execute: %v (out %q)", err, out)
+		}
+		exit = ee.ExitCode()
+	}
+	if exit != wantExit {
+		t.Fatalf("plan_read exited %d, want %d (out %q)", exit, wantExit, out)
+	}
+	var res modernizePlanReadOut
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("plan_read output is not JSON: %v (out %q)", uerr, out)
+	}
+	return res
+}
+
+// TestModernizePlanReadOnlyLotRefusal pins the answer to an EXPLICIT request
+// that cannot be carried out. The unfiltered reader may legitimately find
+// nothing to do; a launch that names a lot the contract carries as landed,
+// does not declare, or holds behind an unmet dependency is refused, typed,
+// instead of finishing green at zero minutes.
+//
+// The failure this guards, measured on a live campaign: four `finished` runs
+// in 24 h that crossed no gate, every one a relaunch from a banked branch
+// whose contract carried a `done` no gate had proven. An operator reading
+// convergence where nothing was measured.
+func TestModernizePlanReadOnlyLotRefusal(t *testing.T) {
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+	script := toolScript(t, "modernize/main.bot", "plan_read")
+	const plan = `version: 1
+lots:
+  - id: L1
+    title: done already
+    status: done
+    exit_gate: [ "true" ]
+  - id: L2
+    title: blocked with a reason
+    status: blocked
+    exit_gate: [ "true" ]
+  - id: L3
+    title: ready
+    status: todo
+    exit_gate: [ "true" ]
+  - id: L4
+    title: waits on L3
+    status: todo
+    depends_on: [L3]
+    exit_gate: [ "true" ]
+`
+	refused := func(t *testing.T, lot string) modernizePlanReadOut {
+		t.Helper()
+		res := modernizePlanRead(t, script, plan, lot, 1)
+		if !strings.HasPrefix(res.Notice, "LOT_NOT_ACTIONABLE: ") {
+			t.Fatalf("only_lot=%s: notice = %q, want a typed LOT_NOT_ACTIONABLE refusal", lot, res.Notice)
+		}
+		if res.LotID != "" {
+			t.Fatalf("only_lot=%s: a refused request must select no lot, got %q", lot, res.LotID)
+		}
+		return res
+	}
+
+	t.Run("done lot is refused, and names the way out", func(t *testing.T) {
+		res := refused(t, "L1")
+		if !strings.Contains(res.Notice, "`done`") || !strings.Contains(res.Notice, "todo") {
+			t.Fatalf("notice = %q, want the status named and the `todo` flip suggested", res.Notice)
+		}
+	})
+	t.Run("blocked lot is refused", func(t *testing.T) {
+		res := refused(t, "L2")
+		if !strings.Contains(res.Notice, "`blocked`") {
+			t.Fatalf("notice = %q, want the status named", res.Notice)
+		}
+	})
+	t.Run("undeclared lot is refused", func(t *testing.T) {
+		res := refused(t, "L9")
+		if !strings.Contains(res.Notice, "does not declare") {
+			t.Fatalf("notice = %q, want the undeclared lot named", res.Notice)
+		}
+	})
+	t.Run("lot behind an unmet dependency is refused", func(t *testing.T) {
+		res := refused(t, "L4")
+		if !strings.Contains(res.Notice, "waits on L3") {
+			t.Fatalf("notice = %q, want the unmet dependency named", res.Notice)
+		}
+	})
+	t.Run("ready lot is selected as before", func(t *testing.T) {
+		res := modernizePlanRead(t, script, plan, "L3", 0)
+		if res.NothingToDo || res.LotID != "L3" {
+			t.Fatalf("only_lot=L3 selected %q (nothing_to_do=%v), want L3", res.LotID, res.NothingToDo)
+		}
+	})
+	t.Run("unfiltered mode keeps its legitimate no-op", func(t *testing.T) {
+		res := modernizePlanRead(t, script, `version: 1
+lots:
+  - id: L1
+    title: landed
+    status: done
+    exit_gate: [ "true" ]
+`, "", 0)
+		if !res.NothingToDo {
+			t.Fatalf("an exhausted programme without only_lot must stay a clean no-op, got %+v", res)
 		}
 	})
 }

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -109,10 +109,12 @@ lots:
 
 // modernizePlanReadOut is the subset of plan_read's output the tests read.
 type modernizePlanReadOut struct {
-	NothingToDo bool   `json:"nothing_to_do"`
-	LotID       string `json:"lot_id"`
-	ExitGate    string `json:"exit_gate"`
-	Notice      string `json:"notice"`
+	NothingToDo      bool   `json:"nothing_to_do"`
+	LotID            string `json:"lot_id"`
+	ExitGate         string `json:"exit_gate"`
+	Notice           string `json:"notice"`
+	LotNotActionable bool   `json:"lot_not_actionable"`
+	LotStatus        string `json:"lot_status"`
 }
 
 // modernizePlanRead executes the REAL plan_read script against a throwaway
@@ -211,11 +213,15 @@ lots:
     depends_on: [L3]
     exit_gate: [ "true" ]
 `
-	refused := func(t *testing.T, lot string) modernizePlanReadOut {
+	// A non-actionable explicit request is a VERDICT the graph reads
+	// (lot_not_actionable + lot_status → work_gate -> fail), never a tool
+	// error: an exit 1 here would be retried once by the engine and end the
+	// run failed_resumable — a typed fail is neither.
+	refused := func(t *testing.T, lot, status string) modernizePlanReadOut {
 		t.Helper()
-		res := modernizePlanRead(t, script, plan, lot, 1)
-		if !strings.HasPrefix(res.Notice, "LOT_NOT_ACTIONABLE: ") {
-			t.Fatalf("only_lot=%s: notice = %q, want a typed LOT_NOT_ACTIONABLE refusal", lot, res.Notice)
+		res := modernizePlanRead(t, script, plan, lot, 0)
+		if !res.LotNotActionable || res.LotStatus != status || res.NothingToDo {
+			t.Fatalf("only_lot=%s: lot_not_actionable=%v lot_status=%q nothing_to_do=%v, want the typed verdict with status %q (%s)", lot, res.LotNotActionable, res.LotStatus, res.NothingToDo, status, res.Notice)
 		}
 		if res.LotID != "" {
 			t.Fatalf("only_lot=%s: a refused request must select no lot, got %q", lot, res.LotID)
@@ -223,26 +229,26 @@ lots:
 		return res
 	}
 
-	t.Run("done lot is refused, and names the way out", func(t *testing.T) {
-		res := refused(t, "L1")
-		if !strings.Contains(res.Notice, "`done`") || !strings.Contains(res.Notice, "todo") {
-			t.Fatalf("notice = %q, want the status named and the `todo` flip suggested", res.Notice)
+	t.Run("done lot is refused, typed", func(t *testing.T) {
+		res := refused(t, "L1", "done")
+		if !strings.Contains(res.Notice, "'done'") {
+			t.Fatalf("notice = %q, want the status named", res.Notice)
 		}
 	})
 	t.Run("blocked lot is refused", func(t *testing.T) {
-		res := refused(t, "L2")
-		if !strings.Contains(res.Notice, "`blocked`") {
+		res := refused(t, "L2", "blocked")
+		if !strings.Contains(res.Notice, "'blocked'") {
 			t.Fatalf("notice = %q, want the status named", res.Notice)
 		}
 	})
 	t.Run("undeclared lot is refused", func(t *testing.T) {
-		res := refused(t, "L9")
-		if !strings.Contains(res.Notice, "does not declare") {
+		res := refused(t, "L9", "absent")
+		if !strings.Contains(res.Notice, "does not exist") {
 			t.Fatalf("notice = %q, want the undeclared lot named", res.Notice)
 		}
 	})
 	t.Run("lot behind an unmet dependency is refused", func(t *testing.T) {
-		res := refused(t, "L4")
+		res := refused(t, "L4", "waiting")
 		if !strings.Contains(res.Notice, "waits on L3") {
 			t.Fatalf("notice = %q, want the unmet dependency named", res.Notice)
 		}
@@ -310,12 +316,12 @@ lots:
 	t.Run("explicit request on a gate-less lot is refused, typed", func(t *testing.T) {
 		res := modernizePlanRead(t, script, `version: 1
 lots:
-  - id: L5
+  - id: L1
     title: no gate
     status: todo
-`, "L5", 1)
-		if !strings.HasPrefix(res.Notice, "LOT_NOT_ACTIONABLE") || !strings.Contains(res.Notice, "no exit_gate") {
-			t.Fatalf("notice = %q", res.Notice)
+`, "L1", 0)
+		if !res.LotNotActionable || res.LotStatus != "no_gate" || !strings.Contains(res.Notice, "no exit_gate") {
+			t.Fatalf("lot_not_actionable=%v lot_status=%q notice=%q, want the typed no_gate verdict", res.LotNotActionable, res.LotStatus, res.Notice)
 		}
 	})
 	t.Run("unfiltered mode keeps the documented no-op on a gate-less lot", func(t *testing.T) {

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -338,4 +338,17 @@ lots:
 			t.Fatalf("notice = %q", res.Notice)
 		}
 	})
+	// The pre-check uses mark_done's regex, anchored to the end of the line:
+	// a status line the gate could not flip — trailing blanks, a second
+	// token — is refused HERE, before the lot is paid for, never at the last
+	// node after the gate has run (review finding: the two regexes differed
+	// on exactly that, and `status: todo  ` passed plan_read to fail mark_done).
+	for _, line := range []string{"    status: todo  ", "    status: todo\t", "    status: todo extra"} {
+		t.Run("a status line the gate could not flip is refused before spend: "+strconv.Quote(line), func(t *testing.T) {
+			res := modernizePlanRead(t, script, "version: 1\nlots:\n  - id: L1\n    title: t\n"+line+"\n    exit_gate:\n      - \"true\"\n", "L1", 1)
+			if !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
+				t.Fatalf("notice = %q, want LOT_UNEDITABLE", res.Notice)
+			}
+		})
+	}
 }

--- a/bots/modernize_tools_test.go
+++ b/bots/modernize_tools_test.go
@@ -1,0 +1,45 @@
+package bots
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// requireModernizeTools skips a modernize bot-level test when a tool it
+// needs is missing on a developer's host — and FAILS instead under CI, where
+// a skipped guard test is a green no-op: the exact class these tests exist
+// to refuse (a verdict that passed because a check never ran).
+func requireModernizeTools(t *testing.T) {
+	t.Helper()
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			if os.Getenv("CI") != "" {
+				t.Fatalf("%s not on PATH under CI — the modernize guard tests would skip into a green no-op; install it in the workflow", tool)
+			}
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+}
+
+// restrictedPATH builds a bin dir holding symlinks to the named tools only,
+// so a script run with PATH=<dir> sees exactly those — the way to prove what
+// a node does when `yq` is NOT on PATH without uninstalling anything.
+func restrictedPATH(t *testing.T, tools ...string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range tools {
+		p, err := exec.LookPath(tool)
+		if err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+		if err := os.Symlink(p, filepath.Join(dir, tool)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}

--- a/e2e/bot_modernize_test.go
+++ b/e2e/bot_modernize_test.go
@@ -1,0 +1,138 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// modernizeStubs registers the deterministic shape of one modernize lot for
+// the scenario executor: plan_read hands out lot L1, the campaign works it,
+// lot_verify answers with whatever `verdict` returns for the pass, and
+// mark_done records that it ran. Compute nodes (work_gate, lot_gate) are the
+// engine's own; the subbot nodes are never reached (no invalid mutant, no
+// pending extension).
+func modernizeStubs(exec *scenarioExecutor, verdict func(pass int) map[string]any) {
+	exec.on("plan_read", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"nothing_to_do": false, "lot_id": "L1", "lot_title": "raise the build tool",
+			"lot_intent": "bump it", "exit_gate": "true", "base_sha": "0123456789abcdef",
+			"refs_dir": ".golden-master/refs", "notice": "", "_tokens": 1,
+		}, nil
+	})
+	pass := 0
+	exec.on("upgrade_campaign", func(_ map[string]any) (map[string]any, error) {
+		pass++
+		return map[string]any{"work_remaining": "", "_tokens": 10}, nil
+	})
+	exec.on("lot_verify", func(_ map[string]any) (map[string]any, error) {
+		out := map[string]any{
+			"gate_passed": false, "oracle_passed": false, "refs_untouched": false,
+			"refs_changed": []any{}, "lot_blocked": false, "block_reason": "",
+			"oracle_invalid": []any{}, "extension_pending": []any{},
+			"done_self_written": false, "contract_rewritten": []any{},
+			"gate_timed_out": false, "log_tail": "", "_tokens": 1,
+		}
+		for k, v := range verdict(pass) {
+			out[k] = v
+		}
+		return out, nil
+	})
+	exec.on("mark_done", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"marked": true, "commit": "feedfacefeedface", "notice": "marked", "_tokens": 1}, nil
+	})
+}
+
+func runModernize(t *testing.T, exec *scenarioExecutor, runID string) *store.Run {
+	t.Helper()
+	wf := compileFixtureStubSafe(t, "modernize/main.bot")
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	_ = eng.Run(context.Background(), runID, nil) // the status is the verdict, read below
+	run, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	return run
+}
+
+// TestModernize_ConvergedLotIsMarkedByTheGate: the green path — the
+// conjunction holds, the gate writes `done` (mark_done), the run finishes.
+func TestModernize_ConvergedLotIsMarkedByTheGate(t *testing.T) {
+	exec := newScenarioExecutor()
+	modernizeStubs(exec, func(int) map[string]any {
+		return map[string]any{"gate_passed": true, "oracle_passed": true, "refs_untouched": true}
+	})
+	run := runModernize(t, exec, "run-mod-converged")
+	if run.Status != store.RunStatusFinished {
+		t.Fatalf("status = %s, want finished", run.Status)
+	}
+	if !exec.wasCalled("mark_done") {
+		t.Fatal("mark_done never ran on a converged lot — `done` is the gate's word")
+	}
+	if got := exec.callCount("upgrade_campaign"); got != 1 {
+		t.Fatalf("upgrade_campaign called %d times, want 1", got)
+	}
+}
+
+// TestModernize_RefusedVerdictNeverEndsGreen: a worker that writes `done`
+// into the contract (or rewrites it) is refused by lot_verify on every pass.
+// The refusal goes back to the worker while repair_loop lasts — and when the
+// loop is exhausted the run must NOT end `finished`: the forged `done` is
+// still in the contract, a merge of a green run would land it, and the lot
+// would vanish from the programme (an only_lot relaunch is refused as not
+// actionable, a free relaunch skips it as landed). Review finding on the
+// change that introduced the refusal: the unconditional `lot_gate -> done`
+// exhaustion edge let it through — a term true by absence.
+func TestModernize_RefusedVerdictNeverEndsGreen(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		refusal map[string]any
+	}{
+		{"worker-written done", map[string]any{"done_self_written": true, "log_tail": "the worker wrote the verdict"}},
+		{"rewritten contract", map[string]any{"contract_rewritten": []any{"lot L1: intent changed"}, "log_tail": "rewritten"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := newScenarioExecutor()
+			modernizeStubs(exec, func(int) map[string]any { return tc.refusal })
+			run := runModernize(t, exec, "run-mod-refused")
+			if run.Status == store.RunStatusFinished {
+				t.Fatalf("a refusal that outlived repair_loop ended `finished` — the unproven `done` would land on a merge")
+			}
+			if exec.wasCalled("mark_done") {
+				t.Fatal("mark_done ran on a refused verdict")
+			}
+			// The refusal goes back to the worker for every pass the loop
+			// has (1 + max_passes=4), and the run fails only once the loop
+			// is exhausted — never instead of it.
+			if got := exec.callCount("upgrade_campaign"); got != 5 {
+				t.Fatalf("upgrade_campaign called %d times, want 5: the refusal sent back for each of max_passes repair passes before the run fails", got)
+			}
+			if run.Status != store.RunStatusFailed {
+				t.Fatalf("status = %s, want failed (the fail terminal, in words)", run.Status)
+			}
+		})
+	}
+}
+
+// TestModernize_DeclaredBlockedStopsWithoutMarking: `blocked` is the worker's
+// word and a STOP, never a success — the run ends without mark_done, on the
+// first pass.
+func TestModernize_DeclaredBlockedStopsWithoutMarking(t *testing.T) {
+	exec := newScenarioExecutor()
+	modernizeStubs(exec, func(int) map[string]any {
+		return map[string]any{"lot_blocked": true, "block_reason": "needs a decision"}
+	})
+	run := runModernize(t, exec, "run-mod-blocked")
+	if run.Status != store.RunStatusFinished {
+		t.Fatalf("status = %s, want finished (a declared block is a stop, read in the tree)", run.Status)
+	}
+	if exec.wasCalled("mark_done") {
+		t.Fatal("mark_done ran on a blocked lot")
+	}
+	if got := exec.callCount("upgrade_campaign"); got != 1 {
+		t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass against a declared wall)", got)
+	}
+}

--- a/e2e/bot_modernize_test.go
+++ b/e2e/bot_modernize_test.go
@@ -117,6 +117,27 @@ func TestModernize_RefusedVerdictNeverEndsGreen(t *testing.T) {
 	}
 }
 
+// TestModernize_GateTimeoutFailsAtOnce: a wall the run never crossed is a
+// verdict in the tree and a `failed` run — never a repair pass that replays
+// an hour against the same wall, never a `finished` the programme would
+// relaunch into it.
+func TestModernize_GateTimeoutFailsAtOnce(t *testing.T) {
+	exec := newScenarioExecutor()
+	modernizeStubs(exec, func(int) map[string]any {
+		return map[string]any{"gate_timed_out": true, "block_reason": "GATE_TIMEOUT: exit_gate command `sleep` exceeded gate_timeout_s=1 after 1s"}
+	})
+	run := runModernize(t, exec, "run-mod-timeout")
+	if run.Status != store.RunStatusFailed {
+		t.Fatalf("status = %s, want failed", run.Status)
+	}
+	if exec.wasCalled("mark_done") {
+		t.Fatal("mark_done ran on a timed-out gate")
+	}
+	if got := exec.callCount("upgrade_campaign"); got != 1 {
+		t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass against the same wall)", got)
+	}
+}
+
 // TestModernize_DeclaredBlockedStopsWithoutMarking: `blocked` is the worker's
 // word and a STOP, never a success — the run ends without mark_done, on the
 // first pass.


### PR DESCRIPTION
## What a run's terminal state may claim

Three defects of one class, measured on a live campaign: a run's terminal state lied about what had been proven, and an operator relaunched on the lie.

- **An explicit `only_lot`** naming a lot the contract carried as `done`/`blocked` (or undeclared, gate-less, or behind an unmet dependency) exited **green** as `nothing_to_do` — four `finished` runs in 24 h that crossed no gate, every one a relaunch from a banked branch. `plan_read` now refuses, typed (`LOT_NOT_ACTIONABLE`, run failed, the way out named). The unfiltered pick-next mode keeps its legitimate no-op.
- **`status: done` was the worker's word.** A bank taken before the verdict carried a completion nobody had proven; the relaunch skipped the lot. The gate writes it now — new tool node `mark_done`: one line, one commit of its own, idempotent — and `lot_verify` refuses a worker-written `done` **before any gate command runs** (seconds, not the hour a full gate costs). The worker keeps `blocked` (a claim of failure cannot cheat toward green).
- **The plan was read-only inside a lot by prompt only.** `lot_verify` judges it in git: existing lots keep title / intent / exit_gate / depends_on / rebaseline_allowed / crosses_major, no lot disappears, no other lot's status moves; adding a lot stays a proposal. Refused before the gate, rewrites named.

## Adversarial round (opus, execute-to-prove) — 1 critical, 3 high, all adopted

- **critical** — `lot_verify` called `yq` on the bare PATH and swallowed its absence, so both new guards vanished silently: with yq off PATH but in the target's devbox profile, a worker-written `done` and an amputated gate converged green. → yq is found where `plan_read`/`mark_done` find it; a contract that cannot be read (no parser, no parse, missing at HEAD, **not committed at base**) is a typed refusal `CONTRACT_UNREADABLE`, never a verdict that skipped its checks.
- **high** — `blocked` + rewritten contract left through `lot_gate.stop` with the rewrite landed → a rewrite clears `lot_blocked`.
- **high** — `only_lot` on a gate-less lot still exited green → refused, typed.
- **high** — a homonym lot added ahead slipped past (first-wins reader, last-wins verifier) → duplicate/non-string ids refused in `plan_read` for both modes; a duplicate at HEAD is a rewrite.
- Negative results kept: `mark_done` over a real 36-lot production contract, one run per lot, **0 failures** (prefix ids `L1`/`L1b`, comments, trailing comments all preserved). Editor anchored on indentation (a `status:` / `- id:` inside an `intent: |` scalar is prose); `plan_read` pre-checks the block shape (`LOT_UNEDITABLE`) before a token is spent.

## Proof

- Bot-level tests run the **real** `plan_read` / `lot_verify` / `mark_done` scripts against throwaway contracts: 8 functions, 33 cases, both faces of every rule (refusal fires; legitimate path passes; a marker file proves the gate never ran on a refusal).
- 8 mutants (each guard removed in turn) each turn their test red.
- `iterion validate bots/modernize/main.bot`: OK (10 nodes, 14 edges).
- CI installed no yq, so every modernize bot-level test **skipped** there — a green no-op of the class these guards refuse. The `test` and `race` jobs now install a pinned yq (version + sha256); under `CI`, a missing tool fails the test instead of skipping.

## Operator notes

No effect on in-flight runs (baked bots). After the next image: a relaunch with `only_lot` on a bank carrying an unproven `done` now **fails typed** — flip the lot back to `todo` on the relaunch branch and let the gate decide; an agent that writes `status: done` is refused at verify in seconds (rule 4 of its contract tells it not to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
