### PR TITLE
fix(ultracode): the model gate admits the Claude 5 family, shared by the compiler and the studio endpoint

### DIFF
--- a/docs/ultracode.md
+++ b/docs/ultracode.md
@@ -9,8 +9,9 @@ Code's "Ultracode" level:
 
 It is delivered through prompt engineering (a standing-consent system
 instruction) rather than a new wire parameter, and it is **reliable only on
-`claude-opus-4-8`** — the orchestration half is backed by Anthropic's
-mid-conversation system messages, which ship on Opus 4.8 only. On any other
+`claude-opus-4-8` and the Claude 5 family (`claude-opus-5`,
+`claude-fable-5-1`)** — the orchestration half is backed by Anthropic's
+mid-conversation system messages, which ship on those models. On any other
 model ultracode degrades gracefully to plain `xhigh`.
 
 See Anthropic's reference: [Effort](https://platform.claude.com/docs/en/build-with-claude/effort)
@@ -86,6 +87,6 @@ and via env substitution, which is resolved (and re-validated) at runtime:
 ## Studio
 
 The effort selector offers **ultracode** only when the node's model is
-`claude-opus-4-8` (the `/api/effort-capabilities` endpoint gates it server-side,
+`claude-opus-4-8` or a Claude 5 model (the `/api/effort-capabilities` endpoint gates it server-side,
 complementing the C089 compile warning). The `EffortBar` renders it full-bar in
 a distinct accent tone, reading as "beyond max".

--- a/examples/ultracode/sample.bot
+++ b/examples/ultracode/sample.bot
@@ -5,7 +5,7 @@
 ## orchestrate multi-agent workflows (the `agent` subagent tool). It is a mode,
 ## not a wire value — the runtime sends `xhigh` to the provider and appends a
 ## "## Workflow Orchestration" system-prompt section. Reliable only on
-## claude-opus-4-8 (else compiles with a C089 warning and runs as plain xhigh).
+## claude-opus-4-8 or a Claude 5 model (else compiles with a C089 warning and runs as plain xhigh).
 ## Restricting tools below shows the runtime auto-adding the `agent` subagent
 ## tool so the orchestration prerogative has something to act on.
 ## See docs/ultracode.md.

--- a/pkg/dsl/ir/diagnostics_codes.go
+++ b/pkg/dsl/ir/diagnostics_codes.go
@@ -27,7 +27,7 @@ const (
 	DiagForeachConflictsLoop     DiagCode = "C118" // edge combines `as foreach` with `as <loop>` (error)
 	DiagSubbotNoSource           DiagCode = "C119" // subbot node without a `source:` child .bot (error)
 	DiagInvalidReasoningEffort   DiagCode = "C027" // invalid reasoning_effort value (was C024, clashed with DiagDuplicateMCPServer)
-	DiagUltracodeModelGate       DiagCode = "C089" // reasoning_effort: ultracode on a model that isn't claude-opus-4-8 (warning)
+	DiagUltracodeModelGate       DiagCode = "C089" // reasoning_effort: ultracode on a model that is neither Opus 4.8 nor Claude 5 (warning)
 	DiagInvalidLoopIterations    DiagCode = "C026" // loop max_iterations must be >= 1
 	DiagDuplicateWithKey         DiagCode = "C028" // duplicate with-mapping key across edges to same target
 	DiagUnknownRefNode           DiagCode = "C029" // outputs ref to non-existent node

--- a/pkg/dsl/ir/ultracode_test.go
+++ b/pkg/dsl/ir/ultracode_test.go
@@ -70,3 +70,21 @@ func TestUltracodeNoWarnOnOpusAlias(t *testing.T) {
 		t.Errorf("C089 must NOT fire on the opus alias, got %+v", cr.Diagnostics)
 	}
 }
+
+// TestUltracodeNoWarnOnClaude5: the Claude 5 family carries ultracode's
+// orchestration half — C089 must stay silent on Opus 5 and Fable 5.1.
+func TestUltracodeNoWarnOnClaude5(t *testing.T) {
+	for _, model := range []string{"anthropic/claude-opus-5", "anthropic/claude-fable-5-1", "fable"} {
+		pr := parser.Parse("t.bot", ultracodeWorkflow(model))
+		if len(pr.Diagnostics) > 0 {
+			t.Fatalf("%s: parse errors: %+v", model, pr.Diagnostics)
+		}
+		cr := Compile(pr.File)
+		if cr.HasErrors() {
+			t.Fatalf("%s: ultracode must compile without errors, got %+v", model, cr.Diagnostics)
+		}
+		if hasDiag(cr.Diagnostics, DiagUltracodeModelGate) {
+			t.Errorf("C089 must NOT fire on %s, got %+v", model, cr.Diagnostics)
+		}
+	}
+}

--- a/pkg/dsl/ir/validate_nodes.go
+++ b/pkg/dsl/ir/validate_nodes.go
@@ -1116,15 +1116,16 @@ func (c *compiler) validateReasoningEffort(w *Workflow) {
 		}
 		// ultracode (xhigh + workflow-orchestration prerogative) relies on
 		// mid-conversation system messages, which Anthropic ships on Opus 4.8
-		// only. On any other model it degrades to plain xhigh — warn so the
-		// author knows the orchestration half won't be reliable.
-		if effort == "ultracode" && !modelIsOpus48(model) {
+		// and the Claude 5 family (Opus 5, Fable 5.1). On any other model it
+		// degrades to plain xhigh — warn so the author knows the orchestration
+		// half won't be reliable.
+		if effort == "ultracode" && !ModelSupportsUltracode(model) {
 			shown := model
 			if shown == "" {
 				shown = "(default)"
 			}
 			c.warnf(DiagUltracodeModelGate,
-				"node %q uses reasoning_effort: ultracode but model %q is not claude-opus-4-8; ultracode's workflow-orchestration prerogative is reliable only on Opus 4.8 and will degrade to plain xhigh elsewhere",
+				"node %q uses reasoning_effort: ultracode but model %q is neither Opus 4.8 nor a Claude 5 model (Opus 5, Fable 5.1); ultracode's workflow-orchestration prerogative is reliable only there and will degrade to plain xhigh elsewhere",
 				node.NodeID(), shown)
 		}
 	}
@@ -1162,12 +1163,14 @@ func (c *compiler) validateNodeTimeout(w *Workflow) {
 	}
 }
 
