### PR TITLE
feat(bots): the plan-budget guard reads the run, and every coded refusal reaches the run as a typed fail

### DIFF
--- a/bots/branch-improve-loop/README.md
+++ b/bots/branch-improve-loop/README.md
@@ -214,13 +214,43 @@ and must never block the campaign — Anthropic alone always suffices) or
 — the deliberate-spend posture). Either way `plan_budget_gate` bounds the
 phase (native:695).
 
+## Plan-phase budget guard (`plan_budget_gate`)
+
+One deterministic `compute`, the sole choke point before `campaign`. It
+reads the run itself — `run.elapsed_seconds` / `run.cost_usd` against
+`run.max_duration_seconds` / `run.max_cost_usd`, the caps IN FORCE after
+any `--max-duration` / `--max-cost-usd` override, the recipe, the
+platform ceiling and any live raise_budget — and refuses when either
+crosses `plan_budget_ratio` (default 0.3) of its cap. `campaign` is
+therefore guaranteed at least `1 - plan_budget_ratio` of the budget
+whenever it starts. A cap of `0` is UNBOUNDED on that axis, so a run
+launched with no cost cap never refuses on cost.
+
+The refusal is the named `plan_exhausted` fail node: `failure_code =
+PLAN_BUDGET_EXHAUSTED` and an `error` naming what was used against what
+was allowed, both on the RUN — `iterion runs list`, the studio, the
+merge-gate notice and the alert sinks read them. It is **resumable**: the
+checkpoint anchors on `plan_budget_gate`, so
+
+```sh
+iterion resume --run-id <id> --file bots/branch-improve-loop/main.bot \
+  --max-duration 5h --max-cost-usd 150
+```
+
+re-evaluates the guard against the new caps and takes the `campaign` edge
+— the plan phase this run already paid for is not re-run. Lowering
+`plan_budget_ratio` on the resume works the same way. Nothing picks the
+refusal up by itself (not `--auto-resume`, not the cloud retry): a
+deliberate refusal only changes verdict when an operator changes an input.
+
 ## Precondition (`workspace_probe`)
 
 The run's entry is a deterministic tool node (~100ms, no LLM): a launch
 whose `workspace_dir` is absent or not a git repository, OR whose
 `base_ref` resolves nowhere or shares no history with HEAD (every
 diff-anchored instruction would then range over nothing), fails typed
-(`WORKSPACE_NOT_A_REPO` on the node's output and in the tool log) before
+(`WORKSPACE_NOT_A_REPO` — on the run's own `failure_code`/`error` through
+the `workspace_not_a_repo` fail node, and on the probe's output) before
 any LLM node spends. `base_ref` is resolved, never fetched: the bare
 name first, then `refs/remotes/origin/<base_ref>` — a cloud PR run's
 checkout carries only the default branch and the PR head as local

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -245,29 +245,17 @@ vars:
   ## +3870/-273 diff spent the planning chain (plan -> plan_review ->
   ## plan_revise) for 150 min / $8.59 and never reached `campaign` — the
   ## whole run's budget died on the enrichment before a single commit.
-  ## plan_budget_ratio caps the FRACTION of the run's own ceilings
-  ## (mirrored below) the planning chain may spend; plan_budget_gate
-  ## (after the chain) fails the run before campaign starts the moment
-  ## planning crosses its share, guaranteeing campaign at least
-  ## (1-ratio) of the budget. Overridable per run
+  ## plan_budget_ratio caps the FRACTION of the run's own ceilings the
+  ## planning chain may spend; plan_budget_gate (after the chain) fails
+  ## the run before campaign starts the moment planning crosses its
+  ## share, guaranteeing campaign at least (1-ratio) of the budget. The
+  ## ceilings are read from the `run` namespace (run.max_duration_seconds
+  ## / run.max_cost_usd), so they are the caps IN FORCE for this run --
+  ## after any --max-duration / --max-cost-usd override, the recipe, the
+  ## platform ceiling and any live raise_budget -- not a literal that
+  ## drifts from the budget: block. Overridable per run
   ## (--var plan_budget_ratio=0.5). See docs/bot-runs/branch-improve-loop.md.
   plan_budget_ratio: float = 0.3
-
-  ## Mirrors of the budget: block below, in units a compute/tool node can
-  ## read. NOT auto-derived: max_cost_usd is a compile-time typed numeric
-  ## literal (C046) and max_duration only takes an OS-env ${VAR:-default}
-  ## substitution (docs/dsl.md "Budget fields") -- neither reads a
-  ## workflow vars: value, and the expr `run` namespace exposes only
-  ## run.id (pkg/runtime/expr_eval.go) -- there is no DSL primitive today
-  ## for a node to read the run's own effective caps or elapsed
-  ## spend/duration. Keep these two vars numerically in sync with the
-  ## budget: block by hand; a CLI --max-cost-usd/--max-duration override
-  ## on this run will NOT reach them automatically (a follow-up: the expr
-  ## `run` namespace could grow run.max_cost_usd / run.elapsed_seconds /
-  ## run.spent_cost_usd) -- pass the matching --var alongside a budget
-  ## override to keep the guard's math honest.
-  budget_max_duration_minutes: int = 150
-  budget_max_cost_usd: float = 75
 
   ## Above this many added lines in the branch diff (git diff --shortstat
   ## insertions), the plan phase reads a git diff --stat footprint +
@@ -1017,14 +1005,11 @@ schema plan_review_topology_state:
   do_review: bool
 
 ## plan_scope_state is plan_scope_probe's contract: the diff footprint +
-## size classification (drives the large-diff adaptation in plan_system/
-## plan_review_system) and the wall-clock start of the planning chain
-## (plan_budget_gate's only way to measure elapsed time -- see the
-## plan_budget_ratio var comment).
+## size classification, which drives the large-diff adaptation in
+## plan_system/plan_review_system.
 schema plan_scope_state:
   diff_stat: string
   large: bool
-  started_epoch: int
 
 schema plan_input:
   diff_stat: string
@@ -1073,47 +1058,30 @@ schema plan_revised_output:
   plan: string
   review_responses: string
 
-## plan_cost_probe's contract: a nil-safe sum of the plan phase's own LLM
-## spend (a skipped/never-run node's _cost_usd is absent, not zero -- the
-## sum must not choke on that) plus a pass-through of the plan/critique/
-## responses text so plan_budget_gate -- the single choke point before
-## campaign -- receives everything it needs to either proceed or fail from
-## ONE input, regardless of which of the two upstream routes (skip_revise
-## vs plan_revise) produced it.
-schema plan_cost_probe_input:
-  plan: string
-  plan_critique: string
-  plan_responses: string
-  plan_provenance: string
-
-schema plan_cost_probe_state:
-  plan: string
-  plan_critique: string
-  plan_responses: string
-  plan_provenance: string
-  plan_cost_usd: float
-
-## plan_budget_gate's contract. exhausted is the deterministic verdict
-## (real wall-clock elapsed + the nil-safe cost sum vs. plan_budget_ratio
-## of the mirrored ceilings); reason is a human-readable comparison for the
-## run's own record (events.jsonl / iterion report) -- the DSL's `-> fail`
-## terminal has no mechanism to carry a custom RuntimeError code/message
-## (pkg/runtime/engine_exec.go hardcodes "workflow reached fail node" +
-## a fixed FailureFailNode code), so `code`/`reason` here are the typed,
-## greppable record of WHY, persisted on this node's own output even
-## though the run's top-level failure message stays generic.
+## plan_budget_gate's contract. It is the single choke point before
+## campaign, so it receives the plan/critique/responses text from
+## whichever of the three upstream routes produced it (review off,
+## skip_revise, plan_revise) and relays it onward -- the campaign reads
+## the same fields whether or not the guard let it through.
 schema plan_budget_gate_input:
   plan: string
   plan_critique: string
   plan_responses: string
   plan_provenance: string
-  plan_cost_usd: float
-  started_epoch: int
 
+## exhausted is the deterministic verdict; the four figures beside it are
+## the comparison it rests on, in the units the plan_exhausted fail node
+## reports to the operator. A share is `cap x plan_budget_ratio`, and a
+## cap of 0 means UNBOUNDED on that axis -- so its share is 0 and the
+## matching over_* stays false.
 schema plan_budget_gate_state:
   exhausted: bool
-  code: string
-  reason: string
+  over_duration: bool
+  over_cost: bool
+  elapsed_seconds: float
+  duration_share_seconds: float
+  spent_usd: float
+  cost_share_usd: float
   plan: string
   plan_critique: string
   plan_responses: string
@@ -1133,7 +1101,7 @@ schema plan_budget_gate_state:
 ## head) carries only the default branch and the head as local branches,
 ## so a PR targeting any other branch has its base ONLY as a
 ## remote-tracking ref. The verdict is the node's OUTPUT (ok/code/
-## reason, routed to `fail` by the workflow) and is echoed on stderr for
+## reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for
 ## the tool log; the process exits 0 on purpose — a non-zero exit would
 ## replace the typed verdict with the engine's generic tool failure.
 ## python3 for safe JSON (mirrors verify_run); read-only, ~100ms.
@@ -1183,16 +1151,14 @@ compute plan_topology:
     do_plan: "vars.plan_phase == 'on'"
 
 ## plan_scope_probe — DETERMINISTIC pre-flight for the plan phase: the diff
-## footprint (git diff --stat, capped) + a large-diff classification (drives
-## the adaptation in plan_system/plan_review_system) + the wall-clock start
-## of the chain (plan_budget_gate's only way to measure elapsed time --
-## see the plan_budget_ratio var comment: no DSL primitive exposes the
-## run's elapsed duration to a node). Pure git plumbing -- no language /
-## package-manager assumption, stack- and repo-agnostic. python3 for safe
-## JSON (mirrors verify_probe/verify_run); read-only, idempotent.
+## footprint (git diff --stat, capped) + a large-diff classification, which
+## drives the adaptation in plan_system/plan_review_system. Pure git
+## plumbing -- no language / package-manager assumption, stack- and
+## repo-agnostic. python3 for safe JSON (mirrors verify_probe/verify_run);
+## read-only, idempotent.
 tool plan_scope_probe:
   command: `WS={{vars.workspace_dir}} BASE={{vars.base_ref}} THRESH={{vars.plan_large_diff_lines}} python3 -c "
-import os, re, subprocess, time, json
+import os, re, subprocess, json
 ws = os.environ.get('WS', '.')
 base = os.environ.get('BASE', 'main')
 try:
@@ -1222,7 +1188,6 @@ diff_stat = (stat.stdout or '')[:8000]
 print(json.dumps({
     'diff_stat': diff_stat,
     'large': added >= threshold,
-    'started_epoch': int(time.time()),
 }))
 "`
   output: plan_scope_state
@@ -1317,72 +1282,66 @@ agent plan_revise:
   session: inherit_if_available
   readonly: true
 
-## plan_cost_probe — nil-safe sum of the plan phase's own LLM spend, and
-## the pass-through relay for plan/critique/responses. A node that never
-## ran this pass (plan_revise on the skip_revise route) is ABSENT from
-## outputs, not zero -- outputs.plan_revise._cost_usd resolves to nil and
-## a raw `nil + nil` in a tool's shell substitution leaves the literal
-## `{{...}}` text in the command (resolveTemplateWith skips nil refs for
-## shell contexts) instead of erroring loud. `if(x, x, 0)` is nil-safe by
-## construction (truthy(nil) == false), so this MUST run as compute (expr),
-## not a tool -- the single choke point that turns "maybe absent" into a
-## guaranteed float before plan_budget_gate's shell arithmetic ever sees it.
-compute plan_cost_probe:
-  description: "Nil-safe plan-phase cost sum + pass-through"
-  input: plan_cost_probe_input
-  output: plan_cost_probe_state
+## plan_budget_gate — the SOLE choke point before campaign (native:695).
+## ONE deterministic compute, no shell and no clock of its own: the run's
+## `run` namespace carries its consumption (elapsed_seconds, cost_usd) AND
+## the caps IN FORCE (max_duration_seconds, max_cost_usd -- after any
+## --max-duration/--max-cost-usd override, the recipe, the platform
+## ceiling and any live raise_budget), so the comparison cannot drift from
+## the budget: block the way a mirror var did. exhausted=true routes to
+## the typed `plan_exhausted` fail instead of letting campaign start on
+## whatever budget the plan phase left behind -- GUARANTEEING campaign at
+## least (1-ratio) of the run's budget whenever it does start.
+##
+## The gate is also the relay: it receives plan/critique/responses from
+## whichever of the three upstream routes produced them and hands the same
+## fields to campaign. Nothing but the plan phase has spent when it runs,
+## so run.cost_usd IS the phase's spend -- including anything a hand-written
+## per-node sum would have forgotten.
+compute plan_budget_gate:
+  description: "Plan-phase budget guard (the sole choke point before campaign)"
+  input: plan_budget_gate_input
+  output: plan_budget_gate_state
   expr:
+    ## A cap of 0 is UNBOUNDED on that axis, never "no allowance left":
+    ## each comparison is guarded on a positive cap, so an unbudgeted run
+    ## (or one capped on the other axis only) never refuses here.
+    over_duration: "run.max_duration_seconds > 0 && run.elapsed_seconds > run.max_duration_seconds * vars.plan_budget_ratio"
+    over_cost: "run.max_cost_usd > 0 && run.cost_usd > run.max_cost_usd * vars.plan_budget_ratio"
+    ## Repeated rather than referenced: a compute's fields are evaluated
+    ## against the node's input and the run, never against its own
+    ## siblings, so `over_duration || over_cost` would read nil.
+    exhausted: "(run.max_duration_seconds > 0 && run.elapsed_seconds > run.max_duration_seconds * vars.plan_budget_ratio) || (run.max_cost_usd > 0 && run.cost_usd > run.max_cost_usd * vars.plan_budget_ratio)"
+    elapsed_seconds: "run.elapsed_seconds"
+    duration_share_seconds: "run.max_duration_seconds * vars.plan_budget_ratio"
+    spent_usd: "run.cost_usd"
+    cost_share_usd: "run.max_cost_usd * vars.plan_budget_ratio"
     plan: "input.plan"
     plan_critique: "input.plan_critique"
     plan_responses: "input.plan_responses"
     plan_provenance: "input.plan_provenance"
-    plan_cost_usd: "if(outputs.plan._cost_usd, outputs.plan._cost_usd, 0) + if(outputs.plan_review._cost_usd, outputs.plan_review._cost_usd, 0) + if(outputs.plan_revise._cost_usd, outputs.plan_revise._cost_usd, 0)"
 
-## plan_budget_gate — the SOLE choke point before campaign (native:695).
-## Deterministic: real wall-clock elapsed (now - plan_scope_probe's
-## started_epoch) + plan_cost_probe's nil-safe cost sum, each compared
-## against plan_budget_ratio of the mirrored ceiling vars. exhausted=true
-## routes to a typed fail instead of letting campaign start on whatever
-## budget the plan phase left behind -- GUARANTEEING campaign at least
-## (1-ratio) of the run's budget whenever it does start. python3 for safe
-## JSON (mirrors verify_run/publish_verdict); read-only, idempotent.
-tool plan_budget_gate:
-  input: plan_budget_gate_input
-  command: `STARTED={{input.started_epoch}} COST={{input.plan_cost_usd}} RATIO={{vars.plan_budget_ratio}} MAXMIN={{vars.budget_max_duration_minutes}} MAXCOST={{vars.budget_max_cost_usd}} PLAN={{input.plan}} CRITIQUE={{input.plan_critique}} RESPONSES={{input.plan_responses}} PROVENANCE={{input.plan_provenance}} python3 -c "
-import os, time, json
-def as_float(name, default):
-    try:
-        return float(os.environ.get(name, str(default)) or default)
-    except ValueError:
-        return default
-started = int(as_float('STARTED', 0))
-now = int(time.time())
-elapsed_min = (now - started) / 60.0 if started > 0 else 0.0
-cost = as_float('COST', 0.0)
-ratio = as_float('RATIO', 0.3)
-max_minutes = as_float('MAXMIN', 150.0)
-max_cost = as_float('MAXCOST', 75.0)
-duration_share = ratio * max_minutes
-cost_share = ratio * max_cost
-over_duration = elapsed_min > duration_share
-over_cost = cost > cost_share
-bits = []
-if over_duration:
-    bits.append('planning spent %.1fmin, over its %.1fmin share (%.0f%% of the %.0fmin budget)' % (elapsed_min, duration_share, ratio * 100, max_minutes))
-if over_cost:
-    bits.append('planning spent USD %.2f, over its USD %.2f share (%.0f%% of the USD %.0f budget)' % (cost, cost_share, ratio * 100, max_cost))
-exhausted = bool(bits)
-print(json.dumps({
-    'exhausted': exhausted,
-    'code': 'PLAN_BUDGET_EXHAUSTED' if exhausted else '',
-    'reason': '; '.join(bits),
-    'plan': os.environ.get('PLAN', ''),
-    'plan_critique': os.environ.get('CRITIQUE', ''),
-    'plan_responses': os.environ.get('RESPONSES', ''),
-    'plan_provenance': os.environ.get('PROVENANCE', ''),
-}))
-"`
-  output: plan_budget_gate_state
+## plan_exhausted — the plan phase outgrew its share. resumable: true
+## because the cure is "widen the budget and carry on": a terminal failure
+## would make the operator re-pay a plan phase this run already completed,
+## which is the very cost the guard exists to avoid. The checkpoint
+## anchors on plan_budget_gate, so the resume re-evaluates the guard
+## against the caps then in force and takes the campaign edge.
+fail plan_exhausted:
+  description: "the plan phase outgrew its share of the run's budget"
+  code: PLAN_BUDGET_EXHAUSTED
+  message: "the plan phase used {{outputs.plan_budget_gate.elapsed_seconds}}s of its {{outputs.plan_budget_gate.duration_share_seconds}}s share and USD {{outputs.plan_budget_gate.spent_usd}} of its USD {{outputs.plan_budget_gate.cost_share_usd}} share (plan_budget_ratio {{vars.plan_budget_ratio}} of the caps in force); campaign never started, so nothing is committed. Raise the caps and resume (iterion resume --run-id <id> --file <bot> --max-duration 5h --max-cost-usd 150), or lower plan_budget_ratio — the guard is re-evaluated, not replayed."
+  resumable: true
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository, name a reachable base_ref) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## campaign — the one adaptive agent. claude_code with the full native
 ## toolset (read/edit/shell/git) so it works exactly like a native Claude
@@ -1956,7 +1915,7 @@ workflow branch_improve_loop:
   ## Precondition: nothing LLM runs on a workspace with no repository
   ## (or with an unreachable base_ref).
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan_scope_probe when do_plan
@@ -1984,7 +1943,7 @@ workflow branch_improve_loop:
     diff_stat:   "{{outputs.plan_scope_probe.diff_stat}}",
     large:       "{{outputs.plan_scope_probe.large}}"
   }
