### PR TITLE
fix(golden-master): the harness reverts a mutant an interrupted gate left applied, at the start of the next

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2398,6 +2398,24 @@ tool oracle_run:
         return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
 
 
+    def overall_revert_clean(verdicts, stopped, ws):
+        """The report's `revert_clean`: did every mutant this gate applied get
+        undone, and did the tree come back?
+
+        Three branches never reach the revert path and so never write the field —
+        a refused apply, an inert mutant, an apply that failed — and reading their
+        SILENCE as True is what let a lot in which almost nothing was measured
+        report a clean revert. Combined with a scoring that stopped (so the later
+        mutants are absent, `blind_lanes` is empty and the held-out loop never ran,
+        leaving a vacuous 0 == 0), that produced a GREEN gate on a tree the harness
+        itself had left mutated with its marker armed. A stop, or a record still
+        standing, is the evidence the tree did not come back.
+        """
+        if stopped is not None or leftover_on_record(ws):
+            return False
+        return all(v.get("revert_clean", True) for v in verdicts)
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3710,12 +3728,28 @@ tool oracle_run:
                       scoring_must_stop(v_inert, tmp), True)
                 check("l'application suivante est de toute facon refusee",
                       apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+                # LE SILENCE N'EST PAS UNE PREUVE DE PROPRETE. `revert_clean` n'est
+                # ecrit que par le chemin complet ; les trois branches qui n'y
+                # arrivent pas ne disent rien, et lire ce silence comme « propre »
+                # rendait VERTE une porte sur un arbre que le harnais venait de
+                # laisser mute, marqueur arme. Mesure : apply.sh mi-edite puis sort
+                # 7, revert.sh sort 1 -> score 100 %, revert_clean vrai, held-out
+                # 0/0, GREEN, `git status` = `M f.txt`.
+                check("un mutant enregistre interdit d'annoncer un revert propre",
+                      overall_revert_clean([{"revert_clean": True}], None, tmp), False)
+                check("un classement arrete aussi, quoi que disent les verdicts",
+                      overall_revert_clean([{"revert_clean": True}], {"id": "x"}, tmp), False)
                 clear_marker()
                 check("rien d'enregistre, un verdict propre : le classement continue",
                       [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
                       [False, False])
                 check("un revert sale arrete le classement meme sans enregistrement",
                       scoring_must_stop({"revert_clean": False}, tmp), True)
+                check("arbre sain, verdicts sains : le revert est annonce propre",
+                      overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
+                check("un seul verdict sale suffit a le nier",
+                      overall_revert_clean([{"revert_clean": True}, {"revert_clean": False}],
+                                           None, tmp), False)
                 sub("git", "checkout", "--", "f.txt")
                 # Seule la disposition « reverti » laisse passer la porte. Le lien entre
                 # la decision et son consommateur est CETTE constante, pas trois lignes
@@ -4389,19 +4423,22 @@ tool oracle_run:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
+                if v.get("valid"):
+                    if not v.get("detected"):
+                        blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                      "mutant_id": v["id"], "entries": v.get("targets_declared", []),
+                                      "why": "no declared target moved"})
+                    elif v.get("undetected_targets"):
+                        blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                      "mutant_id": v["id"], "entries": v["undetected_targets"],
+                                      "why": "these references did not move for a change they cover"})
+                # Classified FIRST, then the stop. A verdict whose revert failed
+                # still reached capture and comparison, so what it says about the
+                # net is evidence; breaking before this line dropped a real blind
+                # lane on the way out.
                 if scoring_must_stop(v, ws):
                     stopped = v
                     break
-                if not v.get("valid"):
-                    continue
-                if not v.get("detected"):
-                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                                  "mutant_id": v["id"], "entries": v.get("targets_declared", []),
-                                  "why": "no declared target moved"})
-                elif v.get("undetected_targets"):
-                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                                  "mutant_id": v["id"], "entries": v["undetected_targets"],
-                                  "why": "these references did not move for a change they cover"})
 
             # The seal relocates the held-out set in BOTH modes — the campaign must
             # lose file access early — but selfcheck neither scores it nor reports
@@ -4438,7 +4475,7 @@ tool oracle_run:
                 valid=len(valid),
                 detected=len(detected),
                 score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
-                revert_clean=all(v.get("revert_clean", True) for v in verdicts + held),
+                revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
                 collateral=sum(len(v.get("collateral") or []) for v in verdicts),
             unstable_controls=sorted({c for v in verdicts
                                       for c in (v.get("unstable_controls") or [])}),
@@ -4463,6 +4500,22 @@ tool oracle_run:
                     "probe: %s. The net saw the change; the lane they were drawn against did "
                     "not. Citing the aggregate alone would report the resemblance."
                     % (len(off), ", ".join(off))))
+            # A lot whose baseline was lost reports a WITHHELD held-out figure, not
+            # a measured one: the held-out loop did not run (or stopped part-way),
+            # so its 0 == 0 is the vacuous equality this file guards against
+            # everywhere else — and it sat right beside a `revert_clean` that read
+            # silence as clean. Measured, end to end: apply.sh half-edits and exits
+            # 7, revert.sh exits 1 — score_pct 100, revert_clean true, blind_lanes
+            # empty, holdout 0/0, GATE GREEN, `git status` showing `M f.txt` and the
+            # marker still armed. The gate approved the exact tree this guard exists
+            # to refuse. `overall_revert_clean` is now the one that says otherwise.
+            baseline_lost = not report["revert_clean"]
+            if baseline_lost and len(held) < len(held_meta):
+                # Withheld, not zero-because-failed — the idiom selfcheck uses just
+                # below, deliberately unequal so an unscored held-out set can never
+                # be taken for a passed one.
+                report["holdout_total"] = len(held_meta)
+                report["holdout_detected"] = -1
             if mode == "selfcheck":
                 # Withheld, not zero-because-failed. The two numbers are made
                 # DELIBERATELY UNEQUAL: the gate converges on
@@ -4473,6 +4526,14 @@ tool oracle_run:
                 report["holdout_detected"] = -1
 
             problems = []
+            if baseline_lost:
+                problems.append(
+                    "THE TREE IS NOT KNOWN TO BE BACK AT BASELINE: %s. The figures above "
+                    "describe what was measured BEFORE that point, not the lot — the mutants "
+                    "after it were never applied, so an empty blind-lane list and a 0/0 "
+                    "held-out figure mean 'not measured', never 'clean'."
+                    % (("scoring stopped after mutant %s" % stopped.get("id")) if stopped
+                       else "a mutant is still recorded as applied"))
             if not report["noop_silent"]:
                 detail = noop.get("noisy_detail") or {}
                 problems.append(
@@ -4539,7 +4600,12 @@ tool oracle_run:
                              "its result is withheld on purpose. Only the final gate scores "
                              "it. An empty log_tail here means the VISIBLE set is clean, "
                              "which is not the same as a green gate.")
-            elif report["holdout_total"] and report["holdout_detected"] < report["holdout_total"]:
+            elif (not baseline_lost and report["holdout_total"]
+                    and report["holdout_detected"] < report["holdout_total"]):
+                # `not baseline_lost`: after a stop the figure is WITHHELD (-1), not
+                # measured, and rendering it would read "HELD-OUT set: -1/2 detected"
+                # — a count where there was no measurement. The red is already said,
+                # once, above.
                 problems.append("HELD-OUT set: %d/%d detected. The oracle was hardened against "
                                 "the mutants it could see, not against divergence in general."
                                 % (report["holdout_detected"], report["holdout_total"]))

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4205,21 +4205,38 @@ tool oracle_run:
             wanted = [i.strip() for i in os.environ.get("GM_MUTANTS", "").split(",") if i.strip()]
             chosen = [m for m in visible if not wanted or m["id"] in wanted]
             report["missing"] = sorted(set(wanted) - {m["id"] for m in chosen})
-            verdicts = []
+            verdicts, stopped_at = [], None
             for m in chosen:
                 v, state = probe_mutation(m, ws)
                 if state != "failed":
                     revert_mutant(m, ws)
                 verdicts.append(v)
+                # The gate's rule, here too. One mutant whose revert failed leaves
+                # the record armed; without this, every LATER mutant came back
+                # invalid quoting that one, while the tail still announced them all
+                # "applied, fingerprinted and reverted" and the tree stayed mutated.
+                # This is the mode the campaign uses to accept a RE-ANCHORED mutant,
+                # so the cascade sent it to repair mutants that were fine.
+                if leftover_on_record(ws):
+                    stopped_at = v
+                    break
             report["total"] = len(verdicts)
             report["valid"] = len([v for v in verdicts if v.get("valid")])
             report["invalid"] = [{"id": v["id"], "reason": v.get("reason", "")}
                                  for v in verdicts if not v.get("valid")]
+            done = len(verdicts) - (1 if stopped_at is not None else 0)
             report["log_tail"] = (
                 "MODE=validate — %d mutant(s) applied, fingerprinted and reverted. This says "
                 "each one CHANGES something; it says NOTHING about whether the net sees it. "
                 "Only the gate captures and compares, and the zeroed fields above are defaults, "
-                "not a verdict." % len(verdicts))
+                "not a verdict." % done)
+            if stopped_at is not None:
+                report["log_tail"] += (
+                    " STOPPED at mutant %s: it is still recorded as applied, so the tree is not "
+                    "at baseline and the %d mutant(s) after it were NOT validated — every "
+                    "application there would be refused, not measured. Revert by hand, delete "
+                    "the marker %s, then re-run."
+                    % (stopped_at.get("id"), len(chosen) - len(verdicts), applied_marker_for(ws)))
             if report["missing"]:
                 report["log_tail"] += (" %d requested mutant(s) do not exist: %s."
                                        % (len(report["missing"]), ", ".join(report["missing"])))

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2506,6 +2506,18 @@ tool oracle_run:
         directory resolves to today, and dropping it would destroy the only
         evidence that the tree is not HEAD. Every application is refused while
         it is there, which is what makes the refusal stick.
+
+        ONE gate per tree is ASSUMED: the record carries no liveness, no pid and
+        no lock. A second gate starting while the first sits between its apply.sh
+        and its revert.sh reads that record as a leftover, reverts a LIVE mutant
+        and drops its owner's record; the first then captures against a reverted
+        tree and reports blind lanes it invented. write_applied_marker's refusal
+        ("another harness is gating this tree") does NOT cover this — the sweep
+        runs before any application, so it never reaches that refusal. Measured.
+        Two harnesses mutating one tree cannot measure anything either way, so
+        this is a limitation rather than a mode to support; the fix, if a real
+        case turns up, is an exclusive lock held for the gate's duration (an
+        flock dies with the process, unlike a recorded pid).
         """
         marker = applied_marker_for(ws)
         meta, why = read_applied_marker(ws)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3700,7 +3700,7 @@ tool oracle_run:
                 check("l'arbre est revenu a HEAD", tree(), "original\n")
                 check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
                 check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-                check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+                check("disposition d'un revert propre", leftover_disposition(left or {})[0], "reverted")
                 # Le chemin nominal efface aussi le marqueur.
                 apply_mutant(lmeta, tmp)
                 revert_mutant(lmeta, tmp)
@@ -3712,7 +3712,7 @@ tool oracle_run:
                 check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
                 check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert en echec : l'arbre est encore mute",
-                      leftover_disposition(left)[0], "still_mutated")
+                      leftover_disposition(left or {})[0], "still_mutated")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 left = revert_leftover_mutant(tmp)
                 check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
@@ -3726,7 +3726,7 @@ tool oracle_run:
                        "revert.sh" in ((left or {}).get("out") or "")],
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
-                check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+                check("disposition d'un revert.sh disparu", leftover_disposition(left or {})[0], "still_mutated")
                 clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
@@ -3841,10 +3841,10 @@ tool oracle_run:
                       [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
                 check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
                       os.path.isfile(applied_marker_for(tmp)), True)
-                check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
-                check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+                check("disposition d'un marqueur etranger", leftover_disposition(left or {})[0], "refused")
+                check("elle arrete la porte", leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS, True)
                 check("et son message nomme le marqueur a effacer a la main",
-                      applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+                      applied_marker_for(tmp) in leftover_disposition(left or {})[1], True)
                 # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
                 # application ne passe tant que le marqueur est la.
                 again = revert_leftover_mutant(tmp)
@@ -3886,7 +3886,7 @@ tool oracle_run:
                     check("un marqueur sous la pile scellee est reverti, pas refuse",
                           [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                           [False, 0, "original\n"])
-                    check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                    check("disposition du held-out reverti", leftover_disposition(left or {})[0], "reverted")
                     # LE CAS MESURE. La pile scellee a bouge entre deux passes —
                     # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
                     # exactement la configuration que le harnais recommande quand la
@@ -3987,7 +3987,7 @@ tool oracle_run:
                           [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                            os.path.isfile(applied_marker_for(tmp))],
                           ["slot", True, "original\nmutant\n", True])
-                    check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+                    check("disposition d'un emplacement inutilisable", leftover_disposition(left or {})[0], "unusable")
                 finally:
                     os.chmod(mdir_marker, 0o700)
                 left = revert_leftover_mutant(tmp)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -271,6 +271,7 @@ tool oracle_run:
     import re
     import shlex
     import shutil
+    import stat
     import subprocess
     import sys
     import tempfile
@@ -2245,6 +2246,9 @@ tool oracle_run:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+    APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+
+
     def applied_marker_for(ws):
         """Where the harness notes the mutant it has applied and not yet reverted.
 
@@ -2260,40 +2264,128 @@ tool oracle_run:
         return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
+    def _private_dir_of_ours(d):
+        """(ok, why): the marker directory is OURS and PRIVATE — a real directory,
+        not a symlink, owned by this uid, no group/other bits. On a shared temp
+        root anyone can pre-create the path; a directory that fails the test is
+        refused, never repaired: chmod on a foreign directory is EPERM anyway, and
+        repairing it would mean trusting what it already holds."""
+        try:
+            st = os.lstat(d)
+        except OSError as e:
+            return False, "%s: %s" % (d, e.strerror or e)
+        if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+            return False, "%s is not a directory of its own (a symlink?)" % d
+        if st.st_uid != os.geteuid():
+            return False, "%s is owned by uid %d, not %d" % (d, st.st_uid, os.geteuid())
+        if st.st_mode & 0o077:
+            return False, "%s is not private (mode %o)" % (d, stat.S_IMODE(st.st_mode))
+        return True, ""
+
+
+    def read_applied_marker(ws):
+        """(meta, why). meta is None when there is no marker. A marker that cannot
+        be trusted — a directory that is not ours, a symlink, a file of another
+        uid, unreadable content — comes back as ({}, why): the caller refuses,
+        executes nothing and deletes nothing. The write side keeps the file
+        private; the read side proves it, because the file is an instruction to
+        run a script."""
+        marker = applied_marker_for(ws)
+        if not os.path.lexists(marker):
+            return None, ""
+        ok, why = _private_dir_of_ours(os.path.dirname(marker))
+        if not ok:
+            return {}, "the marker directory is not the harness's own: %s" % why
+        try:
+            fd = os.open(marker, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError as e:
+            return {}, "cannot open the marker %s: %s" % (marker, e.strerror or e)
+        try:
+            st = os.fstat(fd)
+        except OSError as e:
+            os.close(fd)
+            return {}, "cannot stat the marker %s: %s" % (marker, e.strerror or e)
+        if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid():
+            os.close(fd)
+            return {}, "the marker %s is not a regular file of this uid" % marker
+        try:
+            with os.fdopen(fd, encoding="utf-8") as f:
+                meta = json.load(f)
+        except (OSError, ValueError) as e:
+            return {}, "the marker %s is unreadable: %s" % (marker, e)
+        if not isinstance(meta, dict):
+            return {}, "the marker %s does not hold an object" % marker
+        return meta, ""
+
+
     def write_applied_marker(ws, meta):
-        """Record the mutant about to be applied. Private directory, exclusive
-        create, no symlink following: a marker is an instruction to run a script,
-        and a shared temp root must not let anyone else write one."""
+        """Record the mutant about to be applied. (True, "") — or (False, why),
+        and then apply.sh MUST NOT run.
+
+        Refused when a marker is already there: the mutant it names had its
+        revert fail in this run, or another harness is gating the same tree.
+        Either way the tree is not HEAD, and overwriting the record is the one
+        way to lose a leftover for good: the next mutant's clean revert would
+        then erase a record that was never its own. Refused, too, when the
+        record cannot be written (a read-only, full or foreign scratch root): a
+        mutant the harness cannot keep track of is a mutant it must not apply —
+        the silent alternative is a net behaving exactly as before this guard,
+        with nothing to say so.
+        """
         marker = applied_marker_for(ws)
         d = os.path.dirname(marker)
         try:
             os.makedirs(d, mode=0o700, exist_ok=True)
-            os.chmod(d, 0o700)
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+        except OSError as e:
+            return False, "cannot create the marker directory %s: %s" % (d, e.strerror or e)
+        ok, why = _private_dir_of_ours(d)
+        if not ok:
+            return False, "the marker directory is not usable: %s" % why
+        if os.path.lexists(marker):
+            prior, _why = read_applied_marker(ws)
+            prior = prior or {}
+            return False, ("a mutant is still recorded as applied: %s (%s) — its revert failed "
+                           "in this run, or another harness is gating this tree; the tree is not "
+                           "HEAD and nothing is applied on top of it"
+                           % (prior.get("id") or "?", prior.get("dir") or marker))
+        try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError as e:
+            return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
+        return True, ""
+
+
+    def drop_applied_marker(ws, meta=None):
+        """Remove the marker — only when it records THIS mutant (meta None: any
+        marker of ours). A revert of B must never erase the record of A, whose
+        revert failed: that record is the only trace of a tree that is not HEAD."""
+        prior, why = read_applied_marker(ws)
+        if prior is None or why:
+            return
+        if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+            return
+        try:
+            os.remove(applied_marker_for(ws))
         except OSError:
             pass
 
 
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
-        # two leaves a tree that is mutated and a note that says by what.
-        write_applied_marker(ws, meta)
+        # two leaves a tree that is mutated and a note that says by what. A marker
+        # that cannot go down keeps apply.sh from running at all.
+        ok, why = write_applied_marker(ws, meta)
+        if not ok:
+            return APPLY_REFUSED, "apply.sh NOT run: %s" % why
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
     def revert_mutant(meta, ws):
         code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
         if code == 0:
-            try:
-                os.remove(applied_marker_for(ws))
-            except OSError:
-                pass
+            drop_applied_marker(ws, meta)
         return code, out
 
 
@@ -2305,6 +2397,15 @@ tool oracle_run:
         return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
+    def leftover_roots(ws):
+        """The only two places a mutant of this workspace's net can live: the
+        tree itself (visible mutants, an unsealed held-out) and the sealed
+        held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
+        scratch root: on a shared host that is all of /tmp, and a marker naming
+        a directory there would have the gate run whatever script it found."""
+        return [ws, sealed_dir_for(ws)]
+
+
     def revert_leftover_mutant(ws):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2313,68 +2414,81 @@ tool oracle_run:
         judge a mutated program and call it the lot's. Measured: a tool node
         retried on the same tree after its exec stream broke — the build gate
         went red on a file the mutant had edited, and the oracle reported that
-        file as "not committed".
+        file as "not committed". Run in record mode too: references recorded
+        over a leftover would seal a program nobody wrote, which is worse than
+        an edit lost on a file the mutant had already overwritten.
 
         Returns None when there is nothing to revert. Otherwise a dict with the
         mutant's id and dir, `code` (revert.sh's exit; None when the script is
-        gone), and `marker`. The marker is dropped only when the revert
-        demonstrably succeeded — a leftover the harness could not revert stays
-        recorded, so the next gate reports it again instead of forgetting it;
-        an operator who reverts by hand clears it by deleting the marker.
+        gone), `marker`, and after a clean revert `dirty` — what `git status`
+        still shows, because the script's exit code is its word, not the tree's.
+        The marker is dropped only when the revert demonstrably succeeded — a
+        leftover the harness could not revert stays recorded, so the next gate
+        reports it again instead of forgetting it; an operator who reverts by
+        hand clears it by deleting the marker.
 
-        A marker whose directory is not under the workspace or the scratch root
-        is REFUSED, dropped and reported without executing anything: the marker
-        is an instruction to run a script, and only the harness's own mutants
-        may write it.
+        Refused, nothing executed: a marker whose directory is neither this
+        workspace nor its sealed held-out pile (dropped — it is ours and it is
+        not evidence), and a marker slot that is not the harness's own (kept —
+        not ours to delete; every application is refused until it is gone).
         """
         marker = applied_marker_for(ws)
-        if not os.path.isfile(marker):
+        meta, why = read_applied_marker(ws)
+        if meta is None:
             return None
-        try:
-            with open(marker, encoding="utf-8") as f:
-                meta = json.load(f)
-        except (OSError, ValueError):
-            meta = {}
+        if why:
+            return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
+                    "refused": True, "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
-        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
-        if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+            drop_applied_marker(ws)
             return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                    "marker": marker, "refused": True}
+                    "marker": marker, "refused": True, "kept": False, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+        dirty = ""
         if code == 0:
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+            drop_applied_marker(ws, meta)
+            st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+                                capture_output=True, text=True)
+            dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False}
+                "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
     def leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
-        Returns (kind, text): "reverted" — the tree is HEAD again, a note;
-        "refused" — a foreign marker was dropped, a note; "still_mutated" — the
-        revert failed or its script is gone, the tree is NOT HEAD, the gate must
-        refuse rather than judge a program nobody wrote.
+        Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
+        the tree still shows, if anything); "refused" — a marker of ours naming
+        a foreign directory was dropped, a note; "unusable" — the marker slot is
+        not the harness's own, the gate must stop: every application would be
+        refused; "still_mutated" — the revert failed or its script is gone, the
+        tree is NOT HEAD, the gate must refuse rather than judge a program
+        nobody wrote.
         """
         if left.get("refused"):
+            if left.get("kept"):
+                return "unusable", (
+                    "the application-marker slot %s is not the harness's own: %s. Nothing "
+                    "executed, nothing deleted. Every mutant application is refused until "
+                    "it is removed by hand or GM_SCRATCH points at a private root."
+                    % (left.get("marker"), left.get("out")))
             return "refused", (
                 "a stale application marker named a directory outside this workspace and "
-                "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+                "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
         if left.get("code") == 0:
-            return "reverted", (
-                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-                "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
-                "verdict, if any, judged a mutated program." % left.get("id"))
+            text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                    "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
+                    "mutated program." % left.get("id"))
+            if left.get("dirty"):
+                text += (" The tree still shows uncommitted changes after the revert — the "
+                         "script's exit is its word, not the tree's: %s"
+                         % " ".join(left["dirty"].split())[:300])
+            return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
             "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
@@ -2455,6 +2569,11 @@ tool oracle_run:
         before_tree, before_data = tree_fingerprint(ws), data_fingerprint(meta, ws)
 
         code, out = apply_mutant(meta, ws)
+        if code == APPLY_REFUSED:
+            # Nothing ran: no half-edit to undo, and the marker down there is
+            # another mutant's record of a tree that is not HEAD — this mutant's
+            # revert.sh over it would erase that record and half-restore the tree.
+            return dict(base, valid=False, detected=False, reason=out[-300:]), "failed"
         if code != 0:
             # A failed apply may have half-edited the tree, and the marker is
             # down: revert now, within this run, so neither outlives it — a
@@ -3517,6 +3636,91 @@ tool oracle_run:
                 check("rien n'a ete execute", os.path.exists(canary), False)
                 check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
                 check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+                # Un marqueur sous la racine scratch mais HORS de la pile scellee est
