### PR TITLE
fix(runner): an IR this runner cannot load is a verdict on the run, acked — not eight silent redeliveries to the DLQ

### DIFF
--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/SocialGouv/iterion/pkg/internal/appinfo"
 	"io"
 	"os"
 	"path/filepath"
@@ -697,6 +698,22 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 			level:       logWarn,
 			logFmt:      "runner: run %s: the sandbox could not be placed (resumable) — re-offered in %s (%v)",
 			logArgs:     []any{runID, sandboxCapacityNakDelay, execErr},
+		}
+	}
+	// The IR does not load on this runner (a server ahead of the fleet):
+	// deterministic here, so Ack — a redelivery reaches the same runner
+	// image and the same verdict, eight times, then the DLQ park overwrites
+	// the diagnosis with DLQ_PARKED. The run is failed_resumable with
+	// IR_UNLOADABLE (failUnloadableIR); the resume after the fleet is
+	// aligned re-compiles on the server.
+	if errors.Is(execErr, ErrIRUnloadable) {
+		return execOutcome{
+			finalStatus: "ir_unloadable",
+			op:          "ack-ir-unloadable",
+			action:      actionAck,
+			level:       logError,
+			logFmt:      "runner: run %s: the IR the server compiled does not load on this runner (%s) — failed_resumable, NOT redelivered: align the runner with the server, then resume (%v)",
+			logArgs:     []any{runID, appinfo.Version, execErr},
 		}
 	}
 	// Operator cancel: terminal cancelled, acked (redelivery drops it).
@@ -1827,6 +1844,9 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 
 	wf, err := loadWorkflow(ctx, msg, store.AsIRBlobStore(r.cfg.Store))
 	if err != nil {
+		if errors.Is(err, ErrIRUnloadable) {
+			r.failUnloadableIR(ctx, msg, err)
+		}
 		return err
 	}
 
@@ -2280,13 +2300,60 @@ func loadWorkflow(ctx context.Context, msg *queue.RunMessage, blobs store.IRBlob
 	}
 	file, err := ast.UnmarshalFile(raw)
 	if err != nil {
-		return nil, fmt.Errorf("runner: decode IR: %w", err)
+		return nil, fmt.Errorf("runner: %w: decode IR: %v", ErrIRUnloadable, err)
 	}
 	cr := ir.Compile(file)
 	if cr.HasErrors() {
-		return nil, fmt.Errorf("runner: compile IR: %d diagnostic(s)", len(cr.Diagnostics))
+		return nil, fmt.Errorf("runner: %w: compile IR: %d diagnostic(s): %s", ErrIRUnloadable, len(cr.Diagnostics), summariseDiagnostics(cr.Diagnostics))
 	}
 	return cr.Workflow, nil
+}
+
+// ErrIRUnloadable marks a RunMessage whose compiled IR this runner cannot
+// decode or compile — the shape a server ahead of the runner produces. It
+// is deterministic for this runner, so the delivery is acked, not naked:
+// redelivering it burns the delivery budget on the same verdict and parks
+// it on the DLQ with the diagnosis overwritten, which is how five runs died
+// mute on a five-release server/runner skew.
+var ErrIRUnloadable = errors.New("the IR does not load on this runner")
+
+// summariseDiagnostics keeps the first few compiler messages for a verdict
+// an operator can read on the run, without the whole list.
+func summariseDiagnostics(diags []ir.Diagnostic) string {
+	parts := make([]string, 0, 3)
+	for i, d := range diags {
+		if i == 3 {
+			parts = append(parts, fmt.Sprintf("… (%d more)", len(diags)-3))
+			break
+		}
+		parts = append(parts, fmt.Sprintf("%s %s", d.Code, d.Message))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// failUnloadableIR writes the verdict a mute runner never wrote: the run
+// goes failed_resumable with a typed code — resumable, because a resume
+// after the fleet is aligned re-compiles the source on the server — and a
+// run_failed event carries the runner's version beside the workflow hash,
+// so the skew is readable from the run alone.
+func (r *Runner) failUnloadableIR(ctx context.Context, msg *queue.RunMessage, cause error) {
+	wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
+	if err := r.cfg.Store.FailRunResumable(idCtx, msg.RunID, nil, cause.Error(), store.FailureCode("IR_UNLOADABLE")); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not record the unloadable IR: %v", msg.RunID, err)
+	}
+	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
+		Type: store.EventRunFailed,
+		Data: map[string]any{
+			"code": "IR_UNLOADABLE", "error": cause.Error(),
+			"runner_version": appinfo.Version, "runner_commit": appinfo.Commit,
+			"workflow_hash": msg.WorkflowHash,
+			"hint":          "the IR was compiled by a server this runner cannot follow; align the runner with the server, then resume",
+		},
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_failed for the unloadable IR: %v", msg.RunID, err)
+	}
 }
 
 // applyBudgetOverrides folds launch-time budget overrides from the queue

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2304,7 +2304,8 @@ func loadWorkflow(ctx context.Context, msg *queue.RunMessage, blobs store.IRBlob
 	}
 	cr := ir.Compile(file)
 	if cr.HasErrors() {
-		return nil, fmt.Errorf("runner: %w: compile IR: %d diagnostic(s): %s", ErrIRUnloadable, len(cr.Diagnostics), summariseDiagnostics(cr.Diagnostics))
+		errs := compileErrors(cr.Diagnostics)
+		return nil, fmt.Errorf("runner: %w: compile IR: %d error(s): %s", ErrIRUnloadable, len(errs), summariseDiagnostics(errs))
 	}
 	return cr.Workflow, nil
 }
