### PR TITLE
fix(store/mongo): New retries a late server selection; the CI replica-set init fails without a PRIMARY

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,7 +224,11 @@ jobs:
               rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "localhost:27017" }] });
             }
           '
-          # Wait for primary election before letting tests connect.
+          # Wait for primary election before letting tests connect. No
+          # PRIMARY within the window fails the STEP: falling through would
+          # let the harness connect to a set with no primary and report the
+          # failure as a store bug on whatever PR happens to be in the queue.
+          STATE=""
           for i in $(seq 1 30); do
             STATE=$(docker exec mongo-rs mongosh --quiet --eval 'rs.status().members[0].stateStr' 2>/dev/null || true)
             if [ "$STATE" = "PRIMARY" ]; then
@@ -233,6 +237,12 @@ jobs:
             fi
             sleep 2
           done
+          if [ "$STATE" != "PRIMARY" ]; then
+            echo "rs0: no PRIMARY after 60s (last state: ${STATE:-unknown})" >&2
+            docker exec mongo-rs mongosh --quiet --eval 'printjson(rs.status())' || true
+            docker logs --tail 100 mongo-rs || true
+            exit 1
+          fi
 
       - name: Mongo conformance harness
         # Alongside the pkg/store/mongo harness, run EVERY suite gated on
@@ -253,6 +263,24 @@ jobs:
             ./pkg/runview/runstream/... ./pkg/cloud/orgsweep/... \
             ./pkg/usagecap/... ./pkg/dispatcher/boardmongo/... ./pkg/identity/... \
             ./pkg/pluginsource/... ./pkg/webhooks/... ./pkg/server/cloudpublisher/...
+
+      - name: Mongo diagnostics on failure
+        # A harness failure that reads "ReplicaSetNoPrimary" AFTER the
+        # election step printed "primary elected" is a broker-side event
+        # (a step-down, a restart, a late handshake under load), not a
+        # store regression. Capture what the set and the container saw
+        # so the failure can be attributed without re-running the job.
+        if: failure()
+        run: |
+          echo "::group::rs.status()"
+          docker exec mongo-rs mongosh --quiet --eval 'printjson(rs.status())' || true
+          echo "::endgroup::"
+          echo "::group::container state"
+          docker inspect mongo-rs --format 'status={{.State.Status}} restarts={{.RestartCount}} started={{.State.StartedAt}} oom={{.State.OOMKilled}}' || true
+          echo "::endgroup::"
+          echo "::group::docker logs mongo-rs (tail 300)"
+          docker logs --tail 300 mongo-rs || true
+          echo "::endgroup::"
 
   nats-conformance:
     # Runs the JetStream integration tests (mixed-version schema rollout,

--- a/pkg/store/mongo/ping.go
+++ b/pkg/store/mongo/ping.go
@@ -1,0 +1,99 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology"
+)
+
+// primaryPinger is the slice of *mongo.Client that New needs to validate
+// a connection — a seam so the retry policy below is testable without a
+// broker.
+type primaryPinger interface {
+	Ping(ctx context.Context, rp *readpref.ReadPref) error
+}
+
+// pingPolicy bounds the connection validation in New.
+type pingPolicy struct {
+	// attempt bounds ONE ping. The driver's own server-selection timeout
+	// is 30 s; a shorter attempt keeps a dead URI from stalling boot for
+	// that long between retries.
+	attempt time.Duration
+	// pause separates two attempts.
+	pause time.Duration
+	// budget bounds the whole validation when the caller's context
+	// carries no deadline (a server boot). A caller with a deadline sets
+	// its own bound.
+	budget time.Duration
+}
+
+var defaultPingPolicy = pingPolicy{
+	attempt: 5 * time.Second,
+	pause:   500 * time.Millisecond,
+	budget:  30 * time.Second,
+}
+
+// pingPrimary validates the connection against the PRIMARY, retrying a
+// server-selection failure until the context (or the policy budget) runs
+// out. A fresh client's first server selection can outlast one attempt
+// on a loaded host while the replica set is healthy — the handshake is
+// late, not the primary absent — and a one-shot ping turns that lag into
+// a boot failure, or into a conformance harness that ejects a green PR
+// from the merge queue. A failure no retry can cure (bad credentials, a
+// malformed URI) is returned from the first attempt. A primary that never
+// appears still surfaces: the error names the attempts made and carries
+// the driver's last topology report.
+func pingPrimary(ctx context.Context, cli primaryPinger, pol pingPolicy) error {
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, pol.budget)
+		defer cancel()
+	}
+	for attempt := 1; ; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, pol.attempt)
+		err := cli.Ping(attemptCtx, readpref.Primary())
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if !retryablePing(err) {
+			return fmt.Errorf("store/mongo: ping: %w", err)
+		}
+		exhausted := fmt.Errorf("store/mongo: ping: no primary after %d attempt(s) (%s): %w",
+			attempt, describeBound(ctx), err)
+		if ctx.Err() != nil {
+			return exhausted
+		}
+		select {
+		case <-ctx.Done():
+			return exhausted
+		case <-time.After(pol.pause):
+		}
+	}
+}
+
+// retryablePing reports whether a ping failure means the topology is not
+// ready yet (server selection still running, a timeout on the way) rather
+// than a verdict on the connection itself.
+func retryablePing(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) ||
+		mongo.IsTimeout(err) ||
+		errors.As(err, &topology.ServerSelectionError{})
+}
+
+// describeBound names the bound that ended the retries, so the operator
+// can tell "the caller gave up" from "the boot budget ran out".
+func describeBound(ctx context.Context) string {
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return "context cancelled"
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		return "deadline " + deadline.UTC().Format(time.RFC3339)
+	}
+	return "no bound"
+}

