### PR TITLE
docs(claw): state the expiry-vs-forbid policy, and stop claiming claw can't hold a forfait

### DIFF
--- a/pkg/backend/model/anthropic_forfait_ctx_test.go
+++ b/pkg/backend/model/anthropic_forfait_ctx_test.go
@@ -352,3 +352,28 @@ func TestAnthropicFromCtxForfait_AbsentStillDegradesQuietly(t *testing.T) {
 		t.Errorf("an absent blob must degrade quietly, got ok=%v err=%v", ok, err)
 	}
 }
+
+// Rb29324: expired + an ambient key present is the case where the two branches
+// could plausibly disagree, so it is pinned rather than left implicit. EXPIRED
+// refuses even here — degrading would silently move a broken tenant's spend
+// onto whoever owns the ambient key — while FORBID deliberately degrades,
+// because there the operator configured that arrangement.
+func TestAnthropicFromCtxForfait_ExpiredRefusesEvenWithAmbientKey(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-stale","expiresAt":1000000000000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return dir }, true
+	})
+	t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+
+	_, ok, err := NewRegistry().anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5")
+	if !ok || !errors.Is(err, secrets.ErrAnthropicForfaitExpired) {
+		t.Fatalf("a lapsed forfait must not borrow the ambient key, got ok=%v err=%v", ok, err)
+	}
+}

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1047,11 +1047,21 @@ var providerCredentialEnvVars = []string{
 	"ANTHROPIC_API_KEY",
 	// z.ai (GLM) drives claw's Anthropic provider through an
 	// Anthropic-compatible endpoint, so a sandboxed claw reviewer (e.g.
-	// anthropic/glm-5.2 — the forfait-friendly reviewer model, since claw
-	// can't use the Claude Code OAuth forfait) needs the z.ai creds inside
-	// the container. registry.go synthesises the bearer + ZAIDefaultBaseURL
-	// from ZAI_API_KEY when no other anthropic auth is present;
+	// anthropic/glm-5.2) needs the z.ai creds inside the container.
+	// registry.go synthesises the bearer + ZAIDefaultBaseURL from
+	// ZAI_API_KEY when no other anthropic auth is present;
 	// ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL cover the explicit BYOK path.
+	//
+	// claw CAN use a Claude Code OAuth forfait — its anthropic provider takes
+	// the token as an OAuth bearer, and registry.go feeds it one from the env
+	// (desktop) or from the run's materialised OAuthDir (pod). What is missing
+	// is a channel to carry it ACROSS this boundary: the in-container
+	// __claw-runner rebuilds its registry from env alone, and this list is the
+	// only credential channel, so a sandboxed claw anthropic node still falls
+	// back to the ambient ANTHROPIC_API_KEY. Tracked as the sandbox seam of
+	// the forfait work; seeding an in-container CLAUDE_CONFIG_DIR from the
+	// existing ClaudeCodeSandboxConfigDir mount (mirroring CODEX_HOME) is the
+	// shape that closes it.
 	"ZAI_API_KEY",
 	// xai's provider reads XAI_API_KEY from env, so this is the only
 	// channel into the container — and the pool can grant a donated xai

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -591,12 +591,24 @@ func (r *Registry) anthropicFromCtxForfait(ctx context.Context, modelID string) 
 	}
 	token, terr := secrets.AnthropicForfaitToken(dir)
 	if errors.Is(terr, secrets.ErrAnthropicForfaitExpired) {
-		// The one case that is NOT "no credential here": a forfait was
-		// provisioned and its token lapsed, which means the refresh worker
-		// lagged or failed. Falling through would reach the env factory, find
-		// no ANTHROPIC_* var on a runner pod, and build the unauthenticated
-		// client whose 401 loop is issue #687 — the same reasoning that makes
-		// the forbid branch below refuse rather than degrade.
+		// EXPIRED refuses even when an ambient credential could serve, and the
+		// forbid branch below deliberately does the opposite. The asymmetry is
+		// the policy, not an oversight:
+		//
+		//   - forbid  = the operator CONFIGURED "do not spend subscriptions
+		//     here", so serving the run from the deployment's own ambient key
+		//     is the arrangement they asked for.
+		//   - expired = nobody configured anything; the tenant HAD a
+		//     credential and the refresh worker did not renew it. Degrading to
+		//     the ambient key would put a broken tenant's spend on whoever owns
+		//     that key — the same billing-boundary slip R413769 closed one seam
+		//     over — and it would do so silently, at the exact moment something
+		//     is already wrong.
+		//
+		// So: a lapsed forfait fails loudly rather than borrowing someone
+		// else's account. Falling through would also reach the env factory,
+		// find no ANTHROPIC_* var on a pod with no ambient key, and build the
+		// unauthenticated client whose 401 loop is issue #687.
 		return nil, true, fmt.Errorf("claw: %w (model %s): the runner's OAuth refresh worker has not renewed it", terr, modelID)
 	}
 	if terr != nil || token == "" {


### PR DESCRIPTION
Follow-up to #698 (merged at 09:38Z): this commit — Revi's round-3 non-blocking findings on that PR, authored by the same session — was pushed to the branch two minutes after the merge, so it never reached `main`. Cherry-picked verbatim (`f96d0ac7b`).

- **Rb29324** — the expiry branch and the forbid branch decided the opposite for the same pod shape; the asymmetry is kept and now written down: *forbid* is an arrangement the operator configured (serving from the deployment's ambient key is what they asked for), *expiry* is a failure nobody configured, where degrading would move a broken tenant's spend onto whoever owns that key, silently. Expired+ambient is pinned by a test.
- **R375155** — the "on the pod" contract holds for the in-process path (supervisor evals, `GenerateObjectDirect` — what fixes #687) but not for sandboxed `backend: claw` agent nodes, whose in-container `__claw-runner` rebuilds its registry from env alone; the comments now say so and point at #736 (seed an in-container `CLAUDE_CONFIG_DIR` from the existing sandbox mount, mirroring `CODEX_HOME`).
- Two comments in `claw_backend.go` asserted that claw *cannot* use a Claude Code forfait — the false premise behind #687 itself — corrected to what is actually missing (a channel across the container boundary).

Refs #687, #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)