### PR TITLE
fix(modernize): every refusal is a verdict the graph fails on; the gate's commit is HEAD plus one line; a timeout fails before any subbot

### DIFF
--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -142,6 +142,11 @@ schema plan_state:
   ## The named lot's actual status when lot_not_actionable: "done",
   ## "blocked", or "absent" (no lot with that id in the contract).
   lot_status: string
+  ## The contract could not be READ or cannot be EDITED by the gate
+  ## (CONTRACT_UNREADABLE, LOT_UNEDITABLE): a verdict work_gate routes to
+  ## `fail` — never a tool error, which the engine retries once and then
+  ## leaves `failed_resumable`, a terminal a router may probe-resume.
+  refused: bool
 
 ## The deterministic verdict. Not one field here is an opinion.
 schema lot_report:
@@ -183,6 +188,10 @@ schema lot_report:
   ## fields changed, a lot disappeared, or another lot's status moved. One
   ## entry per rewrite. Refused before any gate command runs, like `done`.
   contract_rewritten: string[]
+  ## The contract could not be READ (CONTRACT_UNREADABLE): a failure to LOOK
+  ## is never turned into a verdict over the lot — every conjunct stays false
+  ## and lot_gate fails the run at once, no repair pass.
+  contract_unreadable: bool
   log_tail: string
 
 schema gate_state:
@@ -198,6 +207,8 @@ schema gate_state:
   ## the first occurrence — never a repair pass against the same wall, never
   ## a `finished` the programme would relaunch into the same wall.
   timed_out: bool
+  ## The verifier could not read the contract. Fails the run at once.
+  unreadable: bool
   fail_log: string
   needs_reanchor: bool
   needs_extend: bool
@@ -220,6 +231,9 @@ schema mark_state:
   marked: bool
   commit: string
   notice: string
+  ## The gate could not write its word (contract shape, git): the run fails
+  ## here, typed, with the lot's work banked — never a tool error.
+  refused: bool
 
 ## ─── Nodes ─────────────────────────────────────────────────────────
 
@@ -244,7 +258,7 @@ tool plan_read:
 
     out = {"nothing_to_do": True, "lot_id": "", "lot_title": "", "lot_intent": "",
            "exit_gate": "", "base_sha": "", "refs_dir": "", "notice": "",
-           "lot_not_actionable": False, "lot_status": ""}
+           "lot_not_actionable": False, "lot_status": "", "refused": False}
 
     def emit(notice):
         """A legitimate no-op: there is genuinely nothing to carry out."""
@@ -284,12 +298,15 @@ tool plan_read:
         nothing at all.
 
         A bot whose whole job is to execute a declared lot must refuse when it
-        cannot read what was declared.
+        cannot read what was declared. The refusal is a VERDICT (`refused`),
+        exit 0: work_gate routes it to `fail`, once, readable in the tree.
         """
+        out["nothing_to_do"] = False
+        out["refused"] = True
         out["notice"] = notice
         print(json.dumps(out))
         sys.stderr.write("modernize: %s\n" % notice)
-        raise SystemExit(1)
+        raise SystemExit(0)
 
     if not os.path.isfile(plan_path):
         emit("no programme contract at %s — nothing to carry out. Write one "
@@ -489,14 +506,15 @@ tool plan_read:
                "must be a single line; put multi-line logic in a script file "
                "and invoke it." % chosen.get("id"))
     if not gate:
-        if only:
-            not_actionable("no_gate",
-                "only_lot %r is not actionable: it declares no exit_gate — an "
-                "explicit request on a lot that cannot be verified is refused, "
-                "not answered with a green no-op." % chosen.get("id"))
-        emit("lot %s declares no exit_gate. A lot with no gate cannot be "
-             "verified, and an unverifiable lot is indistinguishable from one "
-             "that was never done." % chosen.get("id"))
+        # In BOTH modes: the unfiltered scan re-picks this same first ready
+        # lot at every relaunch, so a green no-op here would park the whole
+        # programme in `finished`-at-zero-minutes runs — the same reading-as-
+        # convergence an explicit request is refused for (review finding).
+        not_actionable("no_gate",
+            "lot %s is not actionable: it declares no exit_gate. A lot with no "
+            "gate cannot be verified, an unverifiable lot is indistinguishable "
+            "from one that was never done, and the programme cannot advance past "
+            "it — give it a gate in the contract, then relaunch." % chosen.get("id"))
 
     # The gate writes `done` by editing ONE line of this file (mark_done), and
     # it must be able to. A lot whose block the editor cannot locate — flow
@@ -554,6 +572,7 @@ compute work_gate:
     notice: "outputs.plan_read.notice"
     lot_not_actionable: "outputs.plan_read.lot_not_actionable"
     lot_status: "outputs.plan_read.lot_status"
+    refused: "outputs.plan_read.refused"
 
 agent upgrade_campaign:
   backend: "claude_code"
@@ -589,7 +608,7 @@ tool lot_verify:
     gate_cmds = [c for c in {{input.exit_gate}}.split("\n") if c.strip()]
 
     report = {"gate_passed": False, "oracle_passed": False, "refs_untouched": False,
-              "gate_timed_out": False,
+              "gate_timed_out": False, "contract_unreadable": False,
               "refs_changed": [], "lot_blocked": False, "block_reason": "", "log_tail": "",
               "oracle_invalid": [], "extension_pending": [], "done_self_written": False,
               "contract_rewritten": []}
@@ -623,9 +642,10 @@ tool lot_verify:
         over a contract this node could not read would skip exactly the checks
         that exist to catch a rewritten one."""
         sys.stderr.write("modernize: CONTRACT_UNREADABLE: %s\n" % why)
