### PR TITLE
fix(claw): carry the run's forfait across the sandbox boundary (it currently cannot authenticate there at all)

### DIFF
--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -913,7 +913,10 @@ func (b *ClawBackend) executeViaSandboxRunner(ctx context.Context, task delegate
 	// finds nothing and bails with "API key required for OpenAI-
 	// compatible provider". Pass through only the keys we know
 	// providers consume: anything else stays on the host.
-	runnerEnv := forwardableProviderEnv(ctx)
+	runnerEnv, err := forwardableProviderEnv(ctx, task.Model)
+	if err != nil {
+		return delegate.Result{}, err
+	}
 	cmd := run.Command(ctx, []string{"iterion", "__claw-runner"}, sandbox.ExecOpts{
 		KeepStdinOpen: true,
 		Env:           runnerEnv,
@@ -1118,7 +1121,7 @@ var byokEnvVar = map[secrets.Provider]string{
 // entirely while its donor's lease has already been taken. The failure is
 // invisible whenever the ambient key happens to work, which is the worst
 // possible shape for a billing boundary.
-func forwardableProviderEnv(ctx context.Context) map[string]string {
+func forwardableProviderEnv(ctx context.Context, model string) (map[string]string, error) {
 	env := map[string]string{}
 	for _, name := range providerCredentialEnvVars {
 		if v := os.Getenv(name); v != "" {
@@ -1139,7 +1142,7 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 	}
 	creds, ok := secrets.CredentialsFromContext(ctx)
 	if !ok {
-		return env
+		return env, nil
 	}
 	for provider, key := range creds.APIKeys {
 		if key == "" {
@@ -1171,7 +1174,33 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 			env["ITERION_OPENAI_USE_OAUTH"] = "1"
 		}
 	}
-	// The Anthropic twin (#736). A resolved Claude Code forfait is mounted by
+	// The Anthropic twin (#736), and only for a node the forfait can actually
+	// serve. A z.ai/GLM model rides claw's ANTHROPIC provider too — it arrives
+	// as "anthropic/glm-X" and registry.go SYNTHESISES z.ai's base URL from a
+	// bare ZAI_API_KEY — so the wire check below cannot see it: there is no
+	// ANTHROPIC_BASE_URL to inspect. Clearing ZAI_API_KEY for such a node would
+	// remove its only credential channel and leave the forfait bearer asking
+	// api.anthropic.com for a GLM model it cannot serve, breaking exactly the
+	// forfait-carrying tenants this change is for.
+	if !modelServedByZAI(model) {
+		if err := applyForfaitAcrossSandbox(env, creds); err != nil {
+			return nil, err
+		}
+	}
+	return env, nil
+}
+
+// modelServedByZAI reports whether a model pinned on claw's anthropic provider
+// is actually served by z.ai's Anthropic-compatible endpoint. Same predicate
+// anthropicCapabilities uses to split the two families apart.
+func modelServedByZAI(model string) bool {
+	return strings.Contains(strings.ToLower(model), "glm")
+}
+
+// applyForfaitAcrossSandbox is the body of the forfait crossing, split out so
+// the model gate above reads as one line.
+func applyForfaitAcrossSandbox(env map[string]string, creds secrets.Credentials) error {
+	// A resolved Claude Code forfait is mounted by
 	// runtime.addClaudeOAuthSecretFile and copied into a writable config dir by
 	// seedClaudeConfigDir — both per RUN, not per backend, so the dir is
 	// populated for a claw node too. Pointing CLAUDE_CONFIG_DIR at it is what
@@ -1196,12 +1225,23 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 		creds.APIKeys[secrets.ProviderAnthropic] == "" &&
 		creds.APIKeys[secrets.ProviderZAI] == "" &&
 		secrets.AnthropicForfaitWireOK(os.Getenv("ANTHROPIC_BASE_URL")) {
+		dir := creds.OAuthDir(string(secrets.OAuthKindClaudeCode))
+		// Validate BEFORE clearing. Once the shadows are gone the forfait is
+		// the node's ONLY credential in the container, and the in-container
+		// resolver is the env factory, which swallows expiry — it returns ""
+		// and builds a client with no credential at all, i.e. #687's opaque
+		// 401 loop with nothing naming the forfait. The in-process twin
+		// (anthropicFromCtxForfait) already refuses rather than degrade there;
+		// this seam must decide the same way, or the two disagree again.
+		if _, terr := secrets.AnthropicForfaitToken(dir); terr != nil {
+			return fmt.Errorf("claw backend: sandboxed anthropic node cannot use the run's forfait: %w", terr)
+		}
 		env["CLAUDE_CONFIG_DIR"] = secrets.ClaudeCodeSandboxConfigDir
 		for _, shadow := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ZAI_API_KEY"} {
 			delete(env, shadow)
 		}
 	}
-	return env
+	return nil
 }
 
 // canonicalMCPToolName maps an MCP tool name the model emitted in the

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1171,6 +1171,36 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 			env["ITERION_OPENAI_USE_OAUTH"] = "1"
 		}
 	}
+	// The Anthropic twin (#736). A resolved Claude Code forfait is mounted by
+	// runtime.addClaudeOAuthSecretFile and copied into a writable config dir by
+	// seedClaudeConfigDir — both per RUN, not per backend, so the dir is
+	// populated for a claw node too. Pointing CLAUDE_CONFIG_DIR at it is what
+	// lets the in-container registry find it: its desktop path reads exactly
+	// that variable.
+	//
+	// Clearing the ambient anthropic-wire vars is not a detail, it is the fix.
+	// The registry reads the disk forfait only when no env credential precedes
+	// it, and the ambient ANTHROPIC_API_KEY forwarded above is the POD's — the
+	// platform's — a machine default rather than a credential resolved FOR THIS
+	// RUN, which is the distinction this function exists to enforce. Left in
+	// place, a forfait-only tenant's sandboxed node authenticates and bills
+	// against the platform account, and does so invisibly, because the ambient
+	// key works.
+	//
+	// Two limits, both deliberate: a BYOK anthropic or z.ai key is the tenant's
+	// own explicit instrument and keeps precedence (otherwise the same run
+	// would spend a different one depending on whether it happened to be
+	// sandboxed); and a redirected wire is a destination the operator chose, so
+	// a bearer carrying the whole Claude account does not travel there.
+	if creds.OAuthDir(string(secrets.OAuthKindClaudeCode)) != "" &&
+		creds.APIKeys[secrets.ProviderAnthropic] == "" &&
+		creds.APIKeys[secrets.ProviderZAI] == "" &&
+		secrets.AnthropicForfaitWireOK(os.Getenv("ANTHROPIC_BASE_URL")) {
+		env["CLAUDE_CONFIG_DIR"] = secrets.ClaudeCodeSandboxConfigDir
+		for _, shadow := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ZAI_API_KEY"} {
+			delete(env, shadow)
+		}
+	}
 	return env
 }
 

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -105,3 +105,66 @@ func TestForwardableProviderEnv_forwardsHostProbedCodexVersion(t *testing.T) {
 		t.Errorf("ITERION_CODEX_VERSION = %q set with nothing to forward — an empty value must not cross", v)
 	}
 }
