### PR TITLE
fix(board): derive the degraded readout from the binding, not from one pass

### DIFF
--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -516,6 +516,19 @@ what makes the pass re-derive and arbitrate §9's conflict with real timestamps.
 A previous state the map does not carry is inert (§2), so it is not a
 divergence and the reflect proceeds.
 
+The other thing a board read would have told it is **which columns the board
+still carries**, and §5's repair makes that answerable without one: a lost
+column KEEPS its cached option id, so the option map alone would hand the fast
+path a dead id to fire at the forge — once per move of every card in that
+column, each burning an outbox row's whole retry budget for a column no retry
+can bring back. Both callers therefore build the reflect's column knowledge
+through one constructor, whose lost set is a UNION: the binding's persisted
+`missing_statuses` (all a path with no board read can know, and enough) plus,
+for the pass alone, the live repair it has just computed. `nil` there means
+"this call observed nothing about the board" — never "the board is fine". A
+card the fast path cannot reflect is counted, logged once for that event, and
+its row RETIRES rather than retries.
+
 The pass is unchanged and remains the net. Both orders are idempotent and
 tested as such: after a projection the next pass writes nothing (to the forge
 or to the card — a gratuitous `External` write is a `card.updated` that

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -174,8 +174,9 @@ has already read for the label fields, so the repair costs no API call
 (`BoardBinding.ReconcileStatusOptions`). Per mapped state, in order: the cached
 **id** still on the field ⇒ adopt the board's current name (rename repaired);
 else the mapped **name** still on the field ⇒ adopt its id (re-created column,
-or one added since the bind); else **lost**. The `Status` field's own id is
-re-resolved the same way, by name.
+or one added since the bind); else **lost** — unless the column has never
+resolved for this binding, which is the accepted partial coverage below. The
+`Status` field's own id is re-resolved the same way, by name.
 
 A LOST column is the only unrepairable case, and it becomes an explicit state
 rather than a retry loop (the `pluginsource` quarantine precedent): those cards
@@ -189,33 +190,51 @@ only one.
 
 **That readout is a LEVEL, re-derived from the binding's current shape on every
 pass — never an event.** "Lost" is defined as *a mapped column the board serves
-under neither its cached option id nor its name, that the BIND did not accept as
-absent*; only an EMPTY lost set clears the flag. Three consequences shape the
-code:
+under neither its cached option id nor its name, and that has NEVER resolved for
+this binding*; only an EMPTY lost set clears the flag. Three consequences shape
+the code:
 
 - **the bind-time accepted set is recorded separately** (`unresolved_at_bind`,
-  written by `BindBoard`, never by a reconciliation — unlike `missing_statuses`,
-  which every pass recomputes as "what the board lacks right now"). It is what
-  distinguishes *this column was never there* from *this column broke*. Only
-  something that worked can break: a three-column board bound with the
-  five-column default map is partial coverage, not a degradation;
-- **the rule may not rest on the cached option id.** The first release to ship
-  it deleted that id on the pass that observed the loss, so a binding degraded
-  by it has no id, no column, and a standing `degraded_reason` — "the binding
-  holds an id" finds nothing lost there, and a readout that clears when it
-  finds nothing lost would clear a still-true degradation permanently, since
-  the id never comes back. The same two shapes meet during a rolling deploy, in
-  either order. A binding stored before `unresolved_at_bind` existed has the
-  set RECONSTRUCTED, asymmetrically on its own health: a healthy one accepted
-  whatever it cannot resolve today; a **degraded** one accepted nothing, because
-  from the outside its two possible histories are indistinguishable and the only
-  safe reading of "I cannot tell" is to keep the degradation it declared. *A
-  health flag is never cleared by the absence of the evidence that would have
-  kept it.* The stored shape therefore has to tell an empty set from an
-  unrecorded one — which is why the field is persisted even when empty;
+  written by `BindBoard` and — save the one-off reconstruction below — never by
+  a reconciliation, unlike `missing_statuses`, which every pass recomputes as
+  "what the board lacks right now"). It is what distinguishes *this column was
+  never there* from *this column broke*. Only something that worked can break: a
+  three-column board bound with the five-column default map is partial coverage,
+  not a degradation;
+- **"never resolved" is a CONJUNCTION, and the rule may not rest on either
+  oracle alone** — the bind accepted the column as absent, AND the binding still
+  holds no option id for it. Each half covers what the other misses.
+
+  *The accepted set alone never discharges.* A column absent at bind and later
+  ADOPTED earns a real option id and starts taking cards; its next
+  disappearance is a genuine break, which a rule keyed on the bind-time NAME
+  would go on exempting forever — the binding reading healthy while every card
+  of that column is refused.
+
+  *The cached id alone misreads the upgrade.* The first release to ship this
+  deleted that id on the pass that observed the loss, so a binding degraded by
+  it has no id, no column, and a standing `degraded_reason` — "the binding holds
+  an id" finds nothing lost there, and a readout that clears when it finds
+  nothing lost would clear a still-true degradation permanently, since the id
+  never comes back. The same two shapes meet during a rolling deploy, in either
+  order.
+
+  A binding stored before `unresolved_at_bind` existed has the set
+  RECONSTRUCTED **from the binding, never from the live board** — a mapped
+  column the binding holds no id for is one the bind could not resolve. Reading
+  the board instead would fold a column that broke in the upgrade window into
+  the accepted set, and would persist "the operator accepted all five columns"
+  the day the `Status` field itself vanishes. The reconstruction is asymmetric
+  on the binding's own health: a healthy one accepted every column it never
+  resolved; a **degraded** one accepted nothing, because from the outside its
+  two possible histories are indistinguishable and the only safe reading of "I
+  cannot tell" is to keep the degradation it declared. *A health flag is never
+  cleared by the absence of the evidence that would have kept it.* The stored
+  shape therefore has to tell an empty set from an unrecorded one — which is why
+  the field is persisted even when empty;
 - **the dead option id is nevertheless KEPT**, as the pass's `LostStates` set —
-  what refuses the reflect for those cards — and as a second, independent way
-  to re-derive the loss.
+  what refuses the reflect for those cards — and as the half of the conjunction
+  that keeps the loss re-derivable once the bind-time exemption has discharged.
 
 The repaired vocabulary is persisted through a store method narrow enough to
 touch nothing else (`SaveStatusVocabulary`): a reconciliation may correct what

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -188,22 +188,34 @@ too — which is what makes "re-bind the board" a real remedy rather than the
 only one.
 
 **That readout is a LEVEL, re-derived from the binding's current shape on every
-pass — never an event.** "Lost" is defined as *the binding holds an option id
-for this state and the board answers to neither that id nor the mapped name*,
-which is re-computable from the same inputs indefinitely; only an EMPTY lost set
-clears the flag. Two consequences shape the code:
+pass — never an event.** "Lost" is defined as *a mapped column the board serves
+under neither its cached option id nor its name, that the BIND did not accept as
+absent*; only an EMPTY lost set clears the flag. Three consequences shape the
+code:
 
-- **the dead option id is KEPT.** Dropping it (the obvious "so nothing writes
-  it") destroys the only evidence the column ever resolved, and the very next
-  pass then reads a binding where nothing is wrong — so the first unrelated
-  adoption elsewhere on the board cleared a degradation that was still true,
-  while every reflect onto the missing column kept failing, counted and
-  invisible. What refuses the write is the pass's lost set, handed to the
-  reflect, not a hole in the binding;
-- **a column the binding NEVER resolved is not lost.** That is
-  `missing_statuses`, the partial coverage `BindBoard` accepts on purpose
-  ("the covered half works") — a three-column board bound with the five-column
-  default map is not a board that broke. Only something that worked can break.
+- **the bind-time accepted set is recorded separately** (`unresolved_at_bind`,
+  written by `BindBoard`, never by a reconciliation — unlike `missing_statuses`,
+  which every pass recomputes as "what the board lacks right now"). It is what
+  distinguishes *this column was never there* from *this column broke*. Only
+  something that worked can break: a three-column board bound with the
+  five-column default map is partial coverage, not a degradation;
+- **the rule may not rest on the cached option id.** The first release to ship
+  it deleted that id on the pass that observed the loss, so a binding degraded
+  by it has no id, no column, and a standing `degraded_reason` — "the binding
+  holds an id" finds nothing lost there, and a readout that clears when it
+  finds nothing lost would clear a still-true degradation permanently, since
+  the id never comes back. The same two shapes meet during a rolling deploy, in
+  either order. A binding stored before `unresolved_at_bind` existed has the
+  set RECONSTRUCTED, asymmetrically on its own health: a healthy one accepted
+  whatever it cannot resolve today; a **degraded** one accepted nothing, because
+  from the outside its two possible histories are indistinguishable and the only
+  safe reading of "I cannot tell" is to keep the degradation it declared. *A
+  health flag is never cleared by the absence of the evidence that would have
+  kept it.* The stored shape therefore has to tell an empty set from an
+  unrecorded one — which is why the field is persisted even when empty;
+- **the dead option id is nevertheless KEPT**, as the pass's `LostStates` set —
+  what refuses the reflect for those cards — and as a second, independent way
+  to re-derive the loss.
 
 The repaired vocabulary is persisted through a store method narrow enough to
 touch nothing else (`SaveStatusVocabulary`): a reconciliation may correct what

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -178,14 +178,32 @@ or one added since the bind); else **lost**. The `Status` field's own id is
 re-resolved the same way, by name.
 
 A LOST column is the only unrepairable case, and it becomes an explicit state
-rather than a retry loop (the `pluginsource` quarantine precedent): the dead id
-is dropped so nothing writes it, those cards are counted `reflect_no_column`,
-and the binding carries a `degraded_reason` NAMING the column — surfaced on
+rather than a retry loop (the `pluginsource` quarantine precedent): those cards
+are counted `reflect_no_column` and skipped, and the binding carries a
+`degraded_reason` NAMING the column — surfaced on
 `GET /api/teams/{id}/board-binding` and logged once, on the transition, not on
 every pass. It is a partial outage: every column that still resolves keeps
 syncing. It clears itself when the column reappears, and a re-bind clears it
 too — which is what makes "re-bind the board" a real remedy rather than the
 only one.