+                # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
+                evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
+                os.makedirs(evil2)
+                with open(os.path.join(evil2, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+                write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
+                      [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+                # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
+                # scratch) est le held-out : il est reverti, pas refuse.
+                sealed = tempfile.mkdtemp(prefix="gm-sealed-")
+                saved_sealed = os.environ.get("GM_SEALED_DIR")
+                os.environ["GM_SEALED_DIR"] = sealed
+                try:
+                    hdir = os.path.join(sealed, "h1")
+                    os.makedirs(hdir)
+                    with open(os.path.join(hdir, "apply.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\nprintf 'held\\n' >> f.txt\n")
+                    with open(os.path.join(hdir, "revert.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                    code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                    check("le held-out scelle s'applique", [code, tree()], [0, "original\nheld\n"])
+                    left = revert_leftover_mutant(tmp)
+                    check("un marqueur sous la pile scellee est reverti, pas refuse",
+                          [(left or {}).get("refused"), (left or {}).get("code"), tree()],
+                          [False, 0, "original\n"])
+                    check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                finally:
+                    os.environ.pop("GM_SEALED_DIR", None)
+                    if saved_sealed is not None:
+                        os.environ["GM_SEALED_DIR"] = saved_sealed
+                    shutil.rmtree(sealed, ignore_errors=True)
+                # Un revert en ECHEC garde son enregistrement face au mutant suivant :
+                # la seconde application est refusee, rien ne tourne, et le revert du
+                # second n'efface pas le marqueur du premier.
+                scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+                code, _out = apply_mutant(lmeta, tmp)
+                check("A s'applique", code, 0)
+                code, out = revert_mutant(lmeta, tmp)
+                check("le revert de A echoue et A reste enregistre",
+                      [code, (read_applied_marker(tmp)[0] or {}).get("id")], [3, "leftover-1"])
+                bdir = os.path.join(tmp, "m2")
+                os.makedirs(bdir)
+                with open(os.path.join(bdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\nprintf 'B\\n' >> f.txt\n")
+                with open(os.path.join(bdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                bmeta = {"id": "leftover-2", "dir": bdir}
+                code, out = apply_mutant(bmeta, tmp)
+                check("l'application de B est refusee tant que A est enregistre",
+                      [code, "leftover-1" in out, tree()], [APPLY_REFUSED, True, "original\nmutant\n"])
+                verdict, state = probe_mutation(dict(bmeta, targets=["001"]), tmp)
+                check("la sonde de B est 'failed' sans rien reverter ni toucher au marqueur",
+                      [state, tree(), (read_applied_marker(tmp)[0] or {}).get("id")],
+                      ["failed", "original\nmutant\n", "leftover-1"])
+                code, _out = revert_mutant(bmeta, tmp)
+                check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
+                      [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
+                # l'application est refusee, la porte s'arrete (disposition 'unusable').
+                mdir_marker = os.path.dirname(applied_marker_for(tmp))
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                os.chmod(mdir_marker, 0o755)
+                try:
+                    code, out = apply_mutant(lmeta, tmp)
+                    check("un repertoire de marqueur non prive refuse l'application",
+                          [code, "not private" in out, tree()], [APPLY_REFUSED, True, "original\n"])
+                    os.chmod(mdir_marker, 0o700)
+                    apply_mutant(lmeta, tmp)
+                    os.chmod(mdir_marker, 0o755)
+                    left = revert_leftover_mutant(tmp)
+                    check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
+                          [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
+                           os.path.isfile(applied_marker_for(tmp))],
+                          [True, True, "original\nmutant\n", True])
+                    check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+                finally:
+                    os.chmod(mdir_marker, 0o700)
+                left = revert_leftover_mutant(tmp)
+                check("le meme marqueur, l'emplacement redevenu prive : reverti",
+                      [(left or {}).get("code"), tree()], [0, "original\n"])
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)
@@ -3685,7 +3889,7 @@ tool oracle_run:
         left = revert_leftover_mutant(ws)
         if left:
             kind, text = leftover_disposition(left)
-            if kind == "still_mutated":
+            if kind in ("still_mutated", "unusable"):
                 bail(text)
             note(report, text)
 
@@ -3993,11 +4197,20 @@ tool oracle_run:
                              % ", ".join(sorted(only)))
 
             verdicts, blind = [], []
+            # A revert that did not restore the baseline (revert.sh failed, or the
+            # captures still differ with the mutant gone) ends the scoring: every
+            # later measurement would describe a program nobody wrote, and every
+            # later apply is refused anyway while the leftover is on record. The
+            # gate is red on `revert_clean` either way; stopping keeps it legible.
+            stopped = None
             for seed, meta in enumerate(visible):
                 if only and meta["id"] not in only:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
+                if not v.get("revert_clean", True):
+                    stopped = v
+                    break
                 if not v.get("valid"):
                     continue
                 if not v.get("detected"):
@@ -4014,9 +4227,19 @@ tool oracle_run:
             # it. Revealing `holdout_detected` to whoever runs the check is enough to
             # steer hardening: seeing 3/5 says "keep tuning" even with the files out
             # of reach. The held-out result belongs to the final gate alone.
-            held = [] if mode == "selfcheck" else [
-                score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
-                for i, m in enumerate(held_meta)]
+            held = []
+            if mode != "selfcheck" and stopped is None:
+                for i, m in enumerate(held_meta):
+                    v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
+                    held.append(v)
+                    if not v.get("revert_clean", True):
+                        stopped = v
+                        break
+            if stopped is not None:
+                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
+                     "longer at baseline, so the mutants after it were not scored and are absent "
+                     "from the counts; a leftover, if any, is on record for the next gate."
+                     % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 
             valid = [v for v in verdicts if v.get("valid")]
             detected = [v for v in valid if v.get("detected")]

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2423,7 +2423,9 @@ tool oracle_run:
         Returns None when there is nothing to revert. Otherwise a dict with the
         mutant's id and dir, `code` (revert.sh's exit; None when the script is
         gone), `marker`, and after a clean revert `dirty` — what `git status`
-        still shows, because the script's exit code is its word, not the tree's.
+        still shows, because the script's exit code is its word, not the tree's
+        — or `dirty_unknown`, the reason git could not be asked, which is not
+        the same fact as an empty `dirty`.
         The marker is dropped only when the revert demonstrably succeeded — a
         leftover the harness could not revert stays recorded, so the next gate
         reports it again instead of forgetting it; an operator who reverts by
@@ -2455,14 +2457,24 @@ tool oracle_run:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty = ""
+        dirty, unknown = "", ""
         if code == 0:
             drop_applied_marker(ws, meta)
-            st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
-                                capture_output=True, text=True)
-            dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
+            # Through run(), and on a short leash. This sweep runs in EVERY mode,
+            # record included, and the harness's contract is to answer with a
+            # verdict: a `git` that is absent must not replace the JSON report with
+            # a traceback the campaign reads as "the harness is broken", and a
+            # wedged one must not hang the gate the way the incident behind this
+            # whole guard hung it. Unanswered is reported as UNKNOWN, never as
+            # clean — an empty porcelain and an absent git are not the same fact.
+            st, st_out = run("git status --porcelain", ws, timeout=120)
+            if st == 0:
+                dirty = st_out.strip()
+            else:
+                unknown = "`git status` did not answer (exit %s)" % st
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
+                "marker": marker, "refused": False, "kept": code != 0,
+                "dirty": dirty[:400], "dirty_unknown": unknown}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2511,6 +2523,9 @@ tool oracle_run:
                 text += (" The tree still shows uncommitted changes after the revert — the "
                          "script's exit is its word, not the tree's: %s"
                          % " ".join(left["dirty"].split())[:300])
+            elif left.get("dirty_unknown"):
+                text += (" Whether the tree actually came back could not be checked: %s. "
+                         "Unknown, not clean." % left["dirty_unknown"])
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -3749,6 +3764,34 @@ tool oracle_run:
                     if saved_sealed is not None:
                         os.environ["GM_SEALED_DIR"] = saved_sealed
                     shutil.rmtree(sealed, ignore_errors=True)
+                # Un `git` hors d'atteinte doit donner un VERDICT, pas une trace de
+                # pile : ce balayage tourne dans TOUS les modes, `record` compris, ou
+                # rien d'autre n'appelle git — et la campagne lit du JSON sur la
+                # sortie standard. PATH reduit a `sh` : git est absent, le script de
+                # revert (un `exit 0`, une primitive du shell) tourne encore.
+                scripts("exit 0", "exit 0")
+                apply_mutant(lmeta, tmp)
+                saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+                bindir = tempfile.mkdtemp(prefix="gm-bin-")
+                try:
+                    os.symlink(shbin, os.path.join(bindir, "sh"))
+                    os.environ["PATH"] = bindir
+                    try:
+                        nogit = revert_leftover_mutant(tmp)
+                        raised = ""
+                    except Exception as e:                      # noqa: BLE001 - c'est le test
+                        nogit, raised = None, "%s: %s" % (type(e).__name__, e)
+                finally:
+                    os.environ["PATH"] = saved_path
+                    shutil.rmtree(bindir, ignore_errors=True)
+                check("git absent : un verdict, pas une exception",
+                      [raised, (nogit or {}).get("code")], ["", 0])
+                check("l'etat de l'arbre est INCONNU, pas propre",
+                      [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
+                      ["", True])
+                check("et la note le dit au lieu de laisser croire a un arbre propre",
+                      "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+                clear_marker()
                 # Un revert en ECHEC garde son enregistrement face au mutant suivant :
                 # la seconde application est refusee, rien ne tourne, et le revert du
                 # second n'efface pas le marqueur du premier.

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2350,9 +2350,22 @@ tool oracle_run:
                            % (prior.get("id") or "?", prior.get("dir") or marker))
         try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        except OSError as e:
+            return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
+        try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
         except OSError as e:
+            # The empty shell a failed write leaves behind records NOTHING — apply.sh
+            # will not run — but the NEXT gate reads it as a corrupt marker: kind
+            # `unusable`, a bail, and every application refused until a human deletes
+            # it. A scratch root full for one instant would wedge the gate for good,
+            # over a mutant that was never applied. The open above is O_EXCL, so this
+            # file is ours to remove and removing it takes no record with it.
+            try:
+                os.unlink(marker)
+            except OSError:
+                pass
             return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
         return True, ""
 
@@ -3745,6 +3758,27 @@ tool oracle_run:
                       [False, False])
                 check("un revert sale arrete le classement meme sans enregistrement",
                       scoring_must_stop({"revert_clean": False}, tmp), True)
+                # Une ECRITURE qui echoue ne laisse pas de coquille. O_CREAT a
+                # reussi, l'ecriture non (racine scratch pleine) : le fichier vide
+                # reste, et la porte suivante le lit comme un marqueur corrompu —
+                # `unusable`, bail, toute application refusee — pour un mutant qui
+                # n'a JAMAIS ete applique. Une racine pleine un instant coincait la
+                # porte definitivement. RLIMIT_FSIZE=0 tient lieu d'ENOSPC.
+                # Import local : `resource` est POSIX-seulement et seul l'autotest
+                # s'en sert — en tete de fichier il ferait echouer l'IMPORT du
+                # harnais la ou il manque, au lieu d'un seul controle.
+                import resource
+                soft, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+                try:
+                    resource.setrlimit(resource.RLIMIT_FSIZE, (0, hard))
+                    ok_w, why_w = write_applied_marker(tmp, lmeta)
+                finally:
+                    resource.setrlimit(resource.RLIMIT_FSIZE, (soft, hard))
+                check("une ecriture de marqueur qui echoue refuse l'application",
+                      [ok_w, "cannot write" in why_w], [False, True])
+                check("et ne laisse aucune coquille derriere elle",
+                      [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
+                      [False, False])
                 check("arbre sain, verdicts sains : le revert est annonce propre",
                       overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
                 check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2357,14 +2357,16 @@ tool oracle_run:
         return True, ""
 
 
-    def drop_applied_marker(ws, meta=None):
-        """Remove the marker — only when it records THIS mutant (meta None: any
-        marker of ours). A revert of B must never erase the record of A, whose
-        revert failed: that record is the only trace of a tree that is not HEAD."""
+    def drop_applied_marker(ws, meta):
+        """Remove the marker — only when it records THIS mutant, and only after its
+        revert demonstrably succeeded. A revert of B must never erase the record of
+        A, whose revert failed: that record is the only trace of a tree that is not
+        HEAD. There is deliberately no "drop whatever is there" form — dropping a
+        record the harness did not just undo is how a leftover is lost for good."""
         prior, why = read_applied_marker(ws)
         if prior is None or why:
             return
-        if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+        if prior.get("id") is not None and prior.get("id") != meta.get("id"):
             return
         try:
             os.remove(applied_marker_for(ws))
@@ -2427,10 +2429,14 @@ tool oracle_run:
         reports it again instead of forgetting it; an operator who reverts by
         hand clears it by deleting the marker.
 
-        Refused, nothing executed: a marker whose directory is neither this
-        workspace nor its sealed held-out pile (dropped — it is ours and it is
-        not evidence), and a marker slot that is not the harness's own (kept —
-        not ours to delete; every application is refused until it is gone).
+        Refused, nothing executed AND nothing deleted — `refused` names which
+        half the harness would not touch: "dir", a marker whose directory is
+        neither this workspace nor its sealed held-out pile, and "slot", a
+        marker slot that is not the harness's own. Reading is not deciding: the
+        record goes down BEFORE apply.sh runs, so it stands whatever the
+        directory resolves to today, and dropping it would destroy the only
+        evidence that the tree is not HEAD. Every application is refused while
+        it is there, which is what makes the refusal stick.
         """
         marker = applied_marker_for(ws)
         meta, why = read_applied_marker(ws)
@@ -2438,12 +2444,12 @@ tool oracle_run:
             return None
         if why:
             return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
-                    "refused": True, "kept": True, "dirty": ""}
+                    "refused": "slot", "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
         if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
-            drop_applied_marker(ws)
-            return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                    "marker": marker, "refused": True, "kept": False, "dirty": ""}
+            return {"id": meta.get("id"), "dir": mdir, "code": None,
+                    "out": " and ".join(leftover_roots(ws)),
+                    "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
             code, out = run_script(script, ws)
@@ -2459,27 +2465,44 @@ tool oracle_run:
                 "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
+    # The dispositions on which the gate STOPS rather than judges. Only "reverted"
+    # — the harness undid the leftover and saw the tree come back — lets it
+    # through. The set lives here, beside the function that produces the kinds, so
+    # the decision and its consumer cannot drift apart silently.
+    LEFTOVER_BAIL_KINDS = ("still_mutated", "unusable", "refused")
+
+
     def leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
         Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
-        the tree still shows, if anything); "refused" — a marker of ours naming
-        a foreign directory was dropped, a note; "unusable" — the marker slot is
-        not the harness's own, the gate must stop: every application would be
-        refused; "still_mutated" — the revert failed or its script is gone, the
-        tree is NOT HEAD, the gate must refuse rather than judge a program
+        the tree still shows, if anything), the only kind that lets the gate
+        through; "refused" — a marker of ours naming a directory the harness
+        does not recognise, kept and not executed; "unusable" — the marker slot
+        is not the harness's own; "still_mutated" — the revert failed or its
+        script is gone. The last three are LEFTOVER_BAIL_KINDS: the tree is, or
+        may be, not HEAD, and the gate refuses rather than judge a program
         nobody wrote.
         """
+        if left.get("refused") == "slot":
+            return "unusable", (
+                "the application-marker slot %s is not the harness's own: %s. Nothing "
+                "executed, nothing deleted. Every mutant application is refused until "
+                "it is removed by hand or GM_SCRATCH points at a private root."
+                % (left.get("marker"), left.get("out")))
         if left.get("refused"):
-            if left.get("kept"):
-                return "unusable", (
-                    "the application-marker slot %s is not the harness's own: %s. Nothing "
-                    "executed, nothing deleted. Every mutant application is refused until "
-                    "it is removed by hand or GM_SCRATCH points at a private root."
-                    % (left.get("marker"), left.get("out")))
             return "refused", (
-                "a stale application marker named a directory outside this workspace and "
-                "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+                "a mutant is recorded as APPLIED (%s) and the harness will NOT revert it: "
+                "its directory %s is none of the roots a leftover may live under (%s). "
+                "Nothing executed, nothing deleted. The record goes down BEFORE apply.sh "
+                "runs, so it stands whatever that directory resolves to today: the tree "
+                "is, or may be, mutated, and the gate will not judge it. The ordinary "
+                "cause is a GM_SEALED_DIR that moved between passes — re-run with the one "
+                "that pass used and the harness reverts the mutant itself. Otherwise "
+                "revert by hand (git checkout -- <the mutant's paths>), then delete the "
+                "marker %s."
+                % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
+                   left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                     "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -3574,6 +3597,14 @@ tool oracle_run:
                 def tree():
                     with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
                         return f.read()
+
+                def clear_marker():
+                    # Tolerant on purpose: a mutant on the drop rules must fail as
+                    # CHECKS, not as an OSError that takes the whole self-test with it.
+                    try:
+                        os.remove(applied_marker_for(tmp))
+                    except OSError:
+                        pass
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 lmeta = {"id": "leftover-1", "dir": mdir}
                 code, _out = apply_mutant(lmeta, tmp)
@@ -3614,10 +3645,7 @@ tool oracle_run:
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-                try:
-                    os.remove(applied_marker_for(tmp))
-                except OSError:
-                    pass
+                clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
                 scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
@@ -3625,17 +3653,45 @@ tool oracle_run:
                 check("une application en echec est un mutant 'failed'", state, "failed")
                 check("elle a reverti l'arbre", tree(), "original\n")
                 check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-                # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+                # Seule la disposition « reverti » laisse passer la porte. Le lien entre
+                # la decision et son consommateur est CETTE constante, pas trois lignes
+                # de main() que rien ne conduit.
+                check("seule une disposition 'reverted' laisse passer la porte",
+                      [k in LEFTOVER_BAIL_KINDS
+                       for k in ("still_mutated", "unusable", "refused", "reverted")],
+                      [True, True, True, False])
+                # Un marqueur qui nomme un repertoire que le harnais ne RECONNAIT pas :
+                # rien n'est execute, et rien n'est efface non plus. Lire n'est pas
+                # decider — le marqueur est pose AVANT apply.sh, donc son existence dit
+                # que l'arbre est (ou peut etre) mute, quoi que ce repertoire designe
+                # aujourd'hui. L'effacer detruisait la seule trace, et la porte
+                # continuait sur un arbre d'etat inconnu : #799 qui recommence, en
+                # silence.
                 canary = os.path.join(outside, "ran")
                 os.makedirs(os.path.join(outside, "evil"))
                 with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
                     f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
                 write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
                 left = revert_leftover_mutant(tmp)
-                check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
-                check("rien n'a ete execute", os.path.exists(canary), False)
-                check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+                check("un marqueur etranger est refuse, rien n'est execute",
+                      [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
+                check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
+                      os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+                check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+                check("et son message nomme le marqueur a effacer a la main",
+                      applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+                # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
+                # application ne passe tant que le marqueur est la.
+                again = revert_leftover_mutant(tmp)
+                check("la porte suivante refuse a l'identique, canari toujours pas execute",
+                      [(again or {}).get("refused"), os.path.exists(canary),
+                       os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                code, _out = apply_mutant(lmeta, tmp)
+                check("aucune application ne passe tant qu'un refus est enregistre",
+                      [code, tree()], [APPLY_REFUSED, "original\n"])
+                clear_marker()
                 # Un marqueur sous la racine scratch mais HORS de la pile scellee est
                 # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
                 evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
@@ -3644,8 +3700,10 @@ tool oracle_run:
                     f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
                 write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
                 left = revert_leftover_mutant(tmp)
-                check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
-                      [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+                check("un marqueur sous la racine scratch, hors pile scellee, est refuse et garde",
+                      [(left or {}).get("refused"), os.path.exists(canary),
+                       os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+                clear_marker()
                 # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
                 # scratch) est le held-out : il est reverti, pas refuse.
                 sealed = tempfile.mkdtemp(prefix="gm-sealed-")
@@ -3665,6 +3723,27 @@ tool oracle_run:
                           [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                           [False, 0, "original\n"])
                     check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                    # LE CAS MESURE. La pile scellee a bouge entre deux passes —
+                    # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
+                    # exactement la configuration que le harnais recommande quand la
+                    # racine par defaut n'est pas stable. Le held-out laisse applique
+                    # se lit alors comme etranger. Tant que ce refus jetait le
+                    # marqueur, la porte notait et CONTINUAIT sur l'arbre mute, sans
+                    # rien pour le dire a la suivante.
+                    code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                    check("le held-out est re-applique", [code, tree()], [0, "original\nheld\n"])
+                    os.environ.pop("GM_SEALED_DIR", None)
+                    moved = revert_leftover_mutant(tmp)
+                    check("pile scellee deplacee : refus, marqueur garde, arbre encore mute",
+                          [(moved or {}).get("refused"), os.path.isfile(applied_marker_for(tmp)), tree()],
+                          ["dir", True, "original\nheld\n"])
+                    check("et la porte s'arrete au lieu de juger cet arbre",
+                          leftover_disposition(moved or {})[0] in LEFTOVER_BAIL_KINDS, True)
+                    os.environ["GM_SEALED_DIR"] = sealed
+                    healed = revert_leftover_mutant(tmp)
+                    check("la pile scellee retrouvee, le harnais revertit lui-meme",
+                          [(healed or {}).get("code"), tree(),
+                           os.path.isfile(applied_marker_for(tmp))], [0, "original\n", False])
                 finally:
                     os.environ.pop("GM_SEALED_DIR", None)
                     if saved_sealed is not None:
@@ -3696,7 +3775,7 @@ tool oracle_run:
                 code, _out = revert_mutant(bmeta, tmp)
                 check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
                       [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
-                os.remove(applied_marker_for(tmp))
+                clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
                 # l'application est refusee, la porte s'arrete (disposition 'unusable').
@@ -3714,7 +3793,7 @@ tool oracle_run:
                     check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
                           [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                            os.path.isfile(applied_marker_for(tmp))],
-                          [True, True, "original\nmutant\n", True])
+                          ["slot", True, "original\nmutant\n", True])
                     check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
                 finally:
                     os.chmod(mdir_marker, 0o700)
@@ -3889,7 +3968,7 @@ tool oracle_run:
         left = revert_leftover_mutant(ws)
         if left:
             kind, text = leftover_disposition(left)
-            if kind in ("still_mutated", "unusable"):
+            if kind in LEFTOVER_BAIL_KINDS:
                 bail(text)
             note(report, text)
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3495,7 +3495,10 @@ tool oracle_run:
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-                os.remove(applied_marker_for(tmp))
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
                 scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2374,6 +2374,30 @@ tool oracle_run:
             pass
 
 
+    def leftover_on_record(ws):
+        """True when a mutant is still recorded as applied — the tree is no longer
+        KNOWN to be at baseline.
+
+        The single signal, whatever armed it, and that is the point: `revert_clean`
+        only exists on a verdict that reached the full apply→capture→revert path.
+        Two other ways a revert fails to restore the baseline never set it — the
+        inert branch and the failed-apply branch each call revert_mutant and drop
+        its exit code on the floor. The record is what all three leave behind, so
+        the scoring reads the record and not one verdict's field.
+        """
+        meta, _why = read_applied_marker(ws)
+        return meta is not None
+
+
+    def scoring_must_stop(verdict, ws):
+        """The scoring ends after this verdict: the tree is no longer known to be
+        at baseline, so every later measurement would describe a program nobody
+        wrote — and every later application is refused anyway while the record
+        stands. Named, rather than inline in each of the two scoring loops, so the
+        rule is one expression and the self-test can drive the decision itself."""
+        return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3668,6 +3692,31 @@ tool oracle_run:
                 check("une application en echec est un mutant 'failed'", state, "failed")
                 check("elle a reverti l'arbre", tree(), "original\n")
                 check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                # LE SIGNAL D'ARRET EST L'ENREGISTREMENT, PAS `revert_clean`. Un
+                # mutant INERTE — son point d'appui a disparu sous une modernisation
+                # legitime, apply.sh ne mute plus rien — dont le revert.sh echoue
+                # (`git checkout` d'un fichier que le lot a supprime) laisse un
+                # enregistrement arme, et sa branche ne pose JAMAIS `revert_clean` :
+                # la boucle continuait, chaque mutant suivant revenait INVALIDE en
+                # nommant le coupable, et les comptes decrivaient un lot que
+                # personne n'avait mesure.
+                scripts("exit 0", "exit 1")
+                v_inert, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                check("un mutant qui ne mute rien est 'inert'", state, "inert")
+                revert_mutant(lmeta, tmp)   # ce que fait la branche inerte de score_mutant
+                check("son revert en echec laisse l'enregistrement arme",
+                      [("revert_clean" in v_inert), leftover_on_record(tmp)], [False, True])
+                check("et le classement S'ARRETE dessus, sans `revert_clean`",
+                      scoring_must_stop(v_inert, tmp), True)
+                check("l'application suivante est de toute facon refusee",
+                      apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+                clear_marker()
+                check("rien d'enregistre, un verdict propre : le classement continue",
+                      [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
+                      [False, False])
+                check("un revert sale arrete le classement meme sans enregistrement",
+                      scoring_must_stop({"revert_clean": False}, tmp), True)
+                sub("git", "checkout", "--", "f.txt")
                 # Seule la disposition « reverti » laisse passer la porte. Le lien entre
                 # la decision et son consommateur est CETTE constante, pas trois lignes
                 # de main() que rien ne conduit.
@@ -3772,9 +3821,10 @@ tool oracle_run:
                 scripts("exit 0", "exit 0")
                 apply_mutant(lmeta, tmp)
                 saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+                check("`sh` est sur le PATH (tout le harnais passe par lui)", bool(shbin), True)
                 bindir = tempfile.mkdtemp(prefix="gm-bin-")
                 try:
-                    os.symlink(shbin, os.path.join(bindir, "sh"))
+                    os.symlink(shbin or "/bin/sh", os.path.join(bindir, "sh"))
                     os.environ["PATH"] = bindir
                     try:
                         nogit = revert_leftover_mutant(tmp)
@@ -4319,18 +4369,27 @@ tool oracle_run:
                              % ", ".join(sorted(only)))
 
             verdicts, blind = [], []
-            # A revert that did not restore the baseline (revert.sh failed, or the
-            # captures still differ with the mutant gone) ends the scoring: every
+            # A revert that did not restore the baseline ends the scoring: every
             # later measurement would describe a program nobody wrote, and every
-            # later apply is refused anyway while the leftover is on record. The
-            # gate is red on `revert_clean` either way; stopping keeps it legible.
+            # later apply is refused anyway while the leftover is on record.
+            #
+            # TWO signals, because one does not cover the rule. `revert_clean` is
+            # written only on the full apply→capture→revert path — revert.sh
+            # exited non-zero, or the captures still differ with the mutant gone.
+            # The inert branch and the failed-apply branch also run a revert and
+            # also ignore its exit code, and a leftover armed there used to let the
+            # loop run on: every remaining mutant came back INVALID naming the
+            # culprit, the counts described a lot nobody measured, and the operator
+            # was told to revert a tree by hand. `leftover_on_record` is what all
+            # three leave behind. The gate is red either way; stopping keeps it
+            # legible.
             stopped = None
             for seed, meta in enumerate(visible):
                 if only and meta["id"] not in only:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
-                if not v.get("revert_clean", True):
+                if scoring_must_stop(v, ws):
                     stopped = v
                     break
                 if not v.get("valid"):
@@ -4354,12 +4413,12 @@ tool oracle_run:
                 for i, m in enumerate(held_meta):
                     v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
                     held.append(v)
-                    if not v.get("revert_clean", True):
+                    if scoring_must_stop(v, ws):
                         stopped = v
                         break
             if stopped is not None:
-                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
-                     "longer at baseline, so the mutants after it were not scored and are absent "
+                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
+                     "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
                      "from the counts; a leftover, if any, is on record for the next gate."
                      % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2246,21 +2246,50 @@ tool oracle_run:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
-    APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+    # apply_mutant's code when apply.sh was NOT run because no record could go
+    # down first. A string on purpose: a returncode is an int, and a shell killed
+    # by SIGHUP reports -1 — an apply that DID run and must be reverted.
+    APPLY_REFUSED = "refused"
+
+
+    _git_dir_cache = {}
+
+
+    def git_dir_of(ws):
+        """The tree's git dir (a worktree's own, under the main repo's .git), or
+        "" when ws is not a git repository — or when git does not answer:
+        bounded and guarded, because this runs before the JSON report the
+        campaign parses. Cached per workspace path."""
+        key = os.path.realpath(ws)
+        if key not in _git_dir_cache:
+            try:
+                p = subprocess.run(["git", "-C", ws, "rev-parse", "--git-dir"],
+                                   capture_output=True, text=True, timeout=60)
+                d = (p.stdout or "").strip() if p.returncode == 0 else ""
+            except (OSError, subprocess.SubprocessError):
+                d = ""
+            if d and not os.path.isabs(d):
+                d = os.path.join(key, d)
+            _git_dir_cache[key] = os.path.realpath(d) if d else ""
+        return _git_dir_cache[key]
 
 
     def applied_marker_for(ws):
         """Where the harness notes the mutant it has applied and not yet reverted.
 
-        Outside the tree (the tree is what is judged), keyed on the workspace's
-        absolute path (sibling worktrees share a basename), under the same
-        scratch root as the sealed held-out set (GM_SCRATCH, else the system
-        temp dir) — one rule, so a root that makes the sealed pile survive makes
-        the marker survive too. In a private directory of its own: the marker
-        names a script the next gate will execute.
+        With the TREE, outside what is judged: in the tree's git dir, which lives
+        exactly as long as the mutated files do — a container restarted on the
+        same bind-mounted worktree keeps both, a copy-based pod's fresh copy has
+        neither — whereas a marker in a temp root outlives or predeceases the
+        tree it describes (a retry with a fresh /tmp on the same worktree would
+        keep the mutant and lose the note). A workspace that is not a git
+        repository falls back to the scratch root (GM_SCRATCH, else the system
+        temp dir), keyed on the workspace's real path. In a private directory of
+        its own: the marker names a script the next gate will execute.
         """
-        key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        real = os.path.realpath(ws)
+        key = hashlib.sha256(real.encode("utf-8")).hexdigest()[:12]
+        root = git_dir_of(ws) or os.environ.get("GM_SCRATCH", tempfile.gettempdir())
         return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
@@ -2466,16 +2495,17 @@ tool oracle_run:
         return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
-    def leftover_roots(ws):
+    def leftover_roots(ws, gm_dir=None):
         """The only two places a mutant of this workspace's net can live: the
-        tree itself (visible mutants, an unsealed held-out) and the sealed
-        held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
-        scratch root: on a shared host that is all of /tmp, and a marker naming
-        a directory there would have the gate run whatever script it found."""
-        return [ws, sealed_dir_for(ws)]
+        net's own directory (visible mutants, an unsealed held-out — the whole
+        tree when the caller has no net dir to name) and the sealed held-out
+        pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole scratch
+        root: on a shared host that is all of /tmp, and a marker naming a
+        directory there would have the gate run whatever script it found."""
+        return [gm_dir or ws, sealed_dir_for(ws)]
 
 
-    def revert_leftover_mutant(ws):
+    def revert_leftover_mutant(ws, gm_dir=None):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
         A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
@@ -2527,9 +2557,9 @@ tool oracle_run:
             return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
                     "refused": "slot", "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
-        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws, gm_dir)):
             return {"id": meta.get("id"), "dir": mdir, "code": None,
-                    "out": " and ".join(leftover_roots(ws)),
+                    "out": " and ".join(leftover_roots(ws, gm_dir)),
                     "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
@@ -3671,7 +3701,7 @@ tool oracle_run:
             os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
-                    subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+                    return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
                 sub("git", "init", "-q")
                 sub("git", "config", "user.email", "t@t")
                 sub("git", "config", "user.name", "t")
@@ -3704,8 +3734,16 @@ tool oracle_run:
                 code, _out = apply_mutant(lmeta, tmp)
                 check("apply.sh tourne", code, 0)
                 check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
-                check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
-                      applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
+                check("le marqueur vit dans le git-dir de l'arbre, hors de ce qui est juge",
+                      [applied_marker_for(tmp).startswith(os.path.realpath(os.path.join(tmp, ".git")) + os.sep),
+                       "gm-applied" in sub("git", "status", "--porcelain").stdout],
+                      [True, False])
+                nogit = tempfile.mkdtemp(prefix="gm-nogit-")
+                try:
+                    check("sans depot git, le marqueur retombe sous GM_SCRATCH",
+                          applied_marker_for(nogit).startswith(os.environ["GM_SCRATCH"]), True)
+                finally:
+                    shutil.rmtree(nogit, ignore_errors=True)
                 # Interruption ici : pas de revert. La porte suivante nettoie.
                 left = revert_leftover_mutant(tmp)
                 check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
@@ -4005,6 +4043,43 @@ tool oracle_run:
                 left = revert_leftover_mutant(tmp)
                 check("le meme marqueur, l'emplacement redevenu prive : reverti",
                       [(left or {}).get("code"), tree()], [0, "original\n"])
+                # ── Ajouts : racines resserrees sur le repertoire du filet, sentinelle
+                # qui n'est pas un code de retour. Etat remis a plat d'abord.
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
+                sub("git", "checkout", "--", "f.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp, os.path.join(tmp, ".golden-master"))
+                check("hors du repertoire du filet nomme, le marqueur est refuse et garde",
+                      [(left or {}).get("refused"), tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["dir", "original\nmutant\n", True])
+                left = revert_leftover_mutant(tmp)
+                check("sans repertoire de filet nomme, l'arbre entier est reconnu : reverti",
+                      [(left or {}).get("code"), tree()], [0, "original\n"])
+                # Une application TUEE par un signal (returncode -1, ce que rapporte
+                # subprocess pour un shell mort sur SIGHUP) n'est pas une application
+                # refusee : elle a tourne, elle est revertie dans le run. Le -1 est
+                # injecte par une doublure de run_script (un signal reel depend du
+                # shell : exec ou non de la derniere commande).
+                scripts("printf 'half\\n' >> f.txt", "git checkout -- f.txt")
+                real_run_script = g["run_script"]
+
+                def killed_apply(path, ws, timeout=600):
+                    if path.endswith("apply.sh"):
+                        real_run_script(path, ws, timeout)
+                        return -1, "killed by SIGHUP"
+                    return real_run_script(path, ws, timeout)
+                g["run_script"] = killed_apply
+                try:
+                    verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                finally:
+                    g["run_script"] = real_run_script
+                check("une application tuee par un signal est revertie, pas lue comme refusee",
+                      [state, tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["failed", "original\n", False])
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)
@@ -4170,7 +4245,7 @@ tool oracle_run:
         # is looked at, and said: otherwise the dirty check below names the
         # mutant's file as the lot's uncommitted work, and the build gate judges a
         # program nobody wrote.
-        left = revert_leftover_mutant(ws)
+        left = revert_leftover_mutant(ws, gm_dir)
         if left:
             kind, text = leftover_disposition(left)
             if kind in LEFTOVER_BAIL_KINDS:

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2249,21 +2249,41 @@ tool oracle_run:
         """Where the harness notes the mutant it has applied and not yet reverted.
 
         Outside the tree (the tree is what is judged), keyed on the workspace's
-        absolute path (sibling worktrees share a basename), in the same temp root
-        as the sealed held-out set.
+        absolute path (sibling worktrees share a basename), under the same
+        scratch root as the sealed held-out set (GM_SCRATCH, else the system
+        temp dir) — one rule, so a root that makes the sealed pile survive makes
+        the marker survive too. In a private directory of its own: the marker
+        names a script the next gate will execute.
         """
         key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-        return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
+
+
+    def write_applied_marker(ws, meta):
+        """Record the mutant about to be applied. Private directory, exclusive
+        create, no symlink following: a marker is an instruction to run a script,
+        and a shared temp root must not let anyone else write one."""
+        marker = applied_marker_for(ws)
+        d = os.path.dirname(marker)
+        try:
+            os.makedirs(d, mode=0o700, exist_ok=True)
+            os.chmod(d, 0o700)
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+            fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError:
+            pass
 
 
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what.
-        try:
-            with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
-                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
-        except OSError:
-            pass
+        write_applied_marker(ws, meta)
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
@@ -2277,6 +2297,14 @@ tool oracle_run:
         return code, out
 
 
+    def _under(path, root):
+        """True when path (realpath'd) sits under root (realpath'd)."""
+        if not root:
+            return False
+        p, r = os.path.realpath(path), os.path.realpath(root)
+        return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
+
+
     def revert_leftover_mutant(ws):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2285,8 +2313,19 @@ tool oracle_run:
         judge a mutated program and call it the lot's. Measured: a tool node
         retried on the same tree after its exec stream broke — the build gate
         went red on a file the mutant had edited, and the oracle reported that
-        file as "not committed". Returns None when there is nothing to revert,
-        else what was reverted and how revert.sh exited.
+        file as "not committed".
+
+        Returns None when there is nothing to revert. Otherwise a dict with the
+        mutant's id and dir, `code` (revert.sh's exit; None when the script is
+        gone), and `marker`. The marker is dropped only when the revert
+        demonstrably succeeded — a leftover the harness could not revert stays
+        recorded, so the next gate reports it again instead of forgetting it;
+        an operator who reverts by hand clears it by deleting the marker.
+
+        A marker whose directory is not under the workspace or the scratch root
+        is REFUSED, dropped and reported without executing anything: the marker
+        is an instruction to run a script, and only the harness's own mutants
+        may write it.
         """
         marker = applied_marker_for(ws)
         if not os.path.isfile(marker):
@@ -2296,16 +2335,51 @@ tool oracle_run:
                 meta = json.load(f)
         except (OSError, ValueError):
             meta = {}
-        script = os.path.join(meta.get("dir") or "", "revert.sh")
-        if meta.get("dir") and os.path.isfile(script):
+        mdir = meta.get("dir") or ""
+        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+            return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
+                    "marker": marker, "refused": True}
+        script = os.path.join(mdir, "revert.sh")
+        if os.path.isfile(script):
             code, out = run_script(script, ws)
         else:
-            code, out = None, "the mutant's revert.sh is no longer there"
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
-        return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
+            code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+        if code == 0:
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+        return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
+                "marker": marker, "refused": False}
+
+
+    def leftover_disposition(left):
+        """What the gate says about a leftover, and whether it may proceed.
+
+        Returns (kind, text): "reverted" — the tree is HEAD again, a note;
+        "refused" — a foreign marker was dropped, a note; "still_mutated" — the
+        revert failed or its script is gone, the tree is NOT HEAD, the gate must
+        refuse rather than judge a program nobody wrote.
+        """
+        if left.get("refused"):
+            return "refused", (
+                "a stale application marker named a directory outside this workspace and "
+                "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+        if left.get("code") == 0:
+            return "reverted", (
+                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
+                "verdict, if any, judged a mutated program." % left.get("id"))
+        how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
+        return "still_mutated", (
+            "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
+            "The tree is still mutated and will not be judged. Revert by hand (git checkout -- "
+            "<the mutant's paths>), then delete the marker %s." % (left.get("id"), how, left.get("marker")))
 
 
     # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -2382,6 +2456,11 @@ tool oracle_run:
 
         code, out = apply_mutant(meta, ws)
         if code != 0:
+            # A failed apply may have half-edited the tree, and the marker is
+            # down: revert now, within this run, so neither outlives it — a
+            # marker left here would have the NEXT gate run this revert.sh over
+            # whatever the operator wrote since.
+            revert_mutant(meta, ws)
             return dict(base, valid=False, detected=False,
                         reason="apply.sh exited %s: %s" % (code, out[-300:])), "failed"
 
@@ -3345,9 +3424,15 @@ tool oracle_run:
                 if v is not None:
                     os.environ[k] = v
             # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
-            # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
-            # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+            # demarrage de la suivante. Les VRAIS apply/revert et empreintes, sur un
+            # vrai depot : c'est le marqueur et le nettoyage qui sont juges, pas leur
+            # doublure.
+            g.update(apply_mutant=saved["apply_mutant"], revert_mutant=saved["revert_mutant"],
+                     tree_fingerprint=saved["tree_fingerprint"], data_fingerprint=saved["data_fingerprint"])
             tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+            outside = tempfile.mkdtemp(prefix="gm-outside-")
+            saved_scratch = os.environ.get("GM_SCRATCH")
+            os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
                     subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
@@ -3360,30 +3445,83 @@ tool oracle_run:
                 sub("git", "commit", "-qm", "seed")
                 mdir = os.path.join(tmp, "m1")
                 os.makedirs(mdir)
-                with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
-                    f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
-                with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
-                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+
+                def scripts(apply_body, revert_body):
+                    with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\n" + apply_body + "\n")
+                    with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\n" + revert_body + "\n")
+
+                def tree():
+                    with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                        return f.read()
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 lmeta = {"id": "leftover-1", "dir": mdir}
-                code, _out = saved["apply_mutant"](lmeta, tmp)
+                code, _out = apply_mutant(lmeta, tmp)
                 check("apply.sh tourne", code, 0)
                 check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+                check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
+                      applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
                 # Interruption ici : pas de revert. La porte suivante nettoie.
                 left = revert_leftover_mutant(tmp)
                 check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
-                with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
-                    check("l'arbre est revenu a HEAD", f.read(), "original\n")
-                check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+                check("l'arbre est revenu a HEAD", tree(), "original\n")
+                check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
                 check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-                saved["apply_mutant"](lmeta, tmp)
-                saved["revert_mutant"](lmeta, tmp)
+                check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+                # Le chemin nominal efface aussi le marqueur.
+                apply_mutant(lmeta, tmp)
+                revert_mutant(lmeta, tmp)
                 check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-                saved["apply_mutant"](lmeta, tmp)
-                shutil.rmtree(mdir)
+                # Un revert qui ECHOUE garde le marqueur : la porte suivante le redira.
+                scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+                apply_mutant(lmeta, tmp)
                 left = revert_leftover_mutant(tmp)
-                check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+                check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
+                check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
+                check("disposition d'un revert en echec : l'arbre est encore mute",
+                      leftover_disposition(left)[0], "still_mutated")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                left = revert_leftover_mutant(tmp)
+                check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["original\n", False])
+                # Un revert.sh disparu est signale, pas tu — et le marqueur reste.
+                apply_mutant(lmeta, tmp)
+                os.remove(os.path.join(mdir, "revert.sh"))
+                left = revert_leftover_mutant(tmp)
+                check("un mutant dont revert.sh a disparu est signale, pas tu",
+                      [(left or {}).get("id"), left is not None and left.get("code") is None,
+                       "revert.sh" in ((left or {}).get("out") or "")],
+                      ["leftover-1", True, True])
+                check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
+                check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
+                scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
+                verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                check("une application en echec est un mutant 'failed'", state, "failed")
+                check("elle a reverti l'arbre", tree(), "original\n")
+                check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+                canary = os.path.join(outside, "ran")
+                os.makedirs(os.path.join(outside, "evil"))
+                with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+                write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
+                check("rien n'a ete execute", os.path.exists(canary), False)
+                check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+                check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
+                shutil.rmtree(outside, ignore_errors=True)
+                shutil.rmtree(os.environ["GM_SCRATCH"], ignore_errors=True)
+                if saved_scratch is None:
+                    os.environ.pop("GM_SCRATCH", None)
+                else:
+                    os.environ["GM_SCRATCH"] = saved_scratch
         finally:
             g.update(saved)
 
@@ -3543,10 +3681,10 @@ tool oracle_run:
         # program nobody wrote.
         left = revert_leftover_mutant(ws)
         if left:
-            note(report, (
-                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-                "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
-                "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+            kind, text = leftover_disposition(left)
+            if kind == "still_mutated":
+                bail(text)
+            note(report, text)
 
         if mode != "record":
             dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2311,10 +2311,22 @@ tool oracle_run:
         try:
             with os.fdopen(fd, encoding="utf-8") as f:
                 meta = json.load(f)
-        except (OSError, ValueError) as e:
+        except (OSError, ValueError, RecursionError) as e:
+            # RecursionError too: that is what json.load raises on a deeply nested
+            # document, not ValueError, and it would escape as a traceback.
             return {}, "the marker %s is unreadable: %s" % (marker, e)
         if not isinstance(meta, dict):
             return {}, "the marker %s does not hold an object" % marker
+        # The TYPES, not only the shape. `dir` goes straight into os.path.realpath
+        # and os.path.join: a number, a list or a string with an embedded NUL raises
+        # out of main(), and the harness prints a traceback where the campaign
+        # expects its one JSON verdict — read as "the harness is broken" rather than
+        # "the gate is red". Measured on the real binary with `{"id": "x", "dir": 5}`:
+        # exit 1, empty stdout, TypeError on stderr.
+        for k in ("id", "dir"):
+            v = meta.get(k)
+            if v is not None and (not isinstance(v, str) or "\0" in v):
+                return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
         return meta, ""
 
 
@@ -3779,6 +3791,26 @@ tool oracle_run:
                 check("et ne laisse aucune coquille derriere elle",
                       [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
                       [False, False])
+                # Un marqueur dont les CHAMPS ne sont pas des chaines : `dir` part
+                # directement dans realpath et os.path.join. Un nombre, une liste,
+                # une chaine avec un NUL -> exception hors de main(), et le harnais
+                # imprime une trace de pile la ou la campagne attend son unique
+                # verdict JSON. Refuse comme un marqueur illisible, pas subi.
+                os.makedirs(os.path.dirname(applied_marker_for(tmp)), mode=0o700, exist_ok=True)
+                for label, payload in (("un nombre", '{"id": "x", "dir": 5}'),
+                                       ("une liste", '{"id": "x", "dir": ["a"]}'),
+                                       ("un NUL", '{"id": "x", "dir": "/a\\u0000b"}'),
+                                       ("un id non-chaine", '{"id": 7, "dir": "%s"}' % mdir)):
+                    with open(applied_marker_for(tmp), "w", encoding="utf-8") as f:
+                        f.write(payload)
+                    try:
+                        got, raised = revert_leftover_mutant(tmp), ""
+                    except Exception as e:                  # noqa: BLE001 - c'est le test
+                        got, raised = None, "%s: %s" % (type(e).__name__, e)
+                    check("marqueur dont un champ est %s : refuse, pas subi" % label,
+                          [raised, (got or {}).get("refused"),
+                           leftover_disposition(got or {})[0]], ["", "slot", "unusable"])
+                    clear_marker()
                 check("arbre sain, verdicts sains : le revert est annonce propre",
                       overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
                 check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2245,12 +2245,67 @@ tool oracle_run:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+    def applied_marker_for(ws):
+        """Where the harness notes the mutant it has applied and not yet reverted.
+
+        Outside the tree (the tree is what is judged), keyed on the workspace's
+        absolute path (sibling worktrees share a basename), in the same temp root
+        as the sealed held-out set.
+        """
+        key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
+        return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+
+
     def apply_mutant(meta, ws):
+        # The marker goes down BEFORE apply.sh runs: an interruption between the
+        # two leaves a tree that is mutated and a note that says by what.
+        try:
+            with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError:
+            pass
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
     def revert_mutant(meta, ws):
-        return run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+        code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+        if code == 0:
+            try:
+                os.remove(applied_marker_for(ws))
+            except OSError:
+                pass
+        return code, out
+
+
+    def revert_leftover_mutant(ws):
+        """Revert the mutant a previous, interrupted run left applied — if any.
+
+        A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
+        leaves the mutant in the tree; the next gate, in the same tree, would
+        judge a mutated program and call it the lot's. Measured: a tool node
+        retried on the same tree after its exec stream broke — the build gate
+        went red on a file the mutant had edited, and the oracle reported that
+        file as "not committed". Returns None when there is nothing to revert,
+        else what was reverted and how revert.sh exited.
+        """
+        marker = applied_marker_for(ws)
+        if not os.path.isfile(marker):
+            return None
+        try:
+            with open(marker, encoding="utf-8") as f:
+                meta = json.load(f)
+        except (OSError, ValueError):
+            meta = {}
+        script = os.path.join(meta.get("dir") or "", "revert.sh")
+        if meta.get("dir") and os.path.isfile(script):
+            code, out = run_script(script, ws)
+        else:
+            code, out = None, "the mutant's revert.sh is no longer there"
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+        return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
 
 
     # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -3289,6 +3344,46 @@ tool oracle_run:
                 os.environ.pop(k, None)
                 if v is not None:
                     os.environ[k] = v
+            # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
+            # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
+            # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+            tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+            try:
+                def sub(*a):
+                    subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+                sub("git", "init", "-q")
+                sub("git", "config", "user.email", "t@t")
+                sub("git", "config", "user.name", "t")
+                with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
+                    f.write("original\n")
+                sub("git", "add", "f.txt")
+                sub("git", "commit", "-qm", "seed")
+                mdir = os.path.join(tmp, "m1")
+                os.makedirs(mdir)
+                with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
+                with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                lmeta = {"id": "leftover-1", "dir": mdir}
+                code, _out = saved["apply_mutant"](lmeta, tmp)
+                check("apply.sh tourne", code, 0)
+                check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+                # Interruption ici : pas de revert. La porte suivante nettoie.
+                left = revert_leftover_mutant(tmp)
+                check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
+                with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                    check("l'arbre est revenu a HEAD", f.read(), "original\n")
+                check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+                check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
+                saved["apply_mutant"](lmeta, tmp)
+                saved["revert_mutant"](lmeta, tmp)
+                check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                saved["apply_mutant"](lmeta, tmp)
+                shutil.rmtree(mdir)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+            finally:
+                shutil.rmtree(tmp, ignore_errors=True)
         finally:
             g.update(saved)
 
@@ -3442,6 +3537,17 @@ tool oracle_run:
         # est capturé ensuite décrit autre chose. Le travail non committé est
         # détruit au passage, en silence. Signalé plutôt que refusé : enregistrer et
         # itérer sur un arbre sale est légitime, GATER dessus ne l'est pas.
+        # A mutant left APPLIED by an interrupted gate is reverted BEFORE the tree
+        # is looked at, and said: otherwise the dirty check below names the
+        # mutant's file as the lot's uncommitted work, and the build gate judges a
+        # program nobody wrote.
+        left = revert_leftover_mutant(ws)
+        if left:
+            note(report, (
+                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
+                "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+
         if mode != "record":
             dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
                                    capture_output=True, text=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3986,21 +3986,38 @@ def main():
         wanted = [i.strip() for i in os.environ.get("GM_MUTANTS", "").split(",") if i.strip()]
         chosen = [m for m in visible if not wanted or m["id"] in wanted]
         report["missing"] = sorted(set(wanted) - {m["id"] for m in chosen})
-        verdicts = []
+        verdicts, stopped_at = [], None
         for m in chosen:
             v, state = probe_mutation(m, ws)
             if state != "failed":
                 revert_mutant(m, ws)
             verdicts.append(v)
+            # The gate's rule, here too. One mutant whose revert failed leaves
+            # the record armed; without this, every LATER mutant came back
+            # invalid quoting that one, while the tail still announced them all
+            # "applied, fingerprinted and reverted" and the tree stayed mutated.
+            # This is the mode the campaign uses to accept a RE-ANCHORED mutant,
+            # so the cascade sent it to repair mutants that were fine.
+            if leftover_on_record(ws):
+                stopped_at = v
+                break
         report["total"] = len(verdicts)
         report["valid"] = len([v for v in verdicts if v.get("valid")])
         report["invalid"] = [{"id": v["id"], "reason": v.get("reason", "")}
                              for v in verdicts if not v.get("valid")]
+        done = len(verdicts) - (1 if stopped_at is not None else 0)
         report["log_tail"] = (
             "MODE=validate — %d mutant(s) applied, fingerprinted and reverted. This says "
             "each one CHANGES something; it says NOTHING about whether the net sees it. "
             "Only the gate captures and compares, and the zeroed fields above are defaults, "
-            "not a verdict." % len(verdicts))
+            "not a verdict." % done)
+        if stopped_at is not None:
+            report["log_tail"] += (
+                " STOPPED at mutant %s: it is still recorded as applied, so the tree is not "
+                "at baseline and the %d mutant(s) after it were NOT validated — every "
+                "application there would be refused, not measured. Revert by hand, delete "
+                "the marker %s, then re-run."
+                % (stopped_at.get("id"), len(chosen) - len(verdicts), applied_marker_for(ws)))
         if report["missing"]:
             report["log_tail"] += (" %d requested mutant(s) do not exist: %s."
                                    % (len(report["missing"]), ", ".join(report["missing"])))

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2092,10 +2092,22 @@ def read_applied_marker(ws):
     try:
         with os.fdopen(fd, encoding="utf-8") as f:
             meta = json.load(f)
-    except (OSError, ValueError) as e:
+    except (OSError, ValueError, RecursionError) as e:
+        # RecursionError too: that is what json.load raises on a deeply nested
+        # document, not ValueError, and it would escape as a traceback.
         return {}, "the marker %s is unreadable: %s" % (marker, e)
     if not isinstance(meta, dict):
         return {}, "the marker %s does not hold an object" % marker
+    # The TYPES, not only the shape. `dir` goes straight into os.path.realpath
+    # and os.path.join: a number, a list or a string with an embedded NUL raises
+    # out of main(), and the harness prints a traceback where the campaign
+    # expects its one JSON verdict — read as "the harness is broken" rather than
+    # "the gate is red". Measured on the real binary with `{"id": "x", "dir": 5}`:
+    # exit 1, empty stdout, TypeError on stderr.
+    for k in ("id", "dir"):
+        v = meta.get(k)
+        if v is not None and (not isinstance(v, str) or "\0" in v):
+            return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
     return meta, ""
 
 
@@ -3560,6 +3572,26 @@ def _selftest():
             check("et ne laisse aucune coquille derriere elle",
                   [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
                   [False, False])
+            # Un marqueur dont les CHAMPS ne sont pas des chaines : `dir` part
+            # directement dans realpath et os.path.join. Un nombre, une liste,
+            # une chaine avec un NUL -> exception hors de main(), et le harnais
+            # imprime une trace de pile la ou la campagne attend son unique
+            # verdict JSON. Refuse comme un marqueur illisible, pas subi.
+            os.makedirs(os.path.dirname(applied_marker_for(tmp)), mode=0o700, exist_ok=True)
+            for label, payload in (("un nombre", '{"id": "x", "dir": 5}'),
+                                   ("une liste", '{"id": "x", "dir": ["a"]}'),
+                                   ("un NUL", '{"id": "x", "dir": "/a\\u0000b"}'),
+                                   ("un id non-chaine", '{"id": 7, "dir": "%s"}' % mdir)):
+                with open(applied_marker_for(tmp), "w", encoding="utf-8") as f:
+                    f.write(payload)
+                try:
+                    got, raised = revert_leftover_mutant(tmp), ""
+                except Exception as e:                  # noqa: BLE001 - c'est le test
+                    got, raised = None, "%s: %s" % (type(e).__name__, e)
+                check("marqueur dont un champ est %s : refuse, pas subi" % label,
+                      [raised, (got or {}).get("refused"),
+                       leftover_disposition(got or {})[0]], ["", "slot", "unusable"])
+                clear_marker()
             check("arbre sain, verdicts sains : le revert est annonce propre",
                   overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
             check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2204,7 +2204,9 @@ def revert_leftover_mutant(ws):
     Returns None when there is nothing to revert. Otherwise a dict with the
     mutant's id and dir, `code` (revert.sh's exit; None when the script is
     gone), `marker`, and after a clean revert `dirty` — what `git status`
-    still shows, because the script's exit code is its word, not the tree's.
+    still shows, because the script's exit code is its word, not the tree's
+    — or `dirty_unknown`, the reason git could not be asked, which is not
+    the same fact as an empty `dirty`.
     The marker is dropped only when the revert demonstrably succeeded — a
     leftover the harness could not revert stays recorded, so the next gate
     reports it again instead of forgetting it; an operator who reverts by
@@ -2236,14 +2238,24 @@ def revert_leftover_mutant(ws):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-    dirty = ""
+    dirty, unknown = "", ""
     if code == 0:
         drop_applied_marker(ws, meta)
-        st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
-                            capture_output=True, text=True)
-        dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
+        # Through run(), and on a short leash. This sweep runs in EVERY mode,
+        # record included, and the harness's contract is to answer with a
+        # verdict: a `git` that is absent must not replace the JSON report with
+        # a traceback the campaign reads as "the harness is broken", and a
+        # wedged one must not hang the gate the way the incident behind this
+        # whole guard hung it. Unanswered is reported as UNKNOWN, never as
+        # clean — an empty porcelain and an absent git are not the same fact.
+        st, st_out = run("git status --porcelain", ws, timeout=120)
+        if st == 0:
+            dirty = st_out.strip()
+        else:
+            unknown = "`git status` did not answer (exit %s)" % st
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-            "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
+            "marker": marker, "refused": False, "kept": code != 0,
+            "dirty": dirty[:400], "dirty_unknown": unknown}
 
 
 # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2292,6 +2304,9 @@ def leftover_disposition(left):
             text += (" The tree still shows uncommitted changes after the revert — the "
                      "script's exit is its word, not the tree's: %s"
                      % " ".join(left["dirty"].split())[:300])
+        elif left.get("dirty_unknown"):
+            text += (" Whether the tree actually came back could not be checked: %s. "
+                     "Unknown, not clean." % left["dirty_unknown"])
         return "reverted", text
     how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
     return "still_mutated", (
@@ -3530,6 +3545,34 @@ def _selftest():
                 if saved_sealed is not None:
                     os.environ["GM_SEALED_DIR"] = saved_sealed
                 shutil.rmtree(sealed, ignore_errors=True)
+            # Un `git` hors d'atteinte doit donner un VERDICT, pas une trace de
+            # pile : ce balayage tourne dans TOUS les modes, `record` compris, ou
+            # rien d'autre n'appelle git — et la campagne lit du JSON sur la
+            # sortie standard. PATH reduit a `sh` : git est absent, le script de
+            # revert (un `exit 0`, une primitive du shell) tourne encore.
+            scripts("exit 0", "exit 0")
+            apply_mutant(lmeta, tmp)
+            saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+            bindir = tempfile.mkdtemp(prefix="gm-bin-")
+            try:
+                os.symlink(shbin, os.path.join(bindir, "sh"))
+                os.environ["PATH"] = bindir
+                try:
+                    nogit = revert_leftover_mutant(tmp)
+                    raised = ""
+                except Exception as e:                      # noqa: BLE001 - c'est le test
+                    nogit, raised = None, "%s: %s" % (type(e).__name__, e)
+            finally:
+                os.environ["PATH"] = saved_path
+                shutil.rmtree(bindir, ignore_errors=True)
+            check("git absent : un verdict, pas une exception",
+                  [raised, (nogit or {}).get("code")], ["", 0])
+            check("l'etat de l'arbre est INCONNU, pas propre",
+                  [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
+                  ["", True])
+            check("et la note le dit au lieu de laisser croire a un arbre propre",
+                  "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+            clear_marker()
             # Un revert en ECHEC garde son enregistrement face au mutant suivant :
             # la seconde application est refusee, rien ne tourne, et le revert du
             # second n'efface pas le marqueur du premier.

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2030,21 +2030,41 @@ def applied_marker_for(ws):
     """Where the harness notes the mutant it has applied and not yet reverted.
 
     Outside the tree (the tree is what is judged), keyed on the workspace's
-    absolute path (sibling worktrees share a basename), in the same temp root
-    as the sealed held-out set.
+    absolute path (sibling worktrees share a basename), under the same
+    scratch root as the sealed held-out set (GM_SCRATCH, else the system
+    temp dir) — one rule, so a root that makes the sealed pile survive makes
+    the marker survive too. In a private directory of its own: the marker
+    names a script the next gate will execute.
     """
     key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-    return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+    root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+    return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
+
+
+def write_applied_marker(ws, meta):
+    """Record the mutant about to be applied. Private directory, exclusive
+    create, no symlink following: a marker is an instruction to run a script,
+    and a shared temp root must not let anyone else write one."""
+    marker = applied_marker_for(ws)
+    d = os.path.dirname(marker)
+    try:
+        os.makedirs(d, mode=0o700, exist_ok=True)
+        os.chmod(d, 0o700)
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+        fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+    except OSError:
+        pass
 
 
 def apply_mutant(meta, ws):
     # The marker goes down BEFORE apply.sh runs: an interruption between the
     # two leaves a tree that is mutated and a note that says by what.
-    try:
-        with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
-            json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
-    except OSError:
-        pass
+    write_applied_marker(ws, meta)
     return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
@@ -2058,6 +2078,14 @@ def revert_mutant(meta, ws):
     return code, out
 
 
+def _under(path, root):
+    """True when path (realpath'd) sits under root (realpath'd)."""
+    if not root:
+        return False
+    p, r = os.path.realpath(path), os.path.realpath(root)
+    return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
+
+
 def revert_leftover_mutant(ws):
     """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2066,8 +2094,19 @@ def revert_leftover_mutant(ws):
     judge a mutated program and call it the lot's. Measured: a tool node
     retried on the same tree after its exec stream broke — the build gate
     went red on a file the mutant had edited, and the oracle reported that
-    file as "not committed". Returns None when there is nothing to revert,
-    else what was reverted and how revert.sh exited.
+    file as "not committed".
+
+    Returns None when there is nothing to revert. Otherwise a dict with the
+    mutant's id and dir, `code` (revert.sh's exit; None when the script is
+    gone), and `marker`. The marker is dropped only when the revert
+    demonstrably succeeded — a leftover the harness could not revert stays
+    recorded, so the next gate reports it again instead of forgetting it;
+    an operator who reverts by hand clears it by deleting the marker.
+
+    A marker whose directory is not under the workspace or the scratch root
+    is REFUSED, dropped and reported without executing anything: the marker
+    is an instruction to run a script, and only the harness's own mutants
+    may write it.
     """
     marker = applied_marker_for(ws)
     if not os.path.isfile(marker):
@@ -2077,16 +2116,51 @@ def revert_leftover_mutant(ws):
             meta = json.load(f)
     except (OSError, ValueError):
         meta = {}
-    script = os.path.join(meta.get("dir") or "", "revert.sh")
-    if meta.get("dir") and os.path.isfile(script):
+    mdir = meta.get("dir") or ""
+    root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+    if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+        return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
+                "marker": marker, "refused": True}
+    script = os.path.join(mdir, "revert.sh")
+    if os.path.isfile(script):
         code, out = run_script(script, ws)
     else:
-        code, out = None, "the mutant's revert.sh is no longer there"
-    try:
-        os.remove(marker)
-    except OSError:
-        pass
-    return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
+        code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+    if code == 0:
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+    return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
+            "marker": marker, "refused": False}
+
+
+def leftover_disposition(left):
+    """What the gate says about a leftover, and whether it may proceed.
+
+    Returns (kind, text): "reverted" — the tree is HEAD again, a note;
+    "refused" — a foreign marker was dropped, a note; "still_mutated" — the
+    revert failed or its script is gone, the tree is NOT HEAD, the gate must
+    refuse rather than judge a program nobody wrote.
+    """
+    if left.get("refused"):
+        return "refused", (
+            "a stale application marker named a directory outside this workspace and "
+            "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+    if left.get("code") == 0:
+        return "reverted", (
+            "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+            "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
+            "verdict, if any, judged a mutated program." % left.get("id"))
+    how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
+    return "still_mutated", (
+        "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
+        "The tree is still mutated and will not be judged. Revert by hand (git checkout -- "
+        "<the mutant's paths>), then delete the marker %s." % (left.get("id"), how, left.get("marker")))
 
 
 # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -2163,6 +2237,11 @@ def probe_mutation(meta, ws):
 
     code, out = apply_mutant(meta, ws)
     if code != 0:
+        # A failed apply may have half-edited the tree, and the marker is
+        # down: revert now, within this run, so neither outlives it — a
+        # marker left here would have the NEXT gate run this revert.sh over
+        # whatever the operator wrote since.
+        revert_mutant(meta, ws)
         return dict(base, valid=False, detected=False,
                     reason="apply.sh exited %s: %s" % (code, out[-300:])), "failed"
 
@@ -3126,9 +3205,15 @@ def _selftest():
             if v is not None:
                 os.environ[k] = v
         # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
-        # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
-        # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+        # demarrage de la suivante. Les VRAIS apply/revert et empreintes, sur un
+        # vrai depot : c'est le marqueur et le nettoyage qui sont juges, pas leur
+        # doublure.
+        g.update(apply_mutant=saved["apply_mutant"], revert_mutant=saved["revert_mutant"],
+                 tree_fingerprint=saved["tree_fingerprint"], data_fingerprint=saved["data_fingerprint"])
         tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+        outside = tempfile.mkdtemp(prefix="gm-outside-")
+        saved_scratch = os.environ.get("GM_SCRATCH")
+        os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
         try:
             def sub(*a):
                 subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
@@ -3141,30 +3226,83 @@ def _selftest():
             sub("git", "commit", "-qm", "seed")
             mdir = os.path.join(tmp, "m1")
             os.makedirs(mdir)
-            with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
-                f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
-            with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
-                f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+
+            def scripts(apply_body, revert_body):
+                with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\n" + apply_body + "\n")
+                with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\n" + revert_body + "\n")
+
+            def tree():
+                with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                    return f.read()
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             lmeta = {"id": "leftover-1", "dir": mdir}
-            code, _out = saved["apply_mutant"](lmeta, tmp)
+            code, _out = apply_mutant(lmeta, tmp)
             check("apply.sh tourne", code, 0)
             check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+            check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
+                  applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
             # Interruption ici : pas de revert. La porte suivante nettoie.
             left = revert_leftover_mutant(tmp)
             check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
-            with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
-                check("l'arbre est revenu a HEAD", f.read(), "original\n")
-            check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+            check("l'arbre est revenu a HEAD", tree(), "original\n")
+            check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
             check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-            saved["apply_mutant"](lmeta, tmp)
-            saved["revert_mutant"](lmeta, tmp)
+            check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+            # Le chemin nominal efface aussi le marqueur.
+            apply_mutant(lmeta, tmp)
+            revert_mutant(lmeta, tmp)
             check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-            saved["apply_mutant"](lmeta, tmp)
-            shutil.rmtree(mdir)
+            # Un revert qui ECHOUE garde le marqueur : la porte suivante le redira.
+            scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+            apply_mutant(lmeta, tmp)
             left = revert_leftover_mutant(tmp)
-            check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+            check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
+            check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
+            check("disposition d'un revert en echec : l'arbre est encore mute",
+                  leftover_disposition(left)[0], "still_mutated")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            left = revert_leftover_mutant(tmp)
+            check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
+                  ["original\n", False])
+            # Un revert.sh disparu est signale, pas tu — et le marqueur reste.
+            apply_mutant(lmeta, tmp)
+            os.remove(os.path.join(mdir, "revert.sh"))
+            left = revert_leftover_mutant(tmp)
+            check("un mutant dont revert.sh a disparu est signale, pas tu",
+                  [(left or {}).get("id"), left is not None and left.get("code") is None,
+                   "revert.sh" in ((left or {}).get("out") or "")],
+                  ["leftover-1", True, True])
+            check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
+            check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+            os.remove(applied_marker_for(tmp))
+            sub("git", "checkout", "--", "f.txt")
+            # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
+            scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
+            verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+            check("une application en echec est un mutant 'failed'", state, "failed")
+            check("elle a reverti l'arbre", tree(), "original\n")
+            check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+            # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+            canary = os.path.join(outside, "ran")
+            os.makedirs(os.path.join(outside, "evil"))
+            with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+            write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
+            left = revert_leftover_mutant(tmp)
+            check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
+            check("rien n'a ete execute", os.path.exists(canary), False)
+            check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+            check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
+            shutil.rmtree(outside, ignore_errors=True)
+            shutil.rmtree(os.environ["GM_SCRATCH"], ignore_errors=True)
+            if saved_scratch is None:
+                os.environ.pop("GM_SCRATCH", None)
+            else:
+                os.environ["GM_SCRATCH"] = saved_scratch
     finally:
         g.update(saved)
 
@@ -3324,10 +3462,10 @@ def main():
     # program nobody wrote.
     left = revert_leftover_mutant(ws)
     if left:
-        note(report, (
-            "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-            "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
-            "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+        kind, text = leftover_disposition(left)
+        if kind == "still_mutated":
+            bail(text)
+        note(report, text)
 
     if mode != "record":
         dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2138,14 +2138,16 @@ def write_applied_marker(ws, meta):
     return True, ""
 
 
-def drop_applied_marker(ws, meta=None):
-    """Remove the marker — only when it records THIS mutant (meta None: any
-    marker of ours). A revert of B must never erase the record of A, whose
-    revert failed: that record is the only trace of a tree that is not HEAD."""
+def drop_applied_marker(ws, meta):
+    """Remove the marker — only when it records THIS mutant, and only after its
+    revert demonstrably succeeded. A revert of B must never erase the record of
+    A, whose revert failed: that record is the only trace of a tree that is not
+    HEAD. There is deliberately no "drop whatever is there" form — dropping a
+    record the harness did not just undo is how a leftover is lost for good."""
     prior, why = read_applied_marker(ws)
     if prior is None or why:
         return
-    if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+    if prior.get("id") is not None and prior.get("id") != meta.get("id"):
         return
     try:
         os.remove(applied_marker_for(ws))
@@ -2208,10 +2210,14 @@ def revert_leftover_mutant(ws):
     reports it again instead of forgetting it; an operator who reverts by
     hand clears it by deleting the marker.
 
-    Refused, nothing executed: a marker whose directory is neither this
-    workspace nor its sealed held-out pile (dropped — it is ours and it is
-    not evidence), and a marker slot that is not the harness's own (kept —
-    not ours to delete; every application is refused until it is gone).
+    Refused, nothing executed AND nothing deleted — `refused` names which
+    half the harness would not touch: "dir", a marker whose directory is
+    neither this workspace nor its sealed held-out pile, and "slot", a
+    marker slot that is not the harness's own. Reading is not deciding: the
+    record goes down BEFORE apply.sh runs, so it stands whatever the
+    directory resolves to today, and dropping it would destroy the only
+    evidence that the tree is not HEAD. Every application is refused while
+    it is there, which is what makes the refusal stick.
     """
     marker = applied_marker_for(ws)
     meta, why = read_applied_marker(ws)
@@ -2219,12 +2225,12 @@ def revert_leftover_mutant(ws):
         return None
     if why:
         return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
-                "refused": True, "kept": True, "dirty": ""}
+                "refused": "slot", "kept": True, "dirty": ""}
     mdir = meta.get("dir") or ""
     if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
-        drop_applied_marker(ws)
-        return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                "marker": marker, "refused": True, "kept": False, "dirty": ""}
+        return {"id": meta.get("id"), "dir": mdir, "code": None,
+                "out": " and ".join(leftover_roots(ws)),
+                "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
     script = os.path.join(mdir, "revert.sh")
     if os.path.isfile(script):
         code, out = run_script(script, ws)
@@ -2240,27 +2246,44 @@ def revert_leftover_mutant(ws):
             "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
+# The dispositions on which the gate STOPS rather than judges. Only "reverted"
+# — the harness undid the leftover and saw the tree come back — lets it
+# through. The set lives here, beside the function that produces the kinds, so
+# the decision and its consumer cannot drift apart silently.
+LEFTOVER_BAIL_KINDS = ("still_mutated", "unusable", "refused")
+
+
 def leftover_disposition(left):
     """What the gate says about a leftover, and whether it may proceed.
 
     Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
-    the tree still shows, if anything); "refused" — a marker of ours naming
-    a foreign directory was dropped, a note; "unusable" — the marker slot is
-    not the harness's own, the gate must stop: every application would be
-    refused; "still_mutated" — the revert failed or its script is gone, the
-    tree is NOT HEAD, the gate must refuse rather than judge a program
+    the tree still shows, if anything), the only kind that lets the gate
+    through; "refused" — a marker of ours naming a directory the harness
+    does not recognise, kept and not executed; "unusable" — the marker slot
+    is not the harness's own; "still_mutated" — the revert failed or its
+    script is gone. The last three are LEFTOVER_BAIL_KINDS: the tree is, or
+    may be, not HEAD, and the gate refuses rather than judge a program
     nobody wrote.
     """
+    if left.get("refused") == "slot":
+        return "unusable", (
+            "the application-marker slot %s is not the harness's own: %s. Nothing "
+            "executed, nothing deleted. Every mutant application is refused until "
+            "it is removed by hand or GM_SCRATCH points at a private root."
+            % (left.get("marker"), left.get("out")))
     if left.get("refused"):
-        if left.get("kept"):
-            return "unusable", (
-                "the application-marker slot %s is not the harness's own: %s. Nothing "
-                "executed, nothing deleted. Every mutant application is refused until "
-                "it is removed by hand or GM_SCRATCH points at a private root."
-                % (left.get("marker"), left.get("out")))
         return "refused", (
-            "a stale application marker named a directory outside this workspace and "
-            "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+            "a mutant is recorded as APPLIED (%s) and the harness will NOT revert it: "
+            "its directory %s is none of the roots a leftover may live under (%s). "
+            "Nothing executed, nothing deleted. The record goes down BEFORE apply.sh "
+            "runs, so it stands whatever that directory resolves to today: the tree "
+            "is, or may be, mutated, and the gate will not judge it. The ordinary "
+            "cause is a GM_SEALED_DIR that moved between passes — re-run with the one "
+            "that pass used and the harness reverts the mutant itself. Otherwise "
+            "revert by hand (git checkout -- <the mutant's paths>), then delete the "
+            "marker %s."
+            % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
+               left.get("marker")))
     if left.get("code") == 0:
         text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                 "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -3355,6 +3378,14 @@ def _selftest():
             def tree():
                 with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
                     return f.read()
+
+            def clear_marker():
+                # Tolerant on purpose: a mutant on the drop rules must fail as
+                # CHECKS, not as an OSError that takes the whole self-test with it.
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             lmeta = {"id": "leftover-1", "dir": mdir}
             code, _out = apply_mutant(lmeta, tmp)
@@ -3395,10 +3426,7 @@ def _selftest():
                   ["leftover-1", True, True])
             check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
             check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-            try:
-                os.remove(applied_marker_for(tmp))
-            except OSError:
-                pass
+            clear_marker()
             sub("git", "checkout", "--", "f.txt")
             # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
             scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
@@ -3406,17 +3434,45 @@ def _selftest():
             check("une application en echec est un mutant 'failed'", state, "failed")
             check("elle a reverti l'arbre", tree(), "original\n")
             check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-            # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+            # Seule la disposition « reverti » laisse passer la porte. Le lien entre
+            # la decision et son consommateur est CETTE constante, pas trois lignes
+            # de main() que rien ne conduit.
+            check("seule une disposition 'reverted' laisse passer la porte",
+                  [k in LEFTOVER_BAIL_KINDS
+                   for k in ("still_mutated", "unusable", "refused", "reverted")],
+                  [True, True, True, False])
+            # Un marqueur qui nomme un repertoire que le harnais ne RECONNAIT pas :
+            # rien n'est execute, et rien n'est efface non plus. Lire n'est pas
+            # decider — le marqueur est pose AVANT apply.sh, donc son existence dit
+            # que l'arbre est (ou peut etre) mute, quoi que ce repertoire designe
+            # aujourd'hui. L'effacer detruisait la seule trace, et la porte
+            # continuait sur un arbre d'etat inconnu : #799 qui recommence, en
+            # silence.
             canary = os.path.join(outside, "ran")
             os.makedirs(os.path.join(outside, "evil"))
             with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
                 f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
             write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
             left = revert_leftover_mutant(tmp)
-            check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
-            check("rien n'a ete execute", os.path.exists(canary), False)
-            check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+            check("un marqueur etranger est refuse, rien n'est execute",
+                  [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
+            check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
+                  os.path.isfile(applied_marker_for(tmp)), True)
             check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+            check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+            check("et son message nomme le marqueur a effacer a la main",
+                  applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+            # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
+            # application ne passe tant que le marqueur est la.
+            again = revert_leftover_mutant(tmp)
+            check("la porte suivante refuse a l'identique, canari toujours pas execute",
+                  [(again or {}).get("refused"), os.path.exists(canary),
+                   os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            code, _out = apply_mutant(lmeta, tmp)
+            check("aucune application ne passe tant qu'un refus est enregistre",
+                  [code, tree()], [APPLY_REFUSED, "original\n"])
+            clear_marker()
             # Un marqueur sous la racine scratch mais HORS de la pile scellee est
             # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
             evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
@@ -3425,8 +3481,10 @@ def _selftest():
                 f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
             write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
             left = revert_leftover_mutant(tmp)
-            check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
-                  [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+            check("un marqueur sous la racine scratch, hors pile scellee, est refuse et garde",
+                  [(left or {}).get("refused"), os.path.exists(canary),
+                   os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+            clear_marker()
             # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
             # scratch) est le held-out : il est reverti, pas refuse.
             sealed = tempfile.mkdtemp(prefix="gm-sealed-")
@@ -3446,6 +3504,27 @@ def _selftest():
                       [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                       [False, 0, "original\n"])
                 check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                # LE CAS MESURE. La pile scellee a bouge entre deux passes —
+                # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
+                # exactement la configuration que le harnais recommande quand la
+                # racine par defaut n'est pas stable. Le held-out laisse applique
+                # se lit alors comme etranger. Tant que ce refus jetait le
+                # marqueur, la porte notait et CONTINUAIT sur l'arbre mute, sans
+                # rien pour le dire a la suivante.
+                code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                check("le held-out est re-applique", [code, tree()], [0, "original\nheld\n"])
+                os.environ.pop("GM_SEALED_DIR", None)
+                moved = revert_leftover_mutant(tmp)
+                check("pile scellee deplacee : refus, marqueur garde, arbre encore mute",
+                      [(moved or {}).get("refused"), os.path.isfile(applied_marker_for(tmp)), tree()],
+                      ["dir", True, "original\nheld\n"])
+                check("et la porte s'arrete au lieu de juger cet arbre",
+                      leftover_disposition(moved or {})[0] in LEFTOVER_BAIL_KINDS, True)
+                os.environ["GM_SEALED_DIR"] = sealed
+                healed = revert_leftover_mutant(tmp)
+                check("la pile scellee retrouvee, le harnais revertit lui-meme",
+                      [(healed or {}).get("code"), tree(),
+                       os.path.isfile(applied_marker_for(tmp))], [0, "original\n", False])
             finally:
                 os.environ.pop("GM_SEALED_DIR", None)
                 if saved_sealed is not None:
@@ -3477,7 +3556,7 @@ def _selftest():
             code, _out = revert_mutant(bmeta, tmp)
             check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
                   [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
-            os.remove(applied_marker_for(tmp))
+            clear_marker()
             sub("git", "checkout", "--", "f.txt")
             # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
             # l'application est refusee, la porte s'arrete (disposition 'unusable').
@@ -3495,7 +3574,7 @@ def _selftest():
                 check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
                       [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                        os.path.isfile(applied_marker_for(tmp))],
-                      [True, True, "original\nmutant\n", True])
+                      ["slot", True, "original\nmutant\n", True])
                 check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
             finally:
                 os.chmod(mdir_marker, 0o700)
@@ -3670,7 +3749,7 @@ def main():
     left = revert_leftover_mutant(ws)
     if left:
         kind, text = leftover_disposition(left)
-        if kind in ("still_mutated", "unusable"):
+        if kind in LEFTOVER_BAIL_KINDS:
             bail(text)
         note(report, text)
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2287,6 +2287,18 @@ def revert_leftover_mutant(ws):
     directory resolves to today, and dropping it would destroy the only
     evidence that the tree is not HEAD. Every application is refused while
     it is there, which is what makes the refusal stick.
+
+    ONE gate per tree is ASSUMED: the record carries no liveness, no pid and
+    no lock. A second gate starting while the first sits between its apply.sh
+    and its revert.sh reads that record as a leftover, reverts a LIVE mutant
+    and drops its owner's record; the first then captures against a reverted
+    tree and reports blind lanes it invented. write_applied_marker's refusal
+    ("another harness is gating this tree") does NOT cover this — the sweep
+    runs before any application, so it never reaches that refusal. Measured.
+    Two harnesses mutating one tree cannot measure anything either way, so
+    this is a limitation rather than a mode to support; the fix, if a real
+    case turns up, is an exclusive lock held for the gate's duration (an
+    flock dies with the process, unlike a recorded pid).
     """
     marker = applied_marker_for(ws)
     meta, why = read_applied_marker(ws)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2027,21 +2027,50 @@ def run_script(path, ws, timeout=600):
     return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
-APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+# apply_mutant's code when apply.sh was NOT run because no record could go
+# down first. A string on purpose: a returncode is an int, and a shell killed
+# by SIGHUP reports -1 — an apply that DID run and must be reverted.
+APPLY_REFUSED = "refused"
+
+
+_git_dir_cache = {}
+
+
+def git_dir_of(ws):
+    """The tree's git dir (a worktree's own, under the main repo's .git), or
+    "" when ws is not a git repository — or when git does not answer:
+    bounded and guarded, because this runs before the JSON report the
+    campaign parses. Cached per workspace path."""
+    key = os.path.realpath(ws)
+    if key not in _git_dir_cache:
+        try:
+            p = subprocess.run(["git", "-C", ws, "rev-parse", "--git-dir"],
+                               capture_output=True, text=True, timeout=60)
+            d = (p.stdout or "").strip() if p.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            d = ""
+        if d and not os.path.isabs(d):
+            d = os.path.join(key, d)
+        _git_dir_cache[key] = os.path.realpath(d) if d else ""
+    return _git_dir_cache[key]
 
 
 def applied_marker_for(ws):
     """Where the harness notes the mutant it has applied and not yet reverted.
 
-    Outside the tree (the tree is what is judged), keyed on the workspace's
-    absolute path (sibling worktrees share a basename), under the same
-    scratch root as the sealed held-out set (GM_SCRATCH, else the system
-    temp dir) — one rule, so a root that makes the sealed pile survive makes
-    the marker survive too. In a private directory of its own: the marker
-    names a script the next gate will execute.
+    With the TREE, outside what is judged: in the tree's git dir, which lives
+    exactly as long as the mutated files do — a container restarted on the
+    same bind-mounted worktree keeps both, a copy-based pod's fresh copy has
+    neither — whereas a marker in a temp root outlives or predeceases the
+    tree it describes (a retry with a fresh /tmp on the same worktree would
+    keep the mutant and lose the note). A workspace that is not a git
+    repository falls back to the scratch root (GM_SCRATCH, else the system
+    temp dir), keyed on the workspace's real path. In a private directory of
+    its own: the marker names a script the next gate will execute.
     """
-    key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-    root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+    real = os.path.realpath(ws)
+    key = hashlib.sha256(real.encode("utf-8")).hexdigest()[:12]
+    root = git_dir_of(ws) or os.environ.get("GM_SCRATCH", tempfile.gettempdir())
     return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
@@ -2247,16 +2276,17 @@ def _under(path, root):
     return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
-def leftover_roots(ws):
+def leftover_roots(ws, gm_dir=None):
     """The only two places a mutant of this workspace's net can live: the
-    tree itself (visible mutants, an unsealed held-out) and the sealed
-    held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
-    scratch root: on a shared host that is all of /tmp, and a marker naming
-    a directory there would have the gate run whatever script it found."""
-    return [ws, sealed_dir_for(ws)]
+    net's own directory (visible mutants, an unsealed held-out — the whole
+    tree when the caller has no net dir to name) and the sealed held-out
+    pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole scratch
+    root: on a shared host that is all of /tmp, and a marker naming a
+    directory there would have the gate run whatever script it found."""
+    return [gm_dir or ws, sealed_dir_for(ws)]
 
 
-def revert_leftover_mutant(ws):
+def revert_leftover_mutant(ws, gm_dir=None):
     """Revert the mutant a previous, interrupted run left applied — if any.
 
     A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
@@ -2308,9 +2338,9 @@ def revert_leftover_mutant(ws):
         return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
                 "refused": "slot", "kept": True, "dirty": ""}
     mdir = meta.get("dir") or ""
-    if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+    if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws, gm_dir)):
         return {"id": meta.get("id"), "dir": mdir, "code": None,
-                "out": " and ".join(leftover_roots(ws)),
+                "out": " and ".join(leftover_roots(ws, gm_dir)),
                 "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
     script = os.path.join(mdir, "revert.sh")
     if os.path.isfile(script):
@@ -3452,7 +3482,7 @@ def _selftest():
         os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
         try:
             def sub(*a):
-                subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+                return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
             sub("git", "init", "-q")
             sub("git", "config", "user.email", "t@t")
             sub("git", "config", "user.name", "t")
@@ -3485,8 +3515,16 @@ def _selftest():
             code, _out = apply_mutant(lmeta, tmp)
             check("apply.sh tourne", code, 0)
             check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
-            check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
-                  applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
+            check("le marqueur vit dans le git-dir de l'arbre, hors de ce qui est juge",
+                  [applied_marker_for(tmp).startswith(os.path.realpath(os.path.join(tmp, ".git")) + os.sep),
+                   "gm-applied" in sub("git", "status", "--porcelain").stdout],
+                  [True, False])
+            nogit = tempfile.mkdtemp(prefix="gm-nogit-")
+            try:
+                check("sans depot git, le marqueur retombe sous GM_SCRATCH",
+                      applied_marker_for(nogit).startswith(os.environ["GM_SCRATCH"]), True)
+            finally:
+                shutil.rmtree(nogit, ignore_errors=True)
             # Interruption ici : pas de revert. La porte suivante nettoie.
             left = revert_leftover_mutant(tmp)
             check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
@@ -3786,6 +3824,43 @@ def _selftest():
             left = revert_leftover_mutant(tmp)
             check("le meme marqueur, l'emplacement redevenu prive : reverti",
                   [(left or {}).get("code"), tree()], [0, "original\n"])
+            # ── Ajouts : racines resserrees sur le repertoire du filet, sentinelle
+            # qui n'est pas un code de retour. Etat remis a plat d'abord.
+            try:
+                os.remove(applied_marker_for(tmp))
+            except OSError:
+                pass
+            sub("git", "checkout", "--", "f.txt")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp, os.path.join(tmp, ".golden-master"))
+            check("hors du repertoire du filet nomme, le marqueur est refuse et garde",
+                  [(left or {}).get("refused"), tree(), os.path.isfile(applied_marker_for(tmp))],
+                  ["dir", "original\nmutant\n", True])
+            left = revert_leftover_mutant(tmp)
+            check("sans repertoire de filet nomme, l'arbre entier est reconnu : reverti",
+                  [(left or {}).get("code"), tree()], [0, "original\n"])
+            # Une application TUEE par un signal (returncode -1, ce que rapporte
+            # subprocess pour un shell mort sur SIGHUP) n'est pas une application
+            # refusee : elle a tourne, elle est revertie dans le run. Le -1 est
+            # injecte par une doublure de run_script (un signal reel depend du
+            # shell : exec ou non de la derniere commande).
+            scripts("printf 'half\\n' >> f.txt", "git checkout -- f.txt")
+            real_run_script = g["run_script"]
+
+            def killed_apply(path, ws, timeout=600):
+                if path.endswith("apply.sh"):
+                    real_run_script(path, ws, timeout)
+                    return -1, "killed by SIGHUP"
+                return real_run_script(path, ws, timeout)
+            g["run_script"] = killed_apply
+            try:
+                verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+            finally:
+                g["run_script"] = real_run_script
+            check("une application tuee par un signal est revertie, pas lue comme refusee",
+                  [state, tree(), os.path.isfile(applied_marker_for(tmp))],
+                  ["failed", "original\n", False])
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
             shutil.rmtree(outside, ignore_errors=True)
@@ -3951,7 +4026,7 @@ def main():
     # is looked at, and said: otherwise the dirty check below names the
     # mutant's file as the lot's uncommitted work, and the build gate judges a
     # program nobody wrote.
-    left = revert_leftover_mutant(ws)
+    left = revert_leftover_mutant(ws, gm_dir)
     if left:
         kind, text = leftover_disposition(left)
         if kind in LEFTOVER_BAIL_KINDS:

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2179,6 +2179,24 @@ def scoring_must_stop(verdict, ws):
     return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
 
 
+def overall_revert_clean(verdicts, stopped, ws):
+    """The report's `revert_clean`: did every mutant this gate applied get
+    undone, and did the tree come back?
+
+    Three branches never reach the revert path and so never write the field —
+    a refused apply, an inert mutant, an apply that failed — and reading their
+    SILENCE as True is what let a lot in which almost nothing was measured
+    report a clean revert. Combined with a scoring that stopped (so the later
+    mutants are absent, `blind_lanes` is empty and the held-out loop never ran,
+    leaving a vacuous 0 == 0), that produced a GREEN gate on a tree the harness
+    itself had left mutated with its marker armed. A stop, or a record still
+    standing, is the evidence the tree did not come back.
+    """
+    if stopped is not None or leftover_on_record(ws):
+        return False
+    return all(v.get("revert_clean", True) for v in verdicts)
+
+
 def apply_mutant(meta, ws):
     # The marker goes down BEFORE apply.sh runs: an interruption between the
     # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3491,12 +3509,28 @@ def _selftest():
                   scoring_must_stop(v_inert, tmp), True)
             check("l'application suivante est de toute facon refusee",
                   apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+            # LE SILENCE N'EST PAS UNE PREUVE DE PROPRETE. `revert_clean` n'est
+            # ecrit que par le chemin complet ; les trois branches qui n'y
+            # arrivent pas ne disent rien, et lire ce silence comme « propre »
+            # rendait VERTE une porte sur un arbre que le harnais venait de
+            # laisser mute, marqueur arme. Mesure : apply.sh mi-edite puis sort
+            # 7, revert.sh sort 1 -> score 100 %, revert_clean vrai, held-out
+            # 0/0, GREEN, `git status` = `M f.txt`.
+            check("un mutant enregistre interdit d'annoncer un revert propre",
+                  overall_revert_clean([{"revert_clean": True}], None, tmp), False)
+            check("un classement arrete aussi, quoi que disent les verdicts",
+                  overall_revert_clean([{"revert_clean": True}], {"id": "x"}, tmp), False)
             clear_marker()
             check("rien d'enregistre, un verdict propre : le classement continue",
                   [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
                   [False, False])
             check("un revert sale arrete le classement meme sans enregistrement",
                   scoring_must_stop({"revert_clean": False}, tmp), True)
+            check("arbre sain, verdicts sains : le revert est annonce propre",
+                  overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
+            check("un seul verdict sale suffit a le nier",
+                  overall_revert_clean([{"revert_clean": True}, {"revert_clean": False}],
+                                       None, tmp), False)
             sub("git", "checkout", "--", "f.txt")
             # Seule la disposition « reverti » laisse passer la porte. Le lien entre
             # la decision et son consommateur est CETTE constante, pas trois lignes
@@ -4170,19 +4204,22 @@ def main():
                 continue
             v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
             verdicts.append(v)
+            if v.get("valid"):
+                if not v.get("detected"):
+                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                  "mutant_id": v["id"], "entries": v.get("targets_declared", []),
+                                  "why": "no declared target moved"})
+                elif v.get("undetected_targets"):
+                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                  "mutant_id": v["id"], "entries": v["undetected_targets"],
+                                  "why": "these references did not move for a change they cover"})
+            # Classified FIRST, then the stop. A verdict whose revert failed
+            # still reached capture and comparison, so what it says about the
+            # net is evidence; breaking before this line dropped a real blind
+            # lane on the way out.
             if scoring_must_stop(v, ws):
                 stopped = v
                 break
-            if not v.get("valid"):
-                continue
-            if not v.get("detected"):
-                blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                              "mutant_id": v["id"], "entries": v.get("targets_declared", []),
-                              "why": "no declared target moved"})
-            elif v.get("undetected_targets"):
-                blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                              "mutant_id": v["id"], "entries": v["undetected_targets"],
-                              "why": "these references did not move for a change they cover"})
 
         # The seal relocates the held-out set in BOTH modes — the campaign must
         # lose file access early — but selfcheck neither scores it nor reports
@@ -4219,7 +4256,7 @@ def main():
             valid=len(valid),
             detected=len(detected),
             score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
-            revert_clean=all(v.get("revert_clean", True) for v in verdicts + held),
+            revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
             collateral=sum(len(v.get("collateral") or []) for v in verdicts),
         unstable_controls=sorted({c for v in verdicts
                                   for c in (v.get("unstable_controls") or [])}),
@@ -4244,6 +4281,22 @@ def main():
                 "probe: %s. The net saw the change; the lane they were drawn against did "
                 "not. Citing the aggregate alone would report the resemblance."
                 % (len(off), ", ".join(off))))
+        # A lot whose baseline was lost reports a WITHHELD held-out figure, not
+        # a measured one: the held-out loop did not run (or stopped part-way),
+        # so its 0 == 0 is the vacuous equality this file guards against
+        # everywhere else — and it sat right beside a `revert_clean` that read
+        # silence as clean. Measured, end to end: apply.sh half-edits and exits
+        # 7, revert.sh exits 1 — score_pct 100, revert_clean true, blind_lanes
+        # empty, holdout 0/0, GATE GREEN, `git status` showing `M f.txt` and the
+        # marker still armed. The gate approved the exact tree this guard exists
+        # to refuse. `overall_revert_clean` is now the one that says otherwise.
+        baseline_lost = not report["revert_clean"]
+        if baseline_lost and len(held) < len(held_meta):
+            # Withheld, not zero-because-failed — the idiom selfcheck uses just
+            # below, deliberately unequal so an unscored held-out set can never
+            # be taken for a passed one.
+            report["holdout_total"] = len(held_meta)
+            report["holdout_detected"] = -1
         if mode == "selfcheck":
             # Withheld, not zero-because-failed. The two numbers are made
             # DELIBERATELY UNEQUAL: the gate converges on
@@ -4254,6 +4307,14 @@ def main():
             report["holdout_detected"] = -1
 
         problems = []
+        if baseline_lost:
+            problems.append(
+                "THE TREE IS NOT KNOWN TO BE BACK AT BASELINE: %s. The figures above "
+                "describe what was measured BEFORE that point, not the lot — the mutants "
+                "after it were never applied, so an empty blind-lane list and a 0/0 "
+                "held-out figure mean 'not measured', never 'clean'."
+                % (("scoring stopped after mutant %s" % stopped.get("id")) if stopped
+                   else "a mutant is still recorded as applied"))
         if not report["noop_silent"]:
             detail = noop.get("noisy_detail") or {}
             problems.append(
@@ -4320,7 +4381,12 @@ def main():
                          "its result is withheld on purpose. Only the final gate scores "
                          "it. An empty log_tail here means the VISIBLE set is clean, "
                          "which is not the same as a green gate.")
-        elif report["holdout_total"] and report["holdout_detected"] < report["holdout_total"]:
+        elif (not baseline_lost and report["holdout_total"]
+                and report["holdout_detected"] < report["holdout_total"]):
+            # `not baseline_lost`: after a stop the figure is WITHHELD (-1), not
+            # measured, and rendering it would read "HELD-OUT set: -1/2 detected"
+            # — a count where there was no measurement. The red is already said,
+            # once, above.
             problems.append("HELD-OUT set: %d/%d detected. The oracle was hardened against "
                             "the mutants it could see, not against divergence in general."
                             % (report["holdout_detected"], report["holdout_total"]))

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2131,9 +2131,22 @@ def write_applied_marker(ws, meta):
                        % (prior.get("id") or "?", prior.get("dir") or marker))
     try:
         fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    except OSError as e:
+        return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
+    try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
     except OSError as e:
+        # The empty shell a failed write leaves behind records NOTHING — apply.sh
+        # will not run — but the NEXT gate reads it as a corrupt marker: kind
+        # `unusable`, a bail, and every application refused until a human deletes
+        # it. A scratch root full for one instant would wedge the gate for good,
+        # over a mutant that was never applied. The open above is O_EXCL, so this
+        # file is ours to remove and removing it takes no record with it.
+        try:
+            os.unlink(marker)
+        except OSError:
+            pass
         return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
     return True, ""
 
@@ -3526,6 +3539,27 @@ def _selftest():
                   [False, False])
             check("un revert sale arrete le classement meme sans enregistrement",
                   scoring_must_stop({"revert_clean": False}, tmp), True)
+            # Une ECRITURE qui echoue ne laisse pas de coquille. O_CREAT a
+            # reussi, l'ecriture non (racine scratch pleine) : le fichier vide
+            # reste, et la porte suivante le lit comme un marqueur corrompu —
+            # `unusable`, bail, toute application refusee — pour un mutant qui
+            # n'a JAMAIS ete applique. Une racine pleine un instant coincait la
+            # porte definitivement. RLIMIT_FSIZE=0 tient lieu d'ENOSPC.
+            # Import local : `resource` est POSIX-seulement et seul l'autotest
+            # s'en sert — en tete de fichier il ferait echouer l'IMPORT du
+            # harnais la ou il manque, au lieu d'un seul controle.
+            import resource
+            soft, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+            try:
+                resource.setrlimit(resource.RLIMIT_FSIZE, (0, hard))
+                ok_w, why_w = write_applied_marker(tmp, lmeta)
+            finally:
+                resource.setrlimit(resource.RLIMIT_FSIZE, (soft, hard))
+            check("une ecriture de marqueur qui echoue refuse l'application",
+                  [ok_w, "cannot write" in why_w], [False, True])
+            check("et ne laisse aucune coquille derriere elle",
+                  [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
+                  [False, False])
             check("arbre sain, verdicts sains : le revert est annonce propre",
                   overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
             check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -52,6 +52,7 @@ import os
 import re
 import shlex
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -2026,6 +2027,9 @@ def run_script(path, ws, timeout=600):
     return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+
+
 def applied_marker_for(ws):
     """Where the harness notes the mutant it has applied and not yet reverted.
 
@@ -2041,40 +2045,128 @@ def applied_marker_for(ws):
     return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
+def _private_dir_of_ours(d):
+    """(ok, why): the marker directory is OURS and PRIVATE — a real directory,
+    not a symlink, owned by this uid, no group/other bits. On a shared temp
+    root anyone can pre-create the path; a directory that fails the test is
+    refused, never repaired: chmod on a foreign directory is EPERM anyway, and
+    repairing it would mean trusting what it already holds."""
+    try:
+        st = os.lstat(d)
+    except OSError as e:
+        return False, "%s: %s" % (d, e.strerror or e)
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+        return False, "%s is not a directory of its own (a symlink?)" % d
+    if st.st_uid != os.geteuid():
+        return False, "%s is owned by uid %d, not %d" % (d, st.st_uid, os.geteuid())
+    if st.st_mode & 0o077:
+        return False, "%s is not private (mode %o)" % (d, stat.S_IMODE(st.st_mode))
+    return True, ""
+
+
+def read_applied_marker(ws):
+    """(meta, why). meta is None when there is no marker. A marker that cannot
+    be trusted — a directory that is not ours, a symlink, a file of another
+    uid, unreadable content — comes back as ({}, why): the caller refuses,
+    executes nothing and deletes nothing. The write side keeps the file
+    private; the read side proves it, because the file is an instruction to
+    run a script."""
+    marker = applied_marker_for(ws)
+    if not os.path.lexists(marker):
+        return None, ""
+    ok, why = _private_dir_of_ours(os.path.dirname(marker))
+    if not ok:
+        return {}, "the marker directory is not the harness's own: %s" % why
+    try:
+        fd = os.open(marker, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except OSError as e:
+        return {}, "cannot open the marker %s: %s" % (marker, e.strerror or e)
+    try:
+        st = os.fstat(fd)
+    except OSError as e:
+        os.close(fd)
+        return {}, "cannot stat the marker %s: %s" % (marker, e.strerror or e)
+    if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid():
+        os.close(fd)
+        return {}, "the marker %s is not a regular file of this uid" % marker
+    try:
+        with os.fdopen(fd, encoding="utf-8") as f:
+            meta = json.load(f)
+    except (OSError, ValueError) as e:
+        return {}, "the marker %s is unreadable: %s" % (marker, e)
+    if not isinstance(meta, dict):
+        return {}, "the marker %s does not hold an object" % marker
+    return meta, ""
+
+
 def write_applied_marker(ws, meta):
-    """Record the mutant about to be applied. Private directory, exclusive
-    create, no symlink following: a marker is an instruction to run a script,
-    and a shared temp root must not let anyone else write one."""
+    """Record the mutant about to be applied. (True, "") — or (False, why),
+    and then apply.sh MUST NOT run.
+
+    Refused when a marker is already there: the mutant it names had its
+    revert fail in this run, or another harness is gating the same tree.
+    Either way the tree is not HEAD, and overwriting the record is the one
+    way to lose a leftover for good: the next mutant's clean revert would
+    then erase a record that was never its own. Refused, too, when the
+    record cannot be written (a read-only, full or foreign scratch root): a
+    mutant the harness cannot keep track of is a mutant it must not apply —
+    the silent alternative is a net behaving exactly as before this guard,
+    with nothing to say so.
+    """
     marker = applied_marker_for(ws)
     d = os.path.dirname(marker)
     try:
         os.makedirs(d, mode=0o700, exist_ok=True)
-        os.chmod(d, 0o700)
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
+    except OSError as e:
+        return False, "cannot create the marker directory %s: %s" % (d, e.strerror or e)
+    ok, why = _private_dir_of_ours(d)
+    if not ok:
+        return False, "the marker directory is not usable: %s" % why
+    if os.path.lexists(marker):
+        prior, _why = read_applied_marker(ws)
+        prior = prior or {}
+        return False, ("a mutant is still recorded as applied: %s (%s) — its revert failed "
+                       "in this run, or another harness is gating this tree; the tree is not "
+                       "HEAD and nothing is applied on top of it"
+                       % (prior.get("id") or "?", prior.get("dir") or marker))
+    try:
         fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+    except OSError as e:
+        return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
+    return True, ""
+
+
+def drop_applied_marker(ws, meta=None):
+    """Remove the marker — only when it records THIS mutant (meta None: any
+    marker of ours). A revert of B must never erase the record of A, whose
+    revert failed: that record is the only trace of a tree that is not HEAD."""
+    prior, why = read_applied_marker(ws)
+    if prior is None or why:
+        return
+    if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+        return
+    try:
+        os.remove(applied_marker_for(ws))
     except OSError:
         pass
 
 
 def apply_mutant(meta, ws):
     # The marker goes down BEFORE apply.sh runs: an interruption between the
-    # two leaves a tree that is mutated and a note that says by what.
-    write_applied_marker(ws, meta)
+    # two leaves a tree that is mutated and a note that says by what. A marker
+    # that cannot go down keeps apply.sh from running at all.
+    ok, why = write_applied_marker(ws, meta)
+    if not ok:
+        return APPLY_REFUSED, "apply.sh NOT run: %s" % why
     return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
 def revert_mutant(meta, ws):
     code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
     if code == 0:
-        try:
-            os.remove(applied_marker_for(ws))
-        except OSError:
-            pass
+        drop_applied_marker(ws, meta)
     return code, out
 
 
@@ -2086,6 +2178,15 @@ def _under(path, root):
     return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
+def leftover_roots(ws):
+    """The only two places a mutant of this workspace's net can live: the
+    tree itself (visible mutants, an unsealed held-out) and the sealed
+    held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
+    scratch root: on a shared host that is all of /tmp, and a marker naming
+    a directory there would have the gate run whatever script it found."""
+    return [ws, sealed_dir_for(ws)]
+
+
 def revert_leftover_mutant(ws):
     """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2094,68 +2195,81 @@ def revert_leftover_mutant(ws):
     judge a mutated program and call it the lot's. Measured: a tool node
     retried on the same tree after its exec stream broke — the build gate
     went red on a file the mutant had edited, and the oracle reported that
-    file as "not committed".
+    file as "not committed". Run in record mode too: references recorded
+    over a leftover would seal a program nobody wrote, which is worse than
+    an edit lost on a file the mutant had already overwritten.
 
     Returns None when there is nothing to revert. Otherwise a dict with the
     mutant's id and dir, `code` (revert.sh's exit; None when the script is
-    gone), and `marker`. The marker is dropped only when the revert
-    demonstrably succeeded — a leftover the harness could not revert stays
-    recorded, so the next gate reports it again instead of forgetting it;
-    an operator who reverts by hand clears it by deleting the marker.
+    gone), `marker`, and after a clean revert `dirty` — what `git status`
+    still shows, because the script's exit code is its word, not the tree's.
+    The marker is dropped only when the revert demonstrably succeeded — a
+    leftover the harness could not revert stays recorded, so the next gate
+    reports it again instead of forgetting it; an operator who reverts by
+    hand clears it by deleting the marker.
 
-    A marker whose directory is not under the workspace or the scratch root
-    is REFUSED, dropped and reported without executing anything: the marker
-    is an instruction to run a script, and only the harness's own mutants
-    may write it.
+    Refused, nothing executed: a marker whose directory is neither this
+    workspace nor its sealed held-out pile (dropped — it is ours and it is
+    not evidence), and a marker slot that is not the harness's own (kept —
+    not ours to delete; every application is refused until it is gone).
     """
     marker = applied_marker_for(ws)
-    if not os.path.isfile(marker):
+    meta, why = read_applied_marker(ws)
+    if meta is None:
         return None
-    try:
-        with open(marker, encoding="utf-8") as f:
-            meta = json.load(f)
-    except (OSError, ValueError):
-        meta = {}
+    if why:
+        return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
+                "refused": True, "kept": True, "dirty": ""}
     mdir = meta.get("dir") or ""
-    root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
-    if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
+    if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+        drop_applied_marker(ws)
         return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                "marker": marker, "refused": True}
+                "marker": marker, "refused": True, "kept": False, "dirty": ""}
     script = os.path.join(mdir, "revert.sh")
     if os.path.isfile(script):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+    dirty = ""
     if code == 0:
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
+        drop_applied_marker(ws, meta)
+        st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+                            capture_output=True, text=True)
+        dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-            "marker": marker, "refused": False}
+            "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
 def leftover_disposition(left):
     """What the gate says about a leftover, and whether it may proceed.
 
-    Returns (kind, text): "reverted" — the tree is HEAD again, a note;
-    "refused" — a foreign marker was dropped, a note; "still_mutated" — the
-    revert failed or its script is gone, the tree is NOT HEAD, the gate must
-    refuse rather than judge a program nobody wrote.
+    Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
+    the tree still shows, if anything); "refused" — a marker of ours naming
+    a foreign directory was dropped, a note; "unusable" — the marker slot is
+    not the harness's own, the gate must stop: every application would be
+    refused; "still_mutated" — the revert failed or its script is gone, the
+    tree is NOT HEAD, the gate must refuse rather than judge a program
+    nobody wrote.
     """
     if left.get("refused"):
+        if left.get("kept"):
+            return "unusable", (
+                "the application-marker slot %s is not the harness's own: %s. Nothing "
+                "executed, nothing deleted. Every mutant application is refused until "
+                "it is removed by hand or GM_SCRATCH points at a private root."
+                % (left.get("marker"), left.get("out")))
         return "refused", (
             "a stale application marker named a directory outside this workspace and "
-            "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+            "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
     if left.get("code") == 0:
-        return "reverted", (
-            "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-            "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
-            "verdict, if any, judged a mutated program." % left.get("id"))
+        text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
+                "mutated program." % left.get("id"))
+        if left.get("dirty"):
+            text += (" The tree still shows uncommitted changes after the revert — the "
+                     "script's exit is its word, not the tree's: %s"
+                     % " ".join(left["dirty"].split())[:300])
+        return "reverted", text
     how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
     return "still_mutated", (
         "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
@@ -2236,6 +2350,11 @@ def probe_mutation(meta, ws):
     before_tree, before_data = tree_fingerprint(ws), data_fingerprint(meta, ws)
 
     code, out = apply_mutant(meta, ws)
+    if code == APPLY_REFUSED:
+        # Nothing ran: no half-edit to undo, and the marker down there is
+        # another mutant's record of a tree that is not HEAD — this mutant's
+        # revert.sh over it would erase that record and half-restore the tree.
+        return dict(base, valid=False, detected=False, reason=out[-300:]), "failed"
     if code != 0:
         # A failed apply may have half-edited the tree, and the marker is
         # down: revert now, within this run, so neither outlives it — a
@@ -3298,6 +3417,91 @@ def _selftest():
             check("rien n'a ete execute", os.path.exists(canary), False)
             check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
             check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+            # Un marqueur sous la racine scratch mais HORS de la pile scellee est
+            # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
+            evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
+            os.makedirs(evil2)
+            with open(os.path.join(evil2, "revert.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+            write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
+            left = revert_leftover_mutant(tmp)
+            check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
+                  [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+            # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
+            # scratch) est le held-out : il est reverti, pas refuse.
+            sealed = tempfile.mkdtemp(prefix="gm-sealed-")
+            saved_sealed = os.environ.get("GM_SEALED_DIR")
+            os.environ["GM_SEALED_DIR"] = sealed
+            try:
+                hdir = os.path.join(sealed, "h1")
+                os.makedirs(hdir)
+                with open(os.path.join(hdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\nprintf 'held\\n' >> f.txt\n")
+                with open(os.path.join(hdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                check("le held-out scelle s'applique", [code, tree()], [0, "original\nheld\n"])
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur sous la pile scellee est reverti, pas refuse",
+                      [(left or {}).get("refused"), (left or {}).get("code"), tree()],
+                      [False, 0, "original\n"])
+                check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+            finally:
+                os.environ.pop("GM_SEALED_DIR", None)
+                if saved_sealed is not None:
+                    os.environ["GM_SEALED_DIR"] = saved_sealed
+                shutil.rmtree(sealed, ignore_errors=True)
+            # Un revert en ECHEC garde son enregistrement face au mutant suivant :
+            # la seconde application est refusee, rien ne tourne, et le revert du
+            # second n'efface pas le marqueur du premier.
+            scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+            code, _out = apply_mutant(lmeta, tmp)
+            check("A s'applique", code, 0)
+            code, out = revert_mutant(lmeta, tmp)
+            check("le revert de A echoue et A reste enregistre",
+                  [code, (read_applied_marker(tmp)[0] or {}).get("id")], [3, "leftover-1"])
+            bdir = os.path.join(tmp, "m2")
+            os.makedirs(bdir)
+            with open(os.path.join(bdir, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\nprintf 'B\\n' >> f.txt\n")
+            with open(os.path.join(bdir, "revert.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+            bmeta = {"id": "leftover-2", "dir": bdir}
+            code, out = apply_mutant(bmeta, tmp)
+            check("l'application de B est refusee tant que A est enregistre",
+                  [code, "leftover-1" in out, tree()], [APPLY_REFUSED, True, "original\nmutant\n"])
+            verdict, state = probe_mutation(dict(bmeta, targets=["001"]), tmp)
+            check("la sonde de B est 'failed' sans rien reverter ni toucher au marqueur",
+                  [state, tree(), (read_applied_marker(tmp)[0] or {}).get("id")],
+                  ["failed", "original\nmutant\n", "leftover-1"])
+            code, _out = revert_mutant(bmeta, tmp)
+            check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
+                  [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
+            os.remove(applied_marker_for(tmp))
+            sub("git", "checkout", "--", "f.txt")
+            # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
+            # l'application est refusee, la porte s'arrete (disposition 'unusable').
+            mdir_marker = os.path.dirname(applied_marker_for(tmp))
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            os.chmod(mdir_marker, 0o755)
+            try:
+                code, out = apply_mutant(lmeta, tmp)
+                check("un repertoire de marqueur non prive refuse l'application",
+                      [code, "not private" in out, tree()], [APPLY_REFUSED, True, "original\n"])
+                os.chmod(mdir_marker, 0o700)
+                apply_mutant(lmeta, tmp)
+                os.chmod(mdir_marker, 0o755)
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
+                      [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
+                       os.path.isfile(applied_marker_for(tmp))],
+                      [True, True, "original\nmutant\n", True])
+                check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+            finally:
+                os.chmod(mdir_marker, 0o700)
+            left = revert_leftover_mutant(tmp)
+            check("le meme marqueur, l'emplacement redevenu prive : reverti",
+                  [(left or {}).get("code"), tree()], [0, "original\n"])
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
             shutil.rmtree(outside, ignore_errors=True)
@@ -3466,7 +3670,7 @@ def main():
     left = revert_leftover_mutant(ws)
     if left:
         kind, text = leftover_disposition(left)
-        if kind == "still_mutated":
+        if kind in ("still_mutated", "unusable"):
             bail(text)
         note(report, text)
 
@@ -3774,11 +3978,20 @@ def main():
                          % ", ".join(sorted(only)))
 
         verdicts, blind = [], []
+        # A revert that did not restore the baseline (revert.sh failed, or the
+        # captures still differ with the mutant gone) ends the scoring: every
+        # later measurement would describe a program nobody wrote, and every
+        # later apply is refused anyway while the leftover is on record. The
+        # gate is red on `revert_clean` either way; stopping keeps it legible.
+        stopped = None
         for seed, meta in enumerate(visible):
             if only and meta["id"] not in only:
                 continue
             v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
             verdicts.append(v)
+            if not v.get("revert_clean", True):
+                stopped = v
+                break
             if not v.get("valid"):
                 continue
             if not v.get("detected"):
@@ -3795,9 +4008,19 @@ def main():
         # it. Revealing `holdout_detected` to whoever runs the check is enough to
         # steer hardening: seeing 3/5 says "keep tuning" even with the files out
         # of reach. The held-out result belongs to the final gate alone.
-        held = [] if mode == "selfcheck" else [
-            score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
-            for i, m in enumerate(held_meta)]
+        held = []
+        if mode != "selfcheck" and stopped is None:
+            for i, m in enumerate(held_meta):
+                v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
+                held.append(v)
+                if not v.get("revert_clean", True):
+                    stopped = v
+                    break
+        if stopped is not None:
+            note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
+                 "longer at baseline, so the mutants after it were not scored and are absent "
+                 "from the counts; a leftover, if any, is on record for the next gate."
+                 % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 
         valid = [v for v in verdicts if v.get("valid")]
         detected = [v for v in valid if v.get("detected")]

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2155,6 +2155,30 @@ def drop_applied_marker(ws, meta):
         pass
 
 
+def leftover_on_record(ws):
+    """True when a mutant is still recorded as applied — the tree is no longer
+    KNOWN to be at baseline.
+
+    The single signal, whatever armed it, and that is the point: `revert_clean`
+    only exists on a verdict that reached the full apply→capture→revert path.
+    Two other ways a revert fails to restore the baseline never set it — the
+    inert branch and the failed-apply branch each call revert_mutant and drop
+    its exit code on the floor. The record is what all three leave behind, so
+    the scoring reads the record and not one verdict's field.
+    """
+    meta, _why = read_applied_marker(ws)
+    return meta is not None
+
+
+def scoring_must_stop(verdict, ws):
+    """The scoring ends after this verdict: the tree is no longer known to be
+    at baseline, so every later measurement would describe a program nobody
+    wrote — and every later application is refused anyway while the record
+    stands. Named, rather than inline in each of the two scoring loops, so the
+    rule is one expression and the self-test can drive the decision itself."""
+    return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
+
+
 def apply_mutant(meta, ws):
     # The marker goes down BEFORE apply.sh runs: an interruption between the
     # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3449,6 +3473,31 @@ def _selftest():
             check("une application en echec est un mutant 'failed'", state, "failed")
             check("elle a reverti l'arbre", tree(), "original\n")
             check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+            # LE SIGNAL D'ARRET EST L'ENREGISTREMENT, PAS `revert_clean`. Un
+            # mutant INERTE — son point d'appui a disparu sous une modernisation
+            # legitime, apply.sh ne mute plus rien — dont le revert.sh echoue
+            # (`git checkout` d'un fichier que le lot a supprime) laisse un
+            # enregistrement arme, et sa branche ne pose JAMAIS `revert_clean` :
+            # la boucle continuait, chaque mutant suivant revenait INVALIDE en
+            # nommant le coupable, et les comptes decrivaient un lot que
+            # personne n'avait mesure.
+            scripts("exit 0", "exit 1")
+            v_inert, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+            check("un mutant qui ne mute rien est 'inert'", state, "inert")
+            revert_mutant(lmeta, tmp)   # ce que fait la branche inerte de score_mutant
+            check("son revert en echec laisse l'enregistrement arme",
+                  [("revert_clean" in v_inert), leftover_on_record(tmp)], [False, True])
+            check("et le classement S'ARRETE dessus, sans `revert_clean`",
+                  scoring_must_stop(v_inert, tmp), True)
+            check("l'application suivante est de toute facon refusee",
+                  apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+            clear_marker()
+            check("rien d'enregistre, un verdict propre : le classement continue",
+                  [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
+                  [False, False])
+            check("un revert sale arrete le classement meme sans enregistrement",
+                  scoring_must_stop({"revert_clean": False}, tmp), True)
+            sub("git", "checkout", "--", "f.txt")
             # Seule la disposition « reverti » laisse passer la porte. Le lien entre
             # la decision et son consommateur est CETTE constante, pas trois lignes
             # de main() que rien ne conduit.
@@ -3553,9 +3602,10 @@ def _selftest():
             scripts("exit 0", "exit 0")
             apply_mutant(lmeta, tmp)
             saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+            check("`sh` est sur le PATH (tout le harnais passe par lui)", bool(shbin), True)
             bindir = tempfile.mkdtemp(prefix="gm-bin-")
             try:
-                os.symlink(shbin, os.path.join(bindir, "sh"))
+                os.symlink(shbin or "/bin/sh", os.path.join(bindir, "sh"))
                 os.environ["PATH"] = bindir
                 try:
                     nogit = revert_leftover_mutant(tmp)
@@ -4100,18 +4150,27 @@ def main():
                          % ", ".join(sorted(only)))
 
         verdicts, blind = [], []
-        # A revert that did not restore the baseline (revert.sh failed, or the
-        # captures still differ with the mutant gone) ends the scoring: every
+        # A revert that did not restore the baseline ends the scoring: every
         # later measurement would describe a program nobody wrote, and every
-        # later apply is refused anyway while the leftover is on record. The
-        # gate is red on `revert_clean` either way; stopping keeps it legible.
+        # later apply is refused anyway while the leftover is on record.
+        #
+        # TWO signals, because one does not cover the rule. `revert_clean` is
+        # written only on the full apply→capture→revert path — revert.sh
+        # exited non-zero, or the captures still differ with the mutant gone.
+        # The inert branch and the failed-apply branch also run a revert and
+        # also ignore its exit code, and a leftover armed there used to let the
+        # loop run on: every remaining mutant came back INVALID naming the
+        # culprit, the counts described a lot nobody measured, and the operator
+        # was told to revert a tree by hand. `leftover_on_record` is what all
+        # three leave behind. The gate is red either way; stopping keeps it
+        # legible.
         stopped = None
         for seed, meta in enumerate(visible):
             if only and meta["id"] not in only:
                 continue
             v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
             verdicts.append(v)
-            if not v.get("revert_clean", True):
+            if scoring_must_stop(v, ws):
                 stopped = v
                 break
             if not v.get("valid"):
@@ -4135,12 +4194,12 @@ def main():
             for i, m in enumerate(held_meta):
                 v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
                 held.append(v)
-                if not v.get("revert_clean", True):
+                if scoring_must_stop(v, ws):
                     stopped = v
                     break
         if stopped is not None:
-            note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
-                 "longer at baseline, so the mutants after it were not scored and are absent "
+            note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
+                 "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
                  "from the counts; a leftover, if any, is on record for the next gate."
                  % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3276,7 +3276,10 @@ def _selftest():
                   ["leftover-1", True, True])
             check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
             check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-            os.remove(applied_marker_for(tmp))
+            try:
+                os.remove(applied_marker_for(tmp))
+            except OSError:
+                pass
             sub("git", "checkout", "--", "f.txt")
             # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
             scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2026,12 +2026,67 @@ def run_script(path, ws, timeout=600):
     return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+def applied_marker_for(ws):
+    """Where the harness notes the mutant it has applied and not yet reverted.
+
+    Outside the tree (the tree is what is judged), keyed on the workspace's
+    absolute path (sibling worktrees share a basename), in the same temp root
+    as the sealed held-out set.
+    """
+    key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
+    return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+
+
 def apply_mutant(meta, ws):
+    # The marker goes down BEFORE apply.sh runs: an interruption between the
+    # two leaves a tree that is mutated and a note that says by what.
+    try:
+        with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
+            json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+    except OSError:
+        pass
     return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
 def revert_mutant(meta, ws):
-    return run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+    code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+    if code == 0:
+        try:
+            os.remove(applied_marker_for(ws))
+        except OSError:
+            pass
+    return code, out
+
+
+def revert_leftover_mutant(ws):
+    """Revert the mutant a previous, interrupted run left applied — if any.
+
+    A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
+    leaves the mutant in the tree; the next gate, in the same tree, would
+    judge a mutated program and call it the lot's. Measured: a tool node
+    retried on the same tree after its exec stream broke — the build gate
+    went red on a file the mutant had edited, and the oracle reported that
+    file as "not committed". Returns None when there is nothing to revert,
+    else what was reverted and how revert.sh exited.
+    """
+    marker = applied_marker_for(ws)
+    if not os.path.isfile(marker):
+        return None
+    try:
+        with open(marker, encoding="utf-8") as f:
+            meta = json.load(f)
+    except (OSError, ValueError):
+        meta = {}
+    script = os.path.join(meta.get("dir") or "", "revert.sh")
+    if meta.get("dir") and os.path.isfile(script):
+        code, out = run_script(script, ws)
+    else:
+        code, out = None, "the mutant's revert.sh is no longer there"
+    try:
+        os.remove(marker)
+    except OSError:
+        pass
+    return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
 
 
 # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -3070,6 +3125,46 @@ def _selftest():
             os.environ.pop(k, None)
             if v is not None:
                 os.environ[k] = v
+        # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
+        # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
+        # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+        tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+        try:
+            def sub(*a):
+                subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+            sub("git", "init", "-q")
+            sub("git", "config", "user.email", "t@t")
+            sub("git", "config", "user.name", "t")
+            with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
+                f.write("original\n")
+            sub("git", "add", "f.txt")
+            sub("git", "commit", "-qm", "seed")
+            mdir = os.path.join(tmp, "m1")
+            os.makedirs(mdir)
+            with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
+            with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+            lmeta = {"id": "leftover-1", "dir": mdir}
+            code, _out = saved["apply_mutant"](lmeta, tmp)
+            check("apply.sh tourne", code, 0)
+            check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+            # Interruption ici : pas de revert. La porte suivante nettoie.
+            left = revert_leftover_mutant(tmp)
+            check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
+            with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                check("l'arbre est revenu a HEAD", f.read(), "original\n")
+            check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+            check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
+            saved["apply_mutant"](lmeta, tmp)
+            saved["revert_mutant"](lmeta, tmp)
+            check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+            saved["apply_mutant"](lmeta, tmp)
+            shutil.rmtree(mdir)
+            left = revert_leftover_mutant(tmp)
+            check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
     finally:
         g.update(saved)
 
@@ -3223,6 +3318,17 @@ def main():
     # est capturé ensuite décrit autre chose. Le travail non committé est
     # détruit au passage, en silence. Signalé plutôt que refusé : enregistrer et
     # itérer sur un arbre sale est légitime, GATER dessus ne l'est pas.
+    # A mutant left APPLIED by an interrupted gate is reverted BEFORE the tree
+    # is looked at, and said: otherwise the dirty check below names the
+    # mutant's file as the lot's uncommitted work, and the build gate judges a
+    # program nobody wrote.
+    left = revert_leftover_mutant(ws)
+    if left:
+        note(report, (
+            "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+            "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
+            "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+
     if mode != "record":
         dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
                                capture_output=True, text=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3481,7 +3481,7 @@ def _selftest():
             check("l'arbre est revenu a HEAD", tree(), "original\n")
             check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
             check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-            check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+            check("disposition d'un revert propre", leftover_disposition(left or {})[0], "reverted")
             # Le chemin nominal efface aussi le marqueur.
             apply_mutant(lmeta, tmp)
             revert_mutant(lmeta, tmp)
@@ -3493,7 +3493,7 @@ def _selftest():
             check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
             check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
             check("disposition d'un revert en echec : l'arbre est encore mute",
-                  leftover_disposition(left)[0], "still_mutated")
+                  leftover_disposition(left or {})[0], "still_mutated")
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             left = revert_leftover_mutant(tmp)
             check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
@@ -3507,7 +3507,7 @@ def _selftest():
                    "revert.sh" in ((left or {}).get("out") or "")],
                   ["leftover-1", True, True])
             check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
-            check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+            check("disposition d'un revert.sh disparu", leftover_disposition(left or {})[0], "still_mutated")
             clear_marker()
             sub("git", "checkout", "--", "f.txt")
             # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
@@ -3622,10 +3622,10 @@ def _selftest():
                   [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
             check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
                   os.path.isfile(applied_marker_for(tmp)), True)
-            check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
-            check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+            check("disposition d'un marqueur etranger", leftover_disposition(left or {})[0], "refused")
+            check("elle arrete la porte", leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS, True)
             check("et son message nomme le marqueur a effacer a la main",
-                  applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+                  applied_marker_for(tmp) in leftover_disposition(left or {})[1], True)
             # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
             # application ne passe tant que le marqueur est la.
             again = revert_leftover_mutant(tmp)
@@ -3667,7 +3667,7 @@ def _selftest():
                 check("un marqueur sous la pile scellee est reverti, pas refuse",
                       [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                       [False, 0, "original\n"])
-                check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                check("disposition du held-out reverti", leftover_disposition(left or {})[0], "reverted")
                 # LE CAS MESURE. La pile scellee a bouge entre deux passes —
                 # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
                 # exactement la configuration que le harnais recommande quand la
@@ -3768,7 +3768,7 @@ def _selftest():
                       [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                        os.path.isfile(applied_marker_for(tmp))],
                       ["slot", True, "original\nmutant\n", True])
-                check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+                check("disposition d'un emplacement inutilisable", leftover_disposition(left or {})[0], "unusable")
             finally:
                 os.chmod(mdir_marker, 0o700)
             left = revert_leftover_mutant(tmp)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2197,21 +2197,41 @@ tool sync_harness:
         """Where the harness notes the mutant it has applied and not yet reverted.
 
         Outside the tree (the tree is what is judged), keyed on the workspace's