-// modelIsOpus48 reports whether a model spec resolves to claude-opus-4-8.
-// An empty spec is treated as the default (Opus 4.8 when Anthropic is the
-// resolved backend) and env-substituted forms are deferred to runtime — both
-// suppress the ultracode gate warning. The bare "opus" alias resolves to the
-// newest Opus (4.8) in claw's registry.
-func modelIsOpus48(model string) bool {
+// ModelSupportsUltracode reports whether a model spec resolves to a model
+// that carries ultracode's orchestration half: claude-opus-4-8 or the
+// Claude 5 family (claude-opus-5, claude-fable-5-1). An empty spec is
+// treated as the default (the newest Opus when Anthropic is the resolved
+// backend) and env-substituted forms are deferred to runtime — both
+// suppress the ultracode gate warning. The bare "opus" and "fable" aliases
+// resolve to the newest of their line in claw's registry.
+func ModelSupportsUltracode(model string) bool {
 	m := strings.ToLower(strings.TrimSpace(model))
 	if m == "" || IsEnvSubstitutedEffort(m) {
 		return true
@@ -1175,5 +1178,11 @@ func modelIsOpus48(model string) bool {
 	if i := strings.LastIndex(m, "/"); i >= 0 {
 		m = m[i+1:]
 	}
-	return m == "opus" || strings.Contains(m, "opus-4-8")
+	switch {
+	case m == "opus", m == "fable":
+		return true
+	case strings.Contains(m, "opus-4-8"), strings.Contains(m, "opus-5"), strings.Contains(m, "fable-5"):
+		return true
+	}
+	return false
 }

--- a/pkg/server/effort.go
+++ b/pkg/server/effort.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -202,12 +201,12 @@ func (s *Server) handleEffortCapabilities(w http.ResponseWriter, r *http.Request
 	case "claude_code", "claw":
 		supported, def := apikit.EffortCapabilities(model)
 		// Surface the "ultracode" mode (xhigh + workflow-orchestration
-		// prerogative) only on claude-opus-4-8: its orchestration half is
-		// backed by mid-conversation system messages, which Anthropic ships
-		// on Opus 4.8 only. ResolveModelAlias maps the "opus" alias to the
-		// canonical id and returns any literal unchanged, so it covers both
-		// the alias and the bare/prefixed forms. See docs/ultracode.md.
-		if strings.Contains(apikit.ResolveModelAlias(model), "claude-opus-4-8") {
+		// prerogative) only on the models that carry its orchestration half
+		// (Opus 4.8, the Claude 5 family) — the same predicate the compiler's
+		// C089 gate uses, so the studio and the compiler never disagree.
+		// ResolveModelAlias maps the "opus" alias to the canonical id and
+		// returns any literal unchanged. See docs/ultracode.md.
+		if ir.ModelSupportsUltracode(apikit.ResolveModelAlias(model)) {
 			supported = append(append([]string(nil), supported...), "ultracode")
 		}
 		writeJSON(w, effortCapabilitiesResponse{

--- a/pkg/server/effort_test.go
+++ b/pkg/server/effort_test.go
@@ -32,6 +32,26 @@ func TestEffortCapabilities_ClawOpus48(t *testing.T) {
 	)
 }
 
+// Opus 5 carries ultracode's orchestration half too: the endpoint offers the
+// mode there, through the same predicate the compiler's C089 gate uses.
+func TestEffortCapabilities_ClawOpus5(t *testing.T) {
+	_, hs := newTestServer(t)
+
+	got := getEffortCaps(t, hs.URL, "claw", "claude-opus-5")
+	if got.Source != "claw-registry" {
+		t.Errorf("Source=%q, want %q", got.Source, "claw-registry")
+	}
+	// Only the mode is asserted here: the level table (low … max, default)
+	// for the Claude 5 family is the claw registry's to ship
+	// (apikit.EffortCapabilities returns no levels for claude-opus-5 at the
+	// pinned claw-code-go revision) — a gap of that registry, not of this
+	// endpoint, tracked on claw-code-go.
+	assertEffortLevels(t, got.Supported,
+		[]string{"ultracode"}, // required
+		nil,                   // forbidden
+	)
+}
+
 // TestEffortCapabilities_ClaudeCodeMirrorsClaw proves the claude_code
 // backend routes through the same claw-registry data as claw itself
 // (they share apikit.EffortCapabilities). If a regression tied
@@ -59,7 +79,7 @@ func TestEffortCapabilities_ClaudeCodeMirrorsClaw(t *testing.T) {
 // entry. Opus 4.7 has the same floor levels but must NOT carry
 // ultracode — the mid-conversation system-message plumbing that backs
 // it only ships on 4.8.
-func TestEffortCapabilities_UltracodeOnlyOnOpus48(t *testing.T) {
+func TestEffortCapabilities_UltracodeNotOnOpus47(t *testing.T) {
 	_, hs := newTestServer(t)
 
 	got := getEffortCaps(t, hs.URL, "claw", "claude-opus-4-7")


### PR DESCRIPTION
## Two copies of a stale predicate

`reasoning_effort: ultracode` warned C089 on every model but Opus 4.8, and the studio's `/api/effort-capabilities` endpoint offered the mode on Opus 4.8 alone. Both were written when Opus 4.8 was the only model carrying the orchestration half. The Claude 5 family (Opus 5, Fable 5.1) carries it too, and the campaign bots now default to `claude-opus-5`: on them ultracode compiled with a stale warning and the studio never offered the mode.

The prerogative itself was never gated on the model: `executor_build_task.go` sets the mode flag from the effort alone, so on Opus 5 the orchestration prompt and tool already travel. The warning was the only thing that lied — and the endpoint the only thing that withheld.

## Fix

One exported predicate, `ir.ModelSupportsUltracode`, serves both sites: Opus 4.8, Opus 5, Fable 5.1, the bare `opus`/`fable` aliases, plus the empty/env-substituted forms the gate already deferred. The server calls it on the alias-resolved model, so the studio and the compiler cannot disagree again. Docs and the example say the same.

## Proof

- `TestUltracodeNoWarnOnClaude5`: C089 silent on `claude-opus-5`, `claude-fable-5-1`, `fable`; `TestUltracodeGateWarnsOffOpus48` still fires on sonnet-4-6; `TestEffortCapabilities_UltracodeNotOnOpus47` (renamed for what it tests) still forbids the mode on Opus 4.7.
- `TestEffortCapabilities_ClawOpus5`: the endpoint offers `ultracode` on `claude-opus-5`. It asserts the mode only: the level table (low … max, default) for the Claude 5 family is the claw registry's to ship — `apikit.EffortCapabilities` returns no levels for `claude-opus-5` at the pinned claw-code-go revision — a gap of that registry, tracked there.
- `go test ./pkg/dsl/ir/ ./pkg/server/ -run 'Ultracode|EffortCapabilities'` green; gofmt and vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
