### PR TITLE
dogfood(#695): throwaway draft PR — plan-phase budget guard probe (do not merge)

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -790,3 +790,5 @@ drop, ChatGPT-forfait cap, and an intermittent sandbox bootstrap flake — via
 delegate-level network retries and an auto-resume loop that relaunches from
 the checkpoint (no progress lost) until convergence. None were the
 context-overflow bug; all were absorbed without operator intervention.
+
+<!-- dogfood #695: throwaway PR to exercise branch-improve-loop 1.3.0 plan-phase budget guard on prod; safe to close -->


### PR DESCRIPTION
Throwaway DRAFT PR used as the target of a `branch-improve-loop` 1.3.0 dogfood run on prod (`plan_review=on`, `plan_budget_ratio=0.001`): the run must fail typed at `plan_budget_gate` (PLAN_BUDGET_EXHAUSTED) before `campaign`, pushing nothing. Closed once the probe is recorded on #695. Draft on purpose: the auto-review lane skips drafts.