-        absolute path (sibling worktrees share a basename), in the same temp root
-        as the sealed held-out set.
+        absolute path (sibling worktrees share a basename), under the same
+        scratch root as the sealed held-out set (GM_SCRATCH, else the system
+        temp dir) — one rule, so a root that makes the sealed pile survive makes
+        the marker survive too. In a private directory of its own: the marker
+        names a script the next gate will execute.
         """
         key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-        return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
+
+
+    def write_applied_marker(ws, meta):
+        """Record the mutant about to be applied. Private directory, exclusive
+        create, no symlink following: a marker is an instruction to run a script,
+        and a shared temp root must not let anyone else write one."""
+        marker = applied_marker_for(ws)
+        d = os.path.dirname(marker)
+        try:
+            os.makedirs(d, mode=0o700, exist_ok=True)
+            os.chmod(d, 0o700)
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+            fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError:
+            pass
 
 
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what.
-        try:
-            with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
-                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
-        except OSError:
-            pass
+        write_applied_marker(ws, meta)
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
@@ -2225,6 +2245,14 @@ tool sync_harness:
         return code, out
 
 
+    def _under(path, root):
+        """True when path (realpath'd) sits under root (realpath'd)."""
+        if not root:
+            return False
+        p, r = os.path.realpath(path), os.path.realpath(root)
+        return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
+
+
     def revert_leftover_mutant(ws):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2233,8 +2261,19 @@ tool sync_harness:
         judge a mutated program and call it the lot's. Measured: a tool node
         retried on the same tree after its exec stream broke — the build gate
         went red on a file the mutant had edited, and the oracle reported that
-        file as "not committed". Returns None when there is nothing to revert,
-        else what was reverted and how revert.sh exited.
+        file as "not committed".
+
+        Returns None when there is nothing to revert. Otherwise a dict with the
+        mutant's id and dir, `code` (revert.sh's exit; None when the script is
+        gone), and `marker`. The marker is dropped only when the revert
+        demonstrably succeeded — a leftover the harness could not revert stays
+        recorded, so the next gate reports it again instead of forgetting it;
+        an operator who reverts by hand clears it by deleting the marker.
+
+        A marker whose directory is not under the workspace or the scratch root
+        is REFUSED, dropped and reported without executing anything: the marker
+        is an instruction to run a script, and only the harness's own mutants
+        may write it.
         """
         marker = applied_marker_for(ws)
         if not os.path.isfile(marker):