--- a/pkg/store/mongo/ping_test.go
+++ b/pkg/store/mongo/ping_test.go
@@ -1,0 +1,131 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/mongo/readpref"
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology"
+)
+
+// scriptedPinger answers the scripted errors in order, then succeeds.
+type scriptedPinger struct {
+	errs  []error
+	calls int
+}
+
+func (s *scriptedPinger) Ping(_ context.Context, _ *readpref.ReadPref) error {
+	i := s.calls
+	s.calls++
+	if i < len(s.errs) {
+		return s.errs[i]
+	}
+	return nil
+}
+
+// stuckPinger blocks until its attempt context expires: a host whose
+// handshake never completes within one attempt.
+type stuckPinger struct{ calls int }
+
+func (s *stuckPinger) Ping(ctx context.Context, _ *readpref.ReadPref) error {
+	s.calls++
+	<-ctx.Done()
+	return fmt.Errorf("server selection error: %w", ctx.Err())
+}
+
+var fastPolicy = pingPolicy{attempt: 20 * time.Millisecond, pause: time.Millisecond, budget: 300 * time.Millisecond}
+
+// A late server selection is retried until the primary answers — the
+// shape that ejected PR #698 from the merge queue: "rs0 primary elected"
+// printed, then the 5th fresh client saw ReplicaSetNoPrimary.
+func TestPingPrimaryRetriesALateServerSelection(t *testing.T) {
+	p := &scriptedPinger{errs: []error{
+		fmt.Errorf("server selection error: %w", context.DeadlineExceeded),
+		topology.ServerSelectionError{Wrapped: errors.New("current topology: { Type: ReplicaSetNoPrimary }")},
+	}}
+	if err := pingPrimary(context.Background(), p, fastPolicy); err != nil {
+		t.Fatalf("pingPrimary: %v", err)
+	}
+	if p.calls != 3 {
+		t.Fatalf("calls = %d, want 3 (two retried failures, then success)", p.calls)
+	}
+}
+
+// A failure no retry can cure is returned from the first attempt: an
+// operator with wrong credentials must not wait out the budget to learn
+// it.
+func TestPingPrimaryFailsFastOnANonRetryableError(t *testing.T) {
+	auth := errors.New("(AuthenticationFailed) Authentication failed.")
+	p := &scriptedPinger{errs: []error{auth, auth, auth}}
+	err := pingPrimary(context.Background(), p, fastPolicy)
+	if !errors.Is(err, auth) {
+		t.Fatalf("err = %v, want the auth failure", err)
+	}
+	if p.calls != 1 {
+		t.Fatalf("calls = %d, want 1", p.calls)
+	}
+	if strings.Contains(err.Error(), "attempt") {
+		t.Fatalf("a first-attempt refusal must not read as an exhausted retry: %v", err)
+	}
+}
+
+// Without a caller deadline the policy budget bounds the retries, and
+// the error names the attempts so an absent primary is not mistaken for
+// a hang.
+func TestPingPrimaryIsBoundedByTheBudgetWhenTheContextHasNoDeadline(t *testing.T) {
+	p := &stuckPinger{}
+	start := time.Now()
+	err := pingPrimary(context.Background(), p, fastPolicy)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error after the budget")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want the last attempt's deadline in the chain", err)
+	}
+	if !strings.Contains(err.Error(), "no primary after") || !strings.Contains(err.Error(), "attempt(s)") {
+		t.Fatalf("err = %v, want the attempt count", err)
+	}
+	if p.calls < 2 {
+		t.Fatalf("calls = %d, want at least 2 attempts within the budget", p.calls)
+	}
+	if elapsed > 3*fastPolicy.budget {
+		t.Fatalf("retries ran %v past a %v budget", elapsed, fastPolicy.budget)
+	}
+}
+
+// A caller's own deadline wins over the policy budget: the conformance
+// factory's 15 s and a boot context both end the retries where they say.
+func TestPingPrimaryHonoursTheCallerDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+	p := &stuckPinger{}
+	pol := fastPolicy
+	pol.budget = 10 * time.Second
+	start := time.Now()
+	err := pingPrimary(ctx, p, pol)
+	if err == nil {
+		t.Fatal("expected an error at the caller deadline")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("retries ran %v past a 60ms caller deadline", elapsed)
+	}
+	if !strings.Contains(err.Error(), "deadline ") {
+		t.Fatalf("err = %v, want the caller deadline named", err)
+	}
+}
+
+// A cancelled caller is named as such, not reported as a missing primary.
+func TestPingPrimaryNamesACancelledCaller(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &scriptedPinger{errs: []error{fmt.Errorf("server selection error: %w", context.DeadlineExceeded)}}
+	cancel()
+	err := pingPrimary(ctx, p, fastPolicy)
+	if err == nil || !strings.Contains(err.Error(), "context cancelled") {
+		t.Fatalf("err = %v, want the cancellation named", err)
+	}
+}

