### PR TITLE
fix(server): a forge that will not describe the account asks for the operator's word, not a 502 dead end

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -57,8 +57,10 @@ Apply state on a connection: `account_kind`, `avatar_applied_at`, `avatar_error`
 `POST /api/teams/{id}/forge/connections/{conn_id}/avatar` `{variant?: plain|circle, force?}`
 — 422 with `logo_url` + `logo_circle_url` on GitHub (plus `manage_url` when
 the App is one iterion created), 422 on a revoked connection (reconnect
-first), 409 `needs_force` on an unflagged account, 502 with the forge's
-reason when the upload is refused. Audit event on both the automatic and
+first), 409 `needs_force` on an account the forge does not flag as a bot —
+or would not describe at all (a token without the scope): iterion cannot
+vouch, the operator can — 502 with the forge's reason when the upload is
+refused. Audit event on both the automatic and
 the explicit path: `forge.connection.avatar_applied` (`automatic: true` at
 connect time).
 

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -76,12 +76,17 @@ connect-time upload deployment-wide; the explicit action stays.
 2. Open the App's settings: the *Logo ↗* link on the App row (Integrations →
    Manual setup → Forge OAuth apps), or GitHub → the org → Settings → Developer
    settings → GitHub Apps → the App → **General**.
-3. Under **Display information**, *Upload a logo*, pick a badge background
-   colour if you like, save. Comments and commits signed by
-   `<slug>[bot]` carry the avatar from then on.
+3. Under **Display information**, *Upload a logo…*, then *Set new avatar* in
+   the crop dialog. The logo is live at that click — the form's *Save changes*
+   button belongs to the basic information above it, not to the logo. Comments
+   and commits signed by `<slug>[bot]` carry the avatar from then on.
 
-To do once on the SocialGouv org: every `iterion-forge-*` / `iterion-watch-*`
-App iterion created there, and the `iterion` OAuth App used for SSO.
+An **OAuth App** (the `iterion` SSO app) takes the same file through
+*Application logo → Upload new logo → Set new application logo*.
+
+Done on the SocialGouv org on 2026-09-06 (the four `iterion-forge-*` /
+`iterion-watch-*` Apps and the `iterion` / `iterion preprod` OAuth Apps). An App
+the manifest flow creates afterwards starts without a logo: repeat the steps.
 
 ### GitLab group bot accounts already connected (the PIC)
 

--- a/docs/cloud-rest-api.md
+++ b/docs/cloud-rest-api.md
@@ -205,7 +205,7 @@ requires membership. Sources:
 | `DELETE` | `/api/teams/{id}/forge/connections/{conn_id}` | team admin | Remove a connection |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/health` | team member | Connection health / token probe |
 | `POST` | `/api/teams/{id}/forge/connections/{conn_id}/refresh` | team member | GitHub App only: re-probe live installation grants, persist them, and force a fresh token mint |
-| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person) and GitHub (no API — names the App's settings page), 409 `needs_force` on an account the forge does not flag as a bot. See [brand.md](brand.md) |
+| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person) and GitHub (no API — names the App's settings page), 409 `needs_force` on an account the forge does not flag as a bot, or would not describe at all. See [brand.md](brand.md) |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/repos` | team member | Repos visible to the connection |
 | `GET` | `/api/teams/{id}/forge/repos` | team member | Team's forge-linked repos |
 | `POST` | `/api/teams/{id}/forge/repos` | team admin | Create a repo (opt-in `RepoCreator` capability) |

--- a/pkg/cli/remote_forge.go
+++ b/pkg/cli/remote_forge.go
@@ -100,8 +100,9 @@ func RemoteForgeAvatar(ctx context.Context, c *RemoteClient, p *Printer, path, v
 }
 
 // printAvatarRefusal renders the refusal fields of the avatar endpoint (422 on