@@ -2316,6 +2317,19 @@ func loadWorkflow(ctx context.Context, msg *queue.RunMessage, blobs store.IRBlob
 // it on the DLQ with the diagnosis overwritten, which is how five runs died
 // mute on a five-release server/runner skew.
 var ErrIRUnloadable = errors.New("the IR does not load on this runner")
+
+// compileErrors keeps the diagnostics that blocked the load: the compiler
+// appends warnings and errors in compile order, so an unfiltered head of
+// the list can be three warnings while the error sits further down.
+func compileErrors(diags []ir.Diagnostic) []ir.Diagnostic {
+	errs := make([]ir.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		if d.Severity == ir.SeverityError {
+			errs = append(errs, d)
+		}
+	}
+	return errs
+}
 
 // summariseDiagnostics keeps the first few compiler messages for a verdict
 // an operator can read on the run, without the whole list.
@@ -2340,13 +2354,23 @@ func (r *Runner) failUnloadableIR(ctx context.Context, msg *queue.RunMessage, ca
 	wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parkStoreOpTimeout)
 	defer cancel()
 	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
-	if err := r.cfg.Store.FailRunResumable(idCtx, msg.RunID, nil, cause.Error(), store.FailureCode("IR_UNLOADABLE")); err != nil {
+	// UpdateRunOutcome, not FailRunResumable: the latter assigns the
+	// checkpoint it is handed, and a resume delivery that lands on a stale
+	// image carries a checkpoint worth every node already paid for — a nil
+	// there would erase the anchor the aligned fleet resumes from. The
+	// expected set keeps the cancelled-wins guard: a run the operator
+	// cancelled meanwhile is not flipped back.
+	if changed, err := r.cfg.Store.UpdateRunOutcome(idCtx, msg.RunID, store.RunStatusFailedResumable, cause.Error(),
+		store.RunOutcomeMeta{Code: store.FailureIRUnloadable, Continuation: store.ContinuationFinal},
+		store.RunnerVerdictFromStatuses()); err != nil {
 		r.cfg.Logger.Warn("runner: run %s: could not record the unloadable IR: %v", msg.RunID, err)
+	} else if !changed {
+		r.cfg.Logger.Warn("runner: run %s: the unloadable-IR verdict was declined (status drifted) — the document does not carry IR_UNLOADABLE", msg.RunID)
 	}
 	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
 		Type: store.EventRunFailed,
 		Data: map[string]any{
-			"code": "IR_UNLOADABLE", "error": cause.Error(),
+			"code": string(store.FailureIRUnloadable), "error": cause.Error(),
 			"runner_version": appinfo.Version, "runner_commit": appinfo.Commit,
 			"workflow_hash": msg.WorkflowHash,
 			"hint":          "the IR was compiled by a server this runner cannot follow; align the runner with the server, then resume",

--- a/pkg/runner/loop_nats.go
+++ b/pkg/runner/loop_nats.go
@@ -295,6 +295,10 @@ func (r *Runner) parkOnDLQOnFinalDelivery(err error, delivery *natsq.Delivery, m
 		errors.Is(err, runtime.ErrRunPausedOperator) ||
 		errors.Is(err, runtime.ErrRunCancelled) ||
 		errors.Is(err, runtime.ErrRunInterrupted) ||
+		// An IR this runner cannot load is acked with its own verdict on the
+		// run (IR_UNLOADABLE); a park here on the last delivery would
+		// overwrite that diagnosis with DLQ_PARKED.
+		errors.Is(err, ErrIRUnloadable) ||
 		r.cfg.NATS == nil || delivery.NumDelivered() < r.cfg.NATS.MaxDeliver() {
 		return false, ""
 	}
@@ -319,7 +323,7 @@ func (r *Runner) parkOnDLQOnFinalDelivery(err error, delivery *natsq.Delivery, m
 	if changed, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable,
 		fmt.Sprintf("max deliveries exhausted: %v (parked on DLQ — replay via /api/admin/dlq)", err),
 		store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal},
-		[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued, store.RunStatusFailedResumable}); serr != nil {
+		store.RunnerVerdictFromStatuses()); serr != nil {
 		logger.Warn("runner: DLQ status flip for %s: %v", msg.RunID, serr)
 	} else if !changed {
 		logger.Warn("runner: DLQ status flip for %s declined (status drifted) — the document does not carry DLQ_PARKED", msg.RunID)

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -409,6 +409,10 @@ func TestClassifyExecResult(t *testing.T) {
 		{"interrupted naks for resume", runtime.ErrRunInterrupted, "interrupted", actionNak},
 		{"wrapped interrupted naks", fmt.Errorf("%w: at node n1", runtime.ErrRunInterrupted), "interrupted", actionNak},
 		{"generic failure naks", errors.New("boom"), "failed", actionNak},
+		// An IR this runner cannot load is deterministic for this runner:
+		// Ack (the run is failed_resumable + IR_UNLOADABLE), never a
+		// redelivery that reaches the same image and the same verdict.
+		{"unloadable IR acks (no redelivery)", fmt.Errorf("runner: %w: compile IR: 3 diagnostic(s)", ErrIRUnloadable), "ir_unloadable", actionAck},
 		// Budget exceeded is a resumable checkpoint — Ack, never auto-resume
 		// (auto-redelivery re-fails on the same spent budget and its fresh-pod
 		// recordRunGitMeta clobbers the exported commits; run 019f8e08). It is

--- a/pkg/runner/unloadable_ir_test.go
+++ b/pkg/runner/unloadable_ir_test.go
@@ -1,0 +1,99 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A RunMessage whose IR this runner cannot decode or compile is a typed
+// error, not a generic one — the delivery loop must be able to tell it
+// from a transient.
+func TestLoadWorkflow_UnloadableIRIsTyped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ir   string
+	}{
+		{"undecodable bytes", "not json"},
+		{"decodable, uncompilable", "{}"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadWorkflow(context.Background(), &queue.RunMessage{RunID: "r", IRCompiled: []byte(tc.ir)}, nil)
+			if !errors.Is(err, ErrIRUnloadable) {
+				t.Fatalf("err = %v, want ErrIRUnloadable", err)
+			}
+		})
+	}
+}
+
+// failUnloadableIR writes on the run what a mute runner never wrote: the
+// resumable failure with its code, and a run_failed event that names the
+// runner version beside the workflow hash.
+func TestFailUnloadableIR_WritesTheVerdictOnTheRun(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-skew", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+	msg := &queue.RunMessage{RunID: "run-skew", WorkflowHash: "e7e2f6e6"}
+	r.failUnloadableIR(ctx, msg, errors.New("runner: the IR does not load on this runner: compile IR: 3 diagnostic(s)"))
+
+	run, err := st.LoadRun(ctx, "run-skew")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %q, want failed_resumable (a resume after the fleet is aligned re-compiles on the server)", run.Status)
+	}
+	if run.FailureCode != "IR_UNLOADABLE" {
+		t.Fatalf("failure code = %q, want IR_UNLOADABLE", run.FailureCode)
+	}
+	evs, _ := st.LoadEvents(ctx, "run-skew")
+	var found bool
+	for _, ev := range evs {
+		if ev.Type == store.EventRunFailed && ev.Data["code"] == "IR_UNLOADABLE" {
+			found = true
+			if ev.Data["runner_version"] == nil || ev.Data["workflow_hash"] != "e7e2f6e6" {
+				t.Fatalf("run_failed must carry the runner version and the workflow hash: %v", ev.Data)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no run_failed {code: IR_UNLOADABLE} event: the skew is not readable from the run")
+	}
+}
+
+// The wiring: executeRun, handed a message whose IR does not load, writes
+// the verdict on the run before returning the typed error — the delivery
+// loop then acks it and nothing is left to a redelivery.
+func TestExecuteRun_UnloadableIRWritesTheVerdictBeforeReturning(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-skew-2", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+	msg := &queue.RunMessage{RunID: "run-skew-2", WorkflowHash: "e7e2f6e6", IRCompiled: []byte("not json")}
+	execErr := r.executeRun(ctx, msg, nil)
+	if !errors.Is(execErr, ErrIRUnloadable) {
+		t.Fatalf("executeRun err = %v, want ErrIRUnloadable", execErr)
+	}
+	if got := classifyExecResult(execErr, msg.RunID); got.action != actionAck || got.finalStatus != "ir_unloadable" {
+		t.Fatalf("classified as %s/%v, want ir_unloadable/ack", got.finalStatus, got.action)
+	}
+	run, _ := st.LoadRun(ctx, "run-skew-2")
+	if run.Status != store.RunStatusFailedResumable || run.FailureCode != "IR_UNLOADABLE" {
+		t.Fatalf("run = %s/%s, want failed_resumable/IR_UNLOADABLE written before the return", run.Status, run.FailureCode)
+	}
+}

--- a/pkg/runner/unloadable_ir_test.go
+++ b/pkg/runner/unloadable_ir_test.go
@@ -3,8 +3,10 @@ package runner
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -42,9 +44,14 @@ func TestFailUnloadableIR_WritesTheVerdictOnTheRun(t *testing.T) {
 	if _, err := st.CreateRun(ctx, "run-skew", "wf", nil); err != nil {
 		t.Fatal(err)
 	}
+	// A drained run redelivered on a stale image: it carries a checkpoint
+	// worth every node already paid for.
+	if err := st.FailRunResumable(ctx, "run-skew", &store.Checkpoint{NodeID: "n2"}, "drained", store.FailureExecutionFailed); err != nil {
+		t.Fatal(err)
+	}
 	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
 	msg := &queue.RunMessage{RunID: "run-skew", WorkflowHash: "e7e2f6e6"}
-	r.failUnloadableIR(ctx, msg, errors.New("runner: the IR does not load on this runner: compile IR: 3 diagnostic(s)"))
+	r.failUnloadableIR(ctx, msg, errors.New("runner: the IR does not load on this runner: compile IR: 3 error(s)"))
 
 	run, err := st.LoadRun(ctx, "run-skew")
 	if err != nil {
@@ -53,8 +60,11 @@ func TestFailUnloadableIR_WritesTheVerdictOnTheRun(t *testing.T) {
 	if run.Status != store.RunStatusFailedResumable {
 		t.Fatalf("status = %q, want failed_resumable (a resume after the fleet is aligned re-compiles on the server)", run.Status)
 	}
-	if run.FailureCode != "IR_UNLOADABLE" {
+	if run.FailureCode != store.FailureIRUnloadable {
 		t.Fatalf("failure code = %q, want IR_UNLOADABLE", run.FailureCode)
+	}
+	if run.Checkpoint == nil || run.Checkpoint.NodeID != "n2" {
+		t.Fatalf("checkpoint = %+v, want the drained run's checkpoint preserved: the aligned fleet resumes from it", run.Checkpoint)
 	}
 	evs, _ := st.LoadEvents(ctx, "run-skew")
 	var found bool
@@ -83,6 +93,9 @@ func TestExecuteRun_UnloadableIRWritesTheVerdictBeforeReturning(t *testing.T) {
 	if _, err := st.CreateRun(ctx, "run-skew-2", "wf", nil); err != nil {
 		t.Fatal(err)
 	}
+	if err := st.SaveCheckpoint(ctx, "run-skew-2", &store.Checkpoint{NodeID: "n3"}); err != nil {
+		t.Fatal(err)
+	}
 	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
 	msg := &queue.RunMessage{RunID: "run-skew-2", WorkflowHash: "e7e2f6e6", IRCompiled: []byte("not json")}
 	execErr := r.executeRun(ctx, msg, nil)
@@ -93,7 +106,27 @@ func TestExecuteRun_UnloadableIRWritesTheVerdictBeforeReturning(t *testing.T) {
 		t.Fatalf("classified as %s/%v, want ir_unloadable/ack", got.finalStatus, got.action)
 	}
 	run, _ := st.LoadRun(ctx, "run-skew-2")
-	if run.Status != store.RunStatusFailedResumable || run.FailureCode != "IR_UNLOADABLE" {
+	if run.Status != store.RunStatusFailedResumable || run.FailureCode != store.FailureIRUnloadable {
 		t.Fatalf("run = %s/%s, want failed_resumable/IR_UNLOADABLE written before the return", run.Status, run.FailureCode)
+	}
+	if run.Checkpoint == nil || run.Checkpoint.NodeID != "n3" {
+		t.Fatalf("checkpoint = %+v, want preserved through the verdict", run.Checkpoint)
+	}
+}
+
+// The verdict names the errors that blocked the load, not the warnings the
+// compiler happened to append first.
+func TestSummariseDiagnostics_ErrorsOnly(t *testing.T) {
+	diags := []ir.Diagnostic{
+		{Code: "C089", Severity: ir.SeverityWarning, Message: "ultracode on a model that is not opus"},
+		{Code: "C128", Severity: ir.SeverityWarning, Message: "sandbox note"},
+		{Code: "C001", Severity: ir.SeverityError, Message: "unknown node kind"},
+	}
+	errs := compileErrors(diags)
+	if len(errs) != 1 || errs[0].Code != "C001" {
+		t.Fatalf("compileErrors = %v, want the single error", errs)
+	}
+	if got := summariseDiagnostics(errs); !strings.Contains(got, "C001") || strings.Contains(got, "C089") {
+		t.Fatalf("summary = %q, want the error named and the warnings absent", got)
 	}
 }

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -97,6 +97,13 @@ const (
 	// FailureDLQParked: the queue exhausted its deliveries for this run
 	// and parked it on the DLQ — replay via /api/admin/dlq.
 	FailureDLQParked FailureCode = "DLQ_PARKED"
+	// FailureIRUnloadable: the runner could not decode or compile the IR a
+	// server ahead of it produced. Written by the runner before it acks the
+	// delivery (a redelivery would reach the same image and the same
+	// verdict); resumable, because a resume after the fleet is aligned
+	// re-compiles the source on the server. Reserved so no bot can mint it
+	// and no reader takes it for a bot's own refusal.
+	FailureIRUnloadable FailureCode = "IR_UNLOADABLE"
 	// FailureLaunchFailed: the run never left the launch path. Its row was
 	// persisted but no queue message was ever published for it (the
 	// publish, the IR encoding or the contribution payload failed), so no
@@ -167,6 +174,7 @@ var ReservedFailureCodes = []FailureCode{
 	FailureProcessOrphaned,
 	FailureQueueSchemaMismatch,
 	FailureDLQParked,
+	FailureIRUnloadable,
 	FailureLaunchFailed,
 	FailureSandboxSetupTimeout,
 	FailureSandboxCapacity,
@@ -269,6 +277,15 @@ func (s RunStatus) CanOperatorResume() bool {
 // RequiresResumeAnswers: resuming this status needs the pending human
 // interaction answered first (`--answers-file`, the studio form).
 func (s RunStatus) RequiresResumeAnswers() bool { return s == RunStatusPausedWaitingHuman }
+
+// RunnerVerdictFromStatuses is the CAS set of the runner's own writes on a
+// run it claimed — the DLQ park and the unloadable-IR verdict: a claimed
+// or queued attempt, and the engine's own failed_resumable write, which on
+// the nominal path lands before the runner's (a CAS from running/queued
+// alone could never land). A run cancelled meanwhile is not flipped back.
+func RunnerVerdictFromStatuses() []RunStatus {
+	return []RunStatus{RunStatusRunning, RunStatusQueued, RunStatusFailedResumable}
+}
 
 // CanAutoResume answers the AUTOMATIC eligibility question: may
 // machinery (--auto-resume, usage-window retries) resume this run with

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -295,11 +295,10 @@ var negativeSpaceAllowlist = map[string]allowEntry{
 	"pkg/cli/remote_runs.go :: Cancelled+Failed+FailedResumable+Finished":  {[]string{"followRemoteRun"}, "--follow stop set over the WIRE statuses (strings): IsTerminal's set; the paused non-exit is the known bug #3 follow-up card"},
 
 	// -- pkg/runner.
-	"pkg/runner/loop.go :: Failed+Finished":                     {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
-	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman":  {[]string{"dispositionForStatus"}, "stale-delivery drop set: shapes a redelivery can never legitimately target (the admission switch, shared by the pre-lock pass and the under-lock re-read)"},
-	"pkg/runner/loop.go :: FailedResumable+PausedOperator":      {[]string{"dispositionForStatus"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes; same switch)"},
-	"pkg/runner/loop_nats.go :: FailedResumable+Queued+Running": {[]string{"parkOnDLQOnFinalDelivery"}, "DLQ park CAS: claimed/queued attempts AND the engine's own failed_resumable write — on the nominal path the engine parks first, and a CAS that excluded it dropped the DLQ_PARKED cause silently (gate F4)"},
-	"pkg/runner/usage_cap.go :: Queued+Running":                 {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
+	"pkg/runner/loop.go :: Failed+Finished":                    {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
+	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman": {[]string{"dispositionForStatus"}, "stale-delivery drop set: shapes a redelivery can never legitimately target (the admission switch, shared by the pre-lock pass and the under-lock re-read)"},
+	"pkg/runner/loop.go :: FailedResumable+PausedOperator":     {[]string{"dispositionForStatus"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes; same switch)"},
+	"pkg/runner/usage_cap.go :: Queued+Running":                {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
 
 	// -- pkg/worktreepool.
 	"pkg/worktreepool/classify.go :: PausedOperator+PausedWaitingHuman": {[]string{"isPausedResumable"}, "the paused pair guarding checkout sparing (GC policy nuance documented at the site)"},


### PR DESCRIPTION
## Measured

On a five-release server/runner skew (server on `:edge` at v3.111.0 after an unannounced pod recreation, runners at v3.106.1), six fresh launches — five of one team, one of another — went `failed_resumable` within 75 s with **zero events and an empty final_error**. The runner logs carried the cause on every delivery: `runner: compile IR: 3 diagnostic(s)`, delivery 1 … 8, then `failed on final delivery 8/8 — parking on DLQ`. The IR compiled by the newer server does not load on the older runner; the error came back generic; the delivery loop retried a deterministic failure eight times and parked it — and the run itself said nothing. The operator inferred the cause from the healthz of two deployments. (#774)

## Fix

- `loadWorkflow` wraps a decode or compile failure in `ErrIRUnloadable`, with the first diagnostics in the message.
- `executeRun` writes the verdict **before** returning: `failed_resumable` with code `IR_UNLOADABLE`, and a `run_failed` event carrying `runner_version`, `runner_commit` and `workflow_hash` — the skew reads from the run alone. Resumable, because a resume after the fleet is aligned re-compiles the source on the server.
- `classifyExecResult` **acks** it (`ir_unloadable`): deterministic for this runner image, a redelivery reaches the same verdict, and the DLQ park on the last delivery would overwrite the diagnosis with `DLQ_PARKED` — the pattern the deliberate-refusal case already follows.

## Proof

- `TestLoadWorkflow_UnloadableIRIsTyped` (undecodable bytes, decodable-but-uncompilable AST), `TestFailUnloadableIR_WritesTheVerdictOnTheRun`, `TestExecuteRun_UnloadableIRWritesTheVerdictBeforeReturning` (the wiring, through `executeRun`), and the `TestClassifyExecResult` table.
- Mutants, each red: the classification branch removed; the verdict not written before the return.
- Full `pkg/runner` suite green; golangci-lint 0 issues.

Out of scope, said: the pin of the server image (#774), and the fleet-wide mismatch this fix makes readable but does not prevent.

## Second round (three findings, all reproduced)

- **Checkpoint erased on a resume delivery** (high): `FailRunResumable` assigns the checkpoint it is handed — a nil there deleted the anchor of a drained run redelivered on a stale image, and the promised resume would have restarted at the entry. The writer is now `UpdateRunOutcome` (the DLQ park's own pattern), which leaves the checkpoint alone and keeps the cancelled-wins guard; its status set is one lifecycle predicate, `RunnerVerdictFromStatuses`, shared with the park — whose hand-rolled set leaves the ADR-095 allowlist. Tests on both paths; mutant (erasing writer restored) red.
- **Warnings in the verdict line** (medium): only `SeverityError` diagnostics are counted and named. `TestSummariseDiagnostics_ErrorsOnly`; mutant (unfiltered) red.
- **Ad-hoc failure code** (medium): `FailureIRUnloadable` is a declared, reserved constant — no bot can mint it, and `dispositionForStatus` attributes it to the engine. The drift guard covers it.
- Open question answered: `parkOnDLQOnFinalDelivery` now excludes `ErrIRUnloadable`, so a final delivery cannot overwrite the verdict with `DLQ_PARKED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
