### PR TITLE
fix(server): the avatar record rides its own budget, not the round-trips' deadline

### DIFF
--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -46,13 +46,18 @@ func (r *avatarRefusal) Error() string { return r.msg }
 // an operator has to do by hand.
 func brandLogoPath(v brand.Variant) string { return "/brand/" + v.Filename() }
 
-// avatarApplyTimeout bounds one apply — the forge round-trips (a WhoAmI for a
-// connection older than AccountKind, then the upload) and the record. The
-// apply rides its own context, detached from the caller's: the connection
-// exists, so a caller that gives up must not leave its avatar state
-// half-written, and a hanging forge must not hold a connect or a click for
-// longer than this.
-const avatarApplyTimeout = 20 * time.Second
+// avatarApplyTimeout bounds one apply's forge round-trips (a WhoAmI for a
+// connection older than AccountKind, then the upload). The apply rides its
+// own context, detached from the caller's: the connection exists, so a caller
+// that gives up must not leave its avatar state half-written, and a hanging
+// forge must not hold a connect or a click for longer than this. A variable
+// so a test can shorten it against a forge that hangs.
+var avatarApplyTimeout = 20 * time.Second
+
+// avatarRecordTimeout bounds one write of the outcome onto the connection —
+// on a budget of its OWN: the failure worth recording is a slow forge, i.e.
+// exactly when the round-trips' deadline has expired.
+const avatarRecordTimeout = 10 * time.Second
 
 // applyBotAvatar uploads the iterion-bot avatar onto the account behind conn
 // and records the outcome on the connection. The policy is the point:
@@ -108,38 +113,49 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("%s connections cannot set an avatar through iterion", conn.Provider)}
 	}
-	tctx := store.WithTenant(ctx, conn.TenantID)
 	// The upload is a forge round-trip, and another writer (the orchestrator
 	// stamping ManagedSecretID on a provision) may touch the document
-	// meanwhile — so every outcome is written onto a FRESH read, carrying only
-	// the avatar fields (and a kind just learned), never the copy read before
-	// the round-trip.
+	// meanwhile — so every outcome is written onto a FRESH read, on a record
+	// budget independent of the round-trips' deadline, carrying only what this
+	// apply learned: the account kind, and — when asked — the avatar fields.
 	learned := ""
