### PR TITLE
fix(server): a connection older than account_kind learns it before the avatar gate

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -28,7 +28,10 @@ task brand:check   # regenerates into a temp dir and cmp's each copy (part of `t
 task brand:og      # docs/scripts/og-card.html → docs/public/og.png (needs `task test:e2e:ui:install`)
 ```
 
-Change the mascot = replace a master, run `brand:gen` **then `brand:og`**
+`brand:check` runs in `task check`, not in CI (it needs the devbox toolchain,
+like `pi-ext:check`); a toolchain bump (`devbox update`) can change the
+bytes, and the answer is the same as for a master change: regenerate and
+commit. Change the mascot = replace a master, run `brand:gen` **then `brand:og`**
 (the OG card embeds the regenerated docs logo and has no guard of its own),
 commit everything they touched. Never edit a generated copy: `brand:check`
 fails on it, and on a committed copy the script no longer produces. The
@@ -80,9 +83,10 @@ App iterion created there, and the `iterion` OAuth App used for SSO.
 
 ### GitLab group bot accounts already connected (the PIC)
 
-Connections created before this feature carry no `account_kind`. Apply once
-per connection — the server re-reads nothing, it uploads through the sealed
-token:
+A connection created before this feature carries no `account_kind`: the
+first apply asks the forge who the token is (`WhoAmI`), records what it
+learns, and judges the account — a group-token bot user needs no `--force`.
+Apply once per connection; the upload goes through the sealed token:
 
 ```sh
 iterion remote forge connections avatar <conn-id>          # bot user of the GAT

