### PR TITLE
fix(forge): the GitHub-App client serves the issue API on scoped tokens — the forge→board issue sync works on App connections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,8 +288,11 @@ the hours this one spent.
   log line per pass, and the conflict rule. Read it when a card moved on one
   board and not the other — the three answers are almost always an unmapped
   state (inert by design), a terminal card (automation never reopens), or a
-  card the project pass could not create because the issue import had not run
-  for that repo (it names the repos).
+  card the project pass could not create because that repo's **issue sync**
+  had not run (it names the repos). On cloud that sync is the server's own —
+  `iterion remote forge integrations sync <id>` / `sync_issues_enabled` — not
+  `iterion issue import`, which writes to a local store the instance never
+  reads.
 - [docs/ticket-context.md](docs/ticket-context.md) — plugging tracker
   tickets (Jira Cloud/DC, GitHub/GitLab issues) into a Revi review so it
   verifies the PR delivers what the ticket asks: the team wiring (team

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -12,7 +12,7 @@ Methodology this serves: [AGENTS.md](../AGENTS.md).
 
 | | direction | who writes it |
 |---|---|---|
-| Title, body, labels, assignees, open/closed | GitHub issue → card | `iterion issue import` |
+| Title, body, labels, assignees, open/closed | GitHub issue → card | the **issue sync**: `iterion remote forge integrations sync <id>` on cloud, `iterion issue import` on a local store |
 | **`Status`** | **both ways** | the project pass |
 | `Area` / `Mode` / `Priority` | board → card labels | the project pass |
 | everything else on the board | — | nothing |
@@ -38,7 +38,8 @@ bug until you know it is a decision:
 1. **It never creates a card.** A project item has no body, no labels and no
    author — and creating from one would bypass the author-trust gate that runs
    at issue ingest. Items with no card are counted and their **repositories are
-   named**, so you know which issue imports to run.
+   named**, so you know which issue syncs to run — the cloud one on a cloud
+   instance, see [Troubleshooting](#troubleshooting).
 2. **It never reopens a closed card.** Leaving a terminal column (`done`,
    `blocked`) is a *reopen* — an operator gesture with a dependents check and
    an audit trail. Dragging a card out of *Done* on GitHub is reported
@@ -100,9 +101,17 @@ iterion remote board show                   # the effective map + coverage
 ```
 
 From then on the server reconciles the board on its own (default every 2
-minutes; see [Reconciliation](#reconciliation)). Cards still have to exist:
-enable issue sync on each repository integration, or run the import above once
-per repo.
+minutes; see [Reconciliation](#reconciliation)). Cards still have to exist, and
+`iterion issue import` cannot make them — it writes to a LOCAL store, not the
+instance's. Turn on issue sync per repository integration and let the
+5-minute worker fill the board, or force one pass now:
+
+```bash
+iterion remote forge repo-bots               # the integrations, with their ids
+iterion remote forge integrations update <integration-id> \
+  --data '{"sync_issues_enabled":true}'      # the 5-minute worker takes over
+iterion remote forge integrations sync <integration-id>   # one pass, right now
+```
 
 `iterion remote board unbind` stops it.
 
@@ -256,8 +265,25 @@ The dispatcher can take its workflow state from the board instead of labels —
 
 **`skipped_no_card` is large / a card never appears.**
 The project pass hydrates, it does not create. Read the repositories it names
-(CLI output, `missing_repos` in the API response) and run the issue import for
-each one.
+(CLI output, `missing_repos` in the API response) and run the **issue sync**
+for each one. On a cloud instance that is the server-side pass, not
+`iterion issue import` — the import writes to a local store the instance never
+reads:
+
+```bash
+iterion remote forge repo-bots                            # integration ids
+iterion remote forge integrations sync <integration-id>   # → {"synced":N,…}
+```
+
+Enable `sync_issues_enabled` on the integration (see [Cloud — bind the team
+once](#cloud--bind-the-team-once)) and the 5-minute worker keeps it filled.
+
+**The sync answers `does not implement forge.IssueClient`.**
+The connection's credential shape resolves to a client that cannot read the
+issue API. The message names the connection kind and the concrete client, which
+is what to act on. GitHub App, PAT and OAuth connections all serve it; a
+provider that genuinely does not is the remaining case, and re-connecting the
+repository under a supported one is the fix.
 
 **A card moved on GitHub but not in iterion.**
 Check the column is in the map (`iterion remote board show` — a `!` marks a

--- a/pkg/cli/remote_board_binding.go
+++ b/pkg/cli/remote_board_binding.go
@@ -179,7 +179,7 @@ func printBoardBinding(p *Printer, b forge.BoardBinding) {
 	p.KV("Connection", b.ConnectionID)
 	switch {
 	case b.SyncEvery <= 0:
-		p.KV("Reconcile", "off (the reflect has no net — `iterion issue import --project` by hand)")
+		p.KV("Reconcile", "off (the reflect has no net — re-bind with --sync-every to arm it)")
 	default:
 		p.KV("Reconcile", "every "+b.SyncEvery.String())
 	}

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -106,6 +106,33 @@ func ProjectsInstallationPermissions() map[string]string {
 	}
 }
 
+// IssuesReadInstallationPermissions is the grant set minted for READING issues
+// (the forge→board sync's ListIssues/GetIssue) — the issues read permission
+// plus the mandatory metadata baseline.
+//
+// It is its own profile rather than a reuse of the cached runtime token
+// because that token carries issues:WRITE (finalize_mr posts back on the
+// source issue): letting a listing ride it would hand a read the permission to
+// rewrite every issue in the installation, and a sync pass reads far more
+// often than anything writes.
+func IssuesReadInstallationPermissions() map[string]string {
+	return map[string]string{
+		"issues":   "read",
+		"metadata": "read",
+	}
+}
+
+// IssuesWriteInstallationPermissions is the grant set minted for WRITING
+// issues (board→forge push, a bot's reply on the source issue): the issues
+// write permission plus the mandatory metadata baseline. Narrower than the
+// runtime token, which also carries contents/pull_requests/hooks writes.
+func IssuesWriteInstallationPermissions() map[string]string {
+	return map[string]string{
+		"issues":   "write",
+		"metadata": "read",
+	}
+}
+
 // MissingProjectPermissions lists the project-board grants an installation does
 // NOT have, so a board binding fails at BIND time naming the missing permission
 // rather than hours later on the first status write. Empty when nothing is
@@ -445,9 +472,10 @@ type AppClient struct {
 	// and only a caller that needs one of these would fail — at the write,
 	// unless it asked PreflightFor first.
 	denied map[string]bool
-	// scoped caches the tokens minted for a NARROWER, opt-in grant than the
-	// runtime baseline (the board profile), keyed by the permission set so a
-	// broad grant can never be handed to a differently-scoped call.
+	// scoped caches the tokens minted for a grant OTHER than the runtime
+	// baseline — the board profile, the issue profiles — keyed by the
+	// permission set so one call family's grant can never be handed to a
+	// differently-scoped call.
 	scoped map[string]scopedToken
 }
 
@@ -512,7 +540,9 @@ func (a *AppClient) rest(ctx context.Context) (*AdminClient, error) {
 }
 
 // scopedREST returns an AdminClient backed by a token minted for exactly perms,
-// cached until it nears expiry.
+// cached until it nears expiry. It is the ONE mint-and-cache for every call
+// family that must not ride the runtime baseline — the board profile and the
+// issue profiles alike.
 //
 // Minting per CALL is what this replaces: every board method went through its
 // own mint, so one reconciliation pass cost a token round trip per project

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -133,6 +133,28 @@ func IssuesWriteInstallationPermissions() map[string]string {
 	}
 }
 
+// IssueCommentInstallationPermissions is the grant set minted for POSTing a
+// comment: issues write, pull_requests write, and the mandatory metadata
+// baseline.
+//
+// It carries BOTH writes because the endpoint is shared and the permission is
+// not: GitHub serves a pull request's comments from
+// /repos/{owner}/{repo}/issues/{number}/comments — the same path as an
+// issue's — but gates the call on `pull_requests` when that number is a pull
+// request, and on `issues` when it is an issue. One call, two grants, decided
+// by a number the client cannot classify without an extra round trip.
+//
+// Answering 403 "Resource not accessible by integration" is what a token
+// short of either grant gets, and every caller posts a courtesy notice it
+// logs at Debug and drops — so the gap would be invisible.
+func IssueCommentInstallationPermissions() map[string]string {
+	return map[string]string{
+		"issues":        "write",
+		"pull_requests": "write",
+		"metadata":      "read",
+	}
+}
+
 // MissingProjectPermissions lists the project-board grants an installation does
 // NOT have, so a board binding fails at BIND time naming the missing permission
 // rather than hours later on the first status write. Empty when nothing is

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -155,6 +155,32 @@ func IssueCommentInstallationPermissions() map[string]string {
 	}
 }
 
+// IssueReadOrPullInstallationPermissions is the grant set minted for a read
+// whose target may be either: issues read, pull_requests read, and the
+// mandatory metadata baseline.
+//
+// It is the read counterpart of IssueCommentInstallationPermissions, and it
+// exists for the same reason: GET /repos/{owner}/{repo}/issues/{number} serves
+// a pull request too, and GitHub gates the call on the RESOURCE, not the path
+// — `pull_requests` for a PR, `issues` for an issue. A number the client
+// cannot classify without an extra round trip needs both.
+//
+// GitHub hides what a token cannot see, so the refusal is a 404, not a 403 —
+// indistinguishable from a deleted PR at the call site. The hold-label veto
+// reads through here and fails closed, which stops the autofix and
+// gate-relaunch lanes launching at all; that is why the grant is not optional.
+//
+// ListIssues deliberately does NOT use this profile: it reads the issues
+// COLLECTION, which is gated on `issues` alone, and the board-sync pass runs
+// often enough that keeping its token narrow is worth a fourth cached set.
+func IssueReadOrPullInstallationPermissions() map[string]string {
+	return map[string]string{
+		"issues":        "read",
+		"pull_requests": "read",
+		"metadata":      "read",
+	}
+}
+
 // MissingProjectPermissions lists the project-board grants an installation does
 // NOT have, so a board binding fails at BIND time naming the missing permission
 // rather than hours later on the first status write. Empty when nothing is

--- a/pkg/forge/github/issues.go
+++ b/pkg/forge/github/issues.go
@@ -213,58 +213,58 @@ func (c *AdminClient) CommentIssue(ctx context.Context, repo string, number int,
 // hold-label veto all read the issue API through that assertion.
 var _ forge.IssueClient = (*AppClient)(nil)
 
-// issuesREST resolves the narrowest installation token that can serve an issue
-// call: read for the two readers, write for the two writers. Every method
-// below goes through it (or, for a comment, through its own profile), so no
-// reader can drift onto a write token — and none of them rides the cached
-// management token, which additionally carries contents/repository_hooks
-// writes an issue call has no use for.
+// Each method names the permission profile its own call needs, and reaches it
+// through the one scopedREST chokepoint (minting + per-set caching). None of
+// them rides the cached management token, which additionally carries
+// contents/repository_hooks writes an issue call has no use for.
 //
-// A comment is deliberately NOT one of these two: it needs pull_requests as
-// well, since the issues endpoint serves a PR's comments too — see
-// IssueCommentInstallationPermissions.
-func (a *AppClient) issuesREST(ctx context.Context, write bool) (*AdminClient, error) {
-	if write {
-		return a.scopedREST(ctx, IssuesWriteInstallationPermissions())
-	}
-	return a.scopedREST(ctx, IssuesReadInstallationPermissions())
-}
+// Two of the five need `pull_requests` as well, because the issues endpoint
+// serves pull requests too and GitHub gates the call on the RESOURCE, not the
+// path: a comment (write) and a single read (read). The collection read does
+// not — see IssueReadOrPullInstallationPermissions.
 
+// ListIssues reads the issues COLLECTION, gated on `issues` alone. It keeps
+// the narrow token: this is the board-sync pass, the most frequent caller.
 func (a *AppClient) ListIssues(ctx context.Context, repo string, opts forge.IssueListOptions) ([]forge.IssueRef, error) {
-	c, err := a.issuesREST(ctx, false)
+	c, err := a.scopedREST(ctx, IssuesReadInstallationPermissions())
 	if err != nil {
 		return nil, err
 	}
 	return c.ListIssues(ctx, repo, opts)
 }
 
+// GetIssue may be handed a pull request's number — its only production caller,
+// the hold-label veto, always is — so it reads under both read grants.
 func (a *AppClient) GetIssue(ctx context.Context, repo string, number int) (forge.IssueRef, error) {
-	c, err := a.issuesREST(ctx, false)
+	c, err := a.scopedREST(ctx, IssueReadOrPullInstallationPermissions())
 	if err != nil {
 		return forge.IssueRef{}, err
 	}
 	return c.GetIssue(ctx, repo, number)
 }
 
+// CreateIssue opens a real issue; `pull_requests` cannot apply.
 func (a *AppClient) CreateIssue(ctx context.Context, repo string, in forge.NewIssue) (forge.IssueRef, error) {
-	c, err := a.issuesREST(ctx, true)
+	c, err := a.scopedREST(ctx, IssuesWriteInstallationPermissions())
 	if err != nil {
 		return forge.IssueRef{}, err
 	}
 	return c.CreateIssue(ctx, repo, in)
 }
 
+// UpdateIssue writes a board card back onto its linked forge issue. The
+// linkage is seeded by the issue sync, which drops pull requests, so the
+// number here is always an issue.
 func (a *AppClient) UpdateIssue(ctx context.Context, repo string, number int, patch forge.IssuePatch) (forge.IssueRef, error) {
-	c, err := a.issuesREST(ctx, true)
+	c, err := a.scopedREST(ctx, IssuesWriteInstallationPermissions())
 	if err != nil {
 		return forge.IssueRef{}, err
 	}
 	return c.UpdateIssue(ctx, repo, number, patch)
 }
 
-// CommentIssue rides its own scoped token — a third cached permission set,
-// through the same chokepoint — because `number` may be a pull request, which
-// GitHub gates on pull_requests even though the endpoint is the issues one.
+// CommentIssue may be handed a pull request's number — every one of its
+// production callers is — so it writes under both write grants.
 func (a *AppClient) CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error) {
 	c, err := a.scopedREST(ctx, IssueCommentInstallationPermissions())
 	if err != nil {

--- a/pkg/forge/github/issues.go
+++ b/pkg/forge/github/issues.go
@@ -214,10 +214,15 @@ func (c *AdminClient) CommentIssue(ctx context.Context, repo string, number int,
 var _ forge.IssueClient = (*AppClient)(nil)
 
 // issuesREST resolves the narrowest installation token that can serve an issue
-// call: read for the two readers, write for the three writers. Every method
-// below goes through it, so no reader can drift onto a write token — and none
-// of them rides the cached management token, which additionally carries
-// contents/pull_requests/repository_hooks writes an issue call has no use for.
+// call: read for the two readers, write for the two writers. Every method
+// below goes through it (or, for a comment, through its own profile), so no
+// reader can drift onto a write token — and none of them rides the cached
+// management token, which additionally carries contents/repository_hooks
+// writes an issue call has no use for.
+//
+// A comment is deliberately NOT one of these two: it needs pull_requests as
+// well, since the issues endpoint serves a PR's comments too — see
+// IssueCommentInstallationPermissions.
 func (a *AppClient) issuesREST(ctx context.Context, write bool) (*AdminClient, error) {
 	if write {
 		return a.scopedREST(ctx, IssuesWriteInstallationPermissions())
@@ -257,8 +262,11 @@ func (a *AppClient) UpdateIssue(ctx context.Context, repo string, number int, pa
 	return c.UpdateIssue(ctx, repo, number, patch)
 }
 
+// CommentIssue rides its own scoped token — a third cached permission set,
+// through the same chokepoint — because `number` may be a pull request, which
+// GitHub gates on pull_requests even though the endpoint is the issues one.
 func (a *AppClient) CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error) {
-	c, err := a.issuesREST(ctx, true)
+	c, err := a.scopedREST(ctx, IssueCommentInstallationPermissions())
 	if err != nil {
 		return forge.CommentRef{}, err
 	}

--- a/pkg/forge/github/issues.go
+++ b/pkg/forge/github/issues.go
@@ -205,16 +205,62 @@ func (c *AdminClient) CommentIssue(ctx context.Context, repo string, number int,
 	}, nil
 }
 
-// CommentIssue on an App connection delegates to a management-token
-// AdminClient minted on demand — the same shape CreatePullReview uses, and
-// for the same reason: an App connection resolves to *AppClient, so a
-// capability implemented only on *AdminClient is INVISIBLE to every type
-// assertion the server does. That is not a fringe shape: the studio's
-// GitHub connect wizard creates App connections by default.
+// AppClient's half of forge.IssueClient — the one an App connection resolves
+// to, so a capability implemented only on *AdminClient is INVISIBLE to every
+// `admin.(forge.IssueClient)` the server does. That is not a fringe shape: the
+// studio's GitHub connect wizard creates App connections by default, and the
+// forge→board sync, the board's push-to-forge routes and the autofix lane's
+// hold-label veto all read the issue API through that assertion.
+var _ forge.IssueClient = (*AppClient)(nil)
+
+// issuesREST resolves the narrowest installation token that can serve an issue
+// call: read for the two readers, write for the three writers. Every method
+// below goes through it, so no reader can drift onto a write token — and none
+// of them rides the cached management token, which additionally carries
+// contents/pull_requests/repository_hooks writes an issue call has no use for.
+func (a *AppClient) issuesREST(ctx context.Context, write bool) (*AdminClient, error) {
+	if write {
+		return a.scopedREST(ctx, IssuesWriteInstallationPermissions())
+	}
+	return a.scopedREST(ctx, IssuesReadInstallationPermissions())
+}
+
+func (a *AppClient) ListIssues(ctx context.Context, repo string, opts forge.IssueListOptions) ([]forge.IssueRef, error) {
+	c, err := a.issuesREST(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	return c.ListIssues(ctx, repo, opts)
+}
+
+func (a *AppClient) GetIssue(ctx context.Context, repo string, number int) (forge.IssueRef, error) {
+	c, err := a.issuesREST(ctx, false)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	return c.GetIssue(ctx, repo, number)
+}
+
+func (a *AppClient) CreateIssue(ctx context.Context, repo string, in forge.NewIssue) (forge.IssueRef, error) {
+	c, err := a.issuesREST(ctx, true)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	return c.CreateIssue(ctx, repo, in)
+}
+
+func (a *AppClient) UpdateIssue(ctx context.Context, repo string, number int, patch forge.IssuePatch) (forge.IssueRef, error) {
+	c, err := a.issuesREST(ctx, true)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	return c.UpdateIssue(ctx, repo, number, patch)
+}
+
 func (a *AppClient) CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error) {
-	rest, err := a.rest(ctx)
+	c, err := a.issuesREST(ctx, true)
 	if err != nil {
 		return forge.CommentRef{}, err
 	}
-	return rest.CommentIssue(ctx, repo, number, body)
+	return c.CommentIssue(ctx, repo, number, body)
 }

--- a/pkg/forge/github/issues_app_test.go
+++ b/pkg/forge/github/issues_app_test.go
@@ -1,0 +1,223 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The App client is the PRODUCTION shape of a GitHub connection (the studio's
+// connect wizard creates github_app connections by default), so every
+// capability the server type-asserts must exist on it too. A capability
+// implemented on *AdminClient alone is invisible to `admin.(forge.IssueClient)`
+// and the board sync fails at the assertion, not at a call it could explain.
+var (
+	_ forge.IssueClient = (*AdminClient)(nil)
+	_ forge.IssueClient = (*AppClient)(nil)
+)
+
+// issueMintRecorder is a fake GitHub serving the installation-token mint and
+// the issues endpoints, recording the permission set of every mint and the
+// bearer that reached each REST call.
+type issueMintRecorder struct {
+	mu      sync.Mutex
+	mints   []map[string]string
+	bearers []string
+	paths   []string
+	srv     *httptest.Server
+}
+
+func newIssueMintRecorder(t *testing.T) *issueMintRecorder {
+	t.Helper()
+	r := &issueMintRecorder{}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, "/access_tokens") {
+			var body struct {
+				Permissions map[string]string `json:"permissions"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			r.mu.Lock()
+			r.mints = append(r.mints, body.Permissions)
+			n := len(r.mints)
+			r.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token":      "ghs_scoped_" + string(rune('a'+n-1)),
+				"expires_at": "2099-01-01T00:00:00Z",
+			})
+			return
+		}
+		r.mu.Lock()
+		r.bearers = append(r.bearers, req.Header.Get("Authorization"))
+		// The full request URI, query included: "the same endpoint" means the
+		// same filters too, not just the same path.
+		r.paths = append(r.paths, req.Method+" "+req.URL.RequestURI())
+		r.mu.Unlock()
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/issues"):
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"number": 7, "title": "boom", "state": "open", "html_url": "https://gh/x/7"},
+			})
+		case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/issues"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 8, "title": "made", "state": "open"})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 7, "title": "boom", "state": "open"})
+		}
+	}))
+	t.Cleanup(r.srv.Close)
+	return r
+}
+
+func (r *issueMintRecorder) snapshot() ([]map[string]string, []string, []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]map[string]string(nil), r.mints...),
+		append([]string(nil), r.bearers...),
+		append([]string(nil), r.paths...)
+}
+
+func (r *issueMintRecorder) appClient(t *testing.T) *AppClient {
+	t.Helper()
+	return &AppClient{
+		HTTP: r.srv.Client(), WebBaseURL: r.srv.URL,
+		Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t), AppSlug: "iterion"}, InstallationID: 99,
+	}
+}
+
+// testKeyPEMOnce caches one generated key for the file's tests: RSA keygen
+// dominates their runtime otherwise.
+var (
+	testKeyOnce sync.Once
+	testKeyPEMv string
+)
+
+func testKeyPEMOnce(t *testing.T) string {
+	t.Helper()
+	testKeyOnce.Do(func() { testKeyPEMv, _ = testKeyPEM(t) })
+	return testKeyPEMv
+}
+
+// A read through the App client mints a READ-ONLY issues token and calls the
+// exact endpoint the PAT client calls. Widening it to issues:write — which the
+// cached runtime token already carries — would hand a listing the permission to
+// rewrite every issue in the installation.
+func TestAppClientListIssuesMintsAReadScopedToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	opts := forge.IssueListOptions{State: "all", PerPage: 50, Page: 1}
+
+	// The PAT client first: its recorded request IS the reference the App
+	// client's delegation has to reproduce.
+	pat := &AdminClient{HTTP: r.srv.Client(), APIBase: APIBaseFor(r.srv.URL), Token: "ghp_pat"}
+	if _, err := pat.ListIssues(context.Background(), "SocialGouv/iterion", opts); err != nil {
+		t.Fatalf("PAT ListIssues: %v", err)
+	}
+
+	issues, err := r.appClient(t).ListIssues(context.Background(), "SocialGouv/iterion", opts)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 7 {
+		t.Fatalf("issues = %+v, want the one issue the forge served", issues)
+	}
+	mints, bearers, paths := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want exactly 1 (the PAT call mints nothing)", len(mints))
+	}
+	if mints[0]["issues"] != "read" {
+		t.Errorf("mint permissions = %v, want issues:read", mints[0])
+	}
+	if mints[0]["metadata"] != "read" {
+		t.Errorf("mint permissions = %v, want the mandatory metadata baseline", mints[0])
+	}
+	for _, extra := range []string{"contents", "pull_requests", "repository_hooks", "statuses"} {
+		if _, ok := mints[0][extra]; ok {
+			t.Errorf("a read token must not carry %s, got %v", extra, mints[0])
+		}
+	}
+	if len(paths) != 2 || paths[0] != paths[1] {
+		t.Errorf("paths = %v, want the App client to hit the PAT client's own endpoint", paths)
+	}
+	if len(bearers) != 2 || bearers[0] != "Bearer ghp_pat" || !strings.HasPrefix(bearers[1], "Bearer ghs_scoped_") {
+		t.Errorf("bearers = %v, want [the PAT, the minted installation token]", bearers)
+	}
+}
+
+// A sync pass walks hundreds of issues; a token minted per call would cost a
+// mint per issue and burn the App's rate budget. The scoped token is cached
+// per permission set, like the runtime one.
+func TestAppClientIssueReadsReuseTheCachedToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	a := r.appClient(t)
+	ctx := context.Background()
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{Page: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.GetIssue(ctx, "o/r", 7); err != nil {
+		t.Fatal(err)
+	}
+	mints, bearers, _ := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d over 3 reads, want 1 (the scoped token is cached)", len(mints))
+	}
+	if len(bearers) != 3 {
+		t.Fatalf("bearers = %d, want one per REST call", len(bearers))
+	}
+	for _, b := range bearers[1:] {
+		if b != bearers[0] {
+			t.Errorf("every read must reuse the same cached token, got %v", bearers)
+		}
+	}
+}
+
+// A write mints its OWN issues:write token: the read token cannot serve it,
+// and the read must not be widened to make one token do both.
+func TestAppClientIssueWritesMintTheirOwnScopedToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	a := r.appClient(t)
+	ctx := context.Background()
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.CreateIssue(ctx, "o/r", forge.NewIssue{Title: "made"}); err != nil {
+		t.Fatal(err)
+	}
+	title := "renamed"
+	if _, err := a.UpdateIssue(ctx, "o/r", 7, forge.IssuePatch{Title: &title}); err != nil {
+		t.Fatal(err)
+	}
+	mints, bearers, _ := r.snapshot()
+	if len(mints) != 2 {
+		t.Fatalf("mints = %d, want 2 (one read scope, one write scope, both cached)", len(mints))
+	}
+	if mints[0]["issues"] != "read" || mints[1]["issues"] != "write" {
+		t.Fatalf("mint scopes = %v, want [issues:read, issues:write]", mints)
+	}
+	if len(bearers) != 3 || bearers[1] != bearers[2] {
+		t.Errorf("the two writes must share one cached write token, got %v", bearers)
+	}
+	if bearers[0] == bearers[1] {
+		t.Error("the read and the write must not share a token: that is the widening this test forbids")
+	}
+}
+
+// The scoped profiles are their own, and never leak into the runtime baseline
+// the cached management token carries.
+func TestIssuePermissionProfiles(t *testing.T) {
+	read := IssuesReadInstallationPermissions()
+	if read["issues"] != "read" || read["metadata"] != "read" || len(read) != 2 {
+		t.Errorf("read profile = %v, want exactly issues:read + metadata:read", read)
+	}
+	write := IssuesWriteInstallationPermissions()
+	if write["issues"] != "write" || write["metadata"] != "read" || len(write) != 2 {
+		t.Errorf("write profile = %v, want exactly issues:write + metadata:read", write)
+	}
+}