@@ -2244,16 +2283,51 @@ tool sync_harness:
                 meta = json.load(f)
         except (OSError, ValueError):
             meta = {}
-        script = os.path.join(meta.get("dir") or "", "revert.sh")
-        if meta.get("dir") and os.path.isfile(script):
+        mdir = meta.get("dir") or ""
+        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+            return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
+                    "marker": marker, "refused": True}
+        script = os.path.join(mdir, "revert.sh")
+        if os.path.isfile(script):
             code, out = run_script(script, ws)
         else:
-            code, out = None, "the mutant's revert.sh is no longer there"
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
-        return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
+            code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+        if code == 0:
+            try:
+                os.remove(marker)
+            except OSError:
+                pass
+        return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
+                "marker": marker, "refused": False}
+
+
+    def leftover_disposition(left):
+        """What the gate says about a leftover, and whether it may proceed.
+
+        Returns (kind, text): "reverted" — the tree is HEAD again, a note;
+        "refused" — a foreign marker was dropped, a note; "still_mutated" — the
+        revert failed or its script is gone, the tree is NOT HEAD, the gate must
+        refuse rather than judge a program nobody wrote.
+        """
+        if left.get("refused"):
+            return "refused", (
+                "a stale application marker named a directory outside this workspace and "
+                "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+        if left.get("code") == 0:
+            return "reverted", (
+                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
+                "verdict, if any, judged a mutated program." % left.get("id"))
+        how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
+        return "still_mutated", (
+            "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
+            "The tree is still mutated and will not be judged. Revert by hand (git checkout -- "
+            "<the mutant's paths>), then delete the marker %s." % (left.get("id"), how, left.get("marker")))
 
 
     # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -2330,6 +2404,11 @@ tool sync_harness:
 
         code, out = apply_mutant(meta, ws)
         if code != 0:
+            # A failed apply may have half-edited the tree, and the marker is
+            # down: revert now, within this run, so neither outlives it — a
+            # marker left here would have the NEXT gate run this revert.sh over
+            # whatever the operator wrote since.
+            revert_mutant(meta, ws)
             return dict(base, valid=False, detected=False,
                         reason="apply.sh exited %s: %s" % (code, out[-300:])), "failed"
 
@@ -3293,9 +3372,15 @@ tool sync_harness:
                 if v is not None:
                     os.environ[k] = v
             # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
-            # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
-            # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+            # demarrage de la suivante. Les VRAIS apply/revert et empreintes, sur un
+            # vrai depot : c'est le marqueur et le nettoyage qui sont juges, pas leur
+            # doublure.
+            g.update(apply_mutant=saved["apply_mutant"], revert_mutant=saved["revert_mutant"],
+                     tree_fingerprint=saved["tree_fingerprint"], data_fingerprint=saved["data_fingerprint"])
             tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+            outside = tempfile.mkdtemp(prefix="gm-outside-")
+            saved_scratch = os.environ.get("GM_SCRATCH")
+            os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
                     subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
@@ -3308,30 +3393,83 @@ tool sync_harness:
                 sub("git", "commit", "-qm", "seed")
                 mdir = os.path.join(tmp, "m1")
                 os.makedirs(mdir)
-                with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
-                    f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
-                with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
-                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+
+                def scripts(apply_body, revert_body):
+                    with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\n" + apply_body + "\n")
+                    with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\n" + revert_body + "\n")
+
+                def tree():
+                    with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                        return f.read()
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 lmeta = {"id": "leftover-1", "dir": mdir}
-                code, _out = saved["apply_mutant"](lmeta, tmp)
+                code, _out = apply_mutant(lmeta, tmp)
                 check("apply.sh tourne", code, 0)
                 check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+                check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
+                      applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
                 # Interruption ici : pas de revert. La porte suivante nettoie.
                 left = revert_leftover_mutant(tmp)
                 check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
-                with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
-                    check("l'arbre est revenu a HEAD", f.read(), "original\n")
-                check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+                check("l'arbre est revenu a HEAD", tree(), "original\n")
+                check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
                 check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-                saved["apply_mutant"](lmeta, tmp)
-                saved["revert_mutant"](lmeta, tmp)
+                check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+                # Le chemin nominal efface aussi le marqueur.
+                apply_mutant(lmeta, tmp)
+                revert_mutant(lmeta, tmp)
                 check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-                saved["apply_mutant"](lmeta, tmp)
-                shutil.rmtree(mdir)
+                # Un revert qui ECHOUE garde le marqueur : la porte suivante le redira.
+                scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+                apply_mutant(lmeta, tmp)
                 left = revert_leftover_mutant(tmp)
-                check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+                check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
+                check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
+                check("disposition d'un revert en echec : l'arbre est encore mute",
+                      leftover_disposition(left)[0], "still_mutated")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                left = revert_leftover_mutant(tmp)
+                check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["original\n", False])
+                # Un revert.sh disparu est signale, pas tu — et le marqueur reste.
+                apply_mutant(lmeta, tmp)
+                os.remove(os.path.join(mdir, "revert.sh"))
+                left = revert_leftover_mutant(tmp)
+                check("un mutant dont revert.sh a disparu est signale, pas tu",
+                      [(left or {}).get("id"), left is not None and left.get("code") is None,
+                       "revert.sh" in ((left or {}).get("out") or "")],
+                      ["leftover-1", True, True])
+                check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
+                check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
+                scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
+                verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                check("une application en echec est un mutant 'failed'", state, "failed")
+                check("elle a reverti l'arbre", tree(), "original\n")
+                check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+                canary = os.path.join(outside, "ran")
+                os.makedirs(os.path.join(outside, "evil"))
+                with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+                write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
+                check("rien n'a ete execute", os.path.exists(canary), False)
+                check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+                check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
+                shutil.rmtree(outside, ignore_errors=True)
+                shutil.rmtree(os.environ["GM_SCRATCH"], ignore_errors=True)
+                if saved_scratch is None:
+                    os.environ.pop("GM_SCRATCH", None)
+                else:
+                    os.environ["GM_SCRATCH"] = saved_scratch
         finally:
             g.update(saved)
 
