### PR TITLE
fix(runtime): a loop is priced on any entry into its body; a stale run-start mark is re-based on resume

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -394,6 +394,9 @@
             },
             "type": "object"
           },
+          "loop_budget_marks_v": {
+            "type": "integer"
+          },
           "loop_counters": {
             "additionalProperties": {
               "type": "integer"

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -817,6 +817,14 @@ func (e *Engine) selectEdgeBranch(ctx context.Context, runID, branchID, fromNode
 			}
 			// Price on any entry into the body from outside (see the
 			// engine's edge path); reset the counter on the loop's entries.
+			// Never while the loop is iterating, unless at one of its entries:
+			// a body computed over non-loop edges can leave a node of the
+			// cycle outside it, and the edge from that node back into the
+			// body fires every iteration — re-basing there would price the
+			// iteration at its tail alone and never decline the back-edge.
+			if rs.loopCounters[loopName] > 0 && !loop.Entries[selected.To] {
+				continue
+			}
 			markLoopBudget(rs, loopName)
 			if !loop.Entries[selected.To] {
 				continue

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -812,10 +812,15 @@ func (e *Engine) selectEdgeBranch(ctx context.Context, runID, branchID, fromNode
 
 	if selected.LoopName == "" {
 		for loopName, loop := range e.workflow.Loops {
-			if loop == nil || len(loop.Entries) == 0 || !loop.Entries[selected.To] || loop.Body[selected.From] {
+			if loop == nil || len(loop.Body) == 0 || loop.Body[selected.From] || !loop.Body[selected.To] {
 				continue
 			}
+			// Price on any entry into the body from outside (see the
+			// engine's edge path); reset the counter on the loop's entries.
 			markLoopBudget(rs, loopName)
+			if !loop.Entries[selected.To] {
+				continue
+			}
 			if prior := rs.loopCounters[loopName]; prior > 0 {
 				rs.loopCounters[loopName] = 0
 				delete(rs.loopPreviousOutput, loopName)

--- a/pkg/runtime/checkpoint.go
+++ b/pkg/runtime/checkpoint.go
@@ -29,6 +29,7 @@ func buildCheckpointWithoutParallel(rs *runState, nodeID string) *store.Checkpoi
 		LoopPreviousOutput: rs.loopPreviousOutput,
 		LoopCurrentOutput:  rs.loopCurrentOutput,
 		LoopBudgetMarks:    snapshotLoopBudgetMarks(rs),
+		LoopBudgetMarksV:   loopBudgetMarksVersion,
 		ArtifactVersions:   rs.artifactVersions,
 		SelectedIncoming:   cloneIncoming(rs.selectedIncoming),
 		Vars:               rs.vars,

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -883,6 +883,14 @@ func (e *Engine) selectEdgeRS(rs *runState, fromNodeID string, output map[string
 			// left at run start would price its first crossing at the
 			// whole run and decline it. A FIRST entry needs the baseline
 			// just as much as a re-entry, and leaves the counter at 0.
+			// Never while the loop is iterating, unless at one of its entries:
+			// a body computed over non-loop edges can leave a node of the
+			// cycle outside it, and the edge from that node back into the
+			// body fires every iteration — re-basing there would price the
+			// iteration at its tail alone and never decline the back-edge.
+			if rs.loopCounters[loopName] > 0 && !loop.Entries[selected.To] {
+				continue
+			}
 			markLoopBudget(rs, loopName)
 			if !loop.Entries[selected.To] {
 				continue

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -872,18 +872,21 @@ func (e *Engine) selectEdgeRS(rs *runState, fromNodeID string, output map[string
 	// when a parent iteration legitimately re-enters.
 	if selected.LoopName == "" {
 		for loopName, loop := range e.workflow.Loops {
-			if loop == nil || len(loop.Entries) == 0 {
-				continue
-			}
-			if !loop.Entries[selected.To] || loop.Body[selected.From] {
+			if loop == nil || len(loop.Body) == 0 || loop.Body[selected.From] || !loop.Body[selected.To] {
 				continue
 			}
 			// Entering the body from outside re-bases the loop's price:
 			// its first back-edge crossing must cost one iteration, not
-			// everything the run spent before this loop existed. Outside
-			// the re-entry branch below — a FIRST entry needs the
-			// baseline just as much, and leaves the counter at 0.
+			// everything the run spent before this loop existed. At ANY
+			// body node — a loop that shares its verify/gate nodes with a
+			// sibling loop is entered there, off its own head, and a mark
+			// left at run start would price its first crossing at the
+			// whole run and decline it. A FIRST entry needs the baseline
+			// just as much as a re-entry, and leaves the counter at 0.
 			markLoopBudget(rs, loopName)
+			if !loop.Entries[selected.To] {
+				continue
+			}
 			if prior, ok := rs.loopCounters[loopName]; ok && prior > 0 {
 				e.logger.Debug("loop %q: re-entered via edge %s→%s — counter reset from %d", loopName, selected.From, selected.To, prior)
 				rs.loopCounters[loopName] = 0

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -181,7 +181,7 @@ func (e *Engine) baselineUnpricedLoops(rs *runState) {
 		// everything the run has spent and decline it. Re-based here, it
 		// prices from the resume point like a loop measured for the first
 		// time. A fresh run re-bases a zero with a zero — no change.
-		if priced && !(isRunStartBaseline(mark) && !loopHoldsEntry(loop, e.workflow.Entry)) {
+		if priced && (!isRunStartBaseline(mark) || loopHoldsEntry(loop, e.workflow.Entry)) {
 			continue
 		}
 		markLoopBudget(rs, loopName)

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"fmt"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
 	"os"
 	"strings"
 	"time"
@@ -171,20 +172,39 @@ func markLoopBudget(rs *runState, loopName string) {
 // Loops entered later are re-marked at their entry edge, and a loop
 // whose price survived on the checkpoint keeps it.
 func (e *Engine) baselineUnpricedLoops(rs *runState) {
-	for loopName, loop := range e.workflow.Loops {
-		mark, priced := rs.loopBudgetMarks[loopName]
-		// A restored mark still at the run-start baseline on a loop whose
-		// body does not hold the workflow entry was never measured: the
-		// run entered that body off its head, on an engine that only
-		// priced entries at the head, and carried the zero into the
-		// checkpoint. Kept, it would price the loop's first crossing at
-		// everything the run has spent and decline it. Re-based here, it
-		// prices from the resume point like a loop measured for the first
-		// time. A fresh run re-bases a zero with a zero — no change.
-		if priced && (!isRunStartBaseline(mark) || loopHoldsEntry(loop, e.workflow.Entry)) {
+	for loopName := range e.workflow.Loops {
+		if _, priced := rs.loopBudgetMarks[loopName]; priced {
 			continue
 		}
 		markLoopBudget(rs, loopName)
+	}
+}
+
+// loopBudgetMarksVersion is the format stamped on checkpoints: version 2
+// marks are measured (a loop's entry or its back-edge). Checkpoints below
+// it were written by an engine that also kept the run-start baseline on
+// loops never entered at their head — see restoreCheckpointBudget.
+const loopBudgetMarksVersion = 2
+
+// restoreCheckpointBudget restores consumption and loop prices from a
+// checkpoint, then drops what a legacy checkpoint could only have guessed:
+// a mark still at the run-start baseline on a loop whose body does not hold
+// the workflow entry. Such a loop was entered off its head, on an engine
+// that priced entries at the head only, and never measured; restored, the
+// zero would price its first crossing after the resume at everything the
+// run has spent and decline it. Dropped, the loop reports no shortfall
+// until measured and the session baseline prices it from the resume point.
+// Provenance decides, never the mark's shape: a version-2 checkpoint keeps
+// a zero that a loop legitimately entered at zero consumption.
+func (e *Engine) restoreCheckpointBudget(rs *runState, cp *store.Checkpoint) {
+	restoreBudgetAccounting(rs, cp)
+	if cp == nil || cp.LoopBudgetMarksV >= loopBudgetMarksVersion {
+		return
+	}
+	for loopName, mark := range rs.loopBudgetMarks {
+		if isRunStartBaseline(mark) && !loopHoldsEntry(e.workflow.Loops[loopName], e.workflow.Entry) {
+			delete(rs.loopBudgetMarks, loopName)
+		}
 	}
 }
 

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"os"
 	"strings"
 	"time"
@@ -170,12 +171,44 @@ func markLoopBudget(rs *runState, loopName string) {
 // Loops entered later are re-marked at their entry edge, and a loop
 // whose price survived on the checkpoint keeps it.
 func (e *Engine) baselineUnpricedLoops(rs *runState) {
-	for loopName := range e.workflow.Loops {
-		if _, priced := rs.loopBudgetMarks[loopName]; priced {
+	for loopName, loop := range e.workflow.Loops {
+		mark, priced := rs.loopBudgetMarks[loopName]
+		// A restored mark still at the run-start baseline on a loop whose
+		// body does not hold the workflow entry was never measured: the
+		// run entered that body off its head, on an engine that only
+		// priced entries at the head, and carried the zero into the
+		// checkpoint. Kept, it would price the loop's first crossing at
+		// everything the run has spent and decline it. Re-based here, it
+		// prices from the resume point like a loop measured for the first
+		// time. A fresh run re-bases a zero with a zero — no change.
+		if priced && !(isRunStartBaseline(mark) && !loopHoldsEntry(loop, e.workflow.Entry)) {
 			continue
 		}
 		markLoopBudget(rs, loopName)
 	}
+}
+
+// isRunStartBaseline reports a mark taken before the run consumed anything:
+// no cost, no tokens, and less than a second of wall time.
+func isRunStartBaseline(mark loopBudgetMark) bool {
+	for dim, v := range mark {
+		if dim == "duration" {
+			if v >= float64(time.Second) {
+				return false
+			}
+			continue
+		}
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// loopHoldsEntry reports whether the workflow entry sits in the loop's
+// body — the one case where a run-start mark is the loop's true price.
+func loopHoldsEntry(loop *ir.Loop, entry string) bool {
+	return loop != nil && loop.Body[entry]
 }
 
 // restoreLoopBudgetMarks rehydrates the loop prices from a checkpoint so

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -460,3 +460,118 @@ func TestLoopBudgetVerdict_DurationDisplayIsInSeconds(t *testing.T) {
 		t.Errorf("non-duration axis was converted: %.0f/%.0f %q", s, r, u)
 	}
 }
+
+// lateLoopWorkflow: a costly prelude, then a verify/gate pair shared by a
+// loop whose head is `act` — the body is entered at `verify`, off its head,
+// exactly how a campaign bot's extension loop is entered after the lot's
+// own pass. maxTokens bounds the run.
+func lateLoopWorkflow(maxTokens int) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "late_loop",
+		Entry: "pre",
+		Nodes: map[string]ir.Node{
+			"pre":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "pre"}},
+			"verify": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "verify"}},
+			// A tool node, so the stub executor's verdict (needs_act) reaches
+			// the conditional loop edge — a bare compute node yields nothing.
+			"gate": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"act":  &ir.ToolNode{BaseNode: ir.BaseNode{ID: "act"}},
+			"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "pre", To: "verify"},
+			{From: "verify", To: "gate"},
+			{From: "gate", To: "done", Condition: "converged"},
+			{From: "gate", To: "act", Condition: "needs_act", LoopName: "act_loop"},
+			{From: "act", To: "verify"},
+			{From: "gate", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops: map[string]*ir.Loop{
+			"act_loop": {
+				Name:          "act_loop",
+				MaxIterations: 1,
+				Entries:       map[string]bool{"act": true},
+				Body:          map[string]bool{"act": true, "verify": true, "gate": true},
+			},
+		},
+		Budget: &ir.Budget{MaxTokens: maxTokens},
+	}
+}
+
+// TestLoopBudgetGuard_BodyEnteredOffItsHeadIsPricedFromThatEntry: a loop
+// whose body is entered at a node that is not its head (the verify a
+// sibling loop shares) must be priced from that entry, not from run
+// start. Priced from run start, the prelude's whole cost is what the
+// guard charges the loop's FIRST crossing — and declines it, so the act
+// the gate asked for never runs. Measured on a lot whose extension edge
+// was skipped with "last one took 29.21", the run's entire spend.
+func TestLoopBudgetGuard_BodyEnteredOffItsHeadIsPricedFromThatEntry(t *testing.T) {
+	wf := lateLoopWorkflow(12_000)
+	exec := newStubExecutor()
+	acts, gates := 0, 0
+	exec.on("pre", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"ok": true, "_tokens": 6_000}, nil
+	})
+	exec.on("verify", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"ok": true}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		gates++
+		if acts == 0 {
+			return map[string]any{"converged": false, "needs_act": true}, nil
+		}
+		return map[string]any{"converged": true, "needs_act": false}, nil
+	})
+	exec.on("act", func(_ map[string]any) (map[string]any, error) {
+		acts++
+		return map[string]any{"ok": true, "_tokens": 1_000}, nil
+	})
+	eng := New(wf, tmpStore(t), exec)
+	if err := eng.Run(context.Background(), "late", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if acts != 1 {
+		t.Fatalf("act ran %d times, want 1: the loop's first crossing was priced at the prelude's cost and declined", acts)
+	}
+	if gates != 2 {
+		t.Fatalf("gate ran %d times, want 2", gates)
+	}
+}
+
+// TestBaselineUnpricedLoops_ReBasesAStaleRunStartMarkOfALateLoop: a
+// checkpoint written by an engine that priced entries only at a loop's
+// head carries a run-start zero for a loop entered off its head. Restored
+// as is, that zero prices the loop's first crossing at everything the run
+// spent. The session baseline re-bases it at the resume point; a loop
+// that holds the workflow entry keeps its zero, which is its true price;
+// a measured mark is never touched.
+func TestBaselineUnpricedLoops_ReBasesAStaleRunStartMarkOfALateLoop(t *testing.T) {
+	wf := lateLoopWorkflow(12_000)
+	wf.Loops["outer"] = &ir.Loop{Name: "outer", MaxIterations: 3, Entries: map[string]bool{"pre": true}, Body: map[string]bool{"pre": true, "verify": true, "gate": true}}
+	wf.Loops["measured"] = &ir.Loop{Name: "measured", MaxIterations: 3, Entries: map[string]bool{"act": true}, Body: map[string]bool{"act": true, "verify": true}}
+	eng := New(wf, tmpStore(t), newStubExecutor())
+	rs := eng.newRunState("r", nil)
+	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+	rs.budget.RecordUsage(8_000, 0)
+	restoreLoopBudgetMarks(rs, map[string]map[string]float64{
+		"act_loop": {"tokens": 0, "cost_usd": 0, "duration": 500_000},
+		"outer":    {"tokens": 0, "cost_usd": 0, "duration": 500_000},
+		"measured": {"tokens": 5_000, "cost_usd": 0, "duration": 3e12},
+	})
+	eng.baselineUnpricedLoops(rs)
+	if got := rs.loopBudgetMarks["act_loop"]["tokens"]; got != 8_000 {
+		t.Fatalf("act_loop mark = %v tokens, want 8000: the stale run-start mark must be re-based at the resume point", got)
+	}
+	if got := rs.loopBudgetMarks["outer"]["tokens"]; got != 0 {
+		t.Fatalf("outer mark = %v tokens, want 0: a loop holding the entry keeps its run-start price", got)
+	}
+	if got := rs.loopBudgetMarks["measured"]["tokens"]; got != 5_000 {
+		t.Fatalf("measured mark = %v tokens, want 5000: a measured mark is never touched", got)
+	}
+	if v := eng.loopBudgetShortfall("act_loop", rs); v != nil {
+		t.Fatalf("act_loop reports a shortfall right after re-basing: %+v", v)
+	}
+}

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -541,37 +541,113 @@ func TestLoopBudgetGuard_BodyEnteredOffItsHeadIsPricedFromThatEntry(t *testing.T
 	}
 }
 
-// TestBaselineUnpricedLoops_ReBasesAStaleRunStartMarkOfALateLoop: a
-// checkpoint written by an engine that priced entries only at a loop's
-// head carries a run-start zero for a loop entered off its head. Restored
-// as is, that zero prices the loop's first crossing at everything the run
-// spent. The session baseline re-bases it at the resume point; a loop
-// that holds the workflow entry keeps its zero, which is its true price;
-// a measured mark is never touched.
-func TestBaselineUnpricedLoops_ReBasesAStaleRunStartMarkOfALateLoop(t *testing.T) {
+// narrowBodyLoopWorkflow: the loop's body, computed over non-loop edges,
+// holds only its head and tail; the expensive node on its cycle sits
+// outside, and the edge from it back into the body fires every iteration.
+func narrowBodyLoopWorkflow(maxTokens int) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "narrow_body_loop",
+		Entry: "head",
+		Nodes: map[string]ir.Node{
+			"head": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "head"}},
+			"fix":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "fix"}},
+			"tail": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "tail"}},
+			"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "head", To: "fix"},
+			{From: "fix", To: "tail"},
+			{From: "tail", To: "head", LoopName: "narrow"},
+			{From: "tail", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops: map[string]*ir.Loop{
+			"narrow": {
+				Name:          "narrow",
+				MaxIterations: 10,
+				Entries:       map[string]bool{"head": true},
+				Body:          map[string]bool{"head": true, "tail": true},
+			},
+		},
+		Budget: &ir.Budget{MaxTokens: maxTokens},
+	}
+}
+
+// TestLoopBudgetGuard_MidIterationCrossingDoesNotReBase: once a loop is
+// iterating, the edge from a node outside its computed body back into it
+// must not re-base the price — it fires every iteration, right before the
+// back-edge, and re-basing there prices the iteration at its tail alone:
+// the guard never declines, and the run walks into the hard limit with
+// its work stranded. Priced by the last back-edge, the third crossing is
+// declined and the run leaves through its exit path.
+func TestLoopBudgetGuard_MidIterationCrossingDoesNotReBase(t *testing.T) {
+	wf := narrowBodyLoopWorkflow(10_000)
+	exec := newStubExecutor()
+	fixes := 0
+	exec.on("head", func(_ map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+	exec.on("fix", func(_ map[string]any) (map[string]any, error) {
+		fixes++
+		return map[string]any{"ok": true, "_tokens": 3_000}, nil
+	})
+	exec.on("tail", func(_ map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+	eng := New(wf, tmpStore(t), exec)
+	if err := eng.Run(context.Background(), "narrow", nil); err != nil {
+		t.Fatalf("Run must leave through the exit path, got: %v", err)
+	}
+	if fixes != 2 {
+		t.Fatalf("fix ran %d times, want 2: the third crossing must be declined at 6k spent + 3k priced ≥ 90%% of 10k", fixes)
+	}
+}
+
+// TestRestoreCheckpointBudget_LegacyMarksOfALateLoopAreDropped: provenance,
+// not shape, decides. A checkpoint below the marks version carries the
+// run-start baseline for loops an older engine never priced at their
+// off-head entry: those marks are dropped (unmarked reports no shortfall,
+// the session baseline then prices from the resume point); a loop holding
+// the workflow entry keeps its zero, a measured mark is kept. A version-2
+// checkpoint keeps a zero that a loop legitimately entered at zero.
+func TestRestoreCheckpointBudget_LegacyMarksOfALateLoopAreDropped(t *testing.T) {
 	wf := lateLoopWorkflow(12_000)
 	wf.Loops["outer"] = &ir.Loop{Name: "outer", MaxIterations: 3, Entries: map[string]bool{"pre": true}, Body: map[string]bool{"pre": true, "verify": true, "gate": true}}
 	wf.Loops["measured"] = &ir.Loop{Name: "measured", MaxIterations: 3, Entries: map[string]bool{"act": true}, Body: map[string]bool{"act": true, "verify": true}}
 	eng := New(wf, tmpStore(t), newStubExecutor())
-	rs := eng.newRunState("r", nil)
-	rs.budget = newSharedBudget(wf.Budget, eng.logger)
-	rs.budget.RecordUsage(8_000, 0)
-	restoreLoopBudgetMarks(rs, map[string]map[string]float64{
+	marks := map[string]map[string]float64{
 		"act_loop": {"tokens": 0, "cost_usd": 0, "duration": 500_000},
 		"outer":    {"tokens": 0, "cost_usd": 0, "duration": 500_000},
 		"measured": {"tokens": 5_000, "cost_usd": 0, "duration": 3e12},
-	})
-	eng.baselineUnpricedLoops(rs)
-	if got := rs.loopBudgetMarks["act_loop"]["tokens"]; got != 8_000 {
-		t.Fatalf("act_loop mark = %v tokens, want 8000: the stale run-start mark must be re-based at the resume point", got)
 	}
-	if got := rs.loopBudgetMarks["outer"]["tokens"]; got != 0 {
-		t.Fatalf("outer mark = %v tokens, want 0: a loop holding the entry keeps its run-start price", got)
-	}
-	if got := rs.loopBudgetMarks["measured"]["tokens"]; got != 5_000 {
-		t.Fatalf("measured mark = %v tokens, want 5000: a measured mark is never touched", got)
-	}
-	if v := eng.loopBudgetShortfall("act_loop", rs); v != nil {
-		t.Fatalf("act_loop reports a shortfall right after re-basing: %+v", v)
+	for _, tc := range []struct {
+		name     string
+		version  int
+		wantLate bool
+	}{
+		{"legacy checkpoint: the late loop's run-start mark is dropped", 0, false},
+		{"version-2 checkpoint: a zero is a price", loopBudgetMarksVersion, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rs := eng.newRunState("r", nil)
+			rs.budget = newSharedBudget(wf.Budget, eng.logger)
+			cp := &store.Checkpoint{NodeID: "verify", BudgetTokensUsed: 8_000, LoopBudgetMarks: marks, LoopBudgetMarksV: tc.version}
+			eng.restoreCheckpointBudget(rs, cp)
+			if _, ok := rs.loopBudgetMarks["act_loop"]; ok != tc.wantLate {
+				t.Fatalf("act_loop marked = %v, want %v", ok, tc.wantLate)
+			}
+			if got := rs.loopBudgetMarks["outer"]["tokens"]; got != 0 {
+				t.Fatalf("outer mark = %v, want 0 kept: it holds the entry", got)
+			}
+			if got := rs.loopBudgetMarks["measured"]["tokens"]; got != 5_000 {
+				t.Fatalf("measured mark = %v, want 5000 kept", got)
+			}
+			eng.baselineUnpricedLoops(rs)
+			v := eng.loopBudgetShortfall("act_loop", rs)
+			if !tc.wantLate && v != nil {
+				t.Fatalf("a dropped mark is re-based by the session baseline; act_loop reports a shortfall right after the resume: %+v", v)
+			}
+			if tc.wantLate && v == nil {
+				t.Fatal("a kept zero is a price: act_loop's first crossing after the resume costs the whole spend and must be declined at 8000 + 8000 ≥ 90%% of 12000")
+			}
+		})
 	}
 }

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -749,7 +749,7 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 		rs.parallel = newParallelExecutionState(cp.Parallel)
 	}
 	restoreLoopSnapshots(rs, cp)
-	restoreBudgetAccounting(rs, cp)
+	e.restoreCheckpointBudget(rs, cp)
 	restoreSelectedIncoming(rs, cp)
 	restoreRunEvents(rs, cp)
 	// Do not EvictRun here: pause-resume must keep in-process claw
@@ -1057,7 +1057,7 @@ func (e *Engine) restoreCheckpointState(rs *runState, cp *store.Checkpoint) {
 	}
 	rs.nodeAttempts = restoreNodeAttempts(cp.NodeAttempts)
 	restoreLoopSnapshots(rs, cp)
-	restoreBudgetAccounting(rs, cp)
+	e.restoreCheckpointBudget(rs, cp)
 	restoreSelectedIncoming(rs, cp)
 	restoreRunEvents(rs, cp)
 	pinBackendRehydration(rs, cp)

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -1133,8 +1133,13 @@ type Checkpoint struct {
 	// loop's decision node would cross with no measurement and launch a
 	// pass the budget cannot fund, which is exactly the stranding the
 	// affordability guard exists to prevent.
-	LoopBudgetMarks  map[string]map[string]float64 `json:"loop_budget_marks,omitempty" bson:"loop_budget_marks,omitempty"`
-	ArtifactVersions map[string]int                `json:"artifact_versions" bson:"artifact_versions"` // next artifact version per node
+	LoopBudgetMarks map[string]map[string]float64 `json:"loop_budget_marks,omitempty" bson:"loop_budget_marks,omitempty"`
+	// LoopBudgetMarksV is the format version of LoopBudgetMarks. Version 2
+	// marks are measured at a loop's entry or back-edge; earlier engines also
+	// wrote the run-start baseline for loops never entered at their head, a
+	// zero the resume must not read as a price.
+	LoopBudgetMarksV int            `json:"loop_budget_marks_v,omitempty" bson:"loop_budget_marks_v,omitempty"`
+	ArtifactVersions map[string]int `json:"artifact_versions" bson:"artifact_versions"` // next artifact version per node
 	// SelectedIncoming records, per destination node, the incoming edges
 	// that routing actually selected for the current visit of that node.
 	// buildNodeInputRS applies with-mappings only from those edges so an

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5499,6 +5499,7 @@ export interface components {
                     [key: string]: number;
                 };
             };
+            loop_budget_marks_v?: number;
             loop_counters: {
                 [key: string]: number;
             };


### PR DESCRIPTION
## Measured

A lot whose own pass had cost 29.21 of a 60 cap reached its gate with two extension requests pending and `needs_extend: true`. The gate's `extend` edge was skipped: "loop extend_loop cannot fund another iteration (cost_usd: 30.79 left, last one took 29.21)". The run finished on `stop` without acting. Its checkpoint carried `extend_loop: {cost_usd: 0, duration: 0.5 ms}` — the session baseline from run start, never re-based.

## Why

The guard prices the next iteration by the last one, from a mark set when the loop is entered from outside — but only when the body is entered at the loop's HEAD (`loop.Entries`). The extension loop's body shares the verify and gate nodes with the lot's repair loop, so the run reaches it at verify, off its head; the mark stayed at run start and the first crossing was priced at the run's whole spend. On the cloud the same shape declines the extension of any lot whose own pass is expensive relative to the cap.

## Fix

- A plain edge from outside a loop's body into ANY of its nodes marks the loop (the counter reset stays on its entries).
- The session baseline re-bases a restored mark that is still the run-start baseline on a loop whose body does not hold the workflow entry — an older engine wrote it, it was never measured. A loop holding the entry keeps its zero (its true price); a measured mark is never touched.

## Proof

- `TestLoopBudgetGuard_BodyEnteredOffItsHeadIsPricedFromThatEntry`: a loop entered at a shared verify node after a costly prelude runs its act once. Mutant (entry marking back to head-only): red, act never runs.
- `TestBaselineUnpricedLoops_ReBasesAStaleRunStartMarkOfALateLoop`: a restored run-start mark of a late loop is re-based at the resume point; the entry loop's zero and a measured mark stay; no shortfall right after. Mutant (detection disabled): red.
- Full `pkg/runtime` suite green; golangci-lint 0 issues.

## Second round (two findings, both reproduced)

- **Re-basing in flight** (high): a body computed over non-loop edges can leave a node of the cycle outside it; the edge from that node back into the body fires every iteration, and marking there priced the iteration at its tail alone — the guard never declined and the run hit the hard limit. The mark is now taken on an outside entry only while the loop is not iterating, or at one of its entries. `TestLoopBudgetGuard_MidIterationCrossingDoesNotReBase`: a narrow-body loop leaves through its exit path after two passes; mutant (guard removed) dies at `BUDGET_EXCEEDED`.
- **Shape-sniffed staleness** (medium): a loop legitimately entered at zero consumption looked exactly like a legacy zero and was re-based on every resume. Provenance now decides: the checkpoint carries `loop_budget_marks_v` (2 = measured marks); only a checkpoint below it has the run-start zeros of late loops dropped on restore, in `restoreCheckpointBudget`; the session baseline is back to its original. `TestRestoreCheckpointBudget_LegacyMarksOfALateLoopAreDropped`: a legacy checkpoint's zero is dropped and the loop re-based at the resume point; a version-2 zero is kept and priced; mutant (provenance ignored) red.

Open questions answered: for the campaign topology that motivated the fix the checkpoint itself is the evidence — `extend_loop {cost_usd: 0, duration: 0.5 ms}` after a 29 $ run means the body was never entered at one of its entries, which is what marking at any outside entry addresses; whether the lot node sits inside or outside that body does not change the first-crossing price (the mark is taken at the entry into the body, and re-taken only at entries while the loop is not in flight). The branch-local twin is kept for symmetry only: `loopBudgetShortfall` ignores branch-local state, as noted, so it is inert there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
