### PR TITLE
fix(golden-master): the certifier reads a request in the re-baseline ledger's spelling too; an act already at the base is not an extension

### DIFF
--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -308,20 +308,27 @@ tool extend_verify:
             problems.append("%d touched path(s) no certified act covers: %s "
                             "— acting more than was asked is smuggling"
                             % (len(uncertified), ", ".join(uncertified[:12])))
+        # An act already present at the base is CERTIFIED by the verdict,
+        # not extended by this run: it must not make `additions_ok` true or
+        # count as an extension when this run acted nothing (measured: a
+        # refused request beside a base act came back extended=1,
+        # converged=true — a green by absence).
+        acted_here = [r for r in (verdict.get("acted") or [])
+                      if not r.get("acted_at_base")]
         report["additions_ok"] = (not bad and not verdict.get("problems")
                                   and not uncertified
-                                  and bool(verdict.get("acted")))
-        report["extended"] = len([r for r in (verdict.get("acted") or [])
-                                  if r.get("ok")])
+                                  and bool(acted_here))
+        report["extended"] = len([r for r in acted_here if r.get("ok")])
         for r in bad:
             problems.append("extension %s refused: %s"
                             % (r.get("id"), "; ".join(r.get("problems") or [])))
         for p_ in (verdict.get("problems") or []):
             problems.append(p_)
-        if not verdict.get("acted"):
-            problems.append("no act block was appended — a run that acted "
-                            "nothing extended nothing (refusals are reported, "
-                            "not silently skipped)")
+        if not acted_here:
+            problems.append("no act block was appended by this run — a run that "
+                            "acted nothing extended nothing (refusals are reported, "
+                            "not silently skipped; an act already at the base is "
+                            "certified, not extended)")
 
     # 4. No new requests. This bot ACTS requests; writing one would let it
     #    hand itself work the lot never asked for.
@@ -353,10 +360,15 @@ schema verify_input:
 ## A pure CONJUNCTION, never an aggregate. An extension that is additions-ok
 ## but out of scope is not "mostly fine" — it is a lot writing in the judge's
 ## territory through the net's own bot.
+## A pure conjunction, and a request still PENDING is a term of it: this bot
+## acts every request it was handed, so one it refused (with its reason
+## written) leaves the run not converged — the parent's gate keeps refusing
+## on the pending term either way, and this verdict must not read greener
+## than that gate will.
 compute extend_gate:
   output: gate_state
   expr:
-    converged: "outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests"
+    converged: "outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests && length(outputs.extend_verify.still_pending) == 0"
     fail_log: "outputs.extend_verify.log_tail"
 
 ## What the parent reads back. `extended` is the harness's count, never the

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1301,9 +1301,25 @@ tool oracle_run:
                 # gate — the ledger disabling its own guard (adversarial finding,
                 # executed). Normalising at the single parse point makes such a
                 # block refusable instead of fatal.
-                for field in ("recorded_paths", "paths", "corpus_entries"):
+                for field in ("recorded_paths", "paths", "corpus_entries",
+                              "expected_paths", "entries"):
                     if field in obj and not isinstance(obj[field], list):
                         obj[field] = []
+                # Two spellings of a request are read, at this single parse
+                # point, so every judgement below sees one shape. The canonical
+                # one (`paths`, `corpus_entries` with full entries) is what the
+                # doctrine teaches; the other (`expected_paths`, `entries` as
+                # ids) is the re-baseline ledger's, and a ledger header written
+                # by a worker in that idiom taught it to every request after it
+                # — measured: every conforming request of a programme was judged
+                # "smuggled", because the judge read only the first spelling.
+                if kind == "request":
+                    if "paths" not in obj and isinstance(obj.get("expected_paths"), list):
+                        obj["paths"] = [p for p in obj["expected_paths"] if isinstance(p, str)]
+                    if "corpus_entries" not in obj and isinstance(obj.get("entries"), list):
+                        obj["corpus_entries"] = [
+                            e if isinstance(e, dict) else {"id": e}
+                            for e in obj["entries"] if isinstance(e, (dict, str))]
             out.append(obj)
         return out
 