@@ -3491,10 +3629,10 @@ tool sync_harness:
         # program nobody wrote.
         left = revert_leftover_mutant(ws)
         if left:
-            note(report, (
-                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-                "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
-                "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+            kind, text = leftover_disposition(left)
+            if kind == "still_mutated":
+                bail(text)
+            note(report, text)
 
         if mode != "record":
             dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2259,10 +2259,22 @@ tool sync_harness:
         try:
             with os.fdopen(fd, encoding="utf-8") as f:
                 meta = json.load(f)
-        except (OSError, ValueError) as e:
+        except (OSError, ValueError, RecursionError) as e:
+            # RecursionError too: that is what json.load raises on a deeply nested
+            # document, not ValueError, and it would escape as a traceback.
             return {}, "the marker %s is unreadable: %s" % (marker, e)
         if not isinstance(meta, dict):
             return {}, "the marker %s does not hold an object" % marker
+        # The TYPES, not only the shape. `dir` goes straight into os.path.realpath
+        # and os.path.join: a number, a list or a string with an embedded NUL raises
+        # out of main(), and the harness prints a traceback where the campaign
+        # expects its one JSON verdict — read as "the harness is broken" rather than
+        # "the gate is red". Measured on the real binary with `{"id": "x", "dir": 5}`:
+        # exit 1, empty stdout, TypeError on stderr.
+        for k in ("id", "dir"):
+            v = meta.get(k)
+            if v is not None and (not isinstance(v, str) or "\0" in v):
+                return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
         return meta, ""
 
 
@@ -3727,6 +3739,26 @@ tool sync_harness:
                 check("et ne laisse aucune coquille derriere elle",
                       [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
                       [False, False])
+                # Un marqueur dont les CHAMPS ne sont pas des chaines : `dir` part
+                # directement dans realpath et os.path.join. Un nombre, une liste,
+                # une chaine avec un NUL -> exception hors de main(), et le harnais
+                # imprime une trace de pile la ou la campagne attend son unique
+                # verdict JSON. Refuse comme un marqueur illisible, pas subi.
+                os.makedirs(os.path.dirname(applied_marker_for(tmp)), mode=0o700, exist_ok=True)
+                for label, payload in (("un nombre", '{"id": "x", "dir": 5}'),
+                                       ("une liste", '{"id": "x", "dir": ["a"]}'),
+                                       ("un NUL", '{"id": "x", "dir": "/a\\u0000b"}'),
+                                       ("un id non-chaine", '{"id": 7, "dir": "%s"}' % mdir)):
+                    with open(applied_marker_for(tmp), "w", encoding="utf-8") as f:
+                        f.write(payload)
+                    try:
+                        got, raised = revert_leftover_mutant(tmp), ""
+                    except Exception as e:                  # noqa: BLE001 - c'est le test
+                        got, raised = None, "%s: %s" % (type(e).__name__, e)
+                    check("marqueur dont un champ est %s : refuse, pas subi" % label,
+                          [raised, (got or {}).get("refused"),
+                           leftover_disposition(got or {})[0]], ["", "slot", "unusable"])
+                    clear_marker()
                 check("arbre sain, verdicts sains : le revert est annonce propre",
                       overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
                 check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2305,14 +2305,16 @@ tool sync_harness:
         return True, ""
 
 
-    def drop_applied_marker(ws, meta=None):
-        """Remove the marker — only when it records THIS mutant (meta None: any
-        marker of ours). A revert of B must never erase the record of A, whose
-        revert failed: that record is the only trace of a tree that is not HEAD."""
+    def drop_applied_marker(ws, meta):
+        """Remove the marker — only when it records THIS mutant, and only after its
+        revert demonstrably succeeded. A revert of B must never erase the record of
+        A, whose revert failed: that record is the only trace of a tree that is not
+        HEAD. There is deliberately no "drop whatever is there" form — dropping a
+        record the harness did not just undo is how a leftover is lost for good."""
         prior, why = read_applied_marker(ws)
         if prior is None or why:
             return
-        if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+        if prior.get("id") is not None and prior.get("id") != meta.get("id"):
             return
         try:
             os.remove(applied_marker_for(ws))
@@ -2375,10 +2377,14 @@ tool sync_harness:
         reports it again instead of forgetting it; an operator who reverts by
         hand clears it by deleting the marker.
 
-        Refused, nothing executed: a marker whose directory is neither this
-        workspace nor its sealed held-out pile (dropped — it is ours and it is
-        not evidence), and a marker slot that is not the harness's own (kept —
-        not ours to delete; every application is refused until it is gone).
+        Refused, nothing executed AND nothing deleted — `refused` names which
+        half the harness would not touch: "dir", a marker whose directory is
+        neither this workspace nor its sealed held-out pile, and "slot", a
+        marker slot that is not the harness's own. Reading is not deciding: the
+        record goes down BEFORE apply.sh runs, so it stands whatever the
+        directory resolves to today, and dropping it would destroy the only
+        evidence that the tree is not HEAD. Every application is refused while
+        it is there, which is what makes the refusal stick.
         """
         marker = applied_marker_for(ws)
         meta, why = read_applied_marker(ws)
@@ -2386,12 +2392,12 @@ tool sync_harness:
             return None
         if why:
             return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
-                    "refused": True, "kept": True, "dirty": ""}
+                    "refused": "slot", "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
         if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
-            drop_applied_marker(ws)
-            return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                    "marker": marker, "refused": True, "kept": False, "dirty": ""}
+            return {"id": meta.get("id"), "dir": mdir, "code": None,
+                    "out": " and ".join(leftover_roots(ws)),
+                    "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
             code, out = run_script(script, ws)
@@ -2407,27 +2413,44 @@ tool sync_harness:
                 "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
+    # The dispositions on which the gate STOPS rather than judges. Only "reverted"
+    # — the harness undid the leftover and saw the tree come back — lets it
+    # through. The set lives here, beside the function that produces the kinds, so
+    # the decision and its consumer cannot drift apart silently.
+    LEFTOVER_BAIL_KINDS = ("still_mutated", "unusable", "refused")
+
+
     def leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
         Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
-        the tree still shows, if anything); "refused" — a marker of ours naming
-        a foreign directory was dropped, a note; "unusable" — the marker slot is
-        not the harness's own, the gate must stop: every application would be
-        refused; "still_mutated" — the revert failed or its script is gone, the
-        tree is NOT HEAD, the gate must refuse rather than judge a program
+        the tree still shows, if anything), the only kind that lets the gate
+        through; "refused" — a marker of ours naming a directory the harness
+        does not recognise, kept and not executed; "unusable" — the marker slot
+        is not the harness's own; "still_mutated" — the revert failed or its
+        script is gone. The last three are LEFTOVER_BAIL_KINDS: the tree is, or
+        may be, not HEAD, and the gate refuses rather than judge a program
         nobody wrote.
         """
+        if left.get("refused") == "slot":
+            return "unusable", (
+                "the application-marker slot %s is not the harness's own: %s. Nothing "
+                "executed, nothing deleted. Every mutant application is refused until "
+                "it is removed by hand or GM_SCRATCH points at a private root."
+                % (left.get("marker"), left.get("out")))
         if left.get("refused"):
-            if left.get("kept"):
-                return "unusable", (
-                    "the application-marker slot %s is not the harness's own: %s. Nothing "
-                    "executed, nothing deleted. Every mutant application is refused until "
-                    "it is removed by hand or GM_SCRATCH points at a private root."
-                    % (left.get("marker"), left.get("out")))
             return "refused", (
-                "a stale application marker named a directory outside this workspace and "
-                "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+                "a mutant is recorded as APPLIED (%s) and the harness will NOT revert it: "
+                "its directory %s is none of the roots a leftover may live under (%s). "
+                "Nothing executed, nothing deleted. The record goes down BEFORE apply.sh "
+                "runs, so it stands whatever that directory resolves to today: the tree "
+                "is, or may be, mutated, and the gate will not judge it. The ordinary "
+                "cause is a GM_SEALED_DIR that moved between passes — re-run with the one "
+                "that pass used and the harness reverts the mutant itself. Otherwise "
+                "revert by hand (git checkout -- <the mutant's paths>), then delete the "
+                "marker %s."
+                % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
+                   left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                     "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -3522,6 +3545,14 @@ tool sync_harness:
                 def tree():
                     with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
                         return f.read()
+
+                def clear_marker():
+                    # Tolerant on purpose: a mutant on the drop rules must fail as
+                    # CHECKS, not as an OSError that takes the whole self-test with it.
+                    try:
+                        os.remove(applied_marker_for(tmp))
+                    except OSError:
+                        pass
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 lmeta = {"id": "leftover-1", "dir": mdir}
                 code, _out = apply_mutant(lmeta, tmp)
@@ -3562,10 +3593,7 @@ tool sync_harness:
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-                try:
-                    os.remove(applied_marker_for(tmp))
-                except OSError:
-                    pass
+                clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
                 scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")
@@ -3573,17 +3601,45 @@ tool sync_harness:
                 check("une application en echec est un mutant 'failed'", state, "failed")
                 check("elle a reverti l'arbre", tree(), "original\n")
                 check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
-                # Un marqueur qui nomme un repertoire etranger est refuse, rien n'est execute.
+                # Seule la disposition « reverti » laisse passer la porte. Le lien entre
+                # la decision et son consommateur est CETTE constante, pas trois lignes
+                # de main() que rien ne conduit.
+                check("seule une disposition 'reverted' laisse passer la porte",
+                      [k in LEFTOVER_BAIL_KINDS
+                       for k in ("still_mutated", "unusable", "refused", "reverted")],
+                      [True, True, True, False])
+                # Un marqueur qui nomme un repertoire que le harnais ne RECONNAIT pas :
+                # rien n'est execute, et rien n'est efface non plus. Lire n'est pas
+                # decider — le marqueur est pose AVANT apply.sh, donc son existence dit
+                # que l'arbre est (ou peut etre) mute, quoi que ce repertoire designe
+                # aujourd'hui. L'effacer detruisait la seule trace, et la porte
+                # continuait sur un arbre d'etat inconnu : #799 qui recommence, en
+                # silence.
                 canary = os.path.join(outside, "ran")
                 os.makedirs(os.path.join(outside, "evil"))
                 with open(os.path.join(outside, "evil", "revert.sh"), "w", encoding="utf-8") as f:
                     f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
                 write_applied_marker(tmp, {"id": "evil", "dir": os.path.join(outside, "evil")})
                 left = revert_leftover_mutant(tmp)
-                check("un marqueur etranger est refuse", (left or {}).get("refused"), True)
-                check("rien n'a ete execute", os.path.exists(canary), False)
-                check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
+                check("un marqueur etranger est refuse, rien n'est execute",
+                      [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
+                check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
+                      os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+                check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+                check("et son message nomme le marqueur a effacer a la main",
+                      applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+                # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
+                # application ne passe tant que le marqueur est la.
+                again = revert_leftover_mutant(tmp)
+                check("la porte suivante refuse a l'identique, canari toujours pas execute",
+                      [(again or {}).get("refused"), os.path.exists(canary),
+                       os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                code, _out = apply_mutant(lmeta, tmp)
+                check("aucune application ne passe tant qu'un refus est enregistre",
+                      [code, tree()], [APPLY_REFUSED, "original\n"])
+                clear_marker()
                 # Un marqueur sous la racine scratch mais HORS de la pile scellee est
                 # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
                 evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
@@ -3592,8 +3648,10 @@ tool sync_harness:
                     f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
                 write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
                 left = revert_leftover_mutant(tmp)
-                check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
-                      [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+                check("un marqueur sous la racine scratch, hors pile scellee, est refuse et garde",
+                      [(left or {}).get("refused"), os.path.exists(canary),
+                       os.path.isfile(applied_marker_for(tmp))], ["dir", False, True])
+                clear_marker()
                 # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
                 # scratch) est le held-out : il est reverti, pas refuse.
                 sealed = tempfile.mkdtemp(prefix="gm-sealed-")
@@ -3613,6 +3671,27 @@ tool sync_harness:
                           [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                           [False, 0, "original\n"])
                     check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                    # LE CAS MESURE. La pile scellee a bouge entre deux passes —
+                    # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
+                    # exactement la configuration que le harnais recommande quand la
+                    # racine par defaut n'est pas stable. Le held-out laisse applique
+                    # se lit alors comme etranger. Tant que ce refus jetait le
+                    # marqueur, la porte notait et CONTINUAIT sur l'arbre mute, sans
+                    # rien pour le dire a la suivante.
+                    code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                    check("le held-out est re-applique", [code, tree()], [0, "original\nheld\n"])
+                    os.environ.pop("GM_SEALED_DIR", None)
+                    moved = revert_leftover_mutant(tmp)
+                    check("pile scellee deplacee : refus, marqueur garde, arbre encore mute",
+                          [(moved or {}).get("refused"), os.path.isfile(applied_marker_for(tmp)), tree()],
+                          ["dir", True, "original\nheld\n"])
+                    check("et la porte s'arrete au lieu de juger cet arbre",
+                          leftover_disposition(moved or {})[0] in LEFTOVER_BAIL_KINDS, True)
+                    os.environ["GM_SEALED_DIR"] = sealed
+                    healed = revert_leftover_mutant(tmp)
+                    check("la pile scellee retrouvee, le harnais revertit lui-meme",
+                          [(healed or {}).get("code"), tree(),
+                           os.path.isfile(applied_marker_for(tmp))], [0, "original\n", False])
                 finally:
                     os.environ.pop("GM_SEALED_DIR", None)
                     if saved_sealed is not None:
@@ -3644,7 +3723,7 @@ tool sync_harness:
                 code, _out = revert_mutant(bmeta, tmp)
                 check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
                       [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
-                os.remove(applied_marker_for(tmp))
+                clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
                 # l'application est refusee, la porte s'arrete (disposition 'unusable').
@@ -3662,7 +3741,7 @@ tool sync_harness:
                     check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
                           [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                            os.path.isfile(applied_marker_for(tmp))],
-                          [True, True, "original\nmutant\n", True])
+                          ["slot", True, "original\nmutant\n", True])
                     check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
                 finally:
                     os.chmod(mdir_marker, 0o700)
@@ -3837,7 +3916,7 @@ tool sync_harness:
         left = revert_leftover_mutant(ws)
         if left:
             kind, text = leftover_disposition(left)
-            if kind in ("still_mutated", "unusable"):
+            if kind in LEFTOVER_BAIL_KINDS:
                 bail(text)
             note(report, text)
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2346,6 +2346,24 @@ tool sync_harness:
         return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
 
 
+    def overall_revert_clean(verdicts, stopped, ws):
+        """The report's `revert_clean`: did every mutant this gate applied get
+        undone, and did the tree come back?
+
+        Three branches never reach the revert path and so never write the field —
+        a refused apply, an inert mutant, an apply that failed — and reading their
+        SILENCE as True is what let a lot in which almost nothing was measured
+        report a clean revert. Combined with a scoring that stopped (so the later
+        mutants are absent, `blind_lanes` is empty and the held-out loop never ran,
+        leaving a vacuous 0 == 0), that produced a GREEN gate on a tree the harness
+        itself had left mutated with its marker armed. A stop, or a record still
+        standing, is the evidence the tree did not come back.
+        """
+        if stopped is not None or leftover_on_record(ws):
+            return False
+        return all(v.get("revert_clean", True) for v in verdicts)
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3658,12 +3676,28 @@ tool sync_harness:
                       scoring_must_stop(v_inert, tmp), True)
                 check("l'application suivante est de toute facon refusee",
                       apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+                # LE SILENCE N'EST PAS UNE PREUVE DE PROPRETE. `revert_clean` n'est
+                # ecrit que par le chemin complet ; les trois branches qui n'y
+                # arrivent pas ne disent rien, et lire ce silence comme « propre »
+                # rendait VERTE une porte sur un arbre que le harnais venait de
+                # laisser mute, marqueur arme. Mesure : apply.sh mi-edite puis sort
+                # 7, revert.sh sort 1 -> score 100 %, revert_clean vrai, held-out
+                # 0/0, GREEN, `git status` = `M f.txt`.
+                check("un mutant enregistre interdit d'annoncer un revert propre",
+                      overall_revert_clean([{"revert_clean": True}], None, tmp), False)
+                check("un classement arrete aussi, quoi que disent les verdicts",
+                      overall_revert_clean([{"revert_clean": True}], {"id": "x"}, tmp), False)
                 clear_marker()
                 check("rien d'enregistre, un verdict propre : le classement continue",
                       [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
                       [False, False])
                 check("un revert sale arrete le classement meme sans enregistrement",
                       scoring_must_stop({"revert_clean": False}, tmp), True)
+                check("arbre sain, verdicts sains : le revert est annonce propre",
+                      overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
+                check("un seul verdict sale suffit a le nier",
+                      overall_revert_clean([{"revert_clean": True}, {"revert_clean": False}],
+                                           None, tmp), False)
                 sub("git", "checkout", "--", "f.txt")
                 # Seule la disposition « reverti » laisse passer la porte. Le lien entre
                 # la decision et son consommateur est CETTE constante, pas trois lignes
@@ -4337,19 +4371,22 @@ tool sync_harness:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
+                if v.get("valid"):
+                    if not v.get("detected"):
+                        blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                      "mutant_id": v["id"], "entries": v.get("targets_declared", []),
+                                      "why": "no declared target moved"})
+                    elif v.get("undetected_targets"):
+                        blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
+                                      "mutant_id": v["id"], "entries": v["undetected_targets"],
+                                      "why": "these references did not move for a change they cover"})
+                # Classified FIRST, then the stop. A verdict whose revert failed
+                # still reached capture and comparison, so what it says about the
+                # net is evidence; breaking before this line dropped a real blind
+                # lane on the way out.
                 if scoring_must_stop(v, ws):
                     stopped = v
                     break
-                if not v.get("valid"):
-                    continue
-                if not v.get("detected"):
-                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                                  "mutant_id": v["id"], "entries": v.get("targets_declared", []),
-                                  "why": "no declared target moved"})
-                elif v.get("undetected_targets"):
-                    blind.append({"surface": v.get("surface"), "archetype": v.get("archetype"),
-                                  "mutant_id": v["id"], "entries": v["undetected_targets"],
-                                  "why": "these references did not move for a change they cover"})
 
             # The seal relocates the held-out set in BOTH modes — the campaign must
             # lose file access early — but selfcheck neither scores it nor reports
@@ -4386,7 +4423,7 @@ tool sync_harness:
                 valid=len(valid),
                 detected=len(detected),
                 score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
-                revert_clean=all(v.get("revert_clean", True) for v in verdicts + held),
+                revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
                 collateral=sum(len(v.get("collateral") or []) for v in verdicts),
             unstable_controls=sorted({c for v in verdicts
                                       for c in (v.get("unstable_controls") or [])}),
@@ -4411,6 +4448,22 @@ tool sync_harness:
                     "probe: %s. The net saw the change; the lane they were drawn against did "
                     "not. Citing the aggregate alone would report the resemblance."
                     % (len(off), ", ".join(off))))
+            # A lot whose baseline was lost reports a WITHHELD held-out figure, not
+            # a measured one: the held-out loop did not run (or stopped part-way),
+            # so its 0 == 0 is the vacuous equality this file guards against
+            # everywhere else — and it sat right beside a `revert_clean` that read
+            # silence as clean. Measured, end to end: apply.sh half-edits and exits
+            # 7, revert.sh exits 1 — score_pct 100, revert_clean true, blind_lanes
+            # empty, holdout 0/0, GATE GREEN, `git status` showing `M f.txt` and the
+            # marker still armed. The gate approved the exact tree this guard exists
+            # to refuse. `overall_revert_clean` is now the one that says otherwise.
+            baseline_lost = not report["revert_clean"]
+            if baseline_lost and len(held) < len(held_meta):
+                # Withheld, not zero-because-failed — the idiom selfcheck uses just
+                # below, deliberately unequal so an unscored held-out set can never
+                # be taken for a passed one.
+                report["holdout_total"] = len(held_meta)
+                report["holdout_detected"] = -1
             if mode == "selfcheck":
                 # Withheld, not zero-because-failed. The two numbers are made
                 # DELIBERATELY UNEQUAL: the gate converges on
@@ -4421,6 +4474,14 @@ tool sync_harness:
                 report["holdout_detected"] = -1
 
             problems = []
+            if baseline_lost:
+                problems.append(
+                    "THE TREE IS NOT KNOWN TO BE BACK AT BASELINE: %s. The figures above "
+                    "describe what was measured BEFORE that point, not the lot — the mutants "
+                    "after it were never applied, so an empty blind-lane list and a 0/0 "
+                    "held-out figure mean 'not measured', never 'clean'."
+                    % (("scoring stopped after mutant %s" % stopped.get("id")) if stopped
+                       else "a mutant is still recorded as applied"))
             if not report["noop_silent"]:
                 detail = noop.get("noisy_detail") or {}
                 problems.append(
@@ -4487,7 +4548,12 @@ tool sync_harness:
                              "its result is withheld on purpose. Only the final gate scores "
                              "it. An empty log_tail here means the VISIBLE set is clean, "
                              "which is not the same as a green gate.")
-            elif report["holdout_total"] and report["holdout_detected"] < report["holdout_total"]:
+            elif (not baseline_lost and report["holdout_total"]
+                    and report["holdout_detected"] < report["holdout_total"]):
+                # `not baseline_lost`: after a stop the figure is WITHHELD (-1), not
+                # measured, and rendering it would read "HELD-OUT set: -1/2 detected"
+                # — a count where there was no measurement. The red is already said,
+                # once, above.
                 problems.append("HELD-OUT set: %d/%d detected. The oracle was hardened against "
                                 "the mutants it could see, not against divergence in general."
                                 % (report["holdout_detected"], report["holdout_total"]))

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2371,7 +2371,9 @@ tool sync_harness:
         Returns None when there is nothing to revert. Otherwise a dict with the
         mutant's id and dir, `code` (revert.sh's exit; None when the script is
         gone), `marker`, and after a clean revert `dirty` — what `git status`
-        still shows, because the script's exit code is its word, not the tree's.
+        still shows, because the script's exit code is its word, not the tree's
+        — or `dirty_unknown`, the reason git could not be asked, which is not
+        the same fact as an empty `dirty`.
         The marker is dropped only when the revert demonstrably succeeded — a
         leftover the harness could not revert stays recorded, so the next gate
         reports it again instead of forgetting it; an operator who reverts by
@@ -2403,14 +2405,24 @@ tool sync_harness:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty = ""
+        dirty, unknown = "", ""
         if code == 0:
             drop_applied_marker(ws, meta)
-            st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
-                                capture_output=True, text=True)
-            dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
+            # Through run(), and on a short leash. This sweep runs in EVERY mode,
+            # record included, and the harness's contract is to answer with a
+            # verdict: a `git` that is absent must not replace the JSON report with
+            # a traceback the campaign reads as "the harness is broken", and a
+            # wedged one must not hang the gate the way the incident behind this
+            # whole guard hung it. Unanswered is reported as UNKNOWN, never as
+            # clean — an empty porcelain and an absent git are not the same fact.
+            st, st_out = run("git status --porcelain", ws, timeout=120)
+            if st == 0:
+                dirty = st_out.strip()
+            else:
+                unknown = "`git status` did not answer (exit %s)" % st
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
+                "marker": marker, "refused": False, "kept": code != 0,
+                "dirty": dirty[:400], "dirty_unknown": unknown}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2459,6 +2471,9 @@ tool sync_harness:
                 text += (" The tree still shows uncommitted changes after the revert — the "
                          "script's exit is its word, not the tree's: %s"
                          % " ".join(left["dirty"].split())[:300])