-	persist := func(appliedAt *time.Time, avatarErr string) (forge.Connection, error) {
-		fresh, err := s.forgeConnections.Get(tctx, conn.ID)
+	record := func(mutate func(*forge.Connection)) (forge.Connection, error) {
+		rctx, cancel := context.WithTimeout(context.WithoutCancel(parent), avatarRecordTimeout)
+		defer cancel()
+		rctx = store.WithTenant(rctx, conn.TenantID)
+		fresh, err := s.forgeConnections.Get(rctx, conn.ID)
 		if err != nil {
 			return conn, err
 		}
 		if learned != "" && fresh.AccountKind == "" {
 			fresh.AccountKind = learned
 		}
-		fresh.AvatarAppliedAt, fresh.AvatarError, fresh.UpdatedAt = appliedAt, avatarErr, time.Now().UTC()
-		if err := s.forgeConnections.Update(tctx, fresh); err != nil {
+		mutate(&fresh)
+		fresh.UpdatedAt = time.Now().UTC()
+		if err := s.forgeConnections.Update(rctx, fresh); err != nil {
 			return conn, err
 		}
 		return fresh, nil
 	}
+	persist := func(appliedAt *time.Time, avatarErr string) (forge.Connection, error) {
+		return record(func(c *forge.Connection) { c.AvatarAppliedAt, c.AvatarError = appliedAt, avatarErr })
+	}
 	if conn.AccountKind == "" {
 		// Older than the field: ask the forge who the token is, and remember.
+		// A forced apply is the operator vouching for the account — it does
+		// not hang on /user being readable.
 		ident, err := admin.WhoAmI(ctx)
-		if err != nil {
+		switch {
+		case err == nil:
+			conn.AccountKind, learned = ident.Kind, ident.Kind
+		case !force:
 			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
 		}
-		conn.AccountKind, learned = ident.Kind, ident.Kind
 	}
 	if conn.AccountKind != forge.AccountKindBot && !force {
 		if learned != "" {
-			if updated, err := persist(conn.AvatarAppliedAt, conn.AvatarError); err == nil {
+			// Remember the kind only; the avatar fields are the fresh document's.
+			if updated, err := record(func(*forge.Connection) {}); err == nil {
 				conn = updated
 			}
 		}

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -464,3 +464,71 @@ func TestForgeConnect_AutoApplyIsAudited(t *testing.T) {
 		t.Fatalf("audit trail = %+v", events)
 	}
 }
+
+// A forge that hangs past the apply's deadline is the failure worth
+// recording; the record rides its own budget, so the reason lands on the
+// connection even though the round-trips' context has expired.
+func TestForgeConnectionAvatar_RecordsWhenTheForgeHangs(t *testing.T) {
+	s := newForgeTestServer(t)
+	cs := &cancelAwareStore{ConnectionStore: s.forgeConnections}
+	s.forgeConnections = cs
+	release := make(chan struct{})
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		// Drain the body first: with an unread body the server never starts
+		// the background read that would notice the client hanging up.
+		_, _ = io.Copy(io.Discard, r.Body)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()    // runs last: the handler must be released first
+	defer close(release) // runs first (LIFO), so Close never waits on the handler
+	seedAvatarConn(t, s, forge.Connection{ID: "c-hang", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1_bot_x", AccountKind: forge.AccountKindBot, ForgeBaseURL: srv.URL})
+
+	old := avatarApplyTimeout
+	avatarApplyTimeout = 200 * time.Millisecond
+	defer func() { avatarApplyTimeout = old }()
+
+	w := avatarReq(s, "c-hang", "")
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-hang")
+	if !strings.Contains(stored.AvatarError, "deadline exceeded") || cs.updates != 1 {
+		t.Fatalf("the timeout was not recorded: avatar_error=%q updates=%d", stored.AvatarError, cs.updates)
+	}
+}
+
+// A 409 on a legacy connection records the learned kind and nothing else: the
+// avatar fields stay whatever the fresh document holds.
+func TestForgeConnectionAvatar_RefusalRecordsOnlyTheKind(t *testing.T) {
+	s := newForgeTestServer(t)
+	gl := &mockGitLabAvatar{bot: false}
+	srv := gl.server()
+	defer srv.Close()
+	then := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	seedAvatarConn(t, s, forge.Connection{ID: "c-legacy2", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "iterion-bot", ForgeBaseURL: srv.URL, AvatarAppliedAt: &then, AvatarError: "kept as is"})
+	if w := avatarReq(s, "c-legacy2", ""); w.Code != http.StatusConflict {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-legacy2")
+	if stored.AccountKind != forge.AccountKindUser || stored.AvatarAppliedAt == nil || !stored.AvatarAppliedAt.Equal(then) || stored.AvatarError != "kept as is" {
+		t.Fatalf("refusal rewrote more than the kind: %+v", stored)
+	}
+	// Forced, with a forge whose /user is unreadable: the operator's word
+	// carries the apply, and the kind stays unknown rather than fatal.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"avatar_url": "https://gl/u.png"})
+	})
+	noUser := httptest.NewServer(mux)
+	defer noUser.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-nouser", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: noUser.URL})
+	if w := avatarReq(s, "c-nouser", `{"force":true}`); w.Code != http.StatusOK {
+		t.Fatalf("forced apply with an unreadable /user: code=%d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -254,6 +254,9 @@ function AvatarRow({
       await applyForgeConnectionAvatar(teamID, conn.id, { force });
       onChanged();
     } catch (e) {
+      // A refusal still taught the server something (the account's kind, a
+      // forge error kept on the record): refetch, then show the reason.
+      onChanged();
       onError(errorMessage(e));
     } finally {
       setBusy(false);


### PR DESCRIPTION
Follow-up to #800, from Revi's gate verdict there (`R8b0bd7`, medium — a regression of #800's own change) and its open questions (answered on #800).

- **The record rides its own budget** — #800 gave the apply one bounded context, which put the outcome record under the upload's 20 s deadline: a forge that hangs (the failure worth recording) expired it first and nothing was recorded; an upload landing near the deadline answered 502 for a live avatar. The record now takes a 10 s budget of its own, detached from the round-trips. Test: a forge that hangs past a shortened apply deadline still leaves its reason on the connection.
- **A 409 on a legacy connection records the learned kind only** — the avatar fields stay the fresh document's, never the copy read before the WhoAmI round-trip.
- **A forced apply no longer hangs on `/user`** — the operator's word carries it; the kind stays unknown when the forge cannot say.
- **The card refetches after a refusal** — it shows the learned kind, and a second click does not pay another WhoAmI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
