### PR TITLE
fix(sandbox): the claw bind-mount follows the effective backend; a pod that never got placed parks the run failed_resumable

### DIFF
--- a/docs/resume.md
+++ b/docs/resume.md
@@ -526,6 +526,32 @@ schema validation, edge/routing failures, budget and timeout errors, fan-out
 failures, and resumable sandbox startup failures. A recovery policy may retry,
 repair, or ask a human before the final status is written.
 
+### Sandbox startup — which failures are resumable
+
+A failure at `sandbox start` happens before the first node runs, so it is
+classified from the DRIVER's typed error rather than assumed either way.
+Both resumable codes are persisted on `failed_resumable`, so
+`iterion resume`, `--auto-resume` and the cloud runner's redelivery all
+pick them up; anything else stays terminal `failed`, because a redelivery
+would re-hit it identically and only spend a pod per attempt.
+
+| Failure | Code | Status |
+|---|---|---|
+| A bounded setup phase that RAN and stalled (workspace copy, git fixup) | `SANDBOX_SETUP_TIMEOUT` | `failed_resumable` — a fresh pod routinely clears the stall |
+| The pod is still `Pending` past the deadline, unscheduled (`Unschedulable`, `Insufficient cpu`: the fleet is at its request ceiling) | `SANDBOX_CAPACITY` | `failed_resumable` — the run executed nothing; a later attempt re-places it |
+| The pod is still `Pending`, scheduled, its node not having started the container (`ContainerCreating`, `PodInitializing`, or no container status reported yet) | `SANDBOX_CAPACITY` | `failed_resumable` — same: `Pending` IS the API's guarantee that no container was created |
+| A broken image reference (`ErrImagePull`, `ImagePullBackOff`, `InvalidImageName`) | — | `failed` — every pod re-hits it; the operator fixes the reference. Overrides the phase: such a pod is `Pending` too |
+| An invalid spec (`CreateContainerConfigError`, `CreateContainerError`) or a crash-looping container | — | `failed` |
+| The pod reached `Running` (or `Unknown`) but never Ready | — | `failed` — a container came up; nothing says the run did nothing |
+| The pod could not be inspected at all (RBAC, apiserver blip) | — | `failed` — no evidence, nothing claimed |
+
+The cloud runner re-offers a `SANDBOX_CAPACITY` delivery after a delay
+long enough for a cluster autoscaler to add a node; a fleet that stays
+full through every permitted delivery parks the run on the DLQ like any
+other repeated failure. The start deadline itself is
+`ITERION_SANDBOX_K8S_POD_READY_TIMEOUT` — see
+[sandbox](sandbox.md#scheduling-requests-and-node-spread).
+
 Cancellation saves state with a detached, bounded store context so Ctrl-C can
 still persist after the execution context is cancelled. If checkpoint writing
 itself fails, the runtime logs the loss and can fall back to non-resumable

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -564,6 +564,17 @@ boundary instead of escaping to the host.
 local sandboxes built from third-party images you can mount the host
 binary in (subject to architecture matching) via `runArgs`:
 
+> **The mount decision reads the EFFECTIVE backend, not the `.bot`.**
+> `--backend '*=claw'` (and `--model`, the studio override object,
+> `RunMessage.model_overrides`) is applied at dispatch and never folded
+> back into the IR, so the bind is decided through the executor's own
+> resolution chain — the same one the node will dispatch on. It is a
+> UNION with the authored IR, never a narrowing: a node that *declares*
+> `claw` keeps the mount even when an override routes it elsewhere,
+> because the resolver reads the HOST's credentials and the container may
+> resolve differently, and a missing binary is a hard mid-run death while
+> an unused read-only bind costs nothing.
+
 ```jsonc
 // .devcontainer/devcontainer.json
 {
@@ -1058,6 +1069,10 @@ use an iterion sandbox image that includes the binary, add it to your
 custom image, set `ITERION_BIN` so the host can mount it, or add an
 explicit read-only mount that places a compatible `iterion` binary on
 the container PATH.
+
+The bind and the `sandbox_claw_routed_via_runner` event are decided on
+the backend DISPATCH resolves, launch overrides included — so a workflow
+of `claude_code` nodes run with `--backend '*=claw'` gets both.
 
 ### `network_blocked` events you don't expect
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -863,6 +863,29 @@ an exponent, or the SI/binary byte suffixes (`4Gi`); `m` on memory
 (milli-bytes) and a byte suffix on CPU are refused, as are zero quantities
 (a block that schedules like no block). The API server owns the rest.
 
+**When the deadline does expire, the failure is classified.** The driver
+reads the pod's own status once, before deleting it, and decides between
+a PLACEMENT failure — the pod is still `Pending`, which is the API's own
+guarantee that no container was created: unscheduled (`Unschedulable`,
+`Insufficient cpu`) or scheduled onto a node that had not started it — and
+everything else. A placement failure carries `sandbox.ErrCapacity`, so the run parks
+`failed_resumable` + `SANDBOX_CAPACITY` and the cloud runner re-offers
+the delivery after a delay long enough for an autoscaler cycle, instead
+of dying terminal and silently losing an hourly sentinel's tick. A broken
+image reference, an invalid spec, a crash-looping container or a pod the
+driver could not read stay terminal `failed`: a redelivery re-hits them
+identically and spends a pod for it. The full table is in
+[resume](resume.md#sandbox-startup--which-failures-are-resumable).
+
+The capacity signal is read from the pod's `PodScheduled` condition, not
+from the `TriggeredScaleUp` **Event** the autoscaler writes: Events need
+a `get events` verb the runner's namespaced Role deliberately does not
+grant, and the condition already says the same thing. There is no second
+"keep waiting while a node is coming" deadline either — the resumable
+classification IS that wait, with the queue as its timer and a different,
+less loaded pod free to claim the redelivery; a run that needs longer in
+one shot raises `ITERION_SANDBOX_K8S_POD_READY_TIMEOUT`.
+
 **Nothing is shipped by default.** Measured on a three-worker cluster with the
 image on one node only: no requests → 2/3/1, requests alone → 2/2/2, requests
 plus spread → 2/2/2 — the request is the half that moves the pods (it is what

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -188,6 +188,14 @@ func isNakAction(a deliveryAction) bool {
 // the DLQ park, and nothing on the run's timeline says so in between.
 const sandboxSetupTimeoutNakDelay = 2 * time.Minute
 
+// sandboxCapacityNakDelay spaces the redeliveries of a run whose sandbox
+// pod never got placed. The cure is the cluster growing, not the pod
+// retrying: the measured autoscaler cycle on a full fleet was a
+// TriggeredScaleUp followed by a Ready node about two minutes later, plus
+// the image pull on that cold node. Re-offering sooner just re-hits the
+// same ceiling and spends a delivery for it.
+const sandboxCapacityNakDelay = 3 * time.Minute
+
 // resolveDeliveryPreconditions runs the pre-lock store gauntlet:
 // LoadRun (with its own short detached timeout context so a runner
 // shutdown can't terminate a live delivery) and the status switch
@@ -627,6 +635,24 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 			level:       logWarn,
 			logFmt:      "runner: run %s: sandbox setup phase timed out (resumable) — re-offered to a fresh pod in %s (%v)",
 			logArgs:     []any{runID, sandboxSetupTimeoutNakDelay, execErr},
+		}
+	}
+	// A sandbox pod that never got placed (sandbox.ErrCapacity): the
+	// engine wrote failed_resumable + SANDBOX_CAPACITY. Same treatment as
+	// the phase timeout above and for the same reason, with a longer
+	// spacing — the cure is the cluster growing, not the pod retrying, and
+	// an autoscaler cycle is minutes. The DLQ park on the last permitted
+	// delivery still applies, so a fleet that stays full ends parked and
+	// announced instead of naking into nothing.
+	if errors.Is(execErr, sandbox.ErrCapacity) {
+		return execOutcome{
+			finalStatus: "sandbox_capacity",
+			op:          "nak-sandbox-capacity",
+			action:      actionNakDelayed,
+			delay:       sandboxCapacityNakDelay,
+			level:       logWarn,
+			logFmt:      "runner: run %s: the sandbox could not be placed (resumable) — re-offered in %s (%v)",
+			logArgs:     []any{runID, sandboxCapacityNakDelay, execErr},
 		}
 	}
 	// Operator cancel: terminal cancelled, acked (redelivery drops it).

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -481,6 +481,31 @@ func TestClassifyExecResult_SandboxSetupTimeoutIsReofferedAfterADelay(t *testing
 	}
 }
 
+// A pod that never got placed is re-offered too, after long enough for a
+// cluster autoscaler to add a node (the measured scale-up was ~2 min).
+// Deliberately a delayed NAK and not an interruption: the DLQ park on the
+// last permitted delivery still applies, so a fleet that stays full ends
+// parked and announced rather than naking into nothing.
+func TestClassifyExecResult_SandboxCapacityIsReofferedAfterADelay(t *testing.T) {
+	err := fmt.Errorf("runtime: sandbox: %w",
+		errors.Join(sandbox.ErrCapacity, errors.New("0/12 nodes are available: 11 Insufficient cpu")))
+	out := classifyExecResult(err, "run-1")
+	if out.finalStatus != "sandbox_capacity" {
+		t.Fatalf("finalStatus = %q, want sandbox_capacity", out.finalStatus)
+	}
+	if out.delay != sandboxCapacityNakDelay || out.delay <= 0 {
+		t.Fatalf("delay = %s, want %s — an immediate re-offer re-hits a cluster that has not grown yet", out.delay, sandboxCapacityNakDelay)
+	}
+	if bankableStatus(out.finalStatus) {
+		t.Fatal("a pod that never started has nothing to bank")
+	}
+	d := &fakeDelivery{delivered: 3}
+	dispatchExecOutcome(iterlog.Nop(), d, out, "run-1")
+	if len(d.nakDelays) != 1 || d.nakDelays[0] != sandboxCapacityNakDelay || d.naks != 0 || d.terms != 0 || d.acks != 0 {
+		t.Fatalf("delivery transitions = %+v, want exactly one NakWithDelay(%s)", d, sandboxCapacityNakDelay)
+	}
+}
+
 // The delayed redelivery lands on the run's timeline, naming the phase
 // timeout, the delay and the attempt's rank — the only trace between two
 // attempts of why the run sits failed_resumable.
@@ -557,6 +582,8 @@ func TestOutcomeSideEffectsFire(t *testing.T) {
 		{"interrupted naks — no fire", runtime.ErrRunInterrupted, false},
 		{"wrapped interrupted naks — no fire", fmt.Errorf("%w: at node n1", runtime.ErrRunInterrupted), false},
 		{"sandbox phase timeout naks — no fire", fmt.Errorf("runtime: sandbox: %w", sandbox.ErrPhaseTimeout), false},
+		{"sandbox capacity (delayed nak) does not fire", fmt.Errorf("runtime: sandbox: %w",
+			errors.Join(sandbox.ErrCapacity, errors.New("11 Insufficient cpu"))), false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -499,6 +499,10 @@ func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, 
 //     expired while the run ctx stayed live. failed_resumable, so the
 //     runner's NAK redelivers the run to a healthy pod, which routinely
 //     clears the stall;
+//   - a sandbox the driver could not PLACE (sandbox.ErrCapacity) — the
+//     cluster had no room for the pod, or its node was still bringing the
+//     container up: nothing of the run executed. failed_resumable, so the
+//     redelivery re-places it once the fleet has room;
 //   - the run ctx cancelled with ErrRunInterrupted (runner drain, lost
 //     heartbeat) — infrastructure took the run away: failed_resumable, so
 //     the ordinary retry puts it on a healthy pod;
@@ -518,6 +522,16 @@ func setupFailureStatus(ctx context.Context, phase string, cause error) (store.R
 		return store.RunStatusFailedResumable,
 			fmt.Sprintf("%s: sandbox setup phase timed out (resumable — a fresh pod on redelivery routinely clears the stall): %v", phase, cause),
 			store.FailureSandboxSetupTimeout
+	}
+	// Same arm, same reason, one step earlier: the sandbox never got
+	// PLACED (the driver classified the cluster's own evidence). Nothing
+	// of the run executed, so a terminal status would lose the whole
+	// launch — an hourly sentinel's tick, a campaign's start — over a
+	// condition that clears as soon as the fleet has room.
+	if errors.Is(cause, sandbox.ErrCapacity) {
+		return store.RunStatusFailedResumable,
+			fmt.Sprintf("%s: the sandbox could not be placed (resumable — the run executed nothing; a redelivery re-places it): %v", phase, cause),
+			store.FailureSandboxCapacity
 	}
 	if ctx == nil || ctx.Err() == nil {
 		return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause), setupFailureCode(cause)
@@ -547,11 +561,12 @@ func setupFailureCode(cause error) store.FailureCode {
 // the status written above would say resumable while the queue had
 // already dropped the run — the two halves have to agree.
 //
-// A sandbox phase timeout is NOT dressed up as an interruption: it keeps
-// its own sentinel (sandbox.ErrPhaseTimeout, wrapped through by the
-// driver), and the runner's ack policy classifies that shape itself — a
-// NAK for redelivery, with the DLQ park still applying on the last
-// permitted delivery, which an interruption is exempt from.
+// A sandbox phase timeout and an unplaced sandbox are NOT dressed up as
+// an interruption: each keeps its own sentinel (sandbox.ErrPhaseTimeout /
+// sandbox.ErrCapacity, wrapped through by the driver), and the runner's
+// ack policy classifies those shapes itself — a NAK for redelivery, with
+// the DLQ park still applying on the last permitted delivery, which an
+// interruption is exempt from.
 func (e *Engine) setupErr(ctx context.Context, err error) error {
 	if ctx != nil && ctx.Err() != nil && errors.Is(context.Cause(ctx), ErrRunInterrupted) {
 		return fmt.Errorf("%w: %v", ErrRunInterrupted, err)

--- a/pkg/runtime/fallbacks_plantime_test.go
+++ b/pkg/runtime/fallbacks_plantime_test.go
@@ -20,7 +20,7 @@ func TestContainsClawNode_SeesFallbackRoutes(t *testing.T) {
 			Fallbacks: []ir.Fallback{{Name: "api", Backend: "claw", Model: "openai/gpt-5.5"}},
 		},
 	}}
-	if !containsClawNode(wf) {
+	if !containsClawNode(wf, nil) {
 		t.Error("a claw route inside a fallbacks: block must still mount the iterion binary")
 	}
 }
@@ -36,7 +36,7 @@ func TestContainsClawNode_JudgeFallbackRoutesToo(t *testing.T) {
 			Fallbacks: []ir.Fallback{{Name: "api", Backend: "claw", Model: "openai/gpt-5.5"}},
 		},
 	}}
-	if !containsClawNode(wf) {
+	if !containsClawNode(wf, nil) {
 		t.Error("a judge's claw route must mount the binary too")
 	}
 }
@@ -54,7 +54,7 @@ func TestContainsClawNode_InheritingRouteAddsNothing(t *testing.T) {
 			Fallbacks: []ir.Fallback{{Name: "same", Model: "claude-sonnet-5"}},
 		},
 	}}
-	if containsClawNode(wf) {
+	if containsClawNode(wf, nil) {
 		t.Error("a route with no backend of its own must not be read as claw")
 	}
 }

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -785,7 +785,8 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 // (setupFailureStatus), so the runner's retry lane reads a resumed run
 // exactly as a launched one: a sandbox phase timeout lands as
 // SANDBOX_SETUP_TIMEOUT (a redelivery to a fresh pod routinely clears
-// the stall), a drain as INTERRUPTED. An operator cancel is honoured as
+// the stall), a pod the cluster had no room for as SANDBOX_CAPACITY, a
+// drain as INTERRUPTED. An operator cancel is honoured as
 // `cancelled` with the checkpoint kept — the same CAS shape the node
 // loop uses, so a reason the publisher already recorded is never
 // overwritten. Every write is loud on failure: a park that does not
@@ -802,8 +803,9 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 // The returned error is what the runner classifies, so it carries the
 // same sentinel the status carries — ErrRunCancelled for an operator
 // cancel (acked, never redelivered), ErrRunInterrupted for a drain
-// (naked, exempt from the DLQ park), the driver's own sandbox.ErrPhaseTimeout
-// for a stall (naked with a delay) — mirroring setupErr on the launch
+// (naked, exempt from the DLQ park), the driver's own
+// sandbox.ErrPhaseTimeout for a stall and sandbox.ErrCapacity for a pod
+// that never got placed (both naked with a delay) — mirroring setupErr on the launch
 // path. A bare wrap would read as a generic failure: an operator cancel
 // burning a delivery, a drain parked on the DLQ.
 func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp *store.Checkpoint, fallbackNode string, sbErr error) error {

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/askusermcp"
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -245,6 +246,14 @@ type SandboxParams struct {
 	// board (C082). The engine sets it from WithBoardMCP (server path);
 	// nil (CLI / no server) leaves sandboxed board-emit disabled.
 	BoardMCPHandler http.Handler
+
+	// EffectiveBackend resolves a node's backend the way DISPATCH will —
+	// launch-time `--backend`/`--model` overrides included. The engine
+	// passes its executor; nil (a driver-level test) reads the raw IR
+	// alone. Without it the claw bind-mount decision misses every
+	// override, since they are applied at dispatch and never folded back
+	// into the IR. Same seam as the workspace-safety admission check.
+	EffectiveBackend effectiveBackendResolver
 }
 
 // workflowMaxDurationSeconds returns the workflow budget's max_duration
@@ -394,7 +403,7 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 	// translateMounts; there the iterion/rtk binaries are baked into the
 	// sandbox image instead (see sandbox/*/Dockerfile).
 	if caps.SupportsHostBindMounts {
-		addClawBinaryMount(spec, p.Workflow)
+		addClawBinaryMount(spec, p.Workflow, p.EffectiveBackend)
 		addRewriterMounts(spec)
 		addWorktreeGitMount(spec, p.WorktreeGitDir, logger)
 	}
@@ -425,7 +434,7 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 	// edits) execute inside the sandbox. Surface the routing decision
 	// so operators can audit it and opt out by setting `backend:` on
 	// the affected nodes.
-	if p.Workflow != nil && containsClawNode(p.Workflow) {
+	if p.Workflow != nil && containsClawNode(p.Workflow, p.EffectiveBackend) {
 		_ = emitEvent(store.EventSandboxClawRoutedViaRunner, map[string]any{
 			"reason":         "claw nodes will run via iterion-claw-runner inside the container",
 			"limitations_v1": "no MCP servers, no mid-tool-loop ask_user — see docs/sandbox.md",
@@ -1243,13 +1252,37 @@ func cloneStringMap(m map[string]string) map[string]string {
 	return cloneMap(m)
 }
 
-// containsClawNode reports whether any agent/judge node in the workflow
-// uses the in-process claw backend. Sandboxing claw requires the
-// Phase 4 sub-binary split which is not yet shipped; until then we
-// fail fast with a clear message rather than silently running claw on
-// the host while pretending the workflow is sandboxed.
-func containsClawNode(wf *ir.Workflow) bool {
+// containsClawNode reports whether any route this run may take executes
+// on the in-process claw backend — the predicate the in-container
+// iterion bind-mount and the `sandbox_claw_routed_via_runner` event are
+// taken on, since a claw node dispatches through `iterion __claw-runner`
+// inside the container.
+//
+// It is a UNION of two readings, never a narrowing:
+//
+//   - the IR as authored — the node's `backend:` (empty meaning claw, the
+//     implicit default) and its `fallbacks:` routes;
+//   - the backend DISPATCH will resolve, resolver being the executor's own
+//     chain (launch `--backend`/`--model` overrides → DSL → workflow
+//     default → env → auto-detection). Overrides are applied at dispatch
+//     and never folded into the IR, so `--backend '*=claw'` on a workflow
+//     of claude_code nodes is invisible to the first reading alone.
+//
+// The union is deliberate in both directions. A node the resolver routes
+// onto claw NEEDS the binary. A node that DECLARES claw keeps the mount
+// even when an override routes it elsewhere: the resolver reads this
+// HOST's credentials and env, which need not match what the container
+// resolves, and the two costs are not comparable — a missing binary kills
+// the node mid-run with `exec: /usr/local/bin/iterion: no such file or
+// directory`, an unused read-only bind costs nothing.
+//
+// A nil resolver (a driver-level call, a stub executor) reads the IR
+// alone: today's behaviour, unchanged.
+func containsClawNode(wf *ir.Workflow, resolver effectiveBackendResolver) bool {
 	for _, n := range wf.Nodes {
+		if resolverRoutesToClaw(n, resolver) {
+			return true
+		}
 		switch nn := n.(type) {
 		case *ir.AgentNode:
 			if backendIsClaw(nn.Backend) || fallbacksReachClaw(nn.Fallbacks) {
@@ -1266,6 +1299,29 @@ func containsClawNode(wf *ir.Workflow) bool {
 		}
 	}
 	return false
+}
+
+// resolverRoutesToClaw asks the dispatch resolver where a node will
+// actually run. Restricted to the three kinds the resolver reads a
+// `backend:` from — the same kinds the raw reading above inspects: every
+// other kind falls through the resolver's chain to its last-resort claw
+// arm, which would mount the binary for any sandboxed workflow with a
+// subbot or a compute node.
+//
+// Deliberately NOT backendIsClaw: that helper reads an EMPTY backend as
+// claw, which is right for the raw IR (the implicit default) but says
+// nothing here — an empty answer from the resolver means "no opinion".
+func resolverRoutesToClaw(n ir.Node, resolver effectiveBackendResolver) bool {
+	if resolver == nil {
+		return false
+	}
+	switch n.(type) {
+	case *ir.AgentNode, *ir.JudgeNode, *ir.RouterNode:
+	default:
+		return false
+	}
+	name := strings.ToLower(strings.TrimSpace(resolver.EffectiveBackendName(n)))
+	return name == delegate.BackendClaw
 }
 
 // fallbacksReachClaw reports whether any of a node's `fallbacks:` routes
@@ -1527,6 +1583,7 @@ func (e *Engine) startSandbox(ctx context.Context, runID string, repoRoot string
 		WorktreeGitDir:           worktreeGitDir,
 		SecretRewriter:           e.resolveSecretRewriter(),
 		BoardMCPHandler:          e.boardMCPHandler,
+		EffectiveBackend:         e.backendResolver(),
 	})
 	if sbErr != nil {
 		return noopCleanup, sbErr

--- a/pkg/runtime/sandbox_capacity_park_test.go
+++ b/pkg/runtime/sandbox_capacity_park_test.go
@@ -1,0 +1,102 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// capacityStartError is the shape the kubernetes driver returns when the
+// pod never got placed, wrapped the way engine_run.go wraps it.
+func capacityStartError() error {
+	return fmt.Errorf("runtime: sandbox: %w",
+		fmt.Errorf("kubernetes: wait for pod ready: %w",
+			errors.Join(sandbox.ErrCapacity,
+				errors.New("0/12 nodes are available: 11 Insufficient cpu"))))
+}
+
+// The launch arm: a run whose sandbox never got placed must land
+// failed_resumable + SANDBOX_CAPACITY. Classified `failed`, nothing ever
+// comes back for it — the production shape of #699, where a dead review
+// became a synthetic red gate that launched a fixer with nothing to fix.
+func TestMarkFailedBestEffort_CapacityParksResumableAndTyped(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+	const runID = "run-sandbox-capacity"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	cp := &store.Checkpoint{NodeID: "campaign", Outputs: map[string]map[string]any{"plan": {"steps": 3}}}
+	if err := s.SaveCheckpoint(ctx, runID, cp); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	eng := New(devboxTestWorkflow(), s, newStubExecutor(), WithLogger(iterlog.Nop()))
+	eng.markFailedBestEffort(ctx, runID, "sandbox start", capacityStartError())
+
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %q, want failed_resumable — an hourly sentinel silently loses its tick otherwise", r.Status)
+	}
+	if r.FailureCode != store.FailureSandboxCapacity {
+		t.Fatalf("FailureCode = %q, want SANDBOX_CAPACITY", r.FailureCode)
+	}
+	if !r.Status.CanAutoResume() {
+		t.Fatal("the retry machinery only picks up statuses CanAutoResume admits")
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "campaign" {
+		t.Fatalf("checkpoint = %+v, want the one the run had earned — a park must never wipe it", r.Checkpoint)
+	}
+}
+
+// The half that makes the resumable classification worth anything: a run
+// that never started a node resumes from the workflow ENTRY. Without it a
+// capacity park would be resumable in name only.
+func TestResume_CapacityParkWithNoCheckpointRestartsFromTheEntry(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+	const runID = "run-capacity-resume-entry"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// Exactly what the launch arm leaves behind: no node ran, so no
+	// checkpoint was ever saved.
+	if err := s.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailedResumable,
+		"sandbox start: no capacity", store.FailureSandboxCapacity); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+
+	exec := newStubExecutor()
+	ran := map[string]int{}
+	exec.on("start", func(map[string]any) (map[string]any, error) {
+		ran["start"]++
+		return map[string]any{}, nil
+	})
+
+	eng := New(devboxTestWorkflow(), s, exec,
+		WithWorkDir(t.TempDir()),
+		WithSandboxOverride("none"),
+		WithLogger(iterlog.Nop()),
+	)
+	if err := eng.Resume(ctx, runID, nil); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	if ran["start"] != 1 {
+		t.Fatalf("entry node ran %d times, want 1 — a run with no checkpoint must restart from the workflow entry", ran["start"])
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if r.Status != store.RunStatusFinished {
+		t.Fatalf("status after resume = %q, want finished", r.Status)
+	}
+}

--- a/pkg/runtime/sandbox_claw_mount_override_test.go
+++ b/pkg/runtime/sandbox_claw_mount_override_test.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// claudeCodeWorkflow is the shape the override matters for: every node
+// declares a CLI backend, so the raw IR says "no claw here".
+func claudeCodeWorkflow() *ir.Workflow {
+	return &ir.Workflow{Nodes: map[string]ir.Node{
+		"implement": &ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "implement"},
+			LLMFields: ir.LLMFields{Backend: "claude_code"},
+		},
+		"verdict": &ir.JudgeNode{
+			BaseNode:  ir.BaseNode{ID: "verdict"},
+			LLMFields: ir.LLMFields{Backend: "claude_code"},
+		},
+	}}
+}
+
+// executorWithOverrides builds the REAL executor the run would dispatch
+// through, so the test exercises the same EffectiveBackendName chain
+// production does instead of a hand-rolled stand-in.
+func executorWithOverrides(wf *ir.Workflow, o model.ModelOverrides) effectiveBackendResolver {
+	return model.NewClawExecutor(model.NewRegistry(), wf, model.WithModelOverrides(o))
+}
+
+// `--backend '*=claw'` is applied at dispatch and never folded into the
+// IR, so a mount decision taken on the raw node backend leaves a
+// claw-routed run with no in-container iterion binary — every node then
+// dies on `exec: /usr/local/bin/iterion: no such file or directory`.
+func TestContainsClawNode_HonoursTheLaunchBackendOverride(t *testing.T) {
+	wf := claudeCodeWorkflow()
+	if containsClawNode(wf, nil) {
+		t.Fatal("without an override this workflow reaches no claw node")
+	}
+
+	var o model.ModelOverrides
+	o.SetBackend("*", "claw")
+	if !containsClawNode(wf, executorWithOverrides(wf, o)) {
+		t.Fatal("under --backend '*=claw' every node runs on claw: the iterion binary MUST be mounted, or the first node dies with `exec: /usr/local/bin/iterion: no such file or directory`")
+	}
+}
+
+// A selector narrower than "*" is honoured the same way: one claw node is
+// enough to need the binary.
+func TestContainsClawNode_HonoursAPerNodeBackendOverride(t *testing.T) {
+	wf := claudeCodeWorkflow()
+	var o model.ModelOverrides
+	o.SetBackend("verdict", "claw")
+	if !containsClawNode(wf, executorWithOverrides(wf, o)) {
+		t.Fatal("a single overridden node is enough: it runs through the in-container claw runner like any other claw node")
+	}
+}
+
+// The symmetric case: nodes declare claw, the operator overrides them onto
+// claude_code. The mount is KEPT — the resolver reads HOST credentials,
+// which need not match what the container resolves, and a missing binary
+// is a hard mid-run death while a spare read-only bind costs nothing.
+func TestContainsClawNode_KeepsTheMountWhenTheOverrideLeavesClaw(t *testing.T) {
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"implement": &ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "implement"},
+			LLMFields: ir.LLMFields{Backend: "claw"},
+		},
+	}}
+	var o model.ModelOverrides
+	o.SetBackend("*", "claude_code")
+	if !containsClawNode(wf, executorWithOverrides(wf, o)) {
+		t.Fatal("a declared claw node keeps its mount under an override away from claw: the decision is a UNION, never a narrowing")
+	}
+}
+
+// The composition that actually matters: the spec the driver receives must
+// carry the bind.
+func TestAddClawBinaryMount_MountsUnderTheLaunchBackendOverride(t *testing.T) {
+	bin := fakeIterionBinary(t)
+	t.Setenv("ITERION_BIN", bin)
+
+	wf := claudeCodeWorkflow()
+	var o model.ModelOverrides
+	o.SetBackend("*", "claw")
+
+	spec := &sandbox.Spec{}
+	addClawBinaryMount(spec, wf, executorWithOverrides(wf, o))
+
+	if !hasIterionBinaryMount(spec.Mounts) {
+		t.Fatalf("mounts = %v, want a bind at /usr/local/bin/iterion — the claw runner has no binary to exec inside the container", spec.Mounts)
+	}
+}
+
+// fakeIterionBinary writes an executable file locateHostIterionBinary can
+// find through ITERION_BIN, so the mount assertion does not depend on the
+// host having iterion installed.
+func fakeIterionBinary(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "iterion")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write fake iterion binary: %v", err)
+	}
+	return p
+}
+
+func hasIterionBinaryMount(mounts []string) bool {
+	for _, m := range mounts {
+		if strings.Contains(m, "target=/usr/local/bin/iterion") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runtime/sandbox_helpers_test.go
+++ b/pkg/runtime/sandbox_helpers_test.go
@@ -104,7 +104,7 @@ func TestContainsClawNode(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := containsClawNode(c.wf); got != c.want {
+			if got := containsClawNode(c.wf, nil); got != c.want {
 				t.Errorf("got %v, want %v", got, c.want)
 			}
 		})

--- a/pkg/runtime/sandbox_mounts.go
+++ b/pkg/runtime/sandbox_mounts.go
@@ -554,8 +554,8 @@ func applyHostUIDRemap(
 // the silent skip when no host binary can be located is intentional;
 // the absence will then surface as a clear "exec: iterion: not found"
 // at runner invocation time.
-func addClawBinaryMount(spec *sandbox.Spec, wf *ir.Workflow) {
-	if wf == nil || !containsClawNode(wf) {
+func addClawBinaryMount(spec *sandbox.Spec, wf *ir.Workflow, resolver effectiveBackendResolver) {
+	if wf == nil || !containsClawNode(wf, resolver) {
 		return
 	}
 	hostBin := locateHostIterionBinary()

--- a/pkg/runtime/setup_failure_status_test.go
+++ b/pkg/runtime/setup_failure_status_test.go
@@ -74,6 +74,42 @@ func TestSetupFailureStatus_PhaseTimeoutIsResumable(t *testing.T) {
 	}
 }
 
+// A pod that never got placed executed NOTHING: no node started, no
+// command ran. Classified `failed` it is dead on arrival — an hourly
+// sentinel silently loses its tick and a campaign loses its launch (#699,
+// measured in production with every worker at 88–94 % CPU requested).
+func TestSetupFailureStatus_CapacityIsResumable(t *testing.T) {
+	cause := fmt.Errorf("kubernetes: wait for pod ready: %w",
+		errors.Join(sandbox.ErrCapacity, errors.New("0/12 nodes are available: 11 Insufficient cpu")))
+
+	got, msg, code := setupFailureStatus(context.Background(), "sandbox start", cause)
+	if got != store.RunStatusFailedResumable {
+		t.Fatalf("capacity status = %q, want failed_resumable — nothing retries a terminal failure, and the pod did no work", got)
+	}
+	if code != store.FailureSandboxCapacity {
+		t.Fatalf("capacity code = %q, want SANDBOX_CAPACITY — the retry lane and the gate notice cannot tell it from a generic failure", code)
+	}
+	if !strings.Contains(msg, "Insufficient cpu") {
+		t.Fatalf("the cluster's reason must reach the run record, got %q", msg)
+	}
+}
+
+// The status and the error have to agree: the runner classifies the
+// sentinel itself, so a capacity failure that lost it would be ACKed and
+// dropped by the queue while the run record claims it is resumable.
+func TestSetupErr_CapacityKeepsItsOwnSentinel(t *testing.T) {
+	e := &Engine{}
+	capacity := fmt.Errorf("runtime: sandbox: %w",
+		errors.Join(sandbox.ErrCapacity, errors.New("unschedulable")))
+	err := e.setupErr(context.Background(), capacity)
+	if !errors.Is(err, sandbox.ErrCapacity) {
+		t.Fatalf("capacity identity lost after setupErr; got %v", err)
+	}
+	if errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("capacity was dressed up as an interruption: %v — the runner would exempt it from the DLQ park", err)
+	}
+}
+
 // setupErr hands the phase timeout to the runner under its OWN sentinel:
 // the runner's ack policy classifies sandbox.ErrPhaseTimeout itself. It
 // must not be dressed up as ErrRunInterrupted — an interruption is exempt

--- a/pkg/runtime/workspace_safety.go
+++ b/pkg/runtime/workspace_safety.go
@@ -70,6 +70,21 @@ type effectiveBackendResolver interface {
 	EffectiveBackendName(ir.Node) string
 }
 
+// backendResolver is the ONE place the engine asks its executor for the
+// dispatch-time backend resolution. Every pre-run analysis that keys on a
+// node's backend — workspace-safety admission, the sandbox's claw
+// bind-mount — reads it here rather than re-deriving from the IR, which
+// would silently miss the launch-time `--backend` / `--model` overrides.
+// Returns nil for an executor that does not resolve backends (a stub),
+// which every caller reads as "the IR is all there is".
+func (e *Engine) backendResolver() effectiveBackendResolver {
+	if e == nil {
+		return nil
+	}
+	r, _ := e.executor.(effectiveBackendResolver)
+	return r
+}
+
 func isMutatingNodeWithBackend(node ir.Node, defaultBackend string, resolver effectiveBackendResolver) bool {
 	return isMutatingNodeCtx(node, defaultBackend, resolver, false)
 }
@@ -243,8 +258,7 @@ func (e *Engine) branchContainsMutation(startNodeID, globalConvergence string, f
 		if isTerminalNode(node) {
 			continue
 		}
-		resolver, _ := e.executor.(effectiveBackendResolver)
-		if isMutatingNodeCtx(node, e.workflow.DefaultBackend, resolver, fanOutEachTemplate) {
+		if isMutatingNodeCtx(node, e.workflow.DefaultBackend, e.backendResolver(), fanOutEachTemplate) {
 			return true
 		}
 		for _, edge := range e.workflow.Edges {

--- a/pkg/sandbox/errors.go
+++ b/pkg/sandbox/errors.go
@@ -22,3 +22,28 @@ import "errors"
 //     persists through every permitted delivery parks on the DLQ like any
 //     other repeated failure.
 var ErrPhaseTimeout = errors.New("sandbox: setup phase timeout")
+
+// ErrCapacity is the sentinel a driver returns when the sandbox could not
+// be PLACED before its start deadline: the cluster had no room for the
+// pod, or the node it landed on was still bringing it up. The run
+// executed NOTHING — no node started, no command ran, no side effect
+// happened — so the only thing lost is the placement, which a later
+// attempt redoes from scratch.
+//
+// The classification is EVIDENCE-BASED, never a catch-all for "something
+// went wrong at sandbox start": a driver returns it only when the cluster
+// says the pod was unscheduled or still being created. A broken image
+// reference, an invalid spec or a crash-looping container re-fails
+// identically on every pod and stays a terminal failure.
+//
+// Consumers, mirroring ErrPhaseTimeout's:
+//
+//   - the runtime setup classifier (pkg/runtime setupFailureStatus)
+//     persists RunStatusFailedResumable + FailureSandboxCapacity instead
+//     of the default hard RunStatusFailed, so the run keeps a road back
+//     instead of silently losing a sentinel's tick or a campaign's launch;
+//   - the cloud runner's ack policy (pkg/runner classifyExecResult) NAKs
+//     the delivery after a delay long enough for a cluster autoscaler to
+//     add a node; a cluster that stays full through every permitted
+//     delivery parks the run on the DLQ like any other repeated failure.
+var ErrCapacity = errors.New("sandbox: no capacity to place the sandbox")

--- a/pkg/sandbox/kubernetes/pod_start.go
+++ b/pkg/sandbox/kubernetes/pod_start.go
@@ -1,0 +1,212 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// podStartState is what the cluster says about a pod that never reached
+// Ready. Read ONCE on the wait's error path and used twice: to decorate
+// the error with the scheduling reason an operator needs, and to decide
+// whether the failure is a placement the run may retry.
+type podStartState struct {
+	// Readable is false when the pod could not be inspected at all (RBAC,
+	// an apiserver blip, the pod already gone). Nothing is then claimed
+	// about the failure — no evidence, no classification.
+	Readable bool
+	// Phase is `.status.phase` (Pending, Running, …).
+	Phase string
+	// Scheduled mirrors the PodScheduled condition being True: the
+	// scheduler found a node for this pod.
+	Scheduled bool
+	// ScheduledReason / ScheduledMessage carry the PodScheduled
+	// condition's reason ("Unschedulable") and its message ("0/12 nodes
+	// are available: … Insufficient cpu"), which is the operator-facing
+	// evidence.
+	ScheduledReason  string
+	ScheduledMessage string
+	// WaitingReasons are the `state.waiting.reason` of every container and
+	// init container — where a broken image reference or an invalid spec
+	// shows up.
+	WaitingReasons []string
+}
+
+// terminalWaitingReasons name container states a redelivery re-hits
+// identically: the image reference does not resolve, the spec cannot
+// build a container, the container starts and dies. Retrying spends a pod
+// per delivery and ends on the DLQ with the same cause, so these stay
+// terminal failures the operator has to fix.
+//
+// A slow pull is deliberately NOT here: while the kubelet is pulling, the
+// waiting reason is `ContainerCreating` — `ErrImagePull` and its backoff
+// only appear once the pull has actually failed.
+var terminalWaitingReasons = map[string]bool{
+	"ErrImagePull":               true,
+	"ImagePullBackOff":           true,
+	"InvalidImageName":           true,
+	"ErrImageNeverPull":          true,
+	"ImageInspectError":          true,
+	"CreateContainerConfigError": true,
+	"CreateContainerError":       true,
+	"RunContainerError":          true,
+	"CrashLoopBackOff":           true,
+}
+
+// podPhasePending is Kubernetes' own guarantee that nothing of the run
+// executed: the pod was accepted but at least one container has not been
+// created yet. It is the evidence the resumable classification rests on,
+// stronger than enumerating waiting reasons (a pod whose kubelet has not
+// reported any container status yet carries none at all).
+const podPhasePending = "Pending"
+
+// classifyPodStart decides whether a pod that never reached Ready failed
+// on PLACEMENT — resumable, because the run executed nothing and a later
+// attempt on a cluster with room does the whole thing from scratch — or
+// on something a redelivery would re-hit.
+//
+// It answers `true` only on POSITIVE evidence of a placement failure. No
+// evidence, or evidence of anything else, keeps the historical terminal
+// classification: "everything at sandbox start is resumable" would turn a
+// mistyped image into eight pods and a DLQ park.
+//
+// The rule is the pod's PHASE: still `Pending` past the deadline means no
+// container ever started — the scheduler found no node (`Unschedulable` /
+// `Insufficient cpu`, what a full fleet produces), or the node it landed
+// on was still bringing it up (CNI, volumes, image pull). `Running` past
+// the deadline is a container that came up and failed its readiness, and
+// `Unknown` is a node iterion cannot see: neither says the run did
+// nothing, so both stay terminal.
+//
+// A terminal container reason OVERRIDES the phase: a pod sits `Pending`
+// with `ImagePullBackOff` too, and there the image reference is what the
+// operator must fix — retrying it spends a pod per delivery to re-learn
+// the same thing.
+func classifyPodStart(st podStartState) (resumable bool, why string) {
+	if !st.Readable {
+		return false, ""
+	}
+	for _, r := range st.WaitingReasons {
+		if terminalWaitingReasons[r] {
+			return false, ""
+		}
+	}
+	if st.Phase != podPhasePending {
+		return false, ""
+	}
+	if !st.Scheduled {
+		return true, "the pod was never scheduled" + reasonSuffix(st.ScheduledReason, st.ScheduledMessage)
+	}
+	return true, "the pod was scheduled but its node had not started the container" +
+		reasonSuffix(strings.Join(st.WaitingReasons, ", "), "")
+}
+
+func reasonSuffix(reason, message string) string {
+	parts := make([]string, 0, 2)
+	if r := strings.TrimSpace(reason); r != "" {
+		parts = append(parts, r)
+	}
+	if m := strings.TrimSpace(message); m != "" {
+		parts = append(parts, m)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, ": ") + ")"
+}
+
+// schedulingSuffix renders the PodScheduled condition as the
+// "\nscheduling: …" tail of a wait error — "" when the pod could not be
+// read. `kubectl wait` only says the condition never came; the cluster
+// knows WHY, and the reason decides between two different fixes.
+func (st podStartState) schedulingSuffix() string {
+	if !st.Readable {
+		return ""
+	}
+	status := "False"
+	if st.Scheduled {
+		status = "True"
+	}
+	line := status
+	if r := strings.TrimSpace(st.ScheduledReason); r != "" {
+		line += " " + r
+	}
+	if m := strings.TrimSpace(st.ScheduledMessage); m != "" {
+		line += ": " + m
+	}
+	return "\nscheduling: " + line
+}
+
+// podStatusJSON is the slice of a Pod's status this package reads.
+type podStatusJSON struct {
+	Status struct {
+		Phase      string `json:"phase"`
+		Conditions []struct {
+			Type    string `json:"type"`
+			Status  string `json:"status"`
+			Reason  string `json:"reason"`
+			Message string `json:"message"`
+		} `json:"conditions"`
+		ContainerStatuses     []podContainerStatusJSON `json:"containerStatuses"`
+		InitContainerStatuses []podContainerStatusJSON `json:"initContainerStatuses"`
+	} `json:"status"`
+}
+
+type podContainerStatusJSON struct {
+	State struct {
+		Waiting *struct {
+			Reason string `json:"reason"`
+		} `json:"waiting"`
+	} `json:"state"`
+}
+
+// probePodStart reads the pod's status once. Only `get pod` is needed —
+// the Events the autoscaler writes (`TriggeredScaleUp`) would say the
+// same thing about capacity but need an RBAC verb the runner's namespaced
+// Role deliberately does not grant.
+func probePodStart(ctx context.Context, namespace, podName string) podStartState {
+	cmd := kubectlCmdContext(ctx, "--namespace", namespace, "get", "pod", podName, "-o", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return podStartState{}
+	}
+	var doc podStatusJSON
+	if err := json.Unmarshal(out, &doc); err != nil {
+		return podStartState{}
+	}
+	st := podStartState{Readable: true, Phase: doc.Status.Phase}
+	for _, c := range doc.Status.Conditions {
+		if c.Type != "PodScheduled" {
+			continue
+		}
+		st.Scheduled = c.Status == "True"
+		st.ScheduledReason = c.Reason
+		st.ScheduledMessage = c.Message
+	}
+	for _, cs := range append(append([]podContainerStatusJSON{}, doc.Status.InitContainerStatuses...), doc.Status.ContainerStatuses...) {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason != "" {
+			st.WaitingReasons = append(st.WaitingReasons, cs.State.Waiting.Reason)
+		}
+	}
+	return st
+}
+
+// podStartFailure wraps the raw `kubectl wait` error with what the cluster
+// showed, and — when that evidence says the pod never got PLACED — with
+// sandbox.ErrCapacity, which the runtime maps to failed_resumable +
+// SANDBOX_CAPACITY and the runner re-offers after a delay.
+//
+// The sentinel rides errors.Join like the driver's phase timeout does, so
+// the underlying cause stays reachable through errors.Is/As alongside it.
+func podStartFailure(waitErr error, st podStartState) error {
+	err := fmt.Errorf("%w%s", waitErr, st.schedulingSuffix())
+	resumable, why := classifyPodStart(st)
+	if !resumable {
+		return err
+	}
+	return fmt.Errorf("sandbox not placed — %s: %w", why, errors.Join(sandbox.ErrCapacity, err))
+}

--- a/pkg/sandbox/kubernetes/pod_start_classify_test.go
+++ b/pkg/sandbox/kubernetes/pod_start_classify_test.go
@@ -1,0 +1,152 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// The classification is the whole contract of the resumable lane: a
+// capacity wait must be retried, a broken image must NOT be (it re-fails
+// identically on every pod and would burn the delivery budget), and no
+// evidence must claim nothing.
+func TestClassifyPodStart(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state podStartState
+		want  bool
+	}{
+		{
+			"unschedulable — the fleet is full, another pod later fits",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: false, ScheduledReason: "Unschedulable"},
+			true,
+		},
+		{
+			"pending, unscheduled, no reason yet — still a placement failure",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: false},
+			true,
+		},
+		{
+			"scheduled but the node is still creating the container",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: true, WaitingReasons: []string{"ContainerCreating"}},
+			true,
+		},
+		{
+			"scheduled, PodInitializing",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: true, WaitingReasons: []string{"PodInitializing"}},
+			true,
+		},
+		{
+			"scheduled, pending, kubelet has reported no container status at all",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: true},
+			true,
+		},
+		{
+			"a bad image reference re-fails on every pod",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: true, WaitingReasons: []string{"ErrImagePull"}},
+			false,
+		},
+		{
+			"ImagePullBackOff is the same broken reference, backed off",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: true, WaitingReasons: []string{"ImagePullBackOff"}},
+			false,
+		},
+		{
+			"an invalid spec is terminal even while unscheduled",
+			podStartState{Readable: true, Phase: "Pending", Scheduled: false, ScheduledReason: "Unschedulable", WaitingReasons: []string{"CreateContainerConfigError"}},
+			false,
+		},
+		{
+			"a crash-looping container ran: not a placement failure",
+			podStartState{Readable: true, Phase: "Running", Scheduled: true, WaitingReasons: []string{"CrashLoopBackOff"}},
+			false,
+		},
+		{
+			"scheduled and running but never Ready — the container is up, nothing says capacity",
+			podStartState{Readable: true, Phase: "Running", Scheduled: true},
+			false,
+		},
+		{
+			"no evidence claims nothing",
+			podStartState{},
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, why := classifyPodStart(tc.state)
+			if got != tc.want {
+				t.Fatalf("resumable = %v, want %v (why %q)", got, tc.want, why)
+			}
+			if got && strings.TrimSpace(why) == "" {
+				t.Fatal("a resumable classification must say what the cluster showed — an operator reading `SANDBOX_CAPACITY` needs the evidence")
+			}
+		})
+	}
+}
+
+// kubectlPodJSONShim puts a fake `kubectl` first on PATH whose `wait` times
+// out and whose `get pod` answers with the given pod JSON.
+func kubectlPodJSONShim(t *testing.T, podJSON string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *\" wait \"*) echo 'error: timed out waiting for the condition on pods/iterion-run-x'; exit 1 ;;\n" +
+		"  *\" get pod \"*) cat \"$ITERION_TEST_POD_JSON\"; exit 0 ;;\n" +
+		"esac\n" +
+		"exit 2\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	podFile := filepath.Join(dir, "pod.json")
+	if err := os.WriteFile(podFile, []byte(podJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ITERION_TEST_POD_JSON", podFile)
+}
+
+const unschedulablePodJSON = `{"status":{"phase":"Pending",
+ "conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable",
+   "message":"0/12 nodes are available: 1 node(s) had untolerated taint {pool: ci}, 11 Insufficient cpu."}]}}`
+
+const badImagePodJSON = `{"status":{"phase":"Pending",
+ "conditions":[{"type":"PodScheduled","status":"True"}],
+ "containerStatuses":[{"name":"sandbox","state":{"waiting":{"reason":"ImagePullBackOff","message":"Back-off pulling image"}}}]}}`
+
+// The measured production shape (#699): every worker at 88–94 % CPU
+// requested, the pod waits on the autoscaler and the deadline expires. The
+// error must carry sandbox.ErrCapacity so the run parks failed_resumable
+// instead of dying terminal and losing an hourly sentinel's tick.
+func TestWaitForPodRunning_UnschedulableCarriesTheCapacitySentinel(t *testing.T) {
+	kubectlPodJSONShim(t, unschedulablePodJSON)
+	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
+	if err == nil {
+		t.Fatal("expected the wait to fail")
+	}
+	if !errors.Is(err, sandbox.ErrCapacity) {
+		t.Fatalf("errors.Is(err, sandbox.ErrCapacity) = false — the run hard-fails and nothing retries it: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Insufficient cpu") {
+		t.Fatalf("the cluster's own reason must survive into the error, got %q", err)
+	}
+}
+
+// The other half of the classification, and the one that keeps it honest:
+// a broken image reference re-fails identically on every pod, so it must
+// stay terminal rather than burn the whole delivery budget.
+func TestWaitForPodRunning_BadImageStaysTerminal(t *testing.T) {
+	kubectlPodJSONShim(t, badImagePodJSON)
+	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
+	if err == nil {
+		t.Fatal("expected the wait to fail")
+	}
+	if errors.Is(err, sandbox.ErrCapacity) {
+		t.Fatalf("a broken image reference must NOT be resumable — every redelivery re-hits it: %v", err)
+	}
+}

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -150,8 +150,15 @@ func waitForPodRunning(ctx context.Context, namespace, podName string, timeoutSe
 		// knows WHY, and the reason decides between two different fixes: a
 		// resource request no node can hold (Unschedulable: Insufficient
 		// memory) and a slow or broken image pull. Read it on the error
-		// path only.
-		return fmt.Errorf("kubectl wait pod/%s: %w\noutput: %s%s", podName, err, string(out), podScheduledReason(ctx, namespace, podName))
+		// path only — ONCE, since the same reading both decorates the
+		// error and classifies it (podStartFailure): a pod that never got
+		// placed carries sandbox.ErrCapacity and the run parks resumable,
+		// while a broken image reference stays terminal.
+		//
+		// Read BEFORE the caller's Cleanup, which deletes the pod.
+		return podStartFailure(
+			fmt.Errorf("kubectl wait pod/%s: %w\noutput: %s", podName, err, string(out)),
+			probePodStart(ctx, namespace, podName))
 	}
 	return nil
 }
@@ -190,23 +197,4 @@ func NodeLabelCoverage(ctx context.Context, key string) (labelled, total int, er
 		}
 	}
 	return labelled, len(nodes.Items), nil
-}
-
-// podScheduledReason renders the pod's PodScheduled condition (status,
-// reason, message) as a "\nscheduling: …" suffix for a wait error — "" when
-// it cannot be read. Best-effort: it decorates an error, it never creates one.
-func podScheduledReason(ctx context.Context, namespace, podName string) string {
-	cmd := kubectlCmdContext(ctx, "--namespace", namespace, "get", "pod", podName, "-o",
-		`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}{" "}{.status.conditions[?(@.type=="PodScheduled")].reason}{": "}{.status.conditions[?(@.type=="PodScheduled")].message}`)
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	// A scheduled pod has no reason and no message: the jsonpath's literal
-	// ": " then dangles after the status and is dropped here.
-	reason := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(string(out)), ":"))
-	if reason == "" {
-		return ""
-	}
-	return "\nscheduling: " + reason
 }