+            elif left.get("dirty_unknown"):
+                text += (" Whether the tree actually came back could not be checked: %s. "
+                         "Unknown, not clean." % left["dirty_unknown"])
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -3697,6 +3712,34 @@ tool sync_harness:
                     if saved_sealed is not None:
                         os.environ["GM_SEALED_DIR"] = saved_sealed
                     shutil.rmtree(sealed, ignore_errors=True)
+                # Un `git` hors d'atteinte doit donner un VERDICT, pas une trace de
+                # pile : ce balayage tourne dans TOUS les modes, `record` compris, ou
+                # rien d'autre n'appelle git — et la campagne lit du JSON sur la
+                # sortie standard. PATH reduit a `sh` : git est absent, le script de
+                # revert (un `exit 0`, une primitive du shell) tourne encore.
+                scripts("exit 0", "exit 0")
+                apply_mutant(lmeta, tmp)
+                saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+                bindir = tempfile.mkdtemp(prefix="gm-bin-")
+                try:
+                    os.symlink(shbin, os.path.join(bindir, "sh"))
+                    os.environ["PATH"] = bindir
+                    try:
+                        nogit = revert_leftover_mutant(tmp)
+                        raised = ""
+                    except Exception as e:                      # noqa: BLE001 - c'est le test
+                        nogit, raised = None, "%s: %s" % (type(e).__name__, e)
+                finally:
+                    os.environ["PATH"] = saved_path
+                    shutil.rmtree(bindir, ignore_errors=True)
+                check("git absent : un verdict, pas une exception",
+                      [raised, (nogit or {}).get("code")], ["", 0])
+                check("l'etat de l'arbre est INCONNU, pas propre",
+                      [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
+                      ["", True])
+                check("et la note le dit au lieu de laisser croire a un arbre propre",
+                      "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+                clear_marker()
                 # Un revert en ECHEC garde son enregistrement face au mutant suivant :
                 # la seconde application est refusee, rien ne tourne, et le revert du
                 # second n'efface pas le marqueur du premier.

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2298,9 +2298,22 @@ tool sync_harness:
                            % (prior.get("id") or "?", prior.get("dir") or marker))
         try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+        except OSError as e:
+            return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
+        try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
         except OSError as e:
+            # The empty shell a failed write leaves behind records NOTHING — apply.sh
+            # will not run — but the NEXT gate reads it as a corrupt marker: kind
+            # `unusable`, a bail, and every application refused until a human deletes
+            # it. A scratch root full for one instant would wedge the gate for good,
+            # over a mutant that was never applied. The open above is O_EXCL, so this
+            # file is ours to remove and removing it takes no record with it.
+            try:
+                os.unlink(marker)
+            except OSError:
+                pass
             return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
         return True, ""
 
@@ -3693,6 +3706,27 @@ tool sync_harness:
                       [False, False])
                 check("un revert sale arrete le classement meme sans enregistrement",
                       scoring_must_stop({"revert_clean": False}, tmp), True)