--- a/pkg/forge/github/issues_app_test.go
+++ b/pkg/forge/github/issues_app_test.go
@@ -59,6 +59,9 @@ func newIssueMintRecorder(t *testing.T) *issueMintRecorder {
 		r.paths = append(r.paths, req.Method+" "+req.URL.RequestURI())
 		r.mu.Unlock()
 		switch {
+		case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/comments"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 4242, "body": "hello", "html_url": "https://gh/c/4242"})
 		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/issues"):
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{"number": 7, "title": "boom", "state": "open", "html_url": "https://gh/x/7"},
@@ -209,6 +212,89 @@ func TestAppClientIssueWritesMintTheirOwnScopedToken(t *testing.T) {
 	}
 }
 
+// A comment is the one issue call whose permission depends on WHAT it targets:
+// GitHub serves PR comments from the issues endpoint but gates them on
+// `pull_requests`, and every AppClient.CommentIssue caller in pkg/server
+// targets a pull request (the gate pause notice, the DLQ notice, the
+// approve-rejection reply). All three swallow the error at Debug, so a token
+// short of that grant would turn every notice into a silent 403.
+func TestAppClientCommentIssueMintsAPullRequestScopedToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+
+	// The PAT client first: its recorded request is the reference the App
+	// client's delegation has to reproduce.
+	pat := &AdminClient{HTTP: r.srv.Client(), APIBase: APIBaseFor(r.srv.URL), Token: "ghp_pat"}
+	if _, err := pat.CommentIssue(context.Background(), "o/r", 12, "hello"); err != nil {
+		t.Fatalf("PAT CommentIssue: %v", err)
+	}
+
+	ref, err := r.appClient(t).CommentIssue(context.Background(), "o/r", 12, "hello")
+	if err != nil {
+		t.Fatalf("CommentIssue: %v", err)
+	}
+	if ref.ID != "4242" {
+		t.Errorf("comment ref = %+v, want the comment the forge created", ref)
+	}
+	mints, bearers, paths := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want exactly 1 (the PAT call mints nothing)", len(mints))
+	}
+	if mints[0]["pull_requests"] != "write" {
+		t.Errorf("mint permissions = %v, want pull_requests:write — a comment on a PR number is "+
+			"refused without it (403 \"Resource not accessible by integration\")", mints[0])
+	}
+	if mints[0]["issues"] != "write" {
+		t.Errorf("mint permissions = %v, want issues:write — the same call comments on a real issue too", mints[0])
+	}
+	if mints[0]["metadata"] != "read" {
+		t.Errorf("mint permissions = %v, want the mandatory metadata baseline", mints[0])
+	}
+	for _, extra := range []string{"contents", "repository_hooks", "statuses"} {
+		if _, ok := mints[0][extra]; ok {
+			t.Errorf("a comment token must not carry %s (that is the runtime token's grant), got %v", extra, mints[0])
+		}
+	}
+	if len(paths) != 2 || paths[0] != paths[1] {
+		t.Errorf("paths = %v, want the App client to hit the PAT client's own comment endpoint", paths)
+	}
+	if len(bearers) != 2 || bearers[0] != "Bearer ghp_pat" || !strings.HasPrefix(bearers[1], "Bearer ghs_scoped_") {
+		t.Errorf("bearers = %v, want [the PAT, the minted installation token]", bearers)
+	}
+}
+
+// The comment scope is its OWN cached set: a read must not inherit
+// pull_requests:write by sharing a token with it.
+func TestAppClientCommentAndReadDoNotShareAToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	a := r.appClient(t)
+	ctx := context.Background()
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.CommentIssue(ctx, "o/r", 12, "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.CommentIssue(ctx, "o/r", 13, "again"); err != nil {
+		t.Fatal(err)
+	}
+	mints, bearers, _ := r.snapshot()
+	if len(mints) != 2 {
+		t.Fatalf("mints = %d, want 2 (one read scope, one comment scope, both cached)", len(mints))
+	}
+	if _, ok := mints[0]["pull_requests"]; ok {
+		t.Errorf("the read token must not carry pull_requests, got %v", mints[0])
+	}
+	if mints[1]["pull_requests"] != "write" {
+		t.Errorf("the comment token = %v, want pull_requests:write (its callers all target a PR)", mints[1])
+	}
+	if bearers[0] == bearers[1] {
+		t.Error("the read and the comment must not share a token")
+	}
+	if bearers[1] != bearers[2] {
+		t.Errorf("the two comments must share one cached token, got %v", bearers)
+	}
+}
+
 // The scoped profiles are their own, and never leak into the runtime baseline
 // the cached management token carries.
 func TestIssuePermissionProfiles(t *testing.T) {
@@ -219,5 +305,19 @@ func TestIssuePermissionProfiles(t *testing.T) {
 	write := IssuesWriteInstallationPermissions()
 	if write["issues"] != "write" || write["metadata"] != "read" || len(write) != 2 {
 		t.Errorf("write profile = %v, want exactly issues:write + metadata:read", write)
+	}
+	comment := IssueCommentInstallationPermissions()
+	if comment["issues"] != "write" || comment["pull_requests"] != "write" || comment["metadata"] != "read" || len(comment) != 3 {
+		t.Errorf("comment profile = %v, want exactly issues:write + pull_requests:write + metadata:read", comment)
+	}
+	// The three stay below the runtime baseline: none of them may acquire a
+	// grant the management token holds for other work.
+	base := RuntimeInstallationPermissions()
+	for _, profile := range []map[string]string{read, write, comment} {
+		for name := range profile {
+			if _, ok := base[name]; !ok {
+				t.Errorf("profile %v carries %s, which is not even in the runtime baseline", profile, name)
+			}
+		}
 	}
 }

--- a/pkg/forge/github/issues_app_test.go
+++ b/pkg/forge/github/issues_app_test.go
@@ -164,19 +164,19 @@ func TestAppClientIssueReadsReuseTheCachedToken(t *testing.T) {
 	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{Page: 2}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := a.GetIssue(ctx, "o/r", 7); err != nil {
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{Page: 3}); err != nil {
 		t.Fatal(err)
 	}
 	mints, bearers, _ := r.snapshot()
 	if len(mints) != 1 {
-		t.Fatalf("mints = %d over 3 reads, want 1 (the scoped token is cached)", len(mints))
+		t.Fatalf("mints = %d over 3 pages, want 1 (the scoped token is cached)", len(mints))
 	}
 	if len(bearers) != 3 {
 		t.Fatalf("bearers = %d, want one per REST call", len(bearers))
 	}
 	for _, b := range bearers[1:] {
 		if b != bearers[0] {
-			t.Errorf("every read must reuse the same cached token, got %v", bearers)
+			t.Errorf("every page must reuse the same cached token, got %v", bearers)
 		}
 	}
 }
@@ -212,12 +212,13 @@ func TestAppClientIssueWritesMintTheirOwnScopedToken(t *testing.T) {
 	}
 }
 
