### PR TITLE
fix(board): re-land #745's round-4 fixes the merge queue dropped, plus the round-5 findings and #759

### DIFF
--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -267,6 +267,15 @@ the who-moved oracle and the echo suppressor:
   on the join, and pushing would overwrite a column nobody has reconciled yet;
 - **unmapped native state** ⇒ inert (§2).
 
+A native-wins conflict is the one case that does not advance the recorded
+status inline: the reflect writes it with what it actually pushed. When the
+reflect pushes NOTHING — the two sides already landed on the same column, the
+native state is unmapped, the bound board has no column for it, the pass is
+read-only — the import records what it OBSERVED instead, so a divergence
+nothing can resolve is derived once rather than warned and counted on every
+tick. A *failed* write is deliberately excluded: the stale record is what makes
+the next pass retry it.
+
 Because the recorded status advances on every write, a pass with nothing moving
 writes nothing — the property that keeps the loop from re-pushing forever and
 stamping a fresh `updatedAt` that would then win every conflict against the

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -153,10 +153,51 @@ board — exactly the coupling the ENGINE-stays-bot-agnostic rule forbids. So
 `Status` / `Area` / `Mode` / `Priority` **by name**, and stores the ids it
 found on the binding.
 
-The cache is a cache, never an authority: any sync may re-run discovery, and a
-`Status` write that fails because an option id is gone re-discovers once and
-retries. A field renamed or deleted on GitHub surfaces as an explicit error
-naming the field, never as a silent skip.
+The cache is a cache, never an authority — and it is TWO caches that go stale
+independently:
+
+- the **option ids** are what every write uses. They survive a rename and die
+  with a delete;
+- the **column names** (the stored `StatusMapping`) are what both directions
+  COMPARE — the import maps a board status onto a state, the reflect checks the
+  state's status against the board's. They survive a delete-and-re-add and die
+  with a rename.
+
+So each edit an operator makes to a column breaks exactly one half. A rename
+leaves a perfectly valid id under a name nothing matches: the import goes inert
+and the reflect resolves the same still-valid option, writes it — a no-op on
+the forge's side — and records the old name, on every card, on every pass,
+indefinitely.
+
+**Every pass therefore re-resolves both halves** against the project schema it
+has already read for the label fields, so the repair costs no API call
+(`BoardBinding.ReconcileStatusOptions`). Per mapped state, in order: the cached
+**id** still on the field ⇒ adopt the board's current name (rename repaired);
+else the mapped **name** still on the field ⇒ adopt its id (re-created column,
+or one added since the bind); else **lost**. The `Status` field's own id is
+re-resolved the same way, by name.
+
+A LOST column is the only unrepairable case, and it becomes an explicit state
+rather than a retry loop (the `pluginsource` quarantine precedent): the dead id
+is dropped so nothing writes it, those cards are counted `reflect_no_column`,
+and the binding carries a `degraded_reason` NAMING the column — surfaced on
+`GET /api/teams/{id}/board-binding` and logged once, on the transition, not on
+every pass. It is a partial outage: every column that still resolves keeps
+syncing. It clears itself when the column reappears, and a re-bind clears it
+too — which is what makes "re-bind the board" a real remedy rather than the
+only one.
+
+The repaired vocabulary is persisted through a store method narrow enough to
+touch nothing else (`SaveStatusVocabulary`): a reconciliation may correct what
+the forge changed under it, never the address, credential or policy the
+operator chose. A pass with no binding store (the local one-shot `iterion issue
+import --project`) still repairs in memory — it converges, it just does not
+remember.
+
+Because the reflect ultimately WRITES an option id, it also compares one: when
+the item already carries the option about to be written, nothing is written,
+whatever the names say. The name comparison remains as the fallback for a
+provider that reports no option id.
 
 ### 6. The project import HYDRATES cards; it never creates them
 

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -265,6 +265,23 @@ The native write is a **CAS** (`SetStateFrom(id, seen, want)`), so an operator
 who moved the card between our read and our write wins over the stale fact we
 were carrying, exactly as the issue import already behaves.
 
+**Archived items are off the board, and the two readings differ on purpose.**
+The forge removes an archived item from every view while PRESERVING its field
+values, so one archived in a candidate column keeps reading as that column
+forever. `BoardClient.ListProjectItems` flags rather than filters them, and
+each caller decides:
+
+- the sync pass **skips** them, counted as `skipped_archived` — importing
+  would drive a card from a column nobody can see, reflecting would write into
+  a row nobody can read;
+- the dispatcher's **candidate filter** skips them too: dispatching one
+  launches a bot, and spends LLM budget, on work the operator visibly removed;
+- the dispatcher's **liveness read** (`RefreshStates`) still reports them.
+  Omitting an id there is how the dispatcher learns an issue disappeared, and
+  it answers by cancelling the run and reaping its slot. Archiving is a
+  tidy-up gesture, not a documented kill switch, so a run in flight survives
+  someone clearing the board behind it.
+
 ### 10. The reflect is the second direction of ONE reconciliation pass
 
 Both directions run in the same pass, on the same board read, elected per

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -294,6 +294,13 @@ the CAS matches, and two replicas reconcile the same board at once, issuing
 duplicate `SetSingleSelect` calls and duplicate `External` writes on the same
 cards. With the lease, the second one loses without advancing the watermark.
 
+The release is a **CAS on the pass's own owner token** (`sync_lease_owner`,
+fresh per pass). Without it, a pass that overran the TTL would clear the lease
+of the successor that legitimately took the board, re-admitting exactly the
+concurrent pass the lease refuses; with it, the late release is declined and
+reported (`ErrBoardSyncLeaseLost` → one Warn naming the overrun), which is the
+only moment an overrun is knowable at all.
+
 The TTL is a backstop, not the normal release: `runPass` hands the board back
 when it ends, whatever the outcome, so the TTL only ever fires for a replica
 that **died** mid-pass — bounding that death to one TTL of staleness rather

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -236,12 +236,30 @@ this board), which is what the rule read before.
    it is checked first, in both directions: a Status the reflect just wrote
    reads back as "already equal" at the next import, so a write can never
    ping-pong.
-2. Both sides moved since the last sync ⇒ the **newer** timestamp wins.
-3. Timestamps equal ⇒ **GitHub wins**, because it is the roadmap authority a
+2. **Only one side moved ⇒ no conflict**, and no timestamp is consulted. The
+   native side is unmoved while the card still sits in the state the RECORDED
+   status maps to — that mapped state is iterion's own last write, so a card
+   still there has not moved. The oracle is that fact, not a timestamp
+   comparison: `Issue.StateAt` is bumped by any move, including a move away
+   and back, so "the card's transition is newer than the board's" does not
+   mean the card is anywhere other than where iterion last put it. A one-sided
+   board move is therefore a plain apply and a one-sided native move a plain
+   reflect. A recorded status the mapping does not cover leaves the question
+   undecidable (iterion never derived a state from it) and is treated as
+   moved — a phantom conflict costs one `Warn`, the reverse silently overwrites
+   somebody's decision.
+3. Both sides moved since the last sync ⇒ the **newer** timestamp wins.
+4. Timestamps equal ⇒ **GitHub wins**, because it is the roadmap authority a
    human is looking at.
-4. Every applied conflict resolution is logged at `Warn` with both timestamps,
+5. Every applied conflict resolution is logged at `Warn` with both timestamps,
    both values and the winner — a silent overwrite of somebody's decision is
    the one outcome that must never be invisible.
+
+Rule 2 is what keeps `Conflicts` meaning what §9.2 says it means. Without it a
+human's drag — the ordinary gesture on a project board — counted as "both sides
+moved", and whenever the card's transition happened to be the newer of the two,
+the phantom conflict resolved in the native side's favour and the reflect pushed
+the card's OLD column back over the drag.
 
 The native write is a **CAS** (`SetStateFrom(id, seen, want)`), so an operator
 who moved the card between our read and our write wins over the stale fact we

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -168,6 +168,28 @@ revoked token skips that team, not the sweep.
 
 ---
 
+## Archived items
+
+Archiving is how a board gets cleared. GitHub removes the item from every view
+but **keeps its field values**, so an item archived in "Planned" reads as
+Planned forever.
+
+- The **sync pass skips it entirely**, counted as `skipped_archived`. Neither
+  direction runs: importing would drive a card from a column nobody can see,
+  reflecting would write into a row nobody can read.
+- The **dispatcher never dispatches it**. An archived item in a candidate
+  column would otherwise launch a bot, and spend LLM budget, on work the
+  operator visibly removed.
+- A run **already in flight is not cancelled** by archiving its card. The
+  dispatcher's liveness read still reports an archived item's state, because
+  omitting it means "the issue disappeared" and reaps the run — and tidying a
+  board is not a kill switch. Move the card out of its column, or cancel the
+  run, to stop it.
+
+Un-archive the item to put it back under sync.
+
+---
+
 ## Conflicts
 
 When both sides moved since the last pass:

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -54,7 +54,7 @@ bug until you know it is a decision:
 
 | credential | what it needs |
 |---|---|
-| **GitHub App** | organization permission **Projects: Read and write** (`organization_projects`). It is **org-level**, so an existing installation does not acquire it silently — an org owner must approve the new grant. Request it at App creation: tick *"Allow iterion to sync this org's project boards"* in the connect wizard (`allow_project_board` on `POST /api/teams/{id}/forge/oauth-apps/github-manifest`). At run time iterion mints a dedicated token per board call, so the cached runtime token stays minimal. |
+| **GitHub App** | organization permission **Projects: Read and write** (`organization_projects`). It is **org-level**, so an existing installation does not acquire it silently — an org owner must approve the new grant. Request it at App creation: tick *"Allow iterion to sync this org's project boards"* in the connect wizard (`allow_project_board` on `POST /api/teams/{id}/forge/oauth-apps/github-manifest`). At run time board calls ride a dedicated token, cached separately from and never served to the runtime one, so the token bots push with stays minimal. |
 | **Fine-grained PAT** | organization permission **Projects: Read and write**. |
 | **Classic PAT** | the `project` scope (`read:project` alone gives a read-only binding). |
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -150,7 +150,9 @@ permanent divergence.
   5-minute lease on it*; only the winner runs the pass, so N replicas cost one
   pass, not N — including when a pass outlives the interval, where the
   watermark alone would let a second replica join it. The lease is handed back
-  at pass end, so it only ever expires for a replica that died mid-pass.
+  at pass end — by the pass that took it, never by an older one that overran
+  (that release is declined and logged) — so it only ever expires for a
+  replica that died mid-pass.
 - **Cost**: one project read per bound team per interval. GitHub prices a
   Projects v2 page at a handful of points against a 5000/hour budget.
 - **Logs**: one line per pass.

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -174,12 +174,19 @@ When both sides moved since the last pass:
 
 1. **Value already equal ⇒ nothing happens.** This is checked first and is what
    makes the loop terminate: a status iterion itself wrote reads back as equal.
-2. Otherwise the **newer** state change wins — the card's own transition time
+2. **Only one side moved ⇒ no conflict.** The native side is unmoved while the
+   card still sits in the column the recorded status maps to — iterion's own
+   last write. A one-sided board move is a plain apply, a one-sided native move
+   a plain reflect, and neither touches the counter.
+3. Otherwise the **newer** state change wins — the card's own transition time
    (stamped by the board store at every move, wherever the move came from)
    against the board column's `updatedAt`.
-3. A tie goes to **GitHub** — it is the roadmap a human is looking at.
-4. Every resolution is logged at `Warn` with both timestamps, both values and
+4. A tie goes to **GitHub** — it is the roadmap a human is looking at.
+5. Every resolution is logged at `Warn` with both timestamps, both values and
    the winner.
+
+So `conflicts=N` counts people and bots actually fighting over the board. A
+board whose humans and bots take turns reads `conflicts=0`.
 
 The native write is a CAS, so an operator who moved the card between our read
 and our write wins over the stale fact we were carrying.

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -138,6 +138,35 @@ The same override exists for the dispatcher
 
 ---
 
+## Editing a bound board's columns
+
+Binding caches two things per column: the **option id** (what every write uses)
+and the **name** (what both directions compare). Editing a column on GitHub
+invalidates one or the other, so every reconciliation pass re-resolves both
+against the board's live schema — at no extra API cost, since the pass already
+reads it. What that repairs, and what it cannot:
+
+| you did on GitHub | what survives | what the pass does |
+|---|---|---|
+| **renamed** a column | its id | adopts the new name; both directions keep working, nothing is rewritten |
+| **deleted and re-added** a column under the same name | its name | adopts the new id |
+| **added** a column the map named and the board lacked | — | adopts it and drops it from `missing_statuses` |
+| **deleted** a column for good | nothing | marks the binding **degraded**, naming the column |
+
+A degraded binding is a **partial** outage, not a stop: every column it can
+still resolve keeps syncing, and only the cards whose state has no column are
+left alone (counted as `reflect_no_column` in the pass line). The reason is on
+the binding — `iterion remote board show`, or
+`GET /api/teams/{id}/board-binding` — and is logged **once**, when it starts,
+not on every pass.
+
+It clears by itself the moment the column exists again. Re-binding the board
+(`iterion remote board bind …`) also clears it, and is the way out when the
+column is gone for good: bind with a `--status-map` matching what the board
+actually carries.
+
+---
+
 ## Reconciliation
 
 The board pass IS the convergence: it recomputes the truth from the board and
@@ -159,8 +188,8 @@ permanent divergence.
 
 ```
 board sync: team=t_123 board=SocialGouv/203 items=214 moved=2 reflected=1 \
-  labelled=3 conflicts=0 refused_terminal=0 reflect_failed=0 \
-  skipped_no_card=4 skipped=11 took=812ms
+  labelled=3 conflicts=0 refused_terminal=0 reflect_failed=0 reflect_no_column=0 \
+  skipped_no_card=4 skipped_archived=3 skipped=11 took=812ms
 ```
 
 A failed pass logs `Warn` and **does not block the next tick**; one team's
@@ -237,11 +266,19 @@ mapped column the board lacks). Then check it is not a terminal card:
 which is by design — reopen it in iterion.
 
 **A card moved in iterion but not on GitHub.**
