### PR TITLE
fix(runtime,runner): a subbot child executes in its parent's sandbox — a pod of its own lost its commits

### DIFF
--- a/pkg/runner/subbot.go
+++ b/pkg/runner/subbot.go
@@ -242,6 +242,12 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 				}
 			}),
 		}
+		// The child executes in the PARENT's sandbox when the parent has one:
+		// on a copy-based driver a pod of its own would be a second copy of
+		// the workspace, and its commits would die with that pod.
+		if req.ParentSandbox != nil {
+			opts = append(opts, runtime.WithSharedSandbox(req.ParentSandbox))
+		}
 		// The child's own bundle: its skills and devbox tools, exactly as a
 		// local `iterion run bots/<child>` would provision them.
 		if b, berr := bundle.OpenDir(filepath.Dir(childPath)); berr == nil {

--- a/pkg/runner/subbot_test.go
+++ b/pkg/runner/subbot_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -363,4 +366,99 @@ func TestSubbotRunnerAppliesCloudBudgetCeiling(t *testing.T) {
 			t.Fatalf("child persisted budget = %+v, want max_iterations=1 from the platform ceiling", child.Budget)
 		}
 	})
+}
+
+// parentSandboxFake is the live sandbox a PARENT run would own on a pod:
+// commands run on this host so a tool-only child really executes, and
+// every routed command is counted — the proof that the child ran in the
+// parent's sandbox rather than in one of its own.
+type parentSandboxFake struct {
+	mu       sync.Mutex
+	commands int
+	cleanups int
+}
+
+func (f *parentSandboxFake) Driver() string { return "fake-parent" }
+func (f *parentSandboxFake) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
+	f.mu.Lock()
+	f.commands++
+	f.mu.Unlock()
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	c.Dir = opts.WorkDir
+	c.Env = os.Environ()
+	for k, v := range opts.Env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	return c
+}
+func (f *parentSandboxFake) Exec(ctx context.Context, cmd []string, opts sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	out, err := f.Command(ctx, cmd, opts).CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	}
+	return sandbox.ExecResult{ExitCode: code, Stdout: out}, nil
+}
+func (f *parentSandboxFake) Cleanup(context.Context) error {
+	f.mu.Lock()
+	f.cleanups++
+	f.mu.Unlock()
+	return nil
+}
+
+// TestSubbotRunnerRunsTheChildInTheParentSandbox: a child whose request
+// carries the parent's live sandbox executes IN it — its tool node's
+// command is routed through the parent's handle — and starts no sandbox
+// of its own. Measured on the first cloud subbot: under the kubernetes
+// driver (a copy of the workspace per pod) the child got a pod of its own,
+// and its commits died with that pod while the parent re-judged an
+// unchanged tree.
+func TestSubbotRunnerRunsTheChildInTheParentSandbox(t *testing.T) {
+	r, st := subbotTestRunner(t)
+	dir := t.TempDir()
+	parentDir := filepath.Join(dir, "parent")
+	writeSubbotFixture(t, parentDir, "main.bot", subbotTestParent)
+	writeSubbotFixture(t, parentDir, "child.bot", subbotTestChild)
+	msg := &queue.RunMessage{RunID: "run-parent", TenantID: "t1", OwnerID: "u1", BotID: "parent"}
+	fake := &parentSandboxFake{}
+
+	run := r.subbotRunnerFor(msg, parentDir, dir, iterlog.Nop())
+	out, err := run(context.Background(), runtime.SubbotRequest{
+		Source: "child.bot", Vars: map[string]any{"ticket": "T-3"},
+		ParentRunID: msg.RunID, NodeID: "run_ticket", ReattachKey: "run_ticket",
+		ParentSandbox: &runtime.SharedSandbox{Run: fake, WorkspaceFolder: dir},
+	})
+	if err != nil {
+		t.Fatalf("subbot runner: %v", err)
+	}
+	if e, _ := out["echoed"].(string); e != "T-3" {
+		t.Fatalf("child output = %v, want the child's own tool output", out)
+	}
+	if fake.commands == 0 {
+		t.Fatal("the child's tool command never went through the parent's sandbox handle")
+	}
+	if fake.cleanups != 0 {
+		t.Fatalf("cleanups = %d, want 0: the child must not tear down the parent's sandbox", fake.cleanups)
+	}
+	idCtx := store.WithIdentity(context.Background(), "t1", "u1")
+	ids, _ := st.ListRuns(idCtx)
+	var shared, started int
+	for _, id := range ids {
+		c, cerr := st.LoadRun(idCtx, id)
+		if cerr != nil || c.ParentRunID != msg.RunID {
+			continue
+		}
+		evs, _ := st.LoadEvents(idCtx, id)
+		for _, ev := range evs {
+			switch ev.Type {
+			case store.EventSandboxShared:
+				shared++
+			case store.EventSandboxStarted:
+				started++
+			}
+		}
+	}
+	if shared != 1 || started != 0 {
+		t.Fatalf("child events: sandbox_shared=%d sandbox_started=%d, want 1/0", shared, started)
+	}
 }

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -185,7 +185,7 @@ func (e *Engine) ActiveElapsed() time.Duration {
 // SubbotRunner: the child .bot source, the resolved input vars, and the
 // parent linkage so the runner can record a child run tied to the parent.
 type SubbotRequest struct {
-	Source      string         // child .bot path/ref (relative to the parent workdir)
+	Source string // child .bot path/ref (relative to the parent workdir)
 	// ParentSandbox is the live sandbox the PARENT run executes in, nil when
 	// it has none. A child must execute in it — not in a sandbox of its own:
 	// on a copy-based driver (kubernetes) a second pod is a second copy of
@@ -194,9 +194,9 @@ type SubbotRequest struct {
 	// subbot). On a bind-mount driver (docker) a second container happened
 	// to share the tree; sharing the parent's makes the two drivers agree.
 	ParentSandbox *SharedSandbox
-	Vars        map[string]any // resolved `with:` mappings + `_lease_<resource>` instance ids
-	ParentRunID string
-	NodeID      string
+	Vars          map[string]any // resolved `with:` mappings + `_lease_<resource>` instance ids
+	ParentRunID   string
+	NodeID        string
 	// ReattachKey uniquely identifies THIS execution of the subbot node
 	// (node id + loop-iteration path + fan-out branch id) so the runner can
 	// persist the child run id under it on the parent and, on a resumed

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -147,6 +147,8 @@ type Engine struct {
 	boardMCPHandler          http.Handler             // optional: serves the board MCP routes; when set + a sandbox is active, a per-run gateway-reachable listener is started so sandboxed board-cap nodes can write the operator's board (C082). Set via WithBoardMCP; nil disables sandboxed board-emit (CLI runs with no server).
 	subbotRunner             SubbotRunner             // optional: host-supplied closure that compiles + runs a child .bot for a `subbot` node. nil → subbot nodes hard-error (the runtime can't compile a child itself — import cycle with runview). Set via WithSubbotRunner.
 	sandboxRunObserver       func(sandbox.Run)        // optional: invoked with the live sandbox Run right after it starts, so the host (cloud runner) can drive mid-run file-secret refresh against the driver's SecretFileRefresher. nil disables it. Set via WithSandboxRunObserver.
+	sharedSandbox            *SharedSandbox           // optional: a PARENT run's live sandbox this engine executes in, instead of starting its own (a subbot child). Set via WithSharedSandbox; nil = this engine decides its own sandbox.
+	activeShare              *SharedSandbox           // the facts of the sandbox this run executes in (own or shared), handed to subbot children through SubbotRequest.ParentSandbox; nil when the run has no sandbox
 	answersBell              answersDoorbell          // in-process fast-path waking await_answers nodes when an async interaction is answered (ADR-081); rung via NotifyInteractionAnswered
 
 	// activeBudget points at the SharedBudget of the run currently
@@ -184,6 +186,14 @@ func (e *Engine) ActiveElapsed() time.Duration {
 // parent linkage so the runner can record a child run tied to the parent.
 type SubbotRequest struct {
 	Source      string         // child .bot path/ref (relative to the parent workdir)
+	// ParentSandbox is the live sandbox the PARENT run executes in, nil when
+	// it has none. A child must execute in it — not in a sandbox of its own:
+	// on a copy-based driver (kubernetes) a second pod is a second copy of
+	// the workspace, and the child's commits die with that pod while the
+	// parent re-judges an unchanged tree (measured on the first cloud
+	// subbot). On a bind-mount driver (docker) a second container happened
+	// to share the tree; sharing the parent's makes the two drivers agree.
+	ParentSandbox *SharedSandbox
 	Vars        map[string]any // resolved `with:` mappings + `_lease_<resource>` instance ids
 	ParentRunID string
 	NodeID      string

--- a/pkg/runtime/engine_options.go
+++ b/pkg/runtime/engine_options.go
@@ -38,6 +38,12 @@ type SharedSandbox struct {
 	Run             sandbox.Run
 	WorkspaceFolder string
 	SharedStateDir  string
+	// The parent's per-run MCP listeners, reachable from the same sandbox:
+	// a child's board-capability and interactive nodes use them instead of
+	// listeners of their own (none are started for a child).
+	BoardEndpoint   string
+	AskUserEndpoint string
+	AskUserToken    string
 }
 
 // WithSharedSandbox makes the engine execute every node in the given

--- a/pkg/runtime/engine_options.go
+++ b/pkg/runtime/engine_options.go
@@ -28,6 +28,31 @@ func WithSandboxRunObserver(fn func(sandbox.Run)) EngineOption {
 	return func(e *Engine) { e.sandboxRunObserver = fn }
 }
 
+// SharedSandbox is what a child engine needs to execute inside a PARENT
+// run's live sandbox: the driver handle its executor routes commands
+// through, the in-container workspace path ${PROJECT_DIR} remaps to, and
+// the host-state directory both sides can reach. Facts only — the parent
+// owns the sandbox's lifecycle; a child never prepares, starts or cleans
+// it up.
+type SharedSandbox struct {
+	Run             sandbox.Run
+	WorkspaceFolder string
+	SharedStateDir  string
+}
+
+// WithSharedSandbox makes the engine execute every node in the given
+// live sandbox instead of starting one of its own — the shape of a
+// subbot child under a sandboxed parent. Applies only when the shared
+// Run is non-nil; a nil value leaves the engine's own sandbox decision
+// untouched.
+func WithSharedSandbox(s *SharedSandbox) EngineOption {
+	return func(e *Engine) {
+		if s != nil && s.Run != nil {
+			e.sharedSandbox = s
+		}
+	}
+}
+
 // AttachmentPromoteFunc is invoked once at the start of a run, right
 // after the run is created in the store but before the engine walks
 // the graph. It is expected to populate Run.Attachments by calling

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -106,7 +106,14 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 	var worktreeCleanup func()
 	var wtCtx worktreeContext
 	worktreeActive := false
-	if e.workflow.Worktree == "auto" {
+	if e.workflow.Worktree == "auto" && e.sharedSandbox != nil && e.sharedSandbox.Run != nil {
+		// A subbot child in its parent's sandbox works in the PARENT's tree:
+		// a worktree of its own would be a tree the parent's sandbox never
+		// mounts — its skills mirrored there, its commits landing there.
+		if e.logger != nil {
+			e.logger.Info("runtime: executing in the parent run's sandbox — running in place in %s (no worktree of its own)", e.workDir)
+		}
+	} else if e.workflow.Worktree == "auto" {
 		// Workspace isolation is the IR default (ir.defaultWorktreeMode),
 		// so any `iterion run` against a non-git workspace would otherwise
 		// hard-fail with "not a git repository". Degrade gracefully to

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -88,6 +88,12 @@ func (e *Engine) Resume(ctx context.Context, runID string, answers map[string]an
 			return fmt.Errorf("runtime: resume run %q: %w", runID, linkErr)
 		}
 	}
+	// A child that executed in its parent's copy-based sandbox is resumed
+	// through the parent, never on its own: refused before the claim, so
+	// the run keeps the resumable status the parent's resume relies on.
+	if rerr := e.refuseResumeOfSharedChild(ctx, r); rerr != nil {
+		return rerr
+	}
 	switch r.Status {
 	case store.RunStatusPausedWaitingHuman:
 		return e.resumeFromPause(ctx, r, answers)

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -1473,6 +1473,11 @@ func (e *Engine) startSandbox(ctx context.Context, runID string, repoRoot string
 	emitForSandbox := func(t store.EventType, data map[string]any) error {
 		return e.emit(ctx, runID, t, "", data)
 	}
+	// A subbot child under a sandboxed parent executes in the PARENT's
+	// sandbox — never in one of its own (see SubbotRequest.ParentSandbox).
+	if e.sharedSandbox != nil && e.sharedSandbox.Run != nil {
+		return e.adoptSharedSandbox(ctx, runID, emitForSandbox)
+	}
 	var attachHost string
 	if e.store != nil && e.store.Root() != "" {
 		attachHost = filepath.Join(e.store.Root(), "runs", runID, "attachments")
@@ -1551,10 +1556,13 @@ func (e *Engine) startSandbox(ctx context.Context, runID string, repoRoot string
 	// prevent, inverted.
 	e.sandboxSettled = true
 	e.attachmentsContainerDir = ""
+	e.activeShare = nil
 	if active != nil {
 		e.attachmentsContainerDir = active.attachmentsDir
 	}
 	if active != nil && active.run != nil {
+		// The facts a subbot child needs to execute in this sandbox.
+		e.activeShare = &SharedSandbox{Run: active.run, WorkspaceFolder: active.workspaceFolder, SharedStateDir: active.sharedStateDir}
 		if s, ok := e.executor.(sandboxSetter); ok {
 			s.SetSandbox(active.run)
 		}
@@ -1715,4 +1723,74 @@ func exportSandboxWorkspaceOnCleanup(
 	if logger != nil {
 		logger.Info("runtime: sandbox workspace exported back to host")
 	}
+}
+
+
+// adoptSharedSandbox settles this run on a PARENT run's live sandbox: the
+// executor routes every command through the parent's driver handle,
+// ${PROJECT_DIR} remaps to the parent's in-container workspace, and the
+// files this run mirrored into the host workdir before this point (its
+// bundle's skills) are written through into a copy-based sandbox, which
+// would otherwise never see them. No Prepare, no Start, no Cleanup: the
+// parent owns the sandbox's lifecycle, and the cleanup returned here is a
+// no-op. Grandchildren inherit the same facts through activeShare.
+func (e *Engine) adoptSharedSandbox(ctx context.Context, runID string, emitForSandbox func(store.EventType, map[string]any) error) (func(), error) {
+	shared := e.sharedSandbox
+	e.sandboxSettled = true
+	e.attachmentsContainerDir = ""
+	e.activeShare = shared
+	e.containerWorkspace = shared.WorkspaceFolder
+	if s, ok := e.executor.(sandboxSetter); ok {
+		s.SetSandbox(shared.Run)
+	}
+	if s, ok := e.executor.(sharedStateSetter); ok && shared.SharedStateDir != "" {
+		s.SetSharedStateDir(shared.SharedStateDir)
+	}
+	pushed := 0
+	if refresher, ok := shared.Run.(sandbox.WorkspaceFileRefresher); ok {
+		pushed = writeThroughMirroredSkills(ctx, e.workDir, refresher, e.logger)
+	}
+	if e.logger != nil {
+		e.logger.Info("runtime: executing in the parent run's sandbox (driver=%s, workspace=%s, skills written through=%d)", shared.Run.Driver(), shared.WorkspaceFolder, pushed)
+	}
+	if err := emitForSandbox(store.EventSandboxShared, map[string]any{
+		"driver": shared.Run.Driver(), "workspace": shared.WorkspaceFolder,
+		"parent_run": e.parentRunID, "skills_written_through": pushed,
+	}); err != nil && e.logger != nil {
+		e.logger.Warn("runtime: emit sandbox_shared: %v", err)
+	}
+	return func() {}, nil
+}
+
+// writeThroughMirroredSkills pushes every file under <workDir>/.claude/skills
+// into a copy-based sandbox through the driver's write-through seam. The
+// parent's own skills are already in its copy; re-writing them is
+// idempotent, and the child's are what the copy lacks. Returns the count
+// written; a failed write is logged and skipped — a skill the agent cannot
+// read is a degraded run, not a dead one.
+func writeThroughMirroredSkills(ctx context.Context, workDir string, refresher sandbox.WorkspaceFileRefresher, logger *iterlog.Logger) int {
+	root := filepath.Join(workDir, ".claude", "skills")
+	n := 0
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(workDir, path)
+		if rerr != nil {
+			return nil
+		}
+		body, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil
+		}
+		if werr := refresher.RefreshWorkspaceFile(ctx, filepath.ToSlash(rel), body); werr != nil {
+			if logger != nil {
+				logger.Warn("runtime: write-through of %s into the shared sandbox failed: %v", rel, werr)
+			}
+			return nil
+		}
+		n++
+		return nil
+	})
+	return n
 }

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1775,17 +1776,17 @@ func workflowHasPausingNode(wf *ir.Workflow) bool {
 func (e *Engine) shouldAdoptSharedSandbox(emitForSandbox func(store.EventType, map[string]any) error) (bool, error) {
 	shared := e.sharedSandbox
 	copyBased := sharedSandboxIsCopyBased(shared.Run)
-	explicitNone := e.workflow != nil && e.workflow.Sandbox != nil && e.workflow.Sandbox.Mode == "none"
-	if explicitNone {
+	if declared := declaredSandboxFields(e.workflow); len(declared) > 0 {
+		what := strings.Join(declared, ", ")
 		if copyBased {
-			return false, fmt.Errorf("subbot child declares `sandbox: none` under a parent sandboxed by a copy-based driver (%s): its work would land on the host, outside the tree the parent judges — drop the declaration, or run the parent unsandboxed", shared.Run.Driver())
+			return false, fmt.Errorf("subbot child declares a sandbox of its own (%s) under a parent sandboxed by a copy-based driver (%s): a sandbox of its own is a separate copy of the workspace, and its work would never reach the tree the parent judges — drop the declaration, declare it on the parent, or run the parent unsandboxed", what, shared.Run.Driver())
 		}
 		if e.logger != nil {
-			e.logger.Warn("runtime: child declares `sandbox: none`; honoured — the parent's sandbox (driver=%s, bind-mounted) is not adopted", shared.Run.Driver())
+			e.logger.Warn("runtime: child declares a sandbox of its own (%s); honoured — the parent's sandbox (driver=%s, bind-mounted) is not adopted, the child resolves its own on the same tree", what, shared.Run.Driver())
 		}
 		if err := emitForSandbox(store.EventSandboxShared, map[string]any{
-			"adopted": false, "driver": shared.Run.Driver(), "parent_run": e.parentRunID,
-			"reason": "the child declares sandbox: none; honoured on a bind-mount parent",
+			"adopted": false, "driver": shared.Run.Driver(), "parent_run": e.parentRunID, "declared": declared,
+			"reason": "the child declares a sandbox of its own (" + what + "); honoured on a bind-mount parent",
 		}); err != nil && e.logger != nil {
 			e.logger.Warn("runtime: emit sandbox_shared: %v", err)
 		}
@@ -1795,6 +1796,75 @@ func (e *Engine) shouldAdoptSharedSandbox(emitForSandbox func(store.EventType, m
 		return false, fmt.Errorf("subbot child with a human gate or an interactive node cannot execute in its parent's copy-based sandbox (%s): a parked child is resumed outside its parent, in a sandbox of its own, and its work diverges from the parent's tree — declare the gate in the parent, or run the parent unsandboxed", shared.Run.Driver())
 	}
 	return true, nil
+}
+
+// declaredSandboxFields lists what a workflow declares about its own
+// sandbox — at workflow level and on its nodes — as the fields it sets.
+// Empty when the workflow inherits (no spec, or `sandbox: auto` alone). A
+// declaration is the operator's choice: honoured where a sandbox of its own
+// can share the parent's tree, refused where it cannot, never replaced in
+// silence.
+func declaredSandboxFields(wf *ir.Workflow) []string {
+	if wf == nil {
+		return nil
+	}
+	out := sandboxSpecFields(wf.Sandbox, "")
+	ids := make([]string, 0, len(wf.Nodes))
+	for id := range wf.Nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		var spec *ir.SandboxSpec
+		switch nn := wf.Nodes[id].(type) {
+		case *ir.AgentNode:
+			spec = nn.Sandbox
+		case *ir.JudgeNode:
+			spec = nn.Sandbox
+		}
+		out = append(out, sandboxSpecFields(spec, id+".")...)
+	}
+	return out
+}
+
+func sandboxSpecFields(s *ir.SandboxSpec, prefix string) []string {
+	if s == nil {
+		return nil
+	}
+	var f []string
+	add := func(name string) { f = append(f, prefix+name) }
+	switch s.Mode {
+	case "none", "inline":
+		add("mode=" + s.Mode)
+	}
+	if s.Image != "" {
+		add("image")
+	}
+	if s.Build != nil {
+		add("build")
+	}
+	if len(s.Mounts) > 0 {
+		add("mounts")
+	}
+	if len(s.Env) > 0 {
+		add("env")
+	}
+	if s.User != "" {
+		add("user")
+	}
+	if s.PostCreate != "" {
+		add("post_create")
+	}
+	if s.WorkspaceFolder != "" {
+		add("workspace_folder")
+	}
+	if s.HostState != "" && s.HostState != "auto" {
+		add("host_state")
+	}
+	if n := s.Network; n != nil && (n.Mode != "" || n.Preset != "" || len(n.Rules) > 0) {
+		add("network")
+	}
+	return f
 }
 
 // refuseResumeOfSharedChild refuses to resume, outside its parent, a child
@@ -1820,10 +1890,22 @@ func (e *Engine) refuseResumeOfSharedChild(ctx context.Context, r *store.Run) er
 			return nil
 		}
 		if cb, _ := ev.Data["copy_based"].(bool); cb {
+			if e.forceResume {
+				if e.logger != nil {
+					e.logger.Warn("runtime: run %s executed in its parent run %s's copy-based sandbox; resumed with --force it starts a sandbox of its own — a fresh copy of the workspace — and its later commits will not reach the parent's tree", r.ID, r.ParentRunID)
+				}
+				if err := e.emit(ctx, r.ID, store.EventSandboxShared, "", map[string]any{
+					"adopted": false, "forced": true, "parent_run": r.ParentRunID,
+					"reason": "resumed with --force outside the parent: a sandbox of its own, whose later commits do not reach the parent's tree",
+				}); err != nil && e.logger != nil {
+					e.logger.Warn("runtime: emit sandbox_shared: %v", err)
+				}
+				return nil
+			}
 			return &RuntimeError{
 				Code:    ErrCodeResumeInvalid,
-				Message: fmt.Sprintf("run %s executed in its parent run %s's copy-based sandbox; resumed on its own it would start a fresh copy of the workspace and its work would diverge from the parent's tree — resume it through the parent", r.ID, r.ParentRunID),
-				Hint:    "resume the parent run; it re-attaches to this child",
+				Message: fmt.Sprintf("run %s executed in its parent run %s's copy-based sandbox; resumed on its own it would start a fresh copy of the workspace and its work would diverge from the parent's tree", r.ID, r.ParentRunID),
+				Hint:    "cancel this child and resume the parent: it re-runs the subbot fresh in its sandbox; or resume this child with --force to run it in a sandbox of its own, where its later commits do not reach the parent's tree",
 			}
 		}
 		return nil
@@ -1877,13 +1959,34 @@ func (e *Engine) adoptSharedSandbox(ctx context.Context, runID string, emitForSa
 	if fileSecrets && e.logger != nil {
 		e.logger.Warn("runtime: child declares file secrets; in the parent's sandbox they are not materialised at start (the refresh loop writes them through on its first tick, on drivers that refresh)")
 	}
+	// The parent's listeners are the child's: the board handler is
+	// service-wide and the ask-user listener serves only the tool surface
+	// (interaction semantics stay host-side, per run). A listener the parent
+	// never started is one the child does not get — the delegate falls back
+	// per node, loudly, and the event says so.
+	wantsBoard := workflowHasBoardCapability(e.workflow)
+	wantsAskUser := workflowHasInteractiveNode(e.workflow)
+	if e.logger != nil {
+		if wantsBoard && shared.BoardEndpoint == "" {
+			e.logger.Warn("runtime: child declares board.* capabilities but the parent's sandbox has no board MCP listener (the parent declares none): board-emit is disabled for the child's nodes")
+		}
+		if wantsAskUser && shared.AskUserEndpoint == "" {
+			e.logger.Warn("runtime: child has interactive nodes but the parent's sandbox has no ask-user MCP listener (the parent has no interactive node): native ask_user is disabled, the JSON protocol fallback applies")
+		}
+	}
+	devboxDeclared := fileExists(filepath.Join(bundleResourceDir(e.bundle, e.filePath), "devbox.json"))
+	if devboxDeclared && e.logger != nil {
+		e.logger.Warn("runtime: child bundle ships a devbox.json; in the parent's sandbox it is not provisioned — its packages are the parent's provisioning or nothing")
+	}
 	if e.logger != nil {
 		e.logger.Info("runtime: executing in the parent run's sandbox (driver=%s, workspace=%s, copy_based=%v, files written through=%d)", shared.Run.Driver(), shared.WorkspaceFolder, copyBased, pushed)
 	}
 	if err := emitForSandbox(store.EventSandboxShared, map[string]any{
 		"adopted": true, "driver": shared.Run.Driver(), "workspace": shared.WorkspaceFolder,
 		"parent_run": e.parentRunID, "copy_based": copyBased, "skills_written_through": pushed,
-		"file_secrets_declared": fileSecrets,
+		"file_secrets_declared": fileSecrets, "devbox_declared": devboxDeclared,
+		"board_endpoint_inherited": shared.BoardEndpoint != "", "ask_user_inherited": shared.AskUserEndpoint != "",
+		"attachments_mounted": false,
 	}); err != nil && e.logger != nil {
 		e.logger.Warn("runtime: emit sandbox_shared: %v", err)
 	}

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -1476,7 +1476,13 @@ func (e *Engine) startSandbox(ctx context.Context, runID string, repoRoot string
 	// A subbot child under a sandboxed parent executes in the PARENT's
 	// sandbox — never in one of its own (see SubbotRequest.ParentSandbox).
 	if e.sharedSandbox != nil && e.sharedSandbox.Run != nil {
-		return e.adoptSharedSandbox(ctx, runID, emitForSandbox)
+		adopt, err := e.shouldAdoptSharedSandbox(emitForSandbox)
+		if err != nil {
+			return noopCleanup, err
+		}
+		if adopt {
+			return e.adoptSharedSandbox(ctx, runID, emitForSandbox)
+		}
 	}
 	var attachHost string
 	if e.store != nil && e.store.Root() != "" {
@@ -1562,7 +1568,10 @@ func (e *Engine) startSandbox(ctx context.Context, runID string, repoRoot string
 	}
 	if active != nil && active.run != nil {
 		// The facts a subbot child needs to execute in this sandbox.
-		e.activeShare = &SharedSandbox{Run: active.run, WorkspaceFolder: active.workspaceFolder, SharedStateDir: active.sharedStateDir}
+		e.activeShare = &SharedSandbox{
+			Run: active.run, WorkspaceFolder: active.workspaceFolder, SharedStateDir: active.sharedStateDir,
+			BoardEndpoint: active.boardEndpoint, AskUserEndpoint: active.askUserEndpoint, AskUserToken: active.askUserToken,
+		}
 		if s, ok := e.executor.(sandboxSetter); ok {
 			s.SetSandbox(active.run)
 		}
@@ -1725,6 +1734,102 @@ func exportSandboxWorkspaceOnCleanup(
 	}
 }
 
+// sharedSandboxIsCopyBased reports whether the parent's driver copies the
+// workspace into its sandbox (kubernetes) rather than bind-mounting it:
+// exactly the drivers that implement the write-through seam, because a
+// copy is the only workspace a host-side write cannot reach.
+func sharedSandboxIsCopyBased(run sandbox.Run) bool {
+	_, ok := run.(sandbox.WorkspaceFileRefresher)
+	return ok
+}
+
+// workflowHasPausingNode reports whether the workflow can park the run
+// for an operator: a human node, or an LLM node with a non-none
+// interaction mode. A parked child is resumed OUTSIDE its parent, in an
+// engine with no parent handle to adopt.
+func workflowHasPausingNode(wf *ir.Workflow) bool {
+	if wf == nil {
+		return false
+	}
+	for _, n := range wf.Nodes {
+		if _, ok := n.(*ir.HumanNode); ok {
+			return true
+		}
+	}
+	return workflowHasInteractiveNode(wf)
+}
+
+// shouldAdoptSharedSandbox decides what a child handed its parent's live
+// sandbox does with it. Adopt is the rule; two declarations of the child
+// are honoured or refused in words, never silently overridden:
+//
+//   - an explicit `sandbox: none` on the child is the operator's choice.
+//     Under a bind-mount parent it is honoured (host and container share
+//     the tree, the child's own resolution takes over); under a copy-based
+//     parent it is refused, typed — the child's work would land on the
+//     host, outside the tree the parent judges.
+//   - a child that can pause (human gate, interactive node) is refused
+//     under a copy-based parent: a parked child is resumed outside its
+//     parent, in an engine with no handle to adopt, i.e. in a pod of its
+//     own — the loss this mechanism exists to prevent.
+func (e *Engine) shouldAdoptSharedSandbox(emitForSandbox func(store.EventType, map[string]any) error) (bool, error) {
+	shared := e.sharedSandbox
+	copyBased := sharedSandboxIsCopyBased(shared.Run)
+	explicitNone := e.workflow != nil && e.workflow.Sandbox != nil && e.workflow.Sandbox.Mode == "none"
+	if explicitNone {
+		if copyBased {
+			return false, fmt.Errorf("subbot child declares `sandbox: none` under a parent sandboxed by a copy-based driver (%s): its work would land on the host, outside the tree the parent judges — drop the declaration, or run the parent unsandboxed", shared.Run.Driver())
+		}
+		if e.logger != nil {
+			e.logger.Warn("runtime: child declares `sandbox: none`; honoured — the parent's sandbox (driver=%s, bind-mounted) is not adopted", shared.Run.Driver())
+		}
+		if err := emitForSandbox(store.EventSandboxShared, map[string]any{
+			"adopted": false, "driver": shared.Run.Driver(), "parent_run": e.parentRunID,
+			"reason": "the child declares sandbox: none; honoured on a bind-mount parent",
+		}); err != nil && e.logger != nil {
+			e.logger.Warn("runtime: emit sandbox_shared: %v", err)
+		}
+		return false, nil
+	}
+	if copyBased && workflowHasPausingNode(e.workflow) {
+		return false, fmt.Errorf("subbot child with a human gate or an interactive node cannot execute in its parent's copy-based sandbox (%s): a parked child is resumed outside its parent, in a sandbox of its own, and its work diverges from the parent's tree — declare the gate in the parent, or run the parent unsandboxed", shared.Run.Driver())
+	}
+	return true, nil
+}
+
+// refuseResumeOfSharedChild refuses to resume, outside its parent, a child
+// run that executed in its parent's COPY-BASED sandbox: a resume here would
+// start a sandbox of its own — a fresh copy of the workspace — and the
+// child's later commits would die with it while the parent's tree stays
+// unchanged. Bind-mount lineages resume freely (host and container share
+// the tree). Nil when this engine holds a parent handle to adopt.
+func (e *Engine) refuseResumeOfSharedChild(ctx context.Context, r *store.Run) error {
+	if r == nil || r.ParentRunID == "" || (e.sharedSandbox != nil && e.sharedSandbox.Run != nil) {
+		return nil
+	}
+	evs, err := e.store.LoadEvents(ctx, r.ID)
+	if err != nil {
+		return nil
+	}
+	for i := len(evs) - 1; i >= 0; i-- {
+		ev := evs[i]
+		if ev.Type != store.EventSandboxShared {
+			continue
+		}
+		if adopted, ok := ev.Data["adopted"].(bool); ok && !adopted {
+			return nil
+		}
+		if cb, _ := ev.Data["copy_based"].(bool); cb {
+			return &RuntimeError{
+				Code:    ErrCodeResumeInvalid,
+				Message: fmt.Sprintf("run %s executed in its parent run %s's copy-based sandbox; resumed on its own it would start a fresh copy of the workspace and its work would diverge from the parent's tree — resume it through the parent", r.ID, r.ParentRunID),
+				Hint:    "resume the parent run; it re-attaches to this child",
+			}
+		}
+		return nil
+	}
+	return nil
+}
 
 // adoptSharedSandbox settles this run on a PARENT run's live sandbox: the
 // executor routes every command through the parent's driver handle,
@@ -1746,51 +1851,93 @@ func (e *Engine) adoptSharedSandbox(ctx context.Context, runID string, emitForSa
 	if s, ok := e.executor.(sharedStateSetter); ok && shared.SharedStateDir != "" {
 		s.SetSharedStateDir(shared.SharedStateDir)
 	}
+	// The parent's per-run listeners serve the child too: board-capability
+	// and interactive nodes would otherwise read as configured-but-dead.
+	if bs, ok := e.executor.(boardMCPSetter); ok && shared.BoardEndpoint != "" {
+		bs.SetBoardEndpoint(shared.BoardEndpoint)
+	}
+	if as, ok := e.executor.(askUserMCPSetter); ok && shared.AskUserEndpoint != "" {
+		as.SetAskUserEndpoint(shared.AskUserEndpoint, shared.AskUserToken)
+	}
+	// The host observer (cloud runner) registers this run against the
+	// shared handle — the child's own file-secret refresh rides it.
+	if e.sandboxRunObserver != nil {
+		e.sandboxRunObserver(shared.Run)
+	}
+	copyBased := sharedSandboxIsCopyBased(shared.Run)
 	pushed := 0
 	if refresher, ok := shared.Run.(sandbox.WorkspaceFileRefresher); ok {
 		pushed = writeThroughMirroredSkills(ctx, e.workDir, refresher, e.logger)
 	}
+	// What the child does NOT get in a shared sandbox, said once, in the
+	// events: its own file secrets are not materialised at adoption (no
+	// Prepare of its own — the refresh loop the observer starts writes
+	// them through on its next tick, on drivers that refresh).
+	fileSecrets := workflowHasFileSecrets(e.workflow)
+	if fileSecrets && e.logger != nil {
+		e.logger.Warn("runtime: child declares file secrets; in the parent's sandbox they are not materialised at start (the refresh loop writes them through on its first tick, on drivers that refresh)")
+	}
 	if e.logger != nil {
-		e.logger.Info("runtime: executing in the parent run's sandbox (driver=%s, workspace=%s, skills written through=%d)", shared.Run.Driver(), shared.WorkspaceFolder, pushed)
+		e.logger.Info("runtime: executing in the parent run's sandbox (driver=%s, workspace=%s, copy_based=%v, files written through=%d)", shared.Run.Driver(), shared.WorkspaceFolder, copyBased, pushed)
 	}
 	if err := emitForSandbox(store.EventSandboxShared, map[string]any{
-		"driver": shared.Run.Driver(), "workspace": shared.WorkspaceFolder,
-		"parent_run": e.parentRunID, "skills_written_through": pushed,
+		"adopted": true, "driver": shared.Run.Driver(), "workspace": shared.WorkspaceFolder,
+		"parent_run": e.parentRunID, "copy_based": copyBased, "skills_written_through": pushed,
+		"file_secrets_declared": fileSecrets,
 	}); err != nil && e.logger != nil {
 		e.logger.Warn("runtime: emit sandbox_shared: %v", err)
 	}
 	return func() {}, nil
 }
 
-// writeThroughMirroredSkills pushes every file under <workDir>/.claude/skills
-// into a copy-based sandbox through the driver's write-through seam. The
-// parent's own skills are already in its copy; re-writing them is
-// idempotent, and the child's are what the copy lacks. Returns the count
+// writeThroughMirroredSkills pushes what the run mirrored into the host
+// workdir's .claude/ for its agents — bundle/plugin/library skills,
+// plugin commands and agents, the merged hooks settings — into a copy-based
+// sandbox through the driver's write-through seam. The parent's own files
+// are already in its copy (rewriting them is idempotent: the host mirror
+// already applied the collision policy, workspace first); the child's are
+// what the copy lacks. Each write is bounded on its own. Returns the count
 // written; a failed write is logged and skipped — a skill the agent cannot
 // read is a degraded run, not a dead one.
 func writeThroughMirroredSkills(ctx context.Context, workDir string, refresher sandbox.WorkspaceFileRefresher, logger *iterlog.Logger) int {
-	root := filepath.Join(workDir, ".claude", "skills")
+	const perFile = 30 * time.Second
 	n := 0
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil
-		}
+	push := func(path string) {
 		rel, rerr := filepath.Rel(workDir, path)
 		if rerr != nil {
-			return nil
+			return
 		}
 		body, rerr := os.ReadFile(path)
 		if rerr != nil {
-			return nil
+			return
 		}
-		if werr := refresher.RefreshWorkspaceFile(ctx, filepath.ToSlash(rel), body); werr != nil {
+		wctx, cancel := context.WithTimeout(ctx, perFile)
+		defer cancel()
+		if werr := refresher.RefreshWorkspaceFile(wctx, filepath.ToSlash(rel), body); werr != nil {
 			if logger != nil {
 				logger.Warn("runtime: write-through of %s into the shared sandbox failed: %v", rel, werr)
 			}
-			return nil
+			return
 		}
 		n++
-		return nil
-	})
+	}
+	for _, sub := range []string{"skills", "commands", "agents"} {
+		root := filepath.Join(workDir, ".claude", sub)
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			push(path)
+			return nil
+		})
+	}
+	if settings := filepath.Join(workDir, ".claude", "settings.json"); fileExists(settings) {
+		push(settings)
+	}
 	return n
+}
+
+func fileExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
 }

--- a/pkg/runtime/sandbox_shared_test.go
+++ b/pkg/runtime/sandbox_shared_test.go
@@ -1,0 +1,196 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// sharedFakeRun is a live sandbox handle a PARENT run would own: commands
+// run on this host (so a tool-only child really executes), every call is
+// counted, and the copy-based write-through seam records what a child
+// pushed into "the pod".
+type sharedFakeRun struct {
+	mu       sync.Mutex
+	commands int
+	cleanups int
+	written  map[string][]byte
+}
+
+func (f *sharedFakeRun) Driver() string { return "fake-shared" }
+func (f *sharedFakeRun) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
+	f.mu.Lock()
+	f.commands++
+	f.mu.Unlock()
+	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	c.Dir = opts.WorkDir
+	c.Env = os.Environ()
+	for k, v := range opts.Env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+	return c
+}
+func (f *sharedFakeRun) Exec(ctx context.Context, cmd []string, opts sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	out, err := f.Command(ctx, cmd, opts).CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	}
+	return sandbox.ExecResult{ExitCode: code, Stdout: out}, nil
+}
+func (f *sharedFakeRun) Cleanup(context.Context) error {
+	f.mu.Lock()
+	f.cleanups++
+	f.mu.Unlock()
+	return nil
+}
+func (f *sharedFakeRun) RefreshWorkspaceFile(_ context.Context, rel string, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.written == nil {
+		f.written = map[string][]byte{}
+	}
+	f.written[rel] = append([]byte(nil), value...)
+	return nil
+}
+
+// sandboxCapturingExecutor is a stub executor that also accepts the live
+// sandbox the engine hands it, as ClawExecutor does.
+type sandboxCapturingExecutor struct {
+	*stubExecutor
+	sandbox sandbox.Run
+}
+
+func (s *sandboxCapturingExecutor) SetSandbox(run sandbox.Run) { s.sandbox = run }
+
+// TestStartSandboxSharedAdoptsTheParentRun: a child engine handed its
+// parent's live sandbox settles on it — the executor routes through the
+// parent's handle, ${PROJECT_DIR} remaps to the parent's in-container
+// workspace, the child's mirrored skills are written through into a
+// copy-based sandbox, the run says so in its events — and never
+// prepares, starts or cleans up a sandbox of its own.
+func TestStartSandboxSharedAdoptsTheParentRun(t *testing.T) {
+	st := tmpStore(t)
+	workDir := t.TempDir()
+	// A skill the child's bundle mirrored into the host workdir before the
+	// sandbox settles — invisible to a copy-based parent pod unless pushed.
+	if err := os.MkdirAll(filepath.Join(workDir, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".claude", "skills", "child-skill.md"), []byte("# child skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := &sharedFakeRun{}
+	exec := &sandboxCapturingExecutor{stubExecutor: newStubExecutor()}
+	wf := &ir.Workflow{Name: "child", Nodes: map[string]ir.Node{}}
+	e := New(wf, st, exec,
+		WithWorkDir(workDir),
+		WithSandboxOverride("auto"), // would try to start one of its own — must be ignored
+		WithParentRunID("run-parent"),
+		WithSharedSandbox(&SharedSandbox{Run: fake, WorkspaceFolder: "/workspace", SharedStateDir: "/shared"}),
+	)
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-child", "child", nil); err != nil {
+		t.Fatal(err)
+	}
+	cleanup, err := e.startSandbox(ctx, "run-child", workDir, "", nil)
+	if err != nil {
+		t.Fatalf("startSandbox: %v", err)
+	}
+	if exec.sandbox != fake {
+		t.Fatalf("executor sandbox = %v, want the parent's handle", exec.sandbox)
+	}
+	if !e.sandboxSettled || e.containerWorkspace != "/workspace" {
+		t.Fatalf("settled=%v containerWorkspace=%q, want settled on the parent's workspace", e.sandboxSettled, e.containerWorkspace)
+	}
+	if e.activeShare == nil || e.activeShare.Run != fake {
+		t.Fatal("activeShare must carry the shared facts on to grandchildren")
+	}
+	if got := string(fake.written[".claude/skills/child-skill.md"]); got != "# child skill\n" {
+		t.Fatalf("the child's mirrored skill was not written through into the parent's sandbox: %q", got)
+	}
+	cleanup()
+	if fake.cleanups != 0 {
+		t.Fatalf("cleanups = %d, want 0: the parent owns the sandbox's lifecycle", fake.cleanups)
+	}
+	evs, err := st.LoadEvents(ctx, "run-child")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shared, started int
+	for _, ev := range evs {
+		switch ev.Type {
+		case store.EventSandboxShared:
+			shared++
+			if ev.Data["parent_run"] != "run-parent" || ev.Data["driver"] != "fake-shared" {
+				t.Fatalf("sandbox_shared data = %v", ev.Data)
+			}
+		case store.EventSandboxStarted:
+			started++
+		}
+	}
+	if shared != 1 || started != 0 {
+		t.Fatalf("events: sandbox_shared=%d sandbox_started=%d, want 1/0 (no sandbox of its own)", shared, started)
+	}
+}
+
+// TestSubbotNodeHandsTheParentSandboxToTheChild: the request a subbot
+// node makes carries the sandbox facts of the run it belongs to — nil when
+// the parent has none.
+func TestSubbotNodeHandsTheParentSandboxToTheChild(t *testing.T) {
+	wf := compileBot(t, `
+schema out:
+  ok: bool
+
+subbot kid:
+  source: "kid.bot"
+  output: out
+
+workflow parent:
+  entry: kid
+  kid -> done
+`).Workflow
+	for _, tc := range []struct {
+		name  string
+		share *SharedSandbox
+	}{
+		{"parent sandboxed", &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"}},
+		{"parent unsandboxed", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got *SharedSandbox
+			var called bool
+			opts := []EngineOption{
+				WithSandboxOverride("none"),
+				WithSubbotRunner(func(_ context.Context, req SubbotRequest) (map[string]any, error) {
+					called = true
+					got = req.ParentSandbox
+					return map[string]any{"ok": true}, nil
+				}),
+			}
+			// A sandboxed parent: it executes in a live sandbox (here, one
+			// handed to it — the grandchild shape; an own sandbox settles
+			// the same facts).
+			if tc.share != nil {
+				opts = append(opts, WithSharedSandbox(tc.share))
+			}
+			e := New(wf, tmpStore(t), newStubExecutor(), opts...)
+			if err := e.Run(context.Background(), "run-"+tc.name, nil); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if !called {
+				t.Fatal("the subbot runner was not invoked")
+			}
+			if got != tc.share {
+				t.Fatalf("ParentSandbox = %v, want %v", got, tc.share)
+			}
+		})
+	}
+}

--- a/pkg/runtime/sandbox_shared_test.go
+++ b/pkg/runtime/sandbox_shared_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/sandbox/docker"
+	"github.com/SocialGouv/iterion/pkg/sandbox/kubernetes"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -347,7 +349,7 @@ func TestRefuseResumeOfSharedChild(t *testing.T) {
 		e, r := mk(t, "run-c1", map[string]any{"adopted": true, "copy_based": true}, nil)
 		err := e.refuseResumeOfSharedChild(ctx, r)
 		var rt *RuntimeError
-		if !errors.As(err, &rt) || rt.Code != ErrCodeResumeInvalid || !strings.Contains(rt.Message, "through the parent") {
+		if !errors.As(err, &rt) || rt.Code != ErrCodeResumeInvalid || !strings.Contains(rt.Hint, "resume the parent") {
 			t.Fatalf("err = %v, want RESUME_INVALID naming the parent", err)
 		}
 	})
@@ -405,6 +407,46 @@ workflow child:
 		r, _ := st.LoadRun(ctx, "run-c5")
 		if r.Status != store.RunStatusFailedResumable {
 			t.Fatalf("status = %q, want the run left failed_resumable for its parent to resume", r.Status)
+		}
+	})
+	t.Run("force resume bypasses in words", func(t *testing.T) {
+		wf := compileBot(t, `
+schema out:
+  ok: bool
+
+compute step:
+  output: out
+  expr:
+    ok: "true"
+
+workflow child:
+  entry: step
+  step -> done
+`).Workflow
+		st := tmpStore(t)
+		pc := store.AsParentedRunCreator(st)
+		if _, err := pc.CreateChildRun(ctx, "run-c7", "child", "run-parent", nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.FailRunResumable(ctx, "run-c7", &store.Checkpoint{NodeID: "step"}, "boom", ""); err != nil {
+			t.Fatal(err)
+		}
+		e := New(wf, st, newStubExecutor(), WithWorkDir(t.TempDir()), WithSandboxOverride("none"), WithForceResume(true))
+		if err := e.emit(ctx, "run-c7", store.EventSandboxShared, "", map[string]any{"adopted": true, "copy_based": true}); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.Resume(ctx, "run-c7", nil); err != nil {
+			t.Fatalf("Resume with --force = %v, want the child resumed in a sandbox of its own", err)
+		}
+		evs, _ := st.LoadEvents(ctx, "run-c7")
+		var said bool
+		for _, ev := range evs {
+			if ev.Type == store.EventSandboxShared && ev.Data["forced"] == true && ev.Data["adopted"] == false {
+				said = true
+			}
+		}
+		if !said {
+			t.Fatal("a forced resume outside the parent must be said in the events (sandbox_shared forced=true)")
 		}
 	})
 	t.Run("wired: Resume of a parked child", func(t *testing.T) {
@@ -490,5 +532,86 @@ workflow child:
 	r, _ := st.LoadRun(context.Background(), "run-inplace")
 	if r.WorkDir != "" && r.WorkDir != workDir {
 		t.Fatalf("run.WorkDir = %q, want the parent's tree %q", r.WorkDir, workDir)
+	}
+}
+
+// TestStartSandboxShared_OwnDeclarationIsHonouredOrRefused: every field a
+// child declares about its own sandbox — not only `none` — is the
+// operator's choice: honoured under a bind-mount parent (a sandbox of its
+// own on the same tree), refused typed under a copy-based one, and named
+// either way.
+func TestStartSandboxShared_OwnDeclarationIsHonouredOrRefused(t *testing.T) {
+	ctx := context.Background()
+	wf := &ir.Workflow{Name: "child", Nodes: map[string]ir.Node{}, Sandbox: &ir.SandboxSpec{Mode: "inline", Image: "iterion-sandbox-sec"}}
+
+	t.Run("bind-mount parent: honoured, declaration named", func(t *testing.T) {
+		fake := &sharedFakeRun{}
+		e, exec, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: bindOnly{fake}, WorkspaceFolder: "/workspace"})
+		_, _ = st.CreateRun(ctx, "run-own-bind", "child", nil)
+		if _, err := e.startSandbox(ctx, "run-own-bind", e.workDir, "", nil); err != nil {
+			t.Fatalf("startSandbox: %v", err)
+		}
+		if exec.sandbox != nil {
+			t.Fatalf("the child's own image declaration was overridden by the parent's sandbox (%v)", exec.sandbox)
+		}
+		evs, _ := st.LoadEvents(ctx, "run-own-bind")
+		var named bool
+		for _, ev := range evs {
+			if ev.Type == store.EventSandboxShared && ev.Data["adopted"] == false {
+				if d, ok := ev.Data["declared"].([]any); ok {
+					for _, f := range d {
+						if f == "image" {
+							named = true
+						}
+					}
+				}
+			}
+		}
+		if !named {
+			t.Fatalf("the honoured declaration must be named in the event: %+v", evs)
+		}
+	})
+	t.Run("copy-based parent: refused, declaration named", func(t *testing.T) {
+		e, _, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"})
+		_, _ = st.CreateRun(ctx, "run-own-copy", "child", nil)
+		_, err := e.startSandbox(ctx, "run-own-copy", e.workDir, "", nil)
+		if err == nil || !strings.Contains(err.Error(), "image") || !strings.Contains(err.Error(), "copy-based") {
+			t.Fatalf("err = %v, want the typed refusal naming the declared image and the copy-based parent", err)
+		}
+	})
+	t.Run("node-level network declaration counts", func(t *testing.T) {
+		nwf := &ir.Workflow{Name: "child", Nodes: map[string]ir.Node{
+			"step": &ir.AgentNode{Sandbox: &ir.SandboxSpec{Network: &ir.SandboxNetwork{Mode: "allowlist"}}},
+		}}
+		got := declaredSandboxFields(nwf)
+		if len(got) != 1 || got[0] != "step.network" {
+			t.Fatalf("declaredSandboxFields = %v, want [step.network]", got)
+		}
+		e, _, st := sharedTestEngine(t, nwf, t.TempDir(), &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"})
+		_, _ = st.CreateRun(ctx, "run-own-node", "child", nil)
+		if _, err := e.startSandbox(ctx, "run-own-node", e.workDir, "", nil); err == nil || !strings.Contains(err.Error(), "step.network") {
+			t.Fatalf("err = %v, want the refusal naming the node's network declaration", err)
+		}
+	})
+	t.Run("inherit and auto are not declarations", func(t *testing.T) {
+		if got := declaredSandboxFields(&ir.Workflow{Nodes: map[string]ir.Node{}, Sandbox: &ir.SandboxSpec{Mode: "auto", HostState: "auto"}}); len(got) != 0 {
+			t.Fatalf("declaredSandboxFields = %v, want none", got)
+		}
+		if got := declaredSandboxFields(&ir.Workflow{Nodes: map[string]ir.Node{}}); len(got) != 0 {
+			t.Fatalf("declaredSandboxFields = %v, want none", got)
+		}
+	})
+}
+
+// TestSharedSandboxCopyBasedClassificationPinsEachDriver: "copy-based" is
+// read off the write-through seam the driver implements. This table is
+// where a future driver that copies the workspace without a refresher
+// turns red before it can lose a child's work in silence.
+func TestSharedSandboxCopyBasedClassificationPinsEachDriver(t *testing.T) {
+	if !sharedSandboxIsCopyBased((*kubernetes.Run)(nil)) {
+		t.Fatal("the kubernetes driver copies the workspace into the pod: copy-based")
+	}
+	if sharedSandboxIsCopyBased((*docker.Run)(nil)) {
+		t.Fatal("the docker driver bind-mounts the workspace: not copy-based")
 	}
 }

--- a/pkg/runtime/sandbox_shared_test.go
+++ b/pkg/runtime/sandbox_shared_test.go
@@ -2,9 +2,11 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -87,6 +89,12 @@ func TestStartSandboxSharedAdoptsTheParentRun(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(workDir, ".claude", "skills", "child-skill.md"), []byte("# child skill\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(workDir, ".claude", "commands"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, ".claude", "commands", "child-cmd.md"), []byte("# child command\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	fake := &sharedFakeRun{}
 	exec := &sandboxCapturingExecutor{stubExecutor: newStubExecutor()}
 	wf := &ir.Workflow{Name: "child", Nodes: map[string]ir.Node{}}
@@ -115,6 +123,9 @@ func TestStartSandboxSharedAdoptsTheParentRun(t *testing.T) {
 	}
 	if got := string(fake.written[".claude/skills/child-skill.md"]); got != "# child skill\n" {
 		t.Fatalf("the child's mirrored skill was not written through into the parent's sandbox: %q", got)
+	}
+	if got := string(fake.written[".claude/commands/child-cmd.md"]); got != "# child command\n" {
+		t.Fatalf("the child's plugin command was not written through: %q", got)
 	}
 	cleanup()
 	if fake.cleanups != 0 {
@@ -192,5 +203,292 @@ workflow parent:
 				t.Fatalf("ParentSandbox = %v, want %v", got, tc.share)
 			}
 		})
+	}
+}
+
+// bindOnly is a parent sandbox that bind-mounts the workspace: its method
+// set has NO write-through seam, so the code reads it as bind-mount.
+type bindOnly struct{ r *sharedFakeRun }
+
+func (b bindOnly) Driver() string { return "fake-bind" }
+func (b bindOnly) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
+	return b.r.Command(ctx, cmd, opts)
+}
+func (b bindOnly) Exec(ctx context.Context, cmd []string, opts sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	return b.r.Exec(ctx, cmd, opts)
+}
+func (b bindOnly) Cleanup(ctx context.Context) error { return b.r.Cleanup(ctx) }
+
+func sharedTestEngine(t *testing.T, wf *ir.Workflow, workDir string, share *SharedSandbox, extra ...EngineOption) (*Engine, *sandboxCapturingExecutor, store.RunStore) {
+	t.Helper()
+	st := tmpStore(t)
+	exec := &sandboxCapturingExecutor{stubExecutor: newStubExecutor()}
+	opts := append([]EngineOption{WithWorkDir(workDir), WithSandboxOverride("none"), WithParentRunID("run-parent"), WithSharedSandbox(share)}, extra...)
+	return New(wf, st, exec, opts...), exec, st
+}
+
+// TestStartSandboxShared_ExplicitNoneIsHonouredOrRefused: a child's own
+// `sandbox: none` is the operator's choice — honoured under a bind-mount
+// parent (host and container share the tree), refused in words under a
+// copy-based one (the child's work would land on the host, outside the
+// tree the parent judges). Never silently overridden either way.
+func TestStartSandboxShared_ExplicitNoneIsHonouredOrRefused(t *testing.T) {
+	wf := &ir.Workflow{Name: "child", Nodes: map[string]ir.Node{}, Sandbox: &ir.SandboxSpec{Mode: "none"}}
+	ctx := context.Background()
+
+	t.Run("bind-mount parent: honoured", func(t *testing.T) {
+		fake := &sharedFakeRun{}
+		e, exec, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: bindOnly{fake}, WorkspaceFolder: "/workspace"})
+		if _, err := st.CreateRun(ctx, "run-none-bind", "child", nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := e.startSandbox(ctx, "run-none-bind", e.workDir, "", nil); err != nil {
+			t.Fatalf("startSandbox: %v", err)
+		}
+		if exec.sandbox != nil {
+			t.Fatalf("the child's explicit sandbox: none was overridden by the parent's sandbox (%v)", exec.sandbox)
+		}
+		evs, _ := st.LoadEvents(ctx, "run-none-bind")
+		var saidSo bool
+		for _, ev := range evs {
+			if ev.Type == store.EventSandboxShared && ev.Data["adopted"] == false {
+				saidSo = true
+			}
+		}
+		if !saidSo {
+			t.Fatal("honouring the declaration must be said in the events (sandbox_shared adopted=false)")
+		}
+	})
+	t.Run("copy-based parent: refused, typed", func(t *testing.T) {
+		e, _, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"})
+		if _, err := st.CreateRun(ctx, "run-none-copy", "child", nil); err != nil {
+			t.Fatal(err)
+		}
+		_, err := e.startSandbox(ctx, "run-none-copy", e.workDir, "", nil)
+		if err == nil || !strings.Contains(err.Error(), "copy-based") {
+			t.Fatalf("err = %v, want the typed refusal naming the copy-based parent", err)
+		}
+	})
+}
+
+// TestStartSandboxShared_PausingChildRefusedOnCopyBasedParent: a child
+// that can park for an operator is resumed outside its parent — in a
+// sandbox of its own, a fresh copy — so under a copy-based parent it is
+// refused at the door; under a bind-mount parent it runs.
+func TestStartSandboxShared_PausingChildRefusedOnCopyBasedParent(t *testing.T) {
+	wf := compileBot(t, `
+schema answer:
+  confirmed: bool
+
+prompt ask_text:
+  Confirm.
+
+human gate:
+  instructions: ask_text
+  output: answer
+  interaction: human
+
+workflow child:
+  entry: gate
+  gate -> done
+`).Workflow
+	ctx := context.Background()
+	t.Run("copy-based: refused", func(t *testing.T) {
+		e, _, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"})
+		_, _ = st.CreateRun(ctx, "run-gate-copy", "child", nil)
+		_, err := e.startSandbox(ctx, "run-gate-copy", e.workDir, "", nil)
+		if err == nil || !strings.Contains(err.Error(), "human gate") {
+			t.Fatalf("err = %v, want the typed refusal of a pausing child", err)
+		}
+	})
+	t.Run("bind-mount: adopted", func(t *testing.T) {
+		fake := &sharedFakeRun{}
+		e, exec, st := sharedTestEngine(t, wf, t.TempDir(), &SharedSandbox{Run: bindOnly{fake}, WorkspaceFolder: "/workspace"})
+		_, _ = st.CreateRun(ctx, "run-gate-bind", "child", nil)
+		if _, err := e.startSandbox(ctx, "run-gate-bind", e.workDir, "", nil); err != nil {
+			t.Fatalf("startSandbox: %v", err)
+		}
+		if exec.sandbox == nil {
+			t.Fatal("a pausing child under a bind-mount parent must still adopt the parent's sandbox")
+		}
+	})
+}
+
+// TestRefuseResumeOfSharedChild: a child that executed in its parent's
+// copy-based sandbox is not resumed on its own — a fresh copy, diverging
+// work — but a bind-mount lineage resumes freely, and an engine holding a
+// parent handle is never refused.
+func TestRefuseResumeOfSharedChild(t *testing.T) {
+	ctx := context.Background()
+	mk := func(t *testing.T, id string, data map[string]any, share *SharedSandbox) (*Engine, *store.Run) {
+		t.Helper()
+		st := tmpStore(t)
+		opts := []EngineOption{WithSandboxOverride("none")}
+		if share != nil {
+			opts = append(opts, WithSharedSandbox(share))
+		}
+		e := New(&ir.Workflow{Name: "child", Nodes: map[string]ir.Node{}}, st, newStubExecutor(), opts...)
+		pc := store.AsParentedRunCreator(st)
+		if pc == nil {
+			t.Fatal("the filesystem store must create parented runs")
+		}
+		r, err := pc.CreateChildRun(ctx, id, "child", "run-parent", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if data != nil {
+			if err := e.emit(ctx, id, store.EventSandboxShared, "", data); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return e, r
+	}
+	t.Run("copy-based lineage: refused, typed", func(t *testing.T) {
+		e, r := mk(t, "run-c1", map[string]any{"adopted": true, "copy_based": true}, nil)
+		err := e.refuseResumeOfSharedChild(ctx, r)
+		var rt *RuntimeError
+		if !errors.As(err, &rt) || rt.Code != ErrCodeResumeInvalid || !strings.Contains(rt.Message, "through the parent") {
+			t.Fatalf("err = %v, want RESUME_INVALID naming the parent", err)
+		}
+	})
+	t.Run("bind-mount lineage: resumes", func(t *testing.T) {
+		e, r := mk(t, "run-c2", map[string]any{"adopted": true, "copy_based": false}, nil)
+		if err := e.refuseResumeOfSharedChild(ctx, r); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+	})
+	t.Run("declaration honoured (not adopted): resumes", func(t *testing.T) {
+		e, r := mk(t, "run-c3", map[string]any{"adopted": false}, nil)
+		if err := e.refuseResumeOfSharedChild(ctx, r); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+	})
+	t.Run("with a parent handle to adopt: resumes", func(t *testing.T) {
+		e, r := mk(t, "run-c4", map[string]any{"adopted": true, "copy_based": true}, &SharedSandbox{Run: &sharedFakeRun{}})
+		if err := e.refuseResumeOfSharedChild(ctx, r); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+	})
+	// The guard is wired into both resume paths — a failed child and a
+	// parked one — before any sandbox of their own is started.
+	t.Run("wired: Resume of a failed_resumable child", func(t *testing.T) {
+		wf := compileBot(t, `
+schema out:
+  ok: bool
+
+compute step:
+  output: out
+  expr:
+    ok: "true"
+
+workflow child:
+  entry: step
+  step -> done
+`).Workflow
+		st := tmpStore(t)
+		pc := store.AsParentedRunCreator(st)
+		if _, err := pc.CreateChildRun(ctx, "run-c5", "child", "run-parent", nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.FailRunResumable(ctx, "run-c5", &store.Checkpoint{NodeID: "step"}, "boom", ""); err != nil {
+			t.Fatal(err)
+		}
+		e := New(wf, st, newStubExecutor(), WithWorkDir(t.TempDir()), WithSandboxOverride("none"))
+		if err := e.emit(ctx, "run-c5", store.EventSandboxShared, "", map[string]any{"adopted": true, "copy_based": true}); err != nil {
+			t.Fatal(err)
+		}
+		err := e.Resume(ctx, "run-c5", nil)
+		var rt *RuntimeError
+		if !errors.As(err, &rt) || rt.Code != ErrCodeResumeInvalid {
+			t.Fatalf("Resume err = %v, want RESUME_INVALID from the shared-child guard", err)
+		}
+		r, _ := st.LoadRun(ctx, "run-c5")
+		if r.Status != store.RunStatusFailedResumable {
+			t.Fatalf("status = %q, want the run left failed_resumable for its parent to resume", r.Status)
+		}
+	})
+	t.Run("wired: Resume of a parked child", func(t *testing.T) {
+		wf := compileBot(t, `
+schema answer:
+  confirmed: bool
+
+prompt ask_text:
+  Confirm.
+
+human gate:
+  instructions: ask_text
+  output: answer
+  interaction: human
+
+workflow child:
+  entry: gate
+  gate -> done
+`).Workflow
+		st := tmpStore(t)
+		pc := store.AsParentedRunCreator(st)
+		if _, err := pc.CreateChildRun(ctx, "run-c6", "child", "run-parent", nil); err != nil {
+			t.Fatal(err)
+		}
+		e := New(wf, st, newStubExecutor(), WithWorkDir(t.TempDir()), WithSandboxOverride("none"))
+		if err := e.Run(ctx, "run-c6", nil); !errors.Is(err, ErrRunPaused) {
+			t.Fatalf("Run err = %v, want ErrRunPaused", err)
+		}
+		if err := e.emit(ctx, "run-c6", store.EventSandboxShared, "", map[string]any{"adopted": true, "copy_based": true}); err != nil {
+			t.Fatal(err)
+		}
+		err := e.Resume(ctx, "run-c6", map[string]any{"confirmed": true})
+		var rt *RuntimeError
+		if !errors.As(err, &rt) || rt.Code != ErrCodeResumeInvalid {
+			t.Fatalf("Resume err = %v, want RESUME_INVALID from the shared-child guard", err)
+		}
+		r, _ := st.LoadRun(ctx, "run-c6")
+		if r.Status != store.RunStatusPausedWaitingHuman {
+			t.Fatalf("status = %q, want the run left parked for its parent to resume", r.Status)
+		}
+	})
+}
+
+// TestSharedChildRunsInPlace: a child in its parent's sandbox works in the
+// parent's tree — it never creates a worktree of its own, which the
+// parent's sandbox would never mount.
+func TestSharedChildRunsInPlace(t *testing.T) {
+	workDir := t.TempDir()
+	for _, args := range [][]string{{"init", "-q", "-b", "main"}, {"config", "user.email", "t@x"}, {"config", "user.name", "t"}} {
+		if out, err := exec.Command("git", append([]string{"-C", workDir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", workDir, "add", "-A").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", workDir, "commit", "-qm", "seed").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v %s", err, out)
+	}
+	wf := compileBot(t, `
+schema out:
+  ok: bool
+
+compute step:
+  output: out
+  expr:
+    ok: "true"
+
+workflow child:
+  entry: step
+  step -> done
+`).Workflow
+	e, _, st := sharedTestEngine(t, wf, workDir, &SharedSandbox{Run: &sharedFakeRun{}, WorkspaceFolder: "/workspace"})
+	if err := e.Run(context.Background(), "run-inplace", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if entries, _ := os.ReadDir(filepath.Join(st.Root(), "worktrees")); len(entries) != 0 {
+		t.Fatalf("a shared child created a worktree of its own: %v", entries)
+	}
+	r, _ := st.LoadRun(context.Background(), "run-inplace")
+	if r.WorkDir != "" && r.WorkDir != workDir {
+		t.Fatalf("run.WorkDir = %q, want the parent's tree %q", r.WorkDir, workDir)
 	}
 }

--- a/pkg/runtime/special_node.go
+++ b/pkg/runtime/special_node.go
@@ -230,6 +230,8 @@ func (e *Engine) runSubbotNode(ctx context.Context, rs *runState, nodeID string,
 		NodeID:      nodeID,
 		ReattachKey: e.subbotReattachKey(nodeID, rs.loopCounters, branchID),
 		WorkDir:     e.workDir,
+		// The child executes where THIS run executes.
+		ParentSandbox: e.activeShare,
 	})
 	if err != nil {
 		return nil, &RuntimeError{

--- a/pkg/runview/subbot.go
+++ b/pkg/runview/subbot.go
@@ -157,6 +157,12 @@ func (s *Service) subbotRunnerFor(parentPath string, runLogger *iterlog.Logger) 
 			last   map[string]any
 		)
 		opts := s.engineOptions(runLogger, hash, childPath, "", finalizationOpts{}, launchExtras{})
+		// The child works in the parent's EFFECTIVE workdir (its worktree when
+		// it swapped to one), not the service's repo root: that is the tree
+		// the parent's sandbox mounts and the parent's gate judges.
+		if req.WorkDir != "" {
+			opts = append(opts, runtime.WithWorkDir(req.WorkDir))
+		}
 		opts = append(opts,
 			runtime.WithParentRunID(req.ParentRunID),
 			runtime.WithParentNodeID(req.NodeID),

--- a/pkg/runview/subbot.go
+++ b/pkg/runview/subbot.go
@@ -160,6 +160,9 @@ func (s *Service) subbotRunnerFor(parentPath string, runLogger *iterlog.Logger) 
 		opts = append(opts,
 			runtime.WithParentRunID(req.ParentRunID),
 			runtime.WithParentNodeID(req.NodeID),
+			// The child executes in the parent's sandbox when the parent has
+			// one — the same tree, on every driver.
+			runtime.WithSharedSandbox(req.ParentSandbox),
 			// Recursive wiring so a child that itself declares subbot nodes can
 			// run them (grandchild sources resolve relative to the CHILD's dir);
 			// the ctx-carried depth keeps the recursion bounded.

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -393,6 +393,11 @@ const (
 	//   - mode: the requested mode ("auto" or "inline")
 	//   - reason: human-readable explanation
 	EventSandboxSkipped EventType = "sandbox_skipped"
+	// EventSandboxShared is emitted at run start when the run executes in
+	// its PARENT run's live sandbox instead of one of its own (a subbot
+	// child): {driver, workspace, parent_run}. The parent's sandbox_started
+	// is the only container this lineage starts.
+	EventSandboxShared EventType = "sandbox_shared"
 	// EventSandboxStarted fires after the active sandbox driver finishes
 	// `Start` (container running, postCreate executed). The data block
 	// makes the resolved spec visible to operators without parsing


### PR DESCRIPTION
## A subbot child got a sandbox of its own — and on a copy-based driver, lost its work in it

Measured on the first subbot to run on a cloud pod (#743, one day old): under the **kubernetes** driver the child engine started a sandbox pod of its own, the driver copies the workspace into a pod (tar at `Prepare`), so the child's commits lived in ITS copy and died with its pod — `final_branch: null`, the commit unreachable from anywhere — while the parent, parked on the subbot node, resumed and re-judged an **unchanged** tree. A net's extension loop (a lot asks, the net's subbot acts, the parent's gate re-verifies) cannot converge that way; here the child's act was a refusal, so the verdict happened to be the same, and an act would have been lost outright. On the **docker** driver the same code happened to work: a second container bind-mounts the same worktree.

## The child executes in its parent's sandbox

- `runtime.SharedSandbox` (the live `sandbox.Run`, the in-container workspace folder, the shared-state dir) is what a child needs; the engine records the facts of the sandbox it settled on (`activeShare`, own or inherited) and hands them to every subbot node through `SubbotRequest.ParentSandbox`.
- `WithSharedSandbox` makes an engine adopt those facts instead of starting a sandbox: the executor routes through the parent's handle, `${PROJECT_DIR}` remaps to the parent's in-container workspace, the run emits `sandbox_shared {driver, workspace, parent_run, skills_written_through}` — and never prepares, starts or cleans up a sandbox (the parent owns the lifecycle; the cleanup returned is a no-op). Grandchildren inherit the same facts.
- The child's bundle skills are mirrored into the HOST workdir before the sandbox settles — invisible to a copy-based pod. When the shared driver implements `sandbox.WorkspaceFileRefresher` (kubernetes), every file under `.claude/skills/` is written through into the pod; bind-mount drivers share the inode and need nothing.
- Both hosts of a subbot — the cloud runner (`subbotRunnerFor`) and the in-process service (`runview`) — pass `WithSharedSandbox(req.ParentSandbox)`, so the two drivers now agree by construction.

Limits stated rather than hidden: a child's own `devbox.json` is not provisioned into a shared pod (the parent's provisioning is what the pod carries — a child needing a tool the parent's bundle/repo do not declare must declare it there for now); a child's attachments are not remapped into the shared pod.

## Proof

- `TestStartSandboxSharedAdoptsTheParentRun` (runtime) — executor on the parent's handle, workspace remapped, skill written through, no cleanup of the parent's run, `sandbox_shared` emitted and no `sandbox_started`; mutants: the shared branch skipped, the write-through dropped — each red.
- `TestSubbotNodeHandsTheParentSandboxToTheChild` (runtime) — the request carries the parent's facts, nil when the parent has none.
- `TestSubbotRunnerRunsTheChildInTheParentSandbox` (runner) — a tool-only child's command goes through the parent's handle, no cleanup, the child's events say `sandbox_shared`; mutant: the runner not handing the share — red.
- Mutants of the hardening, each turning its test red: explicit-none detection dropped; explicit none silently adopted under a copy-based parent; pausing-child refusal dropped; the resume guard unwired; the guard ignoring `copy_based`; the worktree skip dropped.
- `go test ./pkg/runtime/ ./pkg/runner/ ./pkg/runview/ ./pkg/store/` green; `golangci-lint` 0 issues; gofmt clean.

## Hardened after the first review round (five findings, each reproduced)

- **The child worked in a tree of its own on the in-process host** (high): `worktree: auto` gave the child a worktree the parent's container never mounts, and `runview` handed it the repo root instead of the parent's effective workdir — its skills mirrored into a tree its agents could not see. A shared child now runs **in place, in the parent's tree** (no worktree of its own), and `runview` passes `req.WorkDir` as the runner does. `TestSharedChildRunsInPlace`.
- **An explicit `sandbox: none` on the child was silently overridden.** Under a bind-mount parent it is honoured (the child's own resolution takes over, said in `sandbox_shared {adopted: false}`); under a copy-based parent it is refused, typed — the child's work would land on the host, outside the tree the parent judges. `TestStartSandboxShared_ExplicitNoneIsHonouredOrRefused`.
- **A paused child resumed outside its parent got a sandbox of its own** — the k8s loss, back for every child with a human gate. Two guards: a child that can park (human node, interactive LLM node) is refused at the door under a copy-based parent; and a child run whose `sandbox_shared` event says `copy_based: true` refuses to resume without a parent handle (`RESUME_INVALID`, "resume it through the parent") — guarded in `Resume()` before the claim, because the wiring test caught the guard placed after it leaving the refused run `running`. Bind-mount lineages resume freely. `TestStartSandboxShared_PausingChildRefusedOnCopyBasedParent`, `TestRefuseResumeOfSharedChild`.
- **Per-run provisioning the shared path skipped**: the parent's board and ask-user MCP endpoints now travel in the facts and are handed to the child's executor (its capability and interactive nodes use the parent's listeners, reachable from the same sandbox); the host observer is invoked with the shared handle, so the runner registers the child and its file-secret refresh rides it. What the child still does not get — its own file secrets materialised at adoption — is said once in the event (`file_secrets_declared`) and the log.
- gofmt (the red `test` job was this check alone).

Open questions answered: concurrent subbot children of one parent are serialised by the parent's workspace-safety rule (a subbot node is a mutating branch) — no interleaving, on any driver; the write-through pushes the host mirror, which already applied the bundle collision policy (workspace first), so a child never replaces a parent skill the policy kept; commands, agents and the merged hooks settings are written through as well now, each write bounded to 30 s.

## Second round (two findings, both reproduced)

- **Only `sandbox: none` was honoured** (high): a child's own `image`, `build`, `mounts`, `env`, `user`, `post_create`, `workspace_folder`, `host_state` or `network` — at workflow level or on a node — fell through to adoption and was never read again: the child ran in the parent's image under the parent's network policy, silently. One rule now covers every declaration, the one `none` already had: under a bind-mount parent the declaration is honoured (the child resolves a sandbox of its own on the same tree, said in `sandbox_shared {adopted: false, declared: [...]}`); under a copy-based parent it is refused, typed, naming the fields. `TestStartSandboxShared_OwnDeclarationIsHonouredOrRefused` covers workflow-level and node-level declarations; mutants: detection dropped, copy-based refusal dropped.
- **An operator-paused shared child had no way back** (medium): the guard refused every direct resume and the hint named a remedy that does not exist — no path resumes a child while holding a parent handle. The hint now names the two that do: cancel the child and resume the parent, which re-runs the subbot fresh in its sandbox (the documented re-attach behaviour); or `iterion resume --force` on the child, which bypasses the guard in words — a warning and a `sandbox_shared {adopted: false, forced: true}` event — and runs it in a sandbox of its own, where its later commits do not reach the parent's tree. `TestRefuseResumeOfSharedChild/force_resume_bypasses_in_words`; mutant: force ignored.

Open questions, answered:

- *Is "copy-based ⇔ implements `WorkspaceFileRefresher`" binding?* It is the contract `pkg/sandbox/iface.go` states, and it is now pinned: `TestSharedSandboxCopyBasedClassificationPinsEachDriver` classifies the kubernetes driver copy-based and the docker driver bind-mount; a future copy-based driver that omits the refresher turns that table red before it can reintroduce the loss.
- *Does the shared ask-user listener scope by run?* The listener serves only the MCP tool surface behind the per-run token; the interaction semantics live host-side in each run's delegate hooks and interaction store. A child calling the parent's listener gets its questions recorded and answered on the child's run, because the hooks that record them are the child's. The board handler is service-wide (`runview` passes the same handler to every engine), so the parent's board endpoint is the endpoint a child listener would have exposed. What a child does not get is a listener the parent never started (no interactive node / no board capability on the parent): the delegate then falls back per node, loudly, and the adoption event says so (`board_endpoint_inherited`, `ask_user_inherited`, plus a warning when the child wanted one).
- *Does the in-process child's `ClearSkillTierMarkers` on the parent's tree change the parent's later re-mirror?* No: tier sidecars are per-pass scratch state, cleared at the start of every run and every resume before the mirror sequence, and the content-hash markers that drive refresh-vs-preserve are untouched. The child's mirror writes hash markers for its own files only; a same-named parent skill is kept by the workspace-first policy and keeps its marker.
- *Attachments under a shared sandbox?* A child's attachments are handed to agents as host paths (`attachmentsContainerDir` is empty). Under a docker parent with `host_state: auto` those paths resolve through the `~/.iterion` bind; under `host_state: none` or a copy-based driver they do not. That is the limit stated in the description, now also said at adoption (`attachments_reachable: false` with the reason) instead of being discovered as ENOENT.
- *A child's `devbox.json` in a shared pod?* Not provisioned, and now said at run time: when the child's bundle ships a `devbox.json`, the adoption event carries `devbox_declared: true` and the log warns that its packages are the parent's provisioning or nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