+
+// #736: a sandboxed claw anthropic node for a forfait-only tenant must not
+// authenticate as the pod. The in-container runner rebuilds its registry from
+// env alone, so the run's forfait reaches it only as CLAUDE_CONFIG_DIR (the
+// dir runtime.seedClaudeConfigDir populates) — and only if the ambient
+// anthropic-wire vars, which are the PLATFORM's, stop shadowing it. Leaving
+// them in place is invisible precisely because the platform key works.
+func TestForwardableProviderEnv_ForfaitOnlyTenantDoesNotInheritPlatformKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-PLATFORM")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+	})
+	env := forwardableProviderEnv(ctx)
+
+	if got := env["CLAUDE_CONFIG_DIR"]; got != secrets.ClaudeCodeSandboxConfigDir {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q, want the seeded in-sandbox dir %q", got, secrets.ClaudeCodeSandboxConfigDir)
+	}
+	for _, shadow := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ZAI_API_KEY"} {
+		if v, present := env[shadow]; present {
+			t.Errorf("%s=%q still forwarded — the platform credential would win over the run's forfait", shadow, v)
+		}
+	}
+}
+
+// The tenant's OWN key is an explicit choice and keeps precedence: holding a
+// forfait as well must not silently switch the run onto the subscription.
+func TestForwardableProviderEnv_TenantKeyBeatsItsOwnForfait(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-PLATFORM")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ZAI_API_KEY", "")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:              map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant-TENANT"},
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+	})
+	env := forwardableProviderEnv(ctx)
+
+	if env["ANTHROPIC_API_KEY"] != "sk-ant-TENANT" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want the tenant's own key", env["ANTHROPIC_API_KEY"])
+	}
+	if _, present := env["CLAUDE_CONFIG_DIR"]; present {
+		t.Error("CLAUDE_CONFIG_DIR set even though the tenant's own key serves — the run would switch instrument when sandboxed")
+	}
+}
+
+// A gateway base URL is a destination the operator chose; a subscription bearer
+// carries the whole Claude account and must not travel there implicitly.
+func TestForwardableProviderEnv_ForfaitNotPointedAtRedirectedWire(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://llm-gateway.corp.example")
+	t.Setenv("ZAI_API_KEY", "")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+	})
+	if _, present := forwardableProviderEnv(ctx)["CLAUDE_CONFIG_DIR"]; present {
+		t.Error("forfait pointed into the container while the wire is redirected at a gateway")
+	}
+}

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -2,6 +2,9 @@ package model
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -22,7 +25,7 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "platform-anthropic")
 
 	t.Run("no credentials in ctx leaves the ambient env alone", func(t *testing.T) {
-		env := forwardableProviderEnv(context.Background())
+		env := envFor(t, context.Background())
 		if env["OPENAI_API_KEY"] != "platform-key" {
 			t.Errorf("OPENAI_API_KEY = %q, want the ambient value passed through", env["OPENAI_API_KEY"])
 		}
@@ -35,7 +38,7 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
 			APIKeys: map[secrets.Provider]string{secrets.ProviderOpenAI: "tenant-key"},
 		})
