### PR TITLE
fix(engine,bots): the engine's script and the judge's report stay out of the judged tree

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4163,7 +4163,9 @@ tool emit_runner:
         # Without this default the very first redirect below writes to an empty
         # filename and the runner dies before reaching the gate. Red, so not a
         # false green -- but an emitted deliverable that cannot run at all.
-        '[ -n "$GM_REPORT_TMP" ] || GM_REPORT_TMP="$GM_WORKSPACE/$GM_DIR/.last-report.json"',
+        # Out of the tree: a report dropped inside the net reads, at the next
+        # gate, as uncommitted work of whoever ran this one.
+        '[ -n "$GM_REPORT_TMP" ] || GM_REPORT_TMP="/tmp/gm-last-report-$$.json"',
         "export GM_DIR GM_WORKSPACE GM_MUTATION_FLOOR GM_REPORT_TMP",
         # The mode comes from the ARGUMENTS and from nothing else. Inherited, it
         # is a way to make this runner green forever WITHOUT touching a line of

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -853,6 +853,14 @@ tool lot_verify:
                         "modernising against it — a green build proves the code "
                         "compiles, never that it still behaves." % verify)
     else:
+        # The gate wrapper writes its report where GM_REPORT_TMP says, and
+        # defaults to a dotfile INSIDE the net. Judged next, that file reads
+        # as uncommitted work of the run — and the finalize banks it as wip,
+        # which a converged lot then never lands over. The report goes to the
+        # run's scratch instead: content of the run, never of the tree.
+        import tempfile
+        scratch = os.environ.get("ITERION_ARTIFACT_FILES_DIR") or tempfile.gettempdir()
+        os.environ.setdefault("GM_REPORT_TMP", os.path.join(scratch, "gm-last-report.json"))
         code, log = run(verify)
         report["oracle_passed"] = code == 0
         if code is None:

