### PR TITLE
feat(chart): a priorityClassName for the server and runner Deployments

### DIFF
--- a/charts/iterion/templates/runner-deployment.yaml
+++ b/charts/iterion/templates/runner-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "iterion.serviceAccountName" . }}
+      {{- with .Values.runner.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml (default .Values.securityContext .Values.runner.podSecurityContext) | nindent 8 }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/iterion/templates/server-deployment.yaml
+++ b/charts/iterion/templates/server-deployment.yaml
@@ -37,6 +37,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "iterion.serviceAccountName" . }}
+      {{- with .Values.server.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/iterion/values.yaml
+++ b/charts/iterion/values.yaml
@@ -68,6 +68,10 @@ server:
       cpu: 1000m
       memory: 1Gi
   podAnnotations: {}
+  # PriorityClass of the server pods (empty = the cluster default). Give the
+  # platform pods a class ABOVE the run pods: a sandboxed run that bursts is
+  # then preempted before the server or a runner is.
+  priorityClassName: ""
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -105,6 +109,10 @@ runner:
   # only. The devbox runner image runs as uid 1000 (Nix store owned by `devbox`),
   # so set runAsUser/runAsGroup/fsGroup: 1000 when using it. Empty = inherit the
   # shared context.
+  # PriorityClass of the runner pods (empty = the cluster default). Same
+  # rule as server.priorityClassName: the runner outranks the run pods it
+  # starts, so a bursting sandbox never evicts the process that owns its run.
+  priorityClassName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
   # Prometheus metrics port for the runner. Defaults to the same


### PR DESCRIPTION
Refs #732 (the operator's decision: PriorityClass `resource-burstable` on the platform Deployments, a memory limit — no CPU limit — on the run pods; the limit half is a values change already live in prod).

The chart's server and runner Deployments had no `priorityClassName`, so a sandboxed run pod bursting on a node committed at 95–99 % of its requests was a scheduling/eviction peer of the runner that owns its run (and of the server). `server.priorityClassName` and `runner.priorityClassName` (default `""` = the cluster default) render `priorityClassName` on the PodTemplate; the run pods stay unclassed (priority 0), so a burst is preempted before the platform is.

Rendered check: `helm template … --set server.priorityClassName=resource-burstable --set runner.priorityClassName=resource-burstable` emits the field on both Deployments; the default render emits none. `helm lint` clean. After the next chart release, prod sets both values to `resource-burstable` (infra-apps chart bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)