+        report["contract_unreadable"] = True
         report["log_tail"] = "CONTRACT_UNREADABLE: %s" % why
         print(json.dumps(report))
-        raise SystemExit(1)
+        raise SystemExit(0)
 
     def plan_doc(text, what):
         """The whole contract as JSON — `lots` and the top-level keys."""
@@ -825,7 +845,10 @@ tool lot_verify:
     #    without the net is a lot verified against nothing, and reporting that
     #    as success is the failure this whole programme exists to prevent.
     verify = os.path.join(ws, ".golden-master", "verify-oracle.sh")
-    if not os.path.isfile(verify):
+    if report["gate_timed_out"]:
+        problems.append("the behavioural oracle was not replayed: the exit gate expired first, "
+                        "and the run ends on that wall.")
+    elif not os.path.isfile(verify):
         problems.append("no behavioural oracle at %s. Build the net before "
                         "modernising against it — a green build proves the code "
                         "compiles, never that it still behaves." % verify)
@@ -1083,6 +1106,7 @@ compute lot_gate:
     stop: "(outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched) || outputs.lot_verify.lot_blocked"
     refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0"
     timed_out: "outputs.lot_verify.gate_timed_out"
+    unreadable: "outputs.lot_verify.contract_unreadable"
     fail_log: "outputs.lot_verify.log_tail"
     ## Read on EVERY outcome, including a converged one, and that is the point.
     ## An invalidated mutant does not fail the gate: its verdict is excluded
@@ -1169,13 +1193,14 @@ tool mark_done:
     lot_id = {{input.lot_id}}
     base = {{input.base_sha}}
 
-    out = {"marked": False, "commit": "", "notice": ""}
+    out = {"marked": False, "commit": "", "notice": "", "refused": False}
 
     def refuse(notice):
+        out["refused"] = True
         out["notice"] = notice
         print(json.dumps(out))
         sys.stderr.write("modernize: %s\n" % notice)
-        raise SystemExit(1)
+        raise SystemExit(0)
 
     def finish(notice):
         out["notice"] = notice
@@ -1290,19 +1315,70 @@ tool mark_done:
         refuse("the status edit changed more than lot %s's status — reverted, "
                "the contract is not one this node knows how to edit." % lot_id)
 
-    # The gate's bookkeeping commit bypasses the target's hooks: a pre-commit
-    # that reformats YAML would commit a contract other than the one just
-    # verified, and one that rejects would fail a converged lot at its last
-    # node. The lot's own commits went through them; this one line is the
-    # gate's.
+    # The committed content derives from HEAD's contract, not the working
+    # tree's: the same one-line flip applied to HEAD's text, so nothing the
+    # worker left uncommitted in the contract rides along under the gate's
+    # subject (review finding: an added lot, accepted by the verdict as a
+    # proposal, was swept into the gate's commit). Built with plumbing on a
+    # scratch index — no hook runs (a pre-commit that reformats would commit
+    # a contract other than the one just verified; one that rejects would
+    # fail a converged lot at its last node), and no other staged change is
+    # swept in either.
     subject = "%s: done — gate, oracle and references green at %s" % (lot_id, base[:12])
