### PR TITLE
feat(trigger): an effect KIND on the outbox — a native card move reaches the bound GitHub board through the durable outbox, the pass stays the net

### DIFF
--- a/docs/adr/094-trigger-effect-outbox.md
+++ b/docs/adr/094-trigger-effect-outbox.md
@@ -39,6 +39,13 @@ matched `(board event, subscription)` pair, in the per-tenant Mongo
 collection `trigger_effects` (`pkg/dispatcher/boardmongo`, implementing
 `trigger.EffectOutbox`; `trigger.MemoryEffectOutbox` is the test twin).
 
+> **Since issue #746** a row carries a `kind`, so the outbox also delivers
+> effects owed to something other than a subscription. `launch` is the row
+> above and the ZERO value — every row written before the field, and by every
+> replica mid-rollout, reads as one — while `projection` is ADR-097 §10's
+> board reflect: no `sub_id`, no bot, a row key no `(event, subscription)` pair
+> can address. Everything below applies to both kinds unchanged.
+
 **Materialization order** (`cloudBoardSource.drainTenant`):
 normalize + match **every** event of the batch first — a transient store
 error aborts the batch with the cursor untouched (retry next tick); only a

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -428,6 +428,52 @@ path is an **effect-kind on `EffectRow`** (expand/contract) with the projection
 as a first-class effect — not a pseudo-subscription. The pass stays the net
 underneath it either way.
 
+#### Addendum (issue #746) — the follow-up shipped; the pass stays the net
+
+The effect kind is in: `EffectRow.Kind` is `launch` (the zero value, so every
+row written before it — and by every replica mid-rollout — reads as one) or
+`projection`. A `card.moved` event on a tenant that has a `BoardBinding`
+materializes ONE projection row, and `Evaluator.applyEffect` gained the arm
+that executes it through `reflectNativeState` — the same reflect, one
+implementation, two callers. **Reflect latency is now the outbox's (seconds),
+not `sync_every`'s.**
+
+Each of the three objections above was answered rather than waived:
+
+1. *No effect kind* — added, expand/contract, both twins, conformance covering
+   a RAW pre-discriminator document. No version integer: the outbox is a store,
+   not a negotiated wire, and the rollout doc's own test — "what does a replica
+   that never sees the field do instead, and is that safe?" — answers *treats
+   it as a launch, finds no subscription, retires it*, i.e. degrades to
+   yesterday's latency with the pass still underneath. It cannot fail open.
+2. *Would have to BE a subscription* — it is not one. No `ExecutionMode`, an
+   EMPTY `sub_id`, and a row key using a separator `EffectID` does not, so
+   `/api/v1/triggers` cannot list it and no operator DELETE can kill the
+   reflect. Tested: materializing one creates no subscription, and the worker
+   reaches the arm through a subscription store that fails on `Get`.
+3. *The machine-caused decline* — the admission path was not edited. The
+   projection is computed **before** `matchingSubscriptions` and dispatched
+   **before** the decline in `applyEffect`, at one line each, with the reason
+   stated there. Launch admission is untouched, and a watchdog filing a card in
+   `blocked` reaches the roadmap in seconds instead of two minutes.
+
+What the fast path cannot do is verify the reflect's precondition ("the board
+still says what iterion last recorded") — it issues no board read. So it checks
+the only thing it can: the column the card **left**. Mapping to the recorded
+status means the two sides agreed right up to this move, and the divergence is
+the move. Not mapping means somebody moved the card on the board since the last
+pass; the projection declines and leaves the record stale, which is exactly
+what makes the pass re-derive and arbitrate §9's conflict with real timestamps.
+A previous state the map does not carry is inert (§2), so it is not a
+divergence and the reflect proceeds.
+
+The pass is unchanged and remains the net. Both orders are idempotent and
+tested as such: after a projection the next pass writes nothing (to the forge
+or to the card — a gratuitous `External` write is a `card.updated` that
+relaunches every label-matching subscription), and after a pass a projection
+row writes nothing. `sync_every: 0` is now a real choice rather than a
+degradation: the fast path runs with no net under it.
+
 Everything else follows the shipped doctrine:
 
 - Every native write is a CAS; every GitHub write is idempotent by construction
@@ -442,7 +488,9 @@ Everything else follows the shipped doctrine:
   *launches*, because they must not spend budget. The pass form needs no
   exemption for that gate: it reads the card's CURRENT column, so a watchdog
   filing a card in `blocked` is reflected like any other move — which is
-  precisely what the roadmap must show.
+  precisely what the roadmap must show. The projection arm added by the
+  addendum below states that exemption explicitly instead of inheriting it,
+  since it *does* ride the shared admission prelude.
 
 ### 11. Permissions, stated up front
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -14,6 +14,9 @@ Methodology this serves: [AGENTS.md](../AGENTS.md).
 |---|---|---|
 | Title, body, labels, assignees, open/closed | GitHub issue → card | the **issue sync**: `iterion remote forge integrations sync <id>` on cloud, `iterion issue import` on a local store |
 | **`Status`** | **both ways** | the project pass |
