### PR TITLE
fix(server): a forced avatar apply bails when /user never answers; the card vouches only on a 409

### DIFF
--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -46,13 +46,21 @@ func (r *avatarRefusal) Error() string { return r.msg }
 // an operator has to do by hand.
 func brandLogoPath(v brand.Variant) string { return "/brand/" + v.Filename() }
 
-// avatarApplyTimeout bounds one apply's forge round-trips (a WhoAmI for a
-// connection older than AccountKind, then the upload). The apply rides its
-// own context, detached from the caller's: the connection exists, so a caller
-// that gives up must not leave its avatar state half-written, and a hanging
-// forge must not hold a connect or a click for longer than this. A variable
-// so a test can shorten it against a forge that hangs.
-var avatarApplyTimeout = 20 * time.Second
+// defaultAvatarApplyTimeout bounds one apply's forge round-trips (a WhoAmI
+// for a connection older than AccountKind, then the upload). The apply rides
+// its own context, detached from the caller's: the connection exists, so a
+// caller that gives up must not leave its avatar state half-written, and a
+// hanging forge must not hold a connect or a click for longer than this.
+// Server.avatarApplyTimeout overrides it (a test shortens it against a forge
+// that hangs).
+const defaultAvatarApplyTimeout = 20 * time.Second
+
+func (s *Server) avatarApplyDeadline() time.Duration {
+	if s.avatarApplyTimeout > 0 {
+		return s.avatarApplyTimeout
+	}
+	return defaultAvatarApplyTimeout
+}
 
 // avatarRecordTimeout bounds one write of the outcome onto the connection —
 // on a budget of its OWN: the failure worth recording is a slow forge, i.e.