-    if git("add", "--", plan_rel).returncode != 0:
-        refuse("git add %s failed" % plan_rel)
-    c = git("-c", "user.name=iterion-modernize", "-c", "user.email=modernize@iterion.local",
-            "commit", "-q", "--only", "--no-verify", "-m", subject, "--", plan_rel)
+    hlines = head.stdout.splitlines(keepends=True)
+    hstart = next((i for i, l in enumerate(hlines) if id_re.match(l)), None)
+    if hstart is None:
+        refuse("lot %s: its `- id:` line was not found in HEAD's contract — nothing committed." % lot_id)
+    hm = id_re.match(hlines[hstart])
+    h_dash = len(hm.group(1))
+    h_col = h_dash + 1 + len(hm.group(2))
+    h_same = re.compile(r"^\s{%d}-\s+id:" % h_dash)
+    h_end = next((i for i in range(hstart + 1, len(hlines)) if h_same.match(hlines[i])), len(hlines))
+    h_status = re.compile(r"^(\s{%d})status:\s*\S+(\s*#.*)?(\r?\n?)$" % h_col)
+    hhit = next((i for i in range(hstart, h_end) if h_status.match(hlines[i])), None)
+    if hhit is None:
+        refuse("lot %s: no `status:` line inside its block at HEAD — nothing committed." % lot_id)
+    hm2 = h_status.match(hlines[hhit])
+    hlines[hhit] = "%sstatus: done%s%s" % (hm2.group(1), hm2.group(2) or "", hm2.group(3) or "")
+    committed_text = "".join(hlines)
+    expect_head = [dict(l) for l in head_lots]
+    expect_head[hidx]["status"] = "done"
+    if lots_json_text(committed_text, "to be committed") != expect_head:
+        refuse("the status edit on HEAD's contract changed more than lot %s's status — nothing committed." % lot_id)
+
+    def plumb(args, **kw):
+        return subprocess.run(["git", "-C", ws] + list(args), capture_output=True,
+                              text=True, timeout=120, **kw)
+
+    head_sha = git("rev-parse", "HEAD").stdout.strip()
+    ls = git("ls-tree", "HEAD", "--", plan_rel).stdout.split()
+    mode = ls[0] if ls else "100644"
+    blob = plumb(["hash-object", "-w", "--stdin"], input=committed_text).stdout.strip()
+    if not blob:
+        refuse("git hash-object failed — nothing committed.")
+    import tempfile
+    tmp_index = tempfile.mktemp(prefix="modernize-index-")
+    env = dict(os.environ, GIT_INDEX_FILE=tmp_index)
+    try:
+        if plumb(["read-tree", "HEAD"], env=env).returncode != 0:
+            refuse("git read-tree HEAD failed — nothing committed.")
+        if plumb(["update-index", "--cacheinfo", "%s,%s,%s" % (mode, blob, plan_rel)], env=env).returncode != 0:
+            refuse("git update-index failed — nothing committed.")
+        tree = plumb(["write-tree"], env=env).stdout.strip()
+    finally:
+        if os.path.exists(tmp_index):
+            os.unlink(tmp_index)
+    c = plumb(["-c", "user.name=iterion-modernize", "-c", "user.email=modernize@iterion.local",
+               "commit-tree", tree, "-p", head_sha, "-m", subject])
     if c.returncode != 0:
         refuse("committing the status failed: %s" % (c.stdout + c.stderr)[-600:])
-    sha = git("rev-parse", "HEAD").stdout.strip()
+    sha = c.stdout.strip()
+    if git("update-ref", "HEAD", sha, head_sha).returncode != 0:
+        refuse("HEAD moved while the gate wrote its word — nothing committed (%s is unreferenced)." % sha[:12])
+    # The real index follows the commit for this path: the tree reads clean
+    # unless the worker left something else uncommitted in the contract,
+    # which then stays theirs, unstaged.
+    git("update-index", "--cacheinfo", "%s,%s,%s" % (mode, blob, plan_rel))
     out["marked"] = True
     out["commit"] = sha
     finish("lot %s marked `done` by the gate in %s" % (lot_id, sha[:12]))
@@ -1331,6 +1407,9 @@ workflow modernize:
   ## native:670) — an explicit only_lot request naming a done/blocked/
   ## absent lot fails loud instead of falling into the done/campaign pair
   ## below, which is exhaustive only over the unfiltered "pick next" scan.
+  ## An unreadable or uneditable contract is a verdict, not a tool error:
+  ## the run fails here, typed, before any token is spent.
+  work_gate -> fail when refused
   work_gate -> fail when lot_not_actionable
 
   ## Exhaustive pair on one bool (C012): an already-finished programme is a
@@ -1357,6 +1436,17 @@ workflow modernize:
   }
 
   lot_verify -> lot_gate
+
+  ## A wall the run never crossed: the verdict is in the tree (gate_timed_out,
+  ## block_reason GATE_TIMEOUT), the run fails at once — no repair pass
+  ## replays an hour against the same wall, and no `finished` invites a
+  ## relaunch into it. Raise `gate_timeout_s` in the contract, or shorten the
+  ## gate, then relaunch. Declared FIRST among lot_gate's edges on purpose: the
+  ## engine takes the first `when` that holds, and a timed-out verdict may
+  ## also carry an invalidated mutant or a pending extension — routed to a
+  ## subbot, it would replay the same gate before failing.
+  lot_gate -> fail when timed_out
+  lot_gate -> fail when unreadable
 
   ## Repair the net BEFORE deciding the lot, and on every outcome — a converged
   ## lot is exactly the case where a lost mutant would never be noticed. Bounded
