### PR TITLE
feat(runner): wire a SubbotRunner into the cloud runner — subbot nodes ran locally only

### DIFF
--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1988,18 +1988,23 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// cannot honor fails the attempt loudly (nak → redelivery → DLQ with an
 	// actionable status) rather than running the run against stale
 	// resources; a resume re-resolves the ref fresh and self-heals.
+	// The parent bundle's directory, for `subbot` nodes to resolve their
+	// children beside it (see subbotRunnerFor).
+	parentBundleDir := ""
 	if msg.BotBundle != nil {
 		b, cleanupBundle, berr := r.materializeBotBundle(ctx, msg.BotBundle)
 		if berr != nil {
 			return fmt.Errorf("runner: bot bundle %s/%s@%d: %w", msg.BotBundle.TenantID, msg.BotBundle.Slug, msg.BotBundle.Version, berr)
 		}
 		defer cleanupBundle()
+		parentBundleDir = b.Dir
 		engineOpts = append(engineOpts, runtime.WithBundle(b))
 	} else if msg.BotID != "" && len(r.cfg.BotsPaths) > 0 {
 		// Best-effort: an unresolvable bot id or a loose .bot just skips the
 		// bundle with a warning — the run proceeds without skills or devbox
 		// tools.
 		if mainFile, rerr := botregistry.ResolveBotPath(msg.BotID, r.cfg.BotsPaths); rerr == nil {
+			parentBundleDir = filepath.Dir(mainFile)
 			if b, berr := bundle.OpenDir(filepath.Dir(mainFile)); berr == nil {
 				engineOpts = append(engineOpts, runtime.WithBundle(b))
 			} else {
@@ -2042,6 +2047,12 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 			msg.RunID, supervise.SpecsFromWorkflow(wf, runLogger), runLogger)
 		defer stopSup()
 	}
+	// `subbot` nodes: the closure that compiles and runs a child bot on
+	// this pod. Every other launch surface wired one; without it a subbot
+	// node dies at dispatch with "no SubbotRunner is wired" — and a
+	// deterministic node failure under the usage-window retry is a
+	// resume loop that recreates the sandbox pod on every attempt.
+	engineOpts = append(engineOpts, runtime.WithSubbotRunner(r.subbotRunnerFor(msg, parentBundleDir, workDir, runLogger)))
 	engine := runtime.New(wf, r.cfg.Store, executor, engineOpts...)
 	// Publish the engine so the store's Event.ActiveMs stamping reads
 	// this run's monotonic active elapsed; drop it when the run returns.

--- a/pkg/runner/subbot.go
+++ b/pkg/runner/subbot.go
@@ -9,11 +9,14 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/errtrack"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
+	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -135,7 +138,24 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 		child.Resume = nil
 		child.BotBundle = nil
 
-		childExec, childUsage, err := r.buildExecutor(ctx, &child, childWf, runLogger, nil)
+		// The child's own run.log — the studio's per-node Logs tab reads the
+		// CHILD's persisted log, and the parent's logger would fold every
+		// line into the parent's. Same shape as the parent's writer.
+		childLogger := runLogger
+		if ls := store.AsRunLogStore(r.cfg.Store); ls != nil {
+			idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+			seed, serr := ls.RunLogSize(idCtx, childRunID)
+			if serr != nil {
+				runLogger.Warn("subbot %s: seed log offset: %v — starting at 0", childRunID, serr)
+			}
+			w := newRunLogWriter(idCtx, ls, childRunID, seed, r.cfg.Logger)
+			defer func() { _ = w.Close() }()
+			r.registerLogWriter(childRunID, w)
+			defer r.unregisterLogWriter(childRunID)
+			childLogger = r.cfg.Logger.WithWriter(io.MultiWriter(r.cfg.Logger.Writer(), w))
+		}
+
+		childExec, childUsage, err := r.buildExecutor(ctx, &child, childWf, childLogger, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -149,10 +169,21 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 			lastMu sync.Mutex
 			last   map[string]any
 		)
+		// Sandbox-run observer: the mid-run credential refreshers write
+		// rotated tokens THROUGH into the child's container, and file
+		// secrets refresh — a child that outlives a token (a per-lot child
+		// of a supervisor runs for hours) would otherwise push with a dead
+		// one, exactly the parent's #99.
+		sbObsCtx, stopSbObs := context.WithCancel(ctx)
+		defer stopSbObs()
+		defer r.unregisterSandboxRun(childRunID)
+
 		opts := []runtime.EngineOption{
-			runtime.WithLogger(runLogger),
+			runtime.WithLogger(childLogger),
 			runtime.WithWorkflowHash(hash),
+			runtime.WithFilePath(childPath),
 			runtime.WithWorkDir(childWorkDir),
+			runtime.WithSandboxRunObserver(r.sandboxRunObserver(sbObsCtx, childRunID, msg.TenantID, r.sandboxFileSecretRefs(ctx, childWf))),
 			runtime.WithSandboxDefault(r.cfg.SandboxDefault),
 			runtime.WithSandboxDefaultImage(msg.SandboxImage),
 			runtime.WithSandboxHostStateDefault(r.cfg.SandboxHostState),
@@ -163,7 +194,7 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 			runtime.WithParentNodeID(req.NodeID),
 			// Recursive wiring: a child that declares subbot nodes resolves
 			// its own children relative to ITS directory.
-			runtime.WithSubbotRunner(r.subbotRunnerFor(&child, filepath.Dir(childPath), childWorkDir, runLogger)),
+			runtime.WithSubbotRunner(r.subbotRunnerFor(&child, filepath.Dir(childPath), childWorkDir, childLogger)),
 			runtime.WithEventObserver(childUsage.observe),
 			runtime.WithOnNodeFinished(func(runID, nodeID string, out map[string]any) {
 				if out != nil {
@@ -180,19 +211,38 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 		} else {
 			runLogger.Warn("subbot %s: bundle open %s: %v (skills not mirrored, devbox tools not provisioned)", req.Source, filepath.Dir(childPath), berr)
 		}
+		// Plugin/library skills the LAUNCHING instance resolved: the pod's
+		// iterion home is empty, so without the payload the child would
+		// silently find only the compiled-in builtins.
+		if msg.Contributions != nil {
+			opts = append(opts, runtime.WithContributions(contributionsFromWire(msg.Contributions)))
+		}
 
 		childEng := runtime.New(childWf, r.cfg.Store, childExec, opts...)
 		r.registerRunEngine(childRunID, childEng)
 		defer r.unregisterRunEngine(childRunID)
 
-		childCtx := context.WithValue(ctx, subbotDepthKey{}, depth+1)
+		childCtx, childCancel := context.WithCancelCause(context.WithValue(ctx, subbotDepthKey{}, depth+1))
 		childLock, err := r.cfg.Store.LockRun(childCtx, childRunID)
 		if err != nil {
+			childCancel(nil)
 			closeExecutor(childExec)
 			return nil, fmt.Errorf("subbot %s: acquire run lock: %w", childRunID, err)
 		}
+		// The child's lease is the orphan sweeper's liveness signal, exactly
+		// like the parent's: on the cloud store LockRun is a NATS-KV entry
+		// with a 60 s TTL that only a refresher keeps alive. The parent's
+		// heartbeat refreshes the PARENT's lease; without one of its own the
+		// child reads dead at T+60 s, the sweeper flips it failed_resumable,
+		// and the reaper deletes its sandbox pod mid-flight.
+		hbDone := make(chan struct{})
+		errtrack.Go("runner.subbot.heartbeat", func() { r.childLeaseHeartbeat(childCtx, childCancel, childLock, hbDone) })
 		runErr := func() error {
 			defer func() { _ = childLock.Unlock() }()
+			defer func() {
+				childCancel(nil)
+				<-hbDone
+			}()
 			return childEng.Run(childCtx, childRunID, req.Vars)
 		}()
 		closeExecutor(childExec)
@@ -220,5 +270,43 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 func closeExecutor(exec runtime.NodeExecutor) {
 	if c, ok := any(exec).(io.Closer); ok {
 		_ = c.Close()
+	}
+}
+
+// childLeaseHeartbeat refreshes a subbot child's run lease while its engine
+// runs — the child half of Runner.heartbeat, without the JetStream delivery
+// (a child has none: it rides its parent's). A refresh failure cancels the
+// child with ErrRunInterrupted so it unwinds to failed_resumable before the
+// lease lapses, rather than letting a sibling pod's redelivery of the parent
+// find two writers on the child's state.
+func (r *Runner) childLeaseHeartbeat(ctx context.Context, cancel context.CancelCauseFunc, lock store.RunLock, done chan<- struct{}) {
+	defer close(done)
+	natsLock, ok := lock.(*natsq.Lock)
+	if !ok {
+		return // no-op lock or non-NATS provider — nothing to refresh
+	}
+	interval := r.cfg.HeartbeatInterval
+	if interval <= 0 {
+		interval = 20 * time.Second
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := natsLock.Refresh(ctx); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				if r.cfg.Metrics != nil {
+					r.cfg.Metrics.RunnerHeartbeatErrors.Inc()
+				}
+				r.cfg.Logger.Error("runner: subbot child lease refresh failed: %v — cancelling the child (resumable) to avoid split-brain", err)
+				cancel(runtime.ErrRunInterrupted)
+				return
+			}
+		}
 	}
 }

--- a/pkg/runner/subbot.go
+++ b/pkg/runner/subbot.go
@@ -1,0 +1,224 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/SocialGouv/iterion/pkg/botregistry"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// maxSubbotDepth bounds nested subbot recursion on a pod, as runview does
+// in-process: a child that (directly or through its own children) reaches
+// its parent again would otherwise recurse until the pod dies.
+const maxSubbotDepth = 8
+
+type subbotDepthKey struct{}
+
+// resolveSubbotSource locates the child .bot a `subbot` node names, for a
+// run executing on a pod.
+//
+// A child is declared relative to its PARENT's bundle — `../golden-master/extend.bot`
+// from bots/modernize/main.bot. Two places can hold it on a pod, tried in
+// order: beside the parent, when the parent is a baked catalogue bot; and
+// the baked catalogue itself, when the parent was materialised from a stored
+// bundle (team-authored or platform override) into a directory that holds no
+// sibling — the sibling is the deployment's, not the tenant's. A child found
+// in neither is a typed error naming both places: a bot declaring a subbot
+// it cannot reach must fail at the node, in words, not at the pod.
+func resolveSubbotSource(source, parentDir string, botsPaths []string) (string, error) {
+	if filepath.IsAbs(source) {
+		if _, err := os.Stat(source); err == nil {
+			return source, nil
+		}
+		return "", fmt.Errorf("subbot source %q: not found", source)
+	}
+	beside := "(no parent bundle directory)"
+	if parentDir != "" {
+		beside = filepath.Join(parentDir, source)
+		if _, err := os.Stat(beside); err == nil {
+			return beside, nil
+		}
+	}
+	// Catalogue fallback: `../<slug>/<file>` names the baked bundle <slug>.
+	parts := strings.Split(filepath.ToSlash(filepath.Clean(source)), "/")
+	i := 0
+	for i < len(parts) && parts[i] == ".." {
+		i++
+	}
+	if i < len(parts)-1 && len(botsPaths) > 0 {
+		slug, file := parts[i], filepath.Join(parts[i+1:]...)
+		// The catalogue's layout first (<bots>/<slug>/<file>), then the
+		// registry's tolerant name match (kebab/snake/case) for a slug spelled
+		// differently from its directory.
+		for _, bp := range botsPaths {
+			cand := filepath.Join(bp, slug, file)
+			if _, err := os.Stat(cand); err == nil {
+				return cand, nil
+			}
+		}
+		if mainFile, err := botregistry.ResolveBotPath(slug, botsPaths); err == nil {
+			cand := filepath.Join(filepath.Dir(mainFile), file)
+			if _, err := os.Stat(cand); err == nil {
+				return cand, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("subbot source %q: not found beside the parent (%s) nor in the baked catalogue %v — a child bot must ship with its parent or in the catalogue the pod carries", source, beside, botsPaths)
+}
+
+// subbotRunnerFor builds the runtime.SubbotRunner a pod's engine invokes for
+// `subbot` nodes. Before this the runner wired none: every `subbot` node on a
+// cloud run died with "no SubbotRunner is wired" — the CLI and studio paths
+// were covered, the one surface that runs unattended was not, so a net's
+// extension and re-anchor subbots, and a supervisor's per-lot child, existed
+// locally only. Mirrors runview.subbotRunnerFor: resolve the child .bot,
+// compile it, build a child executor under the SAME message (credentials,
+// sandbox, model pins travel), run it in the parent's EFFECTIVE workdir
+// (the per-run worktree, when the parent swapped to one), and hand back the
+// child's terminal output. Children carry the parent linkage so the studio
+// folds them into the parent's card, re-attach across a pod restart through
+// the same records runview keeps, and are charged like any attempt.
+func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir string, runLogger *iterlog.Logger) runtime.SubbotRunner {
+	if runLogger == nil {
+		runLogger = r.cfg.Logger
+	}
+	return func(ctx context.Context, req runtime.SubbotRequest) (map[string]any, error) {
+		depth, _ := ctx.Value(subbotDepthKey{}).(int)
+		if depth >= maxSubbotDepth {
+			return nil, fmt.Errorf("subbot recursion too deep (>%d) at %q — possible cycle", maxSubbotDepth, req.Source)
+		}
+		// Every store call below is tenant-scoped; the parent's ctx carries
+		// the identity, and re-stamping it costs nothing where its absence
+		// panics deep inside SaveRun.
+		ctx = store.WithIdentity(ctx, msg.TenantID, msg.OwnerID)
+
+		if out, aerr, handled := runview.ReattachSubbotChild(ctx, r.cfg.Store, req, runLogger); handled {
+			return out, aerr
+		}
+
+		childPath, err := resolveSubbotSource(req.Source, parentDir, r.cfg.BotsPaths)
+		if err != nil {
+			return nil, err
+		}
+		childWf, hash, err := runview.CompileWorkflowWithHash(childPath)
+		if err != nil {
+			return nil, fmt.Errorf("compile child %q: %w", req.Source, err)
+		}
+		childRunID, err := store.GenerateRunID()
+		if err != nil {
+			return nil, err
+		}
+		runview.RecordSubbotChild(ctx, r.cfg.Store, req, childRunID, runLogger)
+
+		// The child runs under the parent's message — same credentials, same
+		// sandbox decision, same pins — as its own run: the doc the engine
+		// creates below is the child's, linked to the parent.
+		child := *msg
+		child.RunID = childRunID
+		child.ParentRunID = msg.RunID
+		child.BotID = runview.ResolveBotID("", runview.BundleNameForPath(childPath), childPath)
+		child.WorkflowHash = hash
+		child.Vars = req.Vars
+		child.Resume = nil
+		child.BotBundle = nil
+
+		childExec, childUsage, err := r.buildExecutor(ctx, &child, childWf, runLogger, nil)
+		if err != nil {
+			return nil, err
+		}
+		defer r.recordOrgSpend(ctx, &child, childUsage)
+
+		childWorkDir := req.WorkDir
+		if childWorkDir == "" {
+			childWorkDir = workDir
+		}
+		var (
+			lastMu sync.Mutex
+			last   map[string]any
+		)
+		opts := []runtime.EngineOption{
+			runtime.WithLogger(runLogger),
+			runtime.WithWorkflowHash(hash),
+			runtime.WithWorkDir(childWorkDir),
+			runtime.WithSandboxDefault(r.cfg.SandboxDefault),
+			runtime.WithSandboxDefaultImage(msg.SandboxImage),
+			runtime.WithSandboxHostStateDefault(r.cfg.SandboxHostState),
+			runtime.WithSandboxOverride(r.cfg.SandboxOverride),
+			runtime.WithLoopBudgetGuard(msg.LoopBudgetGuard),
+			runtime.WithRecoveryDispatch(recovery.Dispatch(recovery.DefaultRecipes())),
+			runtime.WithParentRunID(req.ParentRunID),
+			runtime.WithParentNodeID(req.NodeID),
+			// Recursive wiring: a child that declares subbot nodes resolves
+			// its own children relative to ITS directory.
+			runtime.WithSubbotRunner(r.subbotRunnerFor(&child, filepath.Dir(childPath), childWorkDir, runLogger)),
+			runtime.WithEventObserver(childUsage.observe),
+			runtime.WithOnNodeFinished(func(runID, nodeID string, out map[string]any) {
+				if out != nil {
+					lastMu.Lock()
+					last = out
+					lastMu.Unlock()
+				}
+			}),
+		}
+		// The child's own bundle: its skills and devbox tools, exactly as a
+		// local `iterion run bots/<child>` would provision them.
+		if b, berr := bundle.OpenDir(filepath.Dir(childPath)); berr == nil {
+			opts = append(opts, runtime.WithBundle(b))
+		} else {
+			runLogger.Warn("subbot %s: bundle open %s: %v (skills not mirrored, devbox tools not provisioned)", req.Source, filepath.Dir(childPath), berr)
+		}
+
+		childEng := runtime.New(childWf, r.cfg.Store, childExec, opts...)
+		r.registerRunEngine(childRunID, childEng)
+		defer r.unregisterRunEngine(childRunID)
+
+		childCtx := context.WithValue(ctx, subbotDepthKey{}, depth+1)
+		childLock, err := r.cfg.Store.LockRun(childCtx, childRunID)
+		if err != nil {
+			closeExecutor(childExec)
+			return nil, fmt.Errorf("subbot %s: acquire run lock: %w", childRunID, err)
+		}
+		runErr := func() error {
+			defer func() { _ = childLock.Unlock() }()
+			return childEng.Run(childCtx, childRunID, req.Vars)
+		}()
+		closeExecutor(childExec)
+		if runErr != nil {
+			// A human gate inside the child pauses the CHILD run; that is not
+			// a parent failure. Park until the operator answers and the child
+			// reaches a terminal state, then pick up its output.
+			if errors.Is(runErr, runtime.ErrRunPaused) || errors.Is(runErr, runtime.ErrRunPausedOperator) {
+				out, aerr := runview.AwaitSubbotTerminal(childCtx, r.cfg.Store, childRunID, runLogger)
+				if aerr == nil {
+					runview.ClearSubbotChild(ctx, r.cfg.Store, req)
+				}
+				return out, aerr
+			}
+			// Leave the re-attach record for the resume path.
+			return nil, runErr
+		}
+		runview.ClearSubbotChild(ctx, r.cfg.Store, req)
+		lastMu.Lock()
+		defer lastMu.Unlock()
+		return last, nil
+	}
+}
+
+func closeExecutor(exec runtime.NodeExecutor) {
+	if c, ok := any(exec).(io.Closer); ok {
+		_ = c.Close()
+	}
+}

--- a/pkg/runner/subbot.go
+++ b/pkg/runner/subbot.go
@@ -41,17 +41,42 @@ type subbotDepthKey struct{}
 // sibling — the sibling is the deployment's, not the tenant's. A child found
 // in neither is a typed error naming both places: a bot declaring a subbot
 // it cannot reach must fail at the node, in words, not at the pod.
+//
+// The name is a RELATIVE path into one of those two places and nothing else:
+// an absolute path, or a `..` chain that climbs out of the parent's bundle
+// collection and out of every catalogue root, is refused — a subbot names a
+// bundle, not a file on the pod.
 func resolveSubbotSource(source, parentDir string, botsPaths []string) (string, error) {
 	if filepath.IsAbs(source) {
-		if _, err := os.Stat(source); err == nil {
-			return source, nil
+		return "", fmt.Errorf("subbot source %q: an absolute path is not served on a pod — name the child relative to its parent bundle", source)
+	}
+	roots := make([]string, 0, 1+len(botsPaths))
+	if parentDir != "" {
+		// The parent's bundle COLLECTION, not the bundle itself: a sibling
+		// bundle (`../golden-master/…`) is the designed shape of a child.
+		roots = append(roots, filepath.Dir(filepath.Clean(parentDir)))
+	}
+	for _, bp := range botsPaths {
+		if bp != "" {
+			roots = append(roots, filepath.Clean(bp))
 		}
-		return "", fmt.Errorf("subbot source %q: not found", source)
+	}
+	contained := func(p string) bool {
+		for _, root := range roots {
+			rel, err := filepath.Rel(root, p)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				return true
+			}
+		}
+		return false
 	}
 	beside := "(no parent bundle directory)"
 	if parentDir != "" {
-		beside = filepath.Join(parentDir, source)
+		beside = filepath.Clean(filepath.Join(parentDir, source))
 		if _, err := os.Stat(beside); err == nil {
+			if !contained(beside) {
+				return "", fmt.Errorf("subbot source %q: resolves to %s, outside the parent's bundle collection and every catalogue root %v — a child is named relative to its parent bundle, not by a path across the pod", source, beside, botsPaths)
+			}
 			return beside, nil
 		}
 	}
@@ -65,16 +90,17 @@ func resolveSubbotSource(source, parentDir string, botsPaths []string) (string, 
 		slug, file := parts[i], filepath.Join(parts[i+1:]...)
 		// The catalogue's layout first (<bots>/<slug>/<file>), then the
 		// registry's tolerant name match (kebab/snake/case) for a slug spelled
-		// differently from its directory.
+		// differently from its directory. A <file> that climbs back out of
+		// the bundle is refused by the same containment.
 		for _, bp := range botsPaths {
-			cand := filepath.Join(bp, slug, file)
-			if _, err := os.Stat(cand); err == nil {
+			cand := filepath.Clean(filepath.Join(bp, slug, file))
+			if _, err := os.Stat(cand); err == nil && contained(cand) {
 				return cand, nil
 			}
 		}
 		if mainFile, err := botregistry.ResolveBotPath(slug, botsPaths); err == nil {
-			cand := filepath.Join(filepath.Dir(mainFile), file)
-			if _, err := os.Stat(cand); err == nil {
+			cand := filepath.Clean(filepath.Join(filepath.Dir(mainFile), file))
+			if _, err := os.Stat(cand); err == nil && contained(cand) {
 				return cand, nil
 			}
 		}
@@ -108,6 +134,12 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 		// panics deep inside SaveRun.
 		ctx = store.WithIdentity(ctx, msg.TenantID, msg.OwnerID)
 
+		// Re-attach across a pod restart through the records runview keeps
+		// (ADR-084). A child left `running` by a pod that died mid-child is
+		// parked on until the orphan sweeper flips it — no pod resumes a
+		// child by itself, it rides its parent's delivery — after which the
+		// next parent resume spawns a FRESH child; the child's own
+		// checkpoint is not resumed. Same contract as in-process.
 		if out, aerr, handled := runview.ReattachSubbotChild(ctx, r.cfg.Store, req, runLogger); handled {
 			return out, aerr
 		}
@@ -120,6 +152,12 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 		if err != nil {
 			return nil, fmt.Errorf("compile child %q: %w", req.Source, err)
 		}
+		// The deployment's multitenant ceiling (ITERION_CLOUD_MAX_*) clamps
+		// the child exactly as executeRun clamps the parent: a tenant bot
+		// could otherwise declare its spend in a child and leave the cap
+		// behind. The parent's own launch overrides are NOT replayed — a
+		// child budgets itself from its .bot, as it does in-process.
+		applyCloudBudgetCeiling(childWf, runLogger)
 		childRunID, err := store.GenerateRunID()
 		if err != nil {
 			return nil, err
@@ -251,7 +289,12 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 			// a parent failure. Park until the operator answers and the child
 			// reaches a terminal state, then pick up its output.
 			if errors.Is(runErr, runtime.ErrRunPaused) || errors.Is(runErr, runtime.ErrRunPausedOperator) {
-				out, aerr := runview.AwaitSubbotTerminal(childCtx, r.cfg.Store, childRunID, runLogger)
+				// Parked on the PARENT's ctx: the child's was cancelled the
+				// moment its engine returned (that cancel is the heartbeat's
+				// stop signal), and a park on it returns at once with
+				// `context canceled` — a gate meant to wait for a human read
+				// as a parent failure 20 ms in.
+				out, aerr := runview.AwaitSubbotTerminal(ctx, r.cfg.Store, childRunID, runLogger)
 				if aerr == nil {
 					runview.ClearSubbotChild(ctx, r.cfg.Store, req)
 				}

--- a/pkg/runner/subbot_test.go
+++ b/pkg/runner/subbot_test.go
@@ -1,0 +1,200 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+const subbotTestChild = `## tool-only child: no API keys, no sandbox needed
+schema out:
+  validated: bool
+  echoed: string
+
+vars:
+  ticket: string = "none"
+
+tool work:
+  command: ` + "`" + `printf '{"validated":true,"echoed":"%s"}' {{vars.ticket}}` + "`" + `
+  output: out
+
+workflow child:
+  entry: work
+  work -> done
+`
+
+const subbotTestParent = `schema vout:
+  validated: bool
+  echoed: string
+
+subbot run_ticket:
+  source: "child.bot"
+  with { ticket: "T-1" }
+  output: vout
+
+workflow parent:
+  entry: run_ticket
+  run_ticket -> done when validated
+  run_ticket -> fail
+`
+
+func writeSubbotFixture(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestResolveSubbotSource pins the two places a pod may find a child bot,
+// in order: beside the parent bundle, then the baked catalogue (the case of
+// a parent materialised from a stored bundle, whose sibling bundles are the
+// deployment's). A child in neither is a typed error naming both.
+func TestResolveSubbotSource(t *testing.T) {
+	root := t.TempDir()
+	// A baked catalogue: <root>/bots/golden-master/extend.bot
+	catalogue := filepath.Join(root, "bots")
+	writeSubbotFixture(t, filepath.Join(catalogue, "golden-master"), "main.bot", subbotTestChild)
+	extend := writeSubbotFixture(t, filepath.Join(catalogue, "golden-master"), "extend.bot", subbotTestChild)
+	// A parent beside which the sibling exists.
+	beside := filepath.Join(root, "beside", "modernize")
+	writeSubbotFixture(t, beside, "main.bot", subbotTestParent)
+	sibling := writeSubbotFixture(t, filepath.Join(root, "beside", "golden-master"), "extend.bot", subbotTestChild)
+	// A parent materialised alone (stored bundle): no sibling next to it.
+	alone := filepath.Join(root, "materialised", "modernize")
+	writeSubbotFixture(t, alone, "main.bot", subbotTestParent)
+
+	t.Run("beside the parent wins", func(t *testing.T) {
+		got, err := resolveSubbotSource("../golden-master/extend.bot", beside, []string{catalogue})
+		if err != nil || got != sibling {
+			t.Fatalf("got %q, %v; want %q", got, err, sibling)
+		}
+	})
+	t.Run("a materialised parent falls back to the baked catalogue", func(t *testing.T) {
+		got, err := resolveSubbotSource("../golden-master/extend.bot", alone, []string{catalogue})
+		if err != nil || got != extend {
+			t.Fatalf("got %q, %v; want %q", got, err, extend)
+		}
+	})
+	t.Run("no parent directory at all: the catalogue still serves", func(t *testing.T) {
+		got, err := resolveSubbotSource("../golden-master/extend.bot", "", []string{catalogue})
+		if err != nil || got != extend {
+			t.Fatalf("got %q, %v; want %q", got, err, extend)
+		}
+	})
+	t.Run("found nowhere: a typed error naming both places", func(t *testing.T) {
+		_, err := resolveSubbotSource("../absent-bot/x.bot", alone, []string{catalogue})
+		if err == nil || !strings.Contains(err.Error(), "beside the parent") || !strings.Contains(err.Error(), "baked catalogue") {
+			t.Fatalf("err = %v, want both places named", err)
+		}
+	})
+}
+
+func subbotTestRunner(t *testing.T) (*Runner, store.RunStore) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop(), SandboxOverride: "none"}}
+	return r, st
+}
+
+// TestSubbotRunnerRunsChildOnPod runs a tool-only child through the closure
+// the pod's engine invokes for `subbot` nodes: the child's terminal output
+// comes back as the node's output, and the child ran under the parent's
+// message (its own run id, linked to the parent).
+func TestSubbotRunnerRunsChildOnPod(t *testing.T) {
+	r, _ := subbotTestRunner(t)
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	writeSubbotFixture(t, parentDir, "main.bot", subbotTestParent)
+	writeSubbotFixture(t, parentDir, "child.bot", subbotTestChild)
+	msg := &queue.RunMessage{RunID: "run-parent", TenantID: "t1", OwnerID: "u1", BotID: "parent"}
+
+	run := r.subbotRunnerFor(msg, parentDir, dir, iterlog.Nop())
+	out, err := run(context.Background(), runtime.SubbotRequest{
+		Source:      "child.bot",
+		Vars:        map[string]any{"ticket": "T-9"},
+		ParentRunID: msg.RunID,
+		NodeID:      "run_ticket",
+		ReattachKey: "run_ticket",
+	})
+	if err != nil {
+		t.Fatalf("subbot runner: %v", err)
+	}
+	if v, _ := out["validated"].(bool); !v {
+		t.Fatalf("child output = %v, want validated=true", out)
+	}
+	if e, _ := out["echoed"].(string); e != "T-9" {
+		t.Fatalf("child output = %v, want echoed=T-9 (the `with:` vars reached the child)", out)
+	}
+}
+
+// TestPodEngineRunsSubbotNodes is the pod-side end-to-end: a parent
+// workflow declaring a `subbot` node, run by an engine built the way
+// executeRun builds it, reaches `done`. Without the runner wired the same
+// node dies with "no SubbotRunner is wired" — which is what every cloud run
+// declaring a subbot did before this change.
+func TestPodEngineRunsSubbotNodes(t *testing.T) {
+	r, st := subbotTestRunner(t)
+	dir := t.TempDir()
+	parentPath := writeSubbotFixture(t, dir, "main.bot", subbotTestParent)
+	writeSubbotFixture(t, dir, "child.bot", subbotTestChild)
+	wf, hash, err := runview.CompileWorkflowWithHash(parentPath)
+	if err != nil {
+		t.Fatalf("compile parent: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "t1", "u1")
+	msg := &queue.RunMessage{RunID: "run-parent", TenantID: "t1", OwnerID: "u1", BotID: "parent", WorkflowHash: hash}
+
+	newEngine := func(t *testing.T, runID string, wired bool) *runtime.Engine {
+		t.Helper()
+		exec, usage, err := r.buildExecutor(ctx, msg, wf, iterlog.Nop(), nil)
+		if err != nil {
+			t.Fatalf("buildExecutor: %v", err)
+		}
+		opts := []runtime.EngineOption{
+			runtime.WithLogger(iterlog.Nop()),
+			runtime.WithWorkflowHash(hash),
+			runtime.WithWorkDir(dir),
+			runtime.WithSandboxOverride("none"),
+			runtime.WithEventObserver(usage.observe),
+		}
+		if wired {
+			opts = append(opts, runtime.WithSubbotRunner(r.subbotRunnerFor(msg, dir, dir, iterlog.Nop())))
+		}
+		return runtime.New(wf, st, exec, opts...)
+	}
+
+	t.Run("wired: the parent reaches done through its child", func(t *testing.T) {
+		if err := newEngine(t, "run-parent", true).Run(ctx, "run-parent", nil); err != nil {
+			t.Fatalf("parent run: %v", err)
+		}
+		run, err := st.LoadRun(ctx, "run-parent")
+		if err != nil {
+			t.Fatalf("load parent: %v", err)
+		}
+		if string(run.Status) != "finished" {
+			t.Fatalf("parent status = %q, want finished", run.Status)
+		}
+	})
+	t.Run("not wired: the pre-fix death, pinned", func(t *testing.T) {
+		err := newEngine(t, "run-parent-unwired", false).Run(ctx, "run-parent-unwired", nil)
+		if err == nil || !strings.Contains(err.Error(), "no SubbotRunner is wired") {
+			t.Fatalf("err = %v, want the unwired death", err)
+		}
+	})
+}

--- a/pkg/runner/subbot_test.go
+++ b/pkg/runner/subbot_test.go
@@ -315,7 +315,7 @@ workflow child:
 // budget carries the ceiling, and a two-node child under a one-iteration
 // ceiling does not reach its second node.
 func TestSubbotRunnerAppliesCloudBudgetCeiling(t *testing.T) {
-	runChild := func(t *testing.T) (map[string]any, error, *store.Run) {
+	runChild := func(t *testing.T) (map[string]any, *store.Run, error) {
 		t.Helper()
 		r, st := subbotTestRunner(t)
 		dir := t.TempDir()
@@ -341,11 +341,11 @@ func TestSubbotRunnerAppliesCloudBudgetCeiling(t *testing.T) {
 		if child == nil {
 			t.Fatal("no child run persisted")
 		}
-		return out, err, child
+		return out, child, err
 	}
 
 	t.Run("no ceiling: the child runs both nodes", func(t *testing.T) {
-		out, err, _ := runChild(t)
+		out, _, err := runChild(t)
 		if err != nil {
 			t.Fatalf("child: %v", err)
 		}
@@ -355,7 +355,7 @@ func TestSubbotRunnerAppliesCloudBudgetCeiling(t *testing.T) {
 	})
 	t.Run("ceiling of one iteration: the child is clamped and stops after its first node", func(t *testing.T) {
 		t.Setenv("ITERION_CLOUD_MAX_ITERATIONS", "1")
-		_, err, child := runChild(t)
+		_, child, err := runChild(t)
 		if !errors.Is(err, runtime.ErrBudgetExceeded) {
 			t.Fatalf("err = %v, want the budget refusal — the ceiling did not reach the child", err)
 		}

--- a/pkg/runner/subbot_test.go
+++ b/pkg/runner/subbot_test.go
@@ -2,10 +2,12 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
@@ -98,6 +100,28 @@ func TestResolveSubbotSource(t *testing.T) {
 		_, err := resolveSubbotSource("../absent-bot/x.bot", alone, []string{catalogue})
 		if err == nil || !strings.Contains(err.Error(), "beside the parent") || !strings.Contains(err.Error(), "baked catalogue") {
 			t.Fatalf("err = %v, want both places named", err)
+		}
+	})
+	// A subbot names a bundle, not a file on the pod: the two ways to reach
+	// past the parent's collection and the catalogue are refused even when
+	// the file exists — existence is exactly what a traversal probes for.
+	outside := writeSubbotFixture(t, filepath.Join(root, "outside"), "x.bot", subbotTestChild)
+	t.Run("an absolute path is refused", func(t *testing.T) {
+		_, err := resolveSubbotSource(outside, beside, []string{catalogue})
+		if err == nil || !strings.Contains(err.Error(), "absolute path") {
+			t.Fatalf("err = %v, want the absolute-path refusal", err)
+		}
+	})
+	t.Run("a `..` chain out of the collection and the catalogue is refused", func(t *testing.T) {
+		_, err := resolveSubbotSource("../../outside/x.bot", beside, []string{catalogue})
+		if err == nil || !strings.Contains(err.Error(), "outside the parent's bundle collection") {
+			t.Fatalf("err = %v, want the containment refusal (the file exists)", err)
+		}
+	})
+	t.Run("a catalogue <file> that climbs back out is refused", func(t *testing.T) {
+		_, err := resolveSubbotSource("../golden-master/../../outside/x.bot", alone, []string{catalogue})
+		if err == nil {
+			t.Fatal("err = nil, want a refusal: the catalogue fallback must not serve a path outside its root")
 		}
 	})
 }
@@ -195,6 +219,148 @@ func TestPodEngineRunsSubbotNodes(t *testing.T) {
 		err := newEngine(t, "run-parent-unwired", false).Run(ctx, "run-parent-unwired", nil)
 		if err == nil || !strings.Contains(err.Error(), "no SubbotRunner is wired") {
 			t.Fatalf("err = %v, want the unwired death", err)
+		}
+	})
+}
+
+const subbotTestHumanChild = `schema answer:
+  confirmed: bool
+
+prompt ask_text:
+  Confirm the ticket.
+
+human gate:
+  instructions: ask_text
+  output: answer
+  interaction: human
+
+workflow child:
+  entry: gate
+  gate -> done
+`
+
+// TestSubbotRunnerParksOnHumanGate: a human gate inside the child pauses the
+// CHILD, which is not a parent failure — the node parks until the operator
+// answers. The park must ride the PARENT's ctx: the child's is cancelled the
+// moment its engine returns (that cancel is the heartbeat's stop signal), and
+// a park on it returned at once with `context canceled` — the gate failed the
+// parent node 20 ms in instead of waiting for a human.
+func TestSubbotRunnerParksOnHumanGate(t *testing.T) {
+	r, st := subbotTestRunner(t)
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	writeSubbotFixture(t, parentDir, "main.bot", subbotTestParent)
+	writeSubbotFixture(t, parentDir, "child.bot", subbotTestHumanChild)
+	msg := &queue.RunMessage{RunID: "run-parent", TenantID: "t1", OwnerID: "u1", BotID: "parent"}
+
+	const parentDeadline = 1500 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), parentDeadline)
+	defer cancel()
+	start := time.Now()
+	run := r.subbotRunnerFor(msg, parentDir, dir, iterlog.Nop())
+	_, err := run(ctx, runtime.SubbotRequest{
+		Source: "child.bot", ParentRunID: msg.RunID, NodeID: "run_ticket", ReattachKey: "run_ticket",
+	})
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v after %s, want the PARENT's deadline: a `context canceled` here is the child's own cancel leaking into the park", err, elapsed)
+	}
+	if elapsed < parentDeadline-100*time.Millisecond {
+		t.Fatalf("park returned after %s, want it held until the parent's deadline (%s)", elapsed, parentDeadline)
+	}
+	// The child is parked on its gate, not dead.
+	idCtx := store.WithIdentity(context.Background(), "t1", "u1")
+	ids, lerr := st.ListRuns(idCtx)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	var children int
+	for _, id := range ids {
+		child, cerr := st.LoadRun(idCtx, id)
+		if cerr != nil || child.ParentRunID != msg.RunID {
+			continue
+		}
+		children++
+		if child.Status != store.RunStatusPausedWaitingHuman {
+			t.Fatalf("child %s status = %q, want paused_waiting_human", id, child.Status)
+		}
+	}
+	if children != 1 {
+		t.Fatalf("children of the parent = %d, want exactly one", children)
+	}
+}
+
+const subbotTestTwoNodeChild = `schema out:
+  validated: bool
+  echoed: string
+
+tool first:
+  command: ` + "`" + `printf '{"validated":true,"echoed":"one"}'` + "`" + `
+  output: out
+
+tool second:
+  command: ` + "`" + `printf '{"validated":true,"echoed":"two"}'` + "`" + `
+  output: out
+
+workflow child:
+  entry: first
+  first -> second
+  second -> done
+`
+
+// TestSubbotRunnerAppliesCloudBudgetCeiling: the deployment's multitenant
+// ceiling (ITERION_CLOUD_MAX_*) binds a child as it binds the parent
+// executeRun clamps — a tenant bot could otherwise declare its spend in a
+// subbot and leave the cap behind. Proven two ways: the child's persisted
+// budget carries the ceiling, and a two-node child under a one-iteration
+// ceiling does not reach its second node.
+func TestSubbotRunnerAppliesCloudBudgetCeiling(t *testing.T) {
+	runChild := func(t *testing.T) (map[string]any, error, *store.Run) {
+		t.Helper()
+		r, st := subbotTestRunner(t)
+		dir := t.TempDir()
+		parentDir := filepath.Join(dir, "parent")
+		writeSubbotFixture(t, parentDir, "main.bot", subbotTestParent)
+		writeSubbotFixture(t, parentDir, "child.bot", subbotTestTwoNodeChild)
+		msg := &queue.RunMessage{RunID: "run-parent", TenantID: "t1", OwnerID: "u1", BotID: "parent"}
+		run := r.subbotRunnerFor(msg, parentDir, dir, iterlog.Nop())
+		out, err := run(context.Background(), runtime.SubbotRequest{
+			Source: "child.bot", ParentRunID: msg.RunID, NodeID: "run_ticket", ReattachKey: "run_ticket",
+		})
+		idCtx := store.WithIdentity(context.Background(), "t1", "u1")
+		ids, lerr := st.ListRuns(idCtx)
+		if lerr != nil {
+			t.Fatal(lerr)
+		}
+		var child *store.Run
+		for _, id := range ids {
+			if c, cerr := st.LoadRun(idCtx, id); cerr == nil && c.ParentRunID == msg.RunID {
+				child = c
+			}
+		}
+		if child == nil {
+			t.Fatal("no child run persisted")
+		}
+		return out, err, child
+	}
+
+	t.Run("no ceiling: the child runs both nodes", func(t *testing.T) {
+		out, err, _ := runChild(t)
+		if err != nil {
+			t.Fatalf("child: %v", err)
+		}
+		if e, _ := out["echoed"].(string); e != "two" {
+			t.Fatalf("child output = %v, want the second node's", out)
+		}
+	})
+	t.Run("ceiling of one iteration: the child is clamped and stops after its first node", func(t *testing.T) {
+		t.Setenv("ITERION_CLOUD_MAX_ITERATIONS", "1")
+		_, err, child := runChild(t)
+		if !errors.Is(err, runtime.ErrBudgetExceeded) {
+			t.Fatalf("err = %v, want the budget refusal — the ceiling did not reach the child", err)
+		}
+		if child.Budget == nil || child.Budget.MaxIterations != 1 {
+			t.Fatalf("child persisted budget = %+v, want max_iterations=1 from the platform ceiling", child.Budget)
 		}
 	})
 }

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -264,6 +264,19 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		if err != nil {
 			return nil, fmt.Errorf("runtime: create run: %w", err)
 		}
+		// A store may insert a fresh row as `queued` (the cloud store does —
+		// CreateChildRun mirrors the publisher's shape). This engine is about
+		// to execute it, so the row must read `running` now, as the pickup
+		// path above makes it: otherwise a subbot child on a pod stays
+		// `queued` for its whole life — judged by the queued-row cutoff,
+		// shown queued in the studio, never given a started_at — and ends
+		// `finished` without ever having been running.
+		if created.Status == store.RunStatusQueued {
+			if uerr := e.store.UpdateRunStatus(ctx, runID, store.RunStatusRunning, ""); uerr != nil {
+				return nil, fmt.Errorf("runtime: created-run transition: %w", uerr)
+			}
+			created.Status = store.RunStatusRunning
+		}
 		run = created
 	}
 	if e.workflowHash != "" || e.workflowSource != "" || e.filePath != "" || e.parentRunID != "" || e.parentNodeID != "" || e.runName != "" || e.mergeStrategy != "" || e.autoMerge || e.preset != "" || e.bundle != nil || e.source != nil || e.callbackURL != "" || len(e.modelOverrides) > 0 || e.workflow.Budget != nil ||

--- a/pkg/runtime/engine_run_created_queued_test.go
+++ b/pkg/runtime/engine_run_created_queued_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// queuedCreatingStore mimics the cloud store's CreateRun/CreateChildRun,
+// which insert a fresh row as `queued` (the publisher's shape) — the
+// filesystem store inserts `running`, which is why the direct path never
+// showed the gap locally.
+type queuedCreatingStore struct {
+	*store.FilesystemRunStore
+}
+
+func (q *queuedCreatingStore) CreateRun(ctx context.Context, id, workflowName string, inputs map[string]any) (*store.Run, error) {
+	run, err := q.FilesystemRunStore.CreateRun(ctx, id, workflowName, inputs)
+	if err != nil {
+		return nil, err
+	}
+	if err := q.FilesystemRunStore.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
+		return nil, err
+	}
+	run.Status = store.RunStatusQueued
+	return run, nil
+}
+
+func (q *queuedCreatingStore) CreateChildRun(ctx context.Context, id, workflowName, parentRunID string, inputs map[string]any) (*store.Run, error) {
+	run, err := q.FilesystemRunStore.CreateChildRun(ctx, id, workflowName, parentRunID, inputs)
+	if err != nil {
+		return nil, err
+	}
+	if err := q.FilesystemRunStore.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
+		return nil, err
+	}
+	run.Status = store.RunStatusQueued
+	return run, nil
+}
+
+// TestRunDirectCreateQueuedBecomesRunning pins the direct path against a
+// store that creates rows as `queued`: the engine is about to execute the
+// run, so the row must read `running` at once — as the pickup path makes it.
+// Before this, a subbot child on a pod stayed `queued` for its whole life
+// and ended `finished` without ever having been running.
+func TestRunDirectCreateQueuedBecomesRunning(t *testing.T) {
+	fs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := &queuedCreatingStore{FilesystemRunStore: fs}
+	src := `schema out:
+  ok: bool
+
+tool work:
+  command: ` + "`printf '{\"ok\":true}'`" + `
+  output: out
+
+workflow w:
+  entry: work
+  work -> done
+`
+	pr := parser.Parse("w.bot", src)
+	if pr.File == nil {
+		t.Fatalf("parse: %v", pr.Diagnostics)
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatalf("compile: %v", cr.Diagnostics)
+	}
+	var seen []store.RunStatus
+	exec := newStubExecutor()
+	exec.on("work", func(map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+	observe := WithOnNodeFinished(func(rid, nodeID string, out map[string]any) {
+		if run, lerr := st.LoadRun(context.Background(), rid); lerr == nil {
+			seen = append(seen, run.Status)
+		}
+	})
+	for _, child := range []bool{false, true} {
+		runID := "direct-queued"
+		opts := []EngineOption{WithWorkDir(t.TempDir()), WithSandboxOverride("none"), observe}
+		if child {
+			runID = "direct-queued-child"
+			opts = append(opts, WithParentRunID("parent-1"))
+		}
+		eng := New(cr.Workflow, st, exec, opts...)
+		seen = nil
+		if err := eng.Run(context.Background(), runID, nil); err != nil {
+			t.Fatalf("child=%v run: %v", child, err)
+		}
+		if len(seen) == 0 || seen[0] != store.RunStatusRunning {
+			t.Fatalf("child=%v: status observed while the first node ran = %v, want running (the row was created queued)", child, seen)
+		}
+		final, err := st.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.Status != store.RunStatusFinished {
+			t.Fatalf("child=%v: final status = %s", child, final.Status)
+		}
+	}
+}

--- a/pkg/runtime/engine_run_created_queued_test.go
+++ b/pkg/runtime/engine_run_created_queued_test.go
@@ -22,7 +22,7 @@ func (q *queuedCreatingStore) CreateRun(ctx context.Context, id, workflowName st
 	if err != nil {
 		return nil, err
 	}
-	if err := q.FilesystemRunStore.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
+	if err := q.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
 		return nil, err
 	}
 	run.Status = store.RunStatusQueued
@@ -34,7 +34,7 @@ func (q *queuedCreatingStore) CreateChildRun(ctx context.Context, id, workflowNa
 	if err != nil {
 		return nil, err
 	}
-	if err := q.FilesystemRunStore.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
+	if err := q.UpdateRunStatus(ctx, id, store.RunStatusQueued, ""); err != nil {
 		return nil, err
 	}
 	run.Status = store.RunStatusQueued


### PR DESCRIPTION
## Subbot nodes ran locally only

The pod's engine was built without `WithSubbotRunner` (`pkg/runner/loop.go`), while the CLI and the studio paths carried one. Every `subbot` node on a cloud run therefore died at dispatch with `subbot "x": no SubbotRunner is wired` — a net's extension subbot, its re-anchor subbot, and a programme supervisor's per-lot child all existed locally only. *"No feature ships local-only"*, violated by the one surface that runs unattended.

**Measured on a live campaign**: a lot whose gate requested an extension did 116 min of agent work, then hit the subbot node — **six `run_failed` / six `run_resumed` in twelve minutes, the sandbox pod recreated on every resume** (a deterministic node failure under the usage-window retry is a resume loop, not a state). The same wall explains why the supervisor bot's cloud gate could never be crossed: its per-lot child is a subbot.

## What the runner does now

Mirrors `runview.subbotRunnerFor`: resolve the child `.bot` **beside the parent bundle**, else in the **baked catalogue** (a parent materialised from a stored bundle holds no sibling — the sibling is the deployment's), compile it, build a child executor under the **same message** (credentials, sandbox decision, model pins travel), run it in the parent's effective workdir with its own bundle (skills, devbox), parent linkage, the re-attach records ADR-084 keeps, and spend accounting, and hand back the child's terminal output. A child found nowhere is a typed error naming both places.

## Hardened after two adversarial rounds (execute-to-prove, posture: break)

- **The child's NATS-KV lease was never refreshed** — on the cloud store `LockRun` is a 60 s TTL entry only a refresher keeps alive; the parent's heartbeat refreshes the PARENT's. The child read dead at T+60 s: the orphan sweeper flipped it `failed_resumable`, the reaper deleted its sandbox pod mid-flight. A child heartbeat (`childLeaseHeartbeat`, the child half of `Runner.heartbeat`) refreshes it; a failed refresh cancels the child with `ErrRunInterrupted` (resumable) rather than split-brain.
- **The child doc stayed `queued` in cloud** — `runResolveDoc`'s direct path created the doc as the Mongo store creates it and never flipped it; a child ran for hours reading `queued` (and the sweeper's `queued` window would have swept it). Flipped to `running` at creation; `TestRunDirectCreateQueuedBecomesRunning` pins it (mutant red).
- **The park on a human gate returned in 20 ms with `context canceled`** — the active pass cancels the child's ctx as it returns (the heartbeat's stop signal) and the park reused that ctx: a gate meant to wait for an operator read as a parent failure. The park rides the PARENT's ctx; `TestSubbotRunnerParksOnHumanGate` holds a child under a 1.5 s parent deadline until that deadline, ending `paused_waiting_human`.
- **The child escaped the multitenant ceiling** — `executeRun` clamps the parent through `applyCloudBudgetCeiling`; the child went straight to `runtime.New` (measured: `MaxCostUSD 9999 / 72h` against a `2 $ / 10 min` ceiling). Clamped the same way; `TestSubbotRunnerAppliesCloudBudgetCeiling` stops a two-node child after one node under `ITERION_CLOUD_MAX_ITERATIONS=1` and reads `max_iterations=1` on the persisted child. The parent's own launch overrides are not replayed (a child budgets itself from its `.bot`, as in-process).
- **`resolveSubbotSource` served absolute paths and `..` chains** to any file on the pod. A subbot names a bundle: relative only, resolved inside the parent's bundle collection or a catalogue root, else a typed refusal. Hygiene rather than a boundary (a tenant's tool nodes already run on the pod) — the resolver's contract is now what it says.
- Also carried: the child's own `run.log` writer (the studio's per-node Logs tab reads the CHILD's log), the sandbox-run observer (rotated tokens reach the child's container), `WithFilePath` + `WithContributions` + the child's bundle (skills, devbox tools), `recordOrgSpend` on the child.

**Residual, stated at the re-attach site**: a child left `running` by a pod that died mid-child is parked on until the orphan sweeper flips it (no pod resumes a child by itself — it rides its parent's delivery), then re-run **fresh** on the next parent resume; the child's own checkpoint is not resumed. That is the in-process contract too; resuming the child in place is a follow-up. The pre-flight usage-cap park (`admitAttempt`) is not applied to the child either — the executor's `UsageGuard` is, so a cap still bites mid-run; only the free pre-spend park is missing.

## Proof

- `TestResolveSubbotSource` — beside / catalogue fallback / no parent dir / nowhere (typed).
- `TestSubbotRunnerRunsChildOnPod` — the closure runs a tool-only child; its `with:` vars reach it; its output comes back.
- `TestPodEngineRunsSubbotNodes` — pod-side end-to-end: a parent workflow declaring a `subbot` node reaches `done` through a runner-built engine; **the same engine without the runner dies with the exact pre-fix message** (pinned).
- `TestSubbotRunnerParksOnHumanGate`, `TestSubbotRunnerAppliesCloudBudgetCeiling`, the three containment cases of `TestResolveSubbotSource`, `TestRunDirectCreateQueuedBecomesRunning` (pkg/runtime) — each with its mutant turned red before the fix was kept.
- `go test ./pkg/runner/` green (115 s), `go test ./pkg/runtime/` green. Assumed and documented: the one line wiring the option inside `executeRun` has no unit harness (cloud e2e covers `executeRun`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