@@ -102,7 +110,7 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("%s rejected this connection's token (status %s) — reconnect it first", conn.Host(), conn.Status)}
 	}
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), avatarApplyTimeout)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), s.avatarApplyDeadline())
 	defer cancel()
 	admin, err := s.forgeAdminFor(ctx, conn)
 	if err != nil {
@@ -143,12 +151,14 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 	if conn.AccountKind == "" {
 		// Older than the field: ask the forge who the token is, and remember.
 		// A forced apply is the operator vouching for the account — it does
-		// not hang on /user being readable.
+		// not hang on /user REFUSING to answer. A /user that does not answer
+		// at all has spent the apply's budget: the upload would only fail on
+		// the dead context and stamp a misleading reason on the connection.
 		ident, err := admin.WhoAmI(ctx)
 		switch {
 		case err == nil:
 			conn.AccountKind, learned = ident.Kind, ident.Kind
-		case !force:
+		case !force || ctx.Err() != nil:
 			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
 		}
 	}

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -488,9 +488,7 @@ func TestForgeConnectionAvatar_RecordsWhenTheForgeHangs(t *testing.T) {
 	defer close(release) // runs first (LIFO), so Close never waits on the handler
 	seedAvatarConn(t, s, forge.Connection{ID: "c-hang", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1_bot_x", AccountKind: forge.AccountKindBot, ForgeBaseURL: srv.URL})
 
-	old := avatarApplyTimeout
-	avatarApplyTimeout = 200 * time.Millisecond
-	defer func() { avatarApplyTimeout = old }()
+	s.avatarApplyTimeout = 200 * time.Millisecond
 
 	w := avatarReq(s, "c-hang", "")
 	if w.Code != http.StatusBadGateway {
@@ -530,5 +528,39 @@ func TestForgeConnectionAvatar_RefusalRecordsOnlyTheKind(t *testing.T) {
 	seedAvatarConn(t, s, forge.Connection{ID: "c-nouser", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: noUser.URL})
 	if w := avatarReq(s, "c-nouser", `{"force":true}`); w.Code != http.StatusOK {
 		t.Fatalf("forced apply with an unreadable /user: code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// A forced apply vouches for the account, but a /user that never answers has
+// spent the apply's budget: bail with the accurate reason and record nothing —
+// never an upload on a dead context that would blame the avatar.
+func TestForgeConnectionAvatar_ForcedApplyBailsWhenWhoAmIHangs(t *testing.T) {
+	s := newForgeTestServer(t)
+	release := make(chan struct{})
+	uploads := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	})
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		uploads++
+		_ = json.NewEncoder(w).Encode(map[string]any{"avatar_url": "https://gl/u.png"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer close(release)
+	seedAvatarConn(t, s, forge.Connection{ID: "c-slow-user", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL}) // AccountKind empty
+	s.avatarApplyTimeout = 200 * time.Millisecond
+
+	w := avatarReq(s, "c-slow-user", `{"force":true}`)
+	if w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "could not read the account") {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-slow-user")
+	if uploads != 0 || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("uploaded on a dead context or recorded a misleading reason: uploads=%d error=%q applied=%v", uploads, stored.AvatarError, stored.AvatarAppliedAt)
 	}
 }

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -152,9 +152,9 @@ func (s *Server) connectForgePAT(w http.ResponseWriter, r *http.Request, teamID,
 		// account exists for iterion (a group/project token created for it),
 		// and every comment it will post is signed by that avatar. A failure
 		// is recorded on the connection (AvatarError) and never fails the
-		// connect — the studio names it and offers a retry. The apply owns a
-		// bounded context of its own, so a slow forge cannot hold the connect
-		// past avatarApplyTimeout.
+		// connect — the studio names it and offers a retry. The apply owns
+		// bounded contexts of its own, so a slow forge cannot hold the connect
+		// past the apply budget plus the record's (20 s + 10 s).
 		updated, _, err := s.applyBotAvatar(r.Context(), conn, brand.VariantPlain, false)
 		if err != nil && s.logger != nil {
 			s.logger.Warn("forge connect: iterion-bot avatar not applied on @%s (%s): %v", conn.AccountLogin, conn.Host(), err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -171,6 +171,8 @@ type Server struct {
 	credPoolLeases  credpool.LeaseStore
 	credPoolLedger  credpool.Ledger
 	auditStore      audit.Store
+	// avatarApplyTimeout overrides defaultAvatarApplyTimeout when > 0 (tests).
+	avatarApplyTimeout time.Duration
 	// usageCapSettings + usageCapSource are the platform runtime-settings
 	// store and its TTL-cached resolver (nil in env-only deployments):
 	// the admin settings routes mutate the former, /healthz and the

--- a/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
+++ b/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/api/bots", async () => {
   return { ...actual, listBots: vi.fn(async () => []) };
 });
 
+import { ApiError } from "@/api/client";
 import * as forgeApi from "@/api/forgeConnections";
 import IntegrationsTab from "../IntegrationsTab";
 
@@ -129,6 +130,37 @@ describe("ConnectionCard — iterion-bot avatar", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
     await waitFor(() =>
       expect(forgeApi.applyForgeConnectionAvatar).toHaveBeenCalledWith("t1", "c1", { force: false }),
+    );
+  });
+
+  it("refetches AND keeps the reason when the apply fails", async () => {
+    vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: "bot" })]);
+    vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
+      new ApiError(502, "gitlab: avatar rejected (HTTP 400): boom"),
+    );
+    renderTab();
+    const before = vi.mocked(forgeApi.listForgeConnections).mock.calls.length;
+    fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
+    await screen.findByText(/avatar rejected \(HTTP 400\): boom/);
+    await waitFor(() =>
+      expect(vi.mocked(forgeApi.listForgeConnections).mock.calls.length).toBeGreaterThan(before),
+    );
+  });
+
+  it("tries an account of unknown kind as-is, and vouches only on a 409", async () => {
+    vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: undefined })]);
+    vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
+      new ApiError(409, "gitlab.example.com does not flag @group_1_bot_x as a bot account"),
+    );
+    renderTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
+    await waitFor(() =>
+      expect(forgeApi.applyForgeConnectionAvatar).toHaveBeenNthCalledWith(1, "t1", "c1", { force: false }),
+    );
+    // The 409 asks for the operator's word; confirming vouches with force.
+    fireEvent.click(await screen.findByRole("button", { name: "Apply the avatar" }));
+    await waitFor(() =>
+      expect(forgeApi.applyForgeConnectionAvatar).toHaveBeenNthCalledWith(2, "t1", "c1", { force: true }),
     );
   });
 

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -1,6 +1,8 @@
 import { errorMessage } from "@/lib/errorHints";
 import { useState } from "react";
 