@@ -1404,15 +1494,9 @@ workflow modernize:
     plan_path: "{{vars.plan_path}}",
     base_sha:  "{{outputs.work_gate.base_sha}}"
   }
+  mark_done -> fail when refused
   mark_done -> done
   lot_gate -> done when stop
-
-  ## A wall the run never crossed: the verdict is in the tree (gate_timed_out,
-  ## block_reason GATE_TIMEOUT), the run fails at once — no repair pass
-  ## replays an hour against the same wall, and no `finished` invites a
-  ## relaunch into it. Raise `gate_timeout_s` in the contract, or shorten the
-  ## gate, then relaunch.
-  lot_gate -> fail when timed_out
 
   ## Not converged → another pass on the SAME lot, carrying the deterministic
   ## failure back so the agent fixes the cause rather than re-deriving it.

--- a/bots/modernize/manifest.yaml
+++ b/bots/modernize/manifest.yaml
@@ -1,7 +1,14 @@
 name: modernize
 display_name: Morphy
 icon: 🧱
-version: 0.2.0
+version: 0.3.0
+## 0.3.0 — `done` is the gate's word: a new mark_done node writes it after the
+## lot converged, a worker-written `done` or a rewritten contract is refused
+## before the gate runs, and a refusal that outlives the repair loop fails the
+## run. `gate_timeout_s` (contract, lot over top level, read at the base) walls
+## every gate command; an expiry is a verdict that fails the run at once. A
+## gate-less ready lot, a lot waiting on a dependency and an unreadable or
+## uneditable contract are typed verdicts too — never a green no-op.
 ## 0.2.0 — only_lot targeting a done/blocked/absent lot no longer exits
 ## green as nothing_to_do (native:670): plan_read resolves the named lot's
 ## actual status FIRST and, when it cannot be actioned, routes work_gate

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -20,6 +20,7 @@ type modernizeLotVerifyOut struct {
 	ContractRewrite []string `json:"contract_rewritten"`
 	GateTimedOut    bool     `json:"gate_timed_out"`
 	BlockReason     string   `json:"block_reason"`
+	Unreadable      bool     `json:"contract_unreadable"`
 	LogTail         string   `json:"log_tail"`
 }
 
@@ -366,8 +367,8 @@ lots:
 		ws, base, _ := selfWrittenDone(t)
 		env := append(os.Environ(), "PATH="+restrictedPATH(t, "python3", "git", "sh"))
 		res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, gate, env)
-		if exit != 1 {
-			t.Fatalf("exit=%d, want 1 (typed refusal) — report %+v", exit, res)
+		if exit != 0 || !res.Unreadable {
+			t.Fatalf("exit=%d contract_unreadable=%v, want the typed refusal as a verdict — report %+v", exit, res.Unreadable, res)
 		}
 		if !strings.HasPrefix(res.LogTail, "CONTRACT_UNREADABLE") {
 			t.Fatalf("log_tail = %q, want CONTRACT_UNREADABLE", res.LogTail)
@@ -389,8 +390,8 @@ lots:
 			t.Fatal(err)
 		}
 		res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, gate, nil)
-		if exit != 1 || !strings.Contains(res.LogTail, "not committed at the run's base") {
-			t.Fatalf("exit=%d log_tail=%q, want a typed refusal naming the uncommitted contract", exit, res.LogTail)
+		if exit != 0 || !res.Unreadable || !strings.Contains(res.LogTail, "not committed at the run's base") {
+			t.Fatalf("exit=%d contract_unreadable=%v log_tail=%q, want a typed refusal naming the uncommitted contract", exit, res.Unreadable, res.LogTail)
 		}
 	})
 
@@ -587,8 +588,8 @@ lots:
 			badPlan := strings.Replace(plan, "gate_timeout_s: 1\n", "gate_timeout_s: "+bad+"\n", 1)
 			ws, base, _ := netAndBase(t, badPlan, "")
 			res, exit := modernizeLotVerifyEnv(t, script, ws, "L1", base, "sh -c 'echo ran > gate.marker'", nil)