-Three causes, in order of likelihood: the state is unmapped (`review`,
+Four causes, in order of likelihood: the state is unmapped (`review`,
 `waiting_deps`, `awaiting_input`, `backlog` are inert); the binding has
-`sync_every: 0`; or the credential lacks the write grant —
-`reflect_failed > 0` with a `403 Resource not accessible by integration` in the
-log means the App's *Projects: Read and write* is not approved.
+`sync_every: 0`; the board has no column for that state — `reflect_no_column >
+0`, and `iterion remote board show` says which (a `!` on a mapped column, or a
+`degraded` reason when a column was deleted after the bind, see [Editing a
+bound board's columns](#editing-a-bound-boards-columns)); or the credential
+lacks the write grant — `reflect_failed > 0` with a `403 Resource not
+accessible by integration` in the log means the App's *Projects: Read and
+write* is not approved.
+
+**A card stopped following, and the item is not on the board any more.**
+It is archived. `skipped_archived > 0` in the pass line; un-archive it to put
+it back under sync (see [Archived items](#archived-items)).
 
 **Bind fails with "none of the mapped columns exist".**
 The board's real column names are listed in the error. Either rename them on

--- a/openapi.json
+++ b/openapi.json
@@ -114,6 +114,13 @@
             "format": "date-time",
             "type": "string"
           },
+          "degraded_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "degraded_reason": {
+            "type": "string"
+          },
           "label_fields": {
             "items": {
               "$ref": "#/components/schemas/BoundLabelField"

--- a/openapi.json
+++ b/openapi.json
@@ -172,6 +172,9 @@
           "sync_every_seconds": {
             "type": "integer"
           },
+          "sync_lease_owner": {
+            "type": "string"
+          },
           "sync_lease_until": {
             "format": "date-time",
             "type": "string"

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -520,6 +520,9 @@ func RunIssueImport(p *Printer, opts IssueImportOptions) error {
 		if projectRes.RefusedTerminal > 0 {
 			p.KV("Refused (terminal)", strconv.Itoa(projectRes.RefusedTerminal))
 		}
+		if projectRes.SkippedArchived > 0 {
+			p.KV("Skipped (archived)", strconv.Itoa(projectRes.SkippedArchived))
+		}
 		if projectRes.SkippedNoCard > 0 {
 			p.KV("Skipped (no card yet)", strconv.Itoa(projectRes.SkippedNoCard))
 			// Name the repos: the operator's next command is one issue import

--- a/pkg/cli/remote_board_binding.go
+++ b/pkg/cli/remote_board_binding.go
@@ -186,6 +186,15 @@ func printBoardBinding(p *Printer, b forge.BoardBinding) {
 	if !b.LastSyncedAt.IsZero() {
 		p.KV("Last synced", b.LastSyncedAt.Format(time.RFC3339))
 	}
+	if b.Degraded() {
+		// A partial outage, and the one thing an operator has to act on: the
+		// reason names the column to re-create, or to re-bind around.
+		since := ""
+		if b.DegradedAt != nil {
+			since = " (since " + b.DegradedAt.Format(time.RFC3339) + ")"
+		}
+		p.KV("Degraded", b.DegradedReason+since)
+	}
 	p.Blank()
 	p.Line("Status map:")
 	if b.StatusFieldID == "" {

--- a/pkg/dispatcher/tracker/github_project.go
+++ b/pkg/dispatcher/tracker/github_project.go
@@ -181,7 +181,23 @@ func (s projectSnapshot) state(number int, mapping []forge.StatusMapping) (strin
 
 // isCandidateStatus reports whether an item's column is one the operator
 // dispatches from.
+//
+// An ARCHIVED item never is. Archiving removes it from every board view while
+// PRESERVING its field values, so one archived in a candidate column keeps
+// reading as eligible — and dispatching it launches a bot, and spends LLM
+// budget, on work the operator has visibly taken off the board. Archiving is
+// the ordinary way to clear a board, so this is reachable on the first real
+// one.
+//
+// The counterpart deliberately NOT filtered is `state` (below), which
+// RefreshStates reads: omitting an id there is how the dispatcher learns an
+// issue disappeared, and it answers by cancelling the run. Eligibility
+// excludes archived items; liveness keeps reporting them, so tidying a board
+// never kills a run in flight.
 func (s projectSnapshot) isCandidateStatus(it forge.ProjectItem, want []string) bool {
+	if it.Archived {
+		return false
+	}
 	fv, ok := it.Field(forge.ProjectStatusFieldName)
 	if !ok {
 		return false

--- a/pkg/dispatcher/tracker/github_project_test.go
+++ b/pkg/dispatcher/tracker/github_project_test.go
@@ -418,6 +418,64 @@ func TestGitHubProjectRefreshStatesReadsTheStatusField(t *testing.T) {
 	}
 }
 
+// TestGitHubProjectArchivedItemIsNotACandidate pins the eligibility half of
+// the archive rule.
+//
+// Archiving is the ordinary way to clear a project board, and GitHub PRESERVES
+// an archived item's field values — so an item archived while sitting in
+// "Planned" keeps reading as Planned. Dispatching it launches a bot, and spends
+// LLM budget, on work the operator has visibly taken off the board.
+func TestGitHubProjectArchivedItemIsNotACandidate(t *testing.T) {
+	gh := &fakeGH{listOut: []byte(twoOpenIssues)}
+	archived := projectItem("PVTI_1", "owner/repo", 1, "Planned")
+	archived.Archived = true
+	board := &fakeProjectBoard{
+		fields: []forge.ProjectField{projectStatusField()},
+		items: []forge.ProjectItem{
+			archived,
+			projectItem("PVTI_2", "owner/repo", 2, "Planned"),
+		},
+	}
+	a := boardModeAdapter(t, gh, board)
+
+	got, err := a.ListCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "github:owner/repo#2" {
+		t.Fatalf("candidates = %+v, want only the live Planned item — an archived one is off the board", got)
+	}
+}
+
+// TestGitHubProjectRefreshStatesStillAnswersForAnArchivedItem pins the OTHER
+// half of the archive rule, and it is deliberate rather than an oversight.
+//
+// Omitting an id from RefreshStates is how the dispatcher learns an issue
+// "disappeared", and it answers by CANCELLING the run and reaping its slot
+// (loop.go refreshRunningStates). Archiving a card is a tidy-up gesture, not a
+// documented kill switch, so eligibility excludes archived items while
+// liveness keeps reporting them: a run in flight is never killed by someone
+// clearing the board behind it.
+func TestGitHubProjectRefreshStatesStillAnswersForAnArchivedItem(t *testing.T) {
+	gh := &fakeGH{listOut: []byte(twoOpenIssues)}
+	archived := projectItem("PVTI_1", "owner/repo", 1, "In progress")
+	archived.Archived = true
+	board := &fakeProjectBoard{
+		fields: []forge.ProjectField{projectStatusField()},
+		items:  []forge.ProjectItem{archived},
+	}
+	a := boardModeAdapter(t, gh, board)
+
+	got, err := a.RefreshStates(context.Background(), []string{"github:owner/repo#1"})
+	if err != nil {
+		t.Fatalf("RefreshStates: %v", err)
+	}
+	if got["github:owner/repo#1"] != "in_progress" {
+		t.Errorf("state = %q, want in_progress — archiving must not read as 'disappeared' and cancel a live run",
+			got["github:owner/repo#1"])
+	}
+}
+
 // TestGitHubProjectBoardErrorsAreLoud pins the explicit-errors rule: a board
 // the adapter cannot read must fail the poll, never quietly degrade back to
 // label-derived states — which would dispatch on a state nobody configured.

--- a/pkg/forge/board.go
+++ b/pkg/forge/board.go
@@ -241,6 +241,12 @@ type BoardClient interface {
 	// ListProjectItems returns one page of the board's items with their field
 	// values. Archived items are included and flagged, not filtered — the
 	// caller decides, because "archived" means different things per workflow.
+	//
+	// Every caller in-tree does decide, and the two answers differ on purpose:
+	// the sync pass and the dispatcher's candidate filter SKIP an archived item
+	// (its field values survive archiving, so it would keep reading as
+	// eligible), while the dispatcher's liveness read still reports its state —
+	// there, absence means "the issue disappeared" and cancels the run.
 	ListProjectItems(ctx context.Context, ref ProjectRef, opts ProjectItemListOptions) (ProjectItemPage, error)
 
 	// ItemForIssue resolves ONE issue's item on this board, without reading

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,8 +24,11 @@ import (
 // other store already keys on.
 //
 // The discovered ids (project, status field, per-state option) are a CACHE of
-// what BindBoard read from the board by NAME — never an authority. Any sync
-// may re-run discovery, and a write that fails on a stale id re-discovers.
+// what BindBoard read from the board by NAME — never an authority. Every sync
+// pass re-resolves them, and the column names beside them, against the board's
+// live schema (BoardBinding.ReconcileStatusOptions in board_vocabulary.go) and
+// persists the repair through SaveStatusVocabulary. What no re-resolution can
+// repair — a column deleted outright — becomes DegradedReason.
 
 // ErrBoardBindingNotFound reports a team with no project board bound.
 var ErrBoardBindingNotFound = errors.New("forge: board binding not found")
@@ -138,6 +142,18 @@ type BoardBinding struct {
 	// the board — re-admitting the concurrent pass the lease exists to refuse.
 	SyncLeaseOwner string `bson:"sync_lease_owner,omitempty" json:"sync_lease_owner,omitempty"`
 
+	// DegradedReason is set when a sync pass found a bound status column the
+	// board no longer carries under either its cached id or its mapped name.
+	// Those cards stop being reflected — an explicit state on the record beats
+	// a failed write per card on every pass — and the reason names the columns
+	// so the remedy is readable from the binding itself.
+	//
+	// It is a HEALTH readout, written only through MarkDegraded/ClearDegraded
+	// and cleared by a re-bind (which re-discovers everything by name). The
+	// pluginsource quarantine precedent: degraded is skipped, never fatal.
+	DegradedReason string     `bson:"degraded_reason,omitempty" json:"degraded_reason,omitempty"`
+	DegradedAt     *time.Time `bson:"degraded_at,omitempty" json:"degraded_at,omitempty"`
+
 	CreatedAt time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
@@ -173,6 +189,11 @@ func (b BoardBinding) OptionForState(state string) (string, bool) {
 	id, ok := b.StatusOptions[state]
 	return id, ok && id != ""
 }
+
+// Degraded reports whether the last reconciliation found a bound column the
+// board no longer carries. A degraded binding still syncs every state it CAN
+// resolve — it is a partial outage, not a stop.
+func (b BoardBinding) Degraded() bool { return b.DegradedReason != "" }
 
 // DueAt reports when this binding's next periodic pass is due. The zero time
 // means "not scheduled" (SyncEvery == 0).
@@ -265,6 +286,19 @@ type BoardBindingStore interface {
 	// to a successor must not clear the successor's lease, and is told so with
 	// ErrBoardSyncLeaseLost rather than left believing it released cleanly.
 	ReleaseSync(ctx context.Context, tenantID, owner string) error
+
+	// SaveStatusVocabulary persists ONLY the cached name⇄id half of a binding,
+	// the way a sync pass repaired it against the live board. Narrow on
+	// purpose: a reconciliation may correct what the forge changed under it,
+	// never the address, credential or policy the operator chose.
+	SaveStatusVocabulary(ctx context.Context, tenantID string, v StatusVocabulary) error
+
+	// MarkDegraded / ClearDegraded write the health readout — a bound column
+	// the board no longer carries, and its repair. Separate from Upsert and
+	// SaveStatusVocabulary so neither can silently clear a degradation, and so
+	// the readout has exactly two writers (the pluginsource precedent).
+	MarkDegraded(ctx context.Context, tenantID, reason string) error
+	ClearDegraded(ctx context.Context, tenantID string) error
 }
 
 // ---- in-memory store (tests / local) ----
@@ -298,7 +332,55 @@ func (m *MemoryBoardBindingStore) Upsert(_ context.Context, b BoardBinding) erro
 		// the two twins disagree on whether the board is held.
 		b.SyncLeaseUntil, b.SyncLeaseOwner = prev.SyncLeaseUntil, prev.SyncLeaseOwner
 	}
+	// A re-bind CLEARS the degradation: it re-read the board and re-resolved
+	// every column by name, which is the documented remedy. Written explicitly
+	// rather than left to the zero value — the Mongo twin has to $unset it, so
+	// stating it here is what keeps the two answering the same thing.
+	b.DegradedReason, b.DegradedAt = "", nil
 	m.items[b.TenantID] = b
+	return nil
+}
+
+func (m *MemoryBoardBindingStore) SaveStatusVocabulary(_ context.Context, tenantID string, v StatusVocabulary) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.items[tenantID]
+	if !ok {
+		return ErrBoardBindingNotFound
+	}
+	b.SetVocabulary(v)
+	b.UpdatedAt = time.Now().UTC()
+	m.items[tenantID] = b
+	return nil
+}
+
+func (m *MemoryBoardBindingStore) MarkDegraded(_ context.Context, tenantID, reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("forge: board binding: a degradation needs a reason")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.items[tenantID]
+	if !ok {
+		return ErrBoardBindingNotFound
+	}
+	now := time.Now().UTC()
+	b.DegradedReason, b.DegradedAt = reason, &now
+	b.UpdatedAt = now
+	m.items[tenantID] = b
+	return nil
+}
+
+func (m *MemoryBoardBindingStore) ClearDegraded(_ context.Context, tenantID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.items[tenantID]
+	if !ok {
+		return ErrBoardBindingNotFound
+	}
+	b.DegradedReason, b.DegradedAt = "", nil
+	b.UpdatedAt = time.Now().UTC()
+	m.items[tenantID] = b
 	return nil
 }
 
@@ -445,10 +527,78 @@ func (s *MongoBoardBindingStore) Upsert(ctx context.Context, b BoardBinding) err
 	}
 	_, err := s.coll.UpdateOne(ctx,
 		bson.M{"_id": b.TenantID},
-		bson.M{"$set": set, "$setOnInsert": bson.M{"created_at": b.CreatedAt}},
+		bson.M{
+			"$set": set,
+			// A re-bind re-read the board and re-resolved every column by
+			// name — the documented remedy for a degraded binding, so it
+			// clears the readout. Named explicitly: not writing the field
+			// would leave the stored degradation standing while the memory
+			// twin drops it.
+			"$unset":       bson.M{"degraded_reason": "", "degraded_at": ""},
+			"$setOnInsert": bson.M{"created_at": b.CreatedAt},
+		},
 		options.UpdateOne().SetUpsert(true))
 	if err != nil {
 		return fmt.Errorf("forge: upsert board binding: %w", err)
+	}
+	return nil
+}
+
+// SaveStatusVocabulary writes ONLY the cached name⇄id half — the fields a
+// reconciliation against the live board may correct. `missing_statuses` is set
+// unconditionally (including to nil) because a repair that resolves the last
+// missing column must be able to empty it.
+func (s *MongoBoardBindingStore) SaveStatusVocabulary(ctx context.Context, tenantID string, v StatusVocabulary) error {
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID},
+		bson.M{"$set": bson.M{
+			"status_mapping":   v.Mapping,
+			"status_options":   v.Options,
+			"status_field_id":  v.StatusFieldID,
+			"missing_statuses": v.MissingStatuses,
+			"updated_at":       time.Now().UTC(),
+		}})
+	if err != nil {
+		return fmt.Errorf("forge: save board status vocabulary: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrBoardBindingNotFound
+	}
+	return nil
+}
+
+// MarkDegraded records that a bound status column no longer exists on the
+// board, and why.
+func (s *MongoBoardBindingStore) MarkDegraded(ctx context.Context, tenantID, reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("forge: board binding: a degradation needs a reason")
+	}
+	now := time.Now().UTC()
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID},
+		bson.M{"$set": bson.M{"degraded_reason": reason, "degraded_at": now, "updated_at": now}})
+	if err != nil {
+		return fmt.Errorf("forge: mark board binding degraded: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrBoardBindingNotFound
+	}
+	return nil
+}
+
+// ClearDegraded records a reconciliation that resolved every column again.
+func (s *MongoBoardBindingStore) ClearDegraded(ctx context.Context, tenantID string) error {
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID},
+		bson.M{
+			"$unset": bson.M{"degraded_reason": "", "degraded_at": ""},
+			"$set":   bson.M{"updated_at": time.Now().UTC()},
+		})
+	if err != nil {
+		return fmt.Errorf("forge: clear board binding degraded: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrBoardBindingNotFound
 	}
 	return nil
 }

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -29,6 +29,15 @@ import (
 // ErrBoardBindingNotFound reports a team with no project board bound.
 var ErrBoardBindingNotFound = errors.New("forge: board binding not found")
 
+// ErrBoardSyncLeaseLost reports a release by a pass that no longer holds the
+// lease — it overran the TTL and another replica has since claimed the board.
+//
+// It is an ERROR rather than a quiet no-op because it is the only moment the
+// overrun is knowable: the release is refused (clearing a successor's lease is
+// precisely the damage), and the caller has just learned that its pass may
+// have run alongside another one.
+var ErrBoardSyncLeaseLost = errors.New("forge: board sync lease no longer held")
+
 // DefaultBoardSyncEvery is the reconciliation interval a binding gets when the
 // operator does not choose one. It is the net under the reflect, so it is on
 // by default; `0` turns it off explicitly.
@@ -123,6 +132,11 @@ type BoardBinding struct {
 	// Stamped by ClaimSync, cleared by ReleaseSync at pass end; a value in the
 	// future refuses a second replica's claim. Zero = no pass running.
 	SyncLeaseUntil time.Time `bson:"sync_lease_until,omitempty" json:"sync_lease_until,omitempty"`
+	// SyncLeaseOwner identifies the pass holding the lease, and is what makes
+	// the release CONDITIONAL. Without it a pass that overran the TTL would,
+	// on finishing, clear the lease of the successor that legitimately took
+	// the board — re-admitting the concurrent pass the lease exists to refuse.
+	SyncLeaseOwner string `bson:"sync_lease_owner,omitempty" json:"sync_lease_owner,omitempty"`
 
 	CreatedAt time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
@@ -240,12 +254,17 @@ type BoardBindingStore interface {
 	// replica presenting a stale watermark loses, and so does one whose tick
 	// finds a pass still running (the watermark alone cannot tell them apart —
 	// an overrunning pass leaves a watermark that matches).
-	ClaimSync(ctx context.Context, tenantID string, seen, at time.Time) (bool, error)
+	// owner identifies the claiming pass, and is what ReleaseSync CASes on.
+	ClaimSync(ctx context.Context, tenantID string, seen, at time.Time, owner string) (bool, error)
 	// ReleaseSync clears the lease at pass end, whatever the pass's outcome,
 	// so the next tick may claim immediately. Without it a board would sit out
 	// the whole TTL after every pass; with it the TTL only ever fires for a
 	// replica that died mid-pass.
-	ReleaseSync(ctx context.Context, tenantID string) error
+	//
+	// It is a CAS on `owner`: a pass that overran the TTL and lost the board
+	// to a successor must not clear the successor's lease, and is told so with
+	// ErrBoardSyncLeaseLost rather than left believing it released cleanly.
+	ReleaseSync(ctx context.Context, tenantID, owner string) error
 }
 
 // ---- in-memory store (tests / local) ----
@@ -277,7 +296,7 @@ func (m *MemoryBoardBindingStore) Upsert(_ context.Context, b BoardBinding) erro
 		// A re-bind must not release a pass that is running: the Mongo twin
 		// never names the field in its $set, so dropping it here would make
 		// the two twins disagree on whether the board is held.
-		b.SyncLeaseUntil = prev.SyncLeaseUntil
+		b.SyncLeaseUntil, b.SyncLeaseOwner = prev.SyncLeaseUntil, prev.SyncLeaseOwner
 	}
 	m.items[b.TenantID] = b
 	return nil
@@ -333,7 +352,7 @@ func (m *MemoryBoardBindingStore) snapshot(keep func(BoardBinding) bool) []Board
 	return out
 }
 
-func (m *MemoryBoardBindingStore) ClaimSync(_ context.Context, tenantID string, seen, at time.Time) (bool, error) {
+func (m *MemoryBoardBindingStore) ClaimSync(_ context.Context, tenantID string, seen, at time.Time, owner string) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	b, ok := m.items[tenantID]
@@ -351,19 +370,24 @@ func (m *MemoryBoardBindingStore) ClaimSync(_ context.Context, tenantID string, 
 	}
 	b.LastSyncedAt = at
 	b.SyncLeaseUntil = at.Add(BoardSyncLeaseTTL)
+	b.SyncLeaseOwner = owner
 	b.UpdatedAt = time.Now().UTC()
 	m.items[tenantID] = b
 	return true, nil
 }
 
-func (m *MemoryBoardBindingStore) ReleaseSync(_ context.Context, tenantID string) error {
+func (m *MemoryBoardBindingStore) ReleaseSync(_ context.Context, tenantID, owner string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	b, ok := m.items[tenantID]
 	if !ok {
 		return ErrBoardBindingNotFound
 	}
+	if b.SyncLeaseOwner != owner {
+		return ErrBoardSyncLeaseLost
+	}
 	b.SyncLeaseUntil = time.Time{}
+	b.SyncLeaseOwner = ""
 	b.UpdatedAt = time.Now().UTC()
 	m.items[tenantID] = b
 	return nil
@@ -478,7 +502,7 @@ func (s *MongoBoardBindingStore) DueBindings(ctx context.Context, now time.Time)
 // match after the first pass, which would stop the reconciliation dead. ModifiedCount == 1 means this replica owns the
 // pass; 0 means another replica already claimed it (or the binding is gone,
 // which the follow-up read distinguishes).
-func (s *MongoBoardBindingStore) ClaimSync(ctx context.Context, tenantID string, seen, at time.Time) (bool, error) {
+func (s *MongoBoardBindingStore) ClaimSync(ctx context.Context, tenantID string, seen, at time.Time, owner string) (bool, error) {
 	filter := bson.M{"_id": tenantID}
 	// The lease half of the claim: no pass may be running. An absent field is
 	// a binding that never ran (or was released), so the predicate has to
@@ -503,6 +527,7 @@ func (s *MongoBoardBindingStore) ClaimSync(ctx context.Context, tenantID string,
 		bson.M{"$set": bson.M{
 			"last_synced_at":   at,
 			"sync_lease_until": at.Add(BoardSyncLeaseTTL),
+			"sync_lease_owner": owner,
 			"updated_at":       time.Now().UTC(),
 		}})
 	if err != nil {
@@ -520,20 +545,28 @@ func (s *MongoBoardBindingStore) ClaimSync(ctx context.Context, tenantID string,
 	return false, nil
 }
 
-// ReleaseSync clears the lease. It is deliberately NOT conditional on who
-// holds it: the only caller is the pass that just claimed, and a release that
-// could fail on a lease already expired-and-retaken would leave the board held
-// by a pass that ended.
-func (s *MongoBoardBindingStore) ReleaseSync(ctx context.Context, tenantID string) error {
-	res, err := s.coll.UpdateOne(ctx, bson.M{"_id": tenantID},
-		bson.M{"$unset": bson.M{"sync_lease_until": ""}, "$set": bson.M{"updated_at": time.Now().UTC()}})
+// ReleaseSync clears the lease, CAS'd on the owner that took it: a pass that
+// overran the TTL and lost the board must not clear its SUCCESSOR's lease.
+//
+// Not matching is not the same as not existing, so the two are distinguished:
+// a missing binding is ErrBoardBindingNotFound, a lease that moved on is
+// ErrBoardSyncLeaseLost — the only moment an overrun is knowable, and worth a
+// line in the log rather than a silent success.
+func (s *MongoBoardBindingStore) ReleaseSync(ctx context.Context, tenantID, owner string) error {
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID, "sync_lease_owner": owner},
+		bson.M{"$unset": bson.M{"sync_lease_until": "", "sync_lease_owner": ""},
+			"$set": bson.M{"updated_at": time.Now().UTC()}})
 	if err != nil {
 		return fmt.Errorf("forge: release board sync: %w", err)
 	}
-	if res.MatchedCount == 0 {
-		return ErrBoardBindingNotFound
+	if res.MatchedCount == 1 {
+		return nil
 	}
-	return nil
+	if _, err := s.GetByTenant(ctx, tenantID); err != nil {
+		return err
+	}
+	return ErrBoardSyncLeaseLost
 }
 
 func (s *MongoBoardBindingStore) find(ctx context.Context, filter bson.M) ([]BoardBinding, error) {

--- a/pkg/forge/board_binding_store_test.go
+++ b/pkg/forge/board_binding_store_test.go
@@ -349,6 +349,93 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		}
 	})
 
+	t.Run("the status vocabulary is repairable on its own", func(t *testing.T) {
+		if err := store.Upsert(ctx, binding("team-voc", time.Minute)); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		if err := store.SaveStatusVocabulary(ctx, "team-voc", forge.StatusVocabulary{
+			Mapping:       []forge.StatusMapping{{Status: "Ready to work", State: "ready"}, {Status: "Done", State: "done"}},
+			Options:       map[string]string{"ready": "opt_planned", "done": "opt_fresh"},
+			StatusFieldID: "PVTSSF_status2",
+		}); err != nil {
+			t.Fatalf("SaveStatusVocabulary: %v", err)
+		}
+		got, err := store.GetByTenant(ctx, "team-voc")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if s, ok := forge.StatusForState(got.Mapping(), "ready"); !ok || s != "Ready to work" {
+			t.Errorf("repaired column name = %q (ok=%v)", s, ok)
+		}
+		if got.StatusOptions["done"] != "opt_fresh" || got.StatusFieldID != "PVTSSF_status2" {
+			t.Errorf("repaired ids not stored: %+v / %q", got.StatusOptions, got.StatusFieldID)
+		}
+		// And ONLY the vocabulary: a sync pass may correct what the forge
+		// changed under it, never the address, credential or policy.
+		if got.ConnectionID != "conn-1" || got.Number != 203 || got.SyncEvery != time.Minute {
+			t.Errorf("a vocabulary repair must not touch the rest of the binding: %+v", got)
+		}
+		if err := store.SaveStatusVocabulary(ctx, "nobody", forge.StatusVocabulary{}); !errors.Is(err, forge.ErrBoardBindingNotFound) {
+			t.Errorf("SaveStatusVocabulary on a missing binding: want ErrBoardBindingNotFound, got %v", err)
+		}
+	})
+
+	t.Run("the degraded readout has exactly two writers", func(t *testing.T) {
+		if err := store.Upsert(ctx, binding("team-deg", time.Minute)); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		if err := store.MarkDegraded(ctx, "team-deg", ""); err == nil {
+			t.Error("a degradation with no reason must be refused — the reason IS the remedy")
+		}
+		if err := store.MarkDegraded(ctx, "team-deg", "the Status field no longer carries \"Blocked\""); err != nil {
+			t.Fatalf("MarkDegraded: %v", err)
+		}
+		got, err := store.GetByTenant(ctx, "team-deg")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if !got.Degraded() || got.DegradedAt == nil {
+			t.Fatalf("binding must read degraded with a timestamp: %+v", got)
+		}
+
+		// A vocabulary repair must NOT clear it: only a resolution that
+		// succeeded, or a re-bind, says the board is serviceable again.
+		if err := store.SaveStatusVocabulary(ctx, "team-deg", got.Vocabulary()); err != nil {
+			t.Fatalf("SaveStatusVocabulary: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-deg"); !got.Degraded() {
+			t.Error("a vocabulary write must not silently clear a degradation")
+		}
+
+		if err := store.ClearDegraded(ctx, "team-deg"); err != nil {
+			t.Fatalf("ClearDegraded: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-deg"); got.Degraded() || got.DegradedAt != nil {
+			t.Errorf("ClearDegraded left %+v", got)
+		}
+
+		// A RE-BIND clears it too — it re-read the board and re-resolved every
+		// column by name, which is the documented remedy.
+		if err := store.MarkDegraded(ctx, "team-deg", "gone again"); err != nil {
+			t.Fatalf("MarkDegraded: %v", err)
+		}
+		if err := store.Upsert(ctx, binding("team-deg", time.Minute)); err != nil {
+			t.Fatalf("re-bind: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-deg"); got.Degraded() {
+			t.Errorf("a re-bind must clear the degradation, got %q", got.DegradedReason)
+		}
+
+		for _, err := range []error{
+			store.MarkDegraded(ctx, "nobody", "why"),
+			store.ClearDegraded(ctx, "nobody"),
+		} {
+			if !errors.Is(err, forge.ErrBoardBindingNotFound) {
+				t.Errorf("health write on a missing binding: want ErrBoardBindingNotFound, got %v", err)
+			}
+		}
+	})
+
 	t.Run("tenants are isolated", func(t *testing.T) {
 		if err := store.Upsert(ctx, binding("team-x", time.Minute)); err != nil {
 			t.Fatalf("Upsert: %v", err)

--- a/pkg/forge/board_binding_store_test.go
+++ b/pkg/forge/board_binding_store_test.go
@@ -140,7 +140,7 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 			t.Fatalf("GetByTenant: %v", err)
 		}
 		at := base.Add(2 * time.Hour)
-		won, err := store.ClaimSync(ctx, "team-cas", seen.LastSyncedAt, at)
+		won, err := store.ClaimSync(ctx, "team-cas", seen.LastSyncedAt, at, "owner-cas")
 		if err != nil {
 			t.Fatalf("ClaimSync: %v", err)
 		}
@@ -148,7 +148,7 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 			t.Fatal("the first claimant must win")
 		}
 		// A second replica presenting the SAME stale watermark must lose.
-		won2, err := store.ClaimSync(ctx, "team-cas", seen.LastSyncedAt, at)
+		won2, err := store.ClaimSync(ctx, "team-cas", seen.LastSyncedAt, at, "owner-cas")
 		if err != nil {
 			t.Fatalf("ClaimSync (second): %v", err)
 		}
@@ -192,11 +192,11 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		}
 		// (a) the value the CALLER holds — never round-tripped through the store.
 		at := nsWatermark.Add(time.Hour)
-		won, err := store.ClaimSync(ctx, "team-precision", nsWatermark, at)
+		won, err := store.ClaimSync(ctx, "team-precision", nsWatermark, at, "owner-p")
 		if err != nil || !won {
 			t.Fatalf("claim with the caller's own watermark: won=%v err=%v", won, err)
 		}
-		if err := store.ReleaseSync(ctx, "team-precision"); err != nil {
+		if err := store.ReleaseSync(ctx, "team-precision", "owner-p"); err != nil {
 			t.Fatalf("ReleaseSync: %v", err)
 		}
 		// (b) the value READ BACK — the shape the sync worker actually uses,
@@ -205,16 +205,16 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		if err != nil {
 			t.Fatalf("GetByTenant: %v", err)
 		}
-		won2, err := store.ClaimSync(ctx, "team-precision", seen.LastSyncedAt, at.Add(time.Hour))
+		won2, err := store.ClaimSync(ctx, "team-precision", seen.LastSyncedAt, at.Add(time.Hour), "owner-p")
 		if err != nil || !won2 {
 			t.Fatalf("claim with the stored watermark: won=%v err=%v — the periodic pass would stop after its first run", won2, err)
 		}
-		if err := store.ReleaseSync(ctx, "team-precision"); err != nil {
+		if err := store.ReleaseSync(ctx, "team-precision", "owner-p"); err != nil {
 			t.Fatalf("ReleaseSync (second): %v", err)
 		}
 		// And a watermark that is genuinely different still loses, so the
 		// truncation has not turned the CAS into "always match".
-		if won3, err := store.ClaimSync(ctx, "team-precision", nsWatermark, at.Add(2*time.Hour)); err != nil || won3 {
+		if won3, err := store.ClaimSync(ctx, "team-precision", nsWatermark, at.Add(2*time.Hour), "owner-p"); err != nil || won3 {
 			t.Fatalf("a stale watermark must still lose: won=%v err=%v", won3, err)
 		}
 	})
@@ -231,14 +231,14 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 			t.Fatalf("Upsert: %v", err)
 		}
 		at := base.Add(time.Hour)
-		won, err := store.ClaimSync(ctx, "team-lease", time.Time{}, at)
+		won, err := store.ClaimSync(ctx, "team-lease", time.Time{}, at, "owner-l")
 		if err != nil || !won {
 			t.Fatalf("ClaimSync: won=%v err=%v", won, err)
 		}
 		// One interval later the binding is due again and the pass is still
 		// running. The presented watermark MATCHES — only the lease refuses.
 		overrun := at.Add(90 * time.Second)
-		won2, err := store.ClaimSync(ctx, "team-lease", at, overrun)
+		won2, err := store.ClaimSync(ctx, "team-lease", at, overrun, "owner-l")
 		if err != nil {
 			t.Fatalf("ClaimSync (overlapping): %v", err)
 		}
@@ -259,38 +259,79 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		if err := store.Upsert(ctx, binding("team-lease", time.Minute)); err != nil {
 			t.Fatalf("Upsert during a pass: %v", err)
 		}
-		if wonRebind, err := store.ClaimSync(ctx, "team-lease", at, overrun); err != nil || wonRebind {
+		if wonRebind, err := store.ClaimSync(ctx, "team-lease", at, overrun, "owner-l"); err != nil || wonRebind {
 			t.Fatalf("a re-bind released a running pass's lease: won=%v err=%v", wonRebind, err)
 		}
 		// Releasing at pass end hands the board back immediately — the TTL is
 		// only ever reached by a replica that died mid-pass.
-		if err := store.ReleaseSync(ctx, "team-lease"); err != nil {
+		if err := store.ReleaseSync(ctx, "team-lease", "owner-l"); err != nil {
 			t.Fatalf("ReleaseSync: %v", err)
 		}
-		won3, err := store.ClaimSync(ctx, "team-lease", at, overrun)
+		won3, err := store.ClaimSync(ctx, "team-lease", at, overrun, "owner-l")
 		if err != nil || !won3 {
 			t.Fatalf("after ReleaseSync the next pass must claim: won=%v err=%v", won3, err)
 		}
 		// And a lease nobody released expires, so a dead replica costs one
 		// TTL of staleness rather than the board forever.
 		expired := overrun.Add(forge.BoardSyncLeaseTTL).Add(time.Second)
-		won4, err := store.ClaimSync(ctx, "team-lease", overrun, expired)
+		won4, err := store.ClaimSync(ctx, "team-lease", overrun, expired, "owner-l")
 		if err != nil || !won4 {
 			t.Fatalf("an expired lease must be reclaimable: won=%v err=%v", won4, err)
 		}
-		if err := store.ReleaseSync(ctx, "team-lease"); err != nil {
+		if err := store.ReleaseSync(ctx, "team-lease", "owner-l"); err != nil {
+			t.Fatalf("ReleaseSync (cleanup): %v", err)
+		}
+	})
+
+	t.Run("a late release does not clear its successor's lease", func(t *testing.T) {
+		// A pass that OVERRUNS the TTL loses its lease to the next tick, which
+		// is the point. What must not follow is its deferred release clearing
+		// the lease of the pass that legitimately took over: the board would
+		// be unprotected while that successor is still inside its pass, and
+		// the tick after it would claim — two concurrent passes, which is the
+		// exact overlap the lease exists to refuse.
+		if err := store.Upsert(ctx, binding("team-late", time.Minute)); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		t0 := base.Add(5 * time.Hour)
+		wonA, err := store.ClaimSync(ctx, "team-late", time.Time{}, t0, "replica-A")
+		if err != nil || !wonA {
+			t.Fatalf("A claims: won=%v err=%v", wonA, err)
+		}
+		// A overruns; at T0+TTL its lease has lapsed and B legitimately wins.
+		t1 := t0.Add(forge.BoardSyncLeaseTTL).Add(time.Second)
+		wonB, err := store.ClaimSync(ctx, "team-late", t0, t1, "replica-B")
+		if err != nil || !wonB {
+			t.Fatalf("B reclaims the expired lease: won=%v err=%v", wonB, err)
+		}
+		// A now finishes and releases. It owns nothing any more, and it must
+		// be TOLD so rather than silently clearing B's hold.
+		if err := store.ReleaseSync(ctx, "team-late", "replica-A"); !errors.Is(err, forge.ErrBoardSyncLeaseLost) {
+			t.Fatalf("a late release must report the lost lease, got %v", err)
+		}
+		if wonC, err := store.ClaimSync(ctx, "team-late", t1, t1.Add(90*time.Second), "replica-C"); err != nil || wonC {
+			t.Fatalf("C claimed a board B is still inside: won=%v err=%v", wonC, err)
+		}
+		// B's own release is the one that frees it.
+		if err := store.ReleaseSync(ctx, "team-late", "replica-B"); err != nil {
+			t.Fatalf("B releases its own lease: %v", err)
+		}
+		if wonD, err := store.ClaimSync(ctx, "team-late", t1, t1.Add(90*time.Second), "replica-D"); err != nil || !wonD {
+			t.Fatalf("after B released, the next pass must claim: won=%v err=%v", wonD, err)
+		}
+		if err := store.ReleaseSync(ctx, "team-late", "replica-D"); err != nil {
 			t.Fatalf("ReleaseSync (cleanup): %v", err)
 		}
 	})
 
 	t.Run("ReleaseSync on a missing binding is a typed error", func(t *testing.T) {
-		if err := store.ReleaseSync(ctx, "nobody"); !errors.Is(err, forge.ErrBoardBindingNotFound) {
+		if err := store.ReleaseSync(ctx, "nobody", "anyone"); !errors.Is(err, forge.ErrBoardBindingNotFound) {
 			t.Fatalf("want ErrBoardBindingNotFound, got %v", err)
 		}
 	})
 
 	t.Run("ClaimSync on a missing binding is a typed error", func(t *testing.T) {
-		_, err := store.ClaimSync(ctx, "nobody", time.Time{}, base)
+		_, err := store.ClaimSync(ctx, "nobody", time.Time{}, base, "owner-x")
 		if !errors.Is(err, forge.ErrBoardBindingNotFound) {
 			t.Fatalf("want ErrBoardBindingNotFound, got %v", err)
 		}

--- a/pkg/forge/board_vocabulary.go
+++ b/pkg/forge/board_vocabulary.go
@@ -1,0 +1,208 @@
+package forge
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// The binding's cached STATUS VOCABULARY and its repair (ADR-097 §5).
+//
+// BindBoard turns names into ids once. What it stores is two halves that go
+// stale independently against a board the operator keeps editing:
+//
+//   - the OPTION IDS (state → id) are what every write uses. They survive a
+//     rename and die with a delete;
+//   - the COLUMN NAMES (the StatusMapping) are what both directions COMPARE:
+//     the import maps a board status onto a native state, the reflect checks
+//     the state's status against the board's. They survive a delete-and-re-add
+//     and die with a rename.
+//
+// So a rename leaves a valid id under a name nothing matches — the import goes
+// inert and the reflect rewrites the same option every pass, forever — and a
+// re-add leaves a matching name over a dead id. Neither is an exotic case: a
+// board column is an operator's to edit.
+//
+// The repair below re-resolves both halves against the board's live field, by
+// id first and by name second. It is pure; persistence and the degraded
+// readout belong to the caller.
+
+// StatusVocabulary is the cached half of a binding: the (column ⇄ state) map,
+// the option id per state, and the mapped columns the board does not carry.
+//
+// It is what a repair rewrites, and the ONLY thing it rewrites — a binding's
+// address, credential and policy are the operator's, never a sync pass's.
+type StatusVocabulary struct {
+	Mapping         []StatusMapping   `bson:"status_mapping,omitempty" json:"status_mapping,omitempty"`
+	Options         map[string]string `bson:"status_options,omitempty" json:"status_options,omitempty"`
+	StatusFieldID   string            `bson:"status_field_id,omitempty" json:"status_field_id,omitempty"`
+	MissingStatuses []string          `bson:"missing_statuses,omitempty" json:"missing_statuses,omitempty"`
+}
+
+// Vocabulary reads the binding's cached status vocabulary.
+func (b BoardBinding) Vocabulary() StatusVocabulary {
+	return StatusVocabulary{
+		Mapping: b.StatusMapping, Options: b.StatusOptions,
+		StatusFieldID: b.StatusFieldID, MissingStatuses: b.MissingStatuses,
+	}
+}
+
+// SetVocabulary writes it back.
+func (b *BoardBinding) SetVocabulary(v StatusVocabulary) {
+	b.StatusMapping, b.StatusOptions = v.Mapping, v.Options
+	b.StatusFieldID, b.MissingStatuses = v.StatusFieldID, v.MissingStatuses
+}
+
+// StatusRename is one column the board renamed under a stable option id.
+type StatusRename struct {
+	State string
+	From  string
+	To    string
+}
+
+// LostColumn is one mapped column the board answers to under NEITHER its
+// cached option id nor its name. Both halves are reported: the operator
+// re-creates a COLUMN, the sync serves a STATE.
+type LostColumn struct {
+	State  string
+	Status string
+}
+
+// StatusVocabularyRepair reports what one reconciliation changed, and what it
+// could not. Each list holds NATIVE STATE names, so a caller can act per card.
+type StatusVocabularyRepair struct {
+	// Renamed are columns still identified by their cached id whose NAME the
+	// board changed. Repaired by adopting the board's name.
+	Renamed []StatusRename
+	// Rebound are columns whose cached id is dead but whose name still
+	// resolves — deleted and re-added. Repaired by adopting the new id.
+	Rebound []string
+	// Adopted are states the board had no column for when the binding was made
+	// and now does.
+	Adopted []string
+	// Lost are the columns that answer to NEITHER their cached id nor their
+	// name. Nothing here can repair that: their option is dropped so the
+	// reflect stops retrying them, and the binding is marked degraded.
+	Lost []LostColumn
+}
+
+// Changed reports whether the repair altered the vocabulary at all — i.e.
+// whether the caller owes the store a write.
+func (r StatusVocabularyRepair) Changed() bool {
+	return len(r.Renamed)+len(r.Rebound)+len(r.Adopted)+len(r.Lost) > 0
+}
+
+// Renames maps each renamed column's OLD name (folded) to its new one.
+//
+// A card's recorded sync status is a column NAME, so after a rename every card
+// carries a name the vocabulary no longer knows. Reading those records through
+// this map is what keeps a rename from reading as "the board moved to an
+// unknown column" on every card at once.
+func (r StatusVocabularyRepair) Renames() map[string]string {
+	if len(r.Renamed) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(r.Renamed))
+	for _, m := range r.Renamed {
+		out[foldName(m.From)] = m.To
+	}
+	return out
+}
+
+// Reason renders the degradation message for the lost columns, or "" when
+// nothing was lost. It NAMES them, because the remedy is to re-create one of
+// those columns or re-bind the board with a map that matches what it carries.
+func (r StatusVocabularyRepair) Reason() string {
+	if len(r.Lost) == 0 {
+		return ""
+	}
+	lost := make([]string, 0, len(r.Lost))
+	for _, c := range r.Lost {
+		lost = append(lost, fmt.Sprintf("%q (%s)", c.Status, c.State))
+	}
+	sort.Strings(lost)
+	return fmt.Sprintf("the %s field no longer carries %s; re-create the column, or re-bind the board with a --status-map that matches it",
+		ProjectStatusFieldName, strings.Join(lost, ", "))
+}
+
+// ReconcileStatusOptions re-resolves the binding's cached status vocabulary
+// against the board's LIVE schema, and reports what it repaired.
+//
+// Resolution order per mapped state, and it is the whole point:
+//
+//  1. the cached OPTION ID still on the field ⇒ the column lives; adopt the
+//     board's current NAME for it (this is the rename repair);
+//  2. else the mapped NAME still on the field ⇒ the column was re-created, or
+//     added since the bind; adopt its id;
+//  3. else ⇒ LOST. Drop the dead id so nothing retries it, and report it.
+//
+// The Status FIELD's own id is refreshed the same way — it is resolved by
+// name, so a field deleted and re-created is repaired rather than fatal.
+//
+// A labels-only binding (no Status field at bind time) has no vocabulary and
+// is left alone. A binding whose Status field has vanished loses every state:
+// there is nothing left to write into.
+func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyRepair {
+	var rep StatusVocabularyRepair
+	if b == nil || b.StatusFieldID == "" {
+		return rep
+	}
+	field, ok := project.Field(ProjectStatusFieldName)
+	if !ok || !field.SingleSelect() {
+		// The field itself is gone. Every cached id is unwritable; say so once
+		// rather than failing one write per card per pass.
+		for _, m := range b.Mapping() {
+			if b.StatusOptions[m.State] != "" {
+				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
+			}
+		}
+		if len(rep.Lost) > 0 {
+			b.StatusOptions = map[string]string{}
+		}
+		return rep
+	}
+
+	mapping := append([]StatusMapping(nil), b.Mapping()...)
+	options := make(map[string]string, len(b.StatusOptions))
+	for state, id := range b.StatusOptions {
+		options[state] = id
+	}
+	var missing []string
+	for i, m := range mapping {
+		id := options[m.State]
+		if opt, ok := field.OptionByID(id); id != "" && ok {
+			if !strings.EqualFold(strings.TrimSpace(opt.Name), strings.TrimSpace(m.Status)) {
+				rep.Renamed = append(rep.Renamed, StatusRename{State: m.State, From: m.Status, To: opt.Name})
+				mapping[i].Status = opt.Name
+			}
+			continue
+		}
+		opt, ok := field.Option(m.Status)
+		switch {
+		case !ok:
+			missing = append(missing, m.Status)
+			if id != "" {
+				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
+				delete(options, m.State)
+			}
+		case id == "":
+			options[m.State] = opt.ID
+			rep.Adopted = append(rep.Adopted, m.State)
+		default:
+			options[m.State] = opt.ID
+			rep.Rebound = append(rep.Rebound, m.State)
+		}
+	}
+	sort.Strings(missing) // stable report, like the bind's own
+	if field.ID != "" && field.ID != b.StatusFieldID {
+		// The field was re-created. Its NAME is what resolves it, exactly as
+		// at bind time, so this is repairable rather than fatal.
+		rep.Rebound = append(rep.Rebound, ProjectStatusFieldName)
+		b.StatusFieldID = field.ID
+	}
+	if !rep.Changed() {
+		return rep
+	}
+	b.StatusMapping, b.StatusOptions, b.MissingStatuses = mapping, options, missing
+	return rep
+}

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -1,0 +1,192 @@
+package forge_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The binding caches names AND ids, and the two go stale independently. These
+// pin each way they can disagree with the board, and which of the two the
+// repair believes.
+
+func vocabProject(options ...forge.ProjectFieldOption) forge.Project {
+	return forge.Project{ID: "PVT_p", Number: 203, Fields: []forge.ProjectField{
+		{ID: "PVTSSF_status", Name: "Status", DataType: "SINGLE_SELECT", Options: options},
+	}}
+}
+
+func vocabBinding() *forge.BoardBinding {
+	return &forge.BoardBinding{
+		TenantID: "team-a", Provider: forge.ProviderGitHub,
+		Owner: "SocialGouv", OwnerKind: forge.ProjectOwnerOrg, Number: 203,
+		ConnectionID: "conn-1", ProjectID: "PVT_p", StatusFieldID: "PVTSSF_status",
+		StatusMapping: []forge.StatusMapping{
+			{Status: "Planned", State: "ready"},
+			{Status: "In progress", State: "in_progress"},
+		},
+		StatusOptions: map[string]string{"ready": "o_planned", "in_progress": "o_prog"},
+	}
+}
+
+func TestReconcileStatusOptionsAdoptsARenamedColumn(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		// Same id, new name: the forge keeps the id across a rename.
+		forge.ProjectFieldOption{ID: "o_prog", Name: "Doing"},
+	))
+
+	if len(rep.Renamed) != 1 || rep.Renamed[0].From != "In progress" || rep.Renamed[0].To != "Doing" {
+		t.Fatalf("Renamed = %+v, want the in_progress column", rep.Renamed)
+	}
+	if got, ok := forge.StatusForState(b.Mapping(), "in_progress"); !ok || got != "Doing" {
+		t.Errorf("mapping = %q (ok=%v), want the board's current name", got, ok)
+	}
+	if id, _ := b.OptionForState("in_progress"); id != "o_prog" {
+		t.Errorf("option id = %q, want the unchanged one — a rename keeps it", id)
+	}
+	// The board maps the new name back onto the state, so the IMPORT direction
+	// works again too. Without that it silently no-ops on every item.
+	if st, ok := forge.StateForStatus(b.Mapping(), "Doing"); !ok || st != "in_progress" {
+		t.Errorf("StateForStatus(%q) = %q,%v — the import direction must resolve too", "Doing", st, ok)
+	}
+	if rep.Reason() != "" {
+		t.Errorf("a rename is repairable, not a degradation: %q", rep.Reason())
+	}
+	if got := rep.Renames()["in progress"]; got != "Doing" {
+		t.Errorf("Renames() = %v, want the old name folded to the new", rep.Renames())
+	}
+}
+
+func TestReconcileStatusOptionsRebindsARecreatedColumn(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		// Same name, NEW id: deleted and re-added.
+		forge.ProjectFieldOption{ID: "o_prog2", Name: "In progress"},
+	))
+
+	if len(rep.Rebound) != 1 || rep.Rebound[0] != "in_progress" {
+		t.Fatalf("Rebound = %+v, want the in_progress column", rep.Rebound)
+	}
+	if id, _ := b.OptionForState("in_progress"); id != "o_prog2" {
+		t.Errorf("option id = %q, want the board's current one", id)
+	}
+	if rep.Reason() != "" {
+		t.Errorf("a re-created column resolves by name; it is not a degradation: %q", rep.Reason())
+	}
+}
+
+func TestReconcileStatusOptionsAdoptsAColumnAddedSinceTheBind(t *testing.T) {
+	b := vocabBinding()
+	delete(b.StatusOptions, "in_progress") // the board had no such column at bind time
+	b.MissingStatuses = []string{"In progress"}
+
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "In progress"},
+	))
+	if len(rep.Adopted) != 1 || rep.Adopted[0] != "in_progress" {
+		t.Fatalf("Adopted = %+v, want the column the operator added", rep.Adopted)
+	}
+	if id, _ := b.OptionForState("in_progress"); id != "o_prog" {
+		t.Errorf("option id = %q, want the newly discovered one", id)
+	}
+	if len(b.MissingStatuses) != 0 {
+		t.Errorf("MissingStatuses = %v, want empty — the column exists now", b.MissingStatuses)
+	}
+}
+
+func TestReconcileStatusOptionsLosesADeletedColumn(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+	))
+
+	if len(rep.Lost) != 1 || rep.Lost[0].State != "in_progress" || rep.Lost[0].Status != "In progress" {
+		t.Fatalf("Lost = %+v, want the deleted column with both its names", rep.Lost)
+	}
+	if _, ok := b.OptionForState("in_progress"); ok {
+		t.Error("the dead option id must be dropped, so nothing retries a write that cannot land")
+	}
+	reason := rep.Reason()
+	if !strings.Contains(reason, "In progress") || !strings.Contains(reason, "in_progress") {
+		t.Errorf("reason = %q, want it to name the COLUMN (the remedy) and the state (the effect)", reason)
+	}
+	// The covered half keeps working: a degradation is partial, never a stop.
+	if id, _ := b.OptionForState("ready"); id != "o_planned" {
+		t.Errorf("the surviving column must still resolve, got %q", id)
+	}
+}
+
+func TestReconcileStatusOptionsLosesEverythingWhenTheFieldIsGone(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203})
+
+	if len(rep.Lost) != 2 {
+		t.Fatalf("Lost = %+v, want every mapped column — there is nothing left to write into", rep.Lost)
+	}
+	if len(b.StatusOptions) != 0 {
+		t.Errorf("StatusOptions = %v, want empty", b.StatusOptions)
+	}
+}
+
+func TestReconcileStatusOptionsRebindsARecreatedField(t *testing.T) {
+	b := vocabBinding()
+	project := vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "In progress"},
+	)
+	project.Fields[0].ID = "PVTSSF_fresh" // the whole field deleted and re-added
+
+	rep := b.ReconcileStatusOptions(project)
+	if !rep.Changed() || b.StatusFieldID != "PVTSSF_fresh" {
+		t.Fatalf("the field id must be re-resolved by name: %q (%+v)", b.StatusFieldID, rep)
+	}
+	if rep.Reason() != "" {
+		t.Errorf("a re-created field resolves by name; it is not a degradation: %q", rep.Reason())
+	}
+}
+
+func TestReconcileStatusOptionsIsANoOpOnAnAgreeingBoard(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "In progress"},
+	))
+	if rep.Changed() {
+		t.Fatalf("nothing drifted, so nothing may be written back: %+v", rep)
+	}
+	if rep.Renames() != nil {
+		t.Errorf("Renames() = %v, want nil", rep.Renames())
+	}
+}
+
+// A labels-only binding (the board carries no Status field, a shape BindBoard
+// accepts) has no status vocabulary at all — it must not be reported as
+// degraded for something it never bound.
+func TestReconcileStatusOptionsLeavesALabelsOnlyBindingAlone(t *testing.T) {
+	b := vocabBinding()
+	b.StatusFieldID = ""
+	b.StatusOptions = nil
+
+	rep := b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203})
+	if rep.Changed() || rep.Reason() != "" {
+		t.Fatalf("a labels-only binding has nothing to repair: %+v", rep)
+	}
+}
+
+// Case and whitespace are how a board writes a column, not what it is: the
+// repair must not report "In Progress" as a rename of "In progress".
+func TestReconcileStatusOptionsIgnoresCaseAndSpacing(t *testing.T) {
+	b := vocabBinding()
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: " planned "},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "IN PROGRESS"},
+	))
+	if rep.Changed() {
+		t.Fatalf("a case/spacing difference is the same column: %+v", rep)
+	}
+}

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -444,7 +445,22 @@ type AppClient struct {
 	// and only a caller that needs one of these would fail — at the write,
 	// unless it asked PreflightFor first.
 	denied map[string]bool
+	// scoped caches the tokens minted for a NARROWER, opt-in grant than the
+	// runtime baseline (the board profile), keyed by the permission set so a
+	// broad grant can never be handed to a differently-scoped call.
+	scoped map[string]scopedToken
 }