+
+**That readout is a LEVEL, re-derived from the binding's current shape on every
+pass — never an event.** "Lost" is defined as *the binding holds an option id
+for this state and the board answers to neither that id nor the mapped name*,
+which is re-computable from the same inputs indefinitely; only an EMPTY lost set
+clears the flag. Two consequences shape the code:
+
+- **the dead option id is KEPT.** Dropping it (the obvious "so nothing writes
+  it") destroys the only evidence the column ever resolved, and the very next
+  pass then reads a binding where nothing is wrong — so the first unrelated
+  adoption elsewhere on the board cleared a degradation that was still true,
+  while every reflect onto the missing column kept failing, counted and
+  invisible. What refuses the write is the pass's lost set, handed to the
+  reflect, not a hole in the binding;
+- **a column the binding NEVER resolved is not lost.** That is
+  `missing_statuses`, the partial coverage `BindBoard` accepts on purpose
+  ("the covered half works") — a three-column board bound with the five-column
+  default map is not a board that broke. Only something that worked can break.
 
 The repaired vocabulary is persisted through a store method narrow enough to
 touch nothing else (`SaveStatusVocabulary`): a reconciliation may correct what

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -184,10 +184,30 @@ board never had is reported as `missing_statuses` (a `!` in `board show`) and
 its cards count `reflect_no_column`, but the binding reads healthy — binding a
 three-column board with the five-column default map is a choice, not a break.
 The bind records that choice (`unresolved_at_bind`), which is how a later pass
-tells "never there" from "broke"; a binding created before that field existed
-has it reconstructed on its first pass, and one that is already degraded keeps
-its degradation through the upgrade rather than being cleared by the gap in its
-own record.
+tells "never there" from "broke". **That exemption discharges the moment the
+column works**: if you later add the column, the pass adopts it and it starts
+taking cards — deleting it after that is a break like any other, and the
+binding degrades. Only something that worked can break.
+
+A binding created before `unresolved_at_bind` existed has it reconstructed on
+its first pass **from its own cached option ids** — a mapped column the binding
+holds no id for is one the bind never resolved — and not from what the board
+happens to carry that day, which would fold a column that broke in the upgrade
+window into the accepted set. One that is already degraded keeps its
+degradation through the upgrade rather than being cleared by the gap in its own
+record.
+
+One population that upgrade cannot recover: a binding the previous release
+degraded, whose flag an *unrelated* repair then cleared before the upgrade. It
+arrives reading healthy with no cached id for the missing column — from the
+outside, indistinguishable from partial coverage accepted at bind — so it
+reconstructs as exempt and keeps reading healthy. The visible signal is
+`reflect_no_column` climbing on a binding with no `degraded_reason`; the
+recovery is a re-bind, which re-reads the board and records the accepted set
+afresh. For the same reason, a binding degraded by the previous release with
+*both* a broken column and a genuinely-accepted one will name both after the
+upgrade: the record cannot tell them apart, and over-reporting is the side to
+fail on. A re-bind is the reset there too.
 
 ---
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -172,10 +172,17 @@ the binding — `iterion remote board show`, or
 `GET /api/teams/{id}/board-binding` — and is logged **once**, when it starts,
 not on every pass.
 
-It clears by itself the moment the column exists again. Re-binding the board
-(`iterion remote board bind …`) also clears it, and is the way out when the
-column is gone for good: bind with a `--status-map` matching what the board
-actually carries.
+It stands for exactly as long as the column is missing: each pass re-asks the
+question, so nothing else happening on the board can clear it. It clears by
+itself the moment that column exists again. Re-binding the board (`iterion
+remote board bind …`) also clears it, and is the way out when the column is
+gone for good: bind with a `--status-map` matching what the board actually
+carries.
+
+Partial coverage is **not** a degradation. A column your map names and the
+board never had is reported as `missing_statuses` (a `!` in `board show`) and
+its cards count `reflect_no_column`, but the binding reads healthy — binding a
+three-column board with the five-column default map is a choice, not a break.
 
 ---
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -183,6 +183,11 @@ Partial coverage is **not** a degradation. A column your map names and the
 board never had is reported as `missing_statuses` (a `!` in `board show`) and
 its cards count `reflect_no_column`, but the binding reads healthy — binding a
 three-column board with the five-column default map is a choice, not a break.
+The bind records that choice (`unresolved_at_bind`), which is how a later pass
+tells "never there" from "broke"; a binding created before that field existed
+has it reconstructed on its first pass, and one that is already degraded keeps
+its degradation through the upgrade rather than being cleared by the gap in its
+own record.
 
 ---
 

--- a/openapi.json
+++ b/openapi.json
@@ -189,6 +189,12 @@
           "tenant_id": {
             "type": "string"
           },
+          "unresolved_at_bind": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "updated_at": {
             "format": "date-time",
             "type": "string"

--- a/pkg/cli/remote_board_binding.go
+++ b/pkg/cli/remote_board_binding.go
@@ -200,10 +200,19 @@ func printBoardBinding(p *Printer, b forge.BoardBinding) {
 	if b.StatusFieldID == "" {
 		p.Line("  (this board has no Status field — labels only, no status projection)")
 	}
+	// A column can be absent from the board while the binding still caches its
+	// option id: that is a LOST column, whose id is deliberately KEPT as the
+	// evidence that keeps the degradation re-derivable. So the cached id is not
+	// the test — `missing_statuses`, which every reconciliation recomputes, is.
+	// Marking on the id alone left a broken column rendering exactly like a
+	// working one, while the studio (keyed on the same list) marked it.
+	absent := make(map[string]bool, len(b.MissingStatuses))
+	for _, s := range b.MissingStatuses {
+		absent[strings.ToLower(strings.TrimSpace(s))] = true
+	}
 	for _, m := range b.Mapping() {
-		opt := b.StatusOptions[m.State]
 		mark := "  "
-		if opt == "" {
+		if b.StatusOptions[m.State] == "" || absent[strings.ToLower(strings.TrimSpace(m.Status))] {
 			mark = "! " // present in the map, absent from the board
 		}
 		p.Line("%s%-14s → %s", mark, m.Status, m.State)

--- a/pkg/cli/remote_board_binding_test.go
+++ b/pkg/cli/remote_board_binding_test.go
@@ -1,14 +1,61 @@
 package cli
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
 )
 
 // The `--status-map` flag is the operator's escape hatch from the shipped
 // five-column vocabulary, so its parser has to be strict where it matters
 // (a silently-dropped pair would leave a column unmapped and inert) and
 // forgiving where it does not (spaces around a column name that contains one).
+
+// A LOST column keeps its cached option id — that is what makes the degradation
+// re-derivable on the next pass — so the id is no longer the test for "the
+// board does not carry this". `missing_statuses`, which every reconciliation
+// recomputes, is; without it `board show` renders a broken column exactly like
+// a working one, while the studio (which keys off `missing_statuses`) marks it.
+func TestPrintBoardBindingMarksALostColumnThatKeptItsID(t *testing.T) {
+	var out bytes.Buffer
+	p := NewPrinter(OutputHuman)
+	p.W = &out
+
+	printBoardBinding(p, forge.BoardBinding{
+		TenantID: "team-a", Provider: forge.ProviderGitHub,
+		Owner: "SocialGouv", OwnerKind: forge.ProjectOwnerOrg, Number: 203,
+		ConnectionID: "conn-1", ProjectID: "PVT_p", StatusFieldID: "PVTSSF_status",
+		StatusMapping: []forge.StatusMapping{
+			{Status: "Planned", State: "ready"},
+			{Status: "In progress", State: "in_progress"},
+		},
+		// The lost column KEEPS its id; only `missing_statuses` says it is gone.
+		StatusOptions:   map[string]string{"ready": "o_planned", "in_progress": "o_prog"},
+		MissingStatuses: []string{"In progress"},
+		DegradedReason:  `the Status field no longer carries "In progress" (in_progress)`,
+	})
+
+	var row string
+	for _, line := range strings.Split(out.String(), "\n") {
+		if strings.Contains(line, "→ in_progress") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatal("the status map did not render the in_progress row at all")
+	}
+	if !strings.HasPrefix(row, "! ") {
+		t.Errorf("the lost column's row must be marked, got %q", row)
+	}
+	// ...and the healthy one must NOT be, or the marker says nothing.
+	for _, line := range strings.Split(out.String(), "\n") {
+		if strings.Contains(line, "→ ready") && strings.HasPrefix(line, "! ") {
+			t.Errorf("a column the board still carries must render unmarked, got %q", line)
+		}
+	}
+}
 
 func TestParseStatusMapFlag(t *testing.T) {
 	got, err := ParseStatusMapFlag("Todo=ready,In Progress=in_progress,Shipped=done")

--- a/pkg/forge/board_bind.go
+++ b/pkg/forge/board_bind.go
@@ -167,6 +167,12 @@ func bindStatus(b *BoardBinding, project Project, mapping []StatusMapping) error
 	}
 	sort.Strings(missing) // stable report
 	b.MissingStatuses = missing
+	// The SAME set, recorded separately and never rewritten by a
+	// reconciliation: it is what later tells "this column was never on the
+	// board" from "this column broke". Always non-nil, because "the operator
+	// accepted nothing missing" and "nobody ever recorded this" are different
+	// answers and only the stored shape can tell them apart.
+	b.UnresolvedAtBind = append([]string{}, missing...)
 	return nil
 }
 

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -124,15 +124,24 @@ type BoardBinding struct {
 	MissingStatuses []string `bson:"missing_statuses,omitempty" json:"missing_statuses,omitempty"`
 	// UnresolvedAtBind is the partial coverage the OPERATOR accepted when the
 	// board was bound: the mapped columns BindBoard could not resolve and did
-	// not refuse the bind over. It is written by the BIND, never by a
-	// reconciliation — that is the whole point, since a column outside it that
-	// stops resolving is a column that BROKE, which is what `DegradedReason`
-	// reports.
+	// not refuse the bind over. It is written by the BIND — never by a
+	// reconciliation, save the one-off reconstruction below — because it is a
+	// statement about the PAST, and a column outside it that stops resolving is
+	// a column that BROKE, which is what `DegradedReason` reports.
+	//
+	// It is half of that test, not all of it: the exemption it grants holds
+	// only while the column has never resolved (no cached option id). A column
+	// absent at bind and ADOPTED later has worked, so its next disappearance is
+	// a break like any other — see ReconcileStatusOptions.
 	//
 	// NOT `omitempty` in BSON: an empty set and a never-recorded one are
 	// different answers, and only the stored shape can tell them apart (see
 	// ReconcileStatusOptions, which reconstructs the set for a binding written
-	// before this field existed).
+	// before this field existed). The JSON form DOES drop an empty set, which
+	// is safe only because nothing re-materialises a binding from it — the API
+	// and `iterion remote board show` decode to PRINT, never to re-`Upsert`.
+	// Wire a JSON round-trip back into the store and this asymmetry becomes a
+	// bug: an empty set would decode to nil and re-trigger the reconstruction.
 	UnresolvedAtBind []string `bson:"unresolved_at_bind" json:"unresolved_at_bind,omitempty"`
 
 	// SyncEvery is the reconciliation interval. Zero = OFF (no periodic pass;

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -206,7 +206,16 @@ func (b BoardBinding) Fields() []LabelField {
 	return out
 }
 
-// OptionForState returns the board option id to write for a native state.
+// OptionForState returns the board option id CACHED for a native state.
+//
+// It is NOT an answer to "does the board still carry this column". The
+// reconciliation deliberately KEEPS a lost column's id — that is the evidence
+// that keeps the loss re-derivable on the next pass — so this returns
+// `(id, true)` for a column the board no longer has, and writing that id 422s.
+// A caller that writes must also consult the pass's
+// `StatusVocabularyRepair.LostStates`; one that only wants to know whether the
+// board carries the column should read `MissingStatuses`, which every
+// reconciliation recomputes.
 func (b BoardBinding) OptionForState(state string) (string, bool) {
 	id, ok := b.StatusOptions[state]
 	return id, ok && id != ""

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -117,10 +117,23 @@ type BoardBinding struct {
 	// five, or the operator's own. Stored so what a deployment actually runs
 	// is readable, not inferred.
 	StatusMapping []StatusMapping `bson:"status_mapping,omitempty" json:"status_mapping,omitempty"`
-	// MissingStatuses are mapped columns the board does not carry. A binding
-	// is not refused over them — it is REPORTED, so a half-covered board is a
-	// visible fact rather than a silently inert half of the sync.
+	// MissingStatuses are mapped columns the board does not carry RIGHT NOW. A
+	// binding is not refused over them — it is REPORTED, so a half-covered
+	// board is a visible fact rather than a silently inert half of the sync.
+	// Recomputed by every reconciliation.
 	MissingStatuses []string `bson:"missing_statuses,omitempty" json:"missing_statuses,omitempty"`
+	// UnresolvedAtBind is the partial coverage the OPERATOR accepted when the
+	// board was bound: the mapped columns BindBoard could not resolve and did
+	// not refuse the bind over. It is written by the BIND, never by a
+	// reconciliation — that is the whole point, since a column outside it that
+	// stops resolving is a column that BROKE, which is what `DegradedReason`
+	// reports.
+	//
+	// NOT `omitempty` in BSON: an empty set and a never-recorded one are
+	// different answers, and only the stored shape can tell them apart (see
+	// ReconcileStatusOptions, which reconstructs the set for a binding written
+	// before this field existed).
+	UnresolvedAtBind []string `bson:"unresolved_at_bind" json:"unresolved_at_bind,omitempty"`
 
 	// SyncEvery is the reconciliation interval. Zero = OFF (no periodic pass;
 	// the reflect's fast path still runs, with no net under it).
@@ -520,6 +533,7 @@ func (s *MongoBoardBindingStore) Upsert(ctx context.Context, b BoardBinding) err
 		"status_field_id": b.StatusFieldID, "status_options": b.StatusOptions,
 		"label_fields": b.LabelFields, "status_mapping": b.StatusMapping,
 		"missing_statuses":   b.MissingStatuses,
+		"unresolved_at_bind": b.UnresolvedAtBind,
 		"sync_every_seconds": b.SyncEverySeconds, "updated_at": b.UpdatedAt,
 	}
 	if !b.LastSyncedAt.IsZero() {
@@ -556,7 +570,12 @@ func (s *MongoBoardBindingStore) SaveStatusVocabulary(ctx context.Context, tenan
 			"status_options":   v.Options,
 			"status_field_id":  v.StatusFieldID,
 			"missing_statuses": v.MissingStatuses,
-			"updated_at":       time.Now().UTC(),
+			// Written unconditionally, INCLUDING an empty slice: a
+			// reconstructed-as-empty set and a never-recorded one are
+			// different answers, and only the stored shape can tell them
+			// apart on the next pass.
+			"unresolved_at_bind": v.UnresolvedAtBind,
+			"updated_at":         time.Now().UTC(),
 		}})
 	if err != nil {
 		return fmt.Errorf("forge: save board status vocabulary: %w", err)

--- a/pkg/forge/board_binding_store_test.go
+++ b/pkg/forge/board_binding_store_test.go
@@ -380,6 +380,56 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		}
 	})
 
+	t.Run("an unrecorded bind-time set is distinguishable from an empty one", func(t *testing.T) {
+		// The load-bearing property of UnresolvedAtBind: "the bind accepted
+		// nothing as absent" and "no release ever recorded this" are different
+		// answers, and only the STORED shape can tell them apart. A store that
+		// collapsed the two would make every upgraded binding look like a
+		// board that never had a missing column.
+		legacy := binding("team-legacy", time.Minute)
+		legacy.UnresolvedAtBind = nil // written before the field existed
+		if err := store.Upsert(ctx, legacy); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		got, err := store.GetByTenant(ctx, "team-legacy")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if got.UnresolvedAtBind != nil {
+			t.Errorf("an unrecorded set must read back as nil, got %#v", got.UnresolvedAtBind)
+		}
+
+		bound := binding("team-bound", time.Minute)
+		bound.UnresolvedAtBind = []string{}
+		if err := store.Upsert(ctx, bound); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		got, err = store.GetByTenant(ctx, "team-bound")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if got.UnresolvedAtBind == nil {
+			t.Error("a recorded-but-empty set must read back non-nil, or an upgraded binding cannot be told from a fresh one")
+		}
+		if len(got.UnresolvedAtBind) != 0 {
+			t.Errorf("UnresolvedAtBind = %v, want empty", got.UnresolvedAtBind)
+		}
+
+		// And a reconciliation may persist the set it reconstructed.
+		v := got.Vocabulary()
+		v.UnresolvedAtBind = []string{"Blocked"}
+		if err := store.SaveStatusVocabulary(ctx, "team-bound", v); err != nil {
+			t.Fatalf("SaveStatusVocabulary: %v", err)
+		}
+		got, err = store.GetByTenant(ctx, "team-bound")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if len(got.UnresolvedAtBind) != 1 || got.UnresolvedAtBind[0] != "Blocked" {
+			t.Errorf("UnresolvedAtBind = %v, want the reconstructed set", got.UnresolvedAtBind)
+		}
+	})
+
 	t.Run("the degraded readout has exactly two writers", func(t *testing.T) {
 		if err := store.Upsert(ctx, binding("team-deg", time.Minute)); err != nil {
 			t.Fatalf("Upsert: %v", err)

--- a/pkg/forge/board_vocabulary.go
+++ b/pkg/forge/board_vocabulary.go
@@ -90,14 +90,16 @@ type StatusVocabularyRepair struct {
 	// id re-resolved by name.
 	FieldRebound bool
 	// Lost are the mapped columns the board answers to under neither their
-	// cached option id nor their name, and that the BIND did not accept as
-	// absent. Nothing here can repair that, so it is what marks the binding
+	// cached option id nor their name, and that never resolved for this
+	// binding. Nothing here can repair that, so it is what marks the binding
 	// degraded — and it is re-derived on EVERY pass, for as long as it stays
 	// true.
 	//
 	// A column the bind accepted as absent (`UnresolvedAtBind`, the ordinary
-	// partial-coverage bind) is NOT lost: nothing broke, the map simply names
-	// more than the board carries.
+	// partial-coverage bind) is NOT lost WHILE it has never resolved: nothing
+	// broke, the map simply names more than the board carries. Once a
+	// reconciliation adopts it, it has resolved, and its later disappearance is
+	// a break like any other — the bind-time exemption discharges.
 	Lost []LostColumn
 
 	// changed records whether the reconciliation rewrote the vocabulary, which
@@ -168,24 +170,30 @@ func (r StatusVocabularyRepair) Reason() string {
 //     board's current NAME for it (this is the rename repair);
 //  2. else the mapped NAME still on the field ⇒ the column was re-created, or
 //     added since the bind; adopt its id;
-//  3. else, and only if the BIND did not accept it as absent ⇒ LOST.
+//  3. else, and only if the column never resolved for this binding ⇒ LOST.
 //
 // Rule 3 is a property of the binding's CURRENT shape, not an event: it is
 // re-derived identically on every pass, which is what lets a caller treat
-// "degraded" as a level rather than an edge. The oracle is `UnresolvedAtBind`
-// — what the operator accepted when they bound the board — and NOT the cached
-// option id, deliberately: an earlier release deleted that id on the pass that
-// observed the loss, so a rule reading "the binding HAS an id" finds nothing
-// lost on a binding that release degraded, and a readout that clears when it
-// finds nothing lost would clear a still-true degradation permanently. The
-// same two shapes meet during a rolling deploy, in either order.
+// "degraded" as a level rather than an edge. "Never resolved" is a CONJUNCTION
+// of two oracles, and neither one alone is sound:
+//
+//   - `UnresolvedAtBind` — what the operator accepted when they bound the
+//     board. Alone it never discharges: a column absent at bind and ADOPTED
+//     later earns a real id, so its next disappearance is a genuine break the
+//     bind-time name would go on exempting forever;
+//   - an EMPTY cached option id. Alone it misreads the upgrade: an earlier
+//     release deleted that id on the pass that observed the loss, so a rule
+//     reading "the binding HAS an id" finds nothing lost on a binding that
+//     release degraded — and a readout that clears when it finds nothing lost
+//     would clear a still-true degradation permanently. The same two shapes
+//     meet during a rolling deploy, in either order.
+//
+// Together they say the thing that is actually meant: this column has never
+// worked, so it cannot have broken. Only something that worked can break.
 //
 // The cached id is nevertheless KEPT on a loss: it is what `LostStates` gates
-// the reflect with, and a second, independent way to re-derive the loss.
-//
-// A column the bind accepted as absent is NOT lost — it is the partial
-// coverage BindBoard admits on purpose ("the covered half works"). Only
-// something that worked can break.
+// the reflect with, and the half of the conjunction that keeps the loss
+// re-derivable once the bind-time exemption has discharged.
 //
 // The Status FIELD's own id is refreshed the same way — it is resolved by
 // name, so a field deleted and re-created is repaired rather than fatal.
@@ -256,10 +264,17 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	}
 
 	// 3. LOST: a mapped column the board serves under NEITHER its cached id
-	// nor its name, that the bind did not accept as absent. Deliberately not a
-	// question about the cached id — see the doc comment.
+	// nor its name, that the bind did not accept as absent AND that has never
+	// resolved since. Both halves of that second clause are load-bearing — see
+	// the doc comment.
+	//
+	// The id is read off `b.StatusOptions`, the binding as it stands, not off
+	// the `options` working copy step 1 mutates: the question is what this
+	// state had resolved to BEFORE this pass. Identical today (step 1 only
+	// writes ids for states that then short-circuit as resolved), but it says
+	// what it means and cannot be broken by a later edit to the resolve loop.
 	for _, m := range mapping {
-		if resolved[m.State] || accepted[foldName(m.Status)] {
+		if resolved[m.State] || (accepted[foldName(m.Status)] && b.StatusOptions[m.State] == "") {
 			continue
 		}
 		rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})

--- a/pkg/forge/board_vocabulary.go
+++ b/pkg/forge/board_vocabulary.go
@@ -37,6 +37,10 @@ type StatusVocabulary struct {
 	Options         map[string]string `bson:"status_options,omitempty" json:"status_options,omitempty"`
 	StatusFieldID   string            `bson:"status_field_id,omitempty" json:"status_field_id,omitempty"`
 	MissingStatuses []string          `bson:"missing_statuses,omitempty" json:"missing_statuses,omitempty"`
+	// UnresolvedAtBind travels with the rest so a reconciliation can persist
+	// the set it RECONSTRUCTED for a binding stored before the field existed.
+	// A reconciliation never otherwise writes it — see BoardBinding's own doc.
+	UnresolvedAtBind []string `bson:"unresolved_at_bind" json:"unresolved_at_bind,omitempty"`
 }
 
 // Vocabulary reads the binding's cached status vocabulary.
@@ -44,6 +48,7 @@ func (b BoardBinding) Vocabulary() StatusVocabulary {
 	return StatusVocabulary{
 		Mapping: b.StatusMapping, Options: b.StatusOptions,
 		StatusFieldID: b.StatusFieldID, MissingStatuses: b.MissingStatuses,
+		UnresolvedAtBind: b.UnresolvedAtBind,
 	}
 }
 
@@ -51,6 +56,7 @@ func (b BoardBinding) Vocabulary() StatusVocabulary {
 func (b *BoardBinding) SetVocabulary(v StatusVocabulary) {
 	b.StatusMapping, b.StatusOptions = v.Mapping, v.Options
 	b.StatusFieldID, b.MissingStatuses = v.StatusFieldID, v.MissingStatuses
+	b.UnresolvedAtBind = v.UnresolvedAtBind
 }
 
 // StatusRename is one column the board renamed under a stable option id.
@@ -83,12 +89,13 @@ type StatusVocabularyRepair struct {
 	// FieldRebound reports that the Status FIELD itself was re-created and its
 	// id re-resolved by name.
 	FieldRebound bool
-	// Lost are the columns the binding HAS an option id for that the board
-	// answers to under neither that id nor their name. Nothing here can repair
-	// that, so it is what marks the binding degraded — and it is re-derived on
-	// EVERY pass, for as long as it stays true.
+	// Lost are the mapped columns the board answers to under neither their
+	// cached option id nor their name, and that the BIND did not accept as
+	// absent. Nothing here can repair that, so it is what marks the binding
+	// degraded — and it is re-derived on EVERY pass, for as long as it stays
+	// true.
 	//
-	// A column the binding never resolved (`MissingStatuses`, the ordinary
+	// A column the bind accepted as absent (`UnresolvedAtBind`, the ordinary
 	// partial-coverage bind) is NOT lost: nothing broke, the map simply names
 	// more than the board carries.
 	Lost []LostColumn
@@ -161,19 +168,24 @@ func (r StatusVocabularyRepair) Reason() string {
 //     board's current NAME for it (this is the rename repair);
 //  2. else the mapped NAME still on the field ⇒ the column was re-created, or
 //     added since the bind; adopt its id;
-//  3. else, and only if the binding HAD an id for it ⇒ LOST.
+//  3. else, and only if the BIND did not accept it as absent ⇒ LOST.
 //
 // Rule 3 is a property of the binding's CURRENT shape, not an event: it is
 // re-derived identically on every pass, which is what lets a caller treat
-// "degraded" as a level rather than an edge. The cached id is deliberately
-// KEPT — dropping it destroys the evidence, and the very next pass then
-// reports nothing lost while every write onto that column still fails. What
-// keeps the dead id from being written is LostStates, which the pass hands to
-// the reflect.
+// "degraded" as a level rather than an edge. The oracle is `UnresolvedAtBind`
+// — what the operator accepted when they bound the board — and NOT the cached
+// option id, deliberately: an earlier release deleted that id on the pass that
+// observed the loss, so a rule reading "the binding HAS an id" finds nothing
+// lost on a binding that release degraded, and a readout that clears when it
+// finds nothing lost would clear a still-true degradation permanently. The
+// same two shapes meet during a rolling deploy, in either order.
 //
-// A column the binding never resolved is NOT lost — it is `MissingStatuses`,
-// the partial coverage BindBoard accepts on purpose ("the covered half
-// works"). Only something that worked can break.
+// The cached id is nevertheless KEPT on a loss: it is what `LostStates` gates
+// the reflect with, and a second, independent way to re-derive the loss.
+//
+// A column the bind accepted as absent is NOT lost — it is the partial
+// coverage BindBoard admits on purpose ("the covered half works"). Only
+// something that worked can break.
 //
 // The Status FIELD's own id is refreshed the same way — it is resolved by
 // name, so a field deleted and re-created is repaired rather than fatal.
@@ -186,17 +198,9 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	if b == nil || b.StatusFieldID == "" {
 		return rep
 	}
-	field, ok := project.Field(ProjectStatusFieldName)
-	if !ok || !field.SingleSelect() {
-		// The field itself is gone: every cached id is unwritable. Reported
-		// the same way as a single lost column — from the binding's current
-		// shape, so it keeps being reported for as long as it stays true.
-		for _, m := range b.Mapping() {
-			if b.StatusOptions[m.State] != "" {
-				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
-			}
-		}
-		return rep
+	field, hasField := project.Field(ProjectStatusFieldName)
+	if hasField && !field.SingleSelect() {
+		hasField = false // a Status field with no options can serve no column
 	}
 
 	mapping := append([]StatusMapping(nil), b.Mapping()...)
@@ -204,10 +208,19 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	for state, id := range b.StatusOptions {
 		options[state] = id
 	}
+
+	// 1. Resolve every mapped column against the live field — by cached id
+	// first (a rename keeps it), then by name (a re-created column keeps that).
+	resolved := make(map[string]bool, len(mapping))
 	var missing []string
 	for i, m := range mapping {
+		if !hasField {
+			missing = append(missing, m.Status)
+			continue
+		}
 		id := options[m.State]
 		if opt, ok := field.OptionByID(id); id != "" && ok {
+			resolved[m.State] = true
 			if !strings.EqualFold(strings.TrimSpace(opt.Name), strings.TrimSpace(m.Status)) {
 				rep.Renamed = append(rep.Renamed, StatusRename{State: m.State, From: m.Status, To: opt.Name})
 				mapping[i].Status = opt.Name
@@ -216,34 +229,46 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 			continue
 		}
 		opt, ok := field.Option(m.Status)
-		switch {
-		case !ok:
+		if !ok {
 			missing = append(missing, m.Status)
-			if id != "" {
-				// The binding HAD resolved a column here and the board now
-				// answers to neither its id nor its name. The cached id is
-				// KEPT: it is the evidence that this column once worked, and
-				// so the only thing that makes the loss re-derivable on the
-				// next pass instead of being a one-shot observation. What
-				// stops the reflect from writing it is LostStates, not a hole
-				// in the binding.
-				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
-			}
-		case id == "":
-			options[m.State] = opt.ID
-			rep.Adopted = append(rep.Adopted, m.State)
-			rep.changed = true
-		default:
-			options[m.State] = opt.ID
-			rep.Rebound = append(rep.Rebound, m.State)
-			rep.changed = true
+			continue
 		}
+		resolved[m.State] = true
+		options[m.State] = opt.ID
+		if id == "" {
+			rep.Adopted = append(rep.Adopted, m.State)
+		} else {
+			rep.Rebound = append(rep.Rebound, m.State)
+		}
+		rep.changed = true
 	}
 	sort.Strings(missing) // stable report, like the bind's own
+
+	// 2. Recover the bind-time accepted set for a binding written before it
+	// was recorded, so step 3 can tell "never had one" from "lost one".
+	if b.UnresolvedAtBind == nil {
+		b.UnresolvedAtBind = reconstructUnresolvedAtBind(b, missing)
+		rep.changed = true
+	}
+	accepted := make(map[string]bool, len(b.UnresolvedAtBind))
+	for _, s := range b.UnresolvedAtBind {
+		accepted[foldName(s)] = true
+	}
+
+	// 3. LOST: a mapped column the board serves under NEITHER its cached id
+	// nor its name, that the bind did not accept as absent. Deliberately not a
+	// question about the cached id — see the doc comment.
+	for _, m := range mapping {
+		if resolved[m.State] || accepted[foldName(m.Status)] {
+			continue
+		}
+		rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
+	}
+
 	if !sameStringSet(missing, b.MissingStatuses) {
 		rep.changed = true
 	}
-	if field.ID != "" && field.ID != b.StatusFieldID {
+	if hasField && field.ID != "" && field.ID != b.StatusFieldID {
 		// The field was re-created. Its NAME is what resolves it, exactly as
 		// at bind time, so this is repairable rather than fatal.
 		rep.FieldRebound = true
@@ -255,6 +280,29 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	}
 	b.StatusMapping, b.StatusOptions, b.MissingStatuses = mapping, options, missing
 	return rep
+}
+
+// reconstructUnresolvedAtBind recovers the bind-time accepted set for a binding
+// stored before it was recorded, and the reconstruction is deliberately
+// ASYMMETRIC on the binding's own health:
+//
+//   - a HEALTHY legacy binding: whatever it cannot resolve now is what it has
+//     always run with, so it was accepted. A three-column board bound with the
+//     five-column default map must not start reading as broken on an upgrade;
+//   - a DEGRADED one: NOTHING was accepted. Its record already says a column
+//     broke, and the release that flagged it also deleted that column's cached
+//     id — so from the outside "accepted at bind" and "lost last week" are the
+//     same shape, and the only safe reading of "I cannot tell" is to keep the
+//     degradation the binding itself declared.
+//
+// That is the rule in one line: a health flag is never cleared by the absence
+// of the evidence that would have kept it.
+func reconstructUnresolvedAtBind(b *BoardBinding, unresolvedNow []string) []string {
+	if b.Degraded() {
+		return []string{} // non-nil: reconstructed-as-empty, not un-recorded
+	}
+	out := make([]string, 0, len(unresolvedNow))
+	return append(out, unresolvedNow...)
 }
 
 // sameStringSet compares two already-sorted name lists.

--- a/pkg/forge/board_vocabulary.go
+++ b/pkg/forge/board_vocabulary.go
@@ -80,16 +80,43 @@ type StatusVocabularyRepair struct {
 	// Adopted are states the board had no column for when the binding was made
 	// and now does.
 	Adopted []string
-	// Lost are the columns that answer to NEITHER their cached id nor their
-	// name. Nothing here can repair that: their option is dropped so the
-	// reflect stops retrying them, and the binding is marked degraded.
+	// FieldRebound reports that the Status FIELD itself was re-created and its
+	// id re-resolved by name.
+	FieldRebound bool
+	// Lost are the columns the binding HAS an option id for that the board
+	// answers to under neither that id nor their name. Nothing here can repair
+	// that, so it is what marks the binding degraded — and it is re-derived on
+	// EVERY pass, for as long as it stays true.
+	//
+	// A column the binding never resolved (`MissingStatuses`, the ordinary
+	// partial-coverage bind) is NOT lost: nothing broke, the map simply names
+	// more than the board carries.
 	Lost []LostColumn
+
+	// changed records whether the reconciliation rewrote the vocabulary, which
+	// is a different question from whether anything is wrong: a standing loss
+	// re-reports identically on every pass and must not re-write the store.
+	changed bool
 }
 
-// Changed reports whether the repair altered the vocabulary at all — i.e.
-// whether the caller owes the store a write.
-func (r StatusVocabularyRepair) Changed() bool {
-	return len(r.Renamed)+len(r.Rebound)+len(r.Adopted)+len(r.Lost) > 0
+// Changed reports whether the repair altered the vocabulary — i.e. whether the
+// caller owes the store a write. A LOST column does not: it is re-derived from
+// the same inputs on every pass, and the binding keeps its cached id as the
+// evidence that makes that possible.
+func (r StatusVocabularyRepair) Changed() bool { return r.changed }
+
+// LostStates is the set of native states no card can be reflected onto,
+// keyed for a per-card test. It is what stops the reflect from writing an
+// option id the board no longer knows, now that the id is kept.
+func (r StatusVocabularyRepair) LostStates() map[string]bool {
+	if len(r.Lost) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(r.Lost))
+	for _, c := range r.Lost {
+		out[c.State] = true
+	}
+	return out
 }
 
 // Renames maps each renamed column's OLD name (folded) to its new one.
@@ -134,14 +161,26 @@ func (r StatusVocabularyRepair) Reason() string {
 //     board's current NAME for it (this is the rename repair);
 //  2. else the mapped NAME still on the field ⇒ the column was re-created, or
 //     added since the bind; adopt its id;
-//  3. else ⇒ LOST. Drop the dead id so nothing retries it, and report it.
+//  3. else, and only if the binding HAD an id for it ⇒ LOST.
+//
+// Rule 3 is a property of the binding's CURRENT shape, not an event: it is
+// re-derived identically on every pass, which is what lets a caller treat
+// "degraded" as a level rather than an edge. The cached id is deliberately
+// KEPT — dropping it destroys the evidence, and the very next pass then
+// reports nothing lost while every write onto that column still fails. What
+// keeps the dead id from being written is LostStates, which the pass hands to
+// the reflect.
+//
+// A column the binding never resolved is NOT lost — it is `MissingStatuses`,
+// the partial coverage BindBoard accepts on purpose ("the covered half
+// works"). Only something that worked can break.
 //
 // The Status FIELD's own id is refreshed the same way — it is resolved by
 // name, so a field deleted and re-created is repaired rather than fatal.
 //
 // A labels-only binding (no Status field at bind time) has no vocabulary and
-// is left alone. A binding whose Status field has vanished loses every state:
-// there is nothing left to write into.
+// is left alone. A binding whose Status field has vanished loses every state
+// it had resolved: there is nothing left to write into.
 func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyRepair {
 	var rep StatusVocabularyRepair
 	if b == nil || b.StatusFieldID == "" {
@@ -149,15 +188,13 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	}
 	field, ok := project.Field(ProjectStatusFieldName)
 	if !ok || !field.SingleSelect() {
-		// The field itself is gone. Every cached id is unwritable; say so once
-		// rather than failing one write per card per pass.
+		// The field itself is gone: every cached id is unwritable. Reported
+		// the same way as a single lost column — from the binding's current
+		// shape, so it keeps being reported for as long as it stays true.
 		for _, m := range b.Mapping() {
 			if b.StatusOptions[m.State] != "" {
 				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
 			}
-		}
-		if len(rep.Lost) > 0 {
-			b.StatusOptions = map[string]string{}
 		}
 		return rep
 	}
@@ -174,6 +211,7 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 			if !strings.EqualFold(strings.TrimSpace(opt.Name), strings.TrimSpace(m.Status)) {
 				rep.Renamed = append(rep.Renamed, StatusRename{State: m.State, From: m.Status, To: opt.Name})
 				mapping[i].Status = opt.Name
+				rep.changed = true
 			}
 			continue
 		}
@@ -182,27 +220,52 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 		case !ok:
 			missing = append(missing, m.Status)
 			if id != "" {
+				// The binding HAD resolved a column here and the board now
+				// answers to neither its id nor its name. The cached id is
+				// KEPT: it is the evidence that this column once worked, and
+				// so the only thing that makes the loss re-derivable on the
+				// next pass instead of being a one-shot observation. What
+				// stops the reflect from writing it is LostStates, not a hole
+				// in the binding.
 				rep.Lost = append(rep.Lost, LostColumn{State: m.State, Status: m.Status})
-				delete(options, m.State)
 			}
 		case id == "":
 			options[m.State] = opt.ID
 			rep.Adopted = append(rep.Adopted, m.State)
+			rep.changed = true
 		default:
 			options[m.State] = opt.ID
 			rep.Rebound = append(rep.Rebound, m.State)
+			rep.changed = true
 		}
 	}
 	sort.Strings(missing) // stable report, like the bind's own
+	if !sameStringSet(missing, b.MissingStatuses) {
+		rep.changed = true
+	}
 	if field.ID != "" && field.ID != b.StatusFieldID {
 		// The field was re-created. Its NAME is what resolves it, exactly as
 		// at bind time, so this is repairable rather than fatal.
-		rep.Rebound = append(rep.Rebound, ProjectStatusFieldName)
+		rep.FieldRebound = true
+		rep.changed = true
 		b.StatusFieldID = field.ID
 	}
-	if !rep.Changed() {
+	if !rep.changed {
 		return rep
 	}
 	b.StatusMapping, b.StatusOptions, b.MissingStatuses = mapping, options, missing
 	return rep
+}
+
+// sameStringSet compares two already-sorted name lists.
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/forge/board_vocabulary.go
+++ b/pkg/forge/board_vocabulary.go
@@ -255,7 +255,7 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 	// 2. Recover the bind-time accepted set for a binding written before it
 	// was recorded, so step 3 can tell "never had one" from "lost one".
 	if b.UnresolvedAtBind == nil {
-		b.UnresolvedAtBind = reconstructUnresolvedAtBind(b, missing)
+		b.UnresolvedAtBind = reconstructUnresolvedAtBind(b)
 		rep.changed = true
 	}
 	accepted := make(map[string]bool, len(b.UnresolvedAtBind))
@@ -298,11 +298,21 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 }
 
 // reconstructUnresolvedAtBind recovers the bind-time accepted set for a binding
-// stored before it was recorded, and the reconstruction is deliberately
-// ASYMMETRIC on the binding's own health:
+// stored before it was recorded.
 //
-//   - a HEALTHY legacy binding: whatever it cannot resolve now is what it has
-//     always run with, so it was accepted. A three-column board bound with the
+// It reads the BINDING, never the live board: a mapped column with no cached
+// option id is one the bind could not resolve and did not refuse over, which is
+// the definition of the set. The board's current shape is the wrong oracle —
+// "what the board lacks NOW" and "what the bind accepted" diverge exactly when
+// something broke in the upgrade window, and diverge catastrophically when the
+// Status field has vanished (every mapped column lacks a home, and recording
+// all of them as accepted persists a lie the operator reads back on the binding
+// API). Independent of the board, this cannot be poisoned by one bad pass.
+//
+// It is deliberately ASYMMETRIC on the binding's own health:
+//
+//   - a HEALTHY legacy binding: a column it never resolved is one it has always
+//     run without, so it was accepted. A three-column board bound with the
 //     five-column default map must not start reading as broken on an upgrade;
 //   - a DEGRADED one: NOTHING was accepted. Its record already says a column
 //     broke, and the release that flagged it also deleted that column's cached
@@ -312,12 +322,18 @@ func (b *BoardBinding) ReconcileStatusOptions(project Project) StatusVocabularyR
 //
 // That is the rule in one line: a health flag is never cleared by the absence
 // of the evidence that would have kept it.
-func reconstructUnresolvedAtBind(b *BoardBinding, unresolvedNow []string) []string {
+func reconstructUnresolvedAtBind(b *BoardBinding) []string {
+	out := []string{} // non-nil: reconstructed-as-empty, not un-recorded
 	if b.Degraded() {
-		return []string{} // non-nil: reconstructed-as-empty, not un-recorded
+		return out
 	}
-	out := make([]string, 0, len(unresolvedNow))
-	return append(out, unresolvedNow...)
+	for _, m := range b.Mapping() {
+		if b.StatusOptions[m.State] == "" {
+			out = append(out, m.Status)
+		}
+	}
+	sort.Strings(out) // stable report, like the bind's own
+	return out
 }
 
 // sameStringSet compares two already-sorted name lists.

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -108,8 +108,10 @@ func TestReconcileStatusOptionsLosesADeletedColumn(t *testing.T) {
 	if len(rep.Lost) != 1 || rep.Lost[0].State != "in_progress" || rep.Lost[0].Status != "In progress" {
 		t.Fatalf("Lost = %+v, want the deleted column with both its names", rep.Lost)
 	}
-	if _, ok := b.OptionForState("in_progress"); ok {
-		t.Error("the dead option id must be dropped, so nothing retries a write that cannot land")
+	// The dead id is KEPT — it is the evidence that makes the loss re-derivable
+	// on the next pass. What stops a write that cannot land is LostStates.
+	if !rep.LostStates()["in_progress"] {
+		t.Error("LostStates must refuse the state, since the dead id is still cached")
 	}
 	reason := rep.Reason()
 	if !strings.Contains(reason, "In progress") || !strings.Contains(reason, "in_progress") {
@@ -121,6 +123,73 @@ func TestReconcileStatusOptionsLosesADeletedColumn(t *testing.T) {
 	}
 }
 
+// TestReconcileStatusOptionsKeepsReportingALostColumn: the loss must be
+// RE-DERIVABLE, not a one-shot observation.
+//
+// A repair that dropped the cached id destroyed the only evidence the column
+// had ever resolved, so the very next pass reported nothing lost — and the
+// caller, reading "nothing lost", cleared the degradation on the first
+// unrelated adoption while the column was still gone.
+func TestReconcileStatusOptionsKeepsReportingALostColumn(t *testing.T) {
+	b := vocabBinding()
+	deleted := vocabProject(forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"})
+
+	for pass := 1; pass <= 3; pass++ {
+		rep := b.ReconcileStatusOptions(deleted)
+		if len(rep.Lost) != 1 || rep.Lost[0].State != "in_progress" {
+			t.Fatalf("pass %d: Lost = %+v, want the still-missing column on EVERY pass", pass, rep.Lost)
+		}
+		if !strings.Contains(rep.Reason(), "In progress") {
+			t.Fatalf("pass %d: reason = %q, want it to keep naming the column", pass, rep.Reason())
+		}
+	}
+	// The cached id is what makes it re-derivable, so it is kept — the reflect
+	// is stopped by the LostStates set, not by a hole in the binding.
+	if b.StatusOptions["in_progress"] != "o_prog" {
+		t.Errorf("cached id = %q, want it kept as the evidence of the loss", b.StatusOptions["in_progress"])
+	}
+	if !b.ReconcileStatusOptions(deleted).LostStates()["in_progress"] {
+		t.Error("LostStates must name the state, so the reflect can refuse it instead of writing a dead id")
+	}
+}
+
+// TestReconcileStatusOptionsDoesNotLoseAnUnresolvedColumn: a mapped column the
+// board never carried has no cached id, so nothing was lost — it is the
+// ordinary `missing_statuses` shape, which BindBoard accepts on purpose. Only
+// a column the binding HAD resolved can be lost.
+func TestReconcileStatusOptionsDoesNotLoseAnUnresolvedColumn(t *testing.T) {
+	b := vocabBinding()
+	delete(b.StatusOptions, "in_progress") // never resolved at bind time
+	b.MissingStatuses = []string{"In progress"}
+
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+	))
+	if len(rep.Lost) != 0 || rep.Reason() != "" {
+		t.Fatalf("partial coverage is not a degradation: %+v / %q", rep.Lost, rep.Reason())
+	}
+	if len(b.MissingStatuses) != 1 || b.MissingStatuses[0] != "In progress" {
+		t.Errorf("...but it must still be reported: %v", b.MissingStatuses)
+	}
+}
+
+// A state the binding has no mapping for at all cannot be lost, whatever the
+// board carries: it is inert by design (§2), not broken.
+func TestReconcileStatusOptionsIgnoresAnUnmappedState(t *testing.T) {
+	b := vocabBinding()
+	b.StatusOptions["review"] = "o_review" // an orphan id with no mapping entry
+
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "In progress"},
+	))
+	for _, c := range rep.Lost {
+		if c.State == "review" {
+			t.Fatalf("an unmapped state is inert, never lost: %+v", rep.Lost)
+		}
+	}
+}
+
 func TestReconcileStatusOptionsLosesEverythingWhenTheFieldIsGone(t *testing.T) {
 	b := vocabBinding()
 	rep := b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203})
@@ -128,8 +197,13 @@ func TestReconcileStatusOptionsLosesEverythingWhenTheFieldIsGone(t *testing.T) {
 	if len(rep.Lost) != 2 {
 		t.Fatalf("Lost = %+v, want every mapped column — there is nothing left to write into", rep.Lost)
 	}
-	if len(b.StatusOptions) != 0 {
-		t.Errorf("StatusOptions = %v, want empty", b.StatusOptions)
+	if lost := rep.LostStates(); !lost["ready"] || !lost["in_progress"] {
+		t.Errorf("LostStates = %v, want every state refused", lost)
+	}
+	// Re-derivable: the second pass says the same thing, because the ids the
+	// first one read are still there to read.
+	if again := b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203}); len(again.Lost) != 2 {
+		t.Errorf("second pass Lost = %+v, want the same two", again.Lost)
 	}
 }
 

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -27,6 +27,10 @@ func vocabBinding() *forge.BoardBinding {
 			{Status: "In progress", State: "in_progress"},
 		},
 		StatusOptions: map[string]string{"ready": "o_planned", "in_progress": "o_prog"},
+		// A bind against a board carrying both columns accepted nothing as
+		// absent. Non-nil: "nothing was missing" and "nobody recorded this"
+		// are different answers, and the second triggers a reconstruction.
+		UnresolvedAtBind: []string{},
 	}
 }
 
@@ -83,6 +87,7 @@ func TestReconcileStatusOptionsAdoptsAColumnAddedSinceTheBind(t *testing.T) {
 	b := vocabBinding()
 	delete(b.StatusOptions, "in_progress") // the board had no such column at bind time
 	b.MissingStatuses = []string{"In progress"}
+	b.UnresolvedAtBind = []string{"In progress"}
 
 	rep := b.ReconcileStatusOptions(vocabProject(
 		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
@@ -161,6 +166,7 @@ func TestReconcileStatusOptionsDoesNotLoseAnUnresolvedColumn(t *testing.T) {
 	b := vocabBinding()
 	delete(b.StatusOptions, "in_progress") // never resolved at bind time
 	b.MissingStatuses = []string{"In progress"}
+	b.UnresolvedAtBind = []string{"In progress"} // and the bind ACCEPTED that
 
 	rep := b.ReconcileStatusOptions(vocabProject(
 		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -147,6 +147,13 @@ func TestReconcileStatusOptionsKeepsReportingALostColumn(t *testing.T) {
 		if !strings.Contains(rep.Reason(), "In progress") {
 			t.Fatalf("pass %d: reason = %q, want it to keep naming the column", pass, rep.Reason())
 		}
+		// Re-derived is not re-written: `Changed()` answers "does the caller owe
+		// the store a write", which a standing loss does not. Without this,
+		// every bound team pays a store write per reconciliation interval,
+		// forever, for a fact that has not moved.
+		if pass > 1 && rep.Changed() {
+			t.Fatalf("pass %d: a standing loss re-reports identically; it must not re-write the store: %+v", pass, rep)
+		}
 	}
 	// The cached id is what makes it re-derivable, so it is kept — the reflect
 	// is stopped by the LostStates set, not by a hole in the binding.

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -179,6 +179,100 @@ func TestReconcileStatusOptionsDoesNotLoseAnUnresolvedColumn(t *testing.T) {
 	}
 }
 
+// TestReconcileStatusOptionsLosesAColumnItAdoptedAfterTheBind: the bind-time
+// exemption is a statement about the past, not a permanent licence.
+//
+// A column the bind accepted as absent cannot break — until the operator
+// creates it and a reconciliation ADOPTS it. From that pass on it has resolved,
+// so its later deletion is a break like any other. An exemption keyed on the
+// bind-time NAME alone never discharges, so the binding would read healthy
+// while every card of that column is refused.
+func TestReconcileStatusOptionsLosesAColumnItAdoptedAfterTheBind(t *testing.T) {
+	b := vocabBinding()
+	delete(b.StatusOptions, "in_progress")
+	b.MissingStatuses = []string{"In progress"}
+	b.UnresolvedAtBind = []string{"In progress"} // accepted as absent at bind
+
+	// The operator creates the column: adopted, and it earns a real id.
+	if rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "In progress"},
+	)); len(rep.Adopted) != 1 {
+		t.Fatalf("Adopted = %+v, want the column the operator added", rep.Adopted)
+	}
+
+	// ...and deletes it again. It worked; now it is broken.
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+	))
+	if len(rep.Lost) != 1 || rep.Lost[0].State != "in_progress" {
+		t.Fatalf("Lost = %+v, want the adopted-then-deleted column", rep.Lost)
+	}
+	if rep.Reason() == "" {
+		t.Error("...and the binding must read degraded, not healthy")
+	}
+	if !rep.LostStates()["in_progress"] {
+		t.Error("LostStates must refuse the state, or the reflect writes a dead id")
+	}
+}
+
+// TestReconcileStatusOptionsLosesALegacyColumnDeletedBeforeTheFirstPass is the
+// upgrade window, which the reconstruction structurally cannot see.
+//
+// A binding written before `UnresolvedAtBind` existed reads healthy, and its
+// column is deleted between the last old-release pass and the first new one.
+// The reconstruction runs exactly once, from THIS pass's board read, so it
+// would write the freshly-broken column into the accepted set and exempt it
+// forever. The cached id says otherwise: that column resolved once.
+func TestReconcileStatusOptionsLosesALegacyColumnDeletedBeforeTheFirstPass(t *testing.T) {
+	b := vocabBinding()
+	b.UnresolvedAtBind = nil // written before the field existed, and healthy
+
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+	))
+	if len(rep.Lost) != 1 || rep.Lost[0].State != "in_progress" {
+		t.Fatalf("Lost = %+v, want the column that had an id and stopped resolving", rep.Lost)
+	}
+}
+
+// The same legacy binding, whose Status FIELD is gone: every column it had
+// resolved is lost. A set reconstructed from this pass's board read says the
+// board carries none of them — true, and irrelevant: what the operator
+// accepted at bind was never "everything".
+func TestReconcileStatusOptionsLosesALegacyBindingsColumnsWhenTheFieldIsGone(t *testing.T) {
+	b := vocabBinding()
+	b.UnresolvedAtBind = nil
+
+	rep := b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203})
+	if len(rep.Lost) != 2 {
+		t.Fatalf("Lost = %+v, want every state the binding had resolved", rep.Lost)
+	}
+}
+
+// The accepted set is keyed by the bind-time column NAME, while the rename
+// repair rewrites `mapping[i].Status` in place. Only the resolution ORDER keeps
+// the two apart — a renamed column short-circuits as resolved before the set is
+// ever consulted — so the invariant is pinned rather than assumed.
+func TestReconcileStatusOptionsDoesNotConsultTheAcceptedSetForARenamedColumn(t *testing.T) {
+	b := vocabBinding()
+	// The board renames "In progress" to a name that IS in the bind-time
+	// accepted set. Reading the set with the REWRITTEN name would exempt a
+	// column that resolves perfectly well by its cached id.
+	b.UnresolvedAtBind = []string{"Blocked"}
+
+	rep := b.ReconcileStatusOptions(vocabProject(
+		forge.ProjectFieldOption{ID: "o_planned", Name: "Planned"},
+		forge.ProjectFieldOption{ID: "o_prog", Name: "Blocked"},
+	))
+	if len(rep.Lost) != 0 {
+		t.Fatalf("a renamed column resolves by its cached id, it is never lost: %+v", rep.Lost)
+	}
+	if len(rep.Renamed) != 1 || rep.Renamed[0].To != "Blocked" {
+		t.Fatalf("Renamed = %+v, want the ordinary rename repair", rep.Renamed)
+	}
+}
+
 // A state the binding has no mapping for at all cannot be lost, whatever the
 // board carries: it is inert by design (§2), not broken.
 func TestReconcileStatusOptionsIgnoresAnUnmappedState(t *testing.T) {

--- a/pkg/forge/board_vocabulary_test.go
+++ b/pkg/forge/board_vocabulary_test.go
@@ -250,6 +250,27 @@ func TestReconcileStatusOptionsLosesALegacyBindingsColumnsWhenTheFieldIsGone(t *
 	}
 }
 
+// The reconstruction reads the BINDING's own shape, never this pass's board.
+//
+// A legacy binding whose Status field has just vanished lacks every column
+// right now — recording that as "what the operator accepted at bind" writes a
+// lie into the store, one an operator reads back on the binding API, and one
+// that exempts every column the moment its cached id goes. A mapped column with
+// no cached id is the honest answer: that is a column the bind never resolved.
+func TestReconcileStatusOptionsReconstructsTheAcceptedSetFromTheBinding(t *testing.T) {
+	b := vocabBinding()
+	b.UnresolvedAtBind = nil               // written before the field existed
+	delete(b.StatusOptions, "in_progress") // and never resolved at bind
+	b.MissingStatuses = []string{"In progress"}
+
+	// The field itself is gone, so the board answers for NOTHING.
+	b.ReconcileStatusOptions(forge.Project{ID: "PVT_p", Number: 203})
+
+	if len(b.UnresolvedAtBind) != 1 || b.UnresolvedAtBind[0] != "In progress" {
+		t.Fatalf("UnresolvedAtBind = %v, want only the column that never had an id", b.UnresolvedAtBind)
+	}
+}
+
 // The accepted set is keyed by the bind-time column NAME, while the rename
 // repair rewrites `mapping[i].Status` in place. Only the resolution ORDER keeps
 // the two apart — a renamed column short-circuits as resolved before the set is

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -287,15 +287,59 @@ func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImpo
 			}
 		}
 	}