-			if exit != 1 || !strings.Contains(res.LogTail, "CONTRACT_UNREADABLE") || !strings.Contains(res.LogTail, "gate_timeout_s") {
-				t.Fatalf("exit %d, log %q — want the typed refusal naming gate_timeout_s", exit, res.LogTail)
+			if exit != 0 || !res.Unreadable || !strings.Contains(res.LogTail, "CONTRACT_UNREADABLE") || !strings.Contains(res.LogTail, "gate_timeout_s") {
+				t.Fatalf("exit %d contract_unreadable=%v, log %q — want the typed refusal naming gate_timeout_s", exit, res.Unreadable, res.LogTail)
 			}
 			if _, err := os.Stat(filepath.Join(ws, "gate.marker")); err == nil {
 				t.Fatal("the gate ran under a wall the node could not read")

--- a/bots/modernize_mark_done_test.go
+++ b/bots/modernize_mark_done_test.go
@@ -12,9 +12,10 @@ import (
 
 // modernizeMarkDoneOut is the subset of mark_done's output the tests read.
 type modernizeMarkDoneOut struct {
-	Marked bool   `json:"marked"`
-	Commit string `json:"commit"`
-	Notice string `json:"notice"`
+	Marked  bool   `json:"marked"`
+	Commit  string `json:"commit"`
+	Notice  string `json:"notice"`
+	Refused bool   `json:"refused"`
 }
 
 // modernizeRepo builds a throwaway git repository carrying one committed
@@ -166,6 +167,33 @@ lots:
 		}
 	})
 