@@ -2989,6 +3005,26 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, new_entry]}, f)
             xcommit()
             check("add-entry legitime et revendiquee -> ok",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+
+            # La meme demande dans l'orthographe du registre de re-baseline
+            # (`expected_paths` + `entries` en identifiants) : lue au meme point,
+            # jugee pareil. Mesure : toute demande conforme a un en-tete de
+            # registre ecrit dans cet idiome etait jugee « smuggled ».
+            xreset()
+            req_taught = ('{"id": "E-2", "lot": "L", "entries": ["2"],'
+                          ' "expected_paths": [".golden-master/refs/2.txt"]}')
+            xrequest(req_taught)
+            xledger(("request", req_taught),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json",'
+                            ' ".golden-master/refs/2.txt"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, new_entry]}, f)
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            check("demande ecrite comme le registre de re-baseline l'enseigne -> ok",
                   extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
 
             # Retouche d'une entree existante sous couvert d'ajout.

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1082,9 +1082,25 @@ def _extension_blocks(text, kind):
             # gate — the ledger disabling its own guard (adversarial finding,
             # executed). Normalising at the single parse point makes such a
             # block refusable instead of fatal.
-            for field in ("recorded_paths", "paths", "corpus_entries"):
+            for field in ("recorded_paths", "paths", "corpus_entries",
+                          "expected_paths", "entries"):
                 if field in obj and not isinstance(obj[field], list):
                     obj[field] = []
+            # Two spellings of a request are read, at this single parse
+            # point, so every judgement below sees one shape. The canonical
+            # one (`paths`, `corpus_entries` with full entries) is what the
+            # doctrine teaches; the other (`expected_paths`, `entries` as
+            # ids) is the re-baseline ledger's, and a ledger header written
+            # by a worker in that idiom taught it to every request after it
+            # — measured: every conforming request of a programme was judged
+            # "smuggled", because the judge read only the first spelling.
+            if kind == "request":
+                if "paths" not in obj and isinstance(obj.get("expected_paths"), list):
+                    obj["paths"] = [p for p in obj["expected_paths"] if isinstance(p, str)]
+                if "corpus_entries" not in obj and isinstance(obj.get("entries"), list):
+                    obj["corpus_entries"] = [
+                        e if isinstance(e, dict) else {"id": e}
+                        for e in obj["entries"] if isinstance(e, (dict, str))]
         out.append(obj)
     return out
 
@@ -2770,6 +2786,26 @@ def _selftest():
             json.dump({"entries": [base_entry, new_entry]}, f)
         xcommit()
         check("add-entry legitime et revendiquee -> ok",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+
+        # La meme demande dans l'orthographe du registre de re-baseline
+        # (`expected_paths` + `entries` en identifiants) : lue au meme point,
+        # jugee pareil. Mesure : toute demande conforme a un en-tete de
+        # registre ecrit dans cet idiome etait jugee « smuggled ».
+        xreset()
+        req_taught = ('{"id": "E-2", "lot": "L", "entries": ["2"],'
+                      ' "expected_paths": [".golden-master/refs/2.txt"]}')
+        xrequest(req_taught)
+        xledger(("request", req_taught),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json",'
+                        ' ".golden-master/refs/2.txt"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, new_entry]}, f)
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        check("demande ecrite comme le registre de re-baseline l'enseigne -> ok",
               extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
 
         # Retouche d'une entree existante sous couvert d'ajout.

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -226,6 +226,12 @@ divergence, it can only add a constraint. Same block idiom:
  "corpus_entries": [{"id": "<new-entry-id>", "...": "the full entry, tuple included"}],
  "justification": "one line: the observation the intent requires and the net lacks"}
 -->
+
+The certifier also reads the re-baseline ledger's spelling of the same request —
+`expected_paths` for `paths`, `entries` (a list of new entry ids) for
+`corpus_entries` — at its single parse point, so a ledger whose header taught
+that idiom keeps its requests judgeable. Write the block above; do not mix the
+two spellings in one request.
 <!-- iterion:extension-act
 {"id": "E-<lot>-<n>", "lot": "<lot-id>", "recorded_paths": ["…"], "ts": "…"}
 -->

--- a/bots/golden_master_extend_verify_test.go
+++ b/bots/golden_master_extend_verify_test.go
@@ -1,0 +1,143 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type extendVerifyOut struct {
+	Committed     bool     `json:"committed"`
+	ScopeClean    bool     `json:"scope_clean"`
+	AdditionsOK   bool     `json:"additions_ok"`
+	Refused       []any    `json:"refused"`
+	NoNewRequests bool     `json:"no_new_requests"`
+	StillPending  []any    `json:"still_pending"`
+	Extended      int      `json:"extended"`
+	LogTail       string   `json:"log_tail"`
+	OutOfScope    []string `json:"out_of_scope"`
+}
+
+// extendVerifyRepo is a target tree whose net carries a STUB harness: the
+// extension certifier answers with what `verdict` says, the pending listing
+// with what `pending` says. The node under test reads both through the
+// tree's own harness, exactly as it does in a run.
+func extendVerifyRepo(t *testing.T, verdict, pending string) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	ws := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", ws}, args...)
+		cmd := exec.Command("git", full...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	gm := filepath.Join(ws, ".golden-master")
+	if err := os.MkdirAll(filepath.Join(gm, "refs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	harness := "import json, os\nmode = os.environ.get(\"GM_MODE\", \"gate\")\n" +
+		"if mode == \"extend-verify\":\n    print(json.dumps(" + verdict + "))\n" +
+		"elif mode == \"extensions\":\n    print(json.dumps(" + pending + "))\n" +
+		"else:\n    print(json.dumps({\"error\": \"stub answers only the extension modes\"}))\n"
+	files := map[string]string{
+		"harness.py":    harness,
+		"EXTENSIONS.md": "# ledger\n<!-- iterion:extension-request\n{\"id\": \"E-L29-1\", \"lot\": \"L29\", \"entries\": [\"118\"]}\n-->\n",
+		"refs/001.txt":  "STATUS 200\n",
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(gm, name), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("add", ".golden-master")
+	git("commit", "-qm", "net with a stub certifier")
+	return ws, git("rev-parse", "HEAD")
+}
+
+func runExtendVerify(t *testing.T, ws, head, pendingJSON string) extendVerifyOut {
+	t.Helper()
+	body := toolScript(t, "golden-master/extend.bot", "extend_verify")
+	body = strings.ReplaceAll(body, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	body = strings.ReplaceAll(body, "{{vars.oracle_dir}}", strconv.Quote(".golden-master"))
+	body = strings.ReplaceAll(body, "{{input.head}}", strconv.Quote(head))
+	body = strings.ReplaceAll(body, "{{input.pending}}", pendingJSON)
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in extend_verify near %q", body[i:min(i+40, len(body))])
+	}
+	scriptPath := filepath.Join(t.TempDir(), "extend_verify.py")
+	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", scriptPath).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("extend_verify exited %d: %s (out %q)", ee.ExitCode(), ee.Stderr, out)
+		}
+		t.Fatalf("extend_verify failed to execute: %v", err)
+	}
+	var res extendVerifyOut
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("extend_verify output is not JSON: %v (out %q)", uerr, out)
+	}
+	return res
+}
+
+// TestGoldenMasterExtendVerifyBaseActIsNotAnExtension pins the verdict
+// against a green by absence measured on a live campaign: the subbot
+// refused the one request it was handed, the certifier certified an act
+// already present at the BASE (`acted_at_base`), and the run came back
+// `extended: 1`, `additions_ok: true` — nothing this run did, reported as
+// done. An act at the base is certified, not extended; a run that acted
+// nothing extended nothing.
+func TestGoldenMasterExtendVerifyBaseActIsNotAnExtension(t *testing.T) {
+	const verdict = `{"acted": [{"id": "E-L17-1", "ok": True, "acted_at_base": True, "paths": [], "problems": []}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	const pending = `{"pending": [{"id": "E-L29-1", "lot": "L29"}]}`
+	ws, head := extendVerifyRepo(t, verdict, pending)
+	res := runExtendVerify(t, ws, head, `[{"id": "E-L29-1"}]`)
+	if res.Extended != 0 {
+		t.Fatalf("extended = %d, want 0: an act already at the base is certified, not extended by this run (%s)", res.Extended, res.LogTail)
+	}
+	if res.AdditionsOK {
+		t.Fatalf("additions_ok = true with nothing acted by this run — a green by absence (%s)", res.LogTail)
+	}
+	if !strings.Contains(res.LogTail, "acted nothing") {
+		t.Fatalf("the verdict must say this run acted nothing: %s", res.LogTail)
+	}
+	if len(res.StillPending) != 1 || len(res.Refused) != 1 {
+		t.Fatalf("still_pending=%v refused=%v, want the refused request reported pending", res.StillPending, res.Refused)
+	}
+	if !res.Committed || !res.ScopeClean || !res.NoNewRequests {
+		t.Fatalf("the untouched terms must stay true: %+v", res)
+	}
+}
+
+// TestGoldenMasterExtendVerifyActedHereCounts: the same certifier verdict
+// with an act made by THIS run is an extension — the count and the term
+// follow the act, not the base.
+func TestGoldenMasterExtendVerifyActedHereCounts(t *testing.T) {
+	const verdict = `{"acted": [{"id": "E-L29-1", "ok": True, "paths": [".golden-master/refs/118.txt"], "problems": []}], "ok_paths": [".golden-master/refs/118.txt"], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	const pending = `{"pending": []}`
+	ws, head := extendVerifyRepo(t, verdict, pending)
+	res := runExtendVerify(t, ws, head, `[{"id": "E-L29-1"}]`)
+	if res.Extended != 1 || !res.AdditionsOK {
+		t.Fatalf("extended=%d additions_ok=%v, want 1/true for an act made by this run (%s)", res.Extended, res.AdditionsOK, res.LogTail)
+	}
+	if len(res.StillPending) != 0 || len(res.Refused) != 0 {
+		t.Fatalf("still_pending=%v refused=%v, want nothing pending", res.StillPending, res.Refused)
+	}
+}

--- a/e2e/bot_golden_master_extend_test.go
+++ b/e2e/bot_golden_master_extend_test.go
@@ -1,0 +1,123 @@
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// extendStubs registers the deterministic shape of one extension pass for
+// the scenario executor: the base is read, the campaign acts (or refuses),
+// the verifier answers with what `report` returns for the pass. The compute
+// nodes (extend_gate, extend_result) are the engine's own — they are what
+// these tests pin.
+func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
+	exec.on("extend_base", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"head": "0123456789abcdef", "dirty": "", "notice": "",
+			"pending": []any{map[string]any{"id": "E-1", "lot": "L1"}}, "_tokens": 1,
+		}, nil
+	})
+	pass := 0
+	exec.on("extend_campaign", func(_ map[string]any) (map[string]any, error) {
+		pass++
+		return map[string]any{"summary": "acted what could be acted", "_tokens": 10}, nil
+	})
+	exec.on("extend_verify", func(_ map[string]any) (map[string]any, error) {
+		out := map[string]any{
+			"committed": true, "scope_clean": true, "out_of_scope": []any{},
+			"additions_ok": true, "refused": []any{}, "no_new_requests": true,
+			"still_pending": []any{}, "extended": 1, "log_tail": "", "_tokens": 1,
+		}
+		for k, v := range report(pass) {
+			out[k] = v
+		}
+		return out, nil
+	})
+}
+
+func runExtend(t *testing.T, exec *scenarioExecutor, runID string) *store.Run {
+	t.Helper()
+	wf := compileFixtureStubSafe(t, "golden-master/extend.bot")
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	if err := eng.Run(context.Background(), runID, nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	run, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Checkpoint == nil {
+		t.Fatal("run has no checkpoint")
+	}
+	return run
+}
+
+// TestGoldenMasterExtend_PendingRequestIsNotConverged pins the conjunction
+// the parent reads: a request this bot refused stays pending, and a pass
+// that left one pending is NOT converged, whatever else went green — the
+// parent's gate refuses on the pending term either way, and this verdict
+// must never read greener than that gate. Measured on a live campaign: the
+// child came back `converged: true, extended: 1` with its one request
+// refused, and the parent announced "extensions acted by pure addition".
+func TestGoldenMasterExtend_PendingRequestIsNotConverged(t *testing.T) {
+	exec := newScenarioExecutor()
+	extendStubs(exec, func(int) map[string]any {
+		return map[string]any{
+			"still_pending": []any{map[string]any{"id": "E-1", "lot": "L1"}},
+			"refused":       []any{map[string]any{"id": "E-1", "lot": "L1"}},
+			"extended":      0, "additions_ok": false,
+			"log_tail": "no act block was appended by this run — a run that acted nothing extended nothing",
+		}
+	})
+	run := runExtend(t, exec, "run-extend-pending")
+	res, ok := run.Checkpoint.Outputs["extend_result"]
+	if !ok {
+		t.Fatal("checkpoint carries no extend_result output")
+	}
+	if res["converged"] != false {
+		t.Fatalf("extend_result.converged = %v, want false with a request still pending", res["converged"])
+	}
+	if n, _ := res["notice"].(string); !strings.Contains(n, "REFUSED") {
+		t.Fatalf("notice = %q, want the refusal named", n)
+	}
+	// The bounded repair loop ran its passes (1 + max_passes = 3), then the
+	// honest verdict — never a green one.
+	if got := exec.callCount("extend_campaign"); got != 3 {
+		t.Fatalf("extend_campaign called %d times, want 3 (the first pass + max_passes repairs, then the verdict)", got)
+	}
+}
+
+// TestGoldenMasterExtend_EverythingActedConverges: the green path — every
+// request acted by this run, nothing pending, converged on the first pass.
+func TestGoldenMasterExtend_EverythingActedConverges(t *testing.T) {
+	exec := newScenarioExecutor()
+	extendStubs(exec, func(int) map[string]any { return nil })
+	run := runExtend(t, exec, "run-extend-green")
+	res := run.Checkpoint.Outputs["extend_result"]
+	if res["converged"] != true {
+		t.Fatalf("extend_result.converged = %v, want true", res["converged"])
+	}
+	if got := exec.callCount("extend_campaign"); got != 1 {
+		t.Fatalf("extend_campaign called %d times, want 1", got)
+	}
+}
+
+// TestGoldenMasterExtend_GreenTermsWithAPendingRequestStillRefuse is the
+// exact live shape: every other term green (the verifier certified an act
+// already at the base) and one request pending — the term alone must keep
+// the verdict red.
+func TestGoldenMasterExtend_GreenTermsWithAPendingRequestStillRefuse(t *testing.T) {
+	exec := newScenarioExecutor()
+	extendStubs(exec, func(int) map[string]any {
+		return map[string]any{"still_pending": []any{map[string]any{"id": "E-1"}}}
+	})
+	run := runExtend(t, exec, "run-extend-green-but-pending")
+	if res := run.Checkpoint.Outputs["extend_result"]; res["converged"] != false {
+		t.Fatalf("extend_result.converged = %v with a pending request, want false", res["converged"])
+	}
+}


### PR DESCRIPTION

Measured on the first extension request to reach the additions-only verdict
in cloud: the request had been written as the ledger's own header taught —
`expected_paths` and `entries` (the re-baseline idiom a worker had copied
into the header) — while `extension_verdict` read only `paths` and
`corpus_entries`. Every conforming request was therefore "smuggled": "1
added entry no acted request claims", "refs/<id>.txt is neither declared
in the request's paths nor derived from a claimed corpus entry". The net's
subbot, which may not write a request, refused in writing. The header could
not be corrected: the ledger is judged append-only.

- `_extension_blocks`, the single parse point, reads both spellings of a
  request: `expected_paths` as `paths`, `entries` (ids) as `corpus_entries`
  (`{"id": …}`). Every judgement below sees one shape. Selftest: a request
  written as the re-baseline ledger teaches it, filed then acted, is
  certified (104 checks; reading one spelling only turns it red).
- extend.bot reported the same pass `converged: true, extended: 1` with its
  one request refused: the certifier had certified an act already present at
  the BASE (`acted_at_base`), which counted as this run's extension, and a
  request left pending was no term of the conjunction. An act at the base is
  certified, not extended (`additions_ok` needs an act of this run, `extended`
  counts those); `still_pending` empty is a term of `converged`. Tests: the
  verifier's count on a base act (bots), the routing on the engine with a
  pending request beside green terms (e2e) — each with its mutant red.
- The skill says the alias is read, and which block to write.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