+
+| Title, body, labels, assignees, open/closed | GitHub issue → card | `iterion issue import` |
+| **`Status`** | **both ways** | the project pass, plus the per-move [projection effect](#how-fast-a-native-move-reaches-the-board) on the native → board side |
 | `Area` / `Mode` / `Priority` | board → card labels | the project pass |
 | everything else on the board | — | nothing |
 
@@ -176,6 +179,53 @@ actually carries.
 
 ---
 
+## How fast a native move reaches the board
+
+Two paths push a native card's column onto the bound board, and they run the
+**same reflect** — the fast one just gets there first.
+
+| path | latency | what drives it |
+|---|---|---|
+| **projection effect** | seconds | the card move itself, through the durable effect outbox |
+| **reconciliation pass** | up to `sync_every` (default 2m) | the periodic board read |
+
+A `card.moved` on a bound team writes a `projection` row into the same outbox
+the board triggers use, and a worker executes it on the next drain — so the
+roadmap follows a bot within seconds instead of trailing it by up to two
+minutes. The row inherits the outbox's guarantees for free: a leased claim (two
+replicas cannot both push), bounded retries with backoff, and a **visible
+dead-letter** carrying the forge's refusal when the write keeps failing.
+
+Nothing about it is operator-configurable, and nothing needs to be: the row
+exists iff the team has a binding, and it is not a subscription — it carries no
+bot, appears in no `/api/v1/triggers` listing, and cannot be deleted.
+
+Two cases where the fast path deliberately does nothing and lets the pass
+settle it:
+
+- **The board had already moved.** The fast path issues no board read, so it
+  cannot arbitrate "who moved last". It infers the board's state from the
+  column the card *left*: when that column no longer matches what iterion
+  recorded, somebody dragged the card on GitHub since the last pass, and
+  pushing would silently overwrite them. It defers; the pass reads both
+  timestamps and applies the [conflict rule](#conflicts).
+- **The card is not joined to the board yet**, or was last synced against a
+  different one. The import owns the join (it hydrates cards, it never creates
+  them from items), so the reflect waits for it.
+
+A **machine-caused** move — a claim watchdog filing a card in `blocked`, a
+column rename — is reflected like any other. The trigger spine declines those
+events for *launches* (they must not spend LLM budget); a projection starts no
+run, so it is explicitly exempt. Your roadmap shows what actually happened to
+the card.
+
+> Setting `--sync-every 0` leaves the fast path running with **no net under
+> it**: a move the outbox dead-letters, or one made while the binding was
+> misconfigured, then stays diverged until something moves that card again.
+> Keep the pass on unless you have a reason not to.
+
+---
+
 ## Reconciliation
 
 The board pass IS the convergence: it recomputes the truth from the board and
@@ -301,6 +351,14 @@ bound board's columns](#editing-a-bound-boards-columns)); or the credential
 lacks the write grant — `reflect_failed > 0` with a `403 Resource not
 accessible by integration` in the log means the App's *Projects: Read and
 write* is not approved.
+
+**A card moved in iterion and reached GitHub, but only minutes later.**
+The [projection effect](#how-fast-a-native-move-reaches-the-board) declined and
+the pass did the work. The two reasons it declines are both deliberate: the
+board had already moved (the pass arbitrates that with real timestamps), or the
+card is not joined to this board yet. A third possibility is that the fast path
+*failed*: look for the row parked in the effect outbox with the forge's refusal
+on it — the same `403` / permission causes as `reflect_failed` above.
 
 **A card stopped following, and the item is not on the board any more.**
 It is archived. `skipped_archived > 0` in the pass line; un-archive it to put

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
 // lastStatePayload returns the newest EvtIssueState payload for id — the
@@ -1143,6 +1144,11 @@ func TestNativeStore_Conformance(t *testing.T) {
 		t.Fatalf("native.NewStore (adjust-labels): %v", err)
 	}
 	runAdjustLabelsSuite(t, adjust)
+
+	// The effect outbox's twin is trigger.MemoryEffectOutbox (the native
+	// filesystem board carries no outbox), and the effect KIND has to survive
+	// a round trip on it exactly as it does on Mongo.
+	runEffectOutboxKindSuite(t, trigger.NewMemoryEffectOutbox(), "memory-tenant")
 }
 
 // TestMongoStore_Conformance runs the same suite against the Mongo store.
@@ -1192,6 +1198,8 @@ func TestMongoStore_Conformance(t *testing.T) {
 	runOwnedFromSuite(t, boardmongo.New(db, "owned-from-tenant"))
 	runRenewAfterReleaseSuite(t, boardmongo.New(db, "late-renew-tenant"))
 	runAdjustLabelsSuite(t, boardmongo.New(db, "adjust-labels-tenant"))
+	runEffectOutboxKindSuite(t, boardmongo.New(db, "effect-kind-tenant"), "effect-kind-tenant")
+	runLegacyEffectRowSuite(ctx, t, db)
 
 	// The Coordinator's cross-tenant ListEligible must find ready+unclaimed
 	// cards across tenants (verifies the issue.state / issue.claim BSON paths).

--- a/pkg/dispatcher/boardmongo/effect_kind_conformance_test.go
+++ b/pkg/dispatcher/boardmongo/effect_kind_conformance_test.go
@@ -1,0 +1,115 @@
+package boardmongo_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// runEffectOutboxKindSuite pins EffectRow.Kind on BOTH outbox twins.
+//
+// The kind is what the EffectWorker dispatches on: a store that dropped it, or
+// normalized it to the wrong value, would silently run a projection through the
+// launch arm — which loads a subscription that does not exist, retires the row,
+// and leaves the reflect to the periodic pass with nobody the wiser.
+func runEffectOutboxKindSuite(t *testing.T, ob trigger.EffectOutbox, tenant string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	const eventID = "board:b:card:42"
+	launchID := trigger.EffectID(eventID, "sub-kind")
+	projID := trigger.ProjectionEffectID(eventID)
+
+	rows := []trigger.EffectRow{
+		{
+			// No Kind: what a caller (or a replica from before the field)
+			// writes for a launch. It must come back as a launch.
+			ID: launchID, TenantID: tenant, SubID: "sub-kind",
+			Event:     trigger.Event{ID: eventID, Source: trigger.SourceBoard, Kind: trigger.KindCardMoved},
+			CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: projID, TenantID: tenant, Kind: trigger.EffectKindProjection,
+			Event:     trigger.Event{ID: eventID, Source: trigger.SourceBoard, Kind: trigger.KindCardMoved},
+			CreatedAt: now, UpdatedAt: now,
+		},
+	}
+	if err := ob.UpsertPending(ctx, rows); err != nil {
+		t.Fatalf("upsert effect rows: %v", err)
+	}
+	claimed, err := ob.ClaimDue(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("claim due: %v", err)
+	}
+	got := map[string]trigger.EffectRow{}
+	for _, r := range claimed {
+		got[r.ID] = r
+	}
+	if len(got) != 2 {
+		t.Fatalf("claimed %d distinct rows, want 2 (%v)", len(got), got)
+	}
+	if k := got[launchID].EffectKind(); k != trigger.EffectKindLaunch {
+		t.Fatalf("a row upserted with no kind claimed back as %q, want %q — the launch arm would not run it",
+			k, trigger.EffectKindLaunch)
+	}
+	if got[launchID].SubID != "sub-kind" {
+		t.Fatalf("launch row lost its subscription id: %q", got[launchID].SubID)
+	}
+	proj := got[projID]
+	if k := proj.EffectKind(); k != trigger.EffectKindProjection {
+		t.Fatalf("projection row claimed back as %q, want %q — it would execute through the LAUNCH arm",
+			k, trigger.EffectKindProjection)
+	}
+	if !proj.IsProjection() {
+		t.Fatal("IsProjection() false on a claimed projection row")
+	}
+	if proj.SubID != "" {
+		t.Fatalf("projection row carries sub_id %q — a projection is owed to the board binding, never to a subscription", proj.SubID)
+	}
+	// The two kinds are separate rows for the same event: a projection must
+	// not collapse onto a launch row's key (or vice versa) on the upsert.
+	if launchID == projID {
+		t.Fatal("the launch and projection rows of one event share a key")
+	}
+	for _, r := range []trigger.EffectRow{got[launchID], proj} {
+		if err := ob.MarkDone(ctx, r.ID, r.ClaimID); err != nil {
+			t.Fatalf("mark done %s: %v", r.ID, err)
+		}
+	}
+}
+
+// runLegacyEffectRowSuite is the expand half of the rollout, measured against
+// the shape it actually has to survive: a document already IN the collection,
+// written by a replica that predates the discriminator, carrying no `kind`
+// field at all. A raw insert is the only way to produce one — UpsertPending
+// normalizes — and it is exactly what a rolling deploy leaves behind.
+func runLegacyEffectRowSuite(ctx context.Context, t *testing.T, db *mongo.Database) {
+	t.Helper()
+	const tenant = "legacy-kind-tenant"
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if _, err := db.Collection(boardmongo.EffectsCollection).InsertOne(ctx, bson.M{
+		"_id": "board:b:card:legacy|sub-legacy", "tenant_id": tenant, "sub_id": "sub-legacy",
+		"state": trigger.EffectPending, "attempts": 0, "consume_marked": false,
+		"not_before": time.Time{}, "created_at": now, "updated_at": now,
+		"event": bson.M{"_id": "board:b:card:legacy", "source": string(trigger.SourceBoard)},
+	}); err != nil {
+		t.Fatalf("insert a pre-discriminator effect row: %v", err)
+	}
+	claimed, err := boardmongo.New(db, tenant).ClaimDue(ctx, now, 10)
+	if err != nil || len(claimed) != 1 {
+		t.Fatalf("claim the legacy row: n=%d err=%v", len(claimed), err)
+	}
+	if k := claimed[0].EffectKind(); k != trigger.EffectKindLaunch {
+		t.Fatalf("a row with no stored `kind` reads as %q, want %q — the mixed-fleet window would strand every in-flight launch",
+			k, trigger.EffectKindLaunch)
+	}
+	if claimed[0].IsProjection() {
+		t.Fatal("a row with no stored `kind` reads as a projection — it would reach the reflect arm with no binding behind it")
+	}
+}

--- a/pkg/dispatcher/boardmongo/trigger.go
+++ b/pkg/dispatcher/boardmongo/trigger.go
@@ -138,6 +138,12 @@ func (s *Store) UpsertPending(_ context.Context, rows []trigger.EffectRow) error
 		if r.State == "" {
 			r.State = trigger.EffectPending
 		}
+		// Persist an EXPLICIT kind, the way State already is: a blank `kind`
+		// in the collection then means exactly one thing — a row written by a
+		// replica that predates the discriminator, which reads as a launch.
+		if r.Kind == "" {
+			r.Kind = trigger.EffectKindLaunch
+		}
 		models = append(models, mongo.NewUpdateOneModel().
 			SetFilter(bson.M{"_id": r.ID}).
 			SetUpdate(bson.M{"$setOnInsert": r}).

--- a/pkg/server/board_binding_routes.go
+++ b/pkg/server/board_binding_routes.go
@@ -301,6 +301,35 @@ func (s *Server) boardClientForBoundBinding(ctx context.Context, b forge.BoardBi
 	return bc, err
 }
 
+// boardProjection builds the reflect's fast path (the trigger spine's
+// projection effect), or nil when this instance has nothing to reflect onto.
+//
+// It shares the sync worker's resolvers on purpose: the two paths must run the
+// same reflect, through the same credential and the same card store, or "the
+// fast path wrote it" and "the pass would have written it" stop meaning the
+// same thing.
+func (s *Server) boardProjection() *boardProjectionEffect {
+	if s == nil || s.boardBindings == nil || s.cfg.CloudBoardFor == nil {
+		return nil
+	}
+	return &boardProjectionEffect{
+		Bindings:       s.boardBindings,
+		BoardClientFor: s.boardClientForBoundBinding,
+		CardsFor:       s.cloudCardsFor,
+		Logger:         s.logger,
+	}
+}
+
+// cloudCardsFor resolves a tenant's cloud card store — the one resolver the
+// sync worker and the projection effect share.
+func (s *Server) cloudCardsFor(_ context.Context, tenantID string) (native.BoardStore, error) {
+	b := s.cfg.CloudBoardFor(tenantID)
+	if b == nil {
+		return nil, errors.New("no card store for this team")
+	}
+	return b, nil
+}
+
 // startBoardSync launches the periodic reconciliation worker (ADR-097 §10).
 // It needs a binding store AND a per-tenant card store; without either there
 // is nothing to reconcile, and saying so once at boot beats a worker that
@@ -312,14 +341,8 @@ func (s *Server) startBoardSync() {
 	w := &BoardSyncWorker{
 		Bindings:       s.boardBindings,
 		BoardClientFor: s.boardClientForBoundBinding,
-		CardsFor: func(_ context.Context, tenantID string) (native.BoardStore, error) {
-			b := s.cfg.CloudBoardFor(tenantID)
-			if b == nil {
-				return nil, errors.New("no card store for this team")
-			}
-			return b, nil
-		},
-		Logger: s.logger,
+		CardsFor:       s.cloudCardsFor,
+		Logger:         s.logger,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s.boardSyncCancel = cancel

--- a/pkg/server/board_projection_effect.go
+++ b/pkg/server/board_projection_effect.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// The reflect's FAST path (ADR-097 §10's named follow-up).
+//
+// A native card move materializes a `projection` row in the durable effect
+// outbox, and this is what executes it: the card's current column reaches the
+// bound forge board in seconds instead of at the next reconciliation pass —
+// while inheriting the outbox's leased claim, bounded retry and visible
+// dead-letter, none of which a bespoke worker would have had.
+//
+// It calls reflectNativeState, the SAME reflect the pass calls, with the same
+// binding and the same option vocabulary. One implementation, two callers, so
+// the two paths cannot disagree about what "already there" means — and the
+// periodic pass stays the reconciliation net underneath, unchanged.
+
+// boardProjectionEffect answers BOTH trigger seams — "is a projection owed?"
+// and "execute it" — from one type, so a deployment can never materialize
+// projection rows it has no way to execute.
+type boardProjectionEffect struct {
+	// Bindings is the team ⇄ board registry. Required.
+	Bindings forge.BoardBindingStore
+	// BoardClientFor resolves a binding's forge credential into a board
+	// client — the sync worker's resolver, re-asserting ownership at use time.
+	BoardClientFor func(ctx context.Context, b forge.BoardBinding) (forge.BoardClient, error)
+	// CardsFor resolves a tenant's native card store.
+	CardsFor func(ctx context.Context, tenantID string) (native.BoardStore, error)
+	// Now is the clock, injected for tests.
+	Now    func() time.Time
+	Logger *iterlog.Logger
+}
+
+var (
+	_ trigger.ProjectionBindings = (*boardProjectionEffect)(nil)
+	_ trigger.ProjectionEffect   = (*boardProjectionEffect)(nil)
+)
+
+// HasBoardBinding reports whether this tenant has an external board to reflect
+// onto. A tenant with none is not an error — it is most tenants.
+func (p *boardProjectionEffect) HasBoardBinding(ctx context.Context, tenantID string) (bool, error) {
+	if p == nil || p.Bindings == nil || tenantID == "" {
+		return false, nil
+	}
+	switch _, err := p.Bindings.GetByTenant(ctx, tenantID); {
+	case errors.Is(err, forge.ErrBoardBindingNotFound):
+		return false, nil
+	case err != nil:
+		// Surfaced, never swallowed: the cloud tail materializes before
+		// advancing its cursor, so a skipped projection is a reflect only the
+		// periodic pass would ever make good.
+		return false, fmt.Errorf("board projection: read binding for team %s: %w", tenantID, err)
+	}
+	return true, nil
+}
+
+// ReflectCard pushes one card's current column onto the bound board.
+//
+// Error semantics are the outbox's: nil = nothing more is owed (either the
+// reflect wrote, or there was legitimately nothing to write), non-nil = the
+// effect did not happen and the row must retry. That is why a forge refusal
+// returns here where the 300-card pass merely counts it: a pass abandoning one
+// card must not abandon the rest, while a single-card effect owns its own
+// retry budget and a swallowed refusal would retire the row on a board that
+// stayed diverged.
+func (p *boardProjectionEffect) ReflectCard(ctx context.Context, ev trigger.Event) error {
+	if err := p.validate(); err != nil {
+		return err
+	}
+	tenantID, cardID := ev.TenantID, ev.Subject.ID
+	if tenantID == "" || cardID == "" {
+		return fmt.Errorf("board projection: event %s carries team %q and card %q, need both", ev.ID, tenantID, cardID)
+	}
+	binding, err := p.Bindings.GetByTenant(ctx, tenantID)
+	switch {
+	case errors.Is(err, forge.ErrBoardBindingNotFound):
+		return nil // unbound between materialization and execution — the operator's call
+	case err != nil:
+		return fmt.Errorf("board projection: read binding for team %s: %w", tenantID, err)
+	}
+
+	cards, err := p.CardsFor(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("board projection: card store for team %s: %w", tenantID, err)
+	}
+	card, err := cards.Get(cardID)
+	switch {
+	case errors.Is(err, tracker.ErrNotFound) || (err == nil && card == nil):
+		return nil // deleted between the move and the reflect — definitive
+	case err != nil:
+		return fmt.Errorf("board projection: read card %s: %w", cardID, err)
+	}
+	sync, ok := boundProjectSync(card, binding)
+	if !ok {
+		// Either the card has never been joined to this board — the project
+		// import owns the join and never creates a card from an item (§6) — or
+		// it was last synced against a DIFFERENT board, whose item id a write
+		// here would land on. Both are the pass's to settle.
+		return nil
+	}
+	if !p.boardStillHoldsWhatWeRecorded(ev, binding, sync) {
+		return nil
+	}
+
+	bc, err := p.BoardClientFor(ctx, binding)
+	if err != nil {
+		return fmt.Errorf("board projection: board client for team %s: %w", tenantID, err)
+	}
+	// The recorded status IS what the board says, under the precondition
+	// checked just above — which is exactly what the pass passes after
+	// establishing the same fact by reading the board.
+	var res ProjectImportResult
+	opts := &ProjectImportOptions{Binding: &binding, Now: p.Now, Logger: p.Logger}
+	switch reflectNativeState(ctx, bc, card, forge.ProjectItem{ID: sync.ItemID}, &sync, sync.Status, opts, &res) {
+	case reflectFailed:
+		return fmt.Errorf("board projection: the forge refused the status write for card %s on board %s (see the logged reason)", cardID, binding.Ref())
+	case reflectWrote:
+		return p.recordReflected(cards, card, sync)
+	}
+	return nil // already there, unmapped state, or no column for it — all inert
+}
+
+// boardStillHoldsWhatWeRecorded is the precondition reflectNativeState rests
+// on, checked the only way a path that does NOT read the board can check it.
+//
+// The pass establishes "the board still says what iterion last recorded" by
+// reading the item. The fast path cannot, so it reads the column the card
+// LEFT: when that column maps to the recorded status, the two sides agreed
+// right up to this move and the only divergence is the move itself. When it
+// does NOT, someone moved the card on the board since the last pass — and
+// pushing here would silently overwrite them, with no timestamp to arbitrate
+// on. The pass reads both sides and applies §9's conflict rule; leave it to
+// the pass, whose stale record is exactly what makes it re-derive the case.
+//
+// A previous state the map does not carry (`review`, …) is not a divergence:
+// an unmapped state is inert (§2), so the recorded status is still the last
+// true thing the board was told, and the precondition holds.
+func (p *boardProjectionEffect) boardStillHoldsWhatWeRecorded(ev trigger.Event, b forge.BoardBinding, sync native.ExternalProject) bool {
+	from, _ := ev.Payload["from_state"].(string)
+	if from == "" {
+		return true
+	}
+	was, mapped := forge.StatusForState(b.Mapping(), from)
+	if !mapped {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(was), strings.TrimSpace(sync.Status))
+}
+
+// recordReflected persists what the reflect wrote, so the next pass — and the
+// next projection — read "already equal" and do nothing. Without it the board
+// is rewritten on every tick, burning API budget and stamping a fresh
+// updatedAt that then wins every conflict against the operator.
+//
+// It writes ONLY when something changed, for the reason the pass does: an
+// unconditional External write emits an EvtIssueUpdated the trigger spine
+// consumes as `card.updated`, relaunching every label-matching subscription.
+func (p *boardProjectionEffect) recordReflected(cards native.BoardStore, card *native.Issue, sync native.ExternalProject) error {
+	if card.External != nil && card.External.Project.Equal(sync) {
+		return nil
+	}
+	ext := card.External.Clone()
+	if ext == nil {
+		// Unreachable: boundProjectSync already refused a card with no
+		// external ref. Named rather than assumed, so a future caller that
+		// loosens that gate fails loudly instead of writing a naked ref.
+		return fmt.Errorf("board projection: card %s has no external ref to record the reflect on", card.ID)
+	}
+	ext.Project = &sync
+	if _, err := cards.Update(card.ID, native.Patch{External: ext}); err != nil {
+		// The board write LANDED. Failing here re-runs an idempotent reflect
+		// (the option comparison makes the retry a no-op on the forge) and
+		// keeps the record honest, which beats reporting success on a card
+		// whose sync state still names the old column.
+		return fmt.Errorf("board projection: record the reflected status on card %s: %w", card.ID, err)
+	}
+	return nil
+}
+
+// boundProjectSync returns the card's sync state with THIS board, or false
+// when the card is not joined to it.
+func boundProjectSync(card *native.Issue, b forge.BoardBinding) (native.ExternalProject, bool) {
+	if card.External == nil || card.External.Project == nil {
+		return native.ExternalProject{}, false
+	}
+	sync := *card.External.Project
+	if sync.ItemID == "" || !strings.EqualFold(sync.Owner, b.Owner) || sync.Number != b.Number {
+		return native.ExternalProject{}, false
+	}
+	return sync, true
+}
+
+func (p *boardProjectionEffect) validate() error {
+	switch {
+	case p == nil || p.Bindings == nil:
+		return errors.New("board projection: no binding store")
+	case p.BoardClientFor == nil:
+		return errors.New("board projection: no board-client resolver")
+	case p.CardsFor == nil:
+		return errors.New("board projection: no card-store resolver")
+	}
+	return nil
+}

--- a/pkg/server/board_projection_effect_test.go
+++ b/pkg/server/board_projection_effect_test.go
@@ -1,0 +1,348 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// The projection effect is the FAST path of ADR-097 §2's reflect: a native
+// card move rides the durable effect outbox and reaches the bound board in
+// seconds instead of at the next reconciliation pass. It must call the SAME
+// reflect the pass calls — one implementation — and it must leave the board
+// and the card in a state the pass then reads as "nothing to do", in both
+// orders.
+
+func projectionEffectWorld(t *testing.T, bc forge.BoardClient, board native.BoardStore) (*boardProjectionEffect, forge.BoardBindingStore) {
+	t.Helper()
+	binds := forge.NewMemoryBoardBindingStore()
+	if err := binds.Upsert(context.Background(), *testBinding()); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+	return &boardProjectionEffect{
+		Bindings:       binds,
+		BoardClientFor: func(context.Context, forge.BoardBinding) (forge.BoardClient, error) { return bc, nil },
+		CardsFor:       func(context.Context, string) (native.BoardStore, error) { return board, nil },
+	}, binds
+}
+
+// movedCardEvent is the trigger event a `card.moved` on the native board
+// normalizes to, carrying the column the card LEFT.
+func movedCardEvent(cardID, from string) trigger.Event {
+	return trigger.Event{
+		ID: "board:b:" + cardID + ":7", Source: trigger.SourceBoard, Kind: trigger.KindCardMoved,
+		TenantID: "team-a", Subject: trigger.Subject{Type: "card", ID: cardID},
+		Payload: map[string]any{"from_state": from},
+	}
+}
+
+func TestBoardProjection_HasBoardBinding(t *testing.T) {
+	p, _ := projectionEffectWorld(t, &fakeBoardClient{project: testProject()}, newTestBoard(t))
+	ctx := context.Background()
+	if bound, err := p.HasBoardBinding(ctx, "team-a"); err != nil || !bound {
+		t.Fatalf("bound team: %v %v", bound, err)
+	}
+	if bound, err := p.HasBoardBinding(ctx, "team-unbound"); err != nil || bound {
+		t.Fatalf("unbound team: %v %v — a missing binding is not an error", bound, err)
+	}
+	if bound, err := p.HasBoardBinding(ctx, ""); err != nil || bound {
+		t.Fatalf("no tenant: %v %v", bound, err)
+	}
+}
+
+func TestBoardProjection_ReflectsANativeMove(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	// Recorded status "Planned" is what `ready` maps to, so the board and the
+	// card agreed until this move.
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: testProject()}
+	p, _ := projectionEffectWorld(t, bc, board)
+
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	if len(bc.writes) != 1 {
+		t.Fatalf("writes = %+v, want one Status write", bc.writes)
+	}
+	w := bc.writes[0]
+	if w.ProjectID != "PVT_p" || w.ItemID != "PVTI_1" || w.FieldID != "PVTSSF_status" ||
+		w.OptionID != optionID(t, testProject(), "In progress") {
+		t.Fatalf("write = %+v, want the In progress option on PVTI_1", w)
+	}
+	// The card's own column is untouched — the reflect pushes, never pulls.
+	if got := mustGet(t, board, id).State; got != native.StateInProgress {
+		t.Fatalf("card state = %q, want it untouched", got)
+	}
+	// And the recorded status advanced, which is what makes the NEXT pass (and
+	// the next projection) a no-op.
+	if rec := mustGet(t, board, id).External.Project.Status; rec != "In progress" {
+		t.Fatalf("recorded status = %q, want %q — the pass would re-push forever", rec, "In progress")
+	}
+}
+
+// TestBoardProjection_ThenThePassIsANoop is idempotence in the first
+// direction: the fast path landed, so the periodic pass over the same board
+// must write nothing — to the forge OR to the card.
+func TestBoardProjection_ThenThePassIsANoop(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: testProject()}
+	p, _ := projectionEffectWorld(t, bc, board)
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	wrote := mustGet(t, board, id).External.Project.StatusAt
+
+	// The pass now reads the board saying what the projection wrote.
+	bc.pages = [][]forge.ProjectItem{{item("PVTI_1", 613, statusValue("In progress", wrote))}}
+	before := countCardEvents(t, board)
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.Reflected != 0 || res.Moved != 0 || res.Conflicts != 0 {
+		t.Fatalf("the pass after a fast-path reflect = %+v, want a silent no-op", res)
+	}
+	if len(bc.writes) != 1 {
+		t.Fatalf("the pass issued %d writes in total, want the projection's one", len(bc.writes))
+	}
+	if after := countCardEvents(t, board); after != before {
+		t.Fatalf("the pass emitted %d card event(s) — a quiet pass relaunches every label-matching subscription", after-before)
+	}
+}
+
+// TestBoardProjection_AfterThePassIsANoop is idempotence in the other
+// direction: the pass already reflected this move, so the projection row that
+// arrives (or is retried) afterwards must write nothing.
+func TestBoardProjection_AfterThePassIsANoop(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Planned", at)),
+	}}}
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: testBinding()}); err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if len(bc.writes) != 1 {
+		t.Fatalf("the pass should have reflected once, writes=%+v", bc.writes)
+	}
+	p, _ := projectionEffectWorld(t, bc, board)
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	if len(bc.writes) != 1 {
+		t.Fatalf("the projection re-wrote after the pass had already reflected: %+v", bc.writes)
+	}
+}
+
+// TestBoardProjection_DefersWhenTheBoardHadAlreadyMoved is the precondition
+// the fast path cannot verify for itself. reflectNativeState rests on "the
+// board still says what iterion last recorded"; the pass establishes that by
+// READING the board, the projection cannot. What it can check is the column
+// the card LEFT: when that column does not map to the recorded status, the two
+// sides had already diverged, so someone moved the card on the board — and
+// pushing here would silently overwrite them. Only the pass, which reads both
+// timestamps, may arbitrate that.
+func TestBoardProjection_DefersWhenTheBoardHadAlreadyMoved(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	// Recorded "Blocked" while the card was in `ready` (which maps to
+	// "Planned"): the board and the card had already diverged.
+	id := seedSynced(t, board, 613, native.StateInProgress, "Blocked", at)
+	bc := &fakeBoardClient{project: testProject()}
+	p, _ := projectionEffectWorld(t, bc, board)
+
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Fatalf("the projection pushed over a board that had moved: %+v", bc.writes)
+	}
+	if rec := mustGet(t, board, id).External.Project.Status; rec != "Blocked" {
+		t.Fatalf("recorded status = %q, want it left stale so the pass still re-derives the conflict", rec)
+	}
+}
+
+// TestBoardProjection_UnmappedPreviousStateStillReflects: a card leaving a
+// state the map does not carry (`review`, …) never had its column pushed, so
+// the recorded status is still the last true thing the board was told — the
+// precondition holds and the reflect proceeds.
+func TestBoardProjection_UnmappedPreviousStateStillReflects(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: testProject()}
+	p, _ := projectionEffectWorld(t, bc, board)
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, "review")); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	if len(bc.writes) != 1 {
+		t.Fatalf("writes = %+v, want one — an unmapped previous column tells us nothing against the record", bc.writes)
+	}
+}
+
+// TestBoardProjection_BenignDeclines: each of these means "there is nothing to
+// reflect", not "something failed" — the outbox must retire the row rather
+// than retry it five times and dead-letter.
+func TestBoardProjection_BenignDeclines(t *testing.T) {
+	ctx := context.Background()
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+
+	t.Run("card deleted between the move and the reflect", func(t *testing.T) {
+		board := newTestBoard(t)
+		bc := &fakeBoardClient{project: testProject()}
+		p, _ := projectionEffectWorld(t, bc, board)
+		if err := p.ReflectCard(ctx, movedCardEvent("gone", native.StateReady)); err != nil {
+			t.Fatalf("ReflectCard: %v", err)
+		}
+		if len(bc.writes) != 0 {
+			t.Fatalf("writes = %+v", bc.writes)
+		}
+	})
+
+	t.Run("binding removed between materialization and execution", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+		bc := &fakeBoardClient{project: testProject()}
+		p, binds := projectionEffectWorld(t, bc, board)
+		if err := binds.Delete(ctx, "team-a"); err != nil {
+			t.Fatalf("delete binding: %v", err)
+		}
+		if err := p.ReflectCard(ctx, movedCardEvent(id, native.StateReady)); err != nil {
+			t.Fatalf("ReflectCard: %v", err)
+		}
+		if len(bc.writes) != 0 {
+			t.Fatalf("writes = %+v", bc.writes)
+		}
+	})
+
+	t.Run("card never joined to the board", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedCard(t, board, 613, native.StateInProgress)
+		bc := &fakeBoardClient{project: testProject()}
+		p, _ := projectionEffectWorld(t, bc, board)
+		if err := p.ReflectCard(ctx, movedCardEvent(id, native.StateReady)); err != nil {
+			t.Fatalf("ReflectCard: %v", err)
+		}
+		if len(bc.writes) != 0 {
+			t.Fatalf("writes = %+v — the import owns the join (§6), the reflect never creates it", bc.writes)
+		}
+	})
+
+	t.Run("card synced against a different board", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedCard(t, board, 613, native.StateInProgress)
+		if _, err := board.Update(id, native.Patch{External: &native.ExternalRef{
+			Provider: "github", Repo: "SocialGouv/iterion", Number: 613,
+			Project: &native.ExternalProject{Owner: "SocialGouv", Number: 999, ItemID: "PVTI_other", Status: "Planned", StatusAt: at},
+		}}); err != nil {
+			t.Fatalf("seed foreign sync: %v", err)
+		}
+		bc := &fakeBoardClient{project: testProject()}
+		p, _ := projectionEffectWorld(t, bc, board)
+		if err := p.ReflectCard(ctx, movedCardEvent(id, native.StateReady)); err != nil {
+			t.Fatalf("ReflectCard: %v", err)
+		}
+		if len(bc.writes) != 0 {
+			t.Fatalf("writes = %+v — a re-binding must not push onto the previous board's item", bc.writes)
+		}
+	})
+}
+
+// TestBoardProjection_ForgeRefusalIsAnError: the row must RETRY (and
+// eventually dead-letter), which only happens if the refusal reaches the
+// worker. A counted-and-swallowed refusal, which is right for a 300-card pass,
+// is wrong for a single-card effect that owns its own retry budget.
+func TestBoardProjection_ForgeRefusalIsAnError(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
+	bc := &fakeBoardClient{project: testProject(), setErr: errors.New("403 from the forge")}
+	p, _ := projectionEffectWorld(t, bc, board)
+	err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady))
+	if err == nil {
+		t.Fatal("a refused status write returned nil — the outbox would retire the row and the board stays diverged")
+	}
+	// The record must stay stale, exactly as the pass leaves it after a failed
+	// write: that is what makes the retry (and the next pass) try again.
+	if rec := mustGet(t, board, id).External.Project.Status; rec != "Planned" {
+		t.Fatalf("recorded status = %q after a failed write, want it untouched at %q", rec, "Planned")
+	}
+}
+
+// TestBoardProjection_SatisfiesTheTriggerSeams: one type answers both halves,
+// so a deployment can never materialize projection rows it cannot execute.
+func TestBoardProjection_SatisfiesTheTriggerSeams(t *testing.T) {
+	var p any = &boardProjectionEffect{}
+	if _, ok := p.(trigger.ProjectionBindings); !ok {
+		t.Fatal("boardProjectionEffect does not implement trigger.ProjectionBindings")
+	}
+	if _, ok := p.(trigger.ProjectionEffect); !ok {
+		t.Fatal("boardProjectionEffect does not implement trigger.ProjectionEffect")
+	}
+}
+
+// recordingProjection is the wire's oracle: it answers both seams and records
+// what it was asked to reflect.
+type recordingProjection struct {
+	bound map[string]bool
+	cards []string
+}
+
+func (r *recordingProjection) HasBoardBinding(_ context.Context, tenantID string) (bool, error) {
+	return r.bound[tenantID], nil
+}
+
+func (r *recordingProjection) ReflectCard(_ context.Context, ev trigger.Event) error {
+	r.cards = append(r.cards, ev.Subject.ID)
+	return nil
+}
+
+// TestCloudBoardSource_ProjectsACardMove is the WIRE, not the pieces: a card
+// move tailed off board_events must reach the reflect through the outbox on
+// the cloud source's own path — materialize, claim, execute. Without the
+// bindings oracle on the source, every unit above passes and the fast path
+// still never runs in production.
+func TestCloudBoardSource_ProjectsACardMove(t *testing.T) {
+	src, st, subs := newDrainWorld(t)
+	proj := &recordingProjection{bound: map[string]bool{"t1": true}}
+	src.bindings = proj
+	src.eval = trigger.NewEvaluator(subs, trigger.WithProjectionEffect(proj))
+
+	if _, err := src.drainTenant("t1", st); err != nil {
+		t.Fatalf("drainTenant: %v", err)
+	}
+	// Two card moves, each owing one projection row on top of its launch row.
+	if st.upserted != 4 {
+		t.Fatalf("upserted %d rows, want 4 (2 launches + 2 projections)", st.upserted)
+	}
+	w := &trigger.EffectWorker{Outbox: st, Subs: subs, Evaluator: src.eval}
+	w.Tick(context.Background(), 20)
+	if len(proj.cards) != 2 {
+		t.Fatalf("reflected %v, want both cards — the projection is materialized but never executed", proj.cards)
+	}
+}
+
+// TestCloudBoardSource_NoProjectionWithoutABinding: an unbound tenant's moves
+// materialize launch rows only, so a deployment with no board binding pays
+// nothing for this feature.
+func TestCloudBoardSource_NoProjectionWithoutABinding(t *testing.T) {
+	src, st, _ := newDrainWorld(t)
+	src.bindings = &recordingProjection{bound: map[string]bool{}}
+	if _, err := src.drainTenant("t1", st); err != nil {
+		t.Fatalf("drainTenant: %v", err)
+	}
+	if st.upserted != 2 {
+		t.Fatalf("upserted %d rows for an unbound tenant, want 2 launch rows only", st.upserted)
+	}
+}

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -150,7 +150,7 @@ func (s *Server) ListenAndServe() error {
 		s.cloudTriggerCoord = StartCloudTriggerCoordinator(
 			s.cfg.CloudBoardCoordinator, s.cfg.TriggerStore,
 			newServiceLauncher(s.runs, s.logger, s.resolveRunRetryPolicy, s.resolveBotSource),
-			s.cfg.EventsBus, s.logger)
+			s.boardProjection(), s.cfg.EventsBus, s.logger)
 	}
 	// Wire the run-completion source onto the process's single event spine
 	// (the injected EventsBus, which the trigger coordinator also rides