--- a/pkg/sandbox/kubernetes/runtime_wait_test.go
+++ b/pkg/sandbox/kubernetes/runtime_wait_test.go
@@ -9,27 +9,37 @@ import (
 )
 
 // kubectlShim puts a fake `kubectl` first on PATH whose `wait` times out and
-// whose `get pod … -o jsonpath=…` answers with the given scheduling
-// condition, so the wait error path can be exercised without a cluster.
-func kubectlShim(t *testing.T, scheduledCondition string) {
+// whose `get pod … -o json` answers with the given pod document (empty =
+// unreadable), so the wait error path can be exercised without a cluster.
+func kubectlShim(t *testing.T, podJSON string) {
 	t.Helper()
 	dir := t.TempDir()
+	exit := "0"
+	if strings.TrimSpace(podJSON) == "" {
+		exit = "1"
+	}
 	script := "#!/bin/sh\n" +
 		"case \"$*\" in\n" +
 		"  *\" wait \"*) echo 'error: timed out waiting for the condition on pods/iterion-run-x'; exit 1 ;;\n" +
-		"  *\" get pod \"*) printf '%s' '" + scheduledCondition + "'; exit 0 ;;\n" +
+		"  *\" get pod \"*) cat \"$ITERION_TEST_POD_JSON\"; exit " + exit + " ;;\n" +
 		"esac\n" +
 		"exit 2\n"
 	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	podFile := filepath.Join(dir, "pod.json")
+	if err := os.WriteFile(podFile, []byte(podJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ITERION_TEST_POD_JSON", podFile)
 }
 
 // A pod that never becomes Ready must say why: a request no node can hold
 // reads differently from a slow image pull, and the fix differs.
 func TestWaitForPodRunningNamesTheSchedulingReason(t *testing.T) {
-	kubectlShim(t, "False Unschedulable: 0/3 nodes are available: 3 Insufficient memory.")
+	kubectlShim(t, `{"status":{"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False",`+
+		`"reason":"Unschedulable","message":"0/3 nodes are available: 3 Insufficient memory."}]}}`)
 	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
 	if err == nil {
 		t.Fatal("expected the wait to fail")
@@ -44,9 +54,9 @@ func TestWaitForPodRunningNamesTheSchedulingReason(t *testing.T) {
 }
 
 // A scheduled pod that never became Ready has a status but no reason and no
-// message; the decoration must not end in the jsonpath's dangling colon.
+// message; the decoration must not end in a dangling separator.
 func TestWaitForPodRunningScheduledPodReportsTheStatusOnly(t *testing.T) {
-	kubectlShim(t, "True : ")
+	kubectlShim(t, `{"status":{"phase":"Running","conditions":[{"type":"PodScheduled","status":"True"}]}}`)
 	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
 	if err == nil {
 		t.Fatal("expected the wait to fail")

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -111,6 +111,17 @@ const (
 	// redelivery lands on a healthy pod, where a stuck kubectl-exec pipe
 	// routinely clears.
 	FailureSandboxSetupTimeout FailureCode = "SANDBOX_SETUP_TIMEOUT"
+	// FailureSandboxCapacity: the sandbox never STARTED because the
+	// cluster had no room for its pod (unschedulable past the start
+	// deadline, or still being brought up on the node it landed on).
+	// Distinct from FailureSandboxSetupTimeout, which is a phase that RAN
+	// and stalled: here nothing of the run executed at all, so the retry
+	// is a fresh placement rather than a resume of half-done work — and
+	// distinct from a terminal sandbox failure (a bad image reference, an
+	// invalid spec), which re-fails identically on every pod. Persisted on
+	// RunStatusFailedResumable so an hourly sentinel does not silently
+	// lose its tick when the fleet sits at its request ceiling.
+	FailureSandboxCapacity FailureCode = "SANDBOX_CAPACITY"
 )
 
 // AllRunStatuses is the exhaustive status vocabulary, for callers that


### PR DESCRIPTION
Closes #724, closes #699 (half 2 — half 1 was the configurable pod-ready wait of #707).

## #724 — the claw bind-mount under `--backend '*=claw'`
`containsClawNode` read each node's declared `Backend`/`fallbacks` only, so a workflow whose nodes declare `claude_code`, run with `--backend '*=claw'`, got no `/usr/local/bin/iterion` mount and every claw node died in the container with `exec: … no such file or directory`; the `sandbox_claw_routed_via_runner` event was silent too. The predicate now takes the executor's own resolver (`EffectiveBackendName`: launch override → DSL → workflow default → env → auto-detection), threaded through `SandboxParams.EffectiveBackend` from a shared `Engine.backendResolver()` that workspace-safety admission reads as well — one seam for the two pre-run analyses that key on a node's backend. The reading is a UNION (documented at the predicate): a node the resolver routes onto claw gains the mount, a node that declares claw keeps it under an override away from claw — the host resolves from its own credentials, the container may differ, and a missing binary is a mid-run death while an unused read-only bind is free. Both non-test readers (the mount and the event) go through it, so they can no longer disagree. Tests build a real `model.ClawExecutor` with `model.WithModelOverrides`, so the composition (override → resolver → mount) is what is exercised.

## #699 half 2 — a run whose pod never got placed is `failed_resumable`
When the pod-ready wait expires, the kubernetes driver reads the pod's status ONCE (before `Cleanup` deletes it) and classifies:

| evidence | verdict |
|---|---|
| `Pending`, unscheduled (`Unschedulable` / `Insufficient cpu`) or scheduled but the container never created | **resumable**, `SANDBOX_CAPACITY` (`sandbox.ErrCapacity`) |
| `ErrImagePull` / `ImagePullBackOff` / `InvalidImageName` / `ErrImageNeverPull` / `ImageInspectError` | terminal (re-fails identically on every pod; overrides the phase) |
| `CreateContainerConfigError` / `CreateContainerError` / `RunContainerError` / `CrashLoopBackOff`, or `Running`/`Unknown` past the deadline | terminal (a container came up or the spec is invalid) |
| pod unreadable | terminal, unchanged |

`sandbox.ErrCapacity` has exactly the reader set of `sandbox.ErrPhaseTimeout`: `setupFailureStatus` (engine, `failed_resumable` + the typed code; the resume arm inherits it), and the runner's `classifyExecResult` (delayed NAK 3 min, `finalStatus: sandbox_capacity` on the redelivery event); `bankableStatus` excludes it (nothing ran, nothing to bank). Resume after it is tested end to end: a capacity park with no checkpoint restarts from the entry node and finishes.

The ticket's suggestion 1 (keep waiting on `TriggeredScaleUp`) is deliberately NOT implemented (reasons in the commit body + docs/sandbox.md): the signal is an Event the runner's Role cannot read (`runner-rbac.yaml` grants no `events` verb), the readable `PodScheduled` condition makes it just a longer Pending deadline — the axis `ITERION_SANDBOX_K8S_POD_READY_TIMEOUT` already owns — and the resumable redelivery IS the extension, with the queue as its timer and a less loaded pod free to claim it.

## Red first
```
--- FAIL: TestContainsClawNode_HonoursTheLaunchBackendOverride   (the binary MUST be mounted under --backend '*=claw')
--- FAIL: TestAddClawBinaryMount_MountsUnderTheLaunchBackendOverride   mounts = [], want a bind at /usr/local/bin/iterion
--- FAIL: TestSetupFailureStatus_CapacityIsResumable   capacity status = "failed", want failed_resumable
--- FAIL: TestMarkFailedBestEffort_CapacityParksResumableAndTyped
--- FAIL: TestClassifyExecResult_SandboxCapacityIsReofferedAfterADelay   finalStatus = "failed", want sandbox_capacity
```
plus `TestWaitForPodRunning_UnschedulableCarriesTheCapacitySentinel` / `_BadImageStaysTerminal` on the production pod JSON from the ticket. `task check` exit 0; `go test -race ./pkg/runtime/... ./pkg/sandbox/...` ok; `pkg/runner` ok; OpenAPI verified drift-free (`FailureCode` is an open-world string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)