+	t.Run("an uncommitted worker edit to the contract does not ride along under the gate's subject", func(t *testing.T) {
+		ws, base, git := modernizeRepo(t, plan)
+		// The worker added a lot (a proposal the verdict accepts) and left it
+		// uncommitted: the gate's commit must carry HEAD's contract + its one
+		// flipped line, nothing else — the proposal stays the worker's.
+		added := plan + "  - id: L3\n    title: proposed by the worker\n    status: todo\n    exit_gate:\n      - \"true\"\n"
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(added), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if !res.Marked || res.Commit == "" {
+			t.Fatalf("marked=%v commit=%q (%s)", res.Marked, res.Commit, res.Notice)
+		}
+		committed := git("show", "HEAD:.modernize/plan.yaml")
+		want := strings.TrimSpace(strings.Replace(plan, "status: todo   # a bookmark, never evidence", "status: done   # a bookmark, never evidence", 1))
+		if committed != want {
+			t.Fatalf("HEAD's contract must be the base + one flipped line, got:\n%s", committed)
+		}
+		got, _ := os.ReadFile(filepath.Join(ws, ".modernize", "plan.yaml"))
+		if !strings.Contains(string(got), "L3") || !strings.Contains(string(got), "status: done") {
+			t.Fatalf("the working tree must keep the worker's proposal and the flipped line:\n%s", got)
+		}
+		if dirty := git("status", "--porcelain", "--untracked-files=no"); dirty != "M .modernize/plan.yaml" {
+			t.Fatalf("status = %q, want the contract modified in the tree (the proposal, unstaged)", dirty)
+		}
+	})
+
 	t.Run("a rejecting pre-commit hook does not stop the gate's commit", func(t *testing.T) {
 		ws, base, git := modernizeRepo(t, plan)
 		hooks := filepath.Join(ws, ".git", "hooks")
@@ -183,8 +211,8 @@ lots:
 
 	t.Run("undeclared lot is refused", func(t *testing.T) {
 		ws, base, git := modernizeRepo(t, plan)
-		res := modernizeMarkDone(t, script, ws, "L9", base, 1)
-		if !strings.Contains(res.Notice, "not in the contract") {
+		res := modernizeMarkDone(t, script, ws, "L9", base, 0)
+		if !res.Refused || !strings.Contains(res.Notice, "not in the contract") {
 			t.Fatalf("notice = %q", res.Notice)
 		}
 		if head := git("rev-parse", "HEAD"); head != base {
@@ -195,8 +223,8 @@ lots:
 	t.Run("a block without a status line is refused, contract untouched", func(t *testing.T) {
 		noStatus := strings.Replace(plan, "    status: todo   # a bookmark, never evidence\n", "", 1)
 		ws, base, _ := modernizeRepo(t, noStatus)
-		res := modernizeMarkDone(t, script, ws, "L1", base, 1)
-		if !strings.Contains(res.Notice, "no `status:` line") {
+		res := modernizeMarkDone(t, script, ws, "L1", base, 0)
+		if !res.Refused || !strings.Contains(res.Notice, "no `status:` line") {
 			t.Fatalf("notice = %q", res.Notice)
 		}
 		got, _ := os.ReadFile(filepath.Join(ws, ".modernize", "plan.yaml"))

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -86,7 +86,10 @@ lots:
         test -f "$f"
       done
     status: todo
-`, 1)
+`, 0)
+		if !res.Refused {
+			t.Fatalf("a gate the reader cannot use must be a typed verdict (refused), got %+v", res)
+		}
 		if !strings.Contains(res.Notice, "multi-line") {
 			t.Fatalf("notice = %q, want a multi-line refusal", res.Notice)
 		}
@@ -100,7 +103,10 @@ lots:
     exit_gate:
       build: ./gradlew build
     status: todo
-`, 1)
+`, 0)
+		if !res.Refused {
+			t.Fatalf("a gate the reader cannot use must be a typed verdict (refused), got %+v", res)
+		}
 		if !strings.Contains(res.Notice, "unreadable shape") {
 			t.Fatalf("notice = %q, want an unreadable-shape refusal", res.Notice)
 		}
@@ -115,6 +121,7 @@ type modernizePlanReadOut struct {
 	Notice           string `json:"notice"`
 	LotNotActionable bool   `json:"lot_not_actionable"`
 	LotStatus        string `json:"lot_status"`
+	Refused          bool   `json:"refused"`
 }
 
 // modernizePlanRead executes the REAL plan_read script against a throwaway
@@ -295,8 +302,8 @@ lots:
     exit_gate: [ "false" ]
 `
 		for _, only := range []string{"", "L1"} {
-			res := modernizePlanRead(t, script, dup, only, 1)
-			if !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE: duplicate lot id") {
+			res := modernizePlanRead(t, script, dup, only, 0)
+			if !res.Refused || !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE: duplicate lot id") {
 				t.Fatalf("only=%q notice = %q", only, res.Notice)
 			}
 		}
@@ -308,8 +315,8 @@ lots:
     title: numeric
     status: todo
     exit_gate: [ "true" ]
-`, "", 1)
-		if !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE") {
+`, "", 0)
+		if !res.Refused || !strings.HasPrefix(res.Notice, "CONTRACT_UNREADABLE") {
 			t.Fatalf("notice = %q", res.Notice)
 		}
 	})
@@ -324,23 +331,25 @@ lots:
 			t.Fatalf("lot_not_actionable=%v lot_status=%q notice=%q, want the typed no_gate verdict", res.LotNotActionable, res.LotStatus, res.Notice)
 		}
 	})
-	t.Run("unfiltered mode keeps the documented no-op on a gate-less lot", func(t *testing.T) {
+	t.Run("unfiltered mode: a gate-less READY lot is the same typed verdict, never a no-op", func(t *testing.T) {
+		// The scan would re-pick this same lot at every relaunch: a green
+		// no-op here parks the programme in finished-at-zero-minutes runs.
 		res := modernizePlanRead(t, script, `version: 1
 lots:
-  - id: L5
+  - id: L1
     title: no gate
     status: todo
 `, "", 0)
-		if !res.NothingToDo {
-			t.Fatalf("expected the legitimate no-op, got %+v", res)
+		if !res.LotNotActionable || res.LotStatus != "no_gate" || res.NothingToDo {
+			t.Fatalf("lot_not_actionable=%v lot_status=%q nothing_to_do=%v, want the typed no_gate verdict", res.LotNotActionable, res.LotStatus, res.NothingToDo)
 		}
 	})
 	t.Run("a flow-mapping lot cannot be edited by the gate: refused before spend", func(t *testing.T) {
 		res := modernizePlanRead(t, script, `version: 1
 lots:
   - {id: L1, title: flow, status: todo, exit_gate: ["true"]}
-`, "L1", 1)
-		if !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
+`, "L1", 0)
+		if !res.Refused || !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
 			t.Fatalf("notice = %q", res.Notice)
 		}
 	})
@@ -351,8 +360,8 @@ lots:
 	// on exactly that, and `status: todo  ` passed plan_read to fail mark_done).
 	for _, line := range []string{"    status: todo  ", "    status: todo\t", "    status: todo extra"} {
 		t.Run("a status line the gate could not flip is refused before spend: "+strconv.Quote(line), func(t *testing.T) {
-			res := modernizePlanRead(t, script, "version: 1\nlots:\n  - id: L1\n    title: t\n"+line+"\n    exit_gate:\n      - \"true\"\n", "L1", 1)
-			if !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
+			res := modernizePlanRead(t, script, "version: 1\nlots:\n  - id: L1\n    title: t\n"+line+"\n    exit_gate:\n      - \"true\"\n", "L1", 0)
+			if !res.Refused || !strings.HasPrefix(res.Notice, "LOT_UNEDITABLE") {
 				t.Fatalf("notice = %q, want LOT_UNEDITABLE", res.Notice)
 			}
 		})

--- a/e2e/bot_modernize_test.go
+++ b/e2e/bot_modernize_test.go
@@ -19,7 +19,7 @@ func modernizeStubs(exec *scenarioExecutor, verdict func(pass int) map[string]an
 		return map[string]any{
 			"nothing_to_do": false, "lot_id": "L1", "lot_title": "raise the build tool",
 			"lot_intent": "bump it", "exit_gate": "true", "base_sha": "0123456789abcdef",
-			"refs_dir": ".golden-master/refs", "notice": "", "_tokens": 1,
+			"refs_dir": ".golden-master/refs", "notice": "", "lot_not_actionable": false, "lot_status": "", "refused": false, "_tokens": 1,
 		}, nil
 	})
 	pass := 0
@@ -33,7 +33,7 @@ func modernizeStubs(exec *scenarioExecutor, verdict func(pass int) map[string]an
 			"refs_changed": []any{}, "lot_blocked": false, "block_reason": "",
 			"oracle_invalid": []any{}, "extension_pending": []any{},
 			"done_self_written": false, "contract_rewritten": []any{},
-			"gate_timed_out": false, "log_tail": "", "_tokens": 1,
+			"gate_timed_out": false, "contract_unreadable": false, "log_tail": "", "_tokens": 1,
 		}
 		for k, v := range verdict(pass) {
 			out[k] = v
@@ -41,7 +41,7 @@ func modernizeStubs(exec *scenarioExecutor, verdict func(pass int) map[string]an
 		return out, nil
 	})
 	exec.on("mark_done", func(_ map[string]any) (map[string]any, error) {
-		return map[string]any{"marked": true, "commit": "feedfacefeedface", "notice": "marked", "_tokens": 1}, nil
+		return map[string]any{"marked": true, "commit": "feedfacefeedface", "notice": "marked", "refused": false, "_tokens": 1}, nil
 	})
 }
 
@@ -122,19 +122,40 @@ func TestModernize_RefusedVerdictNeverEndsGreen(t *testing.T) {
 // an hour against the same wall, never a `finished` the programme would
 // relaunch into it.
 func TestModernize_GateTimeoutFailsAtOnce(t *testing.T) {
-	exec := newScenarioExecutor()
-	modernizeStubs(exec, func(int) map[string]any {
-		return map[string]any{"gate_timed_out": true, "block_reason": "GATE_TIMEOUT: exit_gate command `sleep` exceeded gate_timeout_s=1 after 1s"}
-	})
-	run := runModernize(t, exec, "run-mod-timeout")
-	if run.Status != store.RunStatusFailed {
-		t.Fatalf("status = %s, want failed", run.Status)
-	}
-	if exec.wasCalled("mark_done") {
-		t.Fatal("mark_done ran on a timed-out gate")
-	}
-	if got := exec.callCount("upgrade_campaign"); got != 1 {
-		t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass against the same wall)", got)
+	for _, tc := range []struct {
+		name  string
+		extra map[string]any
+	}{
+		{"plain", nil},
+		// The same verdict carrying an invalidated mutant AND a pending
+		// extension: the fail edge is declared before the reanchor/extend
+		// edges, so neither subbot replays the timed-out gate first. With the
+		// edges in the other order the run dies in the subbot (no runner in
+		// this suite) as failed_resumable, not at the fail terminal.
+		{"with an invalidated mutant and a pending extension", map[string]any{
+			"oracle_invalid": []any{map[string]any{"id": "m1", "reason": "anchor vanished"}}, "extension_pending": []any{"E-1"},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			exec := newScenarioExecutor()
+			modernizeStubs(exec, func(int) map[string]any {
+				out := map[string]any{"gate_timed_out": true, "block_reason": "GATE_TIMEOUT: exit_gate command `sleep` exceeded gate_timeout_s=1 after 1s"}
+				for k, v := range tc.extra {
+					out[k] = v
+				}
+				return out
+			})
+			run := runModernize(t, exec, "run-mod-timeout")
+			if run.Status != store.RunStatusFailed {
+				t.Fatalf("status = %s, want failed (the fail terminal, before any subbot)", run.Status)
+			}
+			if exec.wasCalled("mark_done") {
+				t.Fatal("mark_done ran on a timed-out gate")
+			}
+			if got := exec.callCount("upgrade_campaign"); got != 1 {
+				t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass against the same wall)", got)
+			}
+		})
 	}
 }
 
@@ -156,4 +177,57 @@ func TestModernize_DeclaredBlockedStopsWithoutMarking(t *testing.T) {
 	if got := exec.callCount("upgrade_campaign"); got != 1 {
 		t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass against a declared wall)", got)
 	}
+}
+
+// TestModernize_RefusalsAreVerdicts: a contract the reader cannot read or
+// the gate cannot edit, a contract the verifier cannot read, a status the
+// gate cannot write — each is a typed verdict the graph fails on, once, with
+// no campaign pass spent on it (or, for the gate, the lot's work banked).
+// Never a tool error: the engine retries those once and leaves the run
+// `failed_resumable`, a terminal a router may probe-resume for nothing.
+func TestModernize_RefusalsAreVerdicts(t *testing.T) {
+	t.Run("plan_read refused: failed before any campaign pass", func(t *testing.T) {
+		exec := newScenarioExecutor()
+		modernizeStubs(exec, func(int) map[string]any { return nil })
+		exec.on("plan_read", func(_ map[string]any) (map[string]any, error) {
+			return map[string]any{
+				"nothing_to_do": false, "lot_id": "", "lot_title": "", "lot_intent": "", "exit_gate": "",
+				"base_sha": "", "refs_dir": "", "notice": "CONTRACT_UNREADABLE: duplicate lot id L1",
+				"lot_not_actionable": false, "lot_status": "", "refused": true, "_tokens": 1,
+			}, nil
+		})
+		run := runModernize(t, exec, "run-mod-plan-refused")
+		if run.Status != store.RunStatusFailed || exec.wasCalled("upgrade_campaign") {
+			t.Fatalf("status = %s, campaign called = %v; want failed with no campaign pass", run.Status, exec.wasCalled("upgrade_campaign"))
+		}
+	})
+	t.Run("lot_verify unreadable: failed at once, no repair pass", func(t *testing.T) {
+		exec := newScenarioExecutor()
+		modernizeStubs(exec, func(int) map[string]any {
+			return map[string]any{"contract_unreadable": true, "log_tail": "CONTRACT_UNREADABLE: yq is not on PATH"}
+		})
+		run := runModernize(t, exec, "run-mod-verify-unreadable")
+		if run.Status != store.RunStatusFailed {
+			t.Fatalf("status = %s, want failed", run.Status)
+		}
+		if got := exec.callCount("upgrade_campaign"); got != 1 {
+			t.Fatalf("upgrade_campaign called %d times, want 1 (no repair pass on a contract nobody can read)", got)
+		}
+		if exec.wasCalled("mark_done") {
+			t.Fatal("mark_done ran on an unreadable contract")
+		}
+	})
+	t.Run("mark_done refused: failed, the lot's work banked", func(t *testing.T) {
+		exec := newScenarioExecutor()
+		modernizeStubs(exec, func(int) map[string]any {
+			return map[string]any{"gate_passed": true, "oracle_passed": true, "refs_untouched": true}
+		})
+		exec.on("mark_done", func(_ map[string]any) (map[string]any, error) {
+			return map[string]any{"marked": false, "commit": "", "notice": "lot L1: no `status:` line inside its block", "refused": true, "_tokens": 1}, nil
+		})
+		run := runModernize(t, exec, "run-mod-mark-refused")
+		if run.Status != store.RunStatusFailed {
+			t.Fatalf("status = %s, want failed (the gate could not write its word)", run.Status)
+		}
+	})
 }