-		env := forwardableProviderEnv(ctx)
+		env := envFor(t, ctx)
 		if env["OPENAI_API_KEY"] != "tenant-key" {
 			t.Errorf("OPENAI_API_KEY = %q, want the tenant's own key — a sandboxed node billed the platform instead", env["OPENAI_API_KEY"])
 		}
@@ -50,7 +53,7 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
 			OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindCodex): "/host/tmp/whatever"},
 		})
-		env := forwardableProviderEnv(ctx)
+		env := envFor(t, ctx)
 		if env["CODEX_HOME"] != secrets.CodexSandboxConfigDir {
 			t.Errorf("CODEX_HOME = %q, want the in-sandbox seeded dir (the HOST path does not exist in the container)", env["CODEX_HOME"])
 		}
@@ -64,7 +67,7 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
 			APIKeys: map[secrets.Provider]string{secrets.ProviderOpenAI: ""},
 		})
-		if got := forwardableProviderEnv(ctx)["OPENAI_API_KEY"]; got != "platform-key" {
+		if got := envFor(t, ctx)["OPENAI_API_KEY"]; got != "platform-key" {
 			t.Errorf("OPENAI_API_KEY = %q — an absent resolution must not read as 'authenticate with nothing'", got)
 		}
 	})
@@ -76,7 +79,7 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 // or newer models 400 only when sandboxed.
 func TestForwardableProviderEnv_forwardsCodexVersionOverride(t *testing.T) {
 	t.Setenv("ITERION_CODEX_VERSION", "0.144.6")
-	env := forwardableProviderEnv(context.Background())
+	env := envFor(t, context.Background())
 	if env["ITERION_CODEX_VERSION"] != "0.144.6" {
 		t.Errorf("ITERION_CODEX_VERSION = %q, want the ambient override forwarded", env["ITERION_CODEX_VERSION"])
 	}
@@ -93,14 +96,14 @@ func TestForwardableProviderEnv_forwardsHostProbedCodexVersion(t *testing.T) {
 	t.Cleanup(func() { hostCodexVersion = orig })
 
 	hostCodexVersion = func() string { return "0.144.6" }
-	env := forwardableProviderEnv(context.Background())
+	env := envFor(t, context.Background())
 	if env["ITERION_CODEX_VERSION"] != "0.144.6" {
 		t.Errorf("ITERION_CODEX_VERSION = %q, want the host-probed version forwarded when no override is set", env["ITERION_CODEX_VERSION"])
 	}
 
 	// No codex on the host either: forward nothing, never an empty pair.
 	hostCodexVersion = func() string { return "" }
-	env = forwardableProviderEnv(context.Background())
+	env = envFor(t, context.Background())
 	if v, ok := env["ITERION_CODEX_VERSION"]; ok {
 		t.Errorf("ITERION_CODEX_VERSION = %q set with nothing to forward — an empty value must not cross", v)
 	}
@@ -119,9 +122,9 @@ func TestForwardableProviderEnv_ForfaitOnlyTenantDoesNotInheritPlatformKey(t *te
 	t.Setenv("ZAI_API_KEY", "")
 
 	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
-		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): forfaitDirForTest(t)},
 	})