-	return bindingRepair{renamed: rep.Renames(), lost: rep.LostStates()}
+	return newBindingRepair(binding, &rep)
 }
 
-// bindingRepair is what one pass's reconciliation tells the item loop: the
-// column renames a card's recorded status must be read through, and the
-// columns no card can be reflected onto.
+// bindingRepair is what the item loop — and the projection fast path — are
+// told about the board's columns: the renames a card's recorded status must be
+// read through, and the states no card can be reflected onto.
 type bindingRepair struct {
 	renamed map[string]string
 	lost    map[string]bool
+}
+
+// newBindingRepair builds that answer for BOTH reflect callers, which is the
+// point: they disagree about nothing.
+//
+// The lost set is a UNION of two sources, and the second is what lets a caller
+// that never reads the board still refuse a write:
+//
+//   - the binding's own `MissingStatuses` — every mapped column the board did
+//     not carry as of the last reconciliation, persisted. Always consulted,
+//     because it is the only source available to a path with no board read;
+//   - the live repair, when the caller HAS just read the board (the periodic
+//     pass). Fresher, and the one that lets a re-created column resolve again
+//     within the same pass.
+//
+// `rep == nil` means "this call observed nothing about the board" — not "the
+// board is fine". The consequence has to be safe, and is: a lost column keeps
+// its cached option id (that id is the evidence the degradation is re-derived
+// from), so `OptionForState` still answers it and only this set refuses the
+// write. Reading the persisted set is what keeps the fast path from firing a
+// dead option id at the forge on every card of a broken column.
+func newBindingRepair(b *forge.BoardBinding, rep *forge.StatusVocabularyRepair) bindingRepair {
+	out := bindingRepair{}
+	if rep != nil {
+		out.renamed = rep.Renames()
+		out.lost = rep.LostStates()
+	}
+	if b == nil || len(b.MissingStatuses) == 0 {
+		return out
+	}
+	absent := make(map[string]bool, len(b.MissingStatuses))
+	for _, s := range b.MissingStatuses {
+		absent[strings.ToLower(strings.TrimSpace(s))] = true
+	}
+	for _, m := range b.Mapping() {
+		if !absent[strings.ToLower(strings.TrimSpace(m.Status))] {
+			continue
+		}
+		if out.lost == nil {
+			out.lost = map[string]bool{}
+		}
+		out.lost[m.State] = true
+	}
+	return out
 }
 
 // rename resolves a recorded status name through this pass's renames.

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -237,6 +237,16 @@ func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImpo
 	if binding == nil {
 		return bindingRepair{} // read-only pass: nothing is cached, so nothing is stale
 	}
