### PR TITLE
fix(runtime): the loop budget guard's warning says its rule

### DIFF
--- a/pkg/runtime/edges.go
+++ b/pkg/runtime/edges.go
@@ -108,26 +108,10 @@ func (e *Engine) evaluateEdgesWithLoopsRS(fromNodeID, logPrefix string, output m
 				// hands the run to its exit path with the work it banked,
 				// where dying mid-iteration on the hard cap would strand it.
 				if v := e.loopBudgetShortfall(edge.LoopName, rs); v != nil {
-					spent, remaining, used, limit, unit := v.display()
+					spent, remaining, _, _, unit := v.display()
 					e.logger.Warn("%s: node %q: edge to %q skipped — loop %q cannot fund another iteration (%s: %.2f%s left, last one took %.2f%s), falling through to the exit path",
 						logPrefix, fromNodeID, edge.To, edge.LoopName, v.dimension, remaining, unitSuffix(unit), spent, unitSuffix(unit))
-					data := map[string]any{
-						"loop": edge.LoopName, "reason": "loop_budget_guard",
-						"dimension": v.dimension, "remaining": remaining, "needed": spent,
-						// used/limit are what every other budget_warning
-						// carries — the run report and the alert manager
-						// render the axis from them.
-						"used": used, "limit": limit,
-						// The rule itself, so a reader with more remaining than
-						// needed is not left guessing why the edge was declined:
-						// the next iteration would land at or past the threshold
-						// where the engine refuses to start any node.
-						"threshold": v.threshold(), "would_reach": used + spent,
-					}
-					if unit != "" {
-						data["unit"] = unit
-					}
-					if err := e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, fromNodeID, data); err != nil {
+					if err := e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, fromNodeID, v.eventData(edge.LoopName)); err != nil {
 						e.logger.Warn("failed to emit loop_budget_guard warning: %v", err)
 					}
 					continue

--- a/pkg/runtime/edges.go
+++ b/pkg/runtime/edges.go
@@ -118,6 +118,11 @@ func (e *Engine) evaluateEdgesWithLoopsRS(fromNodeID, logPrefix string, output m
 						// carries — the run report and the alert manager
 						// render the axis from them.
 						"used": used, "limit": limit,
+						// The rule itself, so a reader with more remaining than
+						// needed is not left guessing why the edge was declined:
+						// the next iteration would land at or past the threshold
+						// where the engine refuses to start any node.
+						"threshold": v.threshold(), "would_reach": used + spent,
 					}
 					if unit != "" {
 						data["unit"] = unit

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -146,10 +146,25 @@ func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) *loopBudgetV
 	return nil
 }
 
-// threshold is the consumption at which the engine refuses to start a node
-// on this dimension — the line the next iteration must not reach.
-func (v *loopBudgetVerdict) threshold() float64 {
-	return budgetHardThreshold * v.limit
+// eventData is the budget_warning payload of a declined back-edge, every
+// figure in the axis's operator units (seconds on the duration axis, the
+// axis's own unit elsewhere) — used/limit as every other budget_warning
+// carries them, and the rule itself: the next iteration would reach
+// would_reach, at or past threshold (the hard-limit share of the limit),
+// which is where the engine refuses to start any node. A reader with more
+// remaining than needed is not left guessing why the loop stopped.
+func (v loopBudgetVerdict) eventData(loopName string) map[string]any {
+	spent, remaining, used, limit, unit := v.display()
+	data := map[string]any{
+		"loop": loopName, "reason": "loop_budget_guard",
+		"dimension": v.dimension, "remaining": remaining, "needed": spent,
+		"used": used, "limit": limit,
+		"threshold": budgetHardThreshold * limit, "would_reach": used + spent,
+	}
+	if unit != "" {
+		data["unit"] = unit
+	}
+	return data
 }
 
 // markLoopBudget re-bases a loop's price on the run's consumption right

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -146,6 +146,12 @@ func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) *loopBudgetV
 	return nil
 }
 
+// threshold is the consumption at which the engine refuses to start a node
+// on this dimension — the line the next iteration must not reach.
+func (v *loopBudgetVerdict) threshold() float64 {
+	return budgetHardThreshold * v.limit
+}
+
 // markLoopBudget re-bases a loop's price on the run's consumption right
 // now. Called when the loop is ENTERED from outside (so its first
 // crossing prices its first iteration, not the whole run that preceded

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -651,3 +651,33 @@ func TestRestoreCheckpointBudget_LegacyMarksOfALateLoopAreDropped(t *testing.T) 
 		})
 	}
 }