-  plan_review_topology -> plan_cost_probe when not do_review with {
+  plan_review_topology -> plan_budget_gate when not do_review with {
     plan: "{{outputs.plan.plan}}",
     plan_critique: "", plan_responses: "",
     plan_provenance: "authored by the plan node - NOT peer-reviewed (plan_review resolved off: one model family credentialed, or the operator said off); the author-written triage, unchallenged"
@@ -2004,35 +1963,26 @@ workflow branch_improve_loop:
     _session_id: "{{outputs.plan._session_id}}",
     _session_fingerprint: "{{outputs.plan._session_fingerprint}}"
   }
-  plan_gate -> plan_cost_probe when skip_revise with {
+  plan_gate -> plan_budget_gate when skip_revise with {
     plan: "{{outputs.plan.plan}}",
     plan_critique: "{{outputs.plan_review.concerns}}",
     plan_responses: "",
     plan_provenance: "{{outputs.plan_gate.provenance}}"
   }
-  plan_revise -> plan_cost_probe with {
+  plan_revise -> plan_budget_gate with {
     plan:            "{{outputs.plan_revise.plan}}",
     plan_critique:   "{{outputs.plan_review.concerns}}",
     plan_responses:  "{{outputs.plan_revise.review_responses}}",
     plan_provenance: "authored by the plan node, critiqued by a cross-model peer, and revised by the author (its accepted/rejected responses follow)"
   }
 
-  ## plan_cost_probe is a nil-safe relay (see its own comment): it always
-  ## produces a real float even when plan_revise never ran this pass.
-  plan_cost_probe -> plan_budget_gate with {
-    plan:            "{{outputs.plan_cost_probe.plan}}",
-    plan_critique:   "{{outputs.plan_cost_probe.plan_critique}}",
-    plan_responses:  "{{outputs.plan_cost_probe.plan_responses}}",
-    plan_provenance: "{{outputs.plan_cost_probe.plan_provenance}}",
-    plan_cost_usd:   "{{outputs.plan_cost_probe.plan_cost_usd}}",
-    started_epoch:   "{{outputs.plan_scope_probe.started_epoch}}"
-  }
   ## Within its share → the campaign starts, carrying the (possibly
   ## unrevised) plan forward exactly as the pre-guard edges did. Over its
-  ## share → a typed, early failure instead of spending campaign's reserve
-  ## (native:695) — see plan_budget_gate_state's schema comment for why
-  ## the run's OWN failure message stays the engine's generic one while
-  ## this node's output carries the typed code + reason.
+  ## share → `plan_exhausted`, which stamps PLAN_BUDGET_EXHAUSTED and the
+  ## comparison on the RUN (failure_code / error, so `iterion runs list`,
+  ## the studio and the alert sinks read it) instead of spending
+  ## campaign's reserve (native:695). The refusal is resumable: widen the
+  ## caps, resume, and this guard is re-evaluated.
   plan_budget_gate -> campaign when not exhausted with {
     fail_log:        "",
     plan:            "{{outputs.plan_budget_gate.plan}}",
@@ -2040,7 +1990,7 @@ workflow branch_improve_loop:
     plan_responses:  "{{outputs.plan_budget_gate.plan_responses}}",
     plan_provenance: "{{outputs.plan_budget_gate.plan_provenance}}"
   }
-  plan_budget_gate -> fail when exhausted
+  plan_budget_gate -> plan_exhausted when exhausted
 
   ## Each pass: the campaign reviews+improves the branch diff (committing each
   ## fix in stride), then the deterministic build/test gate re-checks the tree.

--- a/bots/branch-improve-loop/manifest.yaml
+++ b/bots/branch-improve-loop/manifest.yaml
@@ -1,7 +1,22 @@
 name: branch-improve-loop
 display_name: Billy
 icon: 🌿
-version: 1.4.0
+version: 1.5.0
+## 1.5.0 — the plan-phase budget guard reads the run itself. ONE `compute`
+## (`plan_budget_gate`) compares `run.elapsed_seconds` / `run.cost_usd`
+## against `run.max_duration_seconds` / `run.max_cost_usd` — the caps IN
+## FORCE, after any `--max-duration` / `--max-cost-usd` override, the
+## recipe, the platform ceiling and any live raise_budget. Gone with it:
+## the two mirror vars (`budget_max_duration_minutes` /
+## `budget_max_cost_usd`, which drifted from the `budget:` block in
+## silence), `plan_scope_probe`'s self-measured `started_epoch`, and the
+## `plan_cost_probe` relay whose nil-safe per-node cost sum the run's own
+## figure supersedes. Both refusals are now NAMED fail nodes, so the code
+## reaches the RUN (`failure_code` / `error`) instead of only the node
+## output: `plan_exhausted` (PLAN_BUDGET_EXHAUSTED, **resumable** — widen
+## the caps and resume, and the guard is re-evaluated rather than the plan
+## phase re-paid) and `workspace_not_a_repo` (WORKSPACE_NOT_A_REPO,
+## terminal — a launch to fix, not a budget).
 ## 1.4.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off); the new `plan_phase` (on|off) is

--- a/bots/e2e-coverage/README.md
+++ b/bots/e2e-coverage/README.md
@@ -40,7 +40,7 @@ skipped.
 ## Shape (v2 — one agent, minimal framing)
 
 ```
-workspace_probe → fail            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
+workspace_probe → workspace_not_a_repo            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
 workspace_probe → plan_topology   when ok
 plan_topology → plan → plan_review_topology → (plan_review → plan_gate → plan_revise)
 campaign → verify_build → verify_run → gate
@@ -52,7 +52,8 @@ gate → done            (loop exhausted — ship what is banked)
 
 - `workspace_probe` — deterministic entry precondition (~100ms, no LLM):
   a launch whose `workspace_dir` is absent or not a git repository fails
-  typed (`WORKSPACE_NOT_A_REPO`) before any LLM node spends.
+  typed (`WORKSPACE_NOT_A_REPO` on the run's own `failure_code`, through
+  the `workspace_not_a_repo` fail node) before any LLM node spends.
 - plan phase (ADR-091) — the plan is AUTHORED by default (`plan_phase:
   off` opts out); `plan_review: auto` gates ONLY the cross-model peer
   review (on iff a second model family is credentialed at launch),

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -701,8 +701,7 @@ schema plan_revised_output:
 ## plan node would otherwise author a plan against nothing). Refuses
 ## with the typed code WORKSPACE_NOT_A_REPO when workspace_dir is absent
 ## or is not a git repository (`git rev-parse --git-dir` fails). The
-## verdict is the node's OUTPUT (ok/code/reason, routed to `fail` by the
-## workflow) and is echoed on stderr for the tool log; the process exits
+## verdict is the node's OUTPUT (ok/code/reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for the tool log; the process exits
 ## 0 on purpose — a non-zero exit would replace the typed verdict with
 ## the engine's generic tool failure. python3 for safe JSON (mirrors
 ## verify_run); read-only, ~100ms.
@@ -723,6 +722,16 @@ if p.returncode != 0:
 print(json.dumps({'ok': True, 'code': '', 'reason': 'git repository at ' + ws}))
 "`
   output: workspace_probe_state
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## plan_topology lifts the plan_phase switch into a bool so the entry
 ## edges use the C012-exhaustive simple form. No LLM. This gate is the
@@ -1285,7 +1294,7 @@ workflow e2e_coverage:
 
   ## Precondition: nothing LLM runs on a workspace with no repository.
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan when do_plan

--- a/bots/e2e-coverage/manifest.yaml
+++ b/bots/e2e-coverage/manifest.yaml
@@ -1,7 +1,12 @@
 name: e2e-coverage
 display_name: Endy
 icon: 🕸️
-version: 0.3.0
+version: 0.4.0
+## 0.4.0 — the entry precondition's refusal is a NAMED fail node
+## (`workspace_not_a_repo`, code WORKSPACE_NOT_A_REPO, terminal), so the
+## code reaches the RUN's own `failure_code` / `error` — read by `iterion
+## runs list`, the studio and the alert sinks — instead of sitting on the
+## probe's output under the generic FAIL_NODE.
 ## 0.3.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off); the new `plan_phase` (on|off) is

--- a/bots/feature-dev/README.md
+++ b/bots/feature-dev/README.md
@@ -26,7 +26,7 @@ on GitLab — the issue-label → PR lineage).
 ## Shape (v2 — one agent, minimal framing)
 
 ```
-workspace_probe → fail                    when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
+workspace_probe → workspace_not_a_repo                    when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
 workspace_probe → plan_topology           when ok
 plan_topology → plan → plan_review_topology ─┬─ plan_review → plan_gate → plan_revise ┐ (peer only when
 plan_topology ──────────────── (plan_phase off) ┴──── (plan_review off: unreviewed) ──┤  plan_review
@@ -45,8 +45,9 @@ mr_gate → done         when not open_mr
 
 **Precondition.** `workspace_probe` (a tool node, ~100ms, no LLM) is the
 entry: a launch whose `workspace_dir` is absent or not a git repository
-fails typed (`WORKSPACE_NOT_A_REPO` on the node's output and in the tool
-log) before any LLM node spends — a `--bot` launch carrying only `pr_url`
+fails typed (`WORKSPACE_NOT_A_REPO` — on the run's own
+`failure_code`/`error` through the `workspace_not_a_repo` fail node, and on
+the probe's output) before any LLM node spends — a `--bot` launch carrying only `pr_url`
 attaches no repository.
 
 **Plan phase (ADR-091).** The plan is AUTHORED by default on every

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -823,8 +823,7 @@ schema plan_revised_output:
 ## plan node would otherwise author a plan against nothing). Refuses
 ## with the typed code WORKSPACE_NOT_A_REPO when workspace_dir is absent
 ## or is not a git repository (`git rev-parse --git-dir` fails). The
-## verdict is the node's OUTPUT (ok/code/reason, routed to `fail` by the
-## workflow) and is echoed on stderr for the tool log; the process exits
+## verdict is the node's OUTPUT (ok/code/reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for the tool log; the process exits
 ## 0 on purpose — a non-zero exit would replace the typed verdict with
 ## the engine's generic tool failure. python3 for safe JSON (mirrors
 ## verify_run); read-only, ~100ms.
@@ -845,6 +844,16 @@ if p.returncode != 0:
 print(json.dumps({'ok': True, 'code': '', 'reason': 'git repository at ' + ws}))
 "`
   output: workspace_probe_state
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## plan_topology lifts the plan_phase switch into a bool so the entry
 ## edges use the C012-exhaustive simple form. No LLM. This gate is the
@@ -1256,7 +1265,7 @@ workflow feature_dev:
 
   ## Precondition: nothing LLM runs on a workspace with no repository.
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan when do_plan

--- a/bots/feature-dev/manifest.yaml
+++ b/bots/feature-dev/manifest.yaml
@@ -1,7 +1,12 @@
 name: feature-dev
 display_name: Featurly
 icon: 🛠️
-version: 2.4.0
+version: 2.5.0
+## 2.5.0 — the entry precondition's refusal is a NAMED fail node
+## (`workspace_not_a_repo`, code WORKSPACE_NOT_A_REPO, terminal), so the
+## code reaches the RUN's own `failure_code` / `error` — read by `iterion
+## runs list`, the studio and the alert sinks — instead of sitting on the
+## probe's output under the generic FAIL_NODE.
 ## 2.4.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off — every single-provider host used to

--- a/bots/feature-gap-fill/README.md
+++ b/bots/feature-gap-fill/README.md
@@ -37,7 +37,7 @@ A gap spec typically lists:
 ## Shape (v2 — one agent, minimal framing)
 
 ```
-workspace_probe → fail            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
+workspace_probe → workspace_not_a_repo            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
 workspace_probe → plan_topology   when ok
 plan_topology → plan → plan_review_topology → (plan_review → plan_gate → plan_revise)
 campaign → verify_build → verify_run → gate
@@ -48,7 +48,8 @@ gate → done            (loop exhausted — ship what is banked)
 
 - `workspace_probe` — deterministic entry precondition (~100ms, no LLM):
   a launch whose `workspace_dir` is absent or not a git repository fails
-  typed (`WORKSPACE_NOT_A_REPO`) before any LLM node spends.
+  typed (`WORKSPACE_NOT_A_REPO` on the run's own `failure_code`, through
+  the `workspace_not_a_repo` fail node) before any LLM node spends.
 - plan phase (ADR-091) — the plan is AUTHORED by default (`plan_phase:
   off` opts out); `plan_review: auto` gates ONLY the cross-model peer
   review (on iff a second model family is credentialed at launch),

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -644,8 +644,7 @@ schema plan_revised_output:
 ## plan node would otherwise author a plan against nothing). Refuses
 ## with the typed code WORKSPACE_NOT_A_REPO when workspace_dir is absent
 ## or is not a git repository (`git rev-parse --git-dir` fails). The
-## verdict is the node's OUTPUT (ok/code/reason, routed to `fail` by the
-## workflow) and is echoed on stderr for the tool log; the process exits
+## verdict is the node's OUTPUT (ok/code/reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for the tool log; the process exits
 ## 0 on purpose — a non-zero exit would replace the typed verdict with
 ## the engine's generic tool failure. python3 for safe JSON (mirrors
 ## verify_run); read-only, ~100ms.
@@ -666,6 +665,16 @@ if p.returncode != 0:
 print(json.dumps({'ok': True, 'code': '', 'reason': 'git repository at ' + ws}))
 "`
   output: workspace_probe_state
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## plan_topology lifts the plan_phase switch into a bool so the entry
 ## edges use the C012-exhaustive simple form. No LLM. This gate is the
@@ -939,7 +948,7 @@ workflow feature_gap_fill:
 
   ## Precondition: nothing LLM runs on a workspace with no repository.
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan when do_plan

--- a/bots/feature-gap-fill/manifest.yaml
+++ b/bots/feature-gap-fill/manifest.yaml
@@ -1,7 +1,12 @@
 name: feature-gap-fill
 display_name: Fini
 icon: 🧩
-version: 2.2.0
+version: 2.3.0
+## 2.3.0 — the entry precondition's refusal is a NAMED fail node
+## (`workspace_not_a_repo`, code WORKSPACE_NOT_A_REPO, terminal), so the
+## code reaches the RUN's own `failure_code` / `error` — read by `iterion
+## runs list`, the studio and the alert sinks — instead of sitting on the
+## probe's output under the generic FAIL_NODE.
 ## 2.2.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off); the new `plan_phase` (on|off) is

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -287,7 +287,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `budget_max_cost_usd` (float), `budget_max_duration_minutes` (int), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `campaign` — Campy

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -574,6 +574,16 @@ compute work_gate:
     lot_status: "outputs.plan_read.lot_status"
     refused: "outputs.plan_read.refused"
 
+## lot_not_actionable — an EXPLICIT only_lot request naming a lot the
+## reader resolved as done / blocked / absent (native:670). Terminal by
+## design: the answer only changes when the contract does, so a resume
+## would re-read the same lot and refuse identically.
+fail lot_not_actionable:
+  description: "only_lot named a lot that cannot be actioned"
+  code: LOT_NOT_ACTIONABLE
+  message: "lot '{{vars.only_lot}}' is {{outputs.work_gate.lot_status}} — {{outputs.work_gate.notice}}"
+  resumable: false
+
 agent upgrade_campaign:
   backend: "claude_code"
   model: "${ITERION_MODERNIZE_MODEL_CLAUDE:-claude-opus-5}"
@@ -1119,6 +1129,26 @@ compute lot_gate:
     ## decides the verdict.
     needs_extend: "vars.extend && length(outputs.lot_verify.extension_pending) > 0"
 
+## gate_timeout — a gate command outlived the contract's `gate_timeout_s`.
+## The verdict is in the tree; ending on the bare `fail` reported the same
+## FAIL_NODE as a forged `done`, and the wall is what the operator must
+## act on. Terminal: a resume would replay the same hour against the same
+## wall — raise gate_timeout_s or shorten the gate, then relaunch.
+fail gate_timeout:
+  description: "a gate command outlived the contract's gate_timeout_s"
+  code: GATE_TIMEOUT
+  message: "{{outputs.lot_verify.block_reason}}"
+  resumable: false
+
+## contract_unreadable — the verifier could not READ the contract. Never a
+## verdict over the lot (every conjunct stays false), so it must not read
+## as one on the run either. Terminal: the contract has to be fixed.
+fail contract_unreadable:
+  description: "the verifier could not read the programme contract"
+  code: CONTRACT_UNREADABLE
+  message: "{{outputs.lot_gate.fail_log}}"
+  resumable: false
+
 ## reanchor — the net's OWN bot, run as a subbot, to repair a mutant this lot
 ## invalidated.
 ##
@@ -1408,9 +1438,12 @@ workflow modernize:
   ## absent lot fails loud instead of falling into the done/campaign pair
   ## below, which is exhaustive only over the unfiltered "pick next" scan.
   ## An unreadable or uneditable contract is a verdict, not a tool error:
-  ## the run fails here, typed, before any token is spent.
+  ## the run fails here, before any token is spent — on the bare `fail`,
+  ## because one bool carries two codes (CONTRACT_UNREADABLE and
+  ## LOT_UNEDITABLE) and a named fail may only stamp one; plan_read's
+  ## notice names which.
   work_gate -> fail when refused
-  work_gate -> fail when lot_not_actionable
+  work_gate -> lot_not_actionable when lot_not_actionable
 
   ## Exhaustive pair on one bool (C012): an already-finished programme is a
   ## clean no-op, not an error — running a done programme must cost nothing and
@@ -1445,8 +1478,8 @@ workflow modernize:
   ## engine takes the first `when` that holds, and a timed-out verdict may
   ## also carry an invalidated mutant or a pending extension — routed to a
   ## subbot, it would replay the same gate before failing.
-  lot_gate -> fail when timed_out
-  lot_gate -> fail when unreadable
+  lot_gate -> gate_timeout when timed_out
+  lot_gate -> contract_unreadable when unreadable
 
   ## Repair the net BEFORE deciding the lot, and on every outcome — a converged
   ## lot is exactly the case where a lost mutant would never be noticed. Bounded

--- a/bots/modernize/manifest.yaml
+++ b/bots/modernize/manifest.yaml
@@ -1,7 +1,16 @@
 name: modernize
 display_name: Morphy
 icon: 🧱
-version: 0.3.0
+version: 0.4.0
+## 0.4.0 — the three coded refusals are NAMED fail nodes, so their code
+## reaches the RUN's own `failure_code` / `error` instead of a prefix on a
+## node output nobody reads without opening the artifacts:
+## `lot_not_actionable` (LOT_NOT_ACTIONABLE — an only_lot request naming a
+## done/blocked/absent lot), `gate_timeout` (GATE_TIMEOUT) and
+## `contract_unreadable` (CONTRACT_UNREADABLE). All terminal: each answer
+## only changes when the contract does. `work_gate -> fail when refused`
+## stays bare — that one bool carries two codes (CONTRACT_UNREADABLE,
+## LOT_UNEDITABLE) and a fail node stamps one.
 ## 0.3.0 — `done` is the gate's word: a new mark_done node writes it after the
 ## lot converged, a worker-written `done` or a rewritten contract is refused
 ## before the gate runs, and a refusal that outlives the repair loop fails the

--- a/bots/plan_phase_split_test.go
+++ b/bots/plan_phase_split_test.go
@@ -186,7 +186,9 @@ var repoRequiringCampaignBots = []string{
 // node (no LLM, no budget) refusing with the typed code WORKSPACE_NOT_A_REPO
 // when workspace_dir is absent / not a git repository — and, for a bot whose
 // mission is anchored on a base ref, when that base is not reachable from
-// HEAD. The verdict lands on the node's output and routes to `fail`.
+// HEAD. The verdict lands on the node's output and routes to the named
+// `workspace_not_a_repo` fail node, which stamps the code on the RUN
+// (bots/typed_fail_test.go owns that half).
 func TestCampaignWorkspacePrecondition(t *testing.T) {
 	for _, bot := range repoRequiringCampaignBots {
 		t.Run(bot, func(t *testing.T) {
@@ -218,7 +220,7 @@ func TestCampaignWorkspacePrecondition(t *testing.T) {
 				switch {
 				case e.To == "plan_topology" && e.Condition == "ok" && !e.Negated:
 					toGate = true
-				case e.To == "fail" && e.Condition == "ok" && e.Negated:
+				case e.To == "workspace_not_a_repo" && e.Condition == "ok" && e.Negated:
 					toFail = true
 				default:
 					t.Errorf("%s: unexpected edge workspace_probe -> %s (when %q negated=%v)", bot, e.To, e.Condition, e.Negated)
@@ -228,7 +230,7 @@ func TestCampaignWorkspacePrecondition(t *testing.T) {
 				t.Errorf("%s: no edge workspace_probe -> plan_topology when ok", bot)
 			}
 			if !toFail {
-				t.Errorf("%s: no edge workspace_probe -> fail when not ok — a refused workspace would not fail the run", bot)
+				t.Errorf("%s: no edge workspace_probe -> workspace_not_a_repo when not ok — a refused workspace would not fail the run", bot)
 			}
 			out, ok := wf.Schemas["workspace_probe_state"]
 			if !ok {

--- a/bots/test-coverage/README.md
+++ b/bots/test-coverage/README.md
@@ -37,7 +37,7 @@ Testy chooses the types that fit the code and the repo's conventions.
 ## Shape (v2 — one agent, minimal framing)
 
 ```
-workspace_probe → fail            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
+workspace_probe → workspace_not_a_repo            when not ok (WORKSPACE_NOT_A_REPO, no LLM spent)
 workspace_probe → plan_topology   when ok
 plan_topology → plan → plan_review_topology → (plan_review → plan_gate → plan_revise)
 campaign → verify_build → verify_run → gate
@@ -48,7 +48,8 @@ gate → done            (loop exhausted — ship what is banked)
 
 - `workspace_probe` — deterministic entry precondition (~100ms, no LLM):
   a launch whose `workspace_dir` is absent or not a git repository fails
-  typed (`WORKSPACE_NOT_A_REPO`) before any LLM node spends.
+  typed (`WORKSPACE_NOT_A_REPO` on the run's own `failure_code`, through
+  the `workspace_not_a_repo` fail node) before any LLM node spends.
 - plan phase (ADR-091) — the plan is AUTHORED by default (`plan_phase:
   off` opts out); `plan_review: auto` gates ONLY the cross-model peer
   review (on iff a second model family is credentialed at launch),

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -647,8 +647,7 @@ schema plan_revised_output:
 ## plan node would otherwise author a plan against nothing). Refuses
 ## with the typed code WORKSPACE_NOT_A_REPO when workspace_dir is absent
 ## or is not a git repository (`git rev-parse --git-dir` fails). The
-## verdict is the node's OUTPUT (ok/code/reason, routed to `fail` by the
-## workflow) and is echoed on stderr for the tool log; the process exits
+## verdict is the node's OUTPUT (ok/code/reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for the tool log; the process exits
 ## 0 on purpose — a non-zero exit would replace the typed verdict with
 ## the engine's generic tool failure. python3 for safe JSON (mirrors
 ## verify_run); read-only, ~100ms.
@@ -669,6 +668,16 @@ if p.returncode != 0:
 print(json.dumps({'ok': True, 'code': '', 'reason': 'git repository at ' + ws}))
 "`
   output: workspace_probe_state
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## plan_topology lifts the plan_phase switch into a bool so the entry
 ## edges use the C012-exhaustive simple form. No LLM. This gate is the
@@ -982,7 +991,7 @@ workflow test_coverage:
 
   ## Precondition: nothing LLM runs on a workspace with no repository.
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan when do_plan

--- a/bots/test-coverage/manifest.yaml
+++ b/bots/test-coverage/manifest.yaml
@@ -1,7 +1,12 @@
 name: test-coverage
 display_name: Testy
 icon: 🧪
-version: 2.2.0
+version: 2.3.0
+## 2.3.0 — the entry precondition's refusal is a NAMED fail node
+## (`workspace_not_a_repo`, code WORKSPACE_NOT_A_REPO, terminal), so the
+## code reaches the RUN's own `failure_code` / `error` — read by `iterion
+## runs list`, the studio and the alert sinks — instead of sitting on the
+## probe's output under the generic FAIL_NODE.
 ## 2.2.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off); the new `plan_phase` (on|off) is

--- a/bots/typed_fail_test.go
+++ b/bots/typed_fail_test.go
@@ -1,0 +1,233 @@
+package bots
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// A bot-declared refusal is a VERDICT the operator has to act on, and the
+// only place a machine reads it is the run's own `failure_code` / `error`
+// (`iterion runs list`, the studio, the merge-gate notice, the alert
+// sinks). Routing such a refusal to the bare `fail` target files it under
+// FAIL_NODE / "workflow reached fail node" — the same wording every other
+// refusal in the fleet produces — and leaves the code on a node output only
+// an artifact reader ever sees.
+//
+// Each entry below is one shipped refusal that carries a code: the edge
+// that takes it, the named `fail` node it must land on, and whether
+// continuing is the cure.
+type codedRefusal struct {
+	bot string
+	// from/condition identify the guard edge; negated matches `when not X`.
+	from      string
+	condition string
+	negated   bool
+	// failNode is the named fail node the edge must target, and code the
+	// value it stamps on the run.
+	failNode  string
+	code      string
+	resumable bool
+	// messageRefs are references the rendered `message:` must carry, so
+	// the operator reads the figure that caused the refusal rather than a
+	// restatement of the code.
+	messageRefs []string
+}
+
+// workspaceProbeRefusals is the same refusal on every campaign bot whose
+// mission needs an existing checkout: the deterministic entry probe found
+// no repository (or an unreachable base). Non-resumable — nothing about
+// the run changes by resuming it; the operator fixes the launch.
+func workspaceProbeRefusals() []codedRefusal {
+	var out []codedRefusal
+	for _, bot := range repoRequiringCampaignBots {
+		out = append(out, codedRefusal{
+			bot: bot, from: "workspace_probe", condition: "ok", negated: true,
+			failNode: "workspace_not_a_repo", code: "WORKSPACE_NOT_A_REPO",
+			messageRefs: []string{"{{outputs.workspace_probe.reason}}"},
+		})
+	}
+	return out
+}
+
+func codedRefusals() []codedRefusal {
+	out := workspaceProbeRefusals()
+	return append(out,
+		// The plan phase outgrew its share of the run's budget. The cure
+		// is "raise the caps and carry on": a terminal failure would make
+		// the operator re-pay a plan phase the run already completed,
+		// which is the exact cost this guard exists to avoid.
+		codedRefusal{
+			bot: "branch-improve-loop", from: "plan_budget_gate", condition: "exhausted",
+			failNode: "plan_exhausted", code: "PLAN_BUDGET_EXHAUSTED", resumable: true,
+			messageRefs: []string{
+				"{{outputs.plan_budget_gate.spent_usd}}",
+				"{{outputs.plan_budget_gate.cost_share_usd}}",
+				"{{outputs.plan_budget_gate.elapsed_seconds}}",
+				"{{outputs.plan_budget_gate.duration_share_seconds}}",
+			},
+		},
+		// An explicit only_lot request naming a done / blocked / absent
+		// lot. Terminal: the contract has to change before the answer can.
+		codedRefusal{
+			bot: "modernize", from: "work_gate", condition: "lot_not_actionable",
+			failNode: "lot_not_actionable", code: "LOT_NOT_ACTIONABLE",
+			messageRefs: []string{"{{outputs.work_gate.lot_status}}"},
+		},
+		// A gate command that outlived the contract's wall, and a contract
+		// the verifier could not read. Both were already typed in prose
+		// (`block_reason` / `log_tail` carry the code as a prefix); the run
+		// itself said FAIL_NODE.
+		codedRefusal{
+			bot: "modernize", from: "lot_gate", condition: "timed_out",
+			failNode: "gate_timeout", code: "GATE_TIMEOUT",
+			messageRefs: []string{"{{outputs.lot_verify.block_reason}}"},
+		},
+		codedRefusal{
+			bot: "modernize", from: "lot_gate", condition: "unreadable",
+			failNode: "contract_unreadable", code: "CONTRACT_UNREADABLE",
+			messageRefs: []string{"{{outputs.lot_gate.fail_log}}"},
+		},
+	)
+}
+
+// TestUncodedFailEdgesStayBare is the other half of the sweep: an edge
+// whose refusal carries NO single code of its own keeps the bare `fail`
+// target, and this test says why for each — so the next reader does not
+// have to re-derive it, and a future code makes the entry stale rather
+// than silently absent.
+func TestUncodedFailEdgesStayBare(t *testing.T) {
+	bare := []struct {
+		bot, from, condition, why string
+	}{
+		{"modernize", "work_gate", "refused",
+			"one bool carries TWO codes — plan_read's refuse() emits CONTRACT_UNREADABLE or LOT_UNEDITABLE — and a fail node stamps one; splitting the bool is a contract change, not an adoption"},
+		{"modernize", "lot_gate", "refused",
+			"the campaign forged a `done` or rewrote the contract: a refusal to JUDGE with no code of its own on either the node output or the tool log"},
+		{"modernize", "mark_done", "refused",
+			"the gate could not write its word (contract shape, git); mark_state carries `notice`, never a code"},
+		{"feed-watch", "plan", "", "an unconditional edge from the planner: plain failure, nothing typed to carry"},
+	}
+	for _, b := range bare {
+		t.Run(b.bot+"/"+b.from, func(t *testing.T) {
+			wf := compilePlanPhaseBot(t, b.bot)
+			for _, e := range wf.Edges {
+				if e.From == b.from && e.Condition == b.condition && e.To == "fail" {
+					return
+				}
+			}
+			t.Errorf("no bare edge %s -> fail when %q — it was typed, or removed; update this entry with the code it now carries (%s)",
+				b.from, b.condition, b.why)
+		})
+	}
+}
+
+// TestCodedRefusalsLandOnANamedFailNode pins, per refusal, that the guard
+// edge targets the named fail node and that the node carries the code, the
+// resumability and a message naming the figures.
+func TestCodedRefusalsLandOnANamedFailNode(t *testing.T) {
+	for _, r := range codedRefusals() {
+		t.Run(r.bot+"/"+r.failNode, func(t *testing.T) {
+			wf := compilePlanPhaseBot(t, r.bot)
+
+			var edge *ir.Edge
+			for _, e := range wf.Edges {
+				if e.From == r.from && e.Condition == r.condition && e.Negated == r.negated {
+					edge = e
+				}
+			}
+			if edge == nil {
+				t.Fatalf("no edge %s -> … when %s (negated=%v)", r.from, r.condition, r.negated)
+			}
+			if edge.To == "fail" {
+				t.Fatalf("%s -> fail: the refusal reads FAIL_NODE / \"workflow reached fail node\" on the run, "+
+					"indistinguishable from every other refusal in the fleet — route it to a named fail node carrying %s",
+					r.from, r.code)
+			}
+			if edge.To != r.failNode {
+				t.Fatalf("%s -> %s, want the named fail node %s", r.from, edge.To, r.failNode)
+			}
+
+			fn, ok := wf.Nodes[r.failNode].(*ir.FailNode)
+			if !ok {
+				t.Fatalf("%s is %T, want *ir.FailNode", r.failNode, wf.Nodes[r.failNode])
+			}
+			if fn.Code != r.code {
+				t.Errorf("%s code = %q, want %q", r.failNode, fn.Code, r.code)
+			}
+			if fn.Resumable != r.resumable {
+				t.Errorf("%s resumable = %v, want %v", r.failNode, fn.Resumable, r.resumable)
+			}
+			if fn.Message == nil || strings.TrimSpace(fn.Message.Raw) == "" {
+				t.Fatalf("%s carries no message — the run's `error` falls back to the generic wording", r.failNode)
+			}
+			for _, ref := range r.messageRefs {
+				if !strings.Contains(fn.Message.Raw, ref) {
+					t.Errorf("%s message does not carry %s — the operator reads a restatement of the code, "+
+						"not the figure that caused the refusal:\n  %s", r.failNode, ref, fn.Message.Raw)
+				}
+			}
+		})
+	}
+}
+
+// TestPlanBudgetGuardReadsTheRunNamespace pins the guard's shape after the
+// `run.*` namespace landed: ONE deterministic compute reading the run's own
+// consumption and the caps IN FORCE.
+//
+// What it replaces is the reason the assertion is worth its lines. The
+// guard used to self-measure wall-clock in a tool node (`plan_scope_probe`
+// stamped `started_epoch`) and compare against two hand-maintained mirror
+// vars — so `iterion run --max-cost-usd 200` re-budgeted the run and the
+// guard went on refusing against the literal 75 nobody had updated.
+func TestPlanBudgetGuardReadsTheRunNamespace(t *testing.T) {
+	wf := compilePlanPhaseBot(t, "branch-improve-loop")
+
+	for _, v := range []string{"budget_max_duration_minutes", "budget_max_cost_usd"} {
+		if _, ok := wf.Vars[v]; ok {
+			t.Errorf("var %s survives — a mirror of the `budget:` block drifts from it in silence; "+
+				"the caps come from run.max_* now", v)
+		}
+	}
+
+	gate, ok := wf.Nodes["plan_budget_gate"].(*ir.ComputeNode)
+	if !ok {
+		t.Fatalf("plan_budget_gate is %T, want *ir.ComputeNode (one deterministic expression, no shell, no clock)", wf.Nodes["plan_budget_gate"])
+	}
+	exprs := map[string]string{}
+	for _, ex := range gate.Exprs {
+		exprs[ex.Key] = ex.Raw
+	}
+	verdict, hasVerdict := exprs["exhausted"]
+	if !hasVerdict {
+		t.Fatal("plan_budget_gate has no `exhausted` expression")
+	}
+	for _, member := range []string{"run.elapsed_seconds", "run.max_duration_seconds", "run.cost_usd", "run.max_cost_usd"} {
+		if !strings.Contains(verdict, member) {
+			t.Errorf("plan_budget_gate.exhausted = %q does not read %s", verdict, member)
+		}
+	}
+	// A cap of 0 is UNBOUNDED on that axis, never "no allowance left":
+	// without the guard-of-the-guard, an unbudgeted run refuses at once.
+	for _, cap := range []string{"run.max_duration_seconds > 0", "run.max_cost_usd > 0"} {
+		if !strings.Contains(verdict, cap) {
+			t.Errorf("plan_budget_gate.exhausted = %q does not check %s — a cap of 0 means unbounded, "+
+				"so an unbudgeted run would refuse on its first pass", verdict, cap)
+		}
+	}
+
+	// The self-measured clock is gone from every schema that carried it.
+	for name, sch := range wf.Schemas {
+		for _, f := range sch.Fields {
+			if f.Name == "started_epoch" {
+				t.Errorf("schema %s still declares started_epoch — the wall clock is run.elapsed_seconds now", name)
+			}
+		}
+	}
+	if probe, ok := wf.Nodes["plan_scope_probe"].(*ir.ToolNode); ok {
+		if strings.Contains(probe.Command, "time.time()") {
+			t.Error("plan_scope_probe still self-measures wall-clock (time.time()) — the run's own clock is monotonic and survives a resume")
+		}
+	}
+}

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -530,7 +530,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `budget_max_cost_usd` (float), `budget_max_duration_minutes` (int), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `campaign` — Campy

--- a/bots/whole-improve-loop/README.md
+++ b/bots/whole-improve-loop/README.md
@@ -184,7 +184,8 @@ it — the deliberate-spend posture).
 
 The run's entry is a deterministic tool node (~100ms, no LLM): a launch
 whose `workspace_dir` is absent or not a git repository fails typed
-(`WORKSPACE_NOT_A_REPO` on the node's output and in the tool log) before
+(`WORKSPACE_NOT_A_REPO` — on the run's own `failure_code`/`error` through
+the `workspace_not_a_repo` fail node, and on the probe's output) before
 any LLM node spends.
 
 ## Persy (perseverance coach)

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -748,8 +748,7 @@ schema plan_revised_output:
 ## plan node would otherwise author a plan against nothing). Refuses
 ## with the typed code WORKSPACE_NOT_A_REPO when workspace_dir is absent
 ## or is not a git repository (`git rev-parse --git-dir` fails). The
-## verdict is the node's OUTPUT (ok/code/reason, routed to `fail` by the
-## workflow) and is echoed on stderr for the tool log; the process exits
+## verdict is the node's OUTPUT (ok/code/reason, routed to the named `workspace_not_a_repo` fail node, which stamps that code on the RUN) and is echoed on stderr for the tool log; the process exits
 ## 0 on purpose — a non-zero exit would replace the typed verdict with
 ## the engine's generic tool failure. python3 for safe JSON (mirrors
 ## verify_run); read-only, ~100ms.
@@ -770,6 +769,16 @@ if p.returncode != 0:
 print(json.dumps({'ok': True, 'code': '', 'reason': 'git repository at ' + ws}))
 "`
   output: workspace_probe_state
+
+## workspace_not_a_repo — the entry precondition refused. NOT resumable:
+## nothing about this run changes by resuming it, because the workspace it
+## was launched against is not the thing the operator can widen. Fix the
+## launch (attach a repository) and start again.
+fail workspace_not_a_repo:
+  description: "the launch has no repository to work on"
+  code: WORKSPACE_NOT_A_REPO
+  message: "{{outputs.workspace_probe.reason}}"
+  resumable: false
 
 ## plan_topology lifts the plan_phase switch into a bool so the entry
 ## edges use the C012-exhaustive simple form. No LLM. This gate is the
@@ -1147,7 +1156,7 @@ workflow whole_improve_loop:
 
   ## Precondition: nothing LLM runs on a workspace with no repository.
   workspace_probe -> plan_topology when ok
-  workspace_probe -> fail when not ok
+  workspace_probe -> workspace_not_a_repo when not ok
 
   ## Plan phase: on by default; plan_phase off → straight to the campaign.
   plan_topology -> plan when do_plan

--- a/bots/whole-improve-loop/manifest.yaml
+++ b/bots/whole-improve-loop/manifest.yaml
@@ -1,7 +1,12 @@
 name: whole-improve-loop
 display_name: Willy
 icon: 🌍
-version: 2.3.0
+version: 2.4.0
+## 2.4.0 — the entry precondition's refusal is a NAMED fail node
+## (`workspace_not_a_repo`, code WORKSPACE_NOT_A_REPO, terminal), so the
+## code reaches the RUN's own `failure_code` / `error` — read by `iterion
+## runs list`, the studio and the alert sinks — instead of sitting on the
+## probe's output under the generic FAIL_NODE.
 ## 2.3.0 — the plan phase runs by default on every deployment: `plan_review`
 ## gates ONLY the cross-model peer review (the plan_topology gate no longer
 ## skips planning when it resolves off); the new `plan_phase` (on|off) is

--- a/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
+++ b/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
@@ -288,11 +288,12 @@ is the class guard):
   targeting any other branch has its base only as a remote-tracking ref;
   `plan_scope_probe` measures the diff against the same resolved base.
   The verdict rides the node's
-  output (`-> fail when not ok`) and stderr; the process exits 0 on
+  output and stderr; the process exits 0 on
   purpose, since a non-zero exit would replace it with the engine's
   generic tool failure. app-dev keeps no precondition: it starts from an
-  empty directory. The `-> fail` terminal still carries no custom code
-  (see `plan_budget_gate_state`'s comment): the typed code lives on the
-  probe's own persisted output.
+  empty directory. The refusal routes to the named `workspace_not_a_repo`
+  fail node (ADR-following work on #739), which stamps the code on the RUN
+  — `failure_code` / `error` — so a machine reads it without opening the
+  artifacts.
 
 `ResolvePlanReview` itself is unchanged.

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,98 @@
 # Billy — branch-improvement validation
 
+## 2026-09-05 — the plan-budget guard reads the run, and both refusals are typed (no run; bot 1.5.0)
+
+- Status: **validated** by the engine, not by a live run — this is a bot
+  change made against two engine features that landed the same day
+  (PR #764: the `run.*` expr namespace, #738; the typed `fail <name>:`
+  node, #739), issue #752/#762. The next dogfood should confirm the
+  refusal reads right in the studio and that a real `iterion remote runs
+  resume --max-cost-usd …` walks past the guard.
+- Versions: bot `branch-improve-loop` 1.4.0 → **1.5.0** · iterion at
+  `c2898c08f` (v3.108.1, the first build carrying `run.*` and typed fails).
+- Method: no LLM run. The guard is exercised through the ENGINE with the
+  scenario stub against the bot's own shipped `budget:` block
+  (`e2e/branch_improve_loop_test.go`, five cases): the stubbed plan nodes
+  bill a chosen amount, and the readout is which tail the run took.
+- Result — what changed in the bot:
+  - `plan_budget_gate` is now **one `compute`** reading
+    `run.elapsed_seconds` / `run.cost_usd` against
+    `run.max_duration_seconds` / `run.max_cost_usd`. It replaces the tool
+    node that shelled out to python for `time.time()` arithmetic.
+  - **The two mirror vars are gone** (`budget_max_duration_minutes` /
+    `budget_max_cost_usd`). They existed only because no primitive exposed
+    the run's caps, and they were kept in sync **by hand**: `iterion run
+    --max-cost-usd 200` re-budgeted the run and never reached them, so the
+    guard went on refusing against a literal `75` nobody had updated. The
+    `run.max_*` members are the caps IN FORCE — after the CLI flags, the
+    recipe, the platform ceiling and any live `raise_budget` — so the
+    drift is structurally impossible now, not merely documented.
+    (`TestBranchImproveLoop_PlanBudgetFollowsTheCapInForce` is that
+    property: the same $37.50 spend refuses under the shipped $75 cap and
+    passes under a re-budgeted $200 one.)
+  - `plan_scope_probe`'s `started_epoch` is gone with it; the run's clock
+    is monotonic and survives a resume, which a `time.time()` stamp did
+    not.
+  - `plan_cost_probe` is gone: it existed to hand the tool node a nil-safe
+    per-node cost SUM. Nothing but the plan phase has spent when the guard
+    runs, so `run.cost_usd` IS the phase's spend — and it also counts
+    anything a hand-written sum would have forgotten. Its relay role moved
+    onto the guard, which now receives the hand-off from all three
+    upstream routes directly.
+  - Both refusals are **named fail nodes**, so the code reaches the RUN
+    (`failure_code` / `error`) instead of only the guard's output:
+    `plan_exhausted` (PLAN_BUDGET_EXHAUSTED, **resumable**) and
+    `workspace_not_a_repo` (WORKSPACE_NOT_A_REPO, terminal). The 09-05
+    dogfood below recorded both as debt: two production runs ended
+    `failed` reading `workflow reached fail node`, and the operator had to
+    open the artifacts to learn which refusal fired.
+- **How to resume a `PLAN_BUDGET_EXHAUSTED` run.** The refusal is
+  `failed_resumable` and the checkpoint anchors on `plan_budget_gate`, not
+  on the fail node — so the resume **re-evaluates the guard** against the
+  caps then in force:
+
+  ```sh
+  iterion resume --run-id <id> --file bots/branch-improve-loop/main.bot \
+    --max-duration 5h --max-cost-usd 150
+  # or, same effect from the other side:
+  iterion resume --run-id <id> --file … --var plan_budget_ratio=0.6
+  ```
+
+  The plan phase this run already paid for is NOT re-run (the checkpoint
+  keeps `plan`/`plan_review`/`plan_revise`'s outputs); the campaign starts
+  on the plan already in hand. Nothing picks the refusal up by itself —
+  not `--auto-resume`, not the cloud runner's retry: a deliberate refusal
+  only changes verdict when an operator changes an input. Widening the cap
+  is the only thing that flips it, which is exactly why re-paying the plan
+  phase would be the wrong cure.
+- Value: the two workarounds the 09-05 bilan filed as debt (#738, #739)
+  are both retired, and the guard's arithmetic can no longer disagree with
+  the budget the run is actually under.
+- Findings / misses (engine, filed as observations for #762's PR):
+  - `{{run.*}}` renders EMPTY inside a `fail` node's `message:` — the fail
+    message resolves through `resolveMapping(scope)`, which carries
+    `outputs`/`vars` but not the run snapshot the expr evaluator and the
+    prompt/tool templates read. Measured on a probe bot: `run.elapsed=
+    cap=`. The bot works around it by putting the four figures on the
+    guard's own output and referencing `{{outputs.plan_budget_gate.…}}`,
+    which is arguably better anyway (the numbers are then also in the
+    artifact) — but the authoring instinct is to write `{{run.cost_usd}}`
+    there and get silence.
+  - A **tiny `max_duration` cannot be the lever** for a deterministic test
+    of the duration axis: the engine refuses a new node at 90% of a cap,
+    so with a small enough cap `BUDGET_EXCEEDED` fires before the guard
+    ever runs. The e2e drives the COST axis instead (a figure the stub
+    sets exactly); the duration axis is covered by the `> 0` unbounded
+    case and by the guard's own expression.
+  - A compute's output schema does **not** coerce a float into an `int`
+    field (probed: `used_pct: int` kept `0.0952…`), and float refs render
+    at full precision in a template. The gate therefore reports seconds
+    and USD rather than a rounded percentage.
+- Lessons for next run: launch with `--var plan_budget_ratio` small to
+  force the guard as before, then check `iterion remote runs list` shows
+  PLAN_BUDGET_EXHAUSTED (not FAIL_NODE) and that the resume with a widened
+  cap starts `campaign` without re-running `plan`.
+
 ## 2026-09-05 — lock-delivery follow-up on PR #770: an "open question" was a two-part defect, and one comment cited a function that never existed
 
 - Status: **delivered**. Run

--- a/e2e/branch_improve_loop_test.go
+++ b/e2e/branch_improve_loop_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -301,34 +300,44 @@ func TestBranchImproveLoop_Structural(t *testing.T) {
 // A production run on a +3870/-273 diff spent the planning chain (plan ->
 // plan_review -> plan_revise) for 150 min / $8.59 and never reached
 // `campaign`. plan_budget_gate is the deterministic choke point that must
-// now fail the run — typed, before campaign starts — the moment planning
+// fail the run — typed, before campaign starts — the moment planning
 // crosses its share of the run's budget, and must otherwise let campaign
 // proceed with the (possibly revised) plan carried forward exactly as
 // before the guard existed.
 //
-// plan_scope_probe, plan, plan_review, plan_revise, and plan_budget_gate
-// are STUBBED (plan_scope_probe and plan_budget_gate are tool nodes whose
-// real bodies shell out to git/python — this harness never exercises a
-// tool node's real subprocess, matching every other tool node in this
-// file). plan_gate and plan_cost_probe are left REAL: they are pure
-// compute/expr, so the test exercises the actual nil-safe cost-sum
-// arithmetic (plan_cost_probe) rather than a hand-picked verdict — the
-// plan_budget_gate stub decides `exhausted` from the REAL summed
-// plan_cost_usd it receives, against a threshold the test picks (standing
-// in for plan_budget_gate's own ratio-of-ceiling math, which is plain
-// python arithmetic with no branch worth a second, non-hermetic test).
+// The guard is REAL here, not stubbed: it is a compute reading the run's
+// own `run.cost_usd` / `run.elapsed_seconds` against the caps in force, so
+// a scenario steers it the only honest way — by choosing what the stubbed
+// LLM nodes BILL against the bot's shipped `budget:` block (max_duration
+// 2h30m, max_cost_usd 75; plan_budget_ratio 0.3, so the plan phase's cost
+// share is $22.50). The COST axis is what these tests drive: it is a
+// figure the stub sets exactly, whereas tripping the duration axis would
+// need the run to genuinely take minutes.
+//
+// plan_scope_probe, plan, plan_review and plan_revise are stubbed
+// (plan_scope_probe is a tool node whose real body shells out to git —
+// this harness never exercises a tool node's real subprocess). plan_gate
+// and plan_budget_gate are REAL computes.
+
+const (
+	// planCostShareUSD is plan_budget_ratio (0.3) x the bot's shipped
+	// max_cost_usd (75) — the share the plan phase may spend.
+	planCostShareUSD = 22.5
+	// planOverShareUSD / planUnderShareUSD are per-LLM-node prices; three
+	// nodes run, so the phase spends 3x. $37.50 crosses the share while
+	// staying under the engine's own 90%-of-cap hard limit ($67.50), and
+	// $7.50 stays well inside it.
+	planOverShareUSD  = 12.50
+	planUnderShareUSD = 2.50
+)
 
 // planBudgetGateStubs wires a full (non-skipped, non-large-diff) plan
 // phase: plan -> plan_review -> plan_gate -> plan_revise, each of the three
-// LLM nodes spending planCostUSD (so plan_cost_probe's real nil-safe sum is
-// 3*planCostUSD). The plan_budget_gate stub captures every input it
-// receives and fails the phase (exhausted=true) iff the real summed cost
-// crosses exhaustAt.
-func planBudgetGateStubs(exec *scenarioExecutor, planCostUSD, exhaustAt float64, gateInputs *[]map[string]any) {
+// LLM nodes billing planCostUSD, so the run's own cost at the guard is
+// 3*planCostUSD.
+func planBudgetGateStubs(exec *scenarioExecutor, planCostUSD float64) {
 	stubWorkspaceProbeOK(exec)
-	exec.on("plan_scope_probe", func(_ map[string]any) (map[string]any, error) {
-		return map[string]any{"diff_stat": "1 file changed, 4 insertions(+)", "large": false, "started_epoch": 1, "_tokens": 1}, nil
-	})
+	stubBranchPlanRelay(exec)
 	exec.on("plan", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"plan": "fix the seam", "assumptions": "small blast radius", "risks": "none flagged",
 			"_tokens": 10, "_cost_usd": planCostUSD}, nil
@@ -341,95 +350,14 @@ func planBudgetGateStubs(exec *scenarioExecutor, planCostUSD, exhaustAt float64,
 		return map[string]any{"plan": "fix the seam, revised", "review_responses": "accepted: added the test",
 			"_tokens": 10, "_cost_usd": planCostUSD}, nil
 	})
-	exec.on("plan_budget_gate", func(in map[string]any) (map[string]any, error) {
-		if gateInputs != nil {
-			*gateInputs = append(*gateInputs, in)
-		}
-		cost, _ := in["plan_cost_usd"].(float64)
-		exhausted := cost > exhaustAt
-		code, reason := "", ""
-		if exhausted {
-			code = "PLAN_BUDGET_EXHAUSTED"
-			reason = fmt.Sprintf("stub verdict: real plan-phase spend %.2f crossed the test threshold %.2f", cost, exhaustAt)
-		}
-		return map[string]any{
-			"exhausted": exhausted, "code": code, "reason": reason,
-			"plan": in["plan"], "plan_critique": in["plan_critique"], "plan_responses": in["plan_responses"],
-			"plan_provenance": in["plan_provenance"],
-			"_tokens":         1,
-		}, nil
-	})
 }
 
-// TestBranchImproveLoop_PlanBudgetExhaustedFailsBeforeCampaign is scenario
-// (a): the plan phase's real, nil-safe-summed spend (3 * $12.50 = $37.50)
-// crosses the test's $10 threshold, so plan_budget_gate reports exhausted —
-// the run must end FAILED, typed PLAN_BUDGET_EXHAUSTED on the gate's own
-// output, with campaign NEVER started (the delivery reserve this guard
-// exists to protect).
-func TestBranchImproveLoop_PlanBudgetExhaustedFailsBeforeCampaign(t *testing.T) {
-	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
-	exec := newScenarioExecutor()
-	var gateIns []map[string]any
-	planBudgetGateStubs(exec, 12.50, 10.0, &gateIns)
-	// campaign must never run; fail loudly if the graph reaches it anyway.
-	exec.on("campaign", func(_ map[string]any) (map[string]any, error) {
-		t.Error("campaign ran — the plan-budget guard must fail the run BEFORE campaign starts")
-		return map[string]any{"branch_clean": true, "commits_this_pass": 0, "issues_remaining": "",
-			"needs_human": false, "human_note": "", "summary": "", "_tokens": 1}, nil
-	})
-
-	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
-	err := eng.Run(context.Background(), "run-bil-plan-budget-fail", map[string]any{"plan_review": "on"})
-	if err == nil {
-		t.Fatal("Run: want an error (the plan budget guard routes to fail), got nil")
-	}
-	run, loadErr := s.LoadRun(context.Background(), "run-bil-plan-budget-fail")
-	if loadErr != nil {
-		t.Fatalf("LoadRun: %v", loadErr)
-	}
-	if run.Status != store.RunStatusFailed {
-		t.Fatalf("status = %s, want %s (plan_budget_gate -> fail)", run.Status, store.RunStatusFailed)
-	}
-	if exec.wasCalled("campaign") {
-		t.Error("campaign was called — the plan-budget guard did not stop the run before campaign")
-	}
-	if len(gateIns) != 1 {
-		t.Fatalf("plan_budget_gate called %d times, want 1", len(gateIns))
-	}
-	gotCost, _ := gateIns[0]["plan_cost_usd"].(float64)
-	wantCost := 3 * 12.50
-	if gotCost != wantCost {
-		t.Errorf("plan_budget_gate received plan_cost_usd = %v, want %v (nil-safe sum of plan+plan_review+plan_revise's _cost_usd)", gotCost, wantCost)
-	}
-	// The DSL `-> fail` terminal has no mechanism to carry a custom
-	// RuntimeError code/message (pkg/runtime/engine_exec.go hardcodes
-	// "workflow reached fail node" + a fixed FailureFailNode code) — so the
-	// run's OWN top-level failure stays generic; the typed code/reason live
-	// on plan_budget_gate's own persisted output instead (asserted above via
-	// the stub's captured input/decision). Document the gap here so a
-	// reader of this test sees why the assertions above don't check
-	// run.Error for "PLAN_BUDGET_EXHAUSTED".
-	if run.Error != "workflow reached fail node" {
-		t.Logf("run.Error = %q (engine's generic fail-node message; the typed PLAN_BUDGET_EXHAUSTED code lives on plan_budget_gate's own output, not here — no DSL primitive carries a custom code/message to a `-> fail` terminal)", run.Error)
-	}
-}
-
-// TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign is scenario (b):
-// the plan phase's real spend (3 * $2.50 = $7.50) stays under the test's
-// $10 threshold, so plan_budget_gate reports NOT exhausted — campaign must
-// run normally, receiving the plan/critique/responses exactly as the
-// pre-guard edges handed them off (no hysteria: the guard is silent when
-// planning stayed inside its share).
-func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
-	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
-	exec := newScenarioExecutor()
-	var gateIns []map[string]any
-	planBudgetGateStubs(exec, 2.50, 10.0, &gateIns)
-	var campaignIns []map[string]any
+// stubConvergingCampaignTail wires a campaign that converges on its first
+// pass plus the deterministic loop tail behind it, capturing every input
+// the campaign received.
+func stubConvergingCampaignTail(exec *scenarioExecutor, into *[]map[string]any) {
 	exec.on("campaign", func(in map[string]any) (map[string]any, error) {
-		campaignIns = append(campaignIns, in)
+		*into = append(*into, in)
 		return map[string]any{"branch_clean": true, "commits_this_pass": 1, "issues_remaining": "",
 			"needs_human": false, "human_note": "", "summary": "converged", "_tokens": 10, "_cost_usd": 0.01}, nil
 	})
@@ -445,6 +373,101 @@ func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
 	exec.on("review", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"clean": true, "findings": "", "_tokens": 1}, nil
 	})
+}
+
+// gateOutput returns plan_budget_gate's persisted output, failing the test
+// when the guard never ran.
+func gateOutput(t *testing.T, run *store.Run) map[string]any {
+	t.Helper()
+	if run.Checkpoint == nil {
+		t.Fatal("the run carries no checkpoint — plan_budget_gate's verdict was not persisted")
+	}
+	out := run.Checkpoint.Outputs["plan_budget_gate"]
+	if out == nil {
+		t.Fatal("plan_budget_gate never ran")
+	}
+	return out
+}
+
+// TestBranchImproveLoop_PlanBudgetExhaustedFailsBeforeCampaign is scenario
+// (a): the plan phase bills 3 * $12.50 = $37.50 against a $22.50 share, so
+// the guard refuses. The run must end FAILED_RESUMABLE, stamped
+// PLAN_BUDGET_EXHAUSTED on the RUN (not merely on a node output), with the
+// checkpoint anchored on the GUARD — so `iterion resume --max-cost-usd …`
+// re-evaluates it — and `campaign` never started (the delivery reserve
+// this guard exists to protect).
+func TestBranchImproveLoop_PlanBudgetExhaustedFailsBeforeCampaign(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
+	exec := newScenarioExecutor()
+	planBudgetGateStubs(exec, planOverShareUSD)
+	// campaign must never run; fail loudly if the graph reaches it anyway.
+	exec.on("campaign", func(_ map[string]any) (map[string]any, error) {
+		t.Error("campaign ran — the plan-budget guard must fail the run BEFORE campaign starts")
+		return map[string]any{"branch_clean": true, "commits_this_pass": 0, "issues_remaining": "",
+			"needs_human": false, "human_note": "", "summary": "", "_tokens": 1}, nil
+	})
+
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-bil-plan-budget-fail", map[string]any{"plan_review": "on"})
+	if err == nil {
+		t.Fatal("Run: want an error (the plan budget guard routes to plan_exhausted), got nil")
+	}
+	run, loadErr := s.LoadRun(context.Background(), "run-bil-plan-budget-fail")
+	if loadErr != nil {
+		t.Fatalf("LoadRun: %v", loadErr)
+	}
+	if exec.wasCalled("campaign") {
+		t.Error("campaign was called — the plan-budget guard did not stop the run before campaign")
+	}
+
+	// The refusal is on the RUN, which is where every machine reads it.
+	if run.FailureCode != "PLAN_BUDGET_EXHAUSTED" {
+		t.Errorf("run.failure_code = %q, want PLAN_BUDGET_EXHAUSTED — the bot's refusal is indistinguishable from any other fail node", run.FailureCode)
+	}
+	// resumable: the cure is "widen the caps and carry on", never "re-pay
+	// the plan phase this run already completed".
+	if run.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want %s", run.Status, store.RunStatusFailedResumable)
+	}
+	if run.Checkpoint == nil || run.Checkpoint.NodeID != "plan_budget_gate" {
+		t.Fatalf("checkpoint anchored on %v, want the GUARD plan_budget_gate — anchored on the fail node, a resume re-enters the refusal and the raised cap changes nothing",
+			run.Checkpoint)
+	}
+	// And it names the figures, not just the code: a message that only
+	// restates PLAN_BUDGET_EXHAUSTED tells the operator nothing about how
+	// much to widen by.
+	for _, want := range []string{"37.5", "22.5"} {
+		if !strings.Contains(run.Error, want) {
+			t.Errorf("run.error does not name %s (spent vs share): %q", want, run.Error)
+		}
+	}
+
+	gate := gateOutput(t, run)
+	if gate["exhausted"] != true {
+		t.Errorf("plan_budget_gate.exhausted = %v, want true", gate["exhausted"])
+	}
+	if gate["over_cost"] != true {
+		t.Errorf("plan_budget_gate.over_cost = %v, want true", gate["over_cost"])
+	}
+	if got := toFloat(gate["spent_usd"]); got != 3*planOverShareUSD {
+		t.Errorf("plan_budget_gate.spent_usd = %v, want %v (the RUN's own cost at the guard)", gate["spent_usd"], 3*planOverShareUSD)
+	}
+	if got := toFloat(gate["cost_share_usd"]); got != planCostShareUSD {
+		t.Errorf("plan_budget_gate.cost_share_usd = %v, want %v (plan_budget_ratio x the cap in force)", gate["cost_share_usd"], planCostShareUSD)
+	}
+}
+
+// TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign is scenario (b):
+// the plan phase bills 3 * $2.50 = $7.50, well inside its $22.50 share, so
+// the guard is silent — campaign runs normally, receiving the
+// plan/critique/responses exactly as the pre-guard edges handed them off.
+func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
+	exec := newScenarioExecutor()
+	planBudgetGateStubs(exec, planUnderShareUSD)
+	var campaignIns []map[string]any
+	stubConvergingCampaignTail(exec, &campaignIns)
 
 	s := tmpStore(t)
 	eng := runtime.New(wf, s, exec)
@@ -458,13 +481,9 @@ func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
 	if run.Status != store.RunStatusFinished {
 		t.Fatalf("status = %s, want %s (within-share plan phase must not block delivery)", run.Status, store.RunStatusFinished)
 	}
-	if len(gateIns) != 1 {
-		t.Fatalf("plan_budget_gate called %d times, want 1", len(gateIns))
-	}
-	gotCost, _ := gateIns[0]["plan_cost_usd"].(float64)
-	wantCost := 3 * 2.50
-	if gotCost != wantCost {
-		t.Errorf("plan_budget_gate received plan_cost_usd = %v, want %v", gotCost, wantCost)
+	gate := gateOutput(t, run)
+	if gate["exhausted"] != false {
+		t.Errorf("plan_budget_gate.exhausted = %v, want false at %v of a %v share", gate["exhausted"], gate["spent_usd"], gate["cost_share_usd"])
 	}
 	if len(campaignIns) != 1 {
 		t.Fatalf("campaign called %d times, want 1 (converges on the first pass)", len(campaignIns))
@@ -477,5 +496,168 @@ func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
 	}
 	if campaignIns[0]["plan_responses"] != "accepted: added the test" {
 		t.Errorf("campaign received plan_responses %q", campaignIns[0]["plan_responses"])
+	}
+}
+
+// TestBranchImproveLoop_PlanBudgetFollowsTheCapInForce is the reason the
+// two mirror vars had to go. The plan phase bills exactly what scenario
+// (a) billed — $37.50 — but the run was re-budgeted to a $200 cap, which
+// puts the phase's share at $60. The guard must follow the cap IN FORCE
+// and let the campaign through.
+//
+// A mirror var (`budget_max_cost_usd = 75`, kept in sync by hand) could
+// not: `iterion run --max-cost-usd 200` never reached it, so the guard
+// went on refusing against a literal nobody had updated.
+func TestBranchImproveLoop_PlanBudgetFollowsTheCapInForce(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
+	if wf.Budget == nil {
+		t.Fatal("branch-improve-loop declares no budget: block — the guard has no cap to read")
+	}
+	wf.Budget.MaxCostUSD = 200 // what `iterion run --max-cost-usd 200` resolves to
+
+	exec := newScenarioExecutor()
+	planBudgetGateStubs(exec, planOverShareUSD)
+	var campaignIns []map[string]any
+	stubConvergingCampaignTail(exec, &campaignIns)
+
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	if err := eng.Run(context.Background(), "run-bil-plan-budget-recap", map[string]any{"plan_review": "on"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	run, err := s.LoadRun(context.Background(), "run-bil-plan-budget-recap")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	gate := gateOutput(t, run)
+	if got := toFloat(gate["cost_share_usd"]); got != 60 {
+		t.Errorf("plan_budget_gate.cost_share_usd = %v, want 60 (0.3 x the RE-BUDGETED cap) — the guard is reading a literal, not run.max_cost_usd", gate["cost_share_usd"])
+	}
+	if gate["exhausted"] != false {
+		t.Fatalf("the guard refused $%v against a $%v share — the raised cap did not reach it", gate["spent_usd"], gate["cost_share_usd"])
+	}
+	if len(campaignIns) != 1 {
+		t.Fatalf("campaign called %d times, want 1", len(campaignIns))
+	}
+}
+
+// TestBranchImproveLoop_PlanBudgetUnboundedNeverTrips pins the documented
+// convention a phase guard is easiest to get wrong: a `max_*` of 0 means
+// UNBOUNDED on that axis, never "no allowance left". Without the `> 0`
+// guard on each comparison, an uncapped run refuses on its first pass —
+// every spend is "over" a share of zero.
+func TestBranchImproveLoop_PlanBudgetUnboundedNeverTrips(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
+	if wf.Budget == nil {
+		t.Fatal("branch-improve-loop declares no budget: block")
+	}
+	wf.Budget.MaxCostUSD = 0   // `--max-cost-usd 0` / no cost cap
+	wf.Budget.MaxDuration = "" // no duration cap
+
+	exec := newScenarioExecutor()
+	planBudgetGateStubs(exec, planOverShareUSD)
+	var campaignIns []map[string]any
+	stubConvergingCampaignTail(exec, &campaignIns)
+
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	if err := eng.Run(context.Background(), "run-bil-plan-budget-uncapped", map[string]any{"plan_review": "on"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	run, err := s.LoadRun(context.Background(), "run-bil-plan-budget-uncapped")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	gate := gateOutput(t, run)
+	if gate["exhausted"] != false {
+		t.Fatalf("the guard refused an UNCAPPED run (cost share %v, duration share %v) — a cap of 0 is unbounded, not exhausted",
+			gate["cost_share_usd"], gate["duration_share_seconds"])
+	}
+	if gate["over_cost"] != false || gate["over_duration"] != false {
+		t.Errorf("over_cost = %v / over_duration = %v on an uncapped run, want false", gate["over_cost"], gate["over_duration"])
+	}
+	if len(campaignIns) != 1 {
+		t.Fatalf("campaign called %d times, want 1 — an uncapped run must still deliver", len(campaignIns))
+	}
+}
+
+// TestBranchImproveLoop_PlanBudgetResumeRunsTheCampaign is the promise the
+// `resumable: true` on `plan_exhausted` makes, exercised on the SHIPPED
+// bot rather than a fixture: the operator widens the caps and resumes, and
+// the campaign starts on the plan the run already paid for.
+//
+// The engine anchors the checkpoint on the GUARD, so the resume re-executes
+// plan_budget_gate — which means the guard has to be re-runnable and its
+// input has to rebuild from the edge that was selected. The readout is the
+// node-start counts: the guard twice, the fail node once, campaign once.
+func TestBranchImproveLoop_PlanBudgetResumeRunsTheCampaign(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "branch-improve-loop/main.bot")
+	s := tmpStore(t)
+	const runID = "run-bil-plan-budget-resume"
+
+	exec := newScenarioExecutor()
+	planBudgetGateStubs(exec, planOverShareUSD)
+	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, map[string]any{"plan_review": "on"}); err == nil {
+		t.Fatal("first pass succeeded; $37.50 must cross the $22.50 share")
+	}
+	run, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s (%s), want failed_resumable", run.Status, run.Error)
+	}
+
+	// What the message asks for: raise the caps, resume. The plan phase's
+	// spend is restored with the checkpoint, so the verdict flips only
+	// because the CAP moved.
+	wf.Budget.MaxCostUSD = 200
+	resumeExec := newScenarioExecutor()
+	planBudgetGateStubs(resumeExec, planOverShareUSD)
+	var campaignIns []map[string]any
+	stubConvergingCampaignTail(resumeExec, &campaignIns)
+	if err := runtime.New(wf, s, resumeExec).Resume(context.Background(), runID, nil); err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+
+	run, err = s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Status != store.RunStatusFinished {
+		t.Fatalf("status = %s (%s), want finished after widening the cap", run.Status, run.Error)
+	}
+	if run.FailureCode != "" {
+		t.Errorf("failure_code = %q, want cleared by the successful resume", run.FailureCode)
+	}
+	if len(campaignIns) != 1 {
+		t.Fatalf("campaign ran %d times, want 1 — the resume did not get past the guard", len(campaignIns))
+	}
+	if campaignIns[0]["plan"] != "fix the seam, revised" {
+		t.Errorf("campaign received plan %q — the resume lost the plan this run already paid for", campaignIns[0]["plan"])
+	}
+
+	events, err := s.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	starts := map[string]int{}
+	for _, e := range events {
+		if e.Type == store.EventNodeStarted {
+			starts[e.NodeID]++
+		}
+	}
+	if starts["plan_budget_gate"] != 2 {
+		t.Errorf("the guard ran %d times, want 2 (once per pass) — the resume did not re-evaluate it", starts["plan_budget_gate"])
+	}
+	if starts["plan_exhausted"] != 1 {
+		t.Errorf("the fail node ran %d times, want 1 — the resume re-entered the refusal instead of the guard", starts["plan_exhausted"])
+	}
+	// The expensive half must NOT be re-paid: the plan chain ran on the
+	// first pass only, which is the whole reason the refusal is resumable.
+	for _, id := range []string{"plan", "plan_review", "plan_revise"} {
+		if starts[id] != 1 {
+			t.Errorf("%s ran %d times, want 1 — the resume re-paid the plan phase the guard exists to protect", id, starts[id])
+		}
 	}
 }

--- a/e2e/campaign_plan_phase_test.go
+++ b/e2e/campaign_plan_phase_test.go
@@ -40,20 +40,15 @@ func stubPlanAuthor(exec *scenarioExecutor) {
 	})
 }
 
-// stubBranchPlanRelay stubs branch-improve-loop's deterministic plan-phase
-// relays (both tool nodes): the scope probe, and the budget gate relaying
-// the hand-off fields to the campaign within its share.
+// stubBranchPlanRelay stubs branch-improve-loop's one deterministic
+// plan-phase tool node, the scope probe. plan_budget_gate is left REAL: it
+// is a compute reading the run's own consumption against the caps in
+// force, and under the bot's shipped budget (2h30m / $75) these cheap
+// stubs stay far inside plan_budget_ratio — so the hand-off it relays to
+// the campaign is exercised, not simulated.
 func stubBranchPlanRelay(exec *scenarioExecutor) {
 	exec.on("plan_scope_probe", func(_ map[string]any) (map[string]any, error) {
-		return map[string]any{"diff_stat": "1 file changed", "large": false, "started_epoch": 1, "_tokens": 1}, nil
-	})
-	exec.on("plan_budget_gate", func(in map[string]any) (map[string]any, error) {
-		return map[string]any{
-			"exhausted": false, "code": "", "reason": "",
-			"plan": in["plan"], "plan_critique": in["plan_critique"], "plan_responses": in["plan_responses"],
-			"plan_provenance": in["plan_provenance"],
-			"_tokens":         1,
-		}, nil
+		return map[string]any{"diff_stat": "1 file changed", "large": false, "_tokens": 1}, nil
 	})
 }
 
@@ -179,9 +174,10 @@ func TestCampaignPlanPhase_OffSkipsPlanningExplicitly(t *testing.T) {
 
 // TestCampaignPrecondition_NotARepoFailsBeforeAnyLLM: the entry probe
 // refusing (workspace_dir absent / not a repository) must end the run
-// FAILED through the `-> fail` edge with NO LLM node started — the typed
-// code WORKSPACE_NOT_A_REPO rides the probe's own persisted output (the DSL
-// `-> fail` terminal carries no custom code, see pkg/runtime/engine_exec.go).
+// FAILED with NO LLM node started, and the typed code must be on the RUN —
+// `failure_code` / `error`, what `iterion runs list`, the studio and the
+// alert sinks read — through the named `workspace_not_a_repo` fail node,
+// not only on the probe's persisted output.
 func TestCampaignPrecondition_NotARepoFailsBeforeAnyLLM(t *testing.T) {
 	for _, tc := range campaignBotCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -248,19 +244,31 @@ func runProbeRefusal(t *testing.T, tc campaignBotCase, reason string) {
 	if got, _ := probeOut["reason"].(string); got != reason {
 		t.Errorf("persisted probe reason = %q, want %q", got, reason)
 	}
+	// And on the RUN itself, which is the readout an operator gets without
+	// opening the artifacts. The fail node's `message:` resolves at fail
+	// time from the probe's own reason, so the two cannot diverge.
+	if run.FailureCode != "WORKSPACE_NOT_A_REPO" {
+		t.Errorf("run.failure_code = %q, want WORKSPACE_NOT_A_REPO — the refusal reads like every other fail node", run.FailureCode)
+	}
+	if run.Error != reason {
+		t.Errorf("run.error = %q, want the probe's reason %q", run.Error, reason)
+	}
+	if run.Status == store.RunStatusFailedResumable {
+		t.Error("status = failed_resumable — a workspace that is not a repository is a launch to fix, not a cap to widen; a resume would refuse identically")
+	}
 	events, err := s.LoadEvents(context.Background(), runID)
 	if err != nil {
 		t.Fatalf("LoadEvents: %v", err)
 	}
-	// Only the probe and the `fail` terminal complete: the run stops right
-	// after the refusal, before any LLM node starts.
+	// Only the probe and its fail node complete: the run stops right after
+	// the refusal, before any LLM node starts.
 	finished := eventNodeIDs(events, store.EventNodeFinished)
 	if len(finished) == 0 || finished[0] != "workspace_probe" {
 		t.Errorf("node_finished events = %v, want workspace_probe first", finished)
 	}
 	for _, id := range finished {
-		if id != "workspace_probe" && id != "fail" {
-			t.Errorf("node %q finished after the refusal — nothing but the probe and the fail terminal may run (events: %v)", id, finished)
+		if id != "workspace_probe" && id != "workspace_not_a_repo" {
+			t.Errorf("node %q finished after the refusal — nothing but the probe and its fail node may run (events: %v)", id, finished)
 		}
 	}
 }


### PR DESCRIPTION
Closes #762. Bots only (`pkg/`, `cmd/` untouched) — the bot-side adoption of #738 / #739 (PR #764).

## branch-improve-loop 1.4.0 → 1.5.0
`plan_budget_gate` is ONE `compute` reading `run.elapsed_seconds` / `run.cost_usd` against `run.max_duration_seconds` / `run.max_cost_usd`, each comparison guarded on `cap > 0` (unbounded ≠ exhausted). Gone: the mirror vars `budget_max_duration_minutes` / `budget_max_cost_usd`, `plan_scope_probe`'s self-measured `started_epoch`, and `plan_cost_probe` (its per-node cost sum is `run.cost_usd` now; its relay role moved onto the guard, which takes the three upstream routes directly). The refusal is a named `fail plan_exhausted:` — `PLAN_BUDGET_EXHAUSTED`, `resumable: true`, a message naming spent-vs-share on both axes and how to resume; `workspace_not_a_repo` is a named terminal fail. README: a "Plan-phase budget guard" section with the resume recipe.

## The fleet
`e2e-coverage`, `feature-dev`, `feature-gap-fill`, `test-coverage`, `whole-improve-loop` (+0.1.0 each): `fail workspace_not_a_repo:` (`WORKSPACE_NOT_A_REPO`, message = the probe's reason). `modernize` 0.3.0 → 0.4.0: `lot_not_actionable` (`LOT_NOT_ACTIONABLE`), `gate_timeout` (`GATE_TIMEOUT`), `contract_unreadable` (`CONTRACT_UNREADABLE`). Class sweep of the 13 `-> fail` edges: 10 typed; the 3 left bare carry no single code (modernize's `work_gate … when refused` carries TWO codes on one bool; two edges have none) and `feed-watch`'s unconditional `plan -> fail` — each pinned by `TestUncodedFailEdgesStayBare` with its reason.

## Red first
`bots/typed_fail_test.go` on the old graphs: `the refusal reads FAIL_NODE / "workflow reached fail node" … route it to a named fail node carrying WORKSPACE_NOT_A_REPO` ×6, the same for `PLAN_BUDGET_EXHAUSTED` and `LOT_NOT_ACTIONABLE`, `var budget_max_duration_minutes survives`, `plan_budget_gate is *ir.ToolNode, want *ir.ComputeNode`. Through the engine (`e2e/branch_improve_loop_test.go`, the REAL compute against the shipped `budget:` 2h30 / $75, ratio 0.3 → $22.50 share): exhausted (3 × $12.50 → `failed_resumable`, `failure_code = PLAN_BUDGET_EXHAUSTED`, checkpoint anchored on the guard, campaign never ran); within share; **caps in force** (`--max-cost-usd 200` → share $60 → campaign runs — the case no mirror var could pass); unbounded never trips; resume after widening → finished, the guard ran twice, the plan phase once (not re-paid). `campaign_plan_phase_test.go` asserts `run.FailureCode == WORKSPACE_NOT_A_REPO` and `run.Error == the probe's reason`.

`go test ./bots/... ./e2e/...` ok, goldens ok, catalog regenerated, `task lint` 0 issues, `iterion validate` OK on the seven touched bots. Bilan appended to `docs/bot-runs/branch-improve-loop.md`.

Engine gaps found, filed separately: `{{run.*}}` renders EMPTY in a `fail` node's `message:` (the fail-outcome resolver's scope lacks the run snapshot); a compute's output schema does not coerce float → `int` (the shipped `used_pct: int` example implies a rounding that does not happen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)