+	if binding.StatusFieldID == "" {
+		// A labels-only binding has no status vocabulary, so this pass
+		// re-derived NOTHING about it. `ReconcileStatusOptions` would hand back
+		// the zero repair, whose empty `Reason()` is indistinguishable from
+		// "every column resolves" — and the clear arm below would act on it.
+		// Nothing reaches here degraded today, but the switch must never be
+		// able to clear a flag on the absence of the evidence that would have
+		// kept it: that is the whole thesis of the level-triggered readout.
+		return bindingRepair{}
+	}
 	was := binding.DegradedReason
 	rep := binding.ReconcileStatusOptions(project)
 	store := opts.bindingStore()

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -188,7 +188,7 @@ func ImportProjectBoard(
 	if err != nil {
 		return res, fmt.Errorf("project import: get project %s: %w", ref, err)
 	}
-	renamed := repairBinding(ctx, project, opts)
+	repair := repairBinding(ctx, project, opts)
 
 	missing := map[string]int{}
 	cursor := ""
@@ -198,7 +198,7 @@ func ImportProjectBoard(
 			return res, fmt.Errorf("project import: list items of %s: %w", ref, err)
 		}
 		for _, it := range page.Items {
-			if err := applyProjectItem(ctx, bc, project, ref, provider, board, it, opts, &res, missing, renamed); err != nil {
+			if err := applyProjectItem(ctx, bc, project, ref, provider, board, it, opts, &res, missing, repair); err != nil {
 				res.MissingRepos = rankMissingRepos(missing)
 				return res, err
 			}
@@ -224,18 +224,23 @@ func ImportProjectBoard(
 //
 // Persisting is best-effort: a store outage must not abandon the reconciliation
 // the operator is watching. The repair still applies in memory for this pass.
-func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImportOptions) map[string]string {
+//
+// The health readout is decided here too, and from the binding's CURRENT shape
+// rather than from what this pass happened to observe. A flag derived from an
+// EVENT ("we noticed the column go") only holds while the evidence survives:
+// the first pass reports the loss, and every pass after it — reading a binding
+// where nothing changed — reports nothing, so the next unrelated repair reads
+// as "it resolves again" and clears a degradation that is still true. Level,
+// not edge: `reason` is recomputed each pass, and only an EMPTY one clears.
+func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImportOptions) bindingRepair {
 	binding := opts.binding()
 	if binding == nil {
-		return nil // read-only pass: nothing is cached, so nothing is stale
+		return bindingRepair{} // read-only pass: nothing is cached, so nothing is stale
 	}
 	was := binding.DegradedReason
 	rep := binding.ReconcileStatusOptions(project)
-	if !rep.Changed() {
-		return nil
-	}
 	store := opts.bindingStore()
-	if store != nil {
+	if rep.Changed() && store != nil {
 		if err := store.SaveStatusVocabulary(ctx, binding.TenantID, binding.Vocabulary()); err != nil {
 			logProjectWarn(opts, "project board: the repaired status vocabulary could not be persisted",
 				"team", binding.TenantID, "error", err.Error())
@@ -244,24 +249,26 @@ func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImpo
 
 	switch reason := rep.Reason(); {
 	case reason != "":
-		if was != reason {
-			// ONCE, on the transition. The state itself lives on the binding
-			// (GET /api/teams/{id}/board-binding), which is where an operator
-			// can act on it — a Warn repeated every two minutes is not a
-			// signal, it is noise that buries the pass's real lines.
-			logProjectWarn(opts, "project board: a bound status column no longer exists on the board",
-				"team", binding.TenantID, "board", binding.Ref().String(), "reason", reason)
-		}
 		binding.DegradedReason = reason
+		if was == reason {
+			break // unchanged standing state: no store write, no second Warn
+		}
+		// ONCE, on the transition. The state itself lives on the binding
+		// (GET /api/teams/{id}/board-binding), which is where an operator can
+		// act on it — a Warn repeated every two minutes is not a signal, it is
+		// noise that buries the pass's real lines.
+		logProjectWarn(opts, "project board: a bound status column no longer exists on the board",
+			"team", binding.TenantID, "board", binding.Ref().String(), "reason", reason)
 		if store != nil {
 			if err := store.MarkDegraded(ctx, binding.TenantID, reason); err != nil {
 				logProjectWarn(opts, "project board: the binding could not be flagged degraded",
 					"team", binding.TenantID, "error", err.Error())
 			}
 		}
-	case was != "" && len(rep.Adopted)+len(rep.Rebound) > 0:
-		// A column the last pass could not resolve resolves again — the flag
-		// is a readout of the LAST resolution, so it clears without a re-bind.
+	case was != "":
+		// Nothing is lost any more — every mapped column the binding resolved
+		// answers again. Only THAT clears the flag; an unrelated adoption
+		// elsewhere on the board never did mean the missing column came back.
 		binding.DegradedReason, binding.DegradedAt = "", nil
 		if store != nil {
 			if err := store.ClearDegraded(ctx, binding.TenantID); err != nil {
@@ -270,8 +277,28 @@ func repairBinding(ctx context.Context, project forge.Project, opts *ProjectImpo
 			}
 		}
 	}
-	return rep.Renames()
+	return bindingRepair{renamed: rep.Renames(), lost: rep.LostStates()}
 }
+
+// bindingRepair is what one pass's reconciliation tells the item loop: the
+// column renames a card's recorded status must be read through, and the
+// columns no card can be reflected onto.
+type bindingRepair struct {
+	renamed map[string]string
+	lost    map[string]bool
+}
+
+// rename resolves a recorded status name through this pass's renames.
+func (r bindingRepair) rename(status string) (string, bool) {
+	if len(r.renamed) == 0 {
+		return "", false
+	}
+	to, ok := r.renamed[strings.ToLower(strings.TrimSpace(status))]
+	return to, ok
+}
+
+// lostState reports whether the board carries no column for this native state.
+func (r bindingRepair) lostState(state string) bool { return r.lost[state] }
 
 // rankMissingRepos orders the skipped repositories most-missing first, ties
 // broken by name, so the operator's first move is the first line.
@@ -311,7 +338,7 @@ func applyProjectItem(
 	opts *ProjectImportOptions,
 	res *ProjectImportResult,
 	missing map[string]int,
-	renamed map[string]string,
+	repair bindingRepair,
 ) error {
 	res.Items++
 	if it.Archived {
@@ -348,7 +375,7 @@ func applyProjectItem(
 	// longer knows. Reading the record through the rename keeps ONE operator
 	// edit from reading as "the board moved to an unknown column" on every
 	// card of that column at once.
-	if to, ok := renamed[strings.ToLower(strings.TrimSpace(sync.Status))]; ok {
+	if to, ok := repair.rename(sync.Status); ok {
 		sync.Status = to
 	}
 	statusName, statusAt := projectStatusValue(it)
@@ -449,7 +476,7 @@ func applyProjectItem(
 		// OBSERVED closes it, and is not a false claim: the board says this
 		// value now, and it is exactly what "the status last synchronized"
 		// means. A FAILED write is the exception — the next pass must retry it.
-		if out := reflectNativeState(ctx, bc, card, it, &sync, statusName, opts, res); out == reflectNothingToWrite &&
+		if out := reflectNativeState(ctx, bc, card, it, &sync, statusName, opts, res, repair); out == reflectNothingToWrite &&
 			decision == projectStatusConflictNative {
 			sync.Status = statusName
 			sync.StatusAt = statusAt
@@ -506,6 +533,7 @@ func reflectNativeState(
 	boardStatus string,
 	opts *ProjectImportOptions,
 	res *ProjectImportResult,
+	repair bindingRepair,
 ) reflectOutcome {
 	binding := opts.binding()
 	if binding == nil {
@@ -528,12 +556,15 @@ func reflectNativeState(
 		return reflectNothingToWrite // already there — the idempotence that keeps a pass free
 	}
 	option, ok := binding.OptionForState(card.State)
-	if !ok {
+	if !ok || repair.lostState(card.State) {
 		// No column for this state: one the map named and the board never had
 		// (reported as `missing_statuses` at bind time), or one deleted since —
-		// which the pass's reconciliation already flagged on the binding, once.
-		// Counted, not warned: this card is unreflectable on EVERY pass until
-		// the binding is repaired, and a per-card Warn buries the rest.
+		// which this pass's reconciliation flagged on the binding, once. The
+		// second case still HAS a cached id (kept as the evidence that keeps
+		// the degradation re-derivable), so the lost set is what refuses it;
+		// writing that id would 422 on every card of that column, every pass.
+		// Counted, not warned: these cards are unreflectable on EVERY pass
+		// until the binding is repaired, and a per-card Warn buries the rest.
 		res.ReflectNoColumn++
 		return reflectNothingToWrite
 	}

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -57,6 +57,25 @@ func deletedColumn(t *testing.T, name string) forge.Project {
 	return withoutColumn(t, testProject(), name)
 }
 
+// withoutStatusField removes the Status field itself — the shape where the
+// binding still holds a field id and an option id per state, and the board has
+// nowhere to put either.
+func withoutStatusField(t *testing.T, p forge.Project) forge.Project {
+	t.Helper()
+	fields := make([]forge.ProjectField, 0, len(p.Fields))
+	for _, f := range p.Fields {
+		if strings.EqualFold(f.Name, forge.ProjectStatusFieldName) {
+			continue
+		}
+		fields = append(fields, f)
+	}
+	if len(fields) == len(p.Fields) {
+		t.Fatalf("fixture has no %s field", forge.ProjectStatusFieldName)
+	}
+	p.Fields = fields
+	return p
+}
+
 // withoutColumn removes one Status option from an arbitrary project, so a
 // fixture can drop two independently.
 func withoutColumn(t *testing.T, p forge.Project, name string) forge.Project {
@@ -604,6 +623,77 @@ func TestSyncProjectBoardDegradesOnAColumnItAdoptedAfterTheBind(t *testing.T) {
 	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 {
 		t.Errorf("ReflectNoColumn = %d writes = %+v — the card must be refused, not written onto a dead id",
 			res.ReflectNoColumn, bc.writes)
+	}
+}
+
+// TestSyncProjectBoardRefusesEveryCardWhenTheStatusFieldIsGone is the shape
+// where keeping the cached ids is riskiest, and the one the old code sidestepped
+// by emptying `StatusOptions` and returning.
+//
+// The binding still holds a Status FIELD id and an option id per state; the
+// board has neither. Nothing in the write path notices that on its own — the
+// reflect's own guard is "does the binding have an option for this state", and
+// the answer is yes. Only the pass's LOST set refuses it. Without that, every
+// card of every column is written to a field the board no longer has: a 422 per
+// card, per pass, forever.
+func TestSyncProjectBoardRefusesEveryCardWhenTheStatusFieldIsGone(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, testProject())
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings}
+	// The schema and the items are two separate reads, so a field deleted
+	// between them gives exactly this: no Status field on the project, a stale
+	// Status value still on the item. It is also the only interleaving that
+	// reaches the reflect at all — an item reporting NO status leaves the
+	// recorded one empty, and the reflect declines on that first.
+	bc := &fakeBoardClient{project: withoutStatusField(t, testProject()),
+		pages: [][]forge.ProjectItem{{
+			item("PVTI_1", 613, statusOption("Planned", optionID(t, testProject(), "Planned"), at)),
+		}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Errorf("writes = %+v — there is no field left to write into", bc.writes)
+	}
+	if res.ReflectNoColumn != 1 {
+		t.Errorf("ReflectNoColumn = %d, want the card counted as unreflectable", res.ReflectNoColumn)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !stored.Degraded() {
+		t.Fatalf("the Status field is gone; the binding must say so: %+v", stored)
+	}
+	if len(stored.MissingStatuses) != len(stored.Mapping()) {
+		t.Errorf("MissingStatuses = %v, want every mapped column", stored.MissingStatuses)
+	}
+	// The cached ids are KEPT — that is what lets the next pass re-derive the
+	// same answer instead of reading a healthy binding.
+	if stored.StatusOptions[native.StateInProgress] == "" {
+		t.Errorf("the cached ids must survive as the evidence of the loss: %v", stored.StatusOptions)
+	}
+
+	// Second pass: the same answer, and still not one write.
+	res2, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if res2.ReflectNoColumn != 1 || len(bc.writes) != 0 {
+		t.Errorf("pass 2: ReflectNoColumn = %d writes = %+v — the refusal must be re-derived, not observed once",
+			res2.ReflectNoColumn, bc.writes)
+	}
+	if after, _ := bindings.GetByTenant(context.Background(), "team-a"); !after.Degraded() {
+		t.Errorf("pass 2 cleared the degradation while the field is still gone: %+v", after)
 	}
 }
 

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -53,7 +54,14 @@ func recreatedColumn(t *testing.T, name, newID string) forge.Project {
 // deletedColumn returns the fixture project with one Status option removed.
 func deletedColumn(t *testing.T, name string) forge.Project {
 	t.Helper()
-	p := testProject()
+	return withoutColumn(t, testProject(), name)
+}
+
+// withoutColumn removes one Status option from an arbitrary project, so a
+// fixture can drop two independently.
+func withoutColumn(t *testing.T, p forge.Project, name string) forge.Project {
+	t.Helper()
+	p.Fields = append([]forge.ProjectField(nil), p.Fields...)
 	for i, f := range p.Fields {
 		if !strings.EqualFold(f.Name, forge.ProjectStatusFieldName) {
 			continue
@@ -267,8 +275,14 @@ func TestSyncProjectBoardDegradesOnADeletedColumn(t *testing.T) {
 	if !stored.Degraded() || !strings.Contains(stored.DegradedReason, "In progress") {
 		t.Fatalf("binding must be degraded and NAME the lost column, got %q", stored.DegradedReason)
 	}
-	if stored.StatusOptions[native.StateInProgress] != "" {
-		t.Errorf("the dead option id must be dropped, got %q", stored.StatusOptions[native.StateInProgress])
+	// The dead id is KEPT: it is what lets the NEXT pass re-derive the loss
+	// instead of reading a healthy binding. The reflect is refused by the
+	// pass's lost set, asserted below.
+	if stored.StatusOptions[native.StateInProgress] == "" {
+		t.Errorf("the cached id must survive as the evidence of the loss: %v", stored.StatusOptions)
+	}
+	if !slices.Contains(stored.MissingStatuses, "In progress") {
+		t.Errorf("MissingStatuses = %v, want the lost column listed", stored.MissingStatuses)
 	}
 
 	// Two more passes: still no writes, and the reason is logged ONCE — an
@@ -325,6 +339,121 @@ func TestSyncProjectBoardClearsDegradedWhenTheColumnComesBack(t *testing.T) {
 	}
 	if len(bc.writes) != 1 || bc.writes[0].OptionID != "PVTSSO_back" {
 		t.Errorf("writes = %+v, want the push the degraded pass could not make", bc.writes)
+	}
+}
+
+// TestSyncProjectBoardStaysDegradedWhileTheColumnIsStillGone is the shape a
+// health flag derived from a single observation cannot hold.
+//
+// The loss is observable on ONE pass only if that pass destroys its own
+// evidence. Then the next pass sees nothing lost, and the first UNRELATED
+// repair — a column somewhere else on the board coming back — reads as "the
+// binding resolves again" and clears the flag. The binding then reads healthy
+// forever while every reflect onto the missing column still refuses, counted
+// and invisible.
+//
+// So the readout is re-derived from the binding's CURRENT shape on every pass:
+// a state the binding HAS an option for, that the board answers to under
+// neither that id nor the mapped name, is lost — for as long as that stays
+// true.
+func TestSyncProjectBoardStaysDegradedWhileTheColumnIsStillGone(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	// `blocked` is a column the board never carried — the ordinary
+	// partial-coverage shape, reported as missing_statuses and NOT a
+	// degradation. It is what comes back later, unrelated to the loss.
+	delete(binding.StatusOptions, native.StateBlocked)
+	binding.MissingStatuses = []string{"Blocked"}
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	var logs bytes.Buffer
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings,
+		Logger: iterlog.New(iterlog.LevelWarn, &logs)}
+
+	// Pass 1: the operator deletes the "In progress" column AND the board has
+	// no "Blocked" one yet.
+	gone := deletedColumn(t, "In progress")
+	bc := &fakeBoardClient{project: withoutColumn(t, gone, "Blocked"), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if stored, _ := bindings.GetByTenant(context.Background(), "team-a"); !stored.Degraded() {
+		t.Fatalf("pass 1 must degrade on the deleted column: %+v", stored)
+	}
+	logged := strings.Count(logs.String(), "no longer exists")
+
+	// Pass 2: the operator adds a "Blocked" column — an adoption that has
+	// nothing to do with the column that is still missing.
+	bc.project = gone
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !stored.Degraded() || !strings.Contains(stored.DegradedReason, "In progress") {
+		t.Fatalf("an unrelated repair cleared the degradation: %q — \"In progress\" is still gone", stored.DegradedReason)
+	}
+	if stored.StatusOptions[native.StateBlocked] == "" {
+		t.Errorf("the unrelated column must still be adopted: %v", stored.StatusOptions)
+	}
+	// Re-derived, not re-announced: the transition is logged once.
+	if got := strings.Count(logs.String(), "no longer exists"); got != logged {
+		t.Errorf("logged %d more times; a standing state is read off the binding, not re-warned every pass", got-logged)
+	}
+	// And the cards of the lost column are still refused, every pass.
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 3: %v", err)
+	}
+	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 {
+		t.Errorf("pass 3: ReflectNoColumn = %d writes = %+v — the reflect must keep refusing a column that is still gone",
+			res.ReflectNoColumn, bc.writes)
+	}
+}
+
+// TestSyncProjectBoardDoesNotDegradeOnPartialCoverage: a column the map names
+// and the board never carried is `missing_statuses` — a bind that was accepted
+// on purpose ("the covered half works"), not a board that broke under us.
+// Degrading it would make the readout fire on the ordinary case of a
+// three-column board bound with the five-column default map.
+func TestSyncProjectBoardDoesNotDegradeOnPartialCoverage(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateReady, "Planned", at)
+	project := deletedColumn(t, "Blocked")
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project) // bound against the board as it IS
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	bc := &fakeBoardClient{project: project, pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: binding, Bindings: bindings}); err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if stored.Degraded() {
+		t.Errorf("partial coverage is a reported bind, not a degradation: %q", stored.DegradedReason)
+	}
+	if len(stored.MissingStatuses) == 0 {
+		t.Errorf("...but it must still be REPORTED: %+v", stored.MissingStatuses)
 	}
 }
 

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -607,6 +607,47 @@ func TestSyncProjectBoardDegradesOnAColumnItAdoptedAfterTheBind(t *testing.T) {
 	}
 }
 
+// TestRepairBindingDoesNotClearADegradationItNeverRederived pins the guard on
+// the level-triggered readout's own failure mode.
+//
+// The clear arm now fires on ANY pass whose `Reason()` is empty — which is what
+// makes the readout a level rather than an edge. But a labels-only binding
+// re-derives nothing at all, and its zero repair's empty reason is
+// indistinguishable from "every column resolves". Nothing reaches here degraded
+// today; the point is that the switch must not be ABLE to clear a flag on the
+// absence of the evidence that would have kept it.
+func TestRepairBindingDoesNotClearADegradationItNeverRederived(t *testing.T) {
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, testProject())
+	binding.StatusFieldID = "" // labels-only: no status vocabulary to reconcile
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	const reason = `the Status field no longer carries "In progress" (in_progress)`
+	if err := bindings.MarkDegraded(context.Background(), "team-a", reason); err != nil {
+		t.Fatalf("seed degradation: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+
+	repairBinding(context.Background(), testProject(),
+		&ProjectImportOptions{Binding: &stored, Bindings: bindings})
+
+	after, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !after.Degraded() {
+		t.Errorf("a pass that re-derived nothing cleared the flag: %+v", after)
+	}
+	if stored.Degraded() != after.Degraded() {
+		t.Errorf("the in-memory binding disagrees with the store: %q vs %q",
+			stored.DegradedReason, after.DegradedReason)
+	}
+}
+
 // TestSyncProjectBoardNeverRewritesTheOptionItAlreadyCarries pins the guard
 // under the repair: the reflect must compare the OPTION ID it is about to
 // write against the one the item carries, not only the names.

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -365,10 +365,12 @@ func TestSyncProjectBoardStaysDegradedWhileTheColumnIsStillGone(t *testing.T) {
 	bindings := forge.NewMemoryBoardBindingStore()
 	binding := boundBinding(t, project)
 	// `blocked` is a column the board never carried — the ordinary
-	// partial-coverage shape, reported as missing_statuses and NOT a
-	// degradation. It is what comes back later, unrelated to the loss.
+	// partial-coverage shape the bind ACCEPTED, reported as missing_statuses
+	// and NOT a degradation. It is what comes back later, unrelated to the
+	// loss.
 	delete(binding.StatusOptions, native.StateBlocked)
 	binding.MissingStatuses = []string{"Blocked"}
+	binding.UnresolvedAtBind = []string{"Blocked"}
 	if err := bindings.Upsert(context.Background(), *binding); err != nil {
 		t.Fatalf("seed binding: %v", err)
 	}
@@ -418,6 +420,83 @@ func TestSyncProjectBoardStaysDegradedWhileTheColumnIsStillGone(t *testing.T) {
 	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 {
 		t.Errorf("pass 3: ReflectNoColumn = %d writes = %+v — the reflect must keep refusing a column that is still gone",
 			res.ReflectNoColumn, bc.writes)
+	}
+}
+
+// TestSyncProjectBoardKeepsADegradationWrittenByAnOlderRelease is the upgrade
+// case, and it is the reason the lost rule may not rest on the cached id.
+//
+// The release in production flags a lost column AND DELETES its cached option
+// id, persisting both. So a binding degraded by it carries: no id for that
+// state, the column absent from the board, the column listed in
+// `missing_statuses`, and a `degraded_reason`. A rule reading "the binding HAS
+// an id and the board answers to neither it nor the name" finds nothing lost
+// there — and a readout that clears when it finds nothing lost would clear a
+// degradation that is still entirely true, permanently, because the id never
+// comes back. The same two shapes meet during a ROLLING deploy: the old
+// replica drops the id, the new one reads a healthy binding.
+//
+// A health flag is never cleared by the absence of the evidence that would
+// have kept it.
+func TestSyncProjectBoardKeepsADegradationWrittenByAnOlderRelease(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	project := testProject()
+
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, project)
+	// Exactly what the older release leaves behind.
+	delete(binding.StatusOptions, native.StateInProgress)
+	binding.MissingStatuses = []string{"In progress"}
+	binding.UnresolvedAtBind = nil // the field did not exist in that release
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	// Upsert clears the readout (a re-bind is the remedy), so the degradation
+	// is stamped after it, as the older release's own pass did.
+	const oldReason = `the Status field no longer carries "In progress" (in_progress); re-create the column, or re-bind the board with a --status-map that matches it`
+	if err := bindings.MarkDegraded(context.Background(), "team-a", oldReason); err != nil {
+		t.Fatalf("seed degradation: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	opts := &ProjectImportOptions{Binding: &stored, Bindings: bindings}
+	bc := &fakeBoardClient{project: deletedColumn(t, "In progress"), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, project, "Planned"), at)),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	after, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !after.Degraded() || !strings.Contains(after.DegradedReason, "In progress") {
+		t.Fatalf("the column is still gone; the upgrade must not clear the degradation, got %q", after.DegradedReason)
+	}
+	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 {
+		t.Errorf("result = %+v writes = %+v — the card must still be refused", res, bc.writes)
+	}
+
+	// And it clears on the ONE thing that fixes it: the column coming back.
+	bc.project = recreatedColumn(t, "In progress", "PVTSSO_back")
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	back, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if back.Degraded() {
+		t.Errorf("the column is back; the binding must clear: %q", back.DegradedReason)
+	}
+	if back.StatusOptions[native.StateInProgress] != "PVTSSO_back" {
+		t.Errorf("stored option id = %q, want the re-resolved one", back.StatusOptions[native.StateInProgress])
 	}
 }
 

--- a/pkg/server/board_project_vocabulary_test.go
+++ b/pkg/server/board_project_vocabulary_test.go
@@ -536,6 +536,77 @@ func TestSyncProjectBoardDoesNotDegradeOnPartialCoverage(t *testing.T) {
 	}
 }
 
+// TestSyncProjectBoardDegradesOnAColumnItAdoptedAfterTheBind is the end-to-end
+// half of the bind-time exemption's DISCHARGE.
+//
+// A column the bind accepted as absent is exempt from the lost rule — while it
+// has never resolved. Adoption ends that: the column earned a real option id
+// and cards were written onto it, so its deletion is a break like any other. An
+// exemption keyed on the bind-time NAME alone never discharges, and the
+// operator would read a healthy binding while every card of that column is
+// refused — the exact failure the level-triggered readout exists to kill.
+func TestSyncProjectBoardDegradesOnAColumnItAdoptedAfterTheBind(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	// The card sits in `blocked` natively and the board agrees with what we
+	// last recorded, so the reflect is the only direction in play.
+	seedSynced(t, board, 613, native.StateBlocked, "Planned", at)
+
+	noBlocked := deletedColumn(t, "Blocked")
+	bindings := forge.NewMemoryBoardBindingStore()
+	binding := boundBinding(t, noBlocked) // bound against a board with no "Blocked"
+	if !slices.Contains(binding.UnresolvedAtBind, "Blocked") {
+		t.Fatalf("the bind must record what it accepted as absent: %v", binding.UnresolvedAtBind)
+	}
+	if err := bindings.Upsert(context.Background(), *binding); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	opts := &ProjectImportOptions{Binding: binding, Bindings: bindings}
+
+	// Pass 1: the accepted partial coverage, with no card in play. Nothing broke.
+	bc := &fakeBoardClient{project: noBlocked, pages: [][]forge.ProjectItem{{}}}
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if stored, _ := bindings.GetByTenant(context.Background(), "team-a"); stored.Degraded() {
+		t.Fatalf("a column the bind accepted as absent is not a degradation: %q", stored.DegradedReason)
+	}
+
+	// Pass 2: the operator creates it. Adopted — from here it HAS resolved.
+	bc.project = testProject()
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	stored, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if stored.StatusOptions[native.StateBlocked] == "" {
+		t.Fatalf("the adopted column must earn its option id: %v", stored.StatusOptions)
+	}
+
+	// Pass 3: and deletes it again, with a card that needs it.
+	bc.project = noBlocked
+	bc.pages = [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusOption("Planned", optionID(t, testProject(), "Planned"), at)),
+	}}
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("pass 3: %v", err)
+	}
+	after, err := bindings.GetByTenant(context.Background(), "team-a")
+	if err != nil {
+		t.Fatalf("read binding: %v", err)
+	}
+	if !after.Degraded() || !strings.Contains(after.DegradedReason, "Blocked") {
+		t.Fatalf("the adopted column is gone; the binding must say so, got %q", after.DegradedReason)
+	}
+	if res.ReflectNoColumn != 1 || len(bc.writes) != 0 {
+		t.Errorf("ReflectNoColumn = %d writes = %+v — the card must be refused, not written onto a dead id",
+			res.ReflectNoColumn, bc.writes)
+	}
+}
+
 // TestSyncProjectBoardNeverRewritesTheOptionItAlreadyCarries pins the guard
 // under the repair: the reflect must compare the OPTION ID it is about to
 // write against the one the item carries, not only the names.

--- a/pkg/server/board_projection_effect.go
+++ b/pkg/server/board_projection_effect.go
@@ -121,15 +121,43 @@ func (p *boardProjectionEffect) ReflectCard(ctx context.Context, ev trigger.Even
 	// The recorded status IS what the board says, under the precondition
 	// checked just above — which is exactly what the pass passes after
 	// establishing the same fact by reading the board.
+	//
+	// The repair is built with NO live observation (`nil`), because this path
+	// deliberately does not read the board — that is what makes it fast. It
+	// still gets the column knowledge the last reconciliation persisted on the
+	// binding, so a card whose state maps to a column the board no longer
+	// carries is refused here exactly as it is in the pass, instead of firing
+	// a dead option id at the forge and burning this row's retry budget. The
+	// pass remains the only thing that can DISCOVER a column coming or going.
 	var res ProjectImportResult
 	opts := &ProjectImportOptions{Binding: &binding, Now: p.Now, Logger: p.Logger}
-	switch reflectNativeState(ctx, bc, card, forge.ProjectItem{ID: sync.ItemID}, &sync, sync.Status, opts, &res) {
+	repair := newBindingRepair(&binding, nil)
+	switch reflectNativeState(ctx, bc, card, forge.ProjectItem{ID: sync.ItemID}, &sync, sync.Status, opts, &res, repair) {
 	case reflectFailed:
 		return fmt.Errorf("board projection: the forge refused the status write for card %s on board %s (see the logged reason)", cardID, binding.Ref())
 	case reflectWrote:
 		return p.recordReflected(cards, card, sync)
 	}
+	if res.ReflectNoColumn > 0 {
+		// The bound board has no column for this state — one the map named and
+		// the board never carried, or one a reconciliation found gone (the
+		// binding's `degraded_reason` says which, and how to repair it).
+		//
+		// The row RETIRES rather than retries: nothing about this card will
+		// make the column exist, so a retry budget spent here buys nothing.
+		// But a single-card effect that quietly does nothing is invisible —
+		// the pass folds this into a per-pass counter it logs anyway, and the
+		// fast path has no such line — so it says so once, here, per event.
+		p.warn("board projection: team=%s board=%s card=%s: the board carries no %s column for state %q; repair the board binding (see its degraded reason)",
+			tenantID, binding.Ref(), cardID, forge.ProjectStatusFieldName, card.State)
+	}
 	return nil // already there, unmapped state, or no column for it — all inert
+}
+
+func (p *boardProjectionEffect) warn(format string, args ...any) {
+	if p.Logger != nil {
+		p.Logger.Warn(format, args...)
+	}
 }
 
 // boardStillHoldsWhatWeRecorded is the precondition reflectNativeState rests

--- a/pkg/server/board_projection_effect_test.go
+++ b/pkg/server/board_projection_effect_test.go
@@ -1,13 +1,16 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/forge"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
@@ -277,6 +280,54 @@ func TestBoardProjection_ForgeRefusalIsAnError(t *testing.T) {
 	// write: that is what makes the retry (and the next pass) try again.
 	if rec := mustGet(t, board, id).External.Project.Status; rec != "Planned" {
 		t.Fatalf("recorded status = %q after a failed write, want it untouched at %q", rec, "Planned")
+	}
+}
+
+// TestBoardProjection_RefusesACardWhoseColumnIsGone: the fast path never reads
+// the board, so everything it knows about the board's columns it reads off the
+// binding — including the ones the last reconciliation found MISSING.
+//
+// That matters because a lost column KEEPS its cached option id (the evidence
+// the degradation is re-derived from), so `OptionForState` still answers one.
+// A fast path that consulted only the binding's option map would fire that
+// dead id at the forge on every move of every card in that column, get a 422,
+// and burn the outbox row's whole retry budget — for a column no retry can
+// bring back.
+func TestBoardProjection_RefusesACardWhoseColumnIsGone(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: deletedColumn(t, "In progress")}
+	p, binds := projectionEffectWorld(t, bc, board)
+	var logs bytes.Buffer
+	p.Logger = iterlog.New(iterlog.LevelWarn, &logs)
+	ctx := context.Background()
+
+	// The shape a reconciliation leaves behind when a bound column is deleted.
+	lost := testBinding()
+	lost.MissingStatuses = []string{"In progress"}
+	lost.UnresolvedAtBind = []string{} // the bind resolved it; the board lost it
+	if err := binds.Upsert(ctx, *lost); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+	if err := binds.MarkDegraded(ctx, "team-a", `the Status field no longer carries "In progress" (in_progress)`); err != nil {
+		t.Fatalf("mark degraded: %v", err)
+	}
+
+	if err := p.ReflectCard(ctx, movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard = %v, want nil — no retry can make a deleted column exist, so the row retires", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Fatalf("writes = %+v, want none — the cached id names a column the board no longer carries", bc.writes)
+	}
+	// The record stays as it was: nothing was pushed, so nothing may claim it.
+	if rec := mustGet(t, board, id).External.Project.Status; rec != "Planned" {
+		t.Errorf("recorded status = %q, want it untouched at %q", rec, "Planned")
+	}
+	// And it is not silent: the pass folds this into a per-pass counter it
+	// logs anyway, the fast path has no such line, so it says so once.
+	if got := strings.Count(logs.String(), "carries no Status column"); got != 1 {
+		t.Errorf("logged %d times, want exactly 1 — a single-card effect that quietly does nothing is invisible: %q", got, logs.String())
 	}
 }
 

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5432,6 +5432,7 @@ export interface components {
             /** Format: date-time */
             sync_lease_until?: string;
             tenant_id: string;
+            unresolved_at_bind?: string[];
             /** Format: date-time */
             updated_at: string;
         };


### PR DESCRIPTION
Closes #775 (Revi finding R6e8130 on #772).

## What was wrong
`ReconcileStatusOptions` reported a lost column only on the ONE pass that observed the loss — both append sites were guarded by `id != ""` and that same pass dropped the cached id — so from the next pass on `rep.Lost` was empty and any unrelated adoption cleared `degraded`: a lost column read healthy forever while every reflect onto it kept failing (`reflect_no_column`). Red first, at both levels: `an unrelated repair cleared the degradation: "" — "In progress" is still gone` (server) and `pass 2: Lost = [], want the still-missing column on EVERY pass` (forge).

## The fix
`degraded` is a LEVEL re-derived from the binding's current shape on every pass; only an empty lost set clears it. Two decisions carry it:
- **The dead option id is kept** — dropping it was the bug's mechanism (it destroyed the only evidence the column ever resolved). The pass's lost set, threaded to `reflectNativeState` through a `bindingRepair` value (which also carries the renames the item loop already needed), is what refuses the write; those cards keep counting `reflect_no_column`.
- **Lost = the binding HAS an id for the state and the board answers to neither that id nor the mapped name.** A column the binding never resolved is `missing_statuses` — the partial coverage `BindBoard` accepts on purpose — so a three-column board bound with the five-column default map does not read as degraded (this reads the issue's "unless the binding maps it" the way that keeps its own `review` example coherent, rather than its literal "id empty AND name absent", which would sweep every partial bind into `degraded`).

`Changed()` now means "the vocabulary was rewritten", not "something is wrong": a standing loss re-reports identically without rewriting the store, and `MarkDegraded` + the Warn fire only when the REASON changes (log-once asserted across three passes).

Tests: still-degraded after an unrelated adoption (log-once + still-refusing-writes), partial coverage does not degrade, re-created column clears; forge: re-derivable across three passes + `LostStates`, unresolved column not lost, unmapped state never lost, field-gone re-derivable. No store field changed (no twin/OpenAPI surface change; board-binding conformance re-run on memory + a live replica set anyway). ADR-097 §5 states the level-vs-edge rule and why the id is kept; `docs/github-board-sync.md` says the flag stands as long as the column is missing.

`task check` exit 0; `-race` on pkg/server + pkg/forge green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)