+import { ApiError } from "@/api/client";
+
 import { Link } from "wouter";
 
 import type { BotEntryWithSchema } from "@/api/bots";
@@ -231,22 +233,34 @@ function AvatarRow({
   }
 
   const isBot = conn.account_kind === "bot";
+  const vouch = () =>
+    confirm({
+      title: "Rebrand this account?",
+      message: (
+        <span>
+          {conn.forge_base_url ?? conn.provider} does not flag{" "}
+          <span className="font-mono">@{conn.account_login}</span> as a bot. Apply the
+          iterion-bot avatar only if this is a dedicated account for iterion — never a
+          person&apos;s.
+        </span>
+      ),
+      confirmLabel: "Apply the avatar",
+    });
+  // A refusal still taught the server something (the account's kind, a forge
+  // error kept on the record): refetch, then show the reason. onChanged clears
+  // the banner synchronously and onError re-sets it in the same batch — keep
+  // this order.
+  const fail = (e: unknown) => {
+    onChanged();
+    onError(errorMessage(e));
+  };
   const apply = async () => {
+    // A known non-bot account needs the operator's word up front. An account
+    // of UNKNOWN kind (a connection older than the field) is tried as-is: the
+    // server learns the kind from the forge and only a 409 asks for the word.
     let force = false;
-    if (!isBot) {
-      const ok = await confirm({
-        title: "Rebrand this account?",
-        message: (
-          <span>
-            {conn.forge_base_url ?? conn.provider} does not flag{" "}
-            <span className="font-mono">@{conn.account_login}</span> as a bot. Apply the
-            iterion-bot avatar only if this is a dedicated account for iterion — never a
-            person&apos;s.
-          </span>
-        ),
-        confirmLabel: "Apply the avatar",
-      });
-      if (!ok) return;
+    if (conn.account_kind && !isBot) {
+      if (!(await vouch())) return;
       force = true;
     }
     setBusy(true);
@@ -254,10 +268,20 @@ function AvatarRow({
       await applyForgeConnectionAvatar(teamID, conn.id, { force });
       onChanged();
     } catch (e) {
-      // A refusal still taught the server something (the account's kind, a
-      // forge error kept on the record): refetch, then show the reason.
-      onChanged();
-      onError(errorMessage(e));
+      if (!force && e instanceof ApiError && e.status === 409) {
+        if (!(await vouch())) {
+          onChanged(); // the server recorded the learned kind
+          return;
+        }
+        try {
+          await applyForgeConnectionAvatar(teamID, conn.id, { force: true });
+          onChanged();
+        } catch (e2) {
+          fail(e2);
+        }
+        return;
+      }
+      fail(e);
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
Follow-up to #803 — the two medium findings Revi left on it, plus the two open questions its verdict raised.

**R77fadf — a forced apply swallowed a dead context.** Under `force`, a `WhoAmI` failure caused by the apply deadline was tolerated and the upload then went out on an already-expired context, persisting a misleading `avatar_error` ("context deadline exceeded" on the upload) where the exact "could not read the account behind connection …" used to surface with nothing written. `applyBotAvatar` now only tolerates a *real* refusal from the forge: when `ctx.Err() != nil` it bails even under `force`, naming the identity, and records nothing. Test: `/user` hangs + `force:true` → 502, connection untouched.

**R4a0ce8 — the refetch-after-failure had no test.** `IntegrationsTab.oauthApps.test.tsx` now rejects `applyForgeConnectionAvatar` and asserts both that `listForgeConnections` is called again and that the reason stays rendered.

**Two follow-ups from the same verdict.**
- The card no longer forces by default on an account of unknown kind: it tries as-is (so the connection learns its `account_kind` from the backfill), and only on a `409 needs_force` asks the operator to vouch, then retries forced. Tested (409 → vouch → force).
- `avatarApplyTimeout` moved from a package `var` mutated by a test to a `Server` field (`s.avatarApplyDeadline()`, zero = 20 s default), so `-race` / `t.Parallel()` cannot trip on it. The connect-time comment now states the true worst case (apply budget + record budget = 20 s + 10 s).

Evidence: full `pkg/server` suite, `golangci-lint`, and the studio lint/typecheck green on the branch (`TEST_EXIT=0`, `0 issues`, `STUDIO_OK`); the avatar suites + the 11-test studio spec green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)