--- a/pkg/forge/transport.go
+++ b/pkg/forge/transport.go
@@ -93,9 +93,10 @@ func StatusErr(errPrefix, op string, code int) error {
 // DoMultipartFile performs one multipart/form-data upload carrying a single
 // file part — the shape GitLab's avatar endpoint takes — with DoJSON's header
 // strategy (the token never rides the URL). Unlike DoJSON it hands the response
-// body back on every status (capped at 8 KiB): an upload refusal names its
-// reason there ("is too big", "content type is invalid"), and the operator
-// needs that verbatim. out (when non-nil, on a 2xx with a body) is JSON-decoded.
+// body back on every status — a refusal's body is capped at 8 KiB and names
+// its reason ("is too big", "content type is invalid"), which the operator
+// needs verbatim; a success is read whole. out (when non-nil, on a 2xx with a
+// body) is JSON-decoded.
 func DoMultipartFile(ctx context.Context, client *http.Client, method, url, errPrefix string, setHeaders func(*http.Request), field, filename, contentType string, data []byte, out any) (int, []byte, error) {
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -131,8 +132,19 @@ func DoMultipartFile(ctx context.Context, client *http.Client, method, url, errP
 		return 0, nil, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-	if out != nil && resp.StatusCode/100 == 2 && len(bytes.TrimSpace(body)) > 0 {
+	if resp.StatusCode/100 != 2 {
+		// A refusal names its reason in the body; the cap keeps a proxy's
+		// error page from becoming the message.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		return resp.StatusCode, body, nil
+	}
+	// A success is decoded whole: capping it would turn an upload that landed
+	// into a decode error on an instance whose answer outgrows the cap.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("%s: read response: %w", errPrefix, err)
+	}
+	if out != nil && len(bytes.TrimSpace(body)) > 0 {
 		if err := json.Unmarshal(body, out); err != nil {
 			return resp.StatusCode, body, fmt.Errorf("%s: decode response: %w", errPrefix, err)
 		}

--- a/pkg/forge/transport_test.go
+++ b/pkg/forge/transport_test.go
@@ -73,3 +73,28 @@ func TestTrimBody_CutsOnARuneBoundary(t *testing.T) {
 		t.Errorf("TrimBody(short) = %q", got)
 	}
 }
+
+// A success is read whole: a GitLab whose answer outgrows a cap must not turn
+// an upload that landed into a decode error stamped on the connection.
+func TestDoMultipartFile_LargeSuccessBodyDecodes(t *testing.T) {
+	pad := strings.Repeat("x", 20<<10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"avatar_url":"https://gl/u.png","padding":"` + pad + `"}`))
+	}))
+	defer srv.Close()
+	var out struct {
+		AvatarURL string `json:"avatar_url"`
+	}
+	code, _, err := DoMultipartFile(context.Background(), srv.Client(), http.MethodPut, srv.URL, "t", nil, "avatar", "a.png", "image/png", []byte("png"), &out)
+	if err != nil || code != http.StatusOK || out.AvatarURL != "https://gl/u.png" {
+		t.Fatalf("code=%d err=%v out=%+v", code, err, out)
+	}
+	refused := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(pad))
+	}))
+	defer refused.Close()
+	if _, body, err := DoMultipartFile(context.Background(), refused.Client(), http.MethodPut, refused.URL, "t", nil, "avatar", "a.png", "image/png", []byte("png"), nil); err != nil || len(body) != 8<<10 {
+		t.Fatalf("a refusal's body is capped at 8 KiB: len=%d err=%v", len(body), err)
+	}
+}

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -46,6 +46,14 @@ func (r *avatarRefusal) Error() string { return r.msg }
 // an operator has to do by hand.
 func brandLogoPath(v brand.Variant) string { return "/brand/" + v.Filename() }
 
+// avatarApplyTimeout bounds one apply — the forge round-trips (a WhoAmI for a
+// connection older than AccountKind, then the upload) and the record. The
+// apply rides its own context, detached from the caller's: the connection
+// exists, so a caller that gives up must not leave its avatar state
+// half-written, and a hanging forge must not hold a connect or a click for
+// longer than this.
+const avatarApplyTimeout = 20 * time.Second
+
 // applyBotAvatar uploads the iterion-bot avatar onto the account behind conn
 // and records the outcome on the connection. The policy is the point:
 //   - an OAuth connection is a person's authorization → refused, no override;
@@ -55,10 +63,12 @@ func brandLogoPath(v brand.Variant) string { return "/brand/" + v.Filename() }
 //     (GitLab group/project tokens, service accounts), or when the operator
 //     forces it for a dedicated account the forge cannot flag (Forgejo).
 //
-// A refusal comes back as *avatarRefusal and persists nothing. A forge-side
-// failure is persisted on AvatarError — so the card can name it and offer a
-// retry — and returned as-is.
-func (s *Server) applyBotAvatar(ctx context.Context, conn forge.Connection, variant brand.Variant, force bool) (forge.Connection, string, error) {
+// A connection older than AccountKind learns it here, from the forge, so the
+// bot gate judges the account and not the field's absence — the kind is
+// recorded either way. A refusal comes back as *avatarRefusal and persists
+// nothing else. A forge-side failure is persisted on AvatarError — so the card
+// can name it and offer a retry — and returned as-is.
+func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, variant brand.Variant, force bool) (forge.Connection, string, error) {
 	switch {
 	case conn.Kind == forge.KindOAuthApp:
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
@@ -70,7 +80,7 @@ func (s *Server) applyBotAvatar(ctx context.Context, conn forge.Connection, vari
 		}
 		msg := "GitHub exposes no API for an account's avatar or an App's logo"
 		if conn.Kind == forge.KindGitHubApp {
-			if u := s.githubAppLogoUploadURL(ctx, conn); u != "" {
+			if u := s.githubAppLogoUploadURL(parent, conn); u != "" {
 				fields["manage_url"] = u
 			}
 			msg += " — upload the logo on the App's settings page (Display information)"
@@ -86,11 +96,9 @@ func (s *Server) applyBotAvatar(ctx context.Context, conn forge.Connection, vari
 		// dressing a reconnect problem as an avatar one.
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("%s rejected this connection's token (status %s) — reconnect it first", conn.Host(), conn.Status)}
-	case conn.AccountKind != forge.AccountKindBot && !force:
-		return conn, "", &avatarRefusal{status: http.StatusConflict,
-			msg:    fmt.Sprintf("%s does not flag @%s as a bot account; if it is a dedicated account for iterion (not a person's), apply with force", conn.Host(), conn.AccountLogin),
-			fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
 	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), avatarApplyTimeout)
+	defer cancel()
 	admin, err := s.forgeAdminFor(ctx, conn)
 	if err != nil {
 		return conn, "", err
@@ -100,23 +108,44 @@ func (s *Server) applyBotAvatar(ctx context.Context, conn forge.Connection, vari
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("%s connections cannot set an avatar through iterion", conn.Provider)}
 	}
-	// The record must outlive the request: the failure worth recording is a
-	// slow forge, i.e. exactly when the caller has already gone away.
-	tctx := store.WithTenant(context.WithoutCancel(ctx), conn.TenantID)
+	tctx := store.WithTenant(ctx, conn.TenantID)
 	// The upload is a forge round-trip, and another writer (the orchestrator
 	// stamping ManagedSecretID on a provision) may touch the document
-	// meanwhile — so the outcome is written onto a FRESH read, carrying only
-	// the avatar fields, never the copy read before the upload.
+	// meanwhile — so every outcome is written onto a FRESH read, carrying only
+	// the avatar fields (and a kind just learned), never the copy read before
+	// the round-trip.
+	learned := ""
 	persist := func(appliedAt *time.Time, avatarErr string) (forge.Connection, error) {
 		fresh, err := s.forgeConnections.Get(tctx, conn.ID)
 		if err != nil {
 			return conn, err
+		}
+		if learned != "" && fresh.AccountKind == "" {
+			fresh.AccountKind = learned
 		}
 		fresh.AvatarAppliedAt, fresh.AvatarError, fresh.UpdatedAt = appliedAt, avatarErr, time.Now().UTC()
 		if err := s.forgeConnections.Update(tctx, fresh); err != nil {
 			return conn, err
 		}
 		return fresh, nil
+	}
+	if conn.AccountKind == "" {
+		// Older than the field: ask the forge who the token is, and remember.
+		ident, err := admin.WhoAmI(ctx)
+		if err != nil {
+			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
+		}
+		conn.AccountKind, learned = ident.Kind, ident.Kind
+	}
+	if conn.AccountKind != forge.AccountKindBot && !force {
+		if learned != "" {
+			if updated, err := persist(conn.AvatarAppliedAt, conn.AvatarError); err == nil {
+				conn = updated
+			}
+		}
+		return conn, "", &avatarRefusal{status: http.StatusConflict,
+			msg:    fmt.Sprintf("%s does not flag @%s as a bot account; if it is a dedicated account for iterion (not a person's), apply with force", conn.Host(), conn.AccountLogin),
+			fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
 	}
 	avatarURL, err := setter.SetAvatar(ctx, brand.BotAvatar(variant))
 	if err != nil {

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -360,9 +360,11 @@ func (c *cancelAwareStore) Update(ctx context.Context, conn forge.Connection) er
 	return c.ConnectionStore.Update(ctx, conn)
 }
 
-// The failure worth recording is a slow forge — exactly when the caller has
-// already gone away. The record must not ride the request context.
-func TestForgeConnectionAvatar_RecordsOnACancelledRequest(t *testing.T) {
+// The apply owns its own context: an operator who closes the tab mid-click
+// gets a finished, recorded apply — never a half state written on a dead
+// request context (Mongo refuses a write on one; the memory store does not,
+// hence the cancel-aware wrapper).
+func TestForgeConnectionAvatar_CompletesOnACancelledRequest(t *testing.T) {
 	s := newForgeTestServer(t)
 	cs := &cancelAwareStore{ConnectionStore: s.forgeConnections}
 	s.forgeConnections = cs
@@ -377,12 +379,50 @@ func TestForgeConnectionAvatar_RecordsOnACancelledRequest(t *testing.T) {
 	r.SetPathValue("conn_id", "c-cancel")
 	w := httptest.NewRecorder()
 	s.handleForgeConnectionAvatar(w, r)
-	if w.Code != http.StatusBadGateway {
+	if w.Code != http.StatusOK {
 		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
 	}
 	stored, _ := s.forgeConnections.Get(context.Background(), "c-cancel")
-	if !strings.Contains(stored.AvatarError, "context canceled") || cs.updates != 1 {
-		t.Fatalf("the failure was not recorded: avatar_error=%q updates=%d", stored.AvatarError, cs.updates)
+	if stored.AvatarAppliedAt == nil || stored.AvatarError != "" || cs.updates != 1 || gl.count() != 1 {
+		t.Fatalf("not completed and recorded: applied_at=%v error=%q updates=%d uploads=%d", stored.AvatarAppliedAt, stored.AvatarError, cs.updates, gl.count())
+	}
+}
+
+// A connection older than AccountKind (the PIC group-token connections)
+// learns it from the forge on its first apply: a bot user needs no force, a
+// person still does — and what was learned is recorded either way.
+func TestForgeConnectionAvatar_LegacyConnectionLearnsItsKind(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		bot      bool
+		wantCode int
+		wantKind string
+	}{
+		{"group-token bot user", true, http.StatusOK, forge.AccountKindBot},
+		{"a person's PAT", false, http.StatusConflict, forge.AccountKindUser},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newForgeTestServer(t)
+			gl := &mockGitLabAvatar{bot: tc.bot}
+			srv := gl.server()
+			defer srv.Close()
+			seedAvatarConn(t, s, forge.Connection{ID: "c-legacy", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1026_bot_a7c08cc4", ForgeBaseURL: srv.URL}) // AccountKind empty
+
+			w := avatarReq(s, "c-legacy", "")
+			if w.Code != tc.wantCode {
+				t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+			}
+			stored, _ := s.forgeConnections.Get(context.Background(), "c-legacy")
+			if stored.AccountKind != tc.wantKind {
+				t.Errorf("account_kind = %q, want %q recorded from WhoAmI", stored.AccountKind, tc.wantKind)
+			}
+			if tc.bot && (stored.AvatarAppliedAt == nil || gl.count() != 1) {
+				t.Errorf("bot user not applied: applied_at=%v uploads=%d", stored.AvatarAppliedAt, gl.count())
+			}
+			if !tc.bot && gl.count() != 0 {
+				t.Error("a person's account was uploaded onto")
+			}
+		})
 	}
 }
 

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"crypto/subtle"
 	"errors"
 	"net/http"
@@ -33,10 +32,6 @@ type forgeConnectReq struct {
 	// team's single app for that host.
 	OAuthAppID string `json:"oauth_app_id,omitempty"`
 }
-
-// connectAvatarTimeout bounds the connect-time avatar upload onto a bot
-// identity: the connect must answer even when the forge crawls.
-const connectAvatarTimeout = 20 * time.Second
 
 type forgeConnectResp struct {
 	Connection   *forge.Connection `json:"connection,omitempty"`
@@ -157,14 +152,10 @@ func (s *Server) connectForgePAT(w http.ResponseWriter, r *http.Request, teamID,
 		// account exists for iterion (a group/project token created for it),
 		// and every comment it will post is signed by that avatar. A failure
 		// is recorded on the connection (AvatarError) and never fails the
-		// connect — the studio names it and offers a retry. The upload rides
-		// its own bounded context: the connection already exists, so a client
-		// that gives up must not leave its avatar state half-written, and a
-		// hanging forge must not hold the connect for the HTTP client's full
-		// timeout.
-		actx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), connectAvatarTimeout)
-		updated, _, err := s.applyBotAvatar(actx, conn, brand.VariantPlain, false)
-		cancel()
+		// connect — the studio names it and offers a retry. The apply owns a
+		// bounded context of its own, so a slow forge cannot hold the connect
+		// past avatarApplyTimeout.
+		updated, _, err := s.applyBotAvatar(r.Context(), conn, brand.VariantPlain, false)
 		if err != nil && s.logger != nil {
 			s.logger.Warn("forge connect: iterion-bot avatar not applied on @%s (%s): %v", conn.AccountLogin, conn.Host(), err)
 		}


### PR DESCRIPTION
Follow-up to #794, from Revi's gate verdict there (medium `Rbd14ad`) and its open questions (answered on #794).

- **`account_kind` backfill** — a connection created before the field (the PIC group-token connections) learns it from the forge on its first apply (`WhoAmI`) and records it: a group-token bot user needs no `--force`, a person's PAT still does. The runbook's non-forced command is now true for the population it describes.
- **One bounded, detached context per apply** — upload + record ride `context.WithoutCancel` + a 20 s deadline, owned by `applyBotAvatar`: an operator who closes the tab mid-click gets a finished, recorded apply; the connect path drops its own wrapper.
- **Whole 2xx decode on multipart uploads** — the 8 KiB cap stays on refusals only, so an instance whose success answer outgrows it cannot turn a landed avatar into a decode error stamped on the connection.

Tests: legacy connection learns its kind (bot → 200 + recorded, person → 409 + recorded), completes on a cancelled request, large 2xx body decodes / refusal body capped. Go suites of the touched packages + golangci-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