-// A comment is the one issue call whose permission depends on WHAT it targets:
-// GitHub serves PR comments from the issues endpoint but gates them on
-// `pull_requests`, and every AppClient.CommentIssue caller in pkg/server
-// targets a pull request (the gate pause notice, the DLQ notice, the
-// approve-rejection reply). All three swallow the error at Debug, so a token
-// short of that grant would turn every notice into a silent 403.
+// A comment is ONE of the two issue calls whose permission depends on WHAT it
+// targets (GetIssue is the other, below): GitHub serves PR comments from the
+// issues endpoint but gates them on `pull_requests`, and every
+// AppClient.CommentIssue caller in pkg/server targets a pull request (the gate
+// pause notice, the DLQ notice, the approve-rejection reply). All three
+// swallow the error at Debug, so a token short of that grant would turn every
+// notice into a silent 403.
 func TestAppClientCommentIssueMintsAPullRequestScopedToken(t *testing.T) {
 	r := newIssueMintRecorder(t)
 
@@ -295,6 +296,68 @@ func TestAppClientCommentAndReadDoNotShareAToken(t *testing.T) {
 	}
 }
 
+// GetIssue is the OTHER call whose grant follows the resource, not the path:
+// its only production caller — the gate-autofix / gate-relaunch hold-label
+// veto — always reads a PULL REQUEST number. A token short of pull_requests
+// gets 404/403 there, the veto cannot be evaluated, and a veto that cannot be
+// evaluated has not been cleared: both lanes stop launching.
+func TestAppClientGetIssueMintsAPullReadableToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	if _, err := r.appClient(t).GetIssue(context.Background(), "o/r", 12); err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	mints, _, _ := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want exactly 1", len(mints))
+	}
+	if mints[0]["pull_requests"] != "read" {
+		t.Errorf("mint permissions = %v, want pull_requests:read — the hold-label veto reads a PR "+
+			"number through this call, and without the grant the read is refused", mints[0])
+	}
+	if mints[0]["issues"] != "read" {
+		t.Errorf("mint permissions = %v, want issues:read — the same call reads a real issue too", mints[0])
+	}
+	for _, w := range []string{"contents", "repository_hooks", "statuses"} {
+		if _, ok := mints[0][w]; ok {
+			t.Errorf("a read token must not carry %s, got %v", w, mints[0])
+		}
+	}
+	for name, level := range mints[0] {
+		if level != "read" {
+			t.Errorf("a read token must carry no write grant, got %s:%s in %v", name, level, mints[0])
+		}
+	}
+}
+
+// The board-sync pass stays on the NARROW read token: it lists the issues
+// collection, which is gated on `issues` alone, and it runs far more often
+// than anything else. Widening it to serve GetIssue would hand every sync a
+// grant it never uses.
+func TestAppClientListIssuesKeepsTheNarrowReadToken(t *testing.T) {
+	r := newIssueMintRecorder(t)
+	a := r.appClient(t)
+	ctx := context.Background()
+	if _, err := a.ListIssues(ctx, "o/r", forge.IssueListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.GetIssue(ctx, "o/r", 12); err != nil {
+		t.Fatal(err)
+	}
+	mints, bearers, _ := r.snapshot()
+	if len(mints) != 2 {
+		t.Fatalf("mints = %d, want 2 (the list and the get do not share a scope)", len(mints))
+	}
+	if _, ok := mints[0]["pull_requests"]; ok {
+		t.Errorf("the list token must stay narrow, got %v", mints[0])
+	}
+	if mints[1]["pull_requests"] != "read" {
+		t.Errorf("the get token = %v, want pull_requests:read", mints[1])
+	}
+	if bearers[0] == bearers[1] {
+		t.Error("the list and the get must not share a token: that is the widening this test forbids")
+	}
+}
+
 // The scoped profiles are their own, and never leak into the runtime baseline
 // the cached management token carries.
 func TestIssuePermissionProfiles(t *testing.T) {
@@ -310,10 +373,14 @@ func TestIssuePermissionProfiles(t *testing.T) {
 	if comment["issues"] != "write" || comment["pull_requests"] != "write" || comment["metadata"] != "read" || len(comment) != 3 {
 		t.Errorf("comment profile = %v, want exactly issues:write + pull_requests:write + metadata:read", comment)
 	}
-	// The three stay below the runtime baseline: none of them may acquire a
+	readOrPull := IssueReadOrPullInstallationPermissions()
+	if readOrPull["issues"] != "read" || readOrPull["pull_requests"] != "read" || readOrPull["metadata"] != "read" || len(readOrPull) != 3 {
+		t.Errorf("read-or-pull profile = %v, want exactly issues:read + pull_requests:read + metadata:read", readOrPull)
+	}
+	// The four stay below the runtime baseline: none of them may acquire a
 	// grant the management token holds for other work.
 	base := RuntimeInstallationPermissions()
-	for _, profile := range []map[string]string{read, write, comment} {
+	for _, profile := range []map[string]string{read, write, comment, readOrPull} {
 		for name := range profile {
 			if _, ok := base[name]; !ok {
 				t.Errorf("profile %v carries %s, which is not even in the runtime baseline", profile, name)

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -51,7 +51,7 @@ func ImportForgeIssues(ctx context.Context, provider forge.Provider, baseURL, to
 	}
 	ic, ok := admin.(forge.IssueClient)
 	if !ok {
-		return 0, 0, fmt.Errorf("forge: provider %q has no issue client", provider)
+		return 0, 0, fmt.Errorf("forge: provider %q client (%T) does not implement forge.IssueClient", provider, admin)
 	}
 	// connID is empty for a self-hosted import: there is no persisted forge
 	// connection, and the deterministic card ID keys on provider+repo+number.
@@ -246,7 +246,7 @@ func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge
 	}
 	ic, ok := admin.(forge.IssueClient)
 	if !ok {
-		return 0, 0, fmt.Errorf("provider %s has no issue client", conn.Provider)
+		return 0, 0, forgeCapabilityErr(conn, admin, "IssueClient")
 	}
 	board := s.cfg.CloudBoardFor(teamID)
 	if board == nil {
@@ -833,7 +833,7 @@ func (s *Server) issueClientForConn(w http.ResponseWriter, ctx context.Context, 
 	}
 	ic, ok := admin.(forge.IssueClient)
 	if !ok {
-		httpError(w, http.StatusNotImplemented, "provider %s has no issue client", conn.Provider)
+		httpError(w, http.StatusNotImplemented, "%v", forgeCapabilityErr(conn, admin, "IssueClient"))
 		return nil, forge.Connection{}, false
 	}
 	return ic, conn, true
@@ -846,7 +846,7 @@ func (s *Server) pullClientForConn(w http.ResponseWriter, ctx context.Context, t
 	}
 	pc, ok := admin.(forge.PullClient)
 	if !ok {
-		httpError(w, http.StatusNotImplemented, "provider %s has no pull/CI client", conn.Provider)
+		httpError(w, http.StatusNotImplemented, "%v", forgeCapabilityErr(conn, admin, "PullClient"))
 		return nil, forge.Connection{}, false
 	}
 	return pc, conn, true

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -131,8 +131,10 @@ type ProjectImportResult struct {
 	// Counted whichever side won — the number an operator needs is "how often
 	// are people and bots fighting over this board".
 	Conflicts int `json:"conflicts"`
-	// SkippedNoCard is items backed by an issue with no native card yet: run
-	// the issue import for that repo first.
+	// SkippedNoCard is items backed by an issue with no native card yet: the
+	// repo's issue sync has to run first — server-side on a cloud instance
+	// (`iterion remote forge integrations sync <id>`, or the periodic worker
+	// on a sync-enabled integration), `iterion issue import` on a local store.
 	SkippedNoCard int `json:"skipped_no_card"`
 	// MissingRepos breaks SkippedNoCard down by repository, most-missing
 	// first. A bare count tells an operator nothing they can act on; the
@@ -331,8 +333,8 @@ func applyProjectItem(
 	switch {
 	case errors.Is(err, tracker.ErrNotFound) || (err == nil && card == nil):
 		// The item's issue has no card yet — the ONE reading that means "run
-		// the issue import for this repo". Both store twins answer a missing
-		// card with this sentinel; the Mongo one wraps everything else.
+		// this repo's issue sync". Both store twins answer a missing card with
+		// this sentinel; the Mongo one wraps everything else.
 		res.SkippedNoCard++
 		missing[it.Content.Repo]++
 		return nil

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -136,6 +136,22 @@ func (s *Server) forgeAdminFor(ctx context.Context, conn forge.Connection) (forg
 	return s.forgeAdminForToken(conn.Provider, conn.BaseURL(), token)
 }
 
+// forgeCapabilityErr explains a failed capability assertion on a client
+// forgeAdminFor built. The client a connection resolves to depends on its
+// KIND — a github_app connection yields an installation-token client, a
+// pat/oauth one a bearer client — and the capabilities differ between them,
+// so naming only the provider ("provider github has no issue client") names
+// neither the thing that lacks the capability nor anything the operator can
+// act on. The kind and the concrete type are what turn the message into a
+// starting point.
+//
+// Kept for the providers that genuinely cannot serve a capability: the point
+// is to say so precisely, not to make the assertion optional.
+func forgeCapabilityErr(conn forge.Connection, client any, capability string) error {
+	return fmt.Errorf("provider %s: the %s connection's client (%T) does not implement forge.%s",
+		conn.Provider, conn.Kind, client, capability)
+}
+
 // forgePreflighter is the optional capability of a forge client whose
 // construction is lazy: a GitHub App client mints its installation token on
 // its first call, so a client forgeAdminFor built without error can still be

--- a/pkg/server/forge_clients_capability_test.go
+++ b/pkg/server/forge_clients_capability_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// forgeAdminFor is the ONE construction every capability assertion downstream
+// reads: the board sync, the push-to-forge routes, the autofix lane and the
+// gate notice all do `admin.(forge.SomeCapability)` on its result. A
+// capability missing from the client that construction returns is invisible
+// until the assertion fails at runtime — on the App connection shape the
+// studio's connect wizard creates BY DEFAULT, which is how the forge→board
+// sync spent every 5-minute tick logging "provider github has no issue
+// client" instead of hydrating a single card.
+//
+// These probes pin the capabilities per connection kind. They need no
+// network: the App client is lazy (it mints on the first call), so what is
+// asserted here is exactly what the server can see before any I/O.
+
+func appConnectionFixture(t *testing.T) (*Server, forge.Connection) {
+	t.Helper()
+	s := newWebhookTestServer(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	conn := forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: "https://github.com", Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AppSlug: "iterion-forge-x", CreatedAt: time.Now().UTC(),
+	}
+	return s, conn
+}
+
+// The defect this file exists for: a GitHub-App connection must yield a
+// client the forge→board sync can use.
+func TestForgeAdminForGitHubAppIsAnIssueClient(t *testing.T) {
+	s, conn := appConnectionFixture(t)
+	admin, err := s.forgeAdminFor(context.Background(), conn)
+	if err != nil {
+		t.Fatalf("forgeAdminFor: %v", err)
+	}
+	if _, ok := admin.(forge.IssueClient); !ok {
+		t.Fatalf("a %s connection yields %T, which does not implement forge.IssueClient: "+
+			"syncOneIntegration fails its assertion and the board is never hydrated", conn.Kind, admin)
+	}
+}
+
+// The class the defect belongs to: every capability a pkg/server lane asserts
+// on forgeAdminFor's result. A gap here is an operator-visible dead lane on
+// App connections, so it must be a deliberate, named decision — not a
+// discovery in production.
+func TestForgeAdminForGitHubAppCapabilityMatrix(t *testing.T) {
+	s, conn := appConnectionFixture(t)
+	admin, err := s.forgeAdminFor(context.Background(), conn)
+	if err != nil {
+		t.Fatalf("forgeAdminFor: %v", err)
+	}
+	served := map[string]bool{
+		"IssueClient":        assertsAs[forge.IssueClient](admin),
+		"PermissionClient":   assertsAs[forge.PermissionClient](admin),
+		"ReviewClient":       assertsAs[forge.ReviewClient](admin),
+		"CommitStatusClient": assertsAs[forge.CommitStatusClient](admin),
+		"CommitStatusLister": assertsAs[forge.CommitStatusLister](admin),
+		"RepoCreator":        assertsAs[forge.RepoCreator](admin),
+		"BoardClient":        assertsAs[forge.BoardClient](admin),
+	}
+	for name, ok := range served {
+		if !ok {
+			t.Errorf("a github_app connection must serve forge.%s; %T does not", name, admin)
+		}
+	}
+	// PullClient is the KNOWN App-connection gap, asserted so it cannot
+	// change in either direction unnoticed. The App client serves
+	// GetPullRequest but not the list/create/merge/CI half, so the board
+	// card's PR panel (GET|POST /api/v1/native/issues/{id}/pulls,
+	// .../pulls/{n}/ci, .../pulls/{n}/merge) answers 501 on a github_app
+	// connection while it works on a PAT one.
+	//
+	// It is not the same shape of fix as IssueClient: GetCIStatus reads
+	// /commits/{ref}/check-runs, which needs `checks: read` — a permission
+	// neither the runtime baseline nor the App manifest requests, so closing
+	// the gap means a manifest change and an org re-approval per
+	// installation, not a delegation. When that lands, delete this assertion.
+	if assertsAs[forge.PullClient](admin) {
+		t.Errorf("forge.PullClient is now served on github_app (%T) — the gap closed: "+
+			"drop this assertion and the 501 note it pins", admin)
+	}
+}
+
+func assertsAs[T any](v any) bool {
+	_, ok := v.(T)
+	return ok
+}
+
+// The forge→board sync is the ONE lane every supported credential shape has to
+// reach: without it a team's cards are never hydrated and the project pass
+// reads skipped_no_card forever. So the conformance is over the whole matrix
+// forgeAdminFor can build — provider × connection kind — not over the one
+// shape a bug was reported on. A new provider or a new kind lands here before
+// it lands in production.
+func TestForgeAdminForEveryConnectionShapeIsAnIssueClient(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	sealed, err := forge.SealPAT(s.sealer, "c-1", "ghp_fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, provider := range []forge.Provider{forge.ProviderGitHub, forge.ProviderGitLab, forge.ProviderForgejo} {
+		for _, kind := range []forge.Kind{forge.KindPAT, forge.KindOAuthApp, forge.KindGitHubApp} {
+			if kind == forge.KindGitHubApp && provider != forge.ProviderGitHub {
+				continue // a GitHub App is a GitHub-only credential shape
+			}
+			t.Run(string(provider)+"/"+string(kind), func(t *testing.T) {
+				conn := forge.Connection{
+					ID: "c-1", TenantID: "t1", Provider: provider, Kind: kind,
+					Status: forge.StatusActive, Purpose: forge.PurposeRuntime,
+					ForgeBaseURL: forge.DefaultBaseURL(provider), InstallationID: 42,
+					AppSlug: "iterion-forge-x", SealedPayload: sealed,
+					CreatedAt: time.Now().UTC(),
+				}
+				admin, err := s.forgeAdminFor(context.Background(), conn)
+				if err != nil {
+					t.Fatalf("forgeAdminFor: %v", err)
+				}
+				if _, ok := admin.(forge.IssueClient); !ok {
+					t.Fatalf("%s/%s yields %T, which does not implement forge.IssueClient: "+
+						"the forge→board sync cannot run on this connection shape", provider, kind, admin)
+				}
+			})
+		}
+	}
+}

--- a/pkg/server/forge_gate_autofix.go
+++ b/pkg/server/forge_gate_autofix.go
@@ -464,7 +464,7 @@ func (s *Server) pullRequestHoldLabel(ctx context.Context, conn forge.Connection
 	}
 	ic, ok := admin.(forge.IssueClient)
 	if !ok {
-		return "", fmt.Errorf("provider %s cannot read issue labels", conn.Provider)
+		return "", fmt.Errorf("cannot read issue labels: %w", forgeCapabilityErr(conn, admin, "IssueClient"))
 	}
 	iss, err := ic.GetIssue(ctx, repo, number)
 	if err != nil {

--- a/pkg/server/forge_hold_label_app_test.go
+++ b/pkg/server/forge_hold_label_app_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The hold-label veto is the operator's automation brake: pullRequestHoldLabel
+// reads the labels of a PULL REQUEST through forge.IssueClient.GetIssue, and
+// both the gate-autofix lane (forge_gate_autofix.go:282) and the gate-relaunch
+// lane (forge_gate_relaunch.go:178) refuse to launch when the read fails —
+// a veto that cannot be evaluated has not been cleared.
+//
+// On a github_app connection that read rides a MINTED token, so its permission
+// set decides whether the brake works at all. GitHub gates a PR read on
+// `pull_requests` even though the path is the issues one, so a token scoped to
+// `issues` alone answers 404 and both lanes stop launching for the whole repo.
+// This probe wires the real App path end to end and lets the fake forge apply
+// exactly that rule, so what is asserted is the LANE working, not a map.
+
+// prReadForge is a fake GitHub whose issue read obeys GitHub's own rule: the
+// number is a pull request, so the call is refused unless the bearer's minted
+// token carried the pull_requests grant.
+type prReadForge struct {
+	mu sync.Mutex
+	// perms maps an issued token to the permission set it was minted with.
+	perms map[string]map[string]string
+	// refused counts reads rejected for want of the grant.
+	refused int
+	srv     *httptest.Server
+}
+
+func newPRReadForge(t *testing.T) *prReadForge {
+	t.Helper()
+	f := &prReadForge{perms: map[string]map[string]string{}}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/access_tokens") {
+			var body struct {
+				Permissions map[string]string `json:"permissions"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			f.mu.Lock()
+			tok := "ghs_" + strings.Join(sortedKeys(body.Permissions), "_")
+			f.perms[tok] = body.Permissions
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": tok, "expires_at": "2099-01-01T00:00:00Z"})
+			return
+		}
+		tok := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		f.mu.Lock()
+		granted := f.perms[tok]
+		_, canReadPulls := granted["pull_requests"]
+		if !canReadPulls {
+			f.refused++
+		}
+		f.mu.Unlock()
+		if !canReadPulls {
+			// GitHub hides what the token cannot see rather than saying why.
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Not Found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 12, "title": "a pull request", "state": "open",
+			"labels":       []map[string]any{{"name": "do-not-merge"}},
+			"pull_request": map[string]any{"url": "https://gh/pulls/12"},
+		})
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	// Deterministic token names; the order itself is irrelevant.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+func (f *prReadForge) refusedCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.refused
+}
+
+// A hold label on a PR is READ through a github_app connection — the lane's
+// brake works. Before GetIssue carried the pull_requests grant this returned
+// the forge's 404 and both lanes declined to launch, for every PR of every
+// repo with hold_labels configured.
+func TestPullRequestHoldLabelReadsThroughAGitHubAppConnection(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	f := newPRReadForge(t)
+	conn := forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: f.srv.URL, Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AppSlug: "iterion-forge-x", CreatedAt: time.Now().UTC(),
+	}
+
+	held, err := s.pullRequestHoldLabel(context.Background(), conn, "o/r", 12, []string{"do-not-merge"})
+	if err != nil {
+		t.Fatalf("the hold-label veto could not be evaluated on an App connection (%d read(s) refused for "+
+			"want of pull_requests): %v — the autofix and gate-relaunch lanes both decline to launch on this", f.refusedCount(), err)
+	}
+	if held != "do-not-merge" {
+		t.Errorf("held = %q, want the hold label the PR carries", held)
+	}
+}
+
+// The other half of the veto: a PR without the label reads cleanly as "not
+// held", so a working read is never mistaken for a brake.
+func TestPullRequestHoldLabelAbsentOnAGitHubAppConnection(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	f := newPRReadForge(t)
+	conn := forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: f.srv.URL, Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AppSlug: "iterion-forge-x", CreatedAt: time.Now().UTC(),
+	}
+
+	held, err := s.pullRequestHoldLabel(context.Background(), conn, "o/r", 12, []string{"wip", "blocked"})
+	if err != nil {
+		t.Fatalf("pullRequestHoldLabel: %v", err)
+	}
+	if held != "" {
+		t.Errorf("held = %q, want empty — the PR carries none of the configured hold labels", held)
+	}
+}


### PR DESCRIPTION
Closes #767.

## What was wrong (prod, 2026-09-05 15:26Z)
`forgeAdminFor` returns a `forgegithub.AppClient` for a GitHub-App connection, and that type did not implement `forge.IssueClient`, so `syncOneIntegration` failed its type assertion: manual `POST …/forge/integrations/{iid}/sync` → `502 sync failed: provider github has no issue client`, and the 5-minute worker logged `warn board sync: <team>/SocialGouv/iterion: provider github has no issue client` on every tick. With ADR-097's project pass being hydrate-never-create, a team whose repo integration rides a GitHub App (the ordinary case) could bind a board and never sync a card (`skipped_no_card=103` on the #613 pilot). Second symptom closed by the same fix: `pullRequestHoldLabel` reads `GetIssue`, so on an App connection the autofix lane's hold-label veto was unevaluable.

## The fix
- `AppClient` implements the five `IssueClient` methods through one chokepoint `issuesREST(ctx, write)` → `scopedREST(ctx, perms)`, which mints a token for EXACTLY that permission set (`issues:read + metadata:read` for reads, `issues:write + metadata:read` for writes) and caches it per set (refresh 60 s before expiry; keys sorted so map order cannot defeat the cache). The runtime token is untouched; no read mints `write`. `CommentIssue` moves onto the same chokepoint (a narrowing). `projectsREST`'s deliberately uncached per-call board token is left as designed.
- A refused forge capability names the connection kind and the client type in the error.
- `docs/github-board-sync.md`: the cloud remedy is `iterion remote forge integrations sync <id>`, not the local `iterion issue import`.

## Red first
```
--- FAIL: TestForgeAdminForGitHubAppIsAnIssueClient
    a github_app connection yields *github.AppClient, which does not implement forge.IssueClient: syncOneIntegration fails its assertion and the board is never hydrated
--- FAIL: TestForgeAdminForGitHubAppCapabilityMatrix
issues_app_test.go: *AppClient does not implement forge.IssueClient (missing method CreateIssue) …
```
Tests: `ListIssues` through the App client mints `issues:read` (asserting no `contents`/`pull_requests`/`repository_hooks`/`statuses` leak) and issues the exact request the PAT client makes (both run against one recorder, method + RequestURI compared); 3 reads = 1 mint; a write mints its own token and the two writes share it; `forgeAdminFor(KindGitHubApp)` yields an `IssueClient`; a capability matrix over provider × kind (7 live shapes) so a new provider or kind lands in the test before production.

## Capability grep (every `admin.(forge.X)` on the result of `forgeAdminFor`)
`RepoCreator`, `CommitStatusLister`, `PermissionClient`, `ReviewClient`, `Admin`, `BoardClient`, now `IssueClient`: served by the App client. Remaining gap, pinned by an assertion that fails when it closes: **`PullClient`** (`board_forge.go:847` — the card's PR panel answers 501 on an App connection) — `GetCIStatus` reads check-runs and needs `checks: read`, which the App manifest does not request; closing it is a manifest change plus an org re-approval per installation, tracked separately. `ReviewerAssigner` / `OAuthAppProvisioner` are documented non-implementations (an App cannot be a PR reviewer nor create an OAuth App).

`task check` exit 0 (136 packages, studio 1319 tests), `-race` on pkg/forge + pkg/server green, `task openapi:check` no drift. Acceptance in prod: integration `429d7b5e` (SocialGouv/iterion) is left `sync_issues_enabled: true` — the worker succeeding after the deploy is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)