### PR DESCRIPTION

Third review round (two medium, three open questions), each reproduced and
pinned.

- The refusals that exited 1 — CONTRACT_UNREADABLE and LOT_UNEDITABLE in
  plan_read, CONTRACT_UNREADABLE in lot_verify, the gate's own refusals in
  mark_done — were tool errors: the engine retries one once and then leaves
  the run `failed_resumable`, a terminal a router may probe-resume for
  nothing. Each is now a field the graph reads (`refused`,
  `contract_unreadable`, `refused`) and an edge to `fail`: the run fails
  once, typed, with no campaign pass spent (or, for the gate, the lot's work
  banked). Every test reads the verdict instead of the exit code; three e2e
  cases route them on the engine.
- mark_done committed the working tree's contract, so anything the worker
  left uncommitted there — an added lot, which the verdict deliberately
  accepts as a proposal — rode along under the gate's subject. The committed
  content is now HEAD's contract with the one flipped line, built with
  plumbing on a scratch index (no hook, no other staged change); the tree
  keeps the worker's edits, unstaged.
- `lot_gate -> fail when timed_out` was declared after the reanchor/extend
  edges; a timed-out verdict that also carried an invalidated mutant or a
  pending extension went to a subbot and replayed the gate before failing.
  The fail edge is first, and an expired exit gate no longer pays for the
  oracle replay.
- A gate-less READY lot is the same typed verdict in the unfiltered mode as
  under only_lot: the scan re-picks it at every relaunch, so a green no-op
  parked the programme in finished-at-zero-minutes runs.
- manifest 0.3.0 with the changelog of this branch.

Mutants: each new fail edge dropped, the timeout edge moved back after the
subbots, mark_done committing the working tree again — each turns its test
red.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