+
+// TestLoopBudgetGuard_EventSaysItsRule: the budget_warning a declined
+// back-edge emits carries the threshold and the consumption the next
+// iteration would reach, so a reader with more remaining than needed is
+// not left guessing why the loop stopped.
+func TestLoopBudgetGuard_EventSaysItsRule(t *testing.T) {
+	wf := campaignShapedWorkflow(10_000)
+	exec, _, _ := costingExecutor(3_000)
+	st := tmpStore(t)
+	eng := New(wf, st, exec)
+	if err := eng.Run(context.Background(), "rule", nil); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	evs, err := st.LoadEvents(context.Background(), "rule")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range evs {
+		if ev.Type != store.EventBudgetWarning || ev.Data["reason"] != "loop_budget_guard" {
+			continue
+		}
+		thr, _ := ev.Data["threshold"].(float64)
+		reach, _ := ev.Data["would_reach"].(float64)
+		if thr != 9_000 || reach < thr {
+			t.Fatalf("event = %v: want threshold 9000 (90%% of 10000) and would_reach ≥ threshold", ev.Data)
+		}
+		return
+	}
+	t.Fatal("no loop_budget_guard warning was emitted")
+}

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -680,4 +681,32 @@ func TestLoopBudgetGuard_EventSaysItsRule(t *testing.T) {
 		return
 	}
 	t.Fatal("no loop_budget_guard warning was emitted")
+}
+
+// TestLoopBudgetVerdict_EventDataInOperatorUnits: the rule the event states
+// is in the same units as the figures it compares — seconds on the
+// duration axis, where the verdict itself is in nanoseconds. Measured on a
+// production run: used 13 156 s + needed 13 154 s = 26 310 s ≥ 25 920 s
+// (90 % of 28 800 s), with 15 644 s remaining.
+func TestLoopBudgetVerdict_EventDataInOperatorUnits(t *testing.T) {
+	s := float64(time.Second)
+	v := loopBudgetVerdict{dimension: "duration", spent: 13153.7 * s, remaining: 15644.2 * s, used: 13155.8 * s, limit: 28800 * s}
+	data := v.eventData("repair_loop")
+	if data["unit"] != "seconds" || data["limit"] != 28800.0 {
+		t.Fatalf("event = %v: want limit 28800 seconds", data)
+	}
+	if thr := data["threshold"].(float64); thr != 25920 {
+		t.Fatalf("threshold = %v, want 25920 (90%% of 28800 s, in seconds)", thr)
+	}
+	if reach := data["would_reach"].(float64); reach < 26309 || reach > 26310 {
+		t.Fatalf("would_reach = %v, want 13155.8 + 13153.7 = 26309.5 s", reach)
+	}
+	if data["would_reach"].(float64) < data["threshold"].(float64) {
+		t.Fatal("the declined edge's event must show would_reach ≥ threshold")
+	}
+	plain := loopBudgetVerdict{dimension: "tokens", spent: 3000, remaining: 2000, used: 8000, limit: 10000}
+	pd := plain.eventData("continuation")
+	if _, hasUnit := pd["unit"]; hasUnit || pd["threshold"] != 9000.0 || pd["would_reach"] != 11000.0 {
+		t.Fatalf("tokens event = %v: want threshold 9000, would_reach 11000, no unit", pd)
+	}
 }


### PR DESCRIPTION
A declined back-edge emitted `budget_warning {remaining, needed, used, limit}`; on a run with more remaining than needed it did not say why the loop stopped. The rule: the next iteration would land at or past the 90 % threshold where the engine refuses to start any node — `remaining > needed` does not contradict it. Measured on a production run whose repair loop was declined with remaining 15 644 s and needed 13 154 s: used 13 156 + needed 13 154 = 26 310 ≥ 25 920 (90 % of 28 800).

The event now carries `threshold` and `would_reach`, so a reader sees the comparison the guard made.

## Second round

Review found the threshold computed from the raw limit — nanoseconds on the duration axis while every sibling figure is in seconds — so the motivating case would have read `threshold: 2.592e+13` against `would_reach: 26310`. The payload is now built by one method, `loopBudgetVerdict.eventData`, from the display-converted figures on every axis; the duration axis is tested with the production figures (threshold 25 920 s, would_reach 26 309.5 s, unit seconds) beside the tokens axis (9 000 / 11 000, no unit). Mutant (threshold from the raw limit): red on the duration case.

Proof: `TestLoopBudgetVerdict_EventDataInOperatorUnits`, `TestLoopBudgetGuard_EventSaysItsRule`; golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)