### PR TITLE
docs: bilans for the #695 dogfood and the review tiers, the GitLab command lane narrative, the ArgoCD sync-liveness runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,14 @@ the hours this one spent.
   is set, one transaction per API request and per in-process LLM call), the
   scrubbing, and the smoke tests. Read it when a deployment needs to answer
   "what crashed, how often, since which release" or "where did the time go".
+- [docs/cloud-deployment.md](docs/cloud-deployment.md#verifying-that-an-infra-apps-push-landed-argocd-sync-liveness) —
+  how a build reaches a deployment: the server follows the moving `:edge`
+  tag (a `rollout restart` picks it up), the runner is pinned BY DIGEST in
+  the deployment's values (an explicit bump per engine build), the
+  generation-aware rollout epoch, and how to verify an infra-apps push
+  actually landed (Deployment generation, never pods — the ArgoCD stall of
+  2026-09-05 sat 2h30 until the next push). Read it on "I pushed the config
+  and nothing happened", or before shipping an engine fix to the runners.
 
 ## Work tracking & session methodology — read AGENTS.md
 

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,55 @@
 # Billy — branch-improvement validation
 
+## 2026-09-05 — plan-budget guard dogfooded on prod: the gate fires typed, before `campaign`, for $0.67–$1.80 (runs 01a0714a, 01a07156)
+
+- Status: **validated** (the guard itself; the entry below, written before
+  any live run, is superseded on its "unvalidated" point).
+- Versions: bot `branch-improve-loop` 1.3.0, pushed to the prod platform
+  bot-override tier (`iterion remote admin bots push bots/branch-improve-loop
+  --slug branch-improve-loop`) so the runners used it without an image
+  rollout · iterion runners `8727674c` (v3.102.6).
+- Method: `plan_budget_ratio=0.001` forces the guard (2h30 × 0.001 ≈ 9 s of
+  plan phase, so any real plan trips it); target SocialGouv/iterion#749;
+  `post_to_board=false`, auto-merge off. Two launches: `iterion remote runs
+  launch --bot branch-improve-loop --var pr_url=…` — which attaches NO
+  repository, so the plan node authored a plan against an empty
+  `/tmp/iterion` — then `POST /api/runs` with `repo_url` + `repo_ref` +
+  `connection_id`, the only shape that carries a checkout.
+- Result:
+
+  | run | repo | active | cost | LLM nodes served | outcome |
+  |---|---|---|---|---|---|
+  | `01a0714a` | none (empty workspace) | 5 m 21 s | $0.67 | plan, plan_review, plan_revise | `plan_budget_gate` → `fail`; `campaign` never entered; 0 push |
+  | `01a07156` | #749 checkout | 7 m 54 s | $1.80 | plan, plan_review, plan_revise | same |
+
+  Both runs end `failed` with the engine's own `workflow reached fail node`:
+  the typed `PLAN_BUDGET_EXHAUSTED` lives on the gate node's output only,
+  because a `fail` node cannot carry a code yet (#739), and a `fail`
+  terminal is non-resumable by design — the right call for a probe, the
+  wrong one for an operator who would rather widen the plan budget and
+  continue (#739's follow-up comment).
+- Value: the class of death of the three runs below — 2h30 of planning,
+  zero commits, $8.59 — is closed. The guard stops the run at the plan
+  phase's own ceiling, having spent 1–2 % of the budget instead of all of it.
+- Findings / misses (each filed): `plan_review=off` skips the WHOLE plan
+  phase, not only the peer review, so a single-provider deployment never
+  plans (#751); six of the seven campaign bots start an opus-class plan node
+  without checking the workspace is a repository — `01a0714a` paid $0.67 to
+  plan against nothing (#752); the guard has to self-measure wall-clock and
+  mirror the budget through two hand-maintained vars because no expr
+  primitive exposes the run's elapsed budget (#738); a bot-declared refusal
+  reads as "workflow reached fail node" at the top level (#739).
+- Engine hardening: #751/#752 (bot-side) and #738/#739 (engine) in flight.
+- Lessons for next run: attach the repository through `POST /api/runs`
+  (`repo_url`, `repo_ref`, `connection_id`) — a CLI `--bot` launch carries
+  `pr_url` and nothing to check out; force the guard with
+  `plan_budget_ratio` rather than waiting on a real long plan. The 04/09
+  friction this closes: Billy `01a06d80`, launched by the zero-touch lane on
+  #683's red gate, died 4 s over `max_duration` (2h30m01s / 2h30m) with a
+  plan and nothing pushed, and the deployed binary had no re-budget flag on
+  `remote runs resume` (#689, since merged) — exactly the shape the guard
+  now refuses in the first minutes.
+
 ## 2026-09-05 — plan-phase budget guard shipped (native:695); three production deaths never reached campaign (runs 01a06d80, 01a06e72, #705)
 
 - Status: **failed** (the three cited production runs, pre-fix) — the fix

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -16,6 +16,9 @@ commit-status gate. Never edits or commits. See
   a real glance-tier run on a small PR is measured against the guard-tier
   baseline documented in the 2026-09-03/04 entry below.
 - Versions: bot 0.7.0 → 0.8.0 · iterion `c6f8bac0f` (v3.102.1) at write time
+- Landed: SocialGouv/iterion#742 (merged 2026-09-05 11:54Z, in v3.102.6);
+  prod runners carry it since 12:25Z (`edd5b9dcf`). The next real PR review
+  on this repo is the first tier measurement — record it here.
 - What shipped: `review_tier` (glance/guard/audit), a deterministic
   `tier_expand` compute node resolving severity_threshold/max_findings/
   post_to_board/effective_review_mode from sentinel-defaulted vars (any

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -377,6 +377,37 @@ literal `ITERION_RUNNER_EPOCH` while pulling whatever the tag means now.
 reason: a moving tag rolled the runner Deployment on every merge to main and
 killed in-flight runs. That is a values-level choice, not a chart default.)
 
+### Verifying that an infra-apps push landed (ArgoCD sync liveness)
+
+Autosync usually applies a push within a minute, but it is not guaranteed
+to: on 2026-09-05 a values push (`runnerEpoch: 1` + a SealedSecret change)
+sat unapplied for ~2h30 with no error anywhere the operator could see, and
+was applied together with the NEXT push, in under a minute. The failure
+mode is indistinguishable from "nothing to do", and the next unrelated push
+silently carries the stalled change in — inside someone else's rollout.
+
+So a push is verified by the Deployments' `metadata.generation` moving,
+never by the pods (a drain-safe runner rollout keeps the old pods around
+for minutes):
+
+```sh
+kubectl -n iterion get deploy iterion iterion-runner \
+  -o custom-columns=NAME:.metadata.name,GEN:.metadata.generation,UPD:.status.updatedReplicas
+```
+
+- Generation unchanged after ~5 min: the cheap nudge is an empty commit on
+  the config repo (`git commit --allow-empty -m "chore: nudge argocd"`) — a
+  new revision is what cleared the 2026-09-05 stall.
+- Still unchanged: read the app's `status.sync` / `status.operationState`
+  with a fresh ArgoCD token (`argocd app get <app>`). An expired operator
+  token is what made that stall unreadable at the time.
+- A runner rollout that DID apply takes ~5 min end to end (new ReplicaSet
+  ready, then the old one drains); the pods' `imageID` is the proof that a
+  digest bump reached them.
+
+A scheduled sync-liveness probe (config-repo HEAD vs the app's
+`status.sync.revision` age) is tracked in SocialGouv/iterion#733.
+
 ### Generation-aware rollout
 
 The chart uses `RollingUpdate` with `maxSurge: 100%` and

--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -90,7 +90,7 @@ MRs.
 
 `pkg/webhooks/gitlab/note.go` (done) parses the `Note Hook`: `discussion_id`
 (the thread to reply in), `note.body`, the author (`User`), and the MR
-context. `ParsedNote.Command()` extracts a leading `/revi …` command;
+context. `ParsedNote.Command()` extracts a leading slash command;
 `IsMergeRequestNote()` filters out issue/commit notes; `SubjectID()` is
 `note:<id>` for idempotency.
 
@@ -102,11 +102,27 @@ The handler (`pkg/server/webhooks_gitlab.go`, dispatch on
    (else the bot's reply re-triggers a run → infinite loop). Resolve the
    bot's forge user once from the forge_token (`GET /user`) and compare
    `author_id`; cache it per webhook.
-3. **Trigger gate:** a note triggers when it is a `/revi` command, a
-   mention of the bot, or a reply inside a bot-authored discussion thread
-   (configurable; `/revi` is the explicit path, reply-in-thread the
-   natural one).
-4. Idempotency on `note:<id>`; `MatchProject` as for MR events.
+3. **Trigger gate:** a note triggers when it carries a slash command or
+   is a reply inside a bot-authored discussion thread. A command — `/revi`
+   included — is routed generically through `webhooks.ResolveCommandRoute`
+   over the webhook's `CommandMap`: the manifests' `when_args_empty` /
+   `when_args_present` + `args_var` pair resolves a bare `/revi` to the
+   reviewer and `/revi <question>` to the conversational bot, exactly as
+   the GitHub `issue_comment` lane does. Only a plain reply-in-thread with
+   no command stays bespoke, routed to the `revi_converse` role bot — and
+   a provisioned but unresolvable converse bot is a visible
+   `launch_error`, not a silent fallback to the reviewer. `/revi approve`
+   uses the same helpers as GitHub: a maintainer floor (`approveFloor`,
+   raise-only), self-approval refused, a forge error on the authorization
+   read answered `200` + `launch_error`, an unauthorized replier silently
+   `filtered`.
+4. **Fork guard:** the note payload names no project ids, so the handler
+   resolves the MR through the forge API and refuses a cross-project or
+   unnamed head (`filtered`, 200); a resolution failure is a visible 502.
+5. Idempotency on `note:<id>`; `MatchProject` as for MR events. The gates
+   are thin wrappers over token-free cores (`gitlabCommandGateWithAPI`,
+   `gitlabNoteGateWithAPI`), so their real logic is unit-tested rather
+   than stubbed away.
 
 ## A2 — Authorization (the heart): two separate things
 


### PR DESCRIPTION
Docs-only. Newest-first bilans and two runbook alignments from today's board-203 wave:

- **`docs/bot-runs/branch-improve-loop.md`** — the plan-budget guard (#695) dogfooded on prod: runs `01a0714a` / `01a07156` stop at the typed gate before `campaign` for $0.67 / $1.80 (the three historical deaths cost 2h30 and $8.59 each); the four findings the runs filed (#751 #752 #738 #739) and the 04/09 Billy friction the guard closes.
- **`docs/bot-runs/review-pr.md`** — where the review tiers (#685) landed and that the next real review is the first measurement.
- **`docs/forge-conversations.md`** — the GitLab note lane as #753 ships it: generic command routing over `ResolveCommandRoute`, reply-in-thread as the only bespoke path, `/revi approve` parity, the fork guard through MR resolution. (Merge after #753 — it is ahead in the queue.)
- **`docs/cloud-deployment.md`** + the CLAUDE.md runbook index — verifying that a config push actually landed (Deployment generation, never pods; the empty-commit nudge; a fresh ArgoCD token), i.e. the runbook half of #733. The probe half stays on the ticket.

Refs #695 #685 #644 #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)