--- a/pkg/backend/model/executor_tool.go
+++ b/pkg/backend/model/executor_tool.go
@@ -481,16 +481,29 @@ func (e *ClawExecutor) scriptRecipe(ctx context.Context, node *ir.ToolNode, inpu
 			if interp == "" {
 				return nil, nil, fmt.Errorf("model: tool node %q: unsupported language %q", node.ID, node.Language)
 			}
-			// Temp file lives in the workspace so it is visible from inside the
-			// sandbox bind-mount (e.workDir is the host-side bind source the
-			// container also sees); a basename written there is reachable from
-			// both sides via the same relative path. Removed on success or
-			// failure via the returned cleanup.
+			// The script file must be reachable from where the interpreter
+			// runs. Out of the judged tree whenever a place exists that both
+			// sides see at the same path: the host's temp dir for an
+			// unsandboxed run, the shared state dir for a bind-mount sandbox
+			// that has one. Only a copy-based sandbox, or a bind-mount without
+			// a shared dir, still gets the file in the workspace (basename,
+			// same relative path on both sides, pushed through the write-
+			// through seam below where the driver copies) — a dotfile a gate
+			// that judges the tree's cleanliness would otherwise read as
+			// uncommitted work of the run. Removed on success or failure via
+			// the returned cleanup.
 			wd := e.workDir
 			if wd == "" {
 				wd = "."
 			}
-			tmpFile, err := os.CreateTemp(wd, ".iterion-script-*"+ext)
+			_, copyBased := e.sandbox.(sandbox.WorkspaceFileRefresher)
+			scriptDir, inWorkspace := scriptScratchDir(wd, e.sharedStateDir, e.sandbox != nil && !e.nodeOptsOutOfSandbox(toolNodeOptOut), copyBased)
+			if !inWorkspace {
+				if merr := os.MkdirAll(scriptDir, 0o755); merr != nil {
+					return nil, nil, fmt.Errorf("model: tool node %q: create script scratch dir: %w", node.ID, merr)
+				}
+			}
+			tmpFile, err := os.CreateTemp(scriptDir, ".iterion-script-*"+ext)
 			if err != nil {
 				return nil, nil, fmt.Errorf("model: tool node %q: create temp script: %w", node.ID, err)
 			}
@@ -510,12 +523,18 @@ func (e *ClawExecutor) scriptRecipe(ctx context.Context, node *ir.ToolNode, inpu
 				return nil, nil, fmt.Errorf("model: tool node %q: close temp script: %w", node.ID, cerr)
 			}
 			base := filepath.Base(tmpPath)
+			// Out of the workspace, the interpreter is handed the absolute
+			// path — the same on both sides by construction of the scratch.
+			scriptArg := base
+			if !inWorkspace {
+				scriptArg = tmpPath
+			}
 			// Copy-based sandboxes (kubernetes: workspace tar-copied at
 			// Prepare time) never see a host-side file created mid-run, so
 			// the script must ALSO be pushed through the write-through seam.
 			// The in-pod copy is removed on cleanup — a stray workspace
 			// dotfile would otherwise be swept up by a later `git add -A`.
-			if e.sandbox != nil && !e.nodeOptsOutOfSandbox(toolNodeOptOut) {
+			if inWorkspace && e.sandbox != nil && !e.nodeOptsOutOfSandbox(toolNodeOptOut) {
 				if refresher, ok := e.sandbox.(sandbox.WorkspaceFileRefresher); ok {
 					if rerr := refresher.RefreshWorkspaceFile(ctx, base, []byte(body)); rerr != nil {
 						cleanup()
@@ -531,9 +550,9 @@ func (e *ClawExecutor) scriptRecipe(ctx context.Context, node *ir.ToolNode, inpu
 					}
 				}
 			}
-			// Pass just the basename for the in-sandbox view (the bind mount
-			// uses the same path; portable whether we run via sandbox or host).
-			return e.toolNodeScriptCommand(ctx, interp, base), cleanup, nil
+			// In the workspace, just the basename (the bind mount uses the same
+			// relative path); out of it, the absolute scratch path.
+			return e.toolNodeScriptCommand(ctx, interp, scriptArg), cleanup, nil
 		}
 }
 
@@ -1193,4 +1212,20 @@ func sliceHasComplexElement(s []any) bool {
 func shellEscape(s string) string {
 	// Replace each ' with '\'': end current quote, insert escaped quote, reopen quote.
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// scriptScratchDir decides where a tool node's script file is written, and
+// whether that is inside the judged workspace. The host's temp dir serves an
+// unsandboxed run; a bind-mount sandbox with a shared state dir gets a
+// `scripts` scratch under it, reachable at the same absolute path on both
+// sides; a copy-based sandbox, or a bind-mount without a shared dir, keeps
+// the file in the workspace — the only place both sides then agree on.
+func scriptScratchDir(workDir, sharedStateDir string, sandboxed, copyBased bool) (dir string, inWorkspace bool) {
+	switch {
+	case !sandboxed:
+		return os.TempDir(), false
+	case !copyBased && sharedStateDir != "":
+		return filepath.Join(sharedStateDir, "scripts"), false
+	}
+	return workDir, true
 }

--- a/pkg/backend/model/script_scratch_test.go
+++ b/pkg/backend/model/script_scratch_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A tool node's script is written out of the judged tree wherever both
+// sides can reach it: a gate that judges the tree's cleanliness must never
+// read the engine's own instrument as uncommitted work of the run.
+func TestScriptScratchDir(t *testing.T) {
+	cases := []struct {
+		name           string
+		sharedStateDir string
+		sandboxed      bool
+		copyBased      bool
+		wantDir        string
+		wantInTree     bool
+	}{
+		{"unsandboxed: the host temp dir", "", false, false, os.TempDir(), false},
+		{"bind-mount sandbox with a shared dir: its scripts scratch", "/shared", true, false, filepath.Join("/shared", "scripts"), false},
+		{"bind-mount sandbox without a shared dir: the workspace", "", true, false, "/ws", true},
+		{"copy-based sandbox: the workspace, pushed through the seam", "/shared", true, true, "/ws", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, inTree := scriptScratchDir("/ws", tc.sharedStateDir, tc.sandboxed, tc.copyBased)
+			if dir != tc.wantDir || inTree != tc.wantInTree {
+				t.Fatalf("scriptScratchDir = (%q, %v), want (%q, %v)", dir, inTree, tc.wantDir, tc.wantInTree)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Measured

An extension act by pure addition, correct in content (three new references and their corpus entries, committed by the net's own subbot), was refused by the net's verify: "NOT COMMITTED (3 path(s): .claude/, .golden-master/.last-report.json, .iterion-script-865168252.py)". None of the three is the acting agent's: the tool node's own script, created by the executor at the workspace root so a bind-mount sandbox can see it; the gate wrapper's report, defaulting to a dotfile inside the net; the skills the engine mirrors. The gate that judges the tree's cleanliness read the engine's instrument and the judge's own report as uncommitted work of the run. The finalize then counted the report as run output and banked the tree as a wip commit — which a converged lot never lands over.

## Fix

- **Executor**: the script goes out of the tree wherever both sides can reach it — the host temp dir for an unsandboxed run, a `scripts` scratch under the shared state dir for a bind-mount sandbox that has one — and the interpreter gets the absolute path. A copy-based sandbox, or a bind-mount without a shared dir, keeps the file in the workspace and the write-through as before. `scriptScratchDir` pins the rule.
- **Lot verify** (modernize) sends the gate's report to the run's artifact scratch through `GM_REPORT_TMP`; the wrapper the net materialises (golden-master) defaults to `/tmp/gm-last-report-$$.json` instead of a dotfile inside the net.
- The mirrored skills under `.claude/` are the tree's to ignore, as the finalize's run-output rule already does.

## Proof

- `TestScriptScratchDir`: four placements; mutant (shared dir ignored → workspace) red.
- `go test ./pkg/backend/model/ ./bots/` green (the catalog gates compile both bots); `iterion validate` on both bots; golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