-	env := forwardableProviderEnv(ctx)
+	env := envFor(t, ctx)
 
 	if got := env["CLAUDE_CONFIG_DIR"]; got != secrets.ClaudeCodeSandboxConfigDir {
 		t.Errorf("CLAUDE_CONFIG_DIR = %q, want the seeded in-sandbox dir %q", got, secrets.ClaudeCodeSandboxConfigDir)
@@ -142,9 +145,9 @@ func TestForwardableProviderEnv_TenantKeyBeatsItsOwnForfait(t *testing.T) {
 
 	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
 		APIKeys:              map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant-TENANT"},
-		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): forfaitDirForTest(t)},
 	})
-	env := forwardableProviderEnv(ctx)
+	env := envFor(t, ctx)
 
 	if env["ANTHROPIC_API_KEY"] != "sk-ant-TENANT" {
 		t.Errorf("ANTHROPIC_API_KEY = %q, want the tenant's own key", env["ANTHROPIC_API_KEY"])
@@ -162,9 +165,81 @@ func TestForwardableProviderEnv_ForfaitNotPointedAtRedirectedWire(t *testing.T) 
 	t.Setenv("ZAI_API_KEY", "")
 
 	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
-		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): "/tmp/run-forfait"},
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): forfaitDirForTest(t)},
 	})