--- a/pkg/server/trigger_cloud.go
+++ b/pkg/server/trigger_cloud.go
@@ -131,7 +131,11 @@ type cloudBoardSource struct {
 	subs    trigger.SubscriptionStore
 	eval    *trigger.Evaluator
 	logger  *iterlog.Logger
-	tick    time.Duration
+	// bindings decides whether a tenant's card move owes its bound external
+	// board a projection row. nil = no board binding store on this instance,
+	// so no projection is ever materialized.
+	bindings trigger.ProjectionBindings
+	tick     time.Duration
 	// ticks counts tickOnce passes (single goroutine) for the slow-cadence
 	// outbox drain.
 	ticks int
@@ -291,7 +295,7 @@ func (s *cloudBoardSource) drainTenant(tenant string, st cloudBoardStore) (bool,
 		if !ok {
 			continue // card deleted between the transition and the read — definitive
 		}
-		evRows, merr := trigger.MaterializeEffects(s.ctx, s.subs, te, now)
+		evRows, merr := trigger.MaterializeEffects(s.ctx, s.subs, s.bindings, te, now)
 		if merr != nil {
 			if s.poisoned(tenant, evt.Seq) {
 				continue

--- a/pkg/server/trigger_cloud.go
+++ b/pkg/server/trigger_cloud.go
@@ -432,7 +432,7 @@ type CloudTriggerCoordinator struct {
 // poll-tail. Returns nil (a no-op, logged) when a prerequisite is missing.
 // The schedule/keepalive kinds stay with cloudsched; forge events stay
 // observational (webhooks remain the launch authority).
-func StartCloudTriggerCoordinator(coord *boardmongo.Coordinator, subs trigger.SubscriptionStore, launcher trigger.Launcher, bus eventbus.Bus, logger *iterlog.Logger) *CloudTriggerCoordinator {
+func StartCloudTriggerCoordinator(coord *boardmongo.Coordinator, subs trigger.SubscriptionStore, launcher trigger.Launcher, projection *boardProjectionEffect, bus eventbus.Bus, logger *iterlog.Logger) *CloudTriggerCoordinator {
 	if coord == nil || subs == nil || bus == nil {
 		return nil
 	}
@@ -444,11 +444,21 @@ func StartCloudTriggerCoordinator(coord *boardmongo.Coordinator, subs trigger.Su
 		return nil
 	}
 	effect := &cloudBoardEffect{coord: coord, logger: logger}
-	eval := trigger.NewEvaluator(subs,
+	evalOpts := []trigger.EvaluatorOption{
 		trigger.WithBoardEffect(effect),
 		trigger.WithLauncher(launcher),
 		trigger.WithLogger(logger),
-	)
+	}
+	// The two halves of the projection travel together — the same value
+	// decides whether a row is owed and executes it — so a deployment can
+	// never materialize projection rows it cannot run. A typed nil would
+	// satisfy both interfaces and defeat that, hence the explicit guard.
+	var bindings trigger.ProjectionBindings
+	if projection != nil {
+		bindings = projection
+		evalOpts = append(evalOpts, trigger.WithProjectionEffect(projection))
+	}
+	eval := trigger.NewEvaluator(subs, evalOpts...)
 	cancelSub, err := bus.Subscribe("trigger-evaluator", trigger.Matcher{}, eval.Handle)
 	if err != nil {
 		if logger != nil {
@@ -458,19 +468,21 @@ func StartCloudTriggerCoordinator(coord *boardmongo.Coordinator, subs trigger.Su
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	src := &cloudBoardSource{
-		coord:   coord,
-		tenants: lister,
-		subs:    subs,
-		eval:    eval,
-		logger:  logger,
-		tick:    cloudBoardTickInterval(),
-		ctx:     ctx,
-		cancel:  cancel,
-		done:    make(chan struct{}),
+		coord:    coord,
+		tenants:  lister,
+		subs:     subs,
+		eval:     eval,
+		logger:   logger,
+		bindings: bindings,
+		tick:     cloudBoardTickInterval(),
+		ctx:      ctx,
+		cancel:   cancel,
+		done:     make(chan struct{}),
 	}
 	go src.run()
 	if logger != nil {
-		logger.Info("server: cloud trigger spine active (board_events poll every %s, durable effect outbox)", src.tick)
+		logger.Info("server: cloud trigger spine active (board_events poll every %s, durable effect outbox, board projection=%v)",
+			src.tick, bindings != nil)
 	}
 	return &CloudTriggerCoordinator{source: src, cancelSub: cancelSub}
 }

--- a/pkg/trigger/effects.go
+++ b/pkg/trigger/effects.go
@@ -141,6 +141,17 @@ func (r EffectRow) EffectKind() string {
 // rather than to a subscription.
 func (r EffectRow) IsProjection() bool { return r.EffectKind() == EffectKindProjection }
 
+// Owner renders what a row is owed TO, for the worker's warnings — which are
+// the only readout a parked row has (nothing lists the outbox). A projection
+// names its kind; anything else names the subscription an operator has to go
+// and look at.
+func (r EffectRow) Owner() string {
+	if r.IsProjection() {
+		return EffectKindProjection
+	}
+	return "sub " + r.SubID
+}
+
 // EffectOutbox is the durable store the source writes and the worker drains.
 // Implemented by boardmongo (cloud) and MemoryEffectOutbox (tests/local).
 type EffectOutbox interface {

--- a/pkg/trigger/effects.go
+++ b/pkg/trigger/effects.go
@@ -45,6 +45,31 @@ const (
 	EffectFailed = "failed"
 )
 
+// Effect kinds — WHAT a row is owed, and therefore which arm executes it.
+//
+// The discriminator ships expand/contract over a durable collection: the ZERO
+// value is EffectKindLaunch, so a row written before the field existed (or by
+// a replica that still predates it, mid-rollout) reads as exactly what it is.
+// Nothing is removed, so there is no contract phase to schedule.
+const (
+	// EffectKindLaunch is ADR-094's original row: one per matched
+	// (board event, subscription) pair, executed as a launch or a board
+	// promote. Read from an ABSENT Kind, which is what makes the rollout
+	// additive.
+	EffectKindLaunch = "launch"
+	// EffectKindProjection is a state PROJECTION owed to the tenant's board
+	// BINDING, not to any subscription — the card's current column pushed
+	// onto the external board it is bound to (ADR-097 §10). It carries no
+	// SubID, spends no budget and starts no run, which is why it is exempt
+	// from the machine-caused decline the launch arm is subject to.
+	EffectKindProjection = "projection"
+)
+
+// projectionRowSuffix keys a projection row. It uses a separator EffectID does
+// not, so no (event, subscription) pair — whatever subscription id an operator
+// ends up with — can address a projection row.
+const projectionRowSuffix = "#projection"
+
 // MaxEffectAttempts bounds execution retries per row before it parks as
 // failed. Backoff is exponential from EffectRetryBase.
 const MaxEffectAttempts = 5
@@ -57,13 +82,22 @@ const EffectRetryBase = 15 * time.Second
 // Generous — an effect is a couple of Mongo writes plus a launch publish.
 const EffectLease = 2 * time.Minute
 
-// EffectRow is one (event, subscription) pair owed an effect execution.
+// EffectRow is one effect execution an event owes: to a matched subscription
+// (EffectKindLaunch) or to the tenant's board binding (EffectKindProjection).
 type EffectRow struct {
 	// ID is EffectID(event, subID) — the idempotency key a duplicate
-	// materialization (two replicas racing the same batch) collapses on.
+	// materialization (two replicas racing the same batch) collapses on. A
+	// projection row uses ProjectionEffectID(event) instead.
 	ID       string `bson:"_id" json:"id"`
 	TenantID string `bson:"tenant_id" json:"tenant_id"`
 	Event    Event  `bson:"event" json:"event"`
+	// Kind selects the executing arm. Empty means EffectKindLaunch — read it
+	// through EffectKind(), never raw, or a row from an older replica routes
+	// nowhere.
+	Kind string `bson:"kind,omitempty" json:"kind,omitempty"`
+	// SubID is the matched subscription, and is EMPTY on a projection row:
+	// there is no subscription behind a projection, which is precisely what
+	// keeps it out of /api/v1/triggers and out of an operator's reach.
 	SubID    string `bson:"sub_id" json:"sub_id"`
 	State    string `bson:"state" json:"state"`
 	Attempts int    `bson:"attempts" json:"attempts"`
@@ -87,6 +121,25 @@ type EffectRow struct {
 // EffectID derives the row key. The event ID already encodes the board event
 // seq (unique per tenant), so (event, sub) is the natural idempotency grain.
 func EffectID(eventID, subID string) string { return eventID + "|" + subID }
+
+// ProjectionEffectID derives a projection row's key. One per event: a
+// projection is owed to the tenant's single board binding, so the event alone
+// is the idempotency grain.
+func ProjectionEffectID(eventID string) string { return eventID + projectionRowSuffix }
+
+// EffectKind normalizes the discriminator. An ABSENT kind is a launch — that
+// is the whole expand half of the rollout, and reading r.Kind raw anywhere
+// else is how a mid-rollout row would route nowhere.
+func (r EffectRow) EffectKind() string {
+	if r.Kind == "" {
+		return EffectKindLaunch
+	}
+	return r.Kind
+}
+
+// IsProjection reports whether the row is owed to the tenant's board binding
+// rather than to a subscription.
+func (r EffectRow) IsProjection() bool { return r.EffectKind() == EffectKindProjection }
 
 // EffectOutbox is the durable store the source writes and the worker drains.
 // Implemented by boardmongo (cloud) and MemoryEffectOutbox (tests/local).

--- a/pkg/trigger/effects_kind_test.go
+++ b/pkg/trigger/effects_kind_test.go
@@ -1,0 +1,87 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestEffectKind_AbsentReadsAsLaunch is the expand half of the expand/contract
+// rollout: every row written before the discriminator existed — and every row
+// a replica that predates it still writes — carries no Kind, and MUST read as
+// a launch. A row that read as anything else would be executed by the wrong
+// arm the moment the new binary claimed it.
+func TestEffectKind_AbsentReadsAsLaunch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		row  EffectRow
+		want string
+	}{
+		{"absent (a row from before the field)", EffectRow{}, EffectKindLaunch},
+		{"explicit launch", EffectRow{Kind: EffectKindLaunch}, EffectKindLaunch},
+		{"projection", EffectRow{Kind: EffectKindProjection}, EffectKindProjection},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.row.EffectKind(); got != tc.want {
+				t.Fatalf("EffectKind() = %q, want %q", got, tc.want)
+			}
+			if got, want := tc.row.IsProjection(), tc.want == EffectKindProjection; got != want {
+				t.Fatalf("IsProjection() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestMemoryEffectOutbox_KindSurvivesAClaim guards the memory twin: the kind is
+// what the worker dispatches on, so a store that dropped it on the round trip
+// would silently run a projection through the launch arm.
+func TestMemoryEffectOutbox_KindSurvivesAClaim(t *testing.T) {
+	ctx := context.Background()
+	ob := NewMemoryEffectOutbox()
+	now := time.Now().UTC()
+	rows := []EffectRow{
+		{ID: "e|sub1", TenantID: "t", SubID: "sub1", CreatedAt: now, UpdatedAt: now},
+		{ID: ProjectionEffectID("e"), TenantID: "t", Kind: EffectKindProjection, CreatedAt: now, UpdatedAt: now},
+	}
+	if err := ob.UpsertPending(ctx, rows); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// A row stored with no kind is NORMALIZED to launch by the store, the way
+	// State already is — so what sits in the store is explicit, and only rows
+	// from an older binary are ever blank.
+	if r, ok := ob.Row("e|sub1"); !ok || r.Kind != EffectKindLaunch {
+		t.Fatalf("stored launch row kind = %q (found=%v), want %q", r.Kind, ok, EffectKindLaunch)
+	}
+	claimed, err := ob.ClaimDue(ctx, now, 10)
+	if err != nil || len(claimed) != 2 {
+		t.Fatalf("claim: n=%d err=%v", len(claimed), err)
+	}
+	kinds := map[string]string{}
+	for _, r := range claimed {
+		kinds[r.ID] = r.EffectKind()
+	}
+	if kinds["e|sub1"] != EffectKindLaunch {
+		t.Fatalf("claimed launch row kind = %q, want %q", kinds["e|sub1"], EffectKindLaunch)
+	}
+	if kinds[ProjectionEffectID("e")] != EffectKindProjection {
+		t.Fatalf("claimed projection row kind = %q, want %q", kinds[ProjectionEffectID("e")], EffectKindProjection)
+	}
+}
+
+// TestProjectionEffectID_CarriesNoSubscriptionID: a projection row is owed to
+// the tenant's board binding, never to a subscription. Its key must not
+// collide with any (event, subscription) pair, and the row must carry an EMPTY
+// SubID — which is what makes it structurally unlistable and undeletable
+// through /api/v1/triggers (a subscription CRUD keyed on a subscription id).
+func TestProjectionEffectID_CarriesNoSubscriptionID(t *testing.T) {
+	const eventID = "board:b:card:7"
+	proj := ProjectionEffectID(eventID)
+	if proj == EffectID(eventID, "") {
+		t.Fatal("the projection row key equals the key of a launch row with an empty sub id — a blank sub id must not address a projection")
+	}
+	for _, sub := range []string{"sub1", "@projection", "projection"} {
+		if got := EffectID(eventID, sub); got == proj {
+			t.Fatalf("subscription %q produces the projection row key %q — a subscription could collide with the projection row", sub, got)
+		}
+	}
+}

--- a/pkg/trigger/effects_memory.go
+++ b/pkg/trigger/effects_memory.go
@@ -29,6 +29,12 @@ func (m *MemoryEffectOutbox) UpsertPending(_ context.Context, rows []EffectRow) 
 		if cp.State == "" {
 			cp.State = EffectPending
 		}
+		// Normalized like State: what this twin stores is always explicit, so
+		// a blank kind in the store can only come from a binary that predates
+		// the field (mirrors boardmongo).
+		if cp.Kind == "" {
+			cp.Kind = EffectKindLaunch
+		}
 		m.rows[cp.ID] = &cp
 	}
 	return nil

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -169,3 +169,127 @@ func TestMaterializeEffects_ProjectionIsNotASubscription(t *testing.T) {
 	}
 }
 
+// stubProjection records the reflects the worker asked for.
+type stubProjection struct {
+	cards []string
+	errs  []error // popped per call; empty → nil
+}
+
+func (s *stubProjection) ReflectCard(_ context.Context, ev Event) error {
+	s.cards = append(s.cards, ev.Subject.ID)
+	if len(s.errs) > 0 {
+		err := s.errs[0]
+		s.errs = s.errs[1:]
+		return err
+	}
+	return nil
+}
+
+// noSubsStore fails any subscription read. A projection row is owed to the
+// tenant's BINDING; consulting the subscription registry for one would be the
+// pseudo-subscription shape coming back in through the worker.
+type noSubsStore struct{ SubscriptionStore }
+
+func (noSubsStore) Get(context.Context, string) (Subscription, error) {
+	return Subscription{}, errors.New("the projection arm must not read the subscription store")
+}
+
+// projectionWorld drives one projection row end to end through the real
+// outbox + worker + evaluator.
+func projectionWorld(t *testing.T, ev Event, proj ProjectionEffect) (*EffectWorker, *MemoryEffectOutbox) {
+	t.Helper()
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore()
+	eval := NewEvaluator(subs, WithProjectionEffect(proj))
+	out := NewMemoryEffectOutbox()
+	rows, err := MaterializeEffects(ctx, subs, &stubBindings{bound: map[string]bool{"t1": true}}, ev, time.Now().UTC())
+	if err != nil || len(rows) != 1 || !rows[0].IsProjection() {
+		t.Fatalf("materialize: rows=%+v err=%v", rows, err)
+	}
+	if err := out.UpsertPending(ctx, rows); err != nil {
+		t.Fatal(err)
+	}
+	return &EffectWorker{Outbox: out, Subs: noSubsStore{subs}, Evaluator: eval}, out
+}
+
+// TestEffectWorker_ProjectionReflectsAndCompletes: the row executes through
+// the projection arm, reaches the reflect with its event, and retires — with
+// the subscription store never consulted.
+func TestEffectWorker_ProjectionReflectsAndCompletes(t *testing.T) {
+	ev := movedEvent()
+	proj := &stubProjection{}
+	w, out := projectionWorld(t, ev, proj)
+	if n := w.Tick(context.Background(), 10); n != 1 {
+		t.Fatalf("tick acted on %d rows, want 1", n)
+	}
+	if len(proj.cards) != 1 || proj.cards[0] != "card1" {
+		t.Fatalf("reflected %v, want [card1]", proj.cards)
+	}
+	row, _ := out.Row(ProjectionEffectID(ev.ID))
+	if row.State != EffectDone {
+		t.Fatalf("projection row state = %q, want %q", row.State, EffectDone)
+	}
+}
+
+// TestEffectWorker_ProjectionIsExemptFromTheMachineDecline is the exemption
+// at its own line: `applyEffect` declines a machine-caused event for every
+// LAUNCH arm, and must not for a projection. A watchdog move that never
+// reaches the external board is the one divergence the reflect exists to
+// prevent.
+func TestEffectWorker_ProjectionIsExemptFromTheMachineDecline(t *testing.T) {
+	ev := movedEvent()
+	ev.Payload = map[string]any{"reason": tracker.ReasonWatchdog}
+	proj := &stubProjection{}
+	w, out := projectionWorld(t, ev, proj)
+	w.Tick(context.Background(), 10)
+	if len(proj.cards) != 1 {
+		t.Fatalf("a machine-caused move reflected %d times, want 1 — the decline leaked into the projection arm", len(proj.cards))
+	}
+	if row, _ := out.Row(ProjectionEffectID(ev.ID)); row.State != EffectDone {
+		t.Fatalf("projection row state = %q, want %q", row.State, EffectDone)
+	}
+}
+
+// TestEffectWorker_ProjectionRetriesThenDeadLetters: the reflect inherits the
+// outbox's bounded retry and visible dead-letter for free — a forge 403 must
+// not vanish, and must not retry forever either.
+func TestEffectWorker_ProjectionRetriesThenDeadLetters(t *testing.T) {
+	ev := movedEvent()
+	boom := errors.New("forge refused the status write")
+	errs := make([]error, MaxEffectAttempts)
+	for i := range errs {
+		errs[i] = boom
+	}
+	proj := &stubProjection{errs: errs}
+	w, out := projectionWorld(t, ev, proj)
+	now := time.Now().UTC()
+	w.Now = func() time.Time { return now }
+	for i := 0; i < MaxEffectAttempts; i++ {
+		w.Tick(context.Background(), 10)
+		now = now.Add(EffectBackoff(MaxEffectAttempts) + time.Second)
+	}
+	row, _ := out.Row(ProjectionEffectID(ev.ID))
+	if row.State != EffectFailed {
+		t.Fatalf("after %d failing attempts the row is %q, want %q (a visible dead-letter)", MaxEffectAttempts, row.State, EffectFailed)
+	}
+	if row.LastError == "" {
+		t.Fatal("dead-lettered projection row carries no last_error — the operator has nothing to read")
+	}
+}
+
+// TestEffectWorker_ProjectionWithNoEffectWiredIsExplicit: a projection row can
+// only exist where a binding does, so an unwired effect is a WIRING bug. It
+// must say so, not retire quietly leaving the board silently unreflected.
+func TestEffectWorker_ProjectionWithNoEffectWiredIsExplicit(t *testing.T) {
+	ev := movedEvent()
+	w, out := projectionWorld(t, ev, nil)
+	w.Tick(context.Background(), 10)
+	row, _ := out.Row(ProjectionEffectID(ev.ID))
+	if row.State == EffectDone {
+		t.Fatal("a projection row with no projection effect wired was retired as done — the reflect is silently lost")
+	}
+	if row.LastError == "" {
+		t.Fatal("no last_error recorded for an unwired projection effect")
+	}
+}
+

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -1,12 +1,15 @@
 package trigger
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
 // stubBindings answers the ONE question the projection arm asks of the forge
@@ -274,6 +277,56 @@ func TestEffectWorker_ProjectionRetriesThenDeadLetters(t *testing.T) {
 	}
 	if row.LastError == "" {
 		t.Fatal("dead-lettered projection row carries no last_error — the operator has nothing to read")
+	}
+}
+
+// TestEffectWorker_DeadLetteredProjectionNamesItself: the worker's warnings
+// are the ONLY readout of a parked row — nothing lists the outbox. A line
+// naming a blank subscription is what an operator would get for every
+// projection, so the row describes itself by kind instead.
+func TestEffectWorker_DeadLetteredProjectionNamesItself(t *testing.T) {
+	ev := movedEvent()
+	errs := make([]error, MaxEffectAttempts)
+	for i := range errs {
+		errs[i] = errors.New("forge refused the status write")
+	}
+	var logs bytes.Buffer
+	w, _ := projectionWorld(t, ev, &stubProjection{errs: errs})
+	w.Logger = iterlog.New(iterlog.LevelWarn, &logs)
+	now := time.Now().UTC()
+	w.Now = func() time.Time { return now }
+	for i := 0; i < MaxEffectAttempts; i++ {
+		w.Tick(context.Background(), 10)
+		now = now.Add(EffectBackoff(MaxEffectAttempts) + time.Second)
+	}
+	out := logs.String()
+	if !strings.Contains(out, EffectKindProjection) {
+		t.Fatalf("the dead-letter warning never names the projection:\n%s", out)
+	}
+	if strings.Contains(out, "sub )") || strings.Contains(out, "sub , ") {
+		t.Fatalf("the warning names a blank subscription for a row that has none:\n%s", out)
+	}
+}
+
+// TestEffectWorker_LaunchWarningStillNamesItsSubscription: the same lines must
+// keep naming the subscription for a launch row — that id is how an operator
+// finds the trigger behind a parked effect.
+func TestEffectWorker_LaunchWarningStillNamesItsSubscription(t *testing.T) {
+	var logs bytes.Buffer
+	l := &stubEffectLauncher{errs: make([]error, MaxEffectAttempts)}
+	for i := range l.errs {
+		l.errs[i] = errors.New("launch refused")
+	}
+	w, _, _ := effectWorld(t, directConsumeSub(), &stubConsumingBoard{consumeLeft: MaxEffectAttempts}, l)
+	w.Logger = iterlog.New(iterlog.LevelWarn, &logs)
+	now := time.Now().UTC()
+	w.Now = func() time.Time { return now }
+	for i := 0; i < MaxEffectAttempts; i++ {
+		w.Tick(context.Background(), 10)
+		now = now.Add(EffectBackoff(MaxEffectAttempts) + time.Second)
+	}
+	if out := logs.String(); !strings.Contains(out, "sub s1") {
+		t.Fatalf("a launch row's warning no longer names its subscription:\n%s", out)
 	}
 }
 

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -17,11 +17,9 @@ import (
 type stubBindings struct {
 	bound map[string]bool
 	err   error
-	calls int
 }
 
 func (s *stubBindings) HasBoardBinding(_ context.Context, tenantID string) (bool, error) {
-	s.calls++
 	if s.err != nil {
 		return false, s.err
 	}
@@ -345,4 +343,3 @@ func TestEffectWorker_ProjectionWithNoEffectWiredIsExplicit(t *testing.T) {
 		t.Fatal("no last_error recorded for an unwired projection effect")
 	}
 }
-

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -1,0 +1,171 @@
+package trigger
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// stubBindings answers the ONE question the projection arm asks of the forge
+// layer: does this tenant have a board binding?
+type stubBindings struct {
+	bound map[string]bool
+	err   error
+	calls int
+}
+
+func (s *stubBindings) HasBoardBinding(_ context.Context, tenantID string) (bool, error) {
+	s.calls++
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.bound[tenantID], nil
+}
+
+func movedEvent() Event {
+	return Event{
+		ID: "board:b:card1:7", Source: SourceBoard, Kind: KindCardMoved,
+		TenantID: "t1", Subject: Subject{Type: "card", ID: "card1", State: "in_progress"},
+		Labels: []string{"triage:auto"}, Payload: map[string]any{"from_state": "ready"},
+	}
+}
+
+func projectionSubs(t *testing.T) SubscriptionStore {
+	t.Helper()
+	subs := NewMemorySubscriptionStore()
+	if err := subs.Create(context.Background(), directConsumeSub()); err != nil {
+		t.Fatal(err)
+	}
+	return subs
+}
+
+// TestMaterializeEffects_ProjectionForABoundTenant: a bound tenant's card move
+// owes a projection row ON TOP OF whatever subscriptions matched — the two are
+// independent, and the projection names no subscription.
+func TestMaterializeEffects_ProjectionForABoundTenant(t *testing.T) {
+	subs := projectionSubs(t)
+	binds := &stubBindings{bound: map[string]bool{"t1": true}}
+	ev := movedEvent()
+	rows, err := MaterializeEffects(context.Background(), subs, binds, ev, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	var proj, launch int
+	for _, r := range rows {
+		if r.IsProjection() {
+			proj++
+			if r.SubID != "" {
+				t.Fatalf("projection row carries sub_id %q", r.SubID)
+			}
+			if r.ID != ProjectionEffectID(ev.ID) {
+				t.Fatalf("projection row id = %q, want %q", r.ID, ProjectionEffectID(ev.ID))
+			}
+			if r.TenantID != "t1" || r.Event.Subject.ID != "card1" {
+				t.Fatalf("projection row lost its tenant/card: %+v", r)
+			}
+			continue
+		}
+		launch++
+	}
+	if proj != 1 || launch != 1 {
+		t.Fatalf("rows: projection=%d launch=%d, want 1 and 1 (%+v)", proj, launch, rows)
+	}
+}
+
+// TestMaterializeEffects_ProjectionOnlyWhereItIsOwED covers the three
+// declines, each for its own reason.
+func TestMaterializeEffects_ProjectionOnlyWhereItIsOwed(t *testing.T) {
+	unmoved := movedEvent()
+	unmoved.Kind = KindCardUpdated
+	noCard := movedEvent()
+	noCard.Subject.ID = ""
+	noTenant := movedEvent()
+	noTenant.TenantID = ""
+
+	for _, tc := range []struct {
+		name  string
+		binds ProjectionBindings
+		ev    Event
+	}{
+		{"tenant with no board binding", &stubBindings{bound: map[string]bool{}}, movedEvent()},
+		{"no bindings oracle wired (local, unbound)", nil, movedEvent()},
+		{"not a state transition", &stubBindings{bound: map[string]bool{"t1": true}}, unmoved},
+		{"no card to reflect", &stubBindings{bound: map[string]bool{"t1": true}}, noCard},
+		{"no tenant to resolve a binding for", &stubBindings{bound: map[string]bool{"": true}}, noTenant},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := MaterializeEffects(context.Background(), projectionSubs(t), tc.binds, tc.ev, time.Now().UTC())
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			for _, r := range rows {
+				if r.IsProjection() {
+					t.Fatalf("a projection row was materialized anyway: %+v", r)
+				}
+			}
+		})
+	}
+}
+
+// TestMaterializeEffects_ProjectionExemptFromTheMachineDecline is the point of
+// the whole exercise: the machine-caused decline guards LAUNCH admission (a
+// column rename must not mass-launch), and a watchdog filing a card in
+// `blocked` is EXACTLY what the external roadmap has to show. The launch rows
+// stay declined; the projection row is owed.
+func TestMaterializeEffects_ProjectionExemptFromTheMachineDecline(t *testing.T) {
+	ev := movedEvent()
+	ev.Payload = map[string]any{"reason": tracker.ReasonWatchdog}
+	if !machineCaused(ev) {
+		t.Fatalf("fixture is not machine-caused — reason %q", ev.Payload["reason"])
+	}
+	rows, err := MaterializeEffects(context.Background(), projectionSubs(t),
+		&stubBindings{bound: map[string]bool{"t1": true}}, ev, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if len(rows) != 1 || !rows[0].IsProjection() {
+		t.Fatalf("machine-caused move materialized %+v, want exactly one projection row and no launch", rows)
+	}
+}
+
+// TestMaterializeEffects_BindingLookupFailureAbortsTheBatch: the cloud tail
+// materializes BEFORE advancing its cursor, so a swallowed store error would
+// silently drop the projection for an event nothing replays. It must surface.
+func TestMaterializeEffects_BindingLookupFailureAbortsTheBatch(t *testing.T) {
+	boom := errors.New("mongo unreachable")
+	rows, err := MaterializeEffects(context.Background(), projectionSubs(t),
+		&stubBindings{err: boom}, movedEvent(), time.Now().UTC())
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want the store failure wrapped — a silent skip loses the reflect for good", err)
+	}
+	if rows != nil {
+		t.Fatalf("rows returned alongside the error: %+v", rows)
+	}
+}
+
+// TestMaterializeEffects_ProjectionIsNotASubscription pins the shape ADR-097
+// §10 rejected: the projection must reach the outbox WITHOUT existing in the
+// subscription registry, so no /api/v1/triggers listing shows it and no
+// operator DELETE can silently kill the reflect.
+func TestMaterializeEffects_ProjectionIsNotASubscription(t *testing.T) {
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore() // deliberately EMPTY
+	rows, err := MaterializeEffects(ctx, subs, &stubBindings{bound: map[string]bool{"t1": true}}, movedEvent(), time.Now().UTC())
+	if err != nil || len(rows) != 1 || !rows[0].IsProjection() {
+		t.Fatalf("materialize with no subscriptions: rows=%+v err=%v, want one projection row", rows, err)
+	}
+	listed, err := subs.ListByTenant(ctx, "t1")
+	if err != nil {
+		t.Fatalf("list subscriptions: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Fatalf("materializing a projection created %d subscription(s) — an operator could delete the reflect", len(listed))
+	}
+	if rows[0].Kind != EffectKindProjection || rows[0].State != EffectPending {
+		t.Fatalf("projection row = %+v, want a pending projection", rows[0])
+	}
+}
+

--- a/pkg/trigger/effects_worker.go
+++ b/pkg/trigger/effects_worker.go
@@ -44,7 +44,7 @@ func (w *EffectWorker) Tick(ctx context.Context, limit int) int {
 		// killed pod) never reaches MarkRetry, so without this check the
 		// MaxEffectAttempts guard would be unreachable for it.
 		if row.Attempts >= MaxEffectAttempts {
-			w.warn("trigger: effect %s (sub %s) reclaimed %d times without completing — parked as dead-letter", row.ID, row.SubID, row.Attempts)
+			w.warn("trigger: effect %s (%s) reclaimed %d times without completing — parked as dead-letter", row.ID, row.Owner(), row.Attempts)
 			if merr := w.Outbox.MarkFailed(ctx, row.ID, row.ClaimID, "reclaimed past the attempt budget without completing"); merr != nil {
 				w.warn("trigger: effect %s failed-write: %v", row.ID, merr)
 			}
@@ -73,16 +73,16 @@ func (w *EffectWorker) executeOne(ctx context.Context, row *EffectRow) {
 	default:
 		attempts := row.Attempts + 1
 		if attempts >= MaxEffectAttempts {
-			w.warn("trigger: effect %s (sub %s, event %s) FAILED after %d attempts — parked as dead-letter: %v",
-				row.ID, row.SubID, row.Event.ID, attempts, err)
+			w.warn("trigger: effect %s (%s, event %s) FAILED after %d attempts — parked as dead-letter: %v",
+				row.ID, row.Owner(), row.Event.ID, attempts, err)
 			if merr := w.Outbox.MarkFailed(ctx, row.ID, row.ClaimID, err.Error()); merr != nil {
 				w.warn("trigger: effect %s failed-write: %v", row.ID, merr)
 			}
 			return
 		}
 		backoff := EffectBackoff(attempts)
-		w.warn("trigger: effect %s (sub %s) attempt %d/%d failed, retrying in %s: %v",
-			row.ID, row.SubID, attempts, MaxEffectAttempts, backoff, err)
+		w.warn("trigger: effect %s (%s) attempt %d/%d failed, retrying in %s: %v",
+			row.ID, row.Owner(), attempts, MaxEffectAttempts, backoff, err)
 		if merr := w.Outbox.MarkRetry(ctx, row.ID, row.ClaimID, attempts, w.now().Add(backoff), err.Error()); merr != nil {
 			w.warn("trigger: effect %s retry-write: %v", row.ID, merr)
 		}

--- a/pkg/trigger/effects_worker.go
+++ b/pkg/trigger/effects_worker.go
@@ -96,6 +96,14 @@ func (w *EffectWorker) executeOne(ctx context.Context, row *EffectRow) {
 // persists "the one-shot is OURS" between the atomic consume and the launch
 // (the pre-outbox shape lost the trigger exactly there).
 func (w *EffectWorker) applyClaimedEffect(ctx context.Context, row *EffectRow) error {
+	if row.IsProjection() {
+		// No subscription to load, re-verify or tenant-check: a projection row
+		// is owed to the tenant's board BINDING. That is also why it can never
+		// be listed or deleted through /api/v1/triggers — it names no
+		// subscription at all. The row's own tenant is on the event, which the
+		// reflect resolves the binding from.
+		return w.Evaluator.applyEffect(ctx, Subscription{}, row.Event, effectOpts{kind: EffectKindProjection})
+	}
 	sub, err := w.Subs.Get(ctx, row.SubID)
 	switch {
 	case errors.Is(err, ErrSubscriptionNotFound):

--- a/pkg/trigger/effects_worker.go
+++ b/pkg/trigger/effects_worker.go
@@ -152,20 +152,54 @@ func (w *EffectWorker) warn(format string, args ...any) {
 	}
 }
 
+// ProjectionBindings answers the ONE question the projection arm asks: does
+// this tenant have an external board bound? Narrow on purpose — pkg/trigger
+// must not learn the forge binding's shape to know that a projection is owed,
+// and the same implementation supplies the ProjectionEffect that executes it,
+// so the pair cannot be half-wired.
+type ProjectionBindings interface {
+	HasBoardBinding(ctx context.Context, tenantID string) (bool, error)
+}
+
 // MaterializeEffects computes the outbox rows one normalized event owes: one
-// row per enabled, matching, non-observational subscription. Shared by the
-// cloud board source (the writer) and tests. now stamps CreatedAt.
-func MaterializeEffects(ctx context.Context, subs SubscriptionStore, ev Event, now time.Time) ([]EffectRow, error) {
+// row per enabled, matching, non-observational subscription, plus — for a card
+// MOVE on a tenant with a bound external board — one projection row. Shared by
+// the cloud board source (the writer) and tests. now stamps CreatedAt.
+//
+// bindings may be nil (a deployment with no board binding at all), in which
+// case no projection row is ever owed.
+func MaterializeEffects(ctx context.Context, subs SubscriptionStore, bindings ProjectionBindings, ev Event, now time.Time) ([]EffectRow, error) {
+	var rows []EffectRow
+	// The projection is computed BEFORE — and outside of —
+	// matchingSubscriptions, deliberately: that prelude declines
+	// machine-caused events to protect the fleet from mass LAUNCHES, and a
+	// watchdog filing a card in `blocked` is exactly what the external
+	// roadmap must show. A projection spends no budget and starts no run.
+	owed, err := projectionOwed(ctx, bindings, ev)
+	if err != nil {
+		return nil, err
+	}
+	if owed {
+		rows = append(rows, EffectRow{
+			ID:        ProjectionEffectID(ev.ID),
+			TenantID:  ev.TenantID,
+			Event:     ev,
+			Kind:      EffectKindProjection,
+			State:     EffectPending,
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+	}
 	matched, err := matchingSubscriptions(ctx, subs, ev)
 	if err != nil {
 		return nil, err
 	}
-	var rows []EffectRow
 	for _, sub := range matched {
 		rows = append(rows, EffectRow{
 			ID:        EffectID(ev.ID, sub.ID),
 			TenantID:  ev.TenantID,
 			Event:     ev,
+			Kind:      EffectKindLaunch,
 			SubID:     sub.ID,
 			State:     EffectPending,
 			CreatedAt: now,
@@ -173,4 +207,22 @@ func MaterializeEffects(ctx context.Context, subs SubscriptionStore, ev Event, n
 		})
 	}
 	return rows, nil
+}
+
+// projectionOwed reports whether this event owes the tenant's bound board a
+// state push. A binding lookup failure is RETURNED, never swallowed: the cloud
+// tail materializes before advancing its cursor, so a skipped projection here
+// is a reflect that only the periodic pass would ever make good.
+func projectionOwed(ctx context.Context, bindings ProjectionBindings, ev Event) (bool, error) {
+	// Only a state transition moves a column, and only a card the reflect can
+	// name, for a tenant a binding can be resolved for.
+	if bindings == nil || ev.Source != SourceBoard || ev.Kind != KindCardMoved ||
+		ev.Subject.ID == "" || ev.TenantID == "" {
+		return false, nil
+	}
+	bound, err := bindings.HasBoardBinding(ctx, ev.TenantID)
+	if err != nil {
+		return false, fmt.Errorf("board binding for tenant %q: %w", ev.TenantID, err)
+	}
+	return bound, nil
 }

--- a/pkg/trigger/effects_worker_test.go
+++ b/pkg/trigger/effects_worker_test.go
@@ -64,7 +64,7 @@ func effectWorld(t *testing.T, sub Subscription, board BoardEffect, l Launcher) 
 		TenantID: "t1", Subject: Subject{Type: "card", ID: "card1"},
 		Labels: []string{"triage:auto"},
 	}
-	rows, err := MaterializeEffects(context.Background(), subs, ev, time.Now().UTC())
+	rows, err := MaterializeEffects(context.Background(), subs, nil, ev, time.Now().UTC())
 	if err != nil || len(rows) != 1 {
 		t.Fatalf("materialize: rows=%d err=%v", len(rows), err)
 	}
@@ -217,13 +217,13 @@ func TestMaterializeEffects_ObservationalAndDisabled(t *testing.T) {
 	sub.Enabled = false
 	_ = subs.Create(context.Background(), sub)
 	ev := Event{ID: "e1", Source: SourceBoard, Kind: KindCardMoved, TenantID: "t1", Labels: []string{"triage:auto"}}
-	if rows, _ := MaterializeEffects(context.Background(), subs, ev, time.Now()); len(rows) != 0 {
+	if rows, _ := MaterializeEffects(context.Background(), subs, nil, ev, time.Now()); len(rows) != 0 {
 		t.Fatal("disabled subscription materialized an effect")
 	}
 	sub.Enabled = true
 	_ = subs.Update(context.Background(), sub)
 	ev.Payload = map[string]any{PayloadLaunchedRunID: "r1"}
-	if rows, _ := MaterializeEffects(context.Background(), subs, ev, time.Now()); len(rows) != 0 {
+	if rows, _ := MaterializeEffects(context.Background(), subs, nil, ev, time.Now()); len(rows) != 0 {
 		t.Fatal("observational (already-launched) event materialized an effect")
 	}
 }

--- a/pkg/trigger/evaluator.go
+++ b/pkg/trigger/evaluator.go
@@ -20,7 +20,19 @@ type Evaluator struct {
 	subs     SubscriptionStore
 	launcher Launcher    // direct mode; nil = direct subs skipped (warn)
 	board    BoardEffect // board mode; nil = board subs skipped (warn)
-	logger   *iterlog.Logger
+	// projection executes EffectKindProjection rows. It has no bus-path
+	// counterpart: a projection is materialized by the outbox writer, never
+	// matched from a subscription.
+	projection ProjectionEffect
+	logger     *iterlog.Logger
+}
+
+// ProjectionEffect pushes a native card's CURRENT state onto the external
+// board its tenant is bound to. Implemented by the server (the reflect lives
+// with the board client and the binding store); nil here means a projection
+// row cannot execute, which is a wiring bug and says so.
+type ProjectionEffect interface {
+	ReflectCard(ctx context.Context, ev Event) error
 }
 
 // EvaluatorOption configures an Evaluator.
@@ -31,6 +43,11 @@ func WithLauncher(l Launcher) EvaluatorOption { return func(e *Evaluator) { e.la
 
 // WithBoardEffect sets the board-mode promote effect.
 func WithBoardEffect(b BoardEffect) EvaluatorOption { return func(e *Evaluator) { e.board = b } }
+
+// WithProjectionEffect sets the reflect executed by EffectKindProjection rows.
+func WithProjectionEffect(p ProjectionEffect) EvaluatorOption {
+	return func(e *Evaluator) { e.projection = p }
+}
 
 // WithLogger sets the leveled logger (nil-safe).
 func WithLogger(l *iterlog.Logger) EvaluatorOption { return func(e *Evaluator) { e.logger = l } }
@@ -103,6 +120,10 @@ func matchingSubscriptions(ctx context.Context, subs SubscriptionStore, ev Event
 // the zero value; the outbox worker threads its persisted consume state
 // through so a retry never re-spends a one-shot.
 type effectOpts struct {
+	// kind selects the arm. The zero value is EffectKindLaunch, matching the
+	// row discriminator's own zero value, so the bus path (which only ever
+	// carries launches) needs no change.
+	kind string
 	// alreadyConsumed skips the one-shot label consume — an outbox retry
 	// whose earlier attempt consumed and persisted the marker.
 	alreadyConsumed bool
@@ -138,6 +159,23 @@ func machineCaused(ev Event) bool {
 // (the bus path warns and moves on, the outbox path retries).
 
 func (e *Evaluator) applyEffect(ctx context.Context, sub Subscription, ev Event, opts effectOpts) error {
+	// The PROJECTION arm, deliberately ahead of the machine-caused decline
+	// below — this is the exemption ADR-097 §10 named, stated at the one line
+	// that grants it rather than left to fall out of the wiring.
+	//
+	// That decline protects LAUNCH admission: a schema migration emits one
+	// event per card, and one run per card is the fan-out it refuses. A
+	// projection starts no run, spends no budget and consumes no one-shot —
+	// it copies a column the native board already holds onto the external
+	// board bound to it. Declining it there would make iterion's OWN moves (a
+	// watchdog filing a card in `blocked`) the only ones the roadmap never
+	// hears about, which is the divergence the reflect exists to close.
+	//
+	// `sub` is the zero value here: a projection is owed to the tenant's board
+	// binding, never to a subscription.
+	if opts.kind == EffectKindProjection {
+		return e.applyProjection(ctx, ev)
+	}
 	// BEFORE the mode switch: a machine-caused event fires NOTHING. A
 	// subscription is written for an operator's (or a bot's) gesture, and
 	// a schema migration emits one event per card in the touched column —
@@ -178,6 +216,25 @@ func (e *Evaluator) applyEffect(ctx context.Context, sub Subscription, ev Event,
 		_, err := e.launcher.Launch(ctx, e.buildPlan(sub, ev))
 		return err
 	}
+}
+
+// applyProjection reflects one card's current state onto the tenant's bound
+// external board, through the SAME reflect the periodic reconciliation pass
+// uses — one implementation, two callers, so the fast path and the net cannot
+// disagree about what "already there" means.
+//
+// Both refusals are errors, not silent successes: a projection row only exists
+// where a binding did at materialization time, so an unwired effect or a
+// card-less event is a defect in the wiring above, and retiring the row would
+// leave the external board diverged with nothing said.
+func (e *Evaluator) applyProjection(ctx context.Context, ev Event) error {
+	if e.projection == nil {
+		return fmt.Errorf("trigger: projection effect for card %q (tenant %q) but no projection effect wired", ev.Subject.ID, ev.TenantID)
+	}
+	if ev.Subject.ID == "" {
+		return fmt.Errorf("trigger: projection effect for event %s carries no card id", ev.ID)
+	}
+	return e.projection.ReflectCard(ctx, ev)
 }
 
 // buildPlan resolves a (subscription, event) pair into a LaunchPlan: the

--- a/pkg/trigger/provenance_wiring_test.go
+++ b/pkg/trigger/provenance_wiring_test.go
@@ -179,7 +179,7 @@ func TestEffectWorker_MachineCausedIsTerminalBenign(t *testing.T) {
 	// machine-caused event materializes ZERO durable rows (a schema
 	// migration is cards x subscriptions of guaranteed no-ops queued
 	// FIFO ahead of the next genuine trigger otherwise).
-	rows, err := MaterializeEffects(context.Background(), subs, ev, time.Now().UTC())
+	rows, err := MaterializeEffects(context.Background(), subs, nil, ev, time.Now().UTC())
 	if err != nil || len(rows) != 0 {
 		t.Fatalf("materialize: rows=%d err=%v — a machine-caused event must not reach the outbox", len(rows), err)
 	}


### PR DESCRIPTION
Closes #746. Refs #613, ADR-097 §10.

## What
`EffectRow.Kind` — `launch` (the zero value; both twins normalize a blank `kind` on write, so a row written by a replica that predates the field reads as a launch) and `projection`. `MaterializeEffects` emits a `projection` row for a `card.moved` board event of a tenant that has a `BoardBinding` — no subscription involved; a projection row never appears in `/api/v1/triggers` and cannot be deleted as if it were one. `applyEffect` gains the projection arm, which calls the SAME reflect code the periodic pass uses and is explicitly exempt from the machine-caused-event decline of the launch-admission prelude (a projection is not a launch — tested as such, not as a side effect). The outbox's leased claim, bounded retry and dead-letter come for free; the 2-minute pass stays the reconciliation net, idempotent both ways (a projection that already landed is a no-op on the next pass, and vice versa — tested).

## Schema / rollout
Expand/contract with a zero-value-compatible discriminator, no version integer (argued in the ADR-097 §10 addendum and ADR-094): the outbox is a store, not a negotiated wire with a compatibility window, and a rejected row has no DLQ replay. An old replica reads a projection row as a launch, fails the subscription lookup, retires the row with a warn, and the periodic pass reflects at the next `sync_every` — it degrades to yesterday's latency, never to a wrong effect, so deploy order is free. The Mongo twin's legacy-row suite inserts a raw pre-discriminator row and asserts it.

## One design call
The pass establishes "the board still says what iterion last recorded" by READING the item; the fast path issues no board read. Rather than push blind (overwriting an operator who dragged the card on GitHub in the window), `boardStillHoldsWhatWeRecorded` checks the column the card LEFT: mapped-and-equal ⇒ the two sides agreed up to this move, push; mapped-and-different ⇒ defer to the pass, leaving the record stale so it re-derives §9's conflict with real timestamps; unmapped ⇒ inert per §2, push.

## Red first (each pasted at the time)
`undefined: EffectKindLaunch` / `unknown field Kind` (7 compile errors); on the Mongo twin with the tag temporarily `bson:"-"`: `projection row claimed back as "launch", want "projection" — it would execute through the LAUNCH arm`; `too many arguments in call to MaterializeEffects` ×4; `undefined: ProjectionEffect`; `upserted 2 rows, want 4 (2 launches + 2 projections)` with the bindings replaced by nil; and the class sweep's catch — a parked projection row's warn rendered a blank subscription (`effect … (sub ) attempt 1/5 failed`) → `EffectRow.Owner()` names what the row is owed to.

Grep of every `EffectRow` reader (writers normalize; dispatchers branch on `IsProjection()` before the subscription load; the three `SubID` warn sites go through `Owner()`). `task check` exit 0; `-race` on pkg/trigger + pkg/server + pkg/forge green; Mongo conformance on a live replica set green (`runEffectOutboxKindSuite` on both twins + the legacy-row suite); no OpenAPI drift.

Noted for review: `HasBoardBinding` is true for any binding, including one whose board has no Status field — such a row materializes and no-ops inside the reflect with one warn (the issue's literal wording kept over a second precondition that would diverge from the pass). Verified against the twins and stubbed forge clients; no live Projects v2 run in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)