-// GitHub with the App's settings page, 409 when the account is not flagged
-// as a bot) so the operator reads the alternative, not a cut JSON blob.
+// GitHub with the App's settings page, 409 when the forge does not flag the
+// account as a bot — or would not describe it at all) so the operator reads
+// the alternative, not a cut JSON blob.
 func printAvatarRefusal(p *Printer, raw []byte) {
 	var refusal struct {
 		Error        string `json:"error"`

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -42,6 +42,11 @@ type avatarRefusal struct {
 
 func (r *avatarRefusal) Error() string { return r.msg }
 
+// avatarForceHint closes every 409 message: "<why iterion cannot vouch>; <the
+// forced retry>". The studio dialog strips the clause and words the retry as
+// its own button, so the reason must stay a single clause before it.
+const avatarForceHint = "; if it is a dedicated account for iterion (not a person's), apply with force"
+
 // brandLogoPath is the public route serving a mascot variant, for the uploads
 // an operator has to do by hand.
 func brandLogoPath(v brand.Variant) string { return "/brand/" + v.Filename() }
@@ -158,8 +163,17 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		switch {
 		case err == nil:
 			conn.AccountKind, learned = ident.Kind, ident.Kind
-		case !force || ctx.Err() != nil:
+		case ctx.Err() != nil:
 			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
+		case !force:
+			// The forge would not describe the account (a token without the
+			// scope, a forge without the field): iterion cannot vouch for it,
+			// the operator can — the same rung as an unflagged account, so
+			// every surface offers the forced retry instead of a 502 that
+			// records nothing and repeats on the next attempt.
+			return conn, "", &avatarRefusal{status: http.StatusConflict,
+				msg:    fmt.Sprintf("%s would not say whether @%s is a bot account (%v)%s", conn.Host(), conn.AccountLogin, err, avatarForceHint),
+				fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
 		}
 	}
 	if conn.AccountKind != forge.AccountKindBot && !force {
@@ -170,7 +184,7 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 			}
 		}
 		return conn, "", &avatarRefusal{status: http.StatusConflict,
-			msg:    fmt.Sprintf("%s does not flag @%s as a bot account; if it is a dedicated account for iterion (not a person's), apply with force", conn.Host(), conn.AccountLogin),
+			msg:    fmt.Sprintf("%s does not flag @%s as a bot account%s", conn.Host(), conn.AccountLogin, avatarForceHint),
 			fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
 	}
 	avatarURL, err := setter.SetAvatar(ctx, brand.BotAvatar(variant))

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -564,3 +564,42 @@ func TestForgeConnectionAvatar_ForcedApplyBailsWhenWhoAmIHangs(t *testing.T) {
 		t.Fatalf("uploaded on a dead context or recorded a misleading reason: uploads=%d error=%q applied=%v", uploads, stored.AvatarError, stored.AvatarAppliedAt)
 	}
 }
+
+// A forge that will not describe the account (a token without the scope, a
+// forge without the field) leaves iterion unable to vouch — but the operator
+// can: the same 409 rung as an unflagged account, so the studio card and the
+// CLI offer the forced retry instead of dead-ending on a 502 that recorded
+// nothing and would repeat on every click.
+func TestForgeConnectionAvatar_UnreadableAccountAsksForTheWord(t *testing.T) {
+	s := newForgeTestServer(t)
+	uploads := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusForbidden) })
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		uploads++
+		_ = json.NewEncoder(w).Encode(map[string]any{"avatar_url": "https://gl/u.png"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-unreadable", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL}) // AccountKind empty
+
+	w := avatarReq(s, "c-unreadable", "")
+	if w.Code != http.StatusConflict {
+		t.Fatalf("unforced apply on an unreadable account: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	msg, _ := body["error"].(string)
+	if body["needs_force"] != true || body["account_login"] != "svc" || !strings.Contains(msg, "would not say whether @svc") || !strings.Contains(msg, "insufficient scope") {
+		t.Fatalf("refusal must offer the forced retry, name the account and the forge's reason: %v", body)
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-unreadable")
+	if uploads != 0 || stored.AccountKind != "" || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("a refusal to vouch must upload and record nothing: uploads=%d stored=%+v", uploads, stored)
+	}
+	if w := avatarReq(s, "c-unreadable", `{"force":true}`); w.Code != http.StatusOK || uploads != 1 {
+		t.Fatalf("the operator's word carries the apply: code=%d uploads=%d body=%s", w.Code, uploads, w.Body.String())
+	}
+}

--- a/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
+++ b/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
@@ -164,6 +164,25 @@ describe("ConnectionCard — iterion-bot avatar", () => {
     );
   });
 
+  it("offers the vouch when the forge would not describe the account, naming the reason", async () => {
+    vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: undefined })]);
+    vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
+      new ApiError(
+        409,
+        "gitlab.example.com would not say whether @group_1_bot_x is a bot account (gitlab: HTTP 403); if it is a dedicated account for iterion (not a person's), apply with force",
+      ),
+    );
+    renderTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
+    // The dialog carries the forge's own answer, and is the forced retry itself.
+    await screen.findByText(/would not say whether @group_1_bot_x is a bot account \(gitlab: HTTP 403\)\./);
+    expect(screen.queryByText(/apply with force/)).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: "Apply the avatar" }));
+    await waitFor(() =>
+      expect(forgeApi.applyForgeConnectionAvatar).toHaveBeenNthCalledWith(2, "t1", "c1", { force: true }),
+    );
+  });
+
   it("shows the applied state and offers a re-apply", async () => {
     vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([
       conn({ account_kind: "bot", avatar_applied_at: "2026-09-05T10:00:00Z" }),

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -233,19 +233,31 @@ function AvatarRow({
   }
 
   const isBot = conn.account_kind === "bot";
-  const vouch = () =>
+  // The dialog opens on what iterion knows: the forge's own answer when a 409
+  // brought one (it may not flag the account — or may have refused to describe
+  // it), the connection's recorded kind otherwise.
+  const vouch = (reason?: string) =>
     confirm({
       title: "Rebrand this account?",
       message: (
         <span>
-          {conn.forge_base_url ?? conn.provider} does not flag{" "}
-          <span className="font-mono">@{conn.account_login}</span> as a bot. Apply the
-          iterion-bot avatar only if this is a dedicated account for iterion — never a
+          {reason ? (
+            <>{reason}.</>
+          ) : (
+            <>
+              {conn.forge_base_url ?? conn.provider} does not flag{" "}
+              <span className="font-mono">@{conn.account_login}</span> as a bot.
+            </>
+          )}{" "}
+          Apply the iterion-bot avatar only if this is a dedicated account for iterion — never a
           person&apos;s.
         </span>
       ),
       confirmLabel: "Apply the avatar",
     });
+  // A 409 reads "<why iterion cannot vouch>; if it is a dedicated account …,
+  // apply with force": the dialog shows the why and is the force itself.
+  const refusalReason = (e: ApiError) => e.message.replace(/;\s*if it is a dedicated account.*$/, "");
   // A refusal still taught the server something (the account's kind, a forge
   // error kept on the record): refetch, then show the reason. onChanged clears
   // the banner synchronously and onError re-sets it in the same batch — keep
@@ -269,7 +281,7 @@ function AvatarRow({
       onChanged();
     } catch (e) {
       if (!force && e instanceof ApiError && e.status === 409) {
-        if (!(await vouch())) {
+        if (!(await vouch(refusalReason(e)))) {
           onChanged(); // the server recorded the learned kind
           return;
         }


### PR DESCRIPTION
Follow-up to #804 — the medium finding Revi left on it (`R97b04f`).

**The dead end.** An avatar apply on a connection of unknown `account_kind` asks the forge who the token is. When the forge refuses to say (a token without the scope, a forge without the field), the unforced apply answered a bare 502 that recorded nothing. Since #804 the studio card only offers the vouch on a 409, so it repeated the identical 502 on every click, and the forced apply the server still supports (`TestForgeConnectionAvatar_RefusalRecordsOnlyTheKind`) was unreachable from the studio.

**The fix.** That refusal is now the same `409 needs_force` rung as an unflagged account, with the forge's own answer as the reason (`avatarForceHint` closes every 409 message, so the studio dialog can show the reason and be the forced retry itself). A `/user` that never answered stays a 502 — that is the apply's own budget expiring, not a refusal, and a forced retry would only hit it again. The CLI already prints `retry with --force` on any `needs_force`.

**Tests.** `TestForgeConnectionAvatar_UnreadableAccountAsksForTheWord`: `/user` 403 → unforced apply is a 409 naming `@svc` and the forge's reason, uploads nothing, records nothing; the forced retry lands. Studio: "offers the vouch when the forge would not describe the account, naming the reason" (the dialog shows the reason, hides the CLI wording, and confirms with `force: true`).

**Docs.** `docs/brand.md`'s manual GitHub upload as it actually goes (the crop dialog's button makes the logo live; the form's Save is not involved), the OAuth App path, and the record of the SocialGouv pass of 2026-09-06.

Evidence: `pkg/server` + `pkg/cli` suites, `golangci-lint` (0 issues) and `task studio:check` (1332 tests) green on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)