-	if _, present := forwardableProviderEnv(ctx)["CLAUDE_CONFIG_DIR"]; present {
+	if _, present := envFor(t, ctx)["CLAUDE_CONFIG_DIR"]; present {
 		t.Error("forfait pointed into the container while the wire is redirected at a gateway")
+	}
+}
+
+// forfaitDirForTest writes a valid, unexpired forfait blob and returns its dir.
+func forfaitDirForTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-run","expiresAt":4102444800000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// envFor calls the sandbox env builder for a first-party Anthropic model and
+// fails the test on error.
+func envFor(t *testing.T, ctx context.Context) map[string]string {
+	t.Helper()
+	env, err := forwardableProviderEnv(ctx, "anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("forwardableProviderEnv: %v", err)
+	}
+	return env
+}
+
+// R97bef9 [high]: a z.ai/GLM model rides the SAME anthropic provider — it
+// arrives as "anthropic/glm-X" and the registry synthesises z.ai's base URL
+// from a bare ZAI_API_KEY, so no ANTHROPIC_BASE_URL exists for a wire check to
+// see. Clearing ZAI_API_KEY there removes the node's only credential channel
+// and points a forfait bearer at api.anthropic.com for a model it cannot
+// serve — breaking exactly the forfait-carrying tenants #736 is for.
+func TestForwardableProviderEnv_GLMNodeKeepsItsZAIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ZAI_API_KEY", "zai-platform-key")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): forfaitDirForTest(t)},
+	})
+	env, err := forwardableProviderEnv(ctx, "anthropic/glm-5.2")
+	if err != nil {
+		t.Fatalf("forwardableProviderEnv: %v", err)
+	}
+	if env["ZAI_API_KEY"] != "zai-platform-key" {
+		t.Errorf("ZAI_API_KEY = %q — a GLM node loses its only credential channel", env["ZAI_API_KEY"])
+	}
+	if _, present := env["CLAUDE_CONFIG_DIR"]; present {
+		t.Error("forfait pointed at a GLM node the forfait cannot serve")
+	}
+}
+
+// R71d7c3 [medium]: once the shadows are cleared the forfait is the node's ONLY
+// credential in the container, and the in-container env factory swallows expiry
+// — it would build a client with no credential and 401-loop with nothing naming
+// the cause. The in-process twin already refuses rather than degrade; this seam
+// must decide the same way, or the two disagree again.
+func TestForwardableProviderEnv_ExpiredForfaitRefusesInsteadOfBlinding(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-stale","expiresAt":1000000000000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-PLATFORM")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ZAI_API_KEY", "")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): dir},
+	})
+	_, err := forwardableProviderEnv(ctx, "anthropic/claude-haiku-4-5")
+	if !errors.Is(err, secrets.ErrAnthropicForfaitExpired) {
+		t.Fatalf("expected a named expiry refusal, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #736 — the seam #698 left open, found by Revi's own R375155 on that PR.

## The gap

#698's "on the pod" contract held for **in-process** generation (supervisor
evals, `GenerateObjectDirect`) — which is what fixed #687's pacer. It did not
hold for `backend: claw` **agent** nodes on a cloud pod, which are the *default*
shape: production runs `ITERION_SANDBOX_DEFAULT=auto` with an empty override, so
those execute sandboxed, and the in-container `__claw-runner` rebuilds its
registry from env alone — ctx never crosses the process boundary.

`forwardableProviderEnv` is the sole credential channel across that boundary and
carries no forfait. What that costs depends on the deployment, and I measured it
rather than assumed:

- **On prod today** there is no ambient `ANTHROPIC_API_KEY` (absent since 07-19),
  so such a node simply **cannot authenticate inside the container**.
- **On any deployment that sets a platform anthropic key** — a supported shape,
  it is what the platform tier is for — the same code path forwards it, and the
  node authenticates and bills against the **platform** account instead.

So the live symptom is a broken node and the billing leak is latent. The earlier
wording of this PR claimed the leak outright; corrected here (see #736).

## Why it was a one-connector fix

Everything needed already existed and was simply unconnected:

- `runtime.addClaudeOAuthSecretFile` mounts the run's forfait into the sandbox;
- `seedClaudeConfigDir` copies it into a writable config dir — both keyed on the
  **run's** credentials, not on a backend, so the dir is populated for a claw
  node too;
- the registry's desktop path added in #698 reads `CLAUDE_CONFIG_DIR`.

The missing piece was pointing one at the other.

## Clearing the shadows is the fix, not a detail

The registry reads the disk forfait only when no env credential precedes it, and
the ambient `ANTHROPIC_API_KEY` is the pod's. Left in place it wins, silently —
and *invisibly*, because the platform key works. This is exactly the contract
`forwardableProviderEnv` already states for BYOK keys ("a tenant's BYOK key is
ignored in favour of the pod's platform key … the worst possible shape for a
billing boundary"), applied to the shape it had not yet covered.

## Two deliberate limits, both tested

- **A tenant's own key keeps precedence.** A BYOK anthropic or z.ai key is an
  explicit instrument; without this guard the same run would spend a *different*
  one depending on whether it happened to be sandboxed.
- **A redirected wire is refused.** A gateway `ANTHROPIC_BASE_URL` is a
  destination the operator chose, and a forfait bearer carries the whole Claude
  account, not a scoped key.

Both reuse `secrets.AnthropicForfaitWireOK` — the predicate the desktop factory,
the ctx factory and the supervisor's funding check already share.

## Tests

`pkg/backend/model/claw_sandbox_env_test.go`: forfait-only tenant → the dir is
pointed at and the platform vars are gone (**proven red first**: the platform key
was forwarded and no `CLAUDE_CONFIG_DIR` was set); tenant key wins over its own
forfait; redirected wire declines. `task check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