+                # Une ECRITURE qui echoue ne laisse pas de coquille. O_CREAT a
+                # reussi, l'ecriture non (racine scratch pleine) : le fichier vide
+                # reste, et la porte suivante le lit comme un marqueur corrompu —
+                # `unusable`, bail, toute application refusee — pour un mutant qui
+                # n'a JAMAIS ete applique. Une racine pleine un instant coincait la
+                # porte definitivement. RLIMIT_FSIZE=0 tient lieu d'ENOSPC.
+                # Import local : `resource` est POSIX-seulement et seul l'autotest
+                # s'en sert — en tete de fichier il ferait echouer l'IMPORT du
+                # harnais la ou il manque, au lieu d'un seul controle.
+                import resource
+                soft, hard = resource.getrlimit(resource.RLIMIT_FSIZE)
+                try:
+                    resource.setrlimit(resource.RLIMIT_FSIZE, (0, hard))
+                    ok_w, why_w = write_applied_marker(tmp, lmeta)
+                finally:
+                    resource.setrlimit(resource.RLIMIT_FSIZE, (soft, hard))
+                check("une ecriture de marqueur qui echoue refuse l'application",
+                      [ok_w, "cannot write" in why_w], [False, True])
+                check("et ne laisse aucune coquille derriere elle",
+                      [os.path.exists(applied_marker_for(tmp)), leftover_on_record(tmp)],
+                      [False, False])
                 check("arbre sain, verdicts sains : le revert est annonce propre",
                       overall_revert_clean([{"revert_clean": True}, {}], None, tmp), True)
                 check("un seul verdict sale suffit a le nier",

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3648,7 +3648,7 @@ tool sync_harness:
                 check("l'arbre est revenu a HEAD", tree(), "original\n")
                 check("le marqueur est efface apres un revert propre", os.path.isfile(applied_marker_for(tmp)), False)
                 check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
-                check("disposition d'un revert propre", leftover_disposition(left)[0], "reverted")
+                check("disposition d'un revert propre", leftover_disposition(left or {})[0], "reverted")
                 # Le chemin nominal efface aussi le marqueur.
                 apply_mutant(lmeta, tmp)
                 revert_mutant(lmeta, tmp)
@@ -3660,7 +3660,7 @@ tool sync_harness:
                 check("un revert en echec est signale avec son code", (left or {}).get("code"), 3)
                 check("le marqueur reste tant que rien n'est reverti", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert en echec : l'arbre est encore mute",
-                      leftover_disposition(left)[0], "still_mutated")
+                      leftover_disposition(left or {})[0], "still_mutated")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 left = revert_leftover_mutant(tmp)
                 check("le revert repare nettoie et efface", [tree(), os.path.isfile(applied_marker_for(tmp))],
@@ -3674,7 +3674,7 @@ tool sync_harness:
                        "revert.sh" in ((left or {}).get("out") or "")],
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
-                check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
+                check("disposition d'un revert.sh disparu", leftover_disposition(left or {})[0], "still_mutated")
                 clear_marker()
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
@@ -3789,10 +3789,10 @@ tool sync_harness:
                       [(left or {}).get("refused"), os.path.exists(canary)], ["dir", False])
                 check("le marqueur etranger est GARDE : c'est la seule trace de l'application",
                       os.path.isfile(applied_marker_for(tmp)), True)
-                check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
-                check("elle arrete la porte", leftover_disposition(left)[0] in LEFTOVER_BAIL_KINDS, True)
+                check("disposition d'un marqueur etranger", leftover_disposition(left or {})[0], "refused")
+                check("elle arrete la porte", leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS, True)
                 check("et son message nomme le marqueur a effacer a la main",
-                      applied_marker_for(tmp) in leftover_disposition(left)[1], True)
+                      applied_marker_for(tmp) in leftover_disposition(left or {})[1], True)
                 # Le refus COLLE : la porte suivante refuse a l'identique, et aucune
                 # application ne passe tant que le marqueur est la.
                 again = revert_leftover_mutant(tmp)
@@ -3834,7 +3834,7 @@ tool sync_harness:
                     check("un marqueur sous la pile scellee est reverti, pas refuse",
                           [(left or {}).get("refused"), (left or {}).get("code"), tree()],
                           [False, 0, "original\n"])
-                    check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                    check("disposition du held-out reverti", leftover_disposition(left or {})[0], "reverted")
                     # LE CAS MESURE. La pile scellee a bouge entre deux passes —
                     # GM_SEALED_DIR pose a l'application, absent a la porte suivante :
                     # exactement la configuration que le harnais recommande quand la
@@ -3935,7 +3935,7 @@ tool sync_harness:
                           [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
                            os.path.isfile(applied_marker_for(tmp))],
                           ["slot", True, "original\nmutant\n", True])
-                    check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+                    check("disposition d'un emplacement inutilisable", leftover_disposition(left or {})[0], "unusable")
                 finally:
                     os.chmod(mdir_marker, 0o700)
                 left = revert_leftover_mutant(tmp)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2193,12 +2193,67 @@ tool sync_harness:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+    def applied_marker_for(ws):
+        """Where the harness notes the mutant it has applied and not yet reverted.
+
+        Outside the tree (the tree is what is judged), keyed on the workspace's
+        absolute path (sibling worktrees share a basename), in the same temp root
+        as the sealed held-out set.
+        """
+        key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
+        return os.path.join(tempfile.gettempdir(), "gm-applied-%s.json" % key)
+
+
     def apply_mutant(meta, ws):
+        # The marker goes down BEFORE apply.sh runs: an interruption between the
+        # two leaves a tree that is mutated and a note that says by what.
+        try:
+            with open(applied_marker_for(ws), "w", encoding="utf-8") as f:
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError:
+            pass
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
     def revert_mutant(meta, ws):
-        return run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+        code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
+        if code == 0:
+            try:
+                os.remove(applied_marker_for(ws))
+            except OSError:
+                pass
+        return code, out
+
+
+    def revert_leftover_mutant(ws):
+        """Revert the mutant a previous, interrupted run left applied — if any.
+
+        A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
+        leaves the mutant in the tree; the next gate, in the same tree, would
+        judge a mutated program and call it the lot's. Measured: a tool node
+        retried on the same tree after its exec stream broke — the build gate
+        went red on a file the mutant had edited, and the oracle reported that
+        file as "not committed". Returns None when there is nothing to revert,
+        else what was reverted and how revert.sh exited.
+        """
+        marker = applied_marker_for(ws)
+        if not os.path.isfile(marker):
+            return None
+        try:
+            with open(marker, encoding="utf-8") as f:
+                meta = json.load(f)
+        except (OSError, ValueError):
+            meta = {}
+        script = os.path.join(meta.get("dir") or "", "revert.sh")
+        if meta.get("dir") and os.path.isfile(script):
+            code, out = run_script(script, ws)
+        else:
+            code, out = None, "the mutant's revert.sh is no longer there"
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+        return {"id": meta.get("id"), "dir": meta.get("dir"), "code": code, "out": (out or "")[-300:]}
 
 
     # ─── Comparison ─────────────────────────────────────────────────────────────
@@ -3237,6 +3292,46 @@ tool sync_harness:
                 os.environ.pop(k, None)
                 if v is not None:
                     os.environ[k] = v
+            # ── Un mutant laisse APPLIQUE par une porte interrompue est reverti au
+            # demarrage de la suivante. Les VRAIS apply/revert, sur un vrai depot :
+            # c'est le marqueur et le nettoyage qui sont juges, pas leur doublure.
+            tmp = tempfile.mkdtemp(prefix="gm-leftover-")
+            try:
+                def sub(*a):
+                    subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+                sub("git", "init", "-q")
+                sub("git", "config", "user.email", "t@t")
+                sub("git", "config", "user.name", "t")
+                with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
+                    f.write("original\n")
+                sub("git", "add", "f.txt")
+                sub("git", "commit", "-qm", "seed")
+                mdir = os.path.join(tmp, "m1")
+                os.makedirs(mdir)
+                with open(os.path.join(mdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\nprintf 'mutant\\n' >> f.txt\n")
+                with open(os.path.join(mdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                lmeta = {"id": "leftover-1", "dir": mdir}
+                code, _out = saved["apply_mutant"](lmeta, tmp)
+                check("apply.sh tourne", code, 0)
+                check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
+                # Interruption ici : pas de revert. La porte suivante nettoie.
+                left = revert_leftover_mutant(tmp)
+                check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
+                with open(os.path.join(tmp, "f.txt"), encoding="utf-8") as f:
+                    check("l'arbre est revenu a HEAD", f.read(), "original\n")
+                check("le marqueur est efface", os.path.isfile(applied_marker_for(tmp)), False)
+                check("rien a revertir la seconde fois", revert_leftover_mutant(tmp), None)
+                saved["apply_mutant"](lmeta, tmp)
+                saved["revert_mutant"](lmeta, tmp)
+                check("le revert nominal efface le marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                saved["apply_mutant"](lmeta, tmp)
+                shutil.rmtree(mdir)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant dont revert.sh a disparu est signale, pas tu", (left or {}).get("code"), None)
+            finally:
+                shutil.rmtree(tmp, ignore_errors=True)
         finally:
             g.update(saved)
 
@@ -3390,6 +3485,17 @@ tool sync_harness:
         # est capturé ensuite décrit autre chose. Le travail non committé est
         # détruit au passage, en silence. Signalé plutôt que refusé : enregistrer et
         # itérer sur un arbre sale est légitime, GATER dessus ne l'est pas.
+        # A mutant left APPLIED by an interrupted gate is reverted BEFORE the tree
+        # is looked at, and said: otherwise the dirty check below names the
+        # mutant's file as the lot's uncommitted work, and the build gate judges a
+        # program nobody wrote.
+        left = revert_leftover_mutant(ws)
+        if left:
+            note(report, (
+                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                "(revert.sh exit %s). The tree below is HEAD again; the interrupted attempt's "
+                "verdict, if any, judged a mutated program." % (left.get("id"), left.get("code"))))
+
         if mode != "record":
             dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
                                    capture_output=True, text=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2322,6 +2322,30 @@ tool sync_harness:
             pass
 
 
+    def leftover_on_record(ws):
+        """True when a mutant is still recorded as applied — the tree is no longer
+        KNOWN to be at baseline.
+
+        The single signal, whatever armed it, and that is the point: `revert_clean`
+        only exists on a verdict that reached the full apply→capture→revert path.
+        Two other ways a revert fails to restore the baseline never set it — the
+        inert branch and the failed-apply branch each call revert_mutant and drop
+        its exit code on the floor. The record is what all three leave behind, so
+        the scoring reads the record and not one verdict's field.
+        """
+        meta, _why = read_applied_marker(ws)
+        return meta is not None
+
+
+    def scoring_must_stop(verdict, ws):
+        """The scoring ends after this verdict: the tree is no longer known to be
+        at baseline, so every later measurement would describe a program nobody
+        wrote — and every later application is refused anyway while the record
+        stands. Named, rather than inline in each of the two scoring loops, so the
+        rule is one expression and the self-test can drive the decision itself."""
+        return (not verdict.get("revert_clean", True)) or leftover_on_record(ws)
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -3616,6 +3640,31 @@ tool sync_harness:
                 check("une application en echec est un mutant 'failed'", state, "failed")
                 check("elle a reverti l'arbre", tree(), "original\n")
                 check("et efface son marqueur", os.path.isfile(applied_marker_for(tmp)), False)
+                # LE SIGNAL D'ARRET EST L'ENREGISTREMENT, PAS `revert_clean`. Un
+                # mutant INERTE — son point d'appui a disparu sous une modernisation
+                # legitime, apply.sh ne mute plus rien — dont le revert.sh echoue
+                # (`git checkout` d'un fichier que le lot a supprime) laisse un
+                # enregistrement arme, et sa branche ne pose JAMAIS `revert_clean` :
+                # la boucle continuait, chaque mutant suivant revenait INVALIDE en
+                # nommant le coupable, et les comptes decrivaient un lot que
+                # personne n'avait mesure.
+                scripts("exit 0", "exit 1")
+                v_inert, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                check("un mutant qui ne mute rien est 'inert'", state, "inert")
+                revert_mutant(lmeta, tmp)   # ce que fait la branche inerte de score_mutant
+                check("son revert en echec laisse l'enregistrement arme",
+                      [("revert_clean" in v_inert), leftover_on_record(tmp)], [False, True])
+                check("et le classement S'ARRETE dessus, sans `revert_clean`",
+                      scoring_must_stop(v_inert, tmp), True)
+                check("l'application suivante est de toute facon refusee",
+                      apply_mutant(lmeta, tmp)[0], APPLY_REFUSED)
+                clear_marker()
+                check("rien d'enregistre, un verdict propre : le classement continue",
+                      [leftover_on_record(tmp), scoring_must_stop({"revert_clean": True}, tmp)],
+                      [False, False])
+                check("un revert sale arrete le classement meme sans enregistrement",
+                      scoring_must_stop({"revert_clean": False}, tmp), True)
+                sub("git", "checkout", "--", "f.txt")
                 # Seule la disposition « reverti » laisse passer la porte. Le lien entre
                 # la decision et son consommateur est CETTE constante, pas trois lignes
                 # de main() que rien ne conduit.
@@ -3720,9 +3769,10 @@ tool sync_harness:
                 scripts("exit 0", "exit 0")
                 apply_mutant(lmeta, tmp)
                 saved_path, shbin = os.environ.get("PATH", ""), shutil.which("sh")
+                check("`sh` est sur le PATH (tout le harnais passe par lui)", bool(shbin), True)
                 bindir = tempfile.mkdtemp(prefix="gm-bin-")
                 try:
-                    os.symlink(shbin, os.path.join(bindir, "sh"))
+                    os.symlink(shbin or "/bin/sh", os.path.join(bindir, "sh"))
                     os.environ["PATH"] = bindir
                     try:
                         nogit = revert_leftover_mutant(tmp)
@@ -4267,18 +4317,27 @@ tool sync_harness:
                              % ", ".join(sorted(only)))
 
             verdicts, blind = [], []
-            # A revert that did not restore the baseline (revert.sh failed, or the
-            # captures still differ with the mutant gone) ends the scoring: every
+            # A revert that did not restore the baseline ends the scoring: every
             # later measurement would describe a program nobody wrote, and every
-            # later apply is refused anyway while the leftover is on record. The
-            # gate is red on `revert_clean` either way; stopping keeps it legible.
+            # later apply is refused anyway while the leftover is on record.
+            #
+            # TWO signals, because one does not cover the rule. `revert_clean` is
+            # written only on the full apply→capture→revert path — revert.sh
+            # exited non-zero, or the captures still differ with the mutant gone.
+            # The inert branch and the failed-apply branch also run a revert and
+            # also ignore its exit code, and a leftover armed there used to let the
+            # loop run on: every remaining mutant came back INVALID naming the
+            # culprit, the counts described a lot nobody measured, and the operator
+            # was told to revert a tree by hand. `leftover_on_record` is what all
+            # three leave behind. The gate is red either way; stopping keeps it
+            # legible.
             stopped = None
             for seed, meta in enumerate(visible):
                 if only and meta["id"] not in only:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
-                if not v.get("revert_clean", True):
+                if scoring_must_stop(v, ws):
                     stopped = v
                     break
                 if not v.get("valid"):
@@ -4302,12 +4361,12 @@ tool sync_harness:
                 for i, m in enumerate(held_meta):
                     v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
                     held.append(v)
-                    if not v.get("revert_clean", True):
+                    if scoring_must_stop(v, ws):
                         stopped = v
                         break
             if stopped is not None:
-                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
-                     "longer at baseline, so the mutants after it were not scored and are absent "
+                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
+                     "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
                      "from the counts; a leftover, if any, is on record for the next gate."
                      % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2454,6 +2454,18 @@ tool sync_harness:
         directory resolves to today, and dropping it would destroy the only
         evidence that the tree is not HEAD. Every application is refused while
         it is there, which is what makes the refusal stick.
+
+        ONE gate per tree is ASSUMED: the record carries no liveness, no pid and
+        no lock. A second gate starting while the first sits between its apply.sh
+        and its revert.sh reads that record as a leftover, reverts a LIVE mutant
+        and drops its owner's record; the first then captures against a reverted
+        tree and reports blind lanes it invented. write_applied_marker's refusal
+        ("another harness is gating this tree") does NOT cover this — the sweep
+        runs before any application, so it never reaches that refusal. Measured.
+        Two harnesses mutating one tree cannot measure anything either way, so
+        this is a limitation rather than a mode to support; the fix, if a real
+        case turns up, is an exclusive lock held for the gate's duration (an
+        flock dies with the process, unlike a recorded pid).
         """
         marker = applied_marker_for(ws)
         meta, why = read_applied_marker(ws)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3443,7 +3443,10 @@ tool sync_harness:
                       ["leftover-1", True, True])
                 check("son marqueur reste", os.path.isfile(applied_marker_for(tmp)), True)
                 check("disposition d'un revert.sh disparu", leftover_disposition(left)[0], "still_mutated")
-                os.remove(applied_marker_for(tmp))
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
                 sub("git", "checkout", "--", "f.txt")
                 # Une application qui ECHOUE nettoie l'arbre et le marqueur dans son propre run.
                 scripts("printf 'half\\n' >> f.txt; exit 1", "git checkout -- f.txt")

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2194,21 +2194,50 @@ tool sync_harness:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
-    APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+    # apply_mutant's code when apply.sh was NOT run because no record could go
+    # down first. A string on purpose: a returncode is an int, and a shell killed
+    # by SIGHUP reports -1 — an apply that DID run and must be reverted.
+    APPLY_REFUSED = "refused"
+
+
+    _git_dir_cache = {}
+
+
+    def git_dir_of(ws):
+        """The tree's git dir (a worktree's own, under the main repo's .git), or
+        "" when ws is not a git repository — or when git does not answer:
+        bounded and guarded, because this runs before the JSON report the
+        campaign parses. Cached per workspace path."""
+        key = os.path.realpath(ws)
+        if key not in _git_dir_cache:
+            try:
+                p = subprocess.run(["git", "-C", ws, "rev-parse", "--git-dir"],
+                                   capture_output=True, text=True, timeout=60)
+                d = (p.stdout or "").strip() if p.returncode == 0 else ""
+            except (OSError, subprocess.SubprocessError):
+                d = ""
+            if d and not os.path.isabs(d):
+                d = os.path.join(key, d)
+            _git_dir_cache[key] = os.path.realpath(d) if d else ""
+        return _git_dir_cache[key]
 
 
     def applied_marker_for(ws):
         """Where the harness notes the mutant it has applied and not yet reverted.
 
-        Outside the tree (the tree is what is judged), keyed on the workspace's
-        absolute path (sibling worktrees share a basename), under the same
-        scratch root as the sealed held-out set (GM_SCRATCH, else the system
-        temp dir) — one rule, so a root that makes the sealed pile survive makes
-        the marker survive too. In a private directory of its own: the marker
-        names a script the next gate will execute.
+        With the TREE, outside what is judged: in the tree's git dir, which lives
+        exactly as long as the mutated files do — a container restarted on the
+        same bind-mounted worktree keeps both, a copy-based pod's fresh copy has
+        neither — whereas a marker in a temp root outlives or predeceases the
+        tree it describes (a retry with a fresh /tmp on the same worktree would
+        keep the mutant and lose the note). A workspace that is not a git
+        repository falls back to the scratch root (GM_SCRATCH, else the system
+        temp dir), keyed on the workspace's real path. In a private directory of
+        its own: the marker names a script the next gate will execute.
         """
-        key = hashlib.sha256(os.path.abspath(ws).encode("utf-8")).hexdigest()[:12]
-        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
+        real = os.path.realpath(ws)
+        key = hashlib.sha256(real.encode("utf-8")).hexdigest()[:12]
+        root = git_dir_of(ws) or os.environ.get("GM_SCRATCH", tempfile.gettempdir())
         return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
@@ -2414,16 +2443,17 @@ tool sync_harness:
         return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
-    def leftover_roots(ws):
+    def leftover_roots(ws, gm_dir=None):
         """The only two places a mutant of this workspace's net can live: the
-        tree itself (visible mutants, an unsealed held-out) and the sealed
-        held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
-        scratch root: on a shared host that is all of /tmp, and a marker naming
-        a directory there would have the gate run whatever script it found."""
-        return [ws, sealed_dir_for(ws)]
+        net's own directory (visible mutants, an unsealed held-out — the whole
+        tree when the caller has no net dir to name) and the sealed held-out
+        pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole scratch
+        root: on a shared host that is all of /tmp, and a marker naming a
+        directory there would have the gate run whatever script it found."""
+        return [gm_dir or ws, sealed_dir_for(ws)]
 
 
-    def revert_leftover_mutant(ws):
+    def revert_leftover_mutant(ws, gm_dir=None):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
         A stream cut, a SIGTERM or a pod kill between apply.sh and revert.sh
@@ -2475,9 +2505,9 @@ tool sync_harness:
             return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
                     "refused": "slot", "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
-        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws, gm_dir)):
             return {"id": meta.get("id"), "dir": mdir, "code": None,
-                    "out": " and ".join(leftover_roots(ws)),
+                    "out": " and ".join(leftover_roots(ws, gm_dir)),
                     "marker": marker, "refused": "dir", "kept": True, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
@@ -3619,7 +3649,7 @@ tool sync_harness:
             os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
-                    subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
+                    return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
                 sub("git", "init", "-q")
                 sub("git", "config", "user.email", "t@t")
                 sub("git", "config", "user.name", "t")
@@ -3652,8 +3682,16 @@ tool sync_harness:
                 code, _out = apply_mutant(lmeta, tmp)
                 check("apply.sh tourne", code, 0)
                 check("le marqueur d'application est pose", os.path.isfile(applied_marker_for(tmp)), True)
-                check("le marqueur vit sous GM_SCRATCH, comme la pile scellee",
-                      applied_marker_for(tmp).startswith(os.environ["GM_SCRATCH"]), True)
+                check("le marqueur vit dans le git-dir de l'arbre, hors de ce qui est juge",
+                      [applied_marker_for(tmp).startswith(os.path.realpath(os.path.join(tmp, ".git")) + os.sep),
+                       "gm-applied" in sub("git", "status", "--porcelain").stdout],
+                      [True, False])
+                nogit = tempfile.mkdtemp(prefix="gm-nogit-")
+                try:
+                    check("sans depot git, le marqueur retombe sous GM_SCRATCH",
+                          applied_marker_for(nogit).startswith(os.environ["GM_SCRATCH"]), True)
+                finally:
+                    shutil.rmtree(nogit, ignore_errors=True)
                 # Interruption ici : pas de revert. La porte suivante nettoie.
                 left = revert_leftover_mutant(tmp)
                 check("le mutant laisse applique est identifie", (left or {}).get("id"), "leftover-1")
@@ -3953,6 +3991,43 @@ tool sync_harness:
                 left = revert_leftover_mutant(tmp)
                 check("le meme marqueur, l'emplacement redevenu prive : reverti",
                       [(left or {}).get("code"), tree()], [0, "original\n"])
+                # ── Ajouts : racines resserrees sur le repertoire du filet, sentinelle
+                # qui n'est pas un code de retour. Etat remis a plat d'abord.
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
+                sub("git", "checkout", "--", "f.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp, os.path.join(tmp, ".golden-master"))
+                check("hors du repertoire du filet nomme, le marqueur est refuse et garde",
+                      [(left or {}).get("refused"), tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["dir", "original\nmutant\n", True])
+                left = revert_leftover_mutant(tmp)
+                check("sans repertoire de filet nomme, l'arbre entier est reconnu : reverti",
+                      [(left or {}).get("code"), tree()], [0, "original\n"])
+                # Une application TUEE par un signal (returncode -1, ce que rapporte
+                # subprocess pour un shell mort sur SIGHUP) n'est pas une application
+                # refusee : elle a tourne, elle est revertie dans le run. Le -1 est
+                # injecte par une doublure de run_script (un signal reel depend du
+                # shell : exec ou non de la derniere commande).
+                scripts("printf 'half\\n' >> f.txt", "git checkout -- f.txt")
+                real_run_script = g["run_script"]
+
+                def killed_apply(path, ws, timeout=600):
+                    if path.endswith("apply.sh"):
+                        real_run_script(path, ws, timeout)
+                        return -1, "killed by SIGHUP"
+                    return real_run_script(path, ws, timeout)
+                g["run_script"] = killed_apply
+                try:
+                    verdict, state = probe_mutation(dict(lmeta, targets=["001"]), tmp)
+                finally:
+                    g["run_script"] = real_run_script
+                check("une application tuee par un signal est revertie, pas lue comme refusee",
+                      [state, tree(), os.path.isfile(applied_marker_for(tmp))],
+                      ["failed", "original\n", False])
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)
@@ -4118,7 +4193,7 @@ tool sync_harness:
         # is looked at, and said: otherwise the dirty check below names the
         # mutant's file as the lot's uncommitted work, and the build gate judges a
         # program nobody wrote.
-        left = revert_leftover_mutant(ws)
+        left = revert_leftover_mutant(ws, gm_dir)
         if left:
             kind, text = leftover_disposition(left)
             if kind in LEFTOVER_BAIL_KINDS:

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -219,6 +219,7 @@ tool sync_harness:
     import re
     import shlex
     import shutil
+    import stat
     import subprocess
     import sys
     import tempfile
@@ -2193,6 +2194,9 @@ tool sync_harness:
         return run("sh %s" % shlex.quote(path), ws, timeout)
 
 
+    APPLY_REFUSED = -1  # apply_mutant's code when apply.sh was NOT run: no record could go down first
+
+
     def applied_marker_for(ws):
         """Where the harness notes the mutant it has applied and not yet reverted.
 
@@ -2208,40 +2212,128 @@ tool sync_harness:
         return os.path.join(root, "gm-applied", "gm-applied-%s.json" % key)
 
 
+    def _private_dir_of_ours(d):
+        """(ok, why): the marker directory is OURS and PRIVATE — a real directory,
+        not a symlink, owned by this uid, no group/other bits. On a shared temp
+        root anyone can pre-create the path; a directory that fails the test is
+        refused, never repaired: chmod on a foreign directory is EPERM anyway, and
+        repairing it would mean trusting what it already holds."""
+        try:
+            st = os.lstat(d)
+        except OSError as e:
+            return False, "%s: %s" % (d, e.strerror or e)
+        if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+            return False, "%s is not a directory of its own (a symlink?)" % d
+        if st.st_uid != os.geteuid():
+            return False, "%s is owned by uid %d, not %d" % (d, st.st_uid, os.geteuid())
+        if st.st_mode & 0o077:
+            return False, "%s is not private (mode %o)" % (d, stat.S_IMODE(st.st_mode))
+        return True, ""
+
+
+    def read_applied_marker(ws):
+        """(meta, why). meta is None when there is no marker. A marker that cannot
+        be trusted — a directory that is not ours, a symlink, a file of another
+        uid, unreadable content — comes back as ({}, why): the caller refuses,
+        executes nothing and deletes nothing. The write side keeps the file
+        private; the read side proves it, because the file is an instruction to
+        run a script."""
+        marker = applied_marker_for(ws)
+        if not os.path.lexists(marker):
+            return None, ""
+        ok, why = _private_dir_of_ours(os.path.dirname(marker))
+        if not ok:
+            return {}, "the marker directory is not the harness's own: %s" % why
+        try:
+            fd = os.open(marker, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError as e:
+            return {}, "cannot open the marker %s: %s" % (marker, e.strerror or e)
+        try:
+            st = os.fstat(fd)
+        except OSError as e:
+            os.close(fd)
+            return {}, "cannot stat the marker %s: %s" % (marker, e.strerror or e)
+        if not stat.S_ISREG(st.st_mode) or st.st_uid != os.geteuid():
+            os.close(fd)
+            return {}, "the marker %s is not a regular file of this uid" % marker
+        try:
+            with os.fdopen(fd, encoding="utf-8") as f:
+                meta = json.load(f)
+        except (OSError, ValueError) as e:
+            return {}, "the marker %s is unreadable: %s" % (marker, e)
+        if not isinstance(meta, dict):
+            return {}, "the marker %s does not hold an object" % marker
+        return meta, ""
+
+
     def write_applied_marker(ws, meta):
-        """Record the mutant about to be applied. Private directory, exclusive
-        create, no symlink following: a marker is an instruction to run a script,
-        and a shared temp root must not let anyone else write one."""
+        """Record the mutant about to be applied. (True, "") — or (False, why),
+        and then apply.sh MUST NOT run.
+
+        Refused when a marker is already there: the mutant it names had its
+        revert fail in this run, or another harness is gating the same tree.
+        Either way the tree is not HEAD, and overwriting the record is the one
+        way to lose a leftover for good: the next mutant's clean revert would
+        then erase a record that was never its own. Refused, too, when the
+        record cannot be written (a read-only, full or foreign scratch root): a
+        mutant the harness cannot keep track of is a mutant it must not apply —
+        the silent alternative is a net behaving exactly as before this guard,
+        with nothing to say so.
+        """
         marker = applied_marker_for(ws)
         d = os.path.dirname(marker)
         try:
             os.makedirs(d, mode=0o700, exist_ok=True)
-            os.chmod(d, 0o700)
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+        except OSError as e:
+            return False, "cannot create the marker directory %s: %s" % (d, e.strerror or e)
+        ok, why = _private_dir_of_ours(d)
+        if not ok:
+            return False, "the marker directory is not usable: %s" % why
+        if os.path.lexists(marker):
+            prior, _why = read_applied_marker(ws)
+            prior = prior or {}
+            return False, ("a mutant is still recorded as applied: %s (%s) — its revert failed "
+                           "in this run, or another harness is gating this tree; the tree is not "
+                           "HEAD and nothing is applied on top of it"
+                           % (prior.get("id") or "?", prior.get("dir") or marker))
+        try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+        except OSError as e:
+            return False, "cannot write the marker %s: %s" % (marker, e.strerror or e)
+        return True, ""
+
+
+    def drop_applied_marker(ws, meta=None):
+        """Remove the marker — only when it records THIS mutant (meta None: any
+        marker of ours). A revert of B must never erase the record of A, whose
+        revert failed: that record is the only trace of a tree that is not HEAD."""
+        prior, why = read_applied_marker(ws)
+        if prior is None or why:
+            return
+        if meta is not None and prior.get("id") is not None and prior.get("id") != meta.get("id"):
+            return
+        try:
+            os.remove(applied_marker_for(ws))
         except OSError:
             pass
 
 
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
-        # two leaves a tree that is mutated and a note that says by what.
-        write_applied_marker(ws, meta)
+        # two leaves a tree that is mutated and a note that says by what. A marker
+        # that cannot go down keeps apply.sh from running at all.
+        ok, why = write_applied_marker(ws, meta)
+        if not ok:
+            return APPLY_REFUSED, "apply.sh NOT run: %s" % why
         return run_script(os.path.join(meta["dir"], "apply.sh"), ws)
 
 
     def revert_mutant(meta, ws):
         code, out = run_script(os.path.join(meta["dir"], "revert.sh"), ws)
         if code == 0:
-            try:
-                os.remove(applied_marker_for(ws))
-            except OSError:
-                pass
+            drop_applied_marker(ws, meta)
         return code, out
 
 
@@ -2253,6 +2345,15 @@ tool sync_harness:
         return p == r or p.startswith(r.rstrip(os.sep) + os.sep)
 
 
+    def leftover_roots(ws):
+        """The only two places a mutant of this workspace's net can live: the
+        tree itself (visible mutants, an unsealed held-out) and the sealed
+        held-out pile (sealed_dir_for — GM_SEALED_DIR honoured). Never the whole
+        scratch root: on a shared host that is all of /tmp, and a marker naming
+        a directory there would have the gate run whatever script it found."""
+        return [ws, sealed_dir_for(ws)]
+
+
     def revert_leftover_mutant(ws):
         """Revert the mutant a previous, interrupted run left applied — if any.
 
@@ -2261,68 +2362,81 @@ tool sync_harness:
         judge a mutated program and call it the lot's. Measured: a tool node
         retried on the same tree after its exec stream broke — the build gate
         went red on a file the mutant had edited, and the oracle reported that
-        file as "not committed".
+        file as "not committed". Run in record mode too: references recorded
+        over a leftover would seal a program nobody wrote, which is worse than
+        an edit lost on a file the mutant had already overwritten.
 
         Returns None when there is nothing to revert. Otherwise a dict with the
         mutant's id and dir, `code` (revert.sh's exit; None when the script is
-        gone), and `marker`. The marker is dropped only when the revert
-        demonstrably succeeded — a leftover the harness could not revert stays
-        recorded, so the next gate reports it again instead of forgetting it;
-        an operator who reverts by hand clears it by deleting the marker.
+        gone), `marker`, and after a clean revert `dirty` — what `git status`
+        still shows, because the script's exit code is its word, not the tree's.
+        The marker is dropped only when the revert demonstrably succeeded — a
+        leftover the harness could not revert stays recorded, so the next gate
+        reports it again instead of forgetting it; an operator who reverts by
+        hand clears it by deleting the marker.
 
-        A marker whose directory is not under the workspace or the scratch root
-        is REFUSED, dropped and reported without executing anything: the marker
-        is an instruction to run a script, and only the harness's own mutants
-        may write it.
+        Refused, nothing executed: a marker whose directory is neither this
+        workspace nor its sealed held-out pile (dropped — it is ours and it is
+        not evidence), and a marker slot that is not the harness's own (kept —
+        not ours to delete; every application is refused until it is gone).
         """
         marker = applied_marker_for(ws)
-        if not os.path.isfile(marker):
+        meta, why = read_applied_marker(ws)
+        if meta is None:
             return None
-        try:
-            with open(marker, encoding="utf-8") as f:
-                meta = json.load(f)
-        except (OSError, ValueError):
-            meta = {}
+        if why:
+            return {"id": None, "dir": "", "code": None, "out": why, "marker": marker,
+                    "refused": True, "kept": True, "dirty": ""}
         mdir = meta.get("dir") or ""
-        root = os.environ.get("GM_SCRATCH", tempfile.gettempdir())
-        if not mdir or not (_under(mdir, ws) or _under(mdir, root)):
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+        if not mdir or not any(_under(mdir, r) for r in leftover_roots(ws)):
+            drop_applied_marker(ws)
             return {"id": meta.get("id"), "dir": mdir, "code": None, "out": "",
-                    "marker": marker, "refused": True}
+                    "marker": marker, "refused": True, "kept": False, "dirty": ""}
         script = os.path.join(mdir, "revert.sh")
         if os.path.isfile(script):
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
+        dirty = ""
         if code == 0:
-            try:
-                os.remove(marker)
-            except OSError:
-                pass
+            drop_applied_marker(ws, meta)
+            st = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+                                capture_output=True, text=True)
+            dirty = (st.stdout or "").strip() if st.returncode == 0 else ""
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False}
+                "marker": marker, "refused": False, "kept": code != 0, "dirty": dirty[:400]}
 
 
     def leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
-        Returns (kind, text): "reverted" — the tree is HEAD again, a note;
-        "refused" — a foreign marker was dropped, a note; "still_mutated" — the
-        revert failed or its script is gone, the tree is NOT HEAD, the gate must
-        refuse rather than judge a program nobody wrote.
+        Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
+        the tree still shows, if anything); "refused" — a marker of ours naming
+        a foreign directory was dropped, a note; "unusable" — the marker slot is
+        not the harness's own, the gate must stop: every application would be
+        refused; "still_mutated" — the revert failed or its script is gone, the
+        tree is NOT HEAD, the gate must refuse rather than judge a program
+        nobody wrote.
         """
         if left.get("refused"):