--- a/pkg/store/mongo/store.go
+++ b/pkg/store/mongo/store.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sync"
-	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -193,11 +192,9 @@ func New(ctx context.Context, cfg Config) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("store/mongo: connect: %w", err)
 	}
-	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := cli.Ping(pingCtx, readpref.Primary()); err != nil {
+	if err := pingPrimary(ctx, cli, defaultPingPolicy); err != nil {
 		_ = cli.Disconnect(context.Background())
-		return nil, fmt.Errorf("store/mongo: ping: %w", err)
+		return nil, err
 	}
 
 	maxAttach := cfg.MaxAttachmentBytes


### PR DESCRIPTION
## Why

Merge-queue run 33951409831 ejected PR #698 on `mongo-conformance`: the init step printed `rs0 primary elected`, and 56 s later the 5th fresh client of the `pkg/store/mongo` suite failed `New` with `server selection error: context deadline exceeded, current topology: { Type: ReplicaSetNoPrimary }`. `New` pinged the primary ONCE with a 5 s deadline, so a late handshake on a loaded runner read as a store regression on whatever PR sat in the queue (#729 — same class as #692 / #686).

## What

- `pkg/store/mongo`: `New` validates the connection through `pingPrimary`, which retries a server-selection failure (timeout / `ServerSelectionError`) until the caller's context runs out — 30 s when it carries no deadline — fails FAST on an error no retry can cure (bad credentials), and names the attempts and the bound in the error. Unit-tested through a pinger seam (five cases: late selection retried, non-retryable fails on attempt 1, budget bound, caller deadline honoured, cancellation named).
- `.github/workflows/tests.yml`: the replica-set init step now FAILS when no PRIMARY appears within its window instead of falling through into the harness; a failure-only diagnostics step captures `rs.status()`, the container's restart count and its logs so a post-election drop can be attributed without re-running the job.

Red first: the retry seam did not exist, so the five tests failed to build against the one-shot `New`; they pass on this branch (`go test ./pkg/store/mongo/ -run TestPingPrimary`: 5/5). `golangci-lint run ./pkg/store/mongo/`: 0 issues.

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)