+
+// scopedToken is one cached installation token and when it stops being usable.
+type scopedToken struct {
+	token string
+	exp   time.Time
+}
+
+// scopedTokenLeeway is how much of a token's life is left unused, so a long
+// pass started just under the wire cannot have its token die mid-way. GitHub
+// issues installation tokens for ~1h, so reuse covers many passes.
+const scopedTokenLeeway = 5 * time.Minute
 
 // PermissionStatuses is the OPTIONAL commit-status permission the management
 // token asks for on top of the runtime baseline — what the merge gate posts
@@ -493,6 +509,60 @@ func (a *AppClient) rest(ctx context.Context) (*AdminClient, error) {
 		a.token, a.exp, a.denied = tok, exp, denied
 	}
 	return &AdminClient{HTTP: a.HTTP, APIBase: a.apiBase(), Token: a.token}, nil
+}
+
+// scopedREST returns an AdminClient backed by a token minted for exactly perms,
+// cached until it nears expiry.
+//
+// Minting per CALL is what this replaces: every board method went through its
+// own mint, so one reconciliation pass cost a token round trip per project
+// read, per item page and per reflected card — each an RS256-signed App JWT
+// against an endpoint GitHub rate-limits for abuse — repeated on the binding's
+// interval forever, and widening the pass duration the sync lease has to cover.
+//
+// Caching does not widen the leak window it was avoided for: GitHub's minimum
+// token life is ~1h whatever the caller does, so a per-call mint bought a
+// shorter blast radius only in theory. What DOES matter is the key: a token is
+// only ever served back to a call asking for the same permission set, so the
+// org-wide board grant cannot ride an ordinary push.
+//
+// The mint happens under the same lock as rest()'s, which makes concurrent
+// callers wait for one mint instead of racing N.
+func (a *AppClient) scopedREST(ctx context.Context, perms map[string]string) (*AdminClient, error) {
+	key := permissionSetKey(perms)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if t, ok := a.scoped[key]; ok && a.clock().Before(t.exp.Add(-scopedTokenLeeway)) {
+		return &AdminClient{HTTP: a.HTTP, APIBase: a.apiBase(), Token: t.token}, nil
+	}
+	tok, exp, err := MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
+		&InstallationTokenOptions{Permissions: perms})
+	if err != nil {
+		return nil, err
+	}
+	if a.scoped == nil {
+		a.scoped = map[string]scopedToken{}
+	}
+	a.scoped[key] = scopedToken{token: tok, exp: exp}
+	return &AdminClient{HTTP: a.HTTP, APIBase: a.apiBase(), Token: tok}, nil
+}
+
+// permissionSetKey renders a grant set as a stable string, so two calls asking
+// for the same permissions share a token and no others do.
+func permissionSetKey(perms map[string]string) string {
+	names := make([]string, 0, len(perms))
+	for name := range perms {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	for _, name := range names {
+		b.WriteString(name)
+		b.WriteByte('=')
+		b.WriteString(perms[name])
+		b.WriteByte(';')
+	}
+	return b.String()
 }
 
 // PreflightFor mints (or reuses) the installation token and nothing else,

--- a/pkg/forge/github/projects_app.go
+++ b/pkg/forge/github/projects_app.go
@@ -6,25 +6,22 @@ import (
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
 
-// AppClient's half of forge.BoardClient. Every call mints a DEDICATED
-// organization_projects:write installation token for that single call — the
-// CreateRepo precedent — so the cached runtime token keeps its minimal
-// permission set and an org-wide roadmap grant never rides an ordinary push.
+// AppClient's half of forge.BoardClient. Every call goes through a DEDICATED
+// organization_projects:write installation token, cached separately from the
+// runtime one, so the runtime token keeps its minimal permission set and an
+// org-wide roadmap grant never rides an ordinary push.
 //
 // The pair exists at all because of the parity rule: a capability wired for
 // one credential shape and not the other is a defect, and a board binding
 // resolves whichever connection the team holds.
 
 // projectsREST returns an AdminClient backed by a token minted for board calls
-// only. It is deliberately NOT cached: the grant is broad, and a short-lived
-// token per call bounds the blast radius of a leak to one operation.
+// only, cached per permission set (scopedREST): the org-wide grant is served
+// back only to another board call, never to an ordinary push, while one
+// reconciliation pass pays ONE mint instead of one per project read, item page
+// and reflected card.
 func (a *AppClient) projectsREST(ctx context.Context) (*AdminClient, error) {
-	tok, _, err := MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
-		&InstallationTokenOptions{Permissions: ProjectsInstallationPermissions()})
-	if err != nil {
-		return nil, err
-	}
-	return &AdminClient{HTTP: a.HTTP, APIBase: a.apiBase(), Token: tok}, nil
+	return a.scopedREST(ctx, ProjectsInstallationPermissions())
 }
 
 // GraphQL performs a GraphQL call under a board-scoped installation token.

--- a/pkg/forge/github/projects_permissions_test.go
+++ b/pkg/forge/github/projects_permissions_test.go
@@ -1,7 +1,14 @@
 package github
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
@@ -67,5 +74,180 @@ func TestAppClientIsABoardClient(t *testing.T) {
 	var admin forge.Admin = &AppClient{}
 	if _, ok := forge.AsBoardClient(admin); !ok {
 		t.Fatal("github AppClient must implement forge.BoardClient")
+	}
+}
+
+// countingMintServer answers the mint endpoint and every GraphQL call, keeping
+// a tally of each. It is the oracle for "how many round trips does one pass
+// actually cost".
+type countingMintServer struct {
+	srv *httptest.Server
+	// mu guards the tallies: httptest serves concurrent requests, so a test
+	// that exercises the client from N goroutines would otherwise race in its
+	// own oracle.
+	mu         sync.Mutex
+	mints      int
+	mintPerms  []map[string]string
+	graphQL    int
+	expiresAt  func() time.Time
+	mintedName func(int) string
+}
+
+func (c *countingMintServer) counts() (mints, graphQL int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mints, c.graphQL
+}
+
+// permsAt returns the permission set of the n-th mint (0-based).
+func (c *countingMintServer) permsAt(n int) map[string]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if n >= len(c.mintPerms) {
+		return nil
+	}
+	return c.mintPerms[n]
+}
+
+func newCountingMintServer(t *testing.T) *countingMintServer {
+	t.Helper()
+	c := &countingMintServer{
+		expiresAt:  func() time.Time { return time.Now().UTC().Add(time.Hour) },
+		mintedName: func(n int) string { return fmt.Sprintf("ghs_board_%d", n) },
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/app/installations/99/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Permissions map[string]string `json:"permissions"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		c.mu.Lock()
+		c.mints++
+		c.mintPerms = append(c.mintPerms, req.Permissions)
+		name, exp := c.mintedName(c.mints), c.expiresAt()
+		c.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token": name, "expires_at": exp.Format(time.RFC3339),
+		})
+	})
+	mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, r *http.Request) {
+		c.mu.Lock()
+		c.graphQL++
+		c.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+			"organization": map[string]any{"projectV2": map[string]any{
+				"id": "PVT_p", "number": 203, "title": "Iterion", "url": "u",
+				"fields": map[string]any{"nodes": []any{}, "pageInfo": map[string]any{"hasNextPage": false}},
+			}},
+		}})
+	})
+	c.srv = httptest.NewServer(mux)
+	t.Cleanup(c.srv.Close)
+	return c
+}
+
+// TestAppClientCachesTheBoardToken pins that a board pass mints ONE token.
+//
+// projectsREST minted a fresh organization_projects:write token for every
+// BoardClient method, so a paged pass cost 1 mint for GetProject plus 1 per
+// item page plus 1 per reflected card — each an extra HTTPS round trip with an
+// RS256-signed App JWT, repeated on the binding's interval forever, against an
+// endpoint GitHub rate-limits for abuse. It also widened the pass duration the
+// lease TTL has to cover.
+func TestAppClientCachesTheBoardToken(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	c := newCountingMintServer(t)
+	app := &AppClient{HTTP: c.srv.Client(), WebBaseURL: c.srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99}
+
+	const calls = 5
+	for i := 0; i < calls; i++ {
+		if _, err := app.GetProject(context.Background(), forge.ProjectRef{Owner: "SocialGouv", Number: 203}); err != nil {
+			t.Fatalf("GetProject %d: %v", i, err)
+		}
+	}
+	mints, graphQL := c.counts()
+	if graphQL != calls {
+		t.Fatalf("graphQL calls = %d, want %d", graphQL, calls)
+	}
+	if mints != 1 {
+		t.Errorf("mints = %d for %d board calls, want 1 — a pass must not pay a token round trip per call", mints, calls)
+	}
+	if got := c.permsAt(0)["organization_projects"]; got != "write" {
+		t.Errorf("the board token was minted with %v, want organization_projects:write", c.permsAt(0))
+	}
+}
+
+// A token near expiry is re-minted rather than served, so a long pass never
+// carries a token that dies mid-way.
+func TestAppClientReMintsAnExpiringBoardToken(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	c := newCountingMintServer(t)
+	// Inside the leeway: every call must re-mint.
+	c.expiresAt = func() time.Time { return time.Now().UTC().Add(2 * time.Minute) }
+	app := &AppClient{HTTP: c.srv.Client(), WebBaseURL: c.srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99}
+
+	for i := 0; i < 3; i++ {
+		if _, err := app.GetProject(context.Background(), forge.ProjectRef{Owner: "SocialGouv", Number: 203}); err != nil {
+			t.Fatalf("GetProject %d: %v", i, err)
+		}
+	}
+	if mints, _ := c.counts(); mints != 3 {
+		t.Errorf("mints = %d, want 3 — a token about to expire must not be reused", mints)
+	}
+}
+
+// The board cache is scoped to its permission set, so the broad
+// organization_projects grant can never be served to an ordinary call — the
+// whole reason the board path does not use the runtime token.
+func TestAppClientBoardTokenNeverServesTheRuntimeCall(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	c := newCountingMintServer(t)
+	c.srv.Config.Handler.(*http.ServeMux).HandleFunc("/api/v3/repos/o/r/hooks", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]any{})
+	})
+	app := &AppClient{HTTP: c.srv.Client(), WebBaseURL: c.srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99}
+
+	if _, err := app.GetProject(context.Background(), forge.ProjectRef{Owner: "SocialGouv", Number: 203}); err != nil {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if _, err := app.ListHooks(context.Background(), "o/r"); err != nil {
+		t.Fatalf("ListHooks: %v", err)
+	}
+	if mints, _ := c.counts(); mints != 2 {
+		t.Fatalf("mints = %d, want 2 — the board token must not serve a runtime call", mints)
+	}
+	if _, ok := c.permsAt(1)["organization_projects"]; ok {
+		t.Errorf("the runtime token was minted with the board grant: %v", c.permsAt(1))
+	}
+}
+
+// Concurrent board calls mint ONCE. A pass reflects cards one at a time today,
+// but the client is shared per connection and the sync worker runs a tenant
+// per goroutine — an unguarded cache would let N callers race into N mints,
+// which is the very amplification the cache removes.
+func TestAppClientBoardTokenMintsOnceUnderConcurrency(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	c := newCountingMintServer(t)
+	app := &AppClient{HTTP: c.srv.Client(), WebBaseURL: c.srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99}
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := app.GetProject(context.Background(), forge.ProjectRef{Owner: "SocialGouv", Number: 203}); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("GetProject: %v", err)
+	}
+	if mints, _ := c.counts(); mints != 1 {
+		t.Errorf("mints = %d for %d concurrent board calls, want 1", mints, workers)
 	}
 }

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -294,8 +294,10 @@ func applyProjectItem(
 	//
 	// A native-wins conflict is the exception: recording the board's status
 	// here would tell the reflect below "the board already agrees", and it
-	// would push nothing. The reflect overwrites these two fields itself with
-	// what it actually wrote, which is what makes the next pass a no-op.
+	// would push nothing. The reflect writes these two fields itself with what
+	// it actually wrote — and when it writes NOTHING the caller closes them
+	// with what it observed, so the divergence is derived once rather than on
+	// every tick (see the reflect call below).
 	//
 	// A REFUSED write is the other exception, and the sharper one: recording a
 	// status iterion could not apply makes the NEXT pass read "the board
@@ -327,7 +329,22 @@ func applyProjectItem(
 	// It does NOT run when the board won (`applied`, or a GitHub-wins
 	// conflict): pushing there would overwrite the decision we just read.
 	if !applied && (decision == projectStatusNoop || decision == projectStatusConflictNative) {
-		reflectNativeState(ctx, bc, card, it, &sync, statusName, opts, res)
+		// A native-wins conflict declined to record the board's status above,
+		// on the promise that the reflect overwrites it with what it WROTE.
+		// The reflect has exits that write nothing — the two sides already
+		// agree, the native state is unmapped, the bound board has no column
+		// for it, the pass is read-only — and there the promise is unkept: the
+		// record stays stale, the next pass recomputes identical inputs and
+		// re-derives the same conflict, warning and counting on every tick for
+		// a divergence nothing is going to resolve. Recording what was
+		// OBSERVED closes it, and is not a false claim: the board says this
+		// value now, and it is exactly what "the status last synchronized"
+		// means. A FAILED write is the exception — the next pass must retry it.
+		if out := reflectNativeState(ctx, bc, card, it, &sync, statusName, opts, res); out == reflectNothingToWrite &&
+			decision == projectStatusConflictNative {
+			sync.Status = statusName
+			sync.StatusAt = statusAt
+		}
 	}
 	// Write ONLY what changed. This pass runs over every card on its interval,
 	// and native.Store.Update treats a non-nil Patch.External as a change with
@@ -367,6 +384,10 @@ func applyProjectItem(
 //
 // A failed write is counted and logged, never fatal: one card's 403 must not
 // abandon the rest of the board.
+//
+// The outcome is the caller's business: it is what tells a native-wins
+// conflict whether the record it declined to write was overwritten here, or
+// has to be closed by the caller instead.
 func reflectNativeState(
 	ctx context.Context,
 	bc forge.BoardClient,
@@ -376,42 +397,43 @@ func reflectNativeState(
 	boardStatus string,
 	opts *ProjectImportOptions,
 	res *ProjectImportResult,
-) {
+) reflectOutcome {
 	binding := opts.binding()
 	if binding == nil {
-		return // read-only pass: no write authority
+		return reflectNothingToWrite // read-only pass: no write authority
 	}
 	if sync.Status == "" {
 		// First sight of this card on this board: the board is the authority
 		// on the join, and the import already applied it. Pushing here would
-		// overwrite a column nobody has reconciled yet.
-		return
+		// overwrite a column nobody has reconciled yet. Only reachable from
+		// the no-op arm, which recorded the status already.
+		return reflectNothingToWrite
 	}
 	want, ok := forge.StatusForState(opts.statusMapping(), card.State)
 	if !ok {
 		// An unmapped native state (`review`, `waiting_deps`, …) is INERT: the
 		// board keeps showing the last true thing it was told.
-		return
+		return reflectNothingToWrite
 	}
 	if strings.EqualFold(strings.TrimSpace(want), strings.TrimSpace(boardStatus)) {
-		return // already there — the idempotence that keeps a pass free
+		return reflectNothingToWrite // already there — the idempotence that keeps a pass free
 	}
 	option, ok := binding.OptionForState(card.State)
 	if !ok {
 		logProjectWarn(opts, "project reflect: the bound board has no column for this state",
 			"card", card.ID, "state", card.State, "status", want)
-		return
+		return reflectNothingToWrite
 	}
 	if binding.ProjectID == "" || binding.StatusFieldID == "" {
 		logProjectWarn(opts, "project reflect: the binding carries no project/status id",
 			"card", card.ID, "state", card.State)
-		return
+		return reflectNothingToWrite
 	}
 	if err := bc.SetSingleSelect(ctx, binding.ProjectID, it.ID, binding.StatusFieldID, option); err != nil {
 		res.ReflectFailed++
 		logProjectWarn(opts, "project reflect: status write refused",
 			"card", card.ID, "item", it.ID, "state", card.State, "status", want, "error", err.Error())
-		return
+		return reflectFailed
 	}
 	res.Reflected++
 	// Record what we just wrote, so the next pass reads "already equal" and
@@ -421,6 +443,7 @@ func reflectNativeState(
 	sync.Status = want
 	sync.StatusAt = opts.now()
 	sync.StateAt = opts.now()
+	return reflectWrote
 }
 
 // projectSyncState reads the card's recorded sync state, resetting it when the
@@ -448,6 +471,23 @@ func projectStatusValue(it forge.ProjectItem) (string, time.Time) {
 	}
 	return fv.Value, fv.UpdatedAt
 }
+
+// reflectOutcome says what one reflect did to the board, which is what decides
+// whether the caller still owes the sync record an update.
+type reflectOutcome int
+
+const (
+	// reflectNothingToWrite: there was nothing to push, or nothing that COULD
+	// be pushed. Either way the board's status will not change on this pass,
+	// so a divergence left open here would be re-derived forever.
+	reflectNothingToWrite reflectOutcome = iota
+	// reflectWrote: the board's Status now says what the card's column means,
+	// and the reflect recorded it itself.
+	reflectWrote
+	// reflectFailed: the forge refused the write. The record stays stale ON
+	// PURPOSE — that is what makes the next pass retry.
+	reflectFailed
+)
 
 type projectStatusDecision int
 

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -39,6 +39,12 @@ type ProjectImportOptions struct {
 	// It is also where the option ids come from, so nothing is discovered
 	// per-card. Its StatusMapping/LabelFields win over the fields below.
 	Binding *forge.BoardBinding
+	// Bindings persists a Binding the pass had to REPAIR against the live
+	// board — a renamed or re-created column — and its degraded readout. Nil
+	// keeps the repair in memory for this pass only, which is what the local
+	// one-shot `iterion issue import --project` wants: it converges, it just
+	// does not remember.
+	Bindings forge.BoardBindingStore
 	// StatusMapping overrides the (board status ⇄ native state) pairs.
 	StatusMapping []forge.StatusMapping
 	// LabelFields overrides which single-select fields land as labels.
@@ -84,6 +90,14 @@ func (o *ProjectImportOptions) binding() *forge.BoardBinding {
 	return o.Binding
 }
 
+// bindingStore returns where a repaired binding is persisted, or nil.
+func (o *ProjectImportOptions) bindingStore() forge.BoardBindingStore {
+	if o == nil {
+		return nil
+	}
+	return o.Bindings
+}
+
 func (o *ProjectImportOptions) now() time.Time {
 	if o != nil && o.Now != nil {
 		return o.Now().UTC()
@@ -101,6 +115,13 @@ type ProjectImportResult struct {
 	// Reflected is the board items whose Status a native move updated — the
 	// other direction of the same pass.
 	Reflected int `json:"reflected"`
+	// ReflectNoColumn is the cards whose native state the bound board has no
+	// column for — a mapped column the board never carried (reported as
+	// `missing_statuses` at bind time), or one deleted since (which degrades
+	// the binding, once). Counted rather than warned per card: the same cards
+	// are unreflectable on every pass until the binding is repaired, and a
+	// per-card Warn on a 300-item board buries everything else.
+	ReflectNoColumn int `json:"reflect_no_column,omitempty"`
 	// ReflectFailed is the reflects the forge refused. Counted rather than
 	// fatal: one card's failed write must not abandon the rest of the board.
 	ReflectFailed int `json:"reflect_failed,omitempty"`
@@ -165,6 +186,7 @@ func ImportProjectBoard(
 	if err != nil {
 		return res, fmt.Errorf("project import: get project %s: %w", ref, err)
 	}
+	renamed := repairBinding(ctx, project, opts)
 
 	missing := map[string]int{}
 	cursor := ""
@@ -174,7 +196,7 @@ func ImportProjectBoard(
 			return res, fmt.Errorf("project import: list items of %s: %w", ref, err)
 		}
 		for _, it := range page.Items {
-			if err := applyProjectItem(ctx, bc, project, ref, provider, board, it, opts, &res, missing); err != nil {
+			if err := applyProjectItem(ctx, bc, project, ref, provider, board, it, opts, &res, missing, renamed); err != nil {
 				res.MissingRepos = rankMissingRepos(missing)
 				return res, err
 			}
@@ -186,6 +208,67 @@ func ImportProjectBoard(
 	}
 	res.MissingRepos = rankMissingRepos(missing)
 	return res, nil
+}
+
+// repairBinding re-resolves the binding's cached status vocabulary — the
+// (state → option id) map and the column NAMES those ids carried — against the
+// board schema this pass has already read, and returns the renames it found.
+//
+// It costs NO extra API call: the pass reads the project for its label fields
+// anyway. That is what makes it the right place. The alternative — discovering
+// the drift on a failed write — discovers it once per card per pass and never
+// repairs it, which is how a renamed column produced one redundant mutation per
+// bound card, on every pass, indefinitely.
+//
+// Persisting is best-effort: a store outage must not abandon the reconciliation
+// the operator is watching. The repair still applies in memory for this pass.
+func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImportOptions) map[string]string {
+	binding := opts.binding()
+	if binding == nil {
+		return nil // read-only pass: nothing is cached, so nothing is stale
+	}
+	was := binding.DegradedReason
+	rep := binding.ReconcileStatusOptions(project)
+	if !rep.Changed() {
+		return nil
+	}
+	store := opts.bindingStore()
+	if store != nil {
+		if err := store.SaveStatusVocabulary(ctx, binding.TenantID, binding.Vocabulary()); err != nil {
+			logProjectWarn(opts, "project board: the repaired status vocabulary could not be persisted",
+				"team", binding.TenantID, "error", err.Error())
+		}
+	}
+
+	switch reason := rep.Reason(); {
+	case reason != "":
+		if was != reason {
+			// ONCE, on the transition. The state itself lives on the binding
+			// (GET /api/teams/{id}/board-binding), which is where an operator
+			// can act on it — a Warn repeated every two minutes is not a
+			// signal, it is noise that buries the pass's real lines.
+			logProjectWarn(opts, "project board: a bound status column no longer exists on the board",
+				"team", binding.TenantID, "board", binding.Ref().String(), "reason", reason)
+		}
+		binding.DegradedReason = reason
+		if store != nil {
+			if err := store.MarkDegraded(ctx, binding.TenantID, reason); err != nil {
+				logProjectWarn(opts, "project board: the binding could not be flagged degraded",
+					"team", binding.TenantID, "error", err.Error())
+			}
+		}
+	case was != "" && len(rep.Adopted)+len(rep.Rebound) > 0:
+		// A column the last pass could not resolve resolves again — the flag
+		// is a readout of the LAST resolution, so it clears without a re-bind.
+		binding.DegradedReason, binding.DegradedAt = "", nil
+		if store != nil {
+			if err := store.ClearDegraded(ctx, binding.TenantID); err != nil {
+				logProjectWarn(opts, "project board: the binding's degraded flag could not be cleared",
+					"team", binding.TenantID, "error", err.Error())
+			}
+		}
+	}
+	return rep.Renames()
 }
 
 // rankMissingRepos orders the skipped repositories most-missing first, ties
@@ -226,6 +309,7 @@ func applyProjectItem(
 	opts *ProjectImportOptions,
 	res *ProjectImportResult,
 	missing map[string]int,
+	renamed map[string]string,
 ) error {
 	res.Items++
 	if it.Archived {
@@ -257,6 +341,14 @@ func applyProjectItem(
 	}
 
 	sync := projectSyncState(card, ref, it)
+	// A card's recorded status is a column NAME, so a rename repaired above
+	// leaves every card of that column naming something the vocabulary no
+	// longer knows. Reading the record through the rename keeps ONE operator
+	// edit from reading as "the board moved to an unknown column" on every
+	// card of that column at once.
+	if to, ok := renamed[strings.ToLower(strings.TrimSpace(sync.Status))]; ok {
+		sync.Status = to
+	}
 	statusName, statusAt := projectStatusValue(it)
 
 	patch := native.Patch{}
@@ -435,13 +527,26 @@ func reflectNativeState(
 	}
 	option, ok := binding.OptionForState(card.State)
 	if !ok {
-		logProjectWarn(opts, "project reflect: the bound board has no column for this state",
-			"card", card.ID, "state", card.State, "status", want)
+		// No column for this state: one the map named and the board never had
+		// (reported as `missing_statuses` at bind time), or one deleted since —
+		// which the pass's reconciliation already flagged on the binding, once.
+		// Counted, not warned: this card is unreflectable on EVERY pass until
+		// the binding is repaired, and a per-card Warn buries the rest.
+		res.ReflectNoColumn++
 		return reflectNothingToWrite
 	}
 	if binding.ProjectID == "" || binding.StatusFieldID == "" {
 		logProjectWarn(opts, "project reflect: the binding carries no project/status id",
 			"card", card.ID, "state", card.State)
+		return reflectNothingToWrite
+	}
+	if fv, ok := it.Field(forge.ProjectStatusFieldName); ok && fv.OptionID != "" && fv.OptionID == option {
+		// The board already carries the very OPTION we would write; only its
+		// NAME differs from what the binding cached. Ids are the write
+		// vocabulary, so this is the authoritative "already there" — the name
+		// comparison above is the fallback for a provider that reports no
+		// option id, and on its own it re-writes the same value forever after
+		// a column is renamed.
 		return reflectNothingToWrite
 	}
 	if err := bc.SetSingleSelect(ctx, binding.ProjectID, it.ID, binding.StatusFieldID, option); err != nil {

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -251,7 +251,7 @@ func applyProjectItem(
 	}
 
 	nativeAt := nativeStateAt(card, sync)
-	targetState, decision := decideProjectStatus(statusName, statusAt, nativeAt, sync, opts)
+	targetState, decision := decideProjectStatus(statusName, statusAt, nativeAt, card.State, sync, opts)
 	switch decision {
 	case projectStatusConflictGitHub, projectStatusConflictNative:
 		res.Conflicts++
@@ -523,8 +523,8 @@ func nativeStateAt(card *native.Issue, sync native.ExternalProject) time.Time {
 
 // decideProjectStatus resolves ADR-097's conflict rule. It returns the native
 // state to write ("" = write nothing) and why. nativeAt is the card's own
-// transition time (nativeStateAt).
-func decideProjectStatus(statusName string, statusAt, nativeAt time.Time, sync native.ExternalProject, opts *ProjectImportOptions) (string, projectStatusDecision) {
+// transition time (nativeStateAt); cardState is the column it sits in now.
+func decideProjectStatus(statusName string, statusAt, nativeAt time.Time, cardState string, sync native.ExternalProject, opts *ProjectImportOptions) (string, projectStatusDecision) {
 	if strings.TrimSpace(statusName) == "" {
 		return "", projectStatusNoop
 	}
@@ -545,12 +545,40 @@ func decideProjectStatus(statusName string, statusAt, nativeAt time.Time, sync n
 		// First sight: the board is the authority on the join.
 		return state, projectStatusApply
 	}
-	// 2/3. Both sides moved. Newer wins; a tie goes to the board, which is
+	// 2. Only the BOARD moved — the ordinary gesture on a forge board. It is a
+	// plain apply, never a conflict: the counter means "both sides moved"
+	// (ADR-097 §9.2), and a conflict resolved in the native side's favour
+	// makes the reflect push the card's old column back over the drag.
+	if !nativeMovedSince(sync, cardState, opts) {
+		return state, projectStatusApply
+	}
+	// 3/4. Both sides moved. Newer wins; a tie goes to the board, which is
 	// what a human is looking at.
 	if nativeAt.After(statusAt) {
 		return "", projectStatusConflictNative
 	}
 	return state, projectStatusConflictGitHub
+}
+
+// nativeMovedSince reports whether the card's column changed since the last
+// synchronization with this board.
+//
+// The oracle is a FACT, not a timestamp comparison: sync.Status is the board
+// status iterion last synchronized, so the native state it maps to IS
+// iterion's own last write. A card still sitting there has not moved, and a
+// timestamp-only rule cannot tell that from a card that moved and came back.
+//
+// A recorded status the mapping does not cover leaves the question
+// undecidable — iterion never derived a state from it — and the answer is
+// "assume it moved". A conflict that turns out one-sided costs one Warn; the
+// reverse silently overwrites somebody's decision, which is the one outcome
+// ADR-097 §9.4 forbids.
+func nativeMovedSince(sync native.ExternalProject, cardState string, opts *ProjectImportOptions) bool {
+	recorded, ok := forge.StateForStatus(opts.statusMapping(), sync.Status)
+	if !ok {
+		return true
+	}
+	return !strings.EqualFold(strings.TrimSpace(recorded), strings.TrimSpace(cardState))
 }
 
 // applyProjectLabels folds the item's label-bound field values into the card's

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -263,14 +263,27 @@ func applyProjectItem(
 		// CAS on the snapshot: an operator who moved the card between our read
 		// and this write wins — the board must not clobber a fresh decision
 		// with a fact it read a moment ago.
-		if _, _, err := board.SetStateFrom(cardID, card.State, targetState); err != nil {
+		//
+		// Losing that CAS is NOT an error: SetStateFrom answers a drifted card
+		// with (issue, changed=false, nil). Reading only the error counted a
+		// transition the store never made and recorded the board's status as
+		// synchronized, which turns every later pass into a no-op — and on the
+		// one-shot `iterion issue import --project` path nothing ever repairs
+		// it. A refused write and a lost CAS are the same fact here: nothing
+		// landed.
+		switch _, changed, err := board.SetStateFrom(cardID, card.State, targetState); {
+		case err != nil:
 			refused = true
 			if errors.Is(err, tracker.ErrTerminalStateExit) {
 				res.RefusedTerminal++
 			}
 			logProjectWarn(opts, "project import: state write refused", "card", cardID,
 				"from", card.State, "to", targetState, "error", err.Error())
-		} else {
+		case !changed:
+			refused = true
+			logProjectWarn(opts, "project import: state write skipped, the card moved first",
+				"card", cardID, "from", card.State, "to", targetState)
+		default:
 			applied = true
 			res.Moved++
 		}

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -122,6 +122,13 @@ type ProjectImportResult struct {
 	// own audit trail and dependents check — and automation never reopens. The
 	// two boards stay legitimately divergent until someone reopens the card.
 	RefusedTerminal int `json:"refused_terminal,omitempty"`
+	// SkippedArchived is the items the operator archived. The forge removes
+	// them from every board view but PRESERVES their field values, so one
+	// archived mid-column keeps reading as that column forever — driving a
+	// card from a value nobody can see, and reflecting onto a row nobody can
+	// read. Counted rather than silent: a card that stops following has to be
+	// explainable from the pass's own numbers.
+	SkippedArchived int `json:"skipped_archived,omitempty"`
 	// Skipped is items with nothing to join on — drafts and pull requests.
 	Skipped int `json:"skipped"`
 }
@@ -221,6 +228,14 @@ func applyProjectItem(
 	missing map[string]int,
 ) error {
 	res.Items++
+	if it.Archived {
+		// The operator took this item off the board. Its field values survive
+		// archiving, so both directions would keep working on a row nobody can
+		// see: the import would drive the card from a frozen column, and the
+		// reflect would push into a view that renders nothing.
+		res.SkippedArchived++
+		return nil
+	}
 	if it.Content.Kind != forge.ProjectContentIssue || it.Content.Repo == "" || it.Content.Number <= 0 {
 		// A draft has no issue; a pull request surfaces through the card's PR
 		// panel, not as a card of its own.

--- a/pkg/server/board_project_reflect_test.go
+++ b/pkg/server/board_project_reflect_test.go
@@ -18,16 +18,31 @@ import (
 // is also the echo suppressor. That double duty is why neither direction needs
 // to maintain a separate "who moved last" flag on every write.
 
+// testBinding is the binding a bind against testProject() produces. Its option
+// ids are READ from that fixture rather than invented: the reflect writes by
+// id and compares by id, so a binding whose ids match no column on the board it
+// is bound to cannot exercise either.
 func testBinding() *forge.BoardBinding {
+	project := testProject()
+	field, ok := project.Field(forge.ProjectStatusFieldName)
+	if !ok {
+		panic("the project fixture must carry a " + forge.ProjectStatusFieldName + " field")
+	}
+	mapping := forge.DefaultStatusMapping()
+	opts := make(map[string]string, len(mapping))
+	for _, m := range mapping {
+		opt, ok := field.Option(m.Status)
+		if !ok {
+			panic("the project fixture must carry the " + m.Status + " column")
+		}
+		opts[m.State] = opt.ID
+	}
 	return &forge.BoardBinding{
 		TenantID: "team-a", Provider: forge.ProviderGitHub,
 		Owner: "SocialGouv", OwnerKind: forge.ProjectOwnerOrg, Number: 203,
-		ConnectionID: "conn-1", ProjectID: "PVT_p", StatusFieldID: "PVTSSF_status",
-		StatusOptions: map[string]string{
-			"inbox": "o_inbox", "ready": "o_planned", "in_progress": "o_prog",
-			"blocked": "o_blocked", "done": "o_done",
-		},
-		StatusMapping: forge.DefaultStatusMapping(),
+		ConnectionID: "conn-1", ProjectID: project.ID, StatusFieldID: field.ID,
+		StatusOptions: opts,
+		StatusMapping: mapping,
 	}
 }
 
@@ -83,7 +98,7 @@ func TestSyncProjectBoardReflectsANativeMove(t *testing.T) {
 		t.Fatalf("writes = %+v, want one Status write", bc.writes)
 	}
 	w := bc.writes[0]
-	if w.ProjectID != "PVT_p" || w.ItemID != "PVTI_1" || w.FieldID != "PVTSSF_status" || w.OptionID != "o_prog" {
+	if w.ProjectID != "PVT_p" || w.ItemID != "PVTI_1" || w.FieldID != "PVTSSF_status" || w.OptionID != optionID(t, testProject(), "In progress") {
 		t.Errorf("write = %+v, want the In progress option on PVTI_1", w)
 	}
 	// The card's state must NOT change — the reflect pushes, it does not pull.
@@ -195,7 +210,7 @@ func TestSyncProjectBoardReflectsWhenNativeWinsTheConflict(t *testing.T) {
 	if res.Reflected != 1 {
 		t.Fatalf("Reflected = %d, want 1 — the winner's state must reach the board (%+v)", res.Reflected, res)
 	}
-	if len(bc.writes) != 1 || bc.writes[0].OptionID != "o_blocked" {
+	if len(bc.writes) != 1 || bc.writes[0].OptionID != optionID(t, testProject(), "Blocked") {
 		t.Fatalf("writes = %+v, want the Blocked option", bc.writes)
 	}
 	if got := mustGet(t, board, id).State; got != native.StateBlocked {
@@ -535,7 +550,7 @@ func TestSyncProjectBoardConflictReadsTheNativeTransitionTime(t *testing.T) {
 	if res.Reflected != 1 || len(bc.writes) != 1 {
 		t.Fatalf("Reflected = %d writes = %+v, want the native move pushed to the board", res.Reflected, bc.writes)
 	}
-	if w := bc.writes[0]; w.OptionID != "o_planned" {
+	if w := bc.writes[0]; w.OptionID != optionID(t, testProject(), "Planned") {
 		t.Errorf("wrote option %q, want the Planned option for `ready`", w.OptionID)
 	}
 }
@@ -632,13 +647,20 @@ func TestSyncProjectBoardConvergesWhenBothSidesAgree(t *testing.T) {
 // unmapped native state, and a bound board with no column for the state.
 func TestSyncProjectBoardConvergesWhenTheReflectCannotWrite(t *testing.T) {
 	for _, tc := range []struct {
-		name  string
-		state string
-		bind  func(*forge.BoardBinding)
+		name    string
+		state   string
+		bind    func(*forge.BoardBinding)
+		project func(*testing.T) forge.Project
 	}{
-		{"an unmapped native state is inert, not a standing conflict", native.StateReview, nil},
-		{"a board with no column for the state is reported once, not every tick", native.StateBlocked,
-			func(b *forge.BoardBinding) { delete(b.StatusOptions, "blocked") }},
+		{name: "an unmapped native state is inert, not a standing conflict", state: native.StateReview},
+		{
+			name: "a board with no column for the state is reported once, not every tick", state: native.StateBlocked,
+			// Both halves, or the fixture contradicts itself: dropping the id
+			// alone describes a binding the pass's reconciliation would
+			// repair from the board's still-present column.
+			bind:    func(b *forge.BoardBinding) { delete(b.StatusOptions, native.StateBlocked) },
+			project: func(t *testing.T) forge.Project { return deletedColumn(t, "Blocked") },
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			board := newTestBoard(t)
@@ -651,7 +673,11 @@ func TestSyncProjectBoardConvergesWhenTheReflectCannotWrite(t *testing.T) {
 			if tc.bind != nil {
 				tc.bind(bind)
 			}
-			bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+			project := testProject()
+			if tc.project != nil {
+				project = tc.project(t)
+			}
+			bc := &fakeBoardClient{project: project, pages: [][]forge.ProjectItem{{
 				item("PVTI_1", 613, statusValue("Done", cardStateAt(t, board, id).Add(-time.Minute))),
 			}}}
 			opts := &ProjectImportOptions{Binding: bind}

--- a/pkg/server/board_project_reflect_test.go
+++ b/pkg/server/board_project_reflect_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/forge"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
 // The REFLECT half: a native card that moved must move its card on the forge
@@ -565,5 +567,106 @@ func TestSyncProjectBoardConflictStillLetsANewerBoardWin(t *testing.T) {
 	}
 	if len(bc.writes) != 0 {
 		t.Errorf("writes = %+v, want none — the board already shows what it decided", bc.writes)
+	}
+}
+
+// TestSyncProjectBoardConvergesWhenBothSidesAgree pins that a native-wins
+// conflict CONVERGES even when the reflect has nothing to write.
+//
+// A native-wins conflict deliberately declines to record the board's status,
+// on the promise that the reflect will overwrite it with what it wrote. The
+// reflect has exits that write nothing — sharpest here: both sides moved
+// independently and landed on the SAME column, so there is nothing to push.
+// The promise is then unkept, the record stays stale, and the next pass feeds
+// decideProjectStatus identical inputs and re-derives the same conflict: a
+// Warn and a Conflicts++ per card, on every tick, for two boards that already
+// agree.
+func TestSyncProjectBoardConvergesWhenBothSidesAgree(t *testing.T) {
+	board := newTestBoard(t)
+	old := time.Now().UTC().Add(-time.Hour)
+	// Recorded "Planned". The card moved natively to blocked, and somebody
+	// moved the board to Blocked too — independently, and EARLIER, so the
+	// native side wins the conflict and the reflect finds nothing to do.
+	id := seedSynced(t, board, 613, native.StateInbox, "Planned", old)
+	if _, _, err := board.SetStateFrom(id, native.StateInbox, native.StateBlocked); err != nil {
+		t.Fatalf("native move: %v", err)
+	}
+	boardAt := cardStateAt(t, board, id).Add(-time.Minute)
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Blocked", boardAt)),
+	}}}
+	var logs bytes.Buffer
+	opts := &ProjectImportOptions{Binding: testBinding(), Logger: iterlog.New(iterlog.LevelWarn, &logs)}
+
+	res1, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if res1.Conflicts != 1 {
+		t.Fatalf("pass 1: Conflicts = %d, want 1 (%+v)", res1.Conflicts, res1)
+	}
+	if len(bc.writes) != 0 {
+		t.Fatalf("pass 1: writes = %+v, want none — the board already shows the card's column", bc.writes)
+	}
+
+	logs.Reset()
+	res2, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if res2.Conflicts != 0 {
+		t.Errorf("pass 2: Conflicts = %d, want 0 — two agreeing boards must stop being a conflict (%+v)", res2.Conflicts, res2)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("pass 2 logged %q, want silence — a resolved divergence must not warn on every tick", logs.String())
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("writes = %+v, want none across both passes", bc.writes)
+	}
+	if got := mustGet(t, board, id).State; got != native.StateBlocked {
+		t.Errorf("state = %q, want it untouched", got)
+	}
+}
+
+// The same non-convergence through the reflect's other silent exits: an
+// unmapped native state, and a bound board with no column for the state.
+func TestSyncProjectBoardConvergesWhenTheReflectCannotWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+		bind  func(*forge.BoardBinding)
+	}{
+		{"an unmapped native state is inert, not a standing conflict", native.StateReview, nil},
+		{"a board with no column for the state is reported once, not every tick", native.StateBlocked,
+			func(b *forge.BoardBinding) { delete(b.StatusOptions, "blocked") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			board := newTestBoard(t)
+			old := time.Now().UTC().Add(-time.Hour)
+			id := seedSynced(t, board, 613, native.StateInbox, "Planned", old)
+			if _, _, err := board.SetStateFrom(id, native.StateInbox, tc.state); err != nil {
+				t.Fatalf("native move: %v", err)
+			}
+			bind := testBinding()
+			if tc.bind != nil {
+				tc.bind(bind)
+			}
+			bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+				item("PVTI_1", 613, statusValue("Done", cardStateAt(t, board, id).Add(-time.Minute))),
+			}}}
+			opts := &ProjectImportOptions{Binding: bind}
+
+			if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+				t.Fatalf("pass 1: %v", err)
+			}
+			res2, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+			if err != nil {
+				t.Fatalf("pass 2: %v", err)
+			}
+			if res2.Conflicts != 0 {
+				t.Errorf("pass 2: Conflicts = %d, want 0 — a divergence nothing can resolve must be derived once, not every tick (%+v)",
+					res2.Conflicts, res2)
+			}
+		})
 	}
 }

--- a/pkg/server/board_project_test.go
+++ b/pkg/server/board_project_test.go
@@ -561,3 +561,58 @@ func TestImportProjectBoardStillReportsAMissingCard(t *testing.T) {
 		t.Errorf("res = %+v, want one skipped item naming its repo", res)
 	}
 }
+
+// projectDriftingBoard moves a card once, just before the write that was decided on
+// the state it read — the shape native.Store.SetStateFrom's CAS exists for.
+// Its SetStateFrom then loses the CAS through the REAL store and answers
+// (issue, changed=false, nil): a CAS loss is not an error.
+type projectDriftingBoard struct {
+	native.BoardStore
+	driftTo string
+	once    bool
+}
+
+func (d *projectDriftingBoard) SetStateFrom(id, from, to string) (*native.Issue, bool, error) {
+	if !d.once {
+		d.once = true
+		if _, err := d.BoardStore.SetState(id, d.driftTo); err != nil {
+			return nil, false, err
+		}
+	}
+	return d.BoardStore.SetStateFrom(id, from, to)
+}
+
+// TestImportProjectBoardDoesNotCountACASLossAsAMove pins that a move the store
+// REFUSED on its CAS is not recorded as applied.
+//
+// SetStateFrom answers a drifted card with (issue, false, nil) — the operator
+// got there first — and the import discarded that flag, taking the nil error
+// as success. It then counted a transition the store never made, and recorded
+// the board's status as synchronized, which makes every later pass a no-op:
+// on the one-shot `iterion issue import --project` path nothing ever repairs
+// that, so the card stays where the operator put it while the record claims
+// the board was applied.
+func TestImportProjectBoardDoesNotCountACASLossAsAMove(t *testing.T) {
+	board := newTestBoard(t)
+	id := seedCard(t, board, 613, native.StateInbox)
+	drifting := &projectDriftingBoard{BoardStore: board, driftTo: native.StateInProgress}
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Planned", time.Now().UTC())),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, drifting, nil)
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.Moved != 0 {
+		t.Errorf("Moved = %d, want 0 — the store refused the write (%+v)", res.Moved, res)
+	}
+	if got := mustGet(t, board, id).State; got != native.StateInProgress {
+		t.Errorf("state = %q, want the operator's %q", got, native.StateInProgress)
+	}
+	// And nothing may claim the board's status was applied, or every later
+	// pass reads "already equal" and the divergence becomes permanent.
+	if ext := mustGet(t, board, id).External; ext != nil && ext.Project != nil && ext.Project.Status != "" {
+		t.Errorf("recorded status = %q, want none — the write did not land", ext.Project.Status)
+	}
+}

--- a/pkg/server/board_project_test.go
+++ b/pkg/server/board_project_test.go
@@ -575,7 +575,7 @@ type projectDriftingBoard struct {
 func (d *projectDriftingBoard) SetStateFrom(id, from, to string) (*native.Issue, bool, error) {
 	if !d.once {
 		d.once = true
-		if _, err := d.BoardStore.SetState(id, d.driftTo); err != nil {
+		if _, err := d.SetState(id, d.driftTo); err != nil {
 			return nil, false, err
 		}
 	}

--- a/pkg/server/board_project_test.go
+++ b/pkg/server/board_project_test.go
@@ -616,3 +616,75 @@ func TestImportProjectBoardDoesNotCountACASLossAsAMove(t *testing.T) {
 		t.Errorf("recorded status = %q, want none — the write did not land", ext.Project.Status)
 	}
 }
+
+// TestImportProjectBoardOneSidedMoveIsNotAConflict pins ADR-097 §9.2's own
+// definition of the counter: items where BOTH sides had moved.
+//
+// Dragging a card is the ordinary gesture on a forge board, and the native
+// side has NOT moved when the card still sits in the column iterion's own last
+// recorded status put it in. Counting that as a conflict saturates the one
+// number that answers "how often are people and bots fighting over this
+// board". Worse, when the card's transition time happens to be the newer of
+// the two, the phantom conflict resolves in the native side's favour and the
+// reflect pushes the card's OLD column back over the human's drag.
+func TestImportProjectBoardOneSidedMoveIsNotAConflict(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// cardState is where the card sits; recorded is the board status
+		// iterion last synchronized — its mapped state IS iterion's own last
+		// write, so cardState == map(recorded) means "the native side has not
+		// moved".
+		cardState, recorded, boardStatus string
+		// boardOffset positions the board's status timestamp relative to the
+		// card's real transition.
+		boardOffset                            time.Duration
+		wantState                              string
+		wantMoved, wantReflected, wantConflict int
+		wantWrites                             int
+	}{
+		{
+			name: "only the board moved", cardState: native.StateReady,
+			recorded: "Planned", boardStatus: "In progress", boardOffset: -time.Hour,
+			wantState: native.StateInProgress, wantMoved: 1,
+		},
+		{
+			name: "only the native board moved", cardState: native.StateInProgress,
+			recorded: "Planned", boardStatus: "Planned", boardOffset: -time.Hour,
+			wantState: native.StateInProgress, wantReflected: 1, wantWrites: 1,
+		},
+		{
+			name: "both moved", cardState: native.StateInProgress,
+			recorded: "Planned", boardStatus: "Blocked", boardOffset: time.Hour,
+			wantState: native.StateBlocked, wantMoved: 1, wantConflict: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			board := newTestBoard(t)
+			id := seedSynced(t, board, 613, tc.cardState, tc.recorded, time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC))
+			ghAt := cardStateAt(t, board, id).Add(tc.boardOffset)
+			bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+				item("PVTI_1", 613, statusValue(tc.boardStatus, ghAt)),
+			}}}
+
+			res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+				&ProjectImportOptions{Binding: testBinding()})
+			if err != nil {
+				t.Fatalf("ImportProjectBoard: %v", err)
+			}
+			if got := mustGet(t, board, id).State; got != tc.wantState {
+				t.Errorf("state = %q, want %q", got, tc.wantState)
+			}
+			if res.Moved != tc.wantMoved || res.Reflected != tc.wantReflected {
+				t.Errorf("Moved/Reflected = %d/%d, want %d/%d (%+v)",
+					res.Moved, res.Reflected, tc.wantMoved, tc.wantReflected, res)
+			}
+			if res.Conflicts != tc.wantConflict {
+				t.Errorf("Conflicts = %d, want %d — the counter means BOTH sides moved", res.Conflicts, tc.wantConflict)
+			}
+			if len(bc.writes) != tc.wantWrites {
+				t.Errorf("board writes = %+v, want %d — a one-sided board move must never be pushed back",
+					bc.writes, tc.wantWrites)
+			}
+		})
+	}
+}

--- a/pkg/server/board_project_test.go
+++ b/pkg/server/board_project_test.go
@@ -307,6 +307,41 @@ func TestImportProjectBoardSkipsDraftsAndPulls(t *testing.T) {
 	}
 }
 
+// TestImportProjectBoardSkipsArchivedItems pins the import half of the archive
+// rule.
+//
+// GitHub PRESERVES an archived item's field values while removing it from
+// every board view, so an item archived in "Planned" keeps reading as Planned
+// forever. Driving a card's column from a value nobody can see or change is
+// not a sync, and reflecting ONTO it writes into an invisible row. Both
+// directions skip it, counted — silence would make an operator hunt for a card
+// that stopped following for no stated reason.
+func TestImportProjectBoardSkipsArchivedItems(t *testing.T) {
+	board := newTestBoard(t)
+	// The card moved natively AND the board says something else, so both
+	// directions would have work to do were the item live.
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned",
+		time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC))
+	archived := item("PVTI_1", 613, statusValue("Blocked", time.Now().UTC()))
+	archived.Archived = true
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{archived}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.SkippedArchived != 1 || res.Moved != 0 || res.Reflected != 0 || res.Conflicts != 0 {
+		t.Errorf("result = %+v, want the item skipped as archived and nothing else touched", res)
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("board writes = %+v, want none — an archived row is invisible to the operator", bc.writes)
+	}
+	if got := mustGet(t, board, id).State; got != native.StateInProgress {
+		t.Errorf("state = %q, want it untouched by an archived item", got)
+	}
+}
+
 // TestImportProjectBoardEchoSuppression is the loop guard: when the board's
 // status is the one iterion itself last recorded, the import changes nothing —
 // even though the card has since moved on. Without this the reflect's own

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -1,0 +1,391 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// The binding's cached status vocabulary — (state → option id) plus the column
+// NAMES those ids carried at bind time — against a board whose columns an
+// operator keeps editing.
+//
+// Ids are what the reflect WRITES; names are what both directions COMPARE. The
+// two go stale independently, and every one of these tests is a shape where
+// they disagree.
+
+// boundBinding resolves a binding the way the bind endpoint does — by READING
+// the board — so its cached option ids are the fixture project's real ones.
+// testBinding()'s hand-written ids predate the id-based reflect and cannot
+// exercise it.
+func boundBinding(t *testing.T, project forge.Project) *forge.BoardBinding {
+	t.Helper()
+	b, err := forge.BindBoard(context.Background(), &fakeBoardClient{project: project}, forge.BindRequest{
+		TenantID: "team-a", Provider: forge.ProviderGitHub,
+		Ref: testProjectRef, ConnectionID: "conn-1",
+	})
+	if err != nil {
+		t.Fatalf("BindBoard: %v", err)
+	}
+	return &b
+}
+
+// renamedColumn returns the fixture project with one Status option renamed,
+// KEEPING its id — which is exactly what the forge does on a rename.
+func renamedColumn(t *testing.T, from, to string) forge.Project {
+	t.Helper()
+	return editColumn(t, from, func(o *forge.ProjectFieldOption) { o.Name = to })
+}
+
+// recreatedColumn returns the fixture project with one Status option given a
+// NEW id under the same name — a column deleted and re-added.
+func recreatedColumn(t *testing.T, name, newID string) forge.Project {
+	t.Helper()
+	return editColumn(t, name, func(o *forge.ProjectFieldOption) { o.ID = newID })
+}
+
+// deletedColumn returns the fixture project with one Status option removed.
+func deletedColumn(t *testing.T, name string) forge.Project {
+	t.Helper()
+	p := testProject()
+	for i, f := range p.Fields {
+		if !strings.EqualFold(f.Name, forge.ProjectStatusFieldName) {
+			continue
+		}
+		opts := make([]forge.ProjectFieldOption, 0, len(f.Options))
+		for _, o := range f.Options {
+			if strings.EqualFold(o.Name, name) {
+				continue
+			}
+			opts = append(opts, o)
+		}
+		if len(opts) == len(f.Options) {
+			t.Fatalf("fixture has no %q column", name)
+		}
+		p.Fields[i].Options = opts
+		return p
+	}
+	t.Fatalf("fixture has no %s field", forge.ProjectStatusFieldName)
+	return p
+}
+
+func editColumn(t *testing.T, name string, edit func(*forge.ProjectFieldOption)) forge.Project {
+	t.Helper()
+	p := testProject()
+	for i, f := range p.Fields {
+		if !strings.EqualFold(f.Name, forge.ProjectStatusFieldName) {
+			continue
+		}
+		opts := append([]forge.ProjectFieldOption(nil), f.Options...)
+		for j := range opts {
+			if strings.EqualFold(opts[j].Name, name) {
+				edit(&opts[j])
+				p.Fields[i].Options = opts
+				return p
+			}
+		}
+		t.Fatalf("fixture has no %q column", name)
+	}
+	t.Fatalf("fixture has no %s field", forge.ProjectStatusFieldName)
+	return p
+}
+
+// statusOption is statusValue plus the option id the forge reports alongside
+// the name. The id is the load-bearing half: it survives a rename, so it is
+// the only honest answer to "is the board already carrying what we would
+// write?".
+func statusOption(name, optionID string, at time.Time) forge.ProjectItemField {
+	fv := statusValue(name, at)
+	fv.OptionID = optionID
+	return fv
+}
+
+// optionID reads a column's id out of the fixture project.
+func optionID(t *testing.T, project forge.Project, name string) string {
+	t.Helper()
+	f, ok := project.Field(forge.ProjectStatusFieldName)
+	if !ok {
+		t.Fatalf("fixture has no %s field", forge.ProjectStatusFieldName)
+	}
+	o, ok := f.Option(name)
+	if !ok {
+		t.Fatalf("fixture has no %q column", name)
+	}
+	return o.ID
+}
+
+// TestSyncProjectBoardConvergesAfterAColumnIsRenamed is the whole finding.
+//
+// The reflect decides by NAME and writes by OPTION ID. A renamed column keeps
+// its id, so after "In progress" becomes "Doing": the import goes inert
+// (StateForStatus misses the new name), and the reflect resolves the SAME
+// still-valid option, calls SetSingleSelect — a no-op on the forge's side —
+// then records the old name again. The next pass reads the board's new name
+// and repeats, identically, forever: one GraphQL mutation per bound card per
+// pass, indefinitely, with nothing anywhere saying why.
+func TestSyncProjectBoardConvergesAfterAColumnIsRenamed(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	// The card moved to in_progress natively; the board still says Planned,
+	// which is what we recorded — so the reflect has a real push to make.
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+	inProgressID := optionID(t, project, "In progress")
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	bc := &fakeBoardClient{project: project, pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if res.Reflected != 1 || len(bc.writes) != 1 || bc.writes[0].OptionID != inProgressID {
+		t.Fatalf("pass 1 must push the native move: reflected=%d writes=%+v", res.Reflected, bc.writes)
+	}
+
+	// The operator renames the column. The option KEEPS its id.
+	renamed := renamedColumn(t, "In progress", "Doing")
+	bc.project = renamed
+	bc.pages = [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Doing", inProgressID, at.Add(time.Minute))),
+	}}
+
+	for pass := 2; pass <= 4; pass++ {
+		if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+	}
+	if len(bc.writes) != 1 {
+		t.Errorf("writes = %+v, want the single pass-1 push — a renamed column must not be rewritten on every pass", bc.writes)
+	}
+
+	// And the binding healed itself, on BOTH twins' contract: the column's new
+	// name is resolved from the id it kept, so the IMPORT direction works too.
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if got, ok := forge.StatusForState(stored.Mapping(), native.StateInProgress); !ok || got != "Doing" {
+		t.Errorf("stored column for in_progress = %q (ok=%v), want %q — the repair must be remembered", got, ok, "Doing")
+	}
+	if stored.StatusOptions[native.StateInProgress] != inProgressID {
+		t.Errorf("stored option id = %q, want the unchanged %q", stored.StatusOptions[native.StateInProgress], inProgressID)
+	}
+	if stored.Degraded() {
+		t.Errorf("a rename is repairable, not a degradation: %q", stored.DegradedReason)
+	}
+}
+
+// TestSyncProjectBoardRebindsARecreatedColumn: a column deleted and re-added
+// under the same name gets a NEW id. The cached id is dead, but the NAME still
+// resolves — which is exactly what the bind did — so this self-heals too.
+func TestSyncProjectBoardRebindsARecreatedColumn(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	recreated := recreatedColumn(t, "In progress", "PVTSSO_fresh")
+	bc := &fakeBoardClient{project: recreated, pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: binding, Bindings: bindings})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.Reflected != 1 || len(bc.writes) != 1 {
+		t.Fatalf("the reflect must still push: reflected=%d writes=%+v", res.Reflected, bc.writes)
+	}
+	if bc.writes[0].OptionID != "PVTSSO_fresh" {
+		t.Errorf("wrote option %q, want the board's CURRENT id — the cached one is dead", bc.writes[0].OptionID)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if stored.StatusOptions[native.StateInProgress] != "PVTSSO_fresh" {
+		t.Errorf("stored option id = %q, want the re-resolved one", stored.StatusOptions[native.StateInProgress])
+	}
+	if got := mustGet(t, board, id).State; got != native.StateInProgress {
+		t.Errorf("state = %q, want it untouched", got)
+	}
+}
+
+// TestSyncProjectBoardDegradesOnADeletedColumn: neither the cached id nor the
+// mapped name is on the field any more. Nothing can repair that from here, so
+// the binding says so ONCE — an explicit state on the record, not a Warn per
+// card per pass forever — and stops retrying the cards it cannot serve.
+func TestSyncProjectBoardDegradesOnADeletedColumn(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	var logs bytes.Buffer
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings,
+		Logger: iterlog.New(iterlog.LevelWarn, &logs)}
+	bc := &fakeBoardClient{project: deletedColumn(t, "In progress"), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 || res.ReflectFailed != 0 {
+		t.Fatalf("result = %+v, writes=%+v: the card must be counted, not written and not failed", res, bc.writes)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !stored.Degraded() || !strings.Contains(stored.DegradedReason, "In progress") {
+		t.Fatalf("binding must be degraded and NAME the lost column, got %q", stored.DegradedReason)
+	}
+	if stored.StatusOptions[native.StateInProgress] != "" {
+		t.Errorf("the dead option id must be dropped, got %q", stored.StatusOptions[native.StateInProgress])
+	}
+
+	// Two more passes: still no writes, and the reason is logged ONCE — an
+	// operator reads the state off the binding, not off a repeating Warn.
+	before := strings.Count(logs.String(), "no longer")
+	for pass := 2; pass <= 3; pass++ {
+		if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("writes = %+v, want none — a degraded column must not be retried", bc.writes)
+	}
+	if got := strings.Count(logs.String(), "no longer"); got != before {
+		t.Errorf("the degradation was logged %d more times; it is a STATE, logged on the transition", got-before)
+	}
+}
+
+// TestSyncProjectBoardClearsDegradedWhenTheColumnComesBack: the flag is a
+// readout of the last resolution, so a re-created column clears it without a
+// re-bind.
+func TestSyncProjectBoardClearsDegradedWhenTheColumnComesBack(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings}
+	bc := &fakeBoardClient{project: deletedColumn(t, "In progress"), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+
+	bc.project = recreatedColumn(t, "In progress", "PVTSSO_back")
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if stored.Degraded() {
+		t.Errorf("the column is back; the binding must not stay degraded: %q", stored.DegradedReason)
+	}
+	if stored.StatusOptions[native.StateInProgress] != "PVTSSO_back" {
+		t.Errorf("stored option id = %q, want the re-resolved one", stored.StatusOptions[native.StateInProgress])
+	}
+	if len(bc.writes) != 1 || bc.writes[0].OptionID != "PVTSSO_back" {
+		t.Errorf("writes = %+v, want the push the degraded pass could not make", bc.writes)
+	}
+}
+
+// TestSyncProjectBoardNeverRewritesTheOptionItAlreadyCarries pins the guard
+// under the repair: the reflect must compare the OPTION ID it is about to
+// write against the one the item carries, not only the names.
+//
+// The reachable case is a caller-supplied StatusMapping, which overrides the
+// binding's own — so `want` comes from the override while the option id comes
+// from the binding, and the names can differ while the value cannot. Names are
+// a view of a column; the id IS the column.
+func TestSyncProjectBoardNeverRewritesTheOptionItAlreadyCarries(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	project := testProject()
+	inProgressID := optionID(t, project, "In progress")
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: project, pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Doing", inProgressID, at)),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{
+			Binding: testBinding(),
+			// The caller names the column differently from what the board
+			// reports for that same option id.
+			StatusMapping: forge.DefaultStatusMapping(),
+		})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("writes = %+v, want none — the item already carries option %s", bc.writes, inProgressID)
+	}
+	if res.Reflected != 0 {
+		t.Errorf("Reflected = %d, want 0 — nothing was written", res.Reflected)
+	}
+}
+
+// TestSyncProjectBoardWithoutABindingStoreStillConverges: the local one-shot
+// `iterion issue import --project` has no binding store. The repair still
+// applies in memory for that pass — it is simply not remembered.
+func TestSyncProjectBoardWithoutABindingStoreStillConverges(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "In progress", at)
+	project := testProject()
+	binding := boundBinding(t, project)
+
+	bc := &fakeBoardClient{project: renamedColumn(t, "In progress", "Doing"), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Doing", optionID(t, project, "In progress"), at)),
+	}}}
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: binding})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("writes = %+v, want none — the board already carries this option", bc.writes)
+	}
+	if res.Moved != 0 {
+		t.Errorf("Moved = %d, want 0 — the renamed column maps to the state the card is already in", res.Moved)
+	}
+}

--- a/pkg/server/board_sync_worker.go
+++ b/pkg/server/board_sync_worker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -123,8 +125,12 @@ func (w *BoardSyncWorker) Tick(ctx context.Context) (int, error) {
 	}
 	ran := 0
 	for _, b := range due {
-		// Elect: exactly one replica advances the watermark, and only it runs.
-		won, err := w.Bindings.ClaimSync(ctx, b.TenantID, b.LastSyncedAt, now)
+		// Elect: exactly one replica advances the watermark and takes the
+		// lease, and only it runs. The owner token is per PASS, not per
+		// replica: a replica whose earlier pass overran and lost the board
+		// must not be able to release the lease its own next pass took.
+		owner := uuid.NewString()
+		won, err := w.Bindings.ClaimSync(ctx, b.TenantID, b.LastSyncedAt, now, owner)
 		if err != nil {
 			if errors.Is(err, forge.ErrBoardBindingNotFound) {
 				continue // unbound between the list and the claim
@@ -135,7 +141,7 @@ func (w *BoardSyncWorker) Tick(ctx context.Context) (int, error) {
 		if !won {
 			continue // another replica owns this pass
 		}
-		if w.runPass(ctx, b) {
+		if w.runPass(ctx, b, owner) {
 			ran++
 		}
 	}
@@ -150,16 +156,26 @@ func (w *BoardSyncWorker) Tick(ctx context.Context) (int, error) {
 // It reports whether the pass RAN — a claim taken and then abandoned on a
 // revoked token is not a reconciliation, and counting it as one would make
 // Tick's return value useless as a health signal.
-func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding) bool {
+func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, owner string) bool {
 	// Hand the board back however this ends, so the next tick may claim
 	// immediately and the lease TTL is only ever reached by a replica that
 	// died. Released on a context that may already be cancelled — a shutdown
 	// must not leave the board held for the whole TTL — so the release gets
 	// its own short-lived context.
+	//
+	// The release is a CAS on this pass's own token: a pass that outlived the
+	// TTL no longer owns the board, and clearing the lease its successor took
+	// would re-admit the concurrent pass the lease exists to refuse. That
+	// refusal is the ONE moment the overrun is knowable, so it is logged as
+	// such rather than swallowed.
 	defer func() {
 		rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
-		if err := w.Bindings.ReleaseSync(rctx, b.TenantID); err != nil && !errors.Is(err, forge.ErrBoardBindingNotFound) {
+		switch err := w.Bindings.ReleaseSync(rctx, b.TenantID, owner); {
+		case errors.Is(err, forge.ErrBoardSyncLeaseLost):
+			w.warn("board sync: team=%s board=%s: this pass outlived its %s lease and another replica has since claimed the board — it may have run concurrently; consider a longer interval",
+				b.TenantID, b.Ref(), forge.BoardSyncLeaseTTL)
+		case err != nil && !errors.Is(err, forge.ErrBoardBindingNotFound):
 			// Not fatal: the lease expires on its own. Visible, though — a
 			// board that keeps needing its TTL to come free is a symptom.
 			w.warn("board sync: team=%s: release lease: %v", b.TenantID, err)

--- a/pkg/server/board_sync_worker.go
+++ b/pkg/server/board_sync_worker.go
@@ -194,8 +194,13 @@ func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, own
 	}
 	res, err := ImportProjectBoard(ctx, bc, b.Ref(), b.Provider, cards, &ProjectImportOptions{
 		Binding: &b,
-		Now:     w.Now,
-		Logger:  w.Logger,
+		// The pass may REPAIR the binding against the live board (a renamed or
+		// re-created column) and flag it degraded when it cannot. Handing it
+		// the store is what makes that repair survive the pass — without it
+		// every tick re-discovers the same drift and pays for it again.
+		Bindings: w.Bindings,
+		Now:      w.Now,
+		Logger:   w.Logger,
 	})
 	took := w.now().Sub(started)
 	if err != nil {
@@ -206,9 +211,10 @@ func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, own
 		w.warn("board sync: team=%s board=%s failed after %s: %v", b.TenantID, b.Ref(), took.Round(time.Millisecond), err)
 		return false
 	}
-	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
+	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d reflect_no_column=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
 		b.TenantID, b.Ref(), res.Items, res.Moved, res.Reflected, res.Labelled,
-		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.SkippedNoCard, res.SkippedArchived, res.Skipped,
+		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.ReflectNoColumn,
+		res.SkippedNoCard, res.SkippedArchived, res.Skipped,
 		took.Round(time.Millisecond))
 	return true
 }

--- a/pkg/server/board_sync_worker.go
+++ b/pkg/server/board_sync_worker.go
@@ -206,9 +206,9 @@ func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, own
 		w.warn("board sync: team=%s board=%s failed after %s: %v", b.TenantID, b.Ref(), took.Round(time.Millisecond), err)
 		return false
 	}
-	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d skipped_no_card=%d skipped=%d took=%s",
+	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
 		b.TenantID, b.Ref(), res.Items, res.Moved, res.Reflected, res.Labelled,
-		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.SkippedNoCard, res.Skipped,
+		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.SkippedNoCard, res.SkippedArchived, res.Skipped,
 		took.Round(time.Millisecond))
 	return true
 }

--- a/pkg/server/board_sync_worker_test.go
+++ b/pkg/server/board_sync_worker_test.go
@@ -252,3 +252,51 @@ func (b *blockingBoardClient) ListProjectItems(ctx context.Context, ref forge.Pr
 	})
 	return b.fakeBoardClient.ListProjectItems(ctx, ref, opts)
 }
+
+// TestBoardSyncWorkerUsesAPerPassLeaseOwner pins that the worker's release is
+// scoped to the pass that took the lease, end to end.
+//
+// The store CASes on the owner; what the worker owes is a token that is FRESH
+// per pass. A per-replica token would let a replica whose earlier pass overran
+// release the lease its own next pass just took — the same re-admission, one
+// level up.
+func TestBoardSyncWorkerUsesAPerPassLeaseOwner(t *testing.T) {
+	bindings, board, bc := syncWorkerFixture(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedCard(t, board, 613, native.StateInbox)
+	bc.pages = [][]forge.ProjectItem{{item("PVTI_1", 613, statusValue("Planned", at))}}
+
+	w := newTestSyncWorker(bindings, board, bc, func() time.Time { return at })
+	if n, err := w.Tick(context.Background()); err != nil || n != 1 {
+		t.Fatalf("pass 1: n=%d err=%v", n, err)
+	}
+	first, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("GetByTenant: %v", err)
+	}
+	// The pass released, so nothing holds the board.
+	if !first.SyncLeaseUntil.IsZero() || first.SyncLeaseOwner != "" {
+		t.Fatalf("the board is still held after a finished pass: %+v", first)
+	}
+
+	w2 := newTestSyncWorker(bindings, board, bc, func() time.Time { return at.Add(2 * time.Minute) })
+	if n, err := w2.Tick(context.Background()); err != nil || n != 1 {
+		t.Fatalf("pass 2: n=%d err=%v", n, err)
+	}
+	// Whatever the first pass's token was, the second's must differ — the
+	// store's CAS is only worth anything if the token is not reused.
+	second, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("GetByTenant: %v", err)
+	}
+	if !second.SyncLeaseUntil.IsZero() || second.SyncLeaseOwner != "" {
+		t.Fatalf("the board is still held after the second pass: %+v", second)
+	}
+	// And a stale token from any earlier pass cannot free a live lease.
+	if _, err := bindings.ClaimSync(context.Background(), "team-a", second.LastSyncedAt, at.Add(4*time.Minute), "replica-live"); err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if err := bindings.ReleaseSync(context.Background(), "team-a", "some-earlier-pass"); !errors.Is(err, forge.ErrBoardSyncLeaseLost) {
+		t.Fatalf("a stale token released a live lease: %v", err)
+	}
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5405,6 +5405,7 @@ export interface components {
             };
             sync_every: number;
             sync_every_seconds: number;
+            sync_lease_owner?: string;
             /** Format: date-time */
             sync_lease_until?: string;
             tenant_id: string;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5387,6 +5387,9 @@ export interface components {
             connection_id: string;
             /** Format: date-time */
             created_at: string;
+            /** Format: date-time */
+            degraded_at?: string;
+            degraded_reason?: string;
             label_fields?: components["schemas"]["BoundLabelField"][];
             /** Format: date-time */
             last_synced_at?: string;


### PR DESCRIPTION
Closes #759. Refs #745, #613.

## Why two halves
The merge queue merged #745 from a STALE head: its squash `3e991ce0a` carries the tree of `1b9087597`, while GitHub reports the PR merged at `c50cccb04` — the four round-3-fix commits pushed while the entry was being enqueued never reached `main` (`git diff --stat 1b9087597 origin/main -- pkg/server/board_project.go pkg/forge/board_binding_store.go` is empty; `git grep ErrBoardSyncLeaseLost origin/main` finds nothing). The first four commits here are those exact commits, cherry-picked unchanged:

- `fix(board): a lost state CAS is not an applied move` (Rd95ffd)
- `fix(board): close a native-wins conflict the reflect cannot resolve` (R1b626a)
- `fix(board): a late sync release cannot clear its successor's lease` (R1bdb50 — per-pass owner token, CAS release on both twins, `ErrBoardSyncLeaseLost`)
- `perf(forge): cache the board installation token per permission set` (Rb79e5f)

## Round 5 + #759 (three commits)
- **R558de3** — a conflict needs BOTH sides to have moved: `decideProjectStatus` takes the card's state and a `nativeMovedSince` predicate (the recorded status maps to iterion's own last write, so a card still sitting there has not moved). Board-only ⇒ plain apply, native-only ⇒ plain reflect, both ⇒ newer-wins as before; an unmapped recorded status stays a conflict (one Warn beats a silent overwrite). Red first: a one-sided human drag was counted `Conflicts:1`, resolved native-wins, and the reflect pushed the card's OLD column back over the drag — ADR-097 §9.4's forbidden outcome.
- **R305efc** — an archived item is off the board: never a dispatch candidate (`isCandidateStatus`, the single gate), skipped and counted `skipped_archived` by the project pass; `RefreshStates` deliberately still answers for it (an omission there reads as "issue disappeared" and cancels the run — archiving is a tidy-up, not a kill switch). Pinned both ways.
- **Rcb5939 + #759** — columns resolved by option ID, cache repaired: `BoardBinding.ReconcileStatusOptions(project)` runs once per pass on the schema the pass already reads (zero extra calls): cached id still on the field ⇒ adopt the board's name (a rename heals in both directions); mapped name still there ⇒ adopt its id (re-created or added since the bind); lost ⇒ drop the dead id, count `reflect_no_column`, `MarkDegraded` naming the column — partial, logged ONCE on the transition, cleared automatically when the column reappears or on re-bind, surfaced on `GET /api/teams/{id}/board-binding` (`degraded_*`, OpenAPI regenerated). The reflect compares the option id it is about to write. Red first: four passes, four identical writes of the same option id after a rename, the import inert, the mapping never healing.

`task check` exit 0 (before the re-stack), `-race` on pkg/server + pkg/forge + pkg/dispatcher with Mongo conformance green on both twins; after re-stacking on `main`: build, the board/project/forge/tracker suites and the OpenAPI drift check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)