+            if left.get("kept"):
+                return "unusable", (
+                    "the application-marker slot %s is not the harness's own: %s. Nothing "
+                    "executed, nothing deleted. Every mutant application is refused until "
+                    "it is removed by hand or GM_SCRATCH points at a private root."
+                    % (left.get("marker"), left.get("out")))
             return "refused", (
                 "a stale application marker named a directory outside this workspace and "
-                "its scratch root (%s): dropped, nothing executed." % (left.get("dir") or "?"))
+                "its sealed held-out pile (%s): dropped, nothing executed." % (left.get("dir") or "?"))
         if left.get("code") == 0:
-            return "reverted", (
-                "a mutant left APPLIED by an interrupted gate was reverted at start: %s "
-                "(revert.sh exit 0). The tree below is HEAD again; the interrupted attempt's "
-                "verdict, if any, judged a mutated program." % left.get("id"))
+            text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
+                    "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
+                    "mutated program." % left.get("id"))
+            if left.get("dirty"):
+                text += (" The tree still shows uncommitted changes after the revert — the "
+                         "script's exit is its word, not the tree's: %s"
+                         % " ".join(left["dirty"].split())[:300])
+            return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
             "a mutant left APPLIED by an interrupted gate could NOT be reverted at start: %s (%s). "
@@ -2403,6 +2517,11 @@ tool sync_harness:
         before_tree, before_data = tree_fingerprint(ws), data_fingerprint(meta, ws)
 
         code, out = apply_mutant(meta, ws)
+        if code == APPLY_REFUSED:
+            # Nothing ran: no half-edit to undo, and the marker down there is
+            # another mutant's record of a tree that is not HEAD — this mutant's
+            # revert.sh over it would erase that record and half-restore the tree.
+            return dict(base, valid=False, detected=False, reason=out[-300:]), "failed"
         if code != 0:
             # A failed apply may have half-edited the tree, and the marker is
             # down: revert now, within this run, so neither outlives it — a
@@ -3465,6 +3584,91 @@ tool sync_harness:
                 check("rien n'a ete execute", os.path.exists(canary), False)
                 check("le marqueur etranger est jete", os.path.isfile(applied_marker_for(tmp)), False)
                 check("disposition d'un marqueur etranger", leftover_disposition(left)[0], "refused")
+                # Un marqueur sous la racine scratch mais HORS de la pile scellee est
+                # etranger aussi : la racine, c'est tout /tmp sur un hote partage.
+                evil2 = os.path.join(os.environ["GM_SCRATCH"], "evil2")
+                os.makedirs(evil2)
+                with open(os.path.join(evil2, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ntouch %s\n" % shlex.quote(canary))
+                write_applied_marker(tmp, {"id": "evil2", "dir": evil2})
+                left = revert_leftover_mutant(tmp)
+                check("un marqueur sous la racine scratch, hors pile scellee, est refuse",
+                      [(left or {}).get("refused"), os.path.exists(canary)], [True, False])
+                # Un marqueur sous la pile scellee (GM_SEALED_DIR, hors arbre et hors
+                # scratch) est le held-out : il est reverti, pas refuse.
+                sealed = tempfile.mkdtemp(prefix="gm-sealed-")
+                saved_sealed = os.environ.get("GM_SEALED_DIR")
+                os.environ["GM_SEALED_DIR"] = sealed
+                try:
+                    hdir = os.path.join(sealed, "h1")
+                    os.makedirs(hdir)
+                    with open(os.path.join(hdir, "apply.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\nprintf 'held\\n' >> f.txt\n")
+                    with open(os.path.join(hdir, "revert.sh"), "w", encoding="utf-8") as f:
+                        f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                    code, _out = apply_mutant({"id": "h1", "dir": hdir}, tmp)
+                    check("le held-out scelle s'applique", [code, tree()], [0, "original\nheld\n"])
+                    left = revert_leftover_mutant(tmp)
+                    check("un marqueur sous la pile scellee est reverti, pas refuse",
+                          [(left or {}).get("refused"), (left or {}).get("code"), tree()],
+                          [False, 0, "original\n"])
+                    check("disposition du held-out reverti", leftover_disposition(left)[0], "reverted")
+                finally:
+                    os.environ.pop("GM_SEALED_DIR", None)
+                    if saved_sealed is not None:
+                        os.environ["GM_SEALED_DIR"] = saved_sealed
+                    shutil.rmtree(sealed, ignore_errors=True)
+                # Un revert en ECHEC garde son enregistrement face au mutant suivant :
+                # la seconde application est refusee, rien ne tourne, et le revert du
+                # second n'efface pas le marqueur du premier.
+                scripts("printf 'mutant\\n' >> f.txt", "exit 3")
+                code, _out = apply_mutant(lmeta, tmp)
+                check("A s'applique", code, 0)
+                code, out = revert_mutant(lmeta, tmp)
+                check("le revert de A echoue et A reste enregistre",
+                      [code, (read_applied_marker(tmp)[0] or {}).get("id")], [3, "leftover-1"])
+                bdir = os.path.join(tmp, "m2")
+                os.makedirs(bdir)
+                with open(os.path.join(bdir, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\nprintf 'B\\n' >> f.txt\n")
+                with open(os.path.join(bdir, "revert.sh"), "w", encoding="utf-8") as f:
+                    f.write("#!/bin/sh\ngit checkout -- f.txt\n")
+                bmeta = {"id": "leftover-2", "dir": bdir}
+                code, out = apply_mutant(bmeta, tmp)
+                check("l'application de B est refusee tant que A est enregistre",
+                      [code, "leftover-1" in out, tree()], [APPLY_REFUSED, True, "original\nmutant\n"])
+                verdict, state = probe_mutation(dict(bmeta, targets=["001"]), tmp)
+                check("la sonde de B est 'failed' sans rien reverter ni toucher au marqueur",
+                      [state, tree(), (read_applied_marker(tmp)[0] or {}).get("id")],
+                      ["failed", "original\nmutant\n", "leftover-1"])
+                code, _out = revert_mutant(bmeta, tmp)
+                check("le revert de B (exit 0) n'efface pas l'enregistrement de A",
+                      [code, (read_applied_marker(tmp)[0] or {}).get("id")], [0, "leftover-1"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Un repertoire de marqueur qui n'est pas prive n'est pas utilisable :
+                # l'application est refusee, la porte s'arrete (disposition 'unusable').
+                mdir_marker = os.path.dirname(applied_marker_for(tmp))
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                os.chmod(mdir_marker, 0o755)
+                try:
+                    code, out = apply_mutant(lmeta, tmp)
+                    check("un repertoire de marqueur non prive refuse l'application",
+                          [code, "not private" in out, tree()], [APPLY_REFUSED, True, "original\n"])
+                    os.chmod(mdir_marker, 0o700)
+                    apply_mutant(lmeta, tmp)
+                    os.chmod(mdir_marker, 0o755)
+                    left = revert_leftover_mutant(tmp)
+                    check("un marqueur dans un repertoire non prive est refuse et garde, rien n'est execute",
+                          [(left or {}).get("refused"), (left or {}).get("kept"), tree(),
+                           os.path.isfile(applied_marker_for(tmp))],
+                          [True, True, "original\nmutant\n", True])
+                    check("disposition d'un emplacement inutilisable", leftover_disposition(left)[0], "unusable")
+                finally:
+                    os.chmod(mdir_marker, 0o700)
+                left = revert_leftover_mutant(tmp)
+                check("le meme marqueur, l'emplacement redevenu prive : reverti",
+                      [(left or {}).get("code"), tree()], [0, "original\n"])
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)
@@ -3633,7 +3837,7 @@ tool sync_harness:
         left = revert_leftover_mutant(ws)
         if left:
             kind, text = leftover_disposition(left)
-            if kind == "still_mutated":
+            if kind in ("still_mutated", "unusable"):
                 bail(text)
             note(report, text)
 
@@ -3941,11 +4145,20 @@ tool sync_harness:
                              % ", ".join(sorted(only)))
 
             verdicts, blind = [], []
+            # A revert that did not restore the baseline (revert.sh failed, or the
+            # captures still differ with the mutant gone) ends the scoring: every
+            # later measurement would describe a program nobody wrote, and every
+            # later apply is refused anyway while the leftover is on record. The
+            # gate is red on `revert_clean` either way; stopping keeps it legible.
+            stopped = None
             for seed, meta in enumerate(visible):
                 if only and meta["id"] not in only:
                     continue
                 v = score_mutant(meta, config, corpus, canon, refs, ws, seed)
                 verdicts.append(v)
+                if not v.get("revert_clean", True):
+                    stopped = v
+                    break
                 if not v.get("valid"):
                     continue
                 if not v.get("detected"):
@@ -3962,9 +4175,19 @@ tool sync_harness:
             # it. Revealing `holdout_detected` to whoever runs the check is enough to
             # steer hardening: seeing 3/5 says "keep tuning" even with the files out
             # of reach. The held-out result belongs to the final gate alone.
-            held = [] if mode == "selfcheck" else [
-                score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
-                for i, m in enumerate(held_meta)]
+            held = []
+            if mode != "selfcheck" and stopped is None:
+                for i, m in enumerate(held_meta):
+                    v = score_mutant(m, config, corpus, canon, refs, ws, 1000 + i)
+                    held.append(v)
+                    if not v.get("revert_clean", True):
+                        stopped = v
+                        break
+            if stopped is not None:
+                note(report, "scoring stopped after mutant %s: %s. The tree or the app is no "
+                     "longer at baseline, so the mutants after it were not scored and are absent "
+                     "from the counts; a leftover, if any, is on record for the next gate."
+                     % (stopped.get("id"), stopped.get("reason") or "its revert did not restore the baseline"))
 
             valid = [v for v in verdicts if v.get("valid")]
             detected = [v for v in valid if v.get("detected")]

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4153,21 +4153,38 @@ tool sync_harness:
             wanted = [i.strip() for i in os.environ.get("GM_MUTANTS", "").split(",") if i.strip()]
             chosen = [m for m in visible if not wanted or m["id"] in wanted]
             report["missing"] = sorted(set(wanted) - {m["id"] for m in chosen})
-            verdicts = []
+            verdicts, stopped_at = [], None
             for m in chosen:
                 v, state = probe_mutation(m, ws)
                 if state != "failed":
                     revert_mutant(m, ws)
                 verdicts.append(v)
+                # The gate's rule, here too. One mutant whose revert failed leaves
+                # the record armed; without this, every LATER mutant came back
+                # invalid quoting that one, while the tail still announced them all
+                # "applied, fingerprinted and reverted" and the tree stayed mutated.
+                # This is the mode the campaign uses to accept a RE-ANCHORED mutant,
+                # so the cascade sent it to repair mutants that were fine.
+                if leftover_on_record(ws):
+                    stopped_at = v
+                    break
             report["total"] = len(verdicts)
             report["valid"] = len([v for v in verdicts if v.get("valid")])
             report["invalid"] = [{"id": v["id"], "reason": v.get("reason", "")}
                                  for v in verdicts if not v.get("valid")]
+            done = len(verdicts) - (1 if stopped_at is not None else 0)
             report["log_tail"] = (
                 "MODE=validate — %d mutant(s) applied, fingerprinted and reverted. This says "
                 "each one CHANGES something; it says NOTHING about whether the net sees it. "
                 "Only the gate captures and compares, and the zeroed fields above are defaults, "
-                "not a verdict." % len(verdicts))
+                "not a verdict." % done)
+            if stopped_at is not None:
+                report["log_tail"] += (
+                    " STOPPED at mutant %s: it is still recorded as applied, so the tree is not "
+                    "at baseline and the %d mutant(s) after it were NOT validated — every "
+                    "application there would be refused, not measured. Revert by hand, delete "
+                    "the marker %s, then re-run."
+                    % (stopped_at.get("id"), len(chosen) - len(verdicts), applied_marker_for(ws)))
             if report["missing"]:
                 report["log_tail"] += (" %d requested mutant(s) do not exist: %s."
                                        % (len(report["missing"]), ", ".join(report["missing"])))


### PR DESCRIPTION
## Measured (#799)

A verify node ran the oracle gate for 7 676 s until the pod's exec stream broke; the engine retried the node on the SAME tree, where a mutant the harness had applied for its falsification pass had not been reverted. The second attempt judged that tree: "WORKSPACE NOT COMMITTED (1 path: the mutant's file)", and the build gate went red on a package that exists on the run's bank. The run finished not converged with hours of budget left; the lot had to be relaunched.

## Fix (judge code — P14: PR + mechanical sync, never a rite)

- `apply_mutant` writes a marker **before** `apply.sh` runs — outside the tree (the tree is what is judged), keyed on the workspace's absolute path, in the temp root beside the sealed set; `revert_mutant` drops it after a clean revert.
- Every gate starts with `revert_leftover_mutant`: a marker left behind runs that mutant's `revert.sh`, drops the marker, and the report says which mutant was reverted and how — before the dirty check, which would otherwise name the mutant's file as the run's uncommitted work. A mutant whose `revert.sh` vanished is reported, not swallowed.

## Proof

- Self-test: 112 checks (+8), with the REAL `apply_mutant`/`revert_mutant` on a real temporary repository: marker set on apply; leftover identified and reverted; tree back at HEAD; marker dropped; a second start has nothing to revert; a nominal revert drops the marker; a vanished `revert.sh` is reported.
- Mutant (the leftover is never reverted): four checks red.
- Both inlined copies regenerated with `sync-harness.py`; `go test ./bots/ -run GoldenMaster` green (byte identity).

Deployment: the harness reaches a target tree through the P14 sync (the `sync-harness` bot or `scripts/sync-harness.sh` with the full gate on the committed tree), coordinated with the campaign's landings; the engine-side half — a retried tool node inheriting the tree its interrupted attempt left — stays open on #799.

## Second round (six findings, all reproduced)

- **A failed or missing revert was reported as "reverted"** (high): `leftover_disposition` now decides — a clean revert is a note; a foreign marker is a note; a revert that failed or whose script vanished REFUSES the gate (`bail`) and says what to do by hand. A knowingly-mutated tree is never judged.
- **A failed `apply.sh` left the marker armed** (high): a later gate would have run that mutant's `revert.sh` over the operator's uncommitted work. A failed apply reverts within its own run — tree and marker.
- **Vacuous vanished-script check** (high): asserts the identity, the missing script and the message.
- **Marker dropped whatever the revert did** (medium): dropped only on a clean revert; a leftover the harness could not revert stays recorded and reported again.
- **Marker root ignored `GM_SCRATCH`** (medium): one rule with the sealed pile.
- **Predictable, world-writable marker naming a script to run** (medium/security): the marker lives in a private `0700` directory, created `O_EXCL|O_NOFOLLOW` `0600`; a marker whose directory is not under the workspace or the scratch root is refused, dropped and reported — nothing executed.

Self-test: 127 checks (+15), real apply/revert and fingerprints on a real repository. Mutants, each red: a failed revert called "reverted"; the failed apply no longer reverting; the marker dropped on a failed revert; a foreign marker executed. Open question answered: the guard relies on the retried attempt seeing the same scratch filesystem (the measured case: a node retried inside the same pod); a fresh pod starts from a fresh copy and has nothing to revert — that is the intended asymmetry.


## Second round (three findings, each reproduced; four questions answered)

- **The containment omitted the sealed held-out pile** (high): with `GM_SEALED_DIR` outside the workspace and the scratch root — the configuration the harness itself asks for when the default root is not stable — a held-out mutant left applied was classified foreign: its marker deleted, its revert never run, the gate judging a mutated tree. The roots a leftover may live under are now `leftover_roots(ws)` = the tree and `sealed_dir_for(ws)`, the one rule the seal already follows. Self-test: a marker under `GM_SEALED_DIR` is reverted, not refused; mutant: the sealed dir dropped — red.
- **The next apply erased the record of a mutant whose revert failed** (medium): the slot was rewritten unconditionally, and the next mutant's clean revert then deleted it — A applied in the tree, nothing recording it. The slot now refuses a second record: `apply_mutant` returns `APPLY_REFUSED` without running apply.sh, `probe_mutation` marks the mutant failed without reverting anything (its revert.sh over A's leftover would half-restore the tree and erase A's record), a revert drops only its own record, and the scoring stops at the first verdict whose revert did not restore the baseline (a note names it; the gate is red on `revert_clean` either way). Self-test: A's failed revert, then B refused, B's probe touching nothing, B's clean revert leaving A's record; mutants: the slot overwritten, a revert dropping any marker, a refused apply running the revert — each red.
- **A planted marker under the scratch root ran its script** (medium, security): the containment accepted all of the default root, and the read side trusted any file at the path. The read side now proves ownership: the marker directory must be a real directory of this uid with no group/other bits (`_private_dir_of_ours`), the file a regular file of this uid opened with `O_NOFOLLOW`; anything else is refused, nothing executed, nothing deleted (not ours to delete), and the gate stops on it (`unusable`), since every application would be refused until the slot is cleared or `GM_SCRATCH` moved. The write side refuses a directory that fails the same test, and a record that cannot be written refuses the apply instead of being swallowed (the first round's finding on the silent `except OSError: pass`). Self-test: a marker under the scratch root outside the sealed pile is refused with its canary unrun; a non-private marker directory refuses the apply and yields `unusable`; mutants: the privacy test always passing, the read side trusting a foreign directory — each red.

Open questions, answered:

- *Does the consumer distinguish a `still_mutated` bail from a genuine 0 %?* A bail prints the report with `stable` false and the cause in `log_tail`, so every consumer reads a red: the standalone wrapper exits 1 on the same conjunction, the modernize gate records the text in its problems. It is not typed apart from a RED, so a modernize run spends a repair pass on it — and that pass reads "revert by hand, then delete the marker", which is the right repair (the mutant's paths are the app's files, not the net's). Typing it apart is a change of the report contract, outside this PR.
- *Is running the revert in record mode intended?* Yes, and the docstring now says why: references recorded over a leftover would seal a program nobody wrote, which is worse than an edit lost on a file the mutant had already overwritten.
- *Should the "reverted" disposition confirm the tree?* The note no longer claims HEAD on the script's exit alone: after a clean revert it reports what `git status --porcelain` still shows. The gate's own dirty check follows in every non-record mode; the note gives it its attribution.
- *A shared or persistent `GM_SCRATCH`, two processes gating the same path?* The second sees the first's record and every one of its applies is refused, loudly, instead of the two clobbering one slot — two harnesses mutating one tree at once cannot measure anything either way.

Self-test: 140 checks (was 127).


## Third round (one finding; nine commits by the improvement loop, one on top)

Revi's finding (Rc4ff19, medium): a marker of the harness's own naming a directory outside the recognised roots was **dropped and the gate went on** — a held-out mutant applied under one `GM_SEALED_DIR` and swept under another lands there, and in record mode nothing else stops the references from being recorded over the mutated tree. The improvement loop reproduced it verbatim and landed the fix (55fb12879: the record is kept in both refusal branches, `LEFTOVER_BAIL_KINDS` holds the dispositions the gate stops on, only `reverted` lets a gate through), then eight more commits it documents in its review on this PR — among them a defect nobody had flagged: three branches that never reached the apply-capture-revert path never wrote `revert_clean`, and `all(v.get("revert_clean", True))` read their silence as clean, so an apply that half-edited and a revert that failed produced a GREEN gate over a mutated tree (a5db4469a, `overall_revert_clean`). Self-test 140 → 168, every new check verified red against the pre-fix behaviour.

One commit on top (a61b33d11) closes the three open questions that were still open in code:

- *Durability of the marker vs. the tree.* The marker now lives in the **tree's git dir** (a worktree's own, under the main repo's `.git`), which lives exactly as long as the mutated files do: a container restarted on the same bind-mounted worktree keeps both, a copy-based pod's fresh copy has neither — whereas a marker in a temp root outlives or predeceases the tree it describes. Outside what is judged (`git status` never lists it). A workspace without a git dir falls back to the scratch root, keyed on the real path; git is bounded and guarded there as in the sweep. Mutant: the root back to the scratch dir — red.
- *`leftover_roots` was the whole workspace.* The shipped rule is now the net's directory (`main` passes `gm_dir`) and the sealed pile; a marker naming a directory elsewhere in the tree is refused and kept. Mutant: the whole tree as root again — red.
- *`APPLY_REFUSED = -1` shares its space with returncodes.* It is a string now: a shell killed by SIGHUP reports -1, which is an apply that ran and must be reverted in-run. The self-test injects the -1 through a `run_script` double (a real signal depends on whether the shell execs its last command). Mutant: the sentinel back to -1 — red.
- *`main`'s kind → bail/note mapping untested* — `LEFTOVER_BAIL_KINDS` beside the function that produces the kinds (loop's commit). *`GM_WORKSPACE` absolute on every path?* — with the git-dir location the key is intrinsic to the tree; the fallback keys on `os.path.realpath`.

Self-test: 172 checks. `go test ./bots/` green (the byte-identity test covers the two inlined copies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
