### PR TITLE
fix(forge): the GitHub-App client serves the pull/CI API on scoped tokens — the card PR panel works on App connections

### DIFF
--- a/docs/forge-permissions.md
+++ b/docs/forge-permissions.md
@@ -84,12 +84,34 @@ Prefer narrowing the *connection*, not the user:
 - **GitHub App** (`github_app`) — the bot acts as the App with exactly the
   permissions in its manifest (`contents:write`, `pull_requests:write`,
   `issues:write` for posting the PR/MR back-link on the source issue,
-  `metadata:read`, `repository_hooks:write` for the per-repo inbound webhook),
-  scoped to the repos the App is installed on. It deliberately does **not**
+  `metadata:read`, `repository_hooks:write` for the per-repo inbound webhook,
+  `statuses:write` for the merge-gate verdict, `checks:read` for the board
+  card's CI panel — it lists a ref's check-runs), scoped to the repos the App
+  is installed on. It deliberately does **not**
   request `administration` (repo deletion/settings/teams/branch-protection) —
   that is over-privileged, and per GitHub docs webhooks require
   `repository_hooks`, not `administration`. The right answer for production: bots get only
   what they need, and PRs are authored by a clearly-non-human bot identity.
+  Tokens are minted **per call family**, each narrowed to the grants its
+  endpoint is gated on ([`pkg/forge/github/app_client.go`](../pkg/forge/github/app_client.go),
+  the `*InstallationPermissions` profiles): the token a bot pushes with never
+  carries `checks`, and the token the CI panel reads with never carries a
+  write.
+
+  **Existing installations must re-approve a permission added after they
+  were installed.** GitHub never widens an installation silently: when the
+  App's requested set grows (`statuses:write` for the merge gate,
+  `checks:read` for the CI panel), every installation shows a *pending
+  permission request* that an org owner approves — org **Settings → GitHub
+  Apps → Configure** on the App, the page the connection health view returns
+  as `manage_install_url` — and an App created before the permission existed
+  must first add it under **Permissions & events** in its own settings. Until
+  then the surface that needs it says so instead of failing silently: the
+  card's CI panel answers `422` naming `checks:read` and the page to approve
+  it on, the health view lists it under `missing_ci_permissions`
+  (`iterion remote forge connections refresh <id>` prints the same line), and
+  nothing else on the connection is affected — the runtime token is never
+  minted with it.
   **Self-service** (no platform App, no manual registration): Integrations →
   "+ Register an OAuth app" → github → **"Create a GitHub App"** (iterion builds
   the scoped App via manifest and captures its private key), then the **"Install"**

--- a/openapi.json
+++ b/openapi.json
@@ -2754,6 +2754,12 @@
           "manage_install_url": {
             "type": "string"
           },
+          "missing_ci_permissions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "missing_permissions": {
             "items": {
               "type": "string"

--- a/pkg/cli/remote_forge.go
+++ b/pkg/cli/remote_forge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strings"
 )
 
 type remoteForgeRefreshResult struct {
@@ -13,6 +14,7 @@ type remoteForgeRefreshResult struct {
 	TokenPermissions        map[string]string `json:"token_permissions"`
 	MissingPermissions      []string          `json:"missing_permissions"`
 	TokenMissingPermissions []string          `json:"token_missing_permissions"`
+	MissingCIPermissions    []string          `json:"missing_ci_permissions"`
 	LiveError               string            `json:"live_error"`
 }
 
@@ -52,6 +54,15 @@ func RemoteForgeRefresh(ctx context.Context, c *RemoteClient, p *Printer, path s
 		rows = append(rows, []string{k, res.GrantedPermissions[k], res.TokenPermissions[k]})
 	}
 	p.Table([]string{"PERMISSION", "GRANTED", "TOKEN"}, rows)
+	// The gaps the health probe computed, each with what it costs — the
+	// table above shows what IS granted, not what a surface is waiting on.
+	if len(res.MissingPermissions) > 0 {
+		p.Line("missing for app delivery (CI workflow + image publish): %s", strings.Join(res.MissingPermissions, ", "))
+	}
+	if len(res.MissingCIPermissions) > 0 {
+		p.Line("missing for the board card CI panel: %s — approve the pending request on %s",
+			strings.Join(res.MissingCIPermissions, ", "), res.ManageInstallURL)
+	}
 	if res.LiveError != "" {
 		p.Line("live probe error: %s", res.LiveError)
 	}

--- a/pkg/cli/remote_forge.go
+++ b/pkg/cli/remote_forge.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -60,8 +61,24 @@ func RemoteForgeRefresh(ctx context.Context, c *RemoteClient, p *Printer, path s
 		p.Line("missing for app delivery (CI workflow + image publish): %s", strings.Join(res.MissingPermissions, ", "))
 	}
 	if len(res.MissingCIPermissions) > 0 {
-		p.Line("missing for the board card CI panel: %s — approve the pending request on %s",
-			strings.Join(res.MissingCIPermissions, ", "), res.ManageInstallURL)
+		// Name every surface the gap darkens, not just the one that prompted
+		// the probe: `statuses` is also what the revi/review merge-gate
+		// verdict is posted and read with, so an operator told only about a
+		// card panel would not know the gate is dark too.
+		line := "missing for the board card CI panel"
+		if slices.Contains(res.MissingCIPermissions, "statuses") {
+			line += " and the merge-gate verdict"
+		}
+		line += ": " + strings.Join(res.MissingCIPermissions, ", ")
+		// The install page is where an owner approves the pending request —
+		// when the probe could not report one, say so instead of trailing off
+		// after "on".
+		if res.ManageInstallURL != "" {
+			line += " — approve the pending request on " + res.ManageInstallURL
+		} else {
+			line += " — approve the pending request on the App's installation page"
+		}
+		p.Line("%s", line)
 	}
 	if res.LiveError != "" {
 		p.Line("live probe error: %s", res.LiveError)

--- a/pkg/cli/remote_forge_test.go
+++ b/pkg/cli/remote_forge_test.go
@@ -9,6 +9,59 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cli"
 )
 
+// The refresh output exists to turn a permission gap into a step. It must name
+// every surface the gap darkens — `statuses` is the merge-gate verdict as well
+// as the card's CI panel — and it must never trail off after "on" when the
+// probe could not report an installation page.
+func TestRemoteForgeRefresh_RendersTheCIGapAndItsPage(t *testing.T) {
+	body := func(missing, manage string) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"installation_account":"acme","manage_install_url":"` + manage +
+				`","granted_permissions":{"contents":"write"},"missing_ci_permissions":` + missing + `}`))
+		}
+	}
+	page := "https://github.com/organizations/acme/settings/installations/99"
+
+	p, out := remotePrinter(cli.OutputHuman)
+	c := remoteTestClient(t, body(`["checks"]`, page))
+	if err := cli.RemoteForgeRefresh(context.Background(), c, p, "/x"); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"checks", "CI panel", page} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "merge-gate") {
+		t.Errorf("only `checks` is missing — the merge gate posts with statuses and is unaffected:\n%s", got)
+	}
+
+	// statuses withheld: the gate is dark too, and the operator has to know.
+	p, out = remotePrinter(cli.OutputHuman)
+	c = remoteTestClient(t, body(`["checks","statuses"]`, page))
+	if err := cli.RemoteForgeRefresh(context.Background(), c, p, "/x"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "merge-gate") {
+		t.Errorf("a withheld `statuses` also darkens the revi/review verdict, which the line must say:\n%s", out.String())
+	}
+
+	// No install page (the probe could not report one): still a whole sentence.
+	p, out = remotePrinter(cli.OutputHuman)
+	c = remoteTestClient(t, body(`["checks"]`, ""))
+	if err := cli.RemoteForgeRefresh(context.Background(), c, p, "/x"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "on \n") || strings.HasSuffix(strings.TrimRight(out.String(), "\n"), " on") {
+		t.Errorf("the line trails off after \"on\" with no page to name:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "installation page") {
+		t.Errorf("with no URL the line must still name where to go:\n%s", out.String())
+	}
+}
+
 // A refusal's actionable field — the App's settings page — sits last in the
 // JSON body, past the generic error line's 300-byte cut. It must reach the
 // operator whole.

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -234,6 +234,21 @@ func PullWriteInstallationPermissions() map[string]string {
 // merge writes the base branch), not on pull_requests write; the
 // pull_requests read serves the re-fetch that returns the merged ref, and
 // contents write also covers the optional source-branch deletion.
+//
+// The METHOD is what carries the rule, and the two methods of this one path
+// sit under different permissions — which is the trap. GitHub's published
+// per-endpoint data lists them as two separate rows:
+//
+//	put …/pulls/{pull_number}/merge  "merge-a-pull-request"                  → Contents, write
+//	get …/pulls/{pull_number}/merge  "check-if-a-pull-request-has-been-merged" → Pull requests, read
+//
+// so reading "…/pulls/{n}/merge appears under Pull requests" as licence to
+// add pull_requests:write here is reading the GET's row. Neither row carries
+// the "additional permissions" marker, i.e. neither is a conjunction — unlike
+// GET …/pulls/{n} three functions up, which IS dual-listed (Contents read AND
+// Pull requests read, both marked) and is why that profile takes both. The
+// two profiles apply the same rule to two differently-shaped rows; they do
+// not apply opposite readings to one.
 func PullMergeInstallationPermissions() map[string]string {
 	return map[string]string{
 		"contents":      "write",

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -181,6 +181,104 @@ func IssueReadOrPullInstallationPermissions() map[string]string {
 	}
 }
 
+// PermissionChecks is the grant the board card's CI panel lists a ref's
+// check-runs with. It is requested at App creation (BuildAppManifest) and
+// minted ONLY into the CI profiles below — never into the runtime baseline:
+// the management and run tokens are minted from that baseline, and an
+// installation approved before the grant existed (every one, until its owner
+// approves the pending request) would then fail EVERY mint, not just the CI
+// read.
+const PermissionChecks = "checks"
+
+// PullListInstallationPermissions is the grant set minted for listing pull
+// requests: pull_requests read plus the mandatory metadata baseline.
+//
+// The pull profiles exist for the same reason the issue profiles do: a
+// PullClient method implemented on *AdminClient alone is invisible to the
+// `admin.(forge.PullClient)` the card's PR/CI panel asserts, and the App
+// client is the connection shape the connect wizard creates by default. Each
+// profile is the endpoint's own rule (GitHub's published per-endpoint
+// permission data), no wider — a read never acquires a write, and none of
+// them rides the runtime baseline, whose contents/pull_requests/issues/hooks
+// WRITES no read here has a use for.
+func PullListInstallationPermissions() map[string]string {
+	return map[string]string{
+		"pull_requests": "read",
+		"metadata":      "read",
+	}
+}
+
+// PullGetInstallationPermissions is the grant set minted for reading ONE pull
+// request. GitHub gates GET /repos/{owner}/{repo}/pulls/{number} on contents
+// read as well as pull_requests read — the object carries content-derived
+// fields (mergeability, diff stats) — which the collection read does not.
+func PullGetInstallationPermissions() map[string]string {
+	return map[string]string{
+		"pull_requests": "read",
+		"contents":      "read",
+		"metadata":      "read",
+	}
+}
+
+// PullWriteInstallationPermissions is the grant set minted for opening or
+// updating a pull request: pull_requests write plus the metadata baseline.
+func PullWriteInstallationPermissions() map[string]string {
+	return map[string]string{
+		"pull_requests": "write",
+		"metadata":      "read",
+	}
+}
+
+// PullMergeInstallationPermissions is the grant set minted for merging a pull
+// request. GitHub gates PUT .../pulls/{number}/merge on contents WRITE (the
+// merge writes the base branch), not on pull_requests write; the
+// pull_requests read serves the re-fetch that returns the merged ref, and
+// contents write also covers the optional source-branch deletion.
+func PullMergeInstallationPermissions() map[string]string {
+	return map[string]string{
+		"contents":      "write",
+		"pull_requests": "read",
+		"metadata":      "read",
+	}
+}
+
+// CIStatusInstallationPermissions is the grant set minted for the CURRENT CI
+// state of a ref: checks read for the check-runs list, statuses read for the
+// legacy combined commit status, plus the metadata baseline.
+func CIStatusInstallationPermissions() map[string]string {
+	return map[string]string{
+		PermissionChecks:   "read",
+		PermissionStatuses: "read",
+		"metadata":         "read",
+	}
+}
+
+// CIHistoryInstallationPermissions is the grant set minted for the CI history
+// of a ref, which reads check-runs alone.
+func CIHistoryInstallationPermissions() map[string]string {
+	return map[string]string{
+		PermissionChecks: "read",
+		"metadata":       "read",
+	}
+}
+
+// MissingCIPermissions lists the grants the board card's CI panel needs and
+// an installation does NOT have, so the connection health view names them
+// before a card shows a dead panel. Empty when nothing is missing, or when
+// the grant set is unknown (absence of data is not evidence of a gap).
+func MissingCIPermissions(granted map[string]string) []string {
+	if len(granted) == 0 {
+		return nil
+	}
+	var missing []string
+	for _, name := range []string{PermissionChecks, PermissionStatuses} { // sorted: stable output
+		if _, ok := granted[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
 // MissingProjectPermissions lists the project-board grants an installation does
 // NOT have, so a board binding fails at BIND time naming the missing permission
 // rather than hours later on the first status write. Empty when nothing is
@@ -616,6 +714,9 @@ func (a *AppClient) scopedREST(ctx context.Context, perms map[string]string) (*A
 	tok, exp, err := MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
 		&InstallationTokenOptions{Permissions: perms})
 	if err != nil {
+		if errors.Is(err, forge.ErrPermissionsNotGranted) {
+			return nil, a.withheldGrant(ctx, perms, err)
+		}
 		return nil, err
 	}
 	if a.scoped == nil {
@@ -623,6 +724,64 @@ func (a *AppClient) scopedREST(ctx context.Context, perms map[string]string) (*A
 	}
 	a.scoped[key] = scopedToken{token: tok, exp: exp}
 	return &AdminClient{HTTP: a.HTTP, APIBase: a.apiBase(), Token: tok}, nil
+}
+
+// withheldGrant turns a scoped mint GitHub refused for want of a grant into
+// the typed refusal naming WHICH grant. GitHub's 422 body names none, so the
+// installation's live grant is read (one App-JWT probe, on the failure path
+// only) and the requested set is resolved against it: what the installation
+// lacks — or holds at a lower level than requested — is named, with the
+// installation page where an owner approves it. When the probe cannot say
+// (it fails, or reports no permissions), the whole requested set is named
+// rather than nothing. The mint sentinel stays reachable through the cause,
+// so the refresh worker's classification is unchanged.
+func (a *AppClient) withheldGrant(ctx context.Context, perms map[string]string, cause error) error {
+	names := make([]string, 0, len(perms))
+	for name := range perms {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var missing []string
+	page := ""
+	if inst, perr := InstallationInfo(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock()); perr == nil {
+		page = inst.HTMLURL
+		if len(inst.Permissions) > 0 {
+			for _, name := range names {
+				if !grantCovers(inst.Permissions, name, perms[name]) {
+					missing = append(missing, name+":"+perms[name])
+				}
+			}
+		}
+	}
+	if len(missing) == 0 {
+		for _, name := range names {
+			missing = append(missing, name+":"+perms[name])
+		}
+	}
+	remedy := "approve " + strings.Join(missing, ", ") + " on the GitHub App installation"
+	if page != "" {
+		remedy += " (" + page + ")"
+	}
+	remedy += " — an org owner reviews the App's pending permission request; an App that does not " +
+		"request it yet adds it under its Permissions & events settings first"
+	return &forge.PermissionError{
+		Provider: forge.ProviderGitHub, Op: "mint installation token",
+		Missing: missing, Remedy: remedy, Cause: cause,
+	}
+}
+
+// grantCovers reports whether an installation's grant serves a requested
+// permission at the requested level: a write needs write (or admin), a read
+// is served by any level.
+func grantCovers(granted map[string]string, name, level string) bool {
+	got, ok := granted[name]
+	if !ok {
+		return false
+	}
+	if level == "write" {
+		return got == "write" || got == "admin"
+	}
+	return true
 }
 
 // permissionSetKey renders a grant set as a stable string, so two calls asking

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -786,17 +786,38 @@ func (a *AppClient) withheldGrant(ctx context.Context, perms map[string]string, 
 }
 
 // grantCovers reports whether an installation's grant serves a requested
-// permission at the requested level: a write needs write (or admin), a read
-// is served by any level.
+// permission at the requested level, on GitHub's own read < write < admin
+// ordering: a grant covers every level at or below its own.
+//
+// The ordering is compared, not special-cased on "write": `admin` is a real
+// level in GitHub's model (the organization_* permissions take it), so a rule
+// written as "a write needs write-or-admin, anything else passes" reports a
+// requested `admin` as served by a bare `read` — and withheldGrant would then
+// stay silent about the one grant it exists to name.
 func grantCovers(granted map[string]string, name, level string) bool {
 	got, ok := granted[name]
 	if !ok {
 		return false
 	}
-	if level == "write" {
-		return got == "write" || got == "admin"
+	return grantRank(got) >= grantRank(level)
+}
+
+// grantRank orders a GitHub permission level. An unrecognised level ranks
+// above admin, which cuts the right way at both ends: an unfamiliar level the
+// INSTALLATION holds covers what is asked of it (naming it missing would
+// accuse the wrong grant on the one path whose job is to name the right one),
+// while an unfamiliar level we REQUEST is not satisfied by any level we know.
+func grantRank(level string) int {
+	switch level {
+	case "read":
+		return 1
+	case "write":
+		return 2
+	case "admin":
+		return 3
+	default:
+		return 4
 	}
-	return true
 }
 
 // permissionSetKey renders a grant set as a stable string, so two calls asking

--- a/pkg/forge/github/app_manifest.go
+++ b/pkg/forge/github/app_manifest.go
@@ -102,7 +102,14 @@ func BuildAppManifest(name, homeURL, redirectURL string, opts ...AppManifestOpti
 	// statuses:write lets Revi post its revi/review merge-gate commit status.
 	// Optional at runtime (the mint falls back without it — see AppClient.rest),
 	// but requested at App creation so new installations grant it up front.
-	perms["statuses"] = "write"
+	perms[PermissionStatuses] = "write"
+	// checks:read lets the board card's CI panel list a ref's check-runs
+	// through an App connection. Minted only into the CI profiles
+	// (CIStatusInstallationPermissions), never into the runtime baseline;
+	// requested here so a new installation grants it up front. An
+	// installation approved before it was requested has to approve the
+	// pending request, and the panel names that gap until it does.
+	perms[PermissionChecks] = "read"
 	for _, o := range opts {
 		if o.AllowRepoCreation {
 			perms["administration"] = "write"
@@ -143,7 +150,9 @@ func newAppManifest(name, homeURL, redirectURL string, perms map[string]string) 
 		// The App's granted permissions are iterion's least-privilege
 		// runtime set (contents: clone + diff + push; pull_requests:
 		// open + comment; metadata: baseline; repository_hooks: per-repo
-		// inbound webhook), plus administration:write ONLY when the
+		// inbound webhook), the two per-call read/verdict grants
+		// (statuses: the merge-gate status; checks: the card CI panel's
+		// check-runs read), plus administration:write ONLY when the
 		// create-repo capability was opted in — minted tokens always
 		// narrow to the subset a call needs. A SecurityReadOnly App instead
 		// carries metadata:read + vulnerability_alerts:read and nothing else.

--- a/pkg/forge/github/app_manifest_test.go
+++ b/pkg/forge/github/app_manifest_test.go
@@ -78,6 +78,19 @@ func TestBuildAppManifest(t *testing.T) {
 	if _, ok := m.DefaultPermissions["vulnerability_alerts"]; ok {
 		t.Fatalf("vulnerability_alerts must NOT be in the baseline: %+v", m.DefaultPermissions)
 	}
+	// checks:read serves the board card's CI panel (GET /commits/{ref}/check-runs
+	// is gated on it). Requested at App creation so a fresh installation grants
+	// it up front; an installation approved before it was requested has to
+	// re-approve, and the CI profile names the gap when its mint is refused.
+	if m.DefaultPermissions["checks"] != "read" {
+		t.Fatalf("checks perm must be read (the card CI panel reads check-runs), got %q: %+v", m.DefaultPermissions["checks"], m.DefaultPermissions)
+	}
+	// statuses:write is what the merge gate posts its verdict with — requested
+	// by the manifest, never part of the runtime baseline (the management mint
+	// falls back without it).
+	if m.DefaultPermissions["statuses"] != "write" {
+		t.Fatalf("statuses perm must be write (merge-gate verdict), got %q", m.DefaultPermissions["statuses"])
+	}
 }
 
 func TestBuildAppManifest_AllowSecurityRead(t *testing.T) {

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -13,6 +13,11 @@ import (
 // PullClient capability — linked PRs + CI status (current + history) for board
 // cards. PRs come from /pulls; CI is the union of check-runs (GitHub Actions /
 // Apps) and the legacy combined commit-status, normalized onto forge.CI*.
+//
+// Every refusal below names the grant GitHub gates the endpoint on (its
+// published per-endpoint permission data — the same rule the App client's
+// profiles mint), so a 403 "Resource not accessible by integration" reaches
+// the operator as the permission to approve, not as a bare status.
 var _ forge.PullClient = (*AdminClient)(nil)
 
 // githubPull is the slice of the GitHub pull-request object we map to PullRef.
@@ -84,12 +89,12 @@ func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts fo
 	vals.Set("page", strconv.Itoa(page))
 
 	var raw []githubPull
-	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls?"+vals.Encode(), nil, &raw)
+	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/pulls?"+vals.Encode(), nil, &raw)
 	if err != nil {
 		return nil, err
 	}
 	if code != http.StatusOK {
-		return nil, statusErr("GET pulls", code)
+		return nil, refusal("GET pulls", code, errBody, "pull_requests:read")
 	}
 	out := make([]forge.PullRef, 0, len(raw))
 	for _, gp := range raw {
@@ -98,15 +103,17 @@ func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts fo
 	return out, nil
 }
 
-// GetPullRequest fetches one PR by number.
+// GetPullRequest fetches one PR by number. GitHub gates the single-PR read on
+// contents read as well as pull_requests read (the object carries
+// content-derived fields), unlike the collection read.
 func (c *AdminClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
 	var gp githubPull
-	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), nil, &gp)
+	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), nil, &gp)
 	if err != nil {
 		return forge.PullRef{}, err
 	}
 	if code != http.StatusOK {
-		return forge.PullRef{}, statusErr("GET pull", code)
+		return forge.PullRef{}, refusal("GET pull", code, errBody, "pull_requests:read", "contents:read")
 	}
 	return gp.toRef(), nil
 }
@@ -186,7 +193,7 @@ func tm(p *time.Time) time.Time {
 // which a repo without GitHub Actions returns).
 func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]forge.CIRun, error) {
 	var cr githubCheckRuns
-	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/check-runs", nil, &cr)
+	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/check-runs", nil, &cr)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +201,7 @@ func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]f
 		return nil, nil
 	}
 	if code != http.StatusOK {
-		return nil, statusErr("GET check-runs", code)
+		return nil, refusal("GET check-runs", code, errBody, "checks:read")
 	}
 	runs := make([]forge.CIRun, 0, len(cr.CheckRuns))
 	for _, r := range cr.CheckRuns {
@@ -214,7 +221,7 @@ func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]f
 // fetchCommitStatuses returns the normalized legacy commit-statuses for a ref.
 func (c *AdminClient) fetchCommitStatuses(ctx context.Context, repo, ref string) (sha string, _ []forge.CIRun, _ error) {
 	var cs githubCombinedStatus
-	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/status", nil, &cs)
+	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/status", nil, &cs)
 	if err != nil {
 		return "", nil, err
 	}
@@ -222,7 +229,7 @@ func (c *AdminClient) fetchCommitStatuses(ctx context.Context, repo, ref string)
 		return "", nil, nil
 	}
 	if code != http.StatusOK {
-		return "", nil, statusErr("GET commit status", code)
+		return "", nil, refusal("GET commit status", code, errBody, "statuses:read")
 	}
 	runs := make([]forge.CIRun, 0, len(cs.Statuses))
 	for _, s := range cs.Statuses {
@@ -340,12 +347,12 @@ func (c *AdminClient) CreatePull(ctx context.Context, repo string, in forge.NewP
 		body["draft"] = true
 	}
 	var gp githubPull
-	code, err := c.do(ctx, http.MethodPost, "/repos/"+repo+"/pulls", body, &gp)
+	code, errBody, err := c.doErr(ctx, http.MethodPost, "/repos/"+repo+"/pulls", body, &gp)
 	if err != nil {
 		return forge.PullRef{}, err
 	}
 	if code/100 != 2 {
-		return forge.PullRef{}, statusErr("create pull", code)
+		return forge.PullRef{}, refusal("create pull", code, errBody, "pull_requests:write")
 	}
 	return gp.toRef(), nil
 }
@@ -368,12 +375,12 @@ func (c *AdminClient) UpdatePull(ctx context.Context, repo string, number int, p
 		body["state"] = *patch.State
 	}
 	var gp githubPull
-	code, err := c.do(ctx, http.MethodPatch, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), body, &gp)
+	code, errBody, err := c.doErr(ctx, http.MethodPatch, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), body, &gp)
 	if err != nil {
 		return forge.PullRef{}, err
 	}
 	if code/100 != 2 {
-		return forge.PullRef{}, statusErr("update pull", code)
+		return forge.PullRef{}, refusal("update pull", code, errBody, "pull_requests:write")
 	}
 	return gp.toRef(), nil
 }
@@ -381,7 +388,8 @@ func (c *AdminClient) UpdatePull(ctx context.Context, repo string, number int, p
 // MergePull merges a PR via PUT /pulls/{n}/merge, then re-fetches it once so the
 // returned ref reflects the merged state. When opts.DeleteBranch is set, the
 // source branch (read off the re-fetched ref) is best-effort deleted afterwards
-// — a failure there does not fail the merge.
+// — a failure there does not fail the merge. GitHub gates the merge on
+// contents write (it writes the base branch), not on pull_requests write.
 func (c *AdminClient) MergePull(ctx context.Context, repo string, number int, opts forge.MergeOptions) (forge.PullRef, error) {
 	body := map[string]any{"merge_method": forge.MergeMethodWire(opts.Method)}
 	if opts.CommitTitle != "" {
@@ -393,12 +401,12 @@ func (c *AdminClient) MergePull(ctx context.Context, repo string, number int, op
 	if opts.SHA != "" {
 		body["sha"] = opts.SHA
 	}
-	code, err := c.do(ctx, http.MethodPut, "/repos/"+repo+"/pulls/"+strconv.Itoa(number)+"/merge", body, nil)
+	code, errBody, err := c.doErr(ctx, http.MethodPut, "/repos/"+repo+"/pulls/"+strconv.Itoa(number)+"/merge", body, nil)
 	if err != nil {
 		return forge.PullRef{}, err
 	}
 	if code/100 != 2 {
-		return forge.PullRef{}, statusErr("merge pull", code)
+		return forge.PullRef{}, refusal("merge pull", code, errBody, "contents:write")
 	}
 	merged, err := c.GetPullRequest(ctx, repo, number)
 	if err != nil {

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -389,7 +389,10 @@ func (c *AdminClient) UpdatePull(ctx context.Context, repo string, number int, p
 // returned ref reflects the merged state. When opts.DeleteBranch is set, the
 // source branch (read off the re-fetched ref) is best-effort deleted afterwards
 // — a failure there does not fail the merge. GitHub gates the merge on
-// contents write (it writes the base branch), not on pull_requests write.
+// contents write (it writes the base branch), not on pull_requests write: the
+// row under Pull requests for this path is the GET ("check if a pull request
+// has been merged"), a different endpoint — see
+// PullMergeInstallationPermissions for the two rows side by side.
 func (c *AdminClient) MergePull(ctx context.Context, repo string, number int, opts forge.MergeOptions) (forge.PullRef, error) {
 	body := map[string]any{"merge_method": forge.MergeMethodWire(opts.Method)}
 	if opts.CommitTitle != "" {

--- a/pkg/forge/github/client.go
+++ b/pkg/forge/github/client.go
@@ -7,6 +7,8 @@ package github
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -68,6 +70,62 @@ func (c *AdminClient) do(ctx context.Context, method, path string, body any, out
 
 func statusErr(op string, code int) error {
 	return forge.StatusErr("github", op, code)
+}
+
+// doErr is do that also hands back a non-2xx body, for the calls whose
+// refusal has to name its cause.
+func (c *AdminClient) doErr(ctx context.Context, method, path string, body any, out any) (int, []byte, error) {
+	return c.http().DoErrBody(ctx, method, path, body, out)
+}
+
+// refusal maps a non-2xx answer onto an error. A 403 whose body is GitHub's
+// "Resource not accessible by integration" (an installation token) or "… by
+// personal access token" (a fine-grained PAT) is a credential short of a
+// permission, not a forge outage: it becomes a *forge.PermissionError naming
+// need — the grants GitHub gates the endpoint on, per its published
+// per-endpoint permission data — and the step that fits the credential kind
+// the body names. Any other 403 keeps its ErrForbidden identity with GitHub's
+// message attached; every other status maps as statusErr does.
+func refusal(op string, code int, errBody []byte, need ...string) error {
+	if code != http.StatusForbidden {
+		return statusErr(op, code)
+	}
+	msg := githubErrorMessage(errBody)
+	grants := strings.Join(need, ", ")
+	switch {
+	case strings.Contains(msg, "not accessible by integration"):
+		return &forge.PermissionError{
+			Provider: forge.ProviderGitHub, Op: op, Missing: need,
+			Remedy: "approve " + grants + " on the GitHub App installation — an org owner reviews the App's pending " +
+				"permission request; an App that does not request it yet adds it under its Permissions & events settings first",
+			Cause: fmt.Errorf("%w: %s", forge.ErrForbidden, msg),
+		}
+	case strings.Contains(msg, "not accessible by personal access token"):
+		return &forge.PermissionError{
+			Provider: forge.ProviderGitHub, Op: op, Missing: need,
+			Remedy: "grant the fine-grained token " + grants + " on this repository",
+			Cause:  fmt.Errorf("%w: %s", forge.ErrForbidden, msg),
+		}
+	case msg != "":
+		return fmt.Errorf("%w: github: %s: %s", forge.ErrForbidden, op, msg)
+	default:
+		return statusErr(op, code)
+	}
+}
+
+// githubErrorMessage extracts the `message` of a GitHub error body; empty
+// when the body is empty or not GitHub's shape.
+func githubErrorMessage(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var e struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(raw, &e) != nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Message)
 }
 
 func (c *AdminClient) WhoAmI(ctx context.Context) (forge.Identity, error) {

--- a/pkg/forge/github/pulls_app.go
+++ b/pkg/forge/github/pulls_app.go
@@ -33,6 +33,26 @@ func (a *AppClient) ListPullRequests(ctx context.Context, repo string, opts forg
 // GetPullRequest also anchors the merge gate (the head SHA its commit status
 // is posted on) and every PR-resolving webhook lane; it reads under the get
 // profile, not the management token.
+//
+// That has a MEASURED price on the gate paths, and it is the price of least
+// privilege rather than an oversight. Those paths resolve the head and then
+// write or read a commit status, and the status half rides rest()'s
+// management token — so where one broad token once served both calls, two
+// disjoint grants now need two mints (publish, gate reconcile, gate autofix,
+// /revi approve; the card's CI panel takes three, one per read profile).
+// Least privilege and one mint are not simultaneously available here: what
+// made it one mint was precisely the read borrowing contents/pull_requests
+// WRITE it has no use for.
+//
+// What is missing is amortization, not a wider token: pkg/server's
+// forgeAdminFor builds a fresh AppClient per request, so scopedREST's
+// per-permission-set cache — and rest()'s — dies with the request and no
+// token is ever reused across two. Caching the client per connection would
+// collapse every count above to one mint per profile per token lifetime; it
+// is deliberately NOT done here, because it needs an eviction story the
+// refresh route depends on (it re-mints on purpose, to show an owner the
+// grant they just approved) and a key that cannot leak a token across
+// tenants.
 func (a *AppClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
 	c, err := a.scopedREST(ctx, PullGetInstallationPermissions())
 	if err != nil {
@@ -67,6 +87,19 @@ func (a *AppClient) MergePull(ctx context.Context, repo string, number int, opts
 	return c.MergePull(ctx, repo, number, opts)
 }
 
+// GetCIStatus takes checks AND statuses on ONE mint, so an installation short
+// of either gets no CI panel at all rather than half of one. That is the
+// deliberate choice, not a missing degradation: the two halves are a single
+// aggregate verdict, and serving the half that answers would report the
+// aggregate of a subset. Concretely — a pre-`checks` installation with a
+// failing GitHub Actions check-run and a green revi/review commit status
+// would render GREEN on the card, on data that omits the only failing run.
+// A panel that can show a false green on a merge decision is worse than one
+// that says which grant to approve, which is what the 422 does.
+//
+// The gap is not silent while it lasts: the connection health view lists it
+// under missing_ci_permissions and `iterion remote forge connections refresh`
+// prints the same line, both before anyone opens a card.
 func (a *AppClient) GetCIStatus(ctx context.Context, repo, ref string) (forge.CIStatus, error) {
 	c, err := a.scopedREST(ctx, CIStatusInstallationPermissions())
 	if err != nil {

--- a/pkg/forge/github/pulls_app.go
+++ b/pkg/forge/github/pulls_app.go
@@ -1,0 +1,84 @@
+package github
+
+import (
+	"context"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// AppClient's half of forge.PullClient — the one an App connection resolves
+// to, so a capability implemented only on *AdminClient is INVISIBLE to the
+// `admin.(forge.PullClient)` the board card's PR/CI panel does. That is the
+// ordinary connection shape: the studio's GitHub connect wizard creates App
+// connections by default, and without this half the panel's routes
+// (GET|POST /api/v1/native/issues/{id}/pulls, .../pulls/{n}/ci,
+// .../pulls/{n}/merge) answered 501 while a PAT connection served them.
+//
+// Each method names the permission profile its own call is gated on and
+// reaches it through the one scopedREST chokepoint (minting + per-set
+// caching). None rides the cached management token, whose write grants no
+// read here has a use for; a profile the installation never approved is
+// refused at the mint and reported as a *forge.PermissionError naming the
+// grant — not as an opaque 422 or a silent 403.
+var _ forge.PullClient = (*AppClient)(nil)
+
+func (a *AppClient) ListPullRequests(ctx context.Context, repo string, opts forge.PullListOptions) ([]forge.PullRef, error) {
+	c, err := a.scopedREST(ctx, PullListInstallationPermissions())
+	if err != nil {
+		return nil, err
+	}
+	return c.ListPullRequests(ctx, repo, opts)
+}
+
+// GetPullRequest also anchors the merge gate (the head SHA its commit status
+// is posted on) and every PR-resolving webhook lane; it reads under the get
+// profile, not the management token.
+func (a *AppClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
+	c, err := a.scopedREST(ctx, PullGetInstallationPermissions())
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return c.GetPullRequest(ctx, repo, number)
+}
+
+func (a *AppClient) CreatePull(ctx context.Context, repo string, in forge.NewPull) (forge.PullRef, error) {
+	c, err := a.scopedREST(ctx, PullWriteInstallationPermissions())
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return c.CreatePull(ctx, repo, in)
+}
+
+func (a *AppClient) UpdatePull(ctx context.Context, repo string, number int, patch forge.PullPatch) (forge.PullRef, error) {
+	c, err := a.scopedREST(ctx, PullWriteInstallationPermissions())
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return c.UpdatePull(ctx, repo, number, patch)
+}
+
+// MergePull delegates the whole merge → re-fetch → optional branch-deletion
+// sequence, so the one token carries what all three steps need.
+func (a *AppClient) MergePull(ctx context.Context, repo string, number int, opts forge.MergeOptions) (forge.PullRef, error) {
+	c, err := a.scopedREST(ctx, PullMergeInstallationPermissions())
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return c.MergePull(ctx, repo, number, opts)
+}
+
+func (a *AppClient) GetCIStatus(ctx context.Context, repo, ref string) (forge.CIStatus, error) {
+	c, err := a.scopedREST(ctx, CIStatusInstallationPermissions())
+	if err != nil {
+		return forge.CIStatus{}, err
+	}
+	return c.GetCIStatus(ctx, repo, ref)
+}
+
+func (a *AppClient) ListCIHistory(ctx context.Context, repo, ref string, limit int) ([]forge.CIRun, error) {
+	c, err := a.scopedREST(ctx, CIHistoryInstallationPermissions())
+	if err != nil {
+		return nil, err
+	}
+	return c.ListCIHistory(ctx, repo, ref, limit)
+}

--- a/pkg/forge/github/pulls_app_test.go
+++ b/pkg/forge/github/pulls_app_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -20,11 +22,73 @@ import (
 // the runtime baseline.
 var _ forge.PullClient = (*AppClient)(nil)
 
+// githubEndpointGrants is GitHub's OWN rule for every endpoint the PullClient
+// calls, transcribed row-for-row from its published per-endpoint permission
+// data (the source behind "Permissions required for GitHub Apps"). It is the
+// ONE place an endpoint's requirement is written down: the fake gates each
+// REST call on it, and TestPullPermissionProfiles derives every profile's
+// expected shape from it — so a profile is checked against GitHub's rule, not
+// against a second hand-written copy of itself.
+//
+// Note the two rows of .../pulls/{n}/merge: the PUT (merge) is Contents write,
+// the GET (check if merged, which iterion does not call) is Pull requests read.
+// Only GET .../pulls/{n} is dual-listed, and that is why its row carries two.
+var githubEndpointGrants = []struct {
+	method string
+	path   *regexp.Regexp
+	grants map[string]string
+	// slug is GitHub's own operation id for the row, so a failure names the
+	// documentation row to re-read rather than a bare path.
+	slug string
+}{
+	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
+		map[string]string{"pull_requests": "read"}, "list-pull-requests"},
+	{"POST", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls$`),
+		map[string]string{"pull_requests": "write"}, "create-a-pull-request"},
+	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+$`),
+		map[string]string{"pull_requests": "read", "contents": "read"}, "get-a-pull-request (dual-listed)"},
+	{"PATCH", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+$`),
+		map[string]string{"pull_requests": "write"}, "update-a-pull-request"},
+	{"PUT", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`),
+		map[string]string{"contents": "write"}, "merge-a-pull-request"},
+	{"DELETE", regexp.MustCompile(`^/repos/[^/]+/[^/]+/git/refs/.+$`),
+		map[string]string{"contents": "write"}, "delete-a-reference"},
+	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits/[^/]+/check-runs$`),
+		map[string]string{"checks": "read"}, "list-check-runs-for-a-git-reference"},
+	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits/[^/]+/status$`),
+		map[string]string{"statuses": "read"}, "get-the-combined-status-for-a-specific-reference"},
+}
+
+// grantsForRequestLine returns GitHub's rule for one recorded request line
+// ("GET /api/v3/repos/o/r/pulls?state=all") and the row's slug, or nil for a
+// path no PullClient method calls. The API-base prefix and the query string
+// are stripped so the table stays the endpoint shapes GitHub publishes.
+func grantsForRequestLine(line string) (map[string]string, string) {
+	method, rest, ok := strings.Cut(line, " ")
+	if !ok {
+		return nil, ""
+	}
+	path, _, _ := strings.Cut(rest, "?")
+	path = strings.TrimPrefix(path, "/api/v3")
+	for _, e := range githubEndpointGrants {
+		if e.method == method && e.path.MatchString(path) {
+			return e.grants, e.slug
+		}
+	}
+	return nil, ""
+}
+
 // pullMintRecorder is a fake GitHub serving the installation-token mint, the
 // installation probe and the pull/CI endpoints. It records the permission set
 // of every mint, the bearer of every REST call and the full request line, and
-// applies GitHub's two refusals on demand: a mint outside the installation's
-// grant (422) and a call the bearer lacks the permission for (403).
+// applies GitHub's two refusals: a mint outside the installation's grant
+// (422), and a call whose BEARER was minted without the grant the endpoint is
+// gated on (403 "Resource not accessible by integration").
+//
+// That second rule is what makes a permission profile falsifiable here. While
+// the fake served every REST call 2xx whatever the token carried, a profile
+// that omitted a grant its endpoint requires passed the whole suite; now the
+// call fails exactly as GitHub would fail it.
 type pullMintRecorder struct {
 	mu sync.Mutex
 	// granted is what the installation approved; nil = accept every mint.
@@ -34,15 +98,52 @@ type pullMintRecorder struct {
 	// notAccessible names URL-path suffixes refused with GitHub's 403
 	// "Resource not accessible by integration" whatever the mint carried.
 	notAccessible map[string]bool
-	mints         []map[string]string
-	bearers       []string
-	paths         []string
-	srv           *httptest.Server
+	// tokenPerms maps an issued installation token to the permission set it
+	// was minted with — the scope every REST call is then held to.
+	tokenPerms map[string]map[string]string
+	mints      []map[string]string
+	bearers    []string
+	paths      []string
+	srv        *httptest.Server
+}
+
+// scopeRefusal reports the grant an endpoint needs and the call's bearer was
+// not minted with, or "" when the call is within scope. A bearer the fake
+// never issued (the PAT client) is unrestricted: a fine-grained PAT's scope is
+// not a mint this fake can see, and the PAT half of these tests is about the
+// wire shape, not about scoping.
+func (r *pullMintRecorder) scopeRefusal(authz, line string) string {
+	tok := strings.TrimPrefix(authz, "Bearer ")
+	r.mu.Lock()
+	perms, minted := r.tokenPerms[tok]
+	r.mu.Unlock()
+	if !minted {
+		return ""
+	}
+	need, _ := grantsForRequestLine(line)
+	for _, name := range sortedGrantNames(need) {
+		level := need[name]
+		if got, ok := perms[name]; !ok || (level == "write" && got != "write" && got != "admin") {
+			return name + ":" + level
+		}
+	}
+	return ""
+}
+
+// sortedGrantNames keeps the refusal deterministic when a call is short of
+// more than one grant.
+func sortedGrantNames(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 	t.Helper()
-	r := &pullMintRecorder{notAccessible: map[string]bool{}}
+	r := &pullMintRecorder{notAccessible: map[string]bool{}, tokenPerms: map[string]map[string]string{}}
 	pr := map[string]any{
 		"number": 7, "title": "feat: x (closes #12)", "state": "open", "html_url": "https://gh/o/r/pull/7",
 		"head": map[string]any{"ref": "feat/x", "sha": "deadbeef", "repo": map[string]any{"full_name": "o/r"}},
@@ -71,8 +172,10 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 			}
 			r.mints = append(r.mints, body.Permissions)
 			n := len(r.mints)
+			tok := "ghs_scoped_" + string(rune('a'+n-1))
+			r.tokenPerms[tok] = body.Permissions
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"token":      "ghs_scoped_" + string(rune('a'+n-1)),
+				"token":      tok,
 				"expires_at": "2099-01-01T00:00:00Z",
 			})
 			return
@@ -88,9 +191,10 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 			})
 			return
 		}
+		line := req.Method + " " + req.URL.RequestURI()
 		r.mu.Lock()
 		r.bearers = append(r.bearers, req.Header.Get("Authorization"))
-		r.paths = append(r.paths, req.Method+" "+req.URL.RequestURI())
+		r.paths = append(r.paths, line)
 		refuse := false
 		for suffix := range r.notAccessible {
 			if strings.HasSuffix(req.URL.Path, suffix) {
@@ -98,6 +202,12 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 			}
 		}
 		r.mu.Unlock()
+		// GitHub's own gate: the endpoint's rule against the scope the
+		// bearer was minted with. A token short of it never sees the
+		// resource, whatever the path serves.
+		if short := r.scopeRefusal(req.Header.Get("Authorization"), line); short != "" {
+			refuse = true
+		}
 		if refuse {
 			w.WriteHeader(http.StatusForbidden)
 			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest"})
@@ -224,51 +334,129 @@ func TestAppClientPullMethodsMintTheirOwnProfile(t *testing.T) {
 	}
 }
 
-// The profiles are their own, exactly as narrow as the endpoint's rule, and
-// every one of them is REQUESTABLE by an App the manifest creates today —
-// a profile the manifest does not cover could never be minted on a fresh
-// installation. `checks` stays out of the runtime baseline on purpose: the
-// management and run tokens are minted from it, and a baseline the
-// installation cannot serve fails EVERY mint for that installation (422),
-// not just the CI panel.
+// Every profile is pinned from BOTH sides against GitHub's own rule, never
+// against a second copy of itself: it must COVER each grant the endpoints its
+// method actually calls are gated on (else the call 403s in production), and
+// carry NOTHING beyond them but the mandatory metadata baseline (else a read
+// acquires a privilege it has no use for). Which endpoints a method calls is
+// observed, not declared — the call runs against the fake and its request
+// lines are read back — so a method that grows a round trip re-derives its own
+// requirement instead of drifting from a frozen literal.
 func TestPullPermissionProfiles(t *testing.T) {
-	exact := map[string]map[string]string{
-		"list":    {"pull_requests": "read", "metadata": "read"},
-		"get":     {"pull_requests": "read", "contents": "read", "metadata": "read"},
-		"write":   {"pull_requests": "write", "metadata": "read"},
-		"merge":   {"contents": "write", "pull_requests": "read", "metadata": "read"},
-		"ci":      {"checks": "read", "statuses": "read", "metadata": "read"},
-		"history": {"checks": "read", "metadata": "read"},
+	for _, tc := range pullCalls {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newPullMintRecorder(t)
+			if err := tc.call(context.Background(), r.appClient(t)); err != nil {
+				t.Fatalf("%s against a fully-granted installation: %v", tc.name, err)
+			}
+			mints, _, paths := r.snapshot()
+			if len(mints) != 1 {
+				t.Fatalf("mints = %d, want exactly 1", len(mints))
+			}
+			got := mints[0]
+
+			// What GitHub gates this method's own request sequence on, and
+			// which published row demands each grant.
+			need, by := map[string]string{}, map[string]string{}
+			covered := 0
+			for _, line := range paths {
+				g, slug := grantsForRequestLine(line)
+				if g == nil {
+					t.Errorf("request %q is not in githubEndpointGrants: its rule is unknown, so no profile can be checked against it", line)
+					continue
+				}
+				covered++
+				for perm, level := range g {
+					if level == "write" || need[perm] == "" {
+						need[perm], by[perm] = level, slug
+					}
+				}
+			}
+			if covered == 0 {
+				t.Fatalf("%s issued no recognised request: %v", tc.name, paths)
+			}
+			for perm, level := range need {
+				if cur, ok := got[perm]; !ok || (level == "write" && cur != "write") {
+					t.Errorf("%s profile %v is short of %s:%s, which GitHub gates %q on", tc.name, got, perm, level, by[perm])
+				}
+			}
+			for perm, level := range got {
+				if perm == "metadata" {
+					if level != "read" {
+						t.Errorf("%s profile: metadata is the mandatory baseline and a read, got %q", tc.name, level)
+					}
+					continue
+				}
+				want, ok := need[perm]
+				if !ok {
+					t.Errorf("%s profile %v carries %s:%s, which none of its endpoints (%v) is gated on", tc.name, got, perm, level, paths)
+					continue
+				}
+				if want == "read" && level == "write" {
+					t.Errorf("%s profile takes %s:write where its endpoints only need read — a read must not acquire a write", tc.name, perm)
+				}
+			}
+			if got["metadata"] != "read" {
+				t.Errorf("%s profile = %v, want the mandatory metadata:read baseline", tc.name, got)
+			}
+		})
 	}
-	got := map[string]map[string]string{
+
+	// Every profile must also be REQUESTABLE by an App the manifest creates
+	// today — one the manifest does not cover could never be minted on a fresh
+	// installation.
+	manifest := BuildAppManifest("it", "https://x", "https://x/cb").DefaultPermissions
+	for name, profile := range map[string]map[string]string{
 		"list":    PullListInstallationPermissions(),
 		"get":     PullGetInstallationPermissions(),
 		"write":   PullWriteInstallationPermissions(),
 		"merge":   PullMergeInstallationPermissions(),
 		"ci":      CIStatusInstallationPermissions(),
 		"history": CIHistoryInstallationPermissions(),
-	}
-	manifest := BuildAppManifest("it", "https://x", "https://x/cb").DefaultPermissions
-	for name, want := range exact {
-		if !reflect.DeepEqual(got[name], want) {
-			t.Errorf("%s profile = %v, want exactly %v", name, got[name], want)
-		}
-		for perm, level := range got[name] {
+	} {
+		for perm, level := range profile {
 			granted, ok := manifest[perm]
 			if !ok || (level == "write" && granted != "write") {
 				t.Errorf("%s profile needs %s:%s, which the App manifest does not request (%v): no fresh installation could mint it", name, perm, level, manifest)
 			}
 		}
 	}
-	for _, ro := range []string{"list", "get", "ci", "history"} {
-		for perm, level := range got[ro] {
-			if level != "read" {
-				t.Errorf("the %s profile is a read: it must carry no write grant, got %s:%s", ro, perm, level)
-			}
-		}
-	}
+
+	// `checks` stays out of the runtime baseline on purpose: the management
+	// and run tokens are minted from it, and a baseline the installation
+	// cannot serve fails EVERY mint for that installation (422), not just the
+	// CI panel.
 	if _, ok := RuntimeInstallationPermissions()["checks"]; ok {
 		t.Error("checks must NOT join the runtime baseline: every existing installation lacks it, and a baseline mint that asks for it 422s the management and run tokens alike")
+	}
+}
+
+// The gate above is only worth its lines if a wrong profile actually fails:
+// mint the CI profile without `checks` and the check-runs read must be
+// refused exactly as GitHub refuses it. Without this, a profile short of a
+// grant its endpoint requires passes the whole suite — which is how one
+// shipped green once already.
+func TestTheFakeRefusesACallOutsideItsMintedScope(t *testing.T) {
+	r := newPullMintRecorder(t)
+	c, err := r.appClient(t).scopedREST(context.Background(), map[string]string{
+		"statuses": "read", "metadata": "read", // deliberately short of checks:read
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.GetCIStatus(context.Background(), "o/r", "deadbeef")
+	var pe *forge.PermissionError
+	if !errors.As(err, &pe) || !reflect.DeepEqual(pe.Missing, []string{"checks:read"}) {
+		t.Fatalf("err = %v, want the check-runs read refused for want of checks:read", err)
+	}
+	// ...and the very same call succeeds once the mint carries it, so the
+	// refusal is the scope and not the path.
+	c, err = r.appClient(t).scopedREST(context.Background(), CIStatusInstallationPermissions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.GetCIStatus(context.Background(), "o/r", "deadbeef"); err != nil {
+		t.Fatalf("the CI profile must serve its own endpoints: %v", err)
 	}
 }
 

--- a/pkg/forge/github/pulls_app_test.go
+++ b/pkg/forge/github/pulls_app_test.go
@@ -1,0 +1,436 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The App client is the PRODUCTION shape of a GitHub connection, so the
+// PullClient capability the card's PR/CI panel asserts must exist on it too —
+// through the same per-profile scoped tokens as the issue capability, never
+// the runtime baseline.
+var _ forge.PullClient = (*AppClient)(nil)
+
+// pullMintRecorder is a fake GitHub serving the installation-token mint, the
+// installation probe and the pull/CI endpoints. It records the permission set
+// of every mint, the bearer of every REST call and the full request line, and
+// applies GitHub's two refusals on demand: a mint outside the installation's
+// grant (422) and a call the bearer lacks the permission for (403).
+type pullMintRecorder struct {
+	mu sync.Mutex
+	// granted is what the installation approved; nil = accept every mint.
+	granted map[string]string
+	// refuseMint forces the 422 regardless of granted.
+	refuseMint bool
+	// notAccessible names URL-path suffixes refused with GitHub's 403
+	// "Resource not accessible by integration" whatever the mint carried.
+	notAccessible map[string]bool
+	mints         []map[string]string
+	bearers       []string
+	paths         []string
+	srv           *httptest.Server
+}
+
+func newPullMintRecorder(t *testing.T) *pullMintRecorder {
+	t.Helper()
+	r := &pullMintRecorder{notAccessible: map[string]bool{}}
+	pr := map[string]any{
+		"number": 7, "title": "feat: x (closes #12)", "state": "open", "html_url": "https://gh/o/r/pull/7",
+		"head": map[string]any{"ref": "feat/x", "sha": "deadbeef", "repo": map[string]any{"full_name": "o/r"}},
+		"base": map[string]any{"ref": "main"}, "user": map[string]any{"login": "dave"},
+	}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(req.URL.Path, "/access_tokens") {
+			var body struct {
+				Permissions map[string]string `json:"permissions"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			refused := r.refuseMint
+			for name, level := range body.Permissions {
+				got, ok := r.granted[name]
+				if r.granted != nil && (!ok || (level == "write" && got != "write" && got != "admin")) {
+					refused = true
+				}
+			}
+			if refused {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "The permissions requested are not granted to this installation."})
+				return
+			}
+			r.mints = append(r.mints, body.Permissions)
+			n := len(r.mints)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"token":      "ghs_scoped_" + string(rune('a'+n-1)),
+				"expires_at": "2099-01-01T00:00:00Z",
+			})
+			return
+		}
+		if strings.Contains(req.URL.Path, "/app/installations/") {
+			r.mu.Lock()
+			granted := r.granted
+			r.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"account":     map[string]any{"login": "acme"},
+				"html_url":    "https://gh/organizations/acme/settings/installations/99",
+				"permissions": granted,
+			})
+			return
+		}
+		r.mu.Lock()
+		r.bearers = append(r.bearers, req.Header.Get("Authorization"))
+		r.paths = append(r.paths, req.Method+" "+req.URL.RequestURI())
+		refuse := false
+		for suffix := range r.notAccessible {
+			if strings.HasSuffix(req.URL.Path, suffix) {
+				refuse = true
+			}
+		}
+		r.mu.Unlock()
+		if refuse {
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest"})
+			return
+		}
+		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/check-runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]any{
+				{"name": "build", "status": "completed", "conclusion": "success", "html_url": "https://gh/o/r/runs/1", "started_at": "2026-01-01T00:00:00Z"},
+			}})
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/status"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"state": "success", "sha": "deadbeef", "statuses": []map[string]any{}})
+		case req.Method == http.MethodPut && strings.HasSuffix(req.URL.Path, "/merge"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"merged": true, "sha": "cafe"})
+		case req.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/pulls"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(pr)
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/pulls"):
+			_ = json.NewEncoder(w).Encode([]map[string]any{pr})
+		default:
+			_ = json.NewEncoder(w).Encode(pr)
+		}
+	}))
+	t.Cleanup(r.srv.Close)
+	return r
+}
+
+func (r *pullMintRecorder) snapshot() ([]map[string]string, []string, []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]map[string]string(nil), r.mints...),
+		append([]string(nil), r.bearers...),
+		append([]string(nil), r.paths...)
+}
+
+func (r *pullMintRecorder) appClient(t *testing.T) *AppClient {
+	t.Helper()
+	return &AppClient{
+		HTTP: r.srv.Client(), WebBaseURL: r.srv.URL,
+		Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t), AppSlug: "iterion"}, InstallationID: 99,
+	}
+}
+
+func (r *pullMintRecorder) patClient() *AdminClient {
+	return &AdminClient{HTTP: r.srv.Client(), APIBase: APIBaseFor(r.srv.URL), Token: "ghp_pat"}
+}
+
+// pullCalls is every PullClient method paired with the permission profile its
+// call is gated on — the profile is GitHub's rule for the endpoint, taken from
+// its published permission data, not a guess.
+var pullCalls = []struct {
+	name string
+	call func(ctx context.Context, c forge.PullClient) error
+	want map[string]string
+}{
+	{"ListPullRequests", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.ListPullRequests(ctx, "o/r", forge.PullListOptions{State: "all", PerPage: 100})
+		return err
+	}, PullListInstallationPermissions()},
+	{"GetPullRequest", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.GetPullRequest(ctx, "o/r", 7)
+		return err
+	}, PullGetInstallationPermissions()},
+	{"CreatePull", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.CreatePull(ctx, "o/r", forge.NewPull{Title: "t", SourceBranch: "feat/x", TargetBranch: "main"})
+		return err
+	}, PullWriteInstallationPermissions()},
+	{"UpdatePull", func(ctx context.Context, c forge.PullClient) error {
+		title := "renamed"
+		_, err := c.UpdatePull(ctx, "o/r", 7, forge.PullPatch{Title: &title})
+		return err
+	}, PullWriteInstallationPermissions()},
+	{"MergePull", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.MergePull(ctx, "o/r", 7, forge.MergeOptions{Method: forge.MergeSquash, DeleteBranch: true})
+		return err
+	}, PullMergeInstallationPermissions()},
+	{"GetCIStatus", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.GetCIStatus(ctx, "o/r", "deadbeef")
+		return err
+	}, CIStatusInstallationPermissions()},
+	{"ListCIHistory", func(ctx context.Context, c forge.PullClient) error {
+		_, err := c.ListCIHistory(ctx, "o/r", "deadbeef", 20)
+		return err
+	}, CIHistoryInstallationPermissions()},
+}
+
+// Each PullClient method mints EXACTLY its own profile — nothing rides the
+// runtime baseline, no read acquires a write — and issues the very requests
+// the PAT client issues (method + URI, query included; MergePull's three-call
+// sequence too), so the two connection kinds are interchangeable on the wire.
+func TestAppClientPullMethodsMintTheirOwnProfile(t *testing.T) {
+	for _, tc := range pullCalls {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newPullMintRecorder(t)
+			ctx := context.Background()
+			if err := tc.call(ctx, r.patClient()); err != nil {
+				t.Fatalf("PAT %s: %v", tc.name, err)
+			}
+			if err := tc.call(ctx, r.appClient(t)); err != nil {
+				t.Fatalf("App %s: %v", tc.name, err)
+			}
+			mints, bearers, paths := r.snapshot()
+			if len(mints) != 1 {
+				t.Fatalf("mints = %d, want exactly 1 (the PAT call mints nothing)", len(mints))
+			}
+			if !reflect.DeepEqual(mints[0], tc.want) {
+				t.Errorf("minted permissions = %v, want the %s profile %v", mints[0], tc.name, tc.want)
+			}
+			if len(paths)%2 != 0 || len(paths) == 0 {
+				t.Fatalf("paths = %v, want the App half to mirror the PAT half", paths)
+			}
+			half := len(paths) / 2
+			for i := 0; i < half; i++ {
+				if paths[i] != paths[half+i] {
+					t.Errorf("request %d: PAT %q vs App %q — the delegation must reproduce the PAT client's own request", i, paths[i], paths[half+i])
+				}
+				if bearers[i] != "Bearer ghp_pat" || !strings.HasPrefix(bearers[half+i], "Bearer ghs_scoped_") {
+					t.Errorf("bearers = %v, want the PAT then the minted installation token", bearers)
+				}
+			}
+		})
+	}
+}
+
+// The profiles are their own, exactly as narrow as the endpoint's rule, and
+// every one of them is REQUESTABLE by an App the manifest creates today —
+// a profile the manifest does not cover could never be minted on a fresh
+// installation. `checks` stays out of the runtime baseline on purpose: the
+// management and run tokens are minted from it, and a baseline the
+// installation cannot serve fails EVERY mint for that installation (422),
+// not just the CI panel.
+func TestPullPermissionProfiles(t *testing.T) {
+	exact := map[string]map[string]string{
+		"list":    {"pull_requests": "read", "metadata": "read"},
+		"get":     {"pull_requests": "read", "contents": "read", "metadata": "read"},
+		"write":   {"pull_requests": "write", "metadata": "read"},
+		"merge":   {"contents": "write", "pull_requests": "read", "metadata": "read"},
+		"ci":      {"checks": "read", "statuses": "read", "metadata": "read"},
+		"history": {"checks": "read", "metadata": "read"},
+	}
+	got := map[string]map[string]string{
+		"list":    PullListInstallationPermissions(),
+		"get":     PullGetInstallationPermissions(),
+		"write":   PullWriteInstallationPermissions(),
+		"merge":   PullMergeInstallationPermissions(),
+		"ci":      CIStatusInstallationPermissions(),
+		"history": CIHistoryInstallationPermissions(),
+	}
+	manifest := BuildAppManifest("it", "https://x", "https://x/cb").DefaultPermissions
+	for name, want := range exact {
+		if !reflect.DeepEqual(got[name], want) {
+			t.Errorf("%s profile = %v, want exactly %v", name, got[name], want)
+		}
+		for perm, level := range got[name] {
+			granted, ok := manifest[perm]
+			if !ok || (level == "write" && granted != "write") {
+				t.Errorf("%s profile needs %s:%s, which the App manifest does not request (%v): no fresh installation could mint it", name, perm, level, manifest)
+			}
+		}
+	}
+	for _, ro := range []string{"list", "get", "ci", "history"} {
+		for perm, level := range got[ro] {
+			if level != "read" {
+				t.Errorf("the %s profile is a read: it must carry no write grant, got %s:%s", ro, perm, level)
+			}
+		}
+	}
+	if _, ok := RuntimeInstallationPermissions()["checks"]; ok {
+		t.Error("checks must NOT join the runtime baseline: every existing installation lacks it, and a baseline mint that asks for it 422s the management and run tokens alike")
+	}
+}
+
+// One CI profile is one cached token: the status read (check-runs + combined
+// status, two calls) mints once and reuses it; the history read is a
+// different profile and gets its own token, never the status one.
+func TestAppClientCIReadsShareOneTokenPerProfile(t *testing.T) {
+	r := newPullMintRecorder(t)
+	a := r.appClient(t)
+	ctx := context.Background()
+	if _, err := a.GetCIStatus(ctx, "o/r", "deadbeef"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.GetCIStatus(ctx, "o/r", "deadbeef"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.ListCIHistory(ctx, "o/r", "deadbeef", 5); err != nil {
+		t.Fatal(err)
+	}
+	mints, bearers, _ := r.snapshot()
+	if len(mints) != 2 {
+		t.Fatalf("mints = %d, want 2 (one status profile reused, one history profile)", len(mints))
+	}
+	if len(bearers) != 5 {
+		t.Fatalf("bearers = %d, want 5 REST calls (2×2 for the statuses, 1 for the history)", len(bearers))
+	}
+	for _, b := range bearers[1:4] {
+		if b != bearers[0] {
+			t.Errorf("the status reads must share one cached token, got %v", bearers)
+		}
+	}
+	if bearers[4] == bearers[0] {
+		t.Error("the history read must not ride the status token: it is a narrower profile of its own")
+	}
+}
+
+// An installation approved before `checks: read` was requested: GitHub
+// refuses the CI profile's mint (422 "permissions not granted"), a body that
+// names NO permission. The client turns it into the typed refusal naming the
+// grant the installation withholds — resolved against the installation's
+// live grant, so a `statuses: write` the owner did approve is not blamed —
+// and the page where it is approved, while the mint sentinel stays
+// reachable for the refresh worker's classification.
+func TestAppClientCIStatusNamesTheWithheldGrant(t *testing.T) {
+	r := newPullMintRecorder(t)
+	r.granted = map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read",
+		"repository_hooks": "write", "statuses": "write",
+	}
+	_, err := r.appClient(t).GetCIStatus(context.Background(), "o/r", "deadbeef")
+	if err == nil {
+		t.Fatal("a refused mint must be an error")
+	}
+	var pe *forge.PermissionError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v (%T), want a *forge.PermissionError naming the withheld grant", err, err)
+	}
+	if !reflect.DeepEqual(pe.Missing, []string{"checks:read"}) {
+		t.Errorf("Missing = %v, want exactly [checks:read] — statuses is granted at write, which covers the read", pe.Missing)
+	}
+	if !errors.Is(err, forge.ErrPermissionsNotGranted) {
+		t.Error("the mint sentinel must stay reachable: the refresh worker classifies on it")
+	}
+	for _, want := range []string{"checks:read", "approve", "settings/installations/99", "not granted"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to carry %q", err.Error(), want)
+		}
+	}
+	if _, _, paths := r.snapshot(); len(paths) != 0 {
+		t.Errorf("no REST call may be attempted on a refused mint, got %v", paths)
+	}
+
+	// Two grants short → both named, sorted, so the operator approves once.
+	r2 := newPullMintRecorder(t)
+	r2.granted = map[string]string{"contents": "write", "pull_requests": "write", "metadata": "read"}
+	_, err = r2.appClient(t).GetCIStatus(context.Background(), "o/r", "deadbeef")
+	if !errors.As(err, &pe) || !reflect.DeepEqual(pe.Missing, []string{"checks:read", "statuses:read"}) {
+		t.Errorf("err = %v, want Missing [checks:read statuses:read]", err)
+	}
+
+	// The probe cannot say which one (an installation record with no
+	// permissions): the whole requested set is named rather than nothing.
+	r3 := newPullMintRecorder(t)
+	r3.refuseMint = true
+	_, err = r3.appClient(t).ListCIHistory(context.Background(), "o/r", "deadbeef", 5)
+	if !errors.As(err, &pe) || !reflect.DeepEqual(pe.Missing, []string{"checks:read", "metadata:read"}) {
+		t.Errorf("err = %v, want the full history profile named when the grant is unknown", err)
+	}
+}
+
+// The call-time shape of the same gap: a token that lacks the permission (a
+// grant revoked after the mint, a fine-grained PAT) gets GitHub's 403
+// "Resource not accessible by integration" on the check-runs read. Both
+// clients turn it into the typed refusal naming checks:read — never a bare
+// ErrForbidden the panel would show as an unexplained 502.
+func TestCheckRunsRefusedByIntegrationIsATypedError(t *testing.T) {
+	r := newPullMintRecorder(t)
+	r.notAccessible["/check-runs"] = true
+	for name, c := range map[string]forge.PullClient{"pat": r.patClient(), "app": r.appClient(t)} {
+		t.Run(name, func(t *testing.T) {
+			_, err := c.GetCIStatus(context.Background(), "o/r", "deadbeef")
+			var pe *forge.PermissionError
+			if !errors.As(err, &pe) {
+				t.Fatalf("err = %v (%T), want a *forge.PermissionError", err, err)
+			}
+			if !reflect.DeepEqual(pe.Missing, []string{"checks:read"}) || pe.Op != "GET check-runs" {
+				t.Errorf("typed error = %+v, want Op GET check-runs, Missing [checks:read]", pe)
+			}
+			if !errors.Is(err, forge.ErrForbidden) {
+				t.Error("a refused call must still read as ErrForbidden for the callers that classify on it")
+			}
+			for _, want := range []string{"checks:read", "Resource not accessible by integration"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to carry %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// A 403 that is NOT a permission gap (rate limit, SAML enforcement) must not
+// be dressed up as one: it stays ErrForbidden, now carrying GitHub's message
+// instead of a bare status.
+func TestOtherForbiddenStaysForbiddenWithTheCause(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "API rate limit exceeded for installation ID 99."})
+	}))
+	defer srv.Close()
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	_, err := c.ListPullRequests(context.Background(), "o/r", forge.PullListOptions{})
+	if !errors.Is(err, forge.ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+	var pe *forge.PermissionError
+	if errors.As(err, &pe) {
+		t.Errorf("a rate-limit 403 must not be reported as a missing permission: %v", err)
+	}
+	if !strings.Contains(err.Error(), "rate limit") {
+		t.Errorf("error = %q, want GitHub's own message kept", err.Error())
+	}
+}
+
+// MissingCIPermissions is what the connection health view reports, so the
+// gap is visible on the connection before anyone opens a card.
+func TestMissingCIPermissions(t *testing.T) {
+	if got := MissingCIPermissions(nil); got != nil {
+		t.Errorf("an unknown grant set is not evidence of a gap, got %v", got)
+	}
+	full := map[string]string{"checks": "read", "statuses": "write", "metadata": "read"}
+	if got := MissingCIPermissions(full); got != nil {
+		t.Errorf("nothing should be missing, got %v", got)
+	}
+	preChecks := map[string]string{"statuses": "write", "contents": "write", "metadata": "read"}
+	if got := MissingCIPermissions(preChecks); !reflect.DeepEqual(got, []string{"checks"}) {
+		t.Errorf("got %v, want [checks]", got)
+	}
+	preGate := map[string]string{"contents": "write", "metadata": "read"}
+	if got := MissingCIPermissions(preGate); !reflect.DeepEqual(got, []string{"checks", "statuses"}) {
+		t.Errorf("got %v, want [checks statuses] (sorted)", got)
+	}
+	if got := MissingCIPermissions(map[string]string{"checks": "read", "statuses": "read"}); got != nil {
+		t.Errorf("statuses:read serves the combined-status read, got %v", got)
+	}
+}

--- a/pkg/forge/github/pulls_app_test.go
+++ b/pkg/forge/github/pulls_app_test.go
@@ -105,6 +105,11 @@ type pullMintRecorder struct {
 	bearers    []string
 	paths      []string
 	srv        *httptest.Server
+	// t reports a served path githubEndpointGrants does not know. The scope
+	// gate can only hold a call to a rule it HAS, so an unknown path would
+	// otherwise be served unchecked — the gate going quiet exactly where a
+	// new method or a new round trip needs it loudest.
+	t *testing.T
 }
 
 // scopeRefusal reports the grant an endpoint needs and the call's bearer was
@@ -177,7 +182,7 @@ func sortedGrantNames(m map[string]string) []string {
 
 func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 	t.Helper()
-	r := &pullMintRecorder{notAccessible: map[string]bool{}, tokenPerms: map[string]map[string]string{}}
+	r := &pullMintRecorder{t: t, notAccessible: map[string]bool{}, tokenPerms: map[string]map[string]string{}}
 	pr := map[string]any{
 		"number": 7, "title": "feat: x (closes #12)", "state": "open", "html_url": "https://gh/o/r/pull/7",
 		"head": map[string]any{"ref": "feat/x", "sha": "deadbeef", "repo": map[string]any{"full_name": "o/r"}},
@@ -193,10 +198,16 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 			r.mu.Lock()
 			defer r.mu.Unlock()
 			refused := r.refuseMint
-			for name, level := range body.Permissions {
-				got, ok := r.granted[name]
-				if r.granted != nil && (!ok || (level == "write" && got != "write" && got != "admin")) {
-					refused = true
+			if r.granted != nil {
+				// The production rule here too: the mint gate carried its own
+				// copy, with the same "a write needs write-or-admin, anything
+				// else passes" shortcut grantCovers replaced — so a requested
+				// `admin` was minted against a bare `read` grant and the
+				// withheld-grant path was never reached for it.
+				for name, level := range body.Permissions {
+					if !grantCovers(r.granted, name, level) {
+						refused = true
+					}
 				}
 			}
 			if refused {
@@ -241,6 +252,12 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 		// resource, whatever the path serves.
 		if short := r.scopeRefusal(req.Header.Get("Authorization"), line); short != "" {
 			refuse = true
+		}
+		// A rule the table does not have is a call nothing held to any scope,
+		// so say so rather than serve it: fail LOUD, never open.
+		if need, _ := grantsForRequestLine(line); need == nil {
+			r.t.Errorf("the fake served %q, which githubEndpointGrants has no row for — its permission rule went unchecked, "+
+				"and an unchecked endpoint is how a wrong profile ships green", line)
 		}
 		if refuse {
 			w.WriteHeader(http.StatusForbidden)
@@ -491,6 +508,31 @@ func TestTheFakeRefusesACallOutsideItsMintedScope(t *testing.T) {
 	}
 	if _, err := c.GetCIStatus(context.Background(), "o/r", "deadbeef"); err != nil {
 		t.Fatalf("the CI profile must serve its own endpoints: %v", err)
+	}
+}
+
+// The MINT gate holds the same level ordering as the scope gate. `admin` is
+// the level that separates a compared ordering from the "a write needs
+// write-or-admin, anything else passes" shortcut: under the shortcut this
+// mint is issued against an installation that holds the grant one level too
+// low, GitHub 422s it for real, and the withheld-grant diagnostic is never
+// exercised for the case.
+func TestTheFakeRefusesAMintAboveTheInstallationsLevel(t *testing.T) {
+	r := newPullMintRecorder(t)
+	r.granted = map[string]string{"organization_projects": "write", "metadata": "read"}
+	_, err := r.appClient(t).scopedREST(context.Background(),
+		map[string]string{"organization_projects": "admin", "metadata": "read"})
+	var pe *forge.PermissionError
+	if !errors.As(err, &pe) {
+		t.Fatalf("err = %v (%T), want the mint refused: write does not cover a requested admin", err, err)
+	}
+	if !reflect.DeepEqual(pe.Missing, []string{"organization_projects:admin"}) {
+		t.Errorf("Missing = %v, want exactly [organization_projects:admin] — metadata:read IS granted", pe.Missing)
+	}
+	// The level the installation does hold is served.
+	if _, err := r.appClient(t).scopedREST(context.Background(),
+		map[string]string{"organization_projects": "write", "metadata": "read"}); err != nil {
+		t.Errorf("a mint at the granted level must be issued: %v", err)
 	}
 }
 

--- a/pkg/forge/github/pulls_app_test.go
+++ b/pkg/forge/github/pulls_app_test.go
@@ -122,12 +122,46 @@ func (r *pullMintRecorder) scopeRefusal(authz, line string) string {
 	}
 	need, _ := grantsForRequestLine(line)
 	for _, name := range sortedGrantNames(need) {
-		level := need[name]
-		if got, ok := perms[name]; !ok || (level == "write" && got != "write" && got != "admin") {
-			return name + ":" + level
+		// The production rule, not a fourth copy of it: what the client uses
+		// to decide a grant is withheld is what the fake uses to withhold it.
+		if !grantCovers(perms, name, need[name]) {
+			return name + ":" + need[name]
 		}
 	}
 	return ""
+}
+
+// grantCovers is the one rule the mint, the withheld-grant diagnostic and this
+// fake all read, so its ordering is worth pinning: read < write < admin, a
+// grant covering every level at or below its own. The `admin` rows are what a
+// "write needs write-or-admin, anything else passes" shortcut gets wrong.
+func TestGrantCoversOrdersTheLevels(t *testing.T) {
+	for _, tc := range []struct {
+		granted, requested string
+		want               bool
+	}{
+		{"read", "read", true},
+		{"write", "read", true},
+		{"admin", "read", true},
+		{"read", "write", false},
+		{"write", "write", true},
+		{"admin", "write", true},
+		{"read", "admin", false},
+		{"write", "admin", false},
+		{"admin", "admin", true},
+		// An unfamiliar level the installation holds covers what is asked of
+		// it; an unfamiliar level we ask for is satisfied by no level we know.
+		{"maintain", "write", true},
+		{"admin", "maintain", false},
+	} {
+		got := grantCovers(map[string]string{"p": tc.granted}, "p", tc.requested)
+		if got != tc.want {
+			t.Errorf("grantCovers(granted %s, want %s) = %v, want %v", tc.granted, tc.requested, got, tc.want)
+		}
+	}
+	if grantCovers(map[string]string{"other": "write"}, "p", "read") {
+		t.Error("a permission the installation does not hold at all is never covered")
+	}
 }
 
 // sortedGrantNames keeps the refusal deterministic when a call is short of

--- a/pkg/forge/github/status.go
+++ b/pkg/forge/github/status.go
@@ -47,16 +47,6 @@ func (a *AppClient) SetCommitStatus(ctx context.Context, repo, sha string, st fo
 	return rest.SetCommitStatus(ctx, repo, sha, st)
 }
 
-// GetPullRequest on an App connection delegates to a fresh-token AdminClient —
-// the merge gate needs the head SHA to anchor the commit status.
-func (a *AppClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
-	rest, err := a.rest(ctx)
-	if err != nil {
-		return forge.PullRef{}, err
-	}
-	return rest.GetPullRequest(ctx, repo, number)
-}
-
 // githubCommitState maps the normalized CommitState onto GitHub's wire
 // vocabulary (error|failure|pending|success). An unknown value fails closed to
 // "error" so a miswired gate blocks rather than silently passes.

--- a/pkg/forge/permission_error.go
+++ b/pkg/forge/permission_error.go
@@ -1,0 +1,65 @@
+package forge
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PermissionError is a forge call refused for want of a NAMED permission:
+// the credential behind the call exists and is valid, but does not carry a
+// grant the call is gated on. It is the typed form of two refusals that are
+// otherwise opaque at the call site — a 403 whose body says "Resource not
+// accessible by integration" (an installation token minted without the
+// grant), and a GitHub-App token mint answered 422 "permissions not granted"
+// (an installation whose owner never approved the grant) — and it exists so
+// the operator reads the permission to approve and where, not an HTTP code.
+//
+// Missing lists "permission:level" pairs ("checks:read"). Cause is the
+// forge's own refusal (ErrForbidden or an ErrPermissionsNotGranted-wrapped
+// mint error), reachable through errors.Is so every caller that classified
+// on those sentinels keeps doing so.
+type PermissionError struct {
+	Provider Provider
+	// Op is the refused call ("GET check-runs", "mint installation token").
+	Op string
+	// Missing is what the call needs and the credential cannot prove, as
+	// "permission:level" pairs.
+	Missing []string
+	// Remedy is the operator step that closes the gap.
+	Remedy string
+	// Cause is the forge's refusal, kept verbatim: it carries the forge's
+	// own wording, which is the evidence the operator needs when the remedy
+	// does not apply.
+	Cause error
+}
+
+func (e *PermissionError) Error() string {
+	var b strings.Builder
+	if e.Provider != "" {
+		b.WriteString(string(e.Provider))
+		b.WriteString(": ")
+	}
+	if e.Op != "" {
+		b.WriteString(e.Op)
+		b.WriteString(": ")
+	}
+	b.WriteString("missing permission ")
+	if len(e.Missing) > 0 {
+		b.WriteString(strings.Join(e.Missing, ", "))
+	} else {
+		b.WriteString("(unnamed)")
+	}
+	if e.Remedy != "" {
+		b.WriteString(" — ")
+		b.WriteString(e.Remedy)
+	}
+	if e.Cause != nil {
+		fmt.Fprintf(&b, " (%v)", e.Cause)
+	}
+	return b.String()
+}
+
+// Unwrap exposes the forge's refusal, so errors.Is(err, ErrForbidden) and
+// errors.Is(err, ErrPermissionsNotGranted) hold exactly as before the error
+// was typed.
+func (e *PermissionError) Unwrap() error { return e.Cause }

--- a/pkg/forge/permission_error_test.go
+++ b/pkg/forge/permission_error_test.go
@@ -1,0 +1,45 @@
+package forge
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The typed refusal has ONE job: turn a bare status code into the permission
+// to approve and where. Its text must carry all three — the call, the grant,
+// the step — and the forge's own sentinel must stay reachable through it, so
+// no caller that classified on ErrForbidden / ErrPermissionsNotGranted
+// changes behaviour when the error grows a type.
+func TestPermissionErrorNamesTheGrantAndKeepsTheSentinel(t *testing.T) {
+	cause := errors.New("github: mint installation token: HTTP 422: The permissions requested are not granted to this installation.")
+	err := &PermissionError{
+		Provider: ProviderGitHub,
+		Op:       "mint installation token",
+		Missing:  []string{"checks:read", "statuses:read"},
+		Remedy:   "approve them on the installation",
+		Cause:    errors.Join(ErrPermissionsNotGranted, cause),
+	}
+	msg := err.Error()
+	for _, want := range []string{"github", "mint installation token", "checks:read", "statuses:read", "approve them on the installation", "not granted to this installation"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Error() = %q, want it to name %q", msg, want)
+		}
+	}
+	if !errors.Is(err, ErrPermissionsNotGranted) {
+		t.Error("the mint sentinel must stay reachable through the typed error")
+	}
+	var pe *PermissionError
+	if !errors.As(err, &pe) || pe.Missing[0] != "checks:read" {
+		t.Errorf("errors.As must recover the typed error with its Missing list, got %+v", pe)
+	}
+
+	// The call-time shape: a 403 the forge explained.
+	refused := &PermissionError{Provider: ProviderGitHub, Op: "GET check-runs", Missing: []string{"checks:read"}, Cause: ErrForbidden}
+	if !errors.Is(refused, ErrForbidden) {
+		t.Error("a refused call must still read as ErrForbidden")
+	}
+	if !strings.Contains(refused.Error(), "missing permission checks:read") {
+		t.Errorf("Error() = %q, want the missing grant named", refused.Error())
+	}
+}

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -565,7 +565,7 @@ func (s *Server) handleListIssuePulls(w http.ResponseWriter, r *http.Request) {
 	}
 	all, err := pc.ListPullRequests(r.Context(), repo, forge.PullListOptions{State: "all", PerPage: 100})
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "list pull requests: %v", err)
+		writeForgePullError(w, "list pull requests", err)
 		return
 	}
 	// Keep only PRs that reference this card's forge issue number.
@@ -638,7 +638,7 @@ func (s *Server) handleCreateIssuePull(w http.ResponseWriter, r *http.Request) {
 		Draft:        req.Draft,
 	})
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "create pull request: %v", err)
+		writeForgePullError(w, "create pull request", err)
 		return
 	}
 	writeJSON(w, ref)
@@ -686,7 +686,7 @@ func (s *Server) handleMergeIssuePull(w http.ResponseWriter, r *http.Request) {
 		DeleteBranch:  req.DeleteBranch,
 	})
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "merge pull request: %v", err)
+		writeForgePullError(w, "merge pull request", err)
 		return
 	}
 	writeJSON(w, ref)
@@ -756,7 +756,7 @@ func (s *Server) handleIssuePullCI(w http.ResponseWriter, r *http.Request) {
 	}
 	pr, err := pc.GetPullRequest(r.Context(), repo, number)
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "get pull request: %v", err)
+		writeForgePullError(w, "get pull request", err)
 		return
 	}
 	ref := pr.HeadSHA
@@ -765,7 +765,7 @@ func (s *Server) handleIssuePullCI(w http.ResponseWriter, r *http.Request) {
 	}
 	status, err := pc.GetCIStatus(r.Context(), repo, ref)
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "get ci status: %v", err)
+		writeForgePullError(w, "get ci status", err)
 		return
 	}
 	history, _ := pc.ListCIHistory(r.Context(), repo, ref, 20)
@@ -850,6 +850,22 @@ func (s *Server) pullClientForConn(w http.ResponseWriter, ctx context.Context, t
 		return nil, forge.Connection{}, false
 	}
 	return pc, conn, true
+}
+
+// writeForgePullError answers a failed PullClient call on the card's PR/CI
+// panel. A *forge.PermissionError is a configuration gap on the connection —
+// its credential lacks a named grant (an App installation approved before
+// `checks: read` was requested, a fine-grained PAT short of a permission) —
+// so it is answered 422 with the permission and the operator step, the same
+// mapping the create-repo and security-read routes give a withheld
+// installation grant. Anything else is the upstream failure it always was.
+func writeForgePullError(w http.ResponseWriter, op string, err error) {
+	var pe *forge.PermissionError
+	if errors.As(err, &pe) {
+		httpError(w, http.StatusUnprocessableEntity, "%s: %v", op, err)
+		return
+	}
+	httpError(w, http.StatusBadGateway, "%s: %v", op, err)
 }
 
 // forgeLinkOf extracts a card's forge linkage from its typed External ref.

--- a/pkg/server/board_forge_pulls_app_test.go
+++ b/pkg/server/board_forge_pulls_app_test.go
@@ -1,0 +1,292 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The board card's PR/CI panel reads forge.PullClient through
+// pullClientForConn. On a github_app connection — the shape the connect
+// wizard creates by default — every one of its routes answered 501 while
+// the same card worked on a PAT connection. These probes wire the REAL App
+// path end to end against a fake GitHub that applies GitHub's own rules: a
+// mint asking for a permission the installation never approved is refused
+// (422), and a call whose bearer lacks the gating permission is refused
+// (403 "Resource not accessible by integration").
+
+// pullPanelForge is that fake: the installation-token mint and probe, plus
+// the pulls, check-runs and combined-status endpoints the panel reads.
+type pullPanelForge struct {
+	mu sync.Mutex
+	// granted is what the installation's owner approved: the mint is refused
+	// for any permission (or level) outside it.
+	granted map[string]string
+	// perms maps an issued token to the permission set it was minted with.
+	perms map[string]map[string]string
+	// refusedMints counts mints GitHub 422'd for want of a grant.
+	refusedMints int
+	srv          *httptest.Server
+}
+
+// grantCovers is GitHub's rule for a mint: a requested permission must be
+// granted, at the requested level or above (write covers read).
+func (f *pullPanelForge) grantCovers(name, level string) bool {
+	got, ok := f.granted[name]
+	if !ok {
+		return false
+	}
+	return level != "write" || got == "write" || got == "admin"
+}
+
+func newPullPanelForge(t *testing.T, granted map[string]string) *pullPanelForge {
+	t.Helper()
+	f := &pullPanelForge{granted: granted, perms: map[string]map[string]string{}}
+	reply := func(w http.ResponseWriter, code int, v any) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_ = json.NewEncoder(w).Encode(v)
+	}
+	// bearerHas reports whether the caller's minted token carries name.
+	bearerHas := func(r *http.Request, name string) bool {
+		tok := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_, ok := f.perms[tok][name]
+		return ok
+	}
+	notAccessible := func(w http.ResponseWriter) {
+		reply(w, http.StatusForbidden, map[string]any{"message": "Resource not accessible by integration"})
+	}
+	pr := map[string]any{
+		"number": 7, "title": "feat: widgets", "body": "Closes #12", "state": "open",
+		"html_url": "https://forge.example/acme/widgets/pull/7",
+		"head":     map[string]any{"ref": "feat/widgets", "sha": "deadbeef1234", "repo": map[string]any{"full_name": "acme/widgets"}},
+		"base":     map[string]any{"ref": "main"},
+		"user":     map[string]any{"login": "alice"},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v3/app/installations/{id}/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Permissions map[string]string `json:"permissions"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		for name, level := range body.Permissions {
+			if !f.grantCovers(name, level) {
+				f.refusedMints++
+				reply(w, http.StatusUnprocessableEntity, map[string]any{"message": "The permissions requested are not granted to this installation."})
+				return
+			}
+		}
+		tok := "ghs_" + strings.Join(sortedKeys(body.Permissions), "_")
+		f.perms[tok] = body.Permissions
+		reply(w, http.StatusCreated, map[string]any{"token": tok, "expires_at": "2099-01-01T00:00:00Z"})
+	})
+	mux.HandleFunc("GET /api/v3/app/installations/{id}", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		reply(w, http.StatusOK, map[string]any{
+			"account":     map[string]any{"login": "acme"},
+			"html_url":    "https://forge.example/organizations/acme/settings/installations/42",
+			"permissions": f.granted,
+		})
+	})
+	mux.HandleFunc("GET /api/v3/installation/repositories", func(w http.ResponseWriter, r *http.Request) {
+		reply(w, http.StatusOK, map[string]any{"repositories": []map[string]any{{"full_name": "acme/widgets"}}})
+	})
+	mux.HandleFunc("GET /api/v3/repos/acme/widgets/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if !bearerHas(r, "pull_requests") {
+			notAccessible(w)
+			return
+		}
+		reply(w, http.StatusOK, []map[string]any{pr})
+	})
+	mux.HandleFunc("GET /api/v3/repos/acme/widgets/pulls/7", func(w http.ResponseWriter, r *http.Request) {
+		if !bearerHas(r, "pull_requests") {
+			notAccessible(w)
+			return
+		}
+		reply(w, http.StatusOK, pr)
+	})
+	mux.HandleFunc("GET /api/v3/repos/acme/widgets/commits/{sha}/check-runs", func(w http.ResponseWriter, r *http.Request) {
+		if !bearerHas(r, "checks") {
+			notAccessible(w)
+			return
+		}
+		reply(w, http.StatusOK, map[string]any{"total_count": 1, "check_runs": []map[string]any{
+			{"name": "build", "status": "completed", "conclusion": "success", "html_url": "https://forge.example/acme/widgets/runs/1", "started_at": "2026-01-01T00:00:00Z"},
+		}})
+	})
+	mux.HandleFunc("GET /api/v3/repos/acme/widgets/commits/{sha}/status", func(w http.ResponseWriter, r *http.Request) {
+		if !bearerHas(r, "statuses") {
+			notAccessible(w)
+			return
+		}
+		reply(w, http.StatusOK, map[string]any{"state": "success", "sha": r.PathValue("sha"), "statuses": []map[string]any{}})
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *pullPanelForge) refused() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.refusedMints
+}
+
+// pullPanelFixture wires a server with a github_app connection pointed at the
+// fake and a forge-linked card on the team's board, and returns the card id.
+func pullPanelFixture(t *testing.T, f *pullPanelForge) (*Server, string) {
+	t.Helper()
+	s := newWebhookTestServer(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	s.forgeConnections = forge.NewMemoryConnectionStore()
+	if err := s.forgeConnections.Create(context.Background(), forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: f.srv.URL, Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AppSlug: "iterion-forge-x", CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.CloudBoardFor = func(string) native.BoardStore { return board }
+	card, err := board.Create(native.Issue{
+		Title:    "widgets",
+		External: &native.ExternalRef{Provider: "github", ConnectionID: "c-app", Repo: "acme/widgets", Number: 12},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, card.ID
+}
+
+func pullPanelReq(method, path, cardID, number string) *http.Request {
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "t1"})
+	r := httptest.NewRequest(method, path, nil).WithContext(ctx)
+	r.SetPathValue("id", cardID)
+	if number != "" {
+		r.SetPathValue("number", number)
+	}
+	return r
+}
+
+// The panel WORKS on a github_app connection whose installation approved
+// every grant the manifest requests: the linked PR is listed and its CI
+// state is read — no 501 anywhere on the path.
+func TestCardPullPanelServesOnAGitHubAppConnection(t *testing.T) {
+	f := newPullPanelForge(t, map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read",
+		"repository_hooks": "write", "statuses": "write", "checks": "read",
+	})
+	s, cardID := pullPanelFixture(t, f)
+
+	w := httptest.NewRecorder()
+	s.handleListIssuePulls(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls", cardID, ""))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list pulls on a github_app connection: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var list struct {
+		Pulls []forge.PullRef `json:"pulls"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Pulls) != 1 || list.Pulls[0].Number != 7 {
+		t.Fatalf("pulls = %+v, want the PR that closes the card's issue #12", list.Pulls)
+	}
+
+	w = httptest.NewRecorder()
+	s.handleIssuePullCI(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls/7/ci", cardID, "7"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("pull CI on a github_app connection: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var ci struct {
+		Status forge.CIStatus `json:"status"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &ci); err != nil {
+		t.Fatal(err)
+	}
+	if ci.Status.State != forge.CISuccess || len(ci.Status.Runs) != 1 {
+		t.Fatalf("ci status = %+v, want the green check-run the forge served", ci.Status)
+	}
+	if f.refused() != 0 {
+		t.Errorf("%d mint(s) refused on a fully-granted installation: a profile asks for more than the manifest requests", f.refused())
+	}
+}
+
+// An installation approved BEFORE checks:read was requested — every
+// installation that predates the grant — must not answer an opaque 502/403:
+// the panel names the permission and the step that closes the gap, and the
+// connection health view reports the same gap before anyone opens a card.
+func TestCardPullPanelNamesTheMissingChecksGrant(t *testing.T) {
+	f := newPullPanelForge(t, map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read",
+		"repository_hooks": "write", "statuses": "write", // no checks: the pre-existing installation shape
+	})
+	s, cardID := pullPanelFixture(t, f)
+
+	// The PR half still works: it needs no grant the installation lacks.
+	w := httptest.NewRecorder()
+	s.handleListIssuePulls(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls", cardID, ""))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list pulls must not depend on checks:read: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	s.handleIssuePullCI(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls/7/ci", cardID, "7"))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("a withheld grant is a configuration gap on the connection, want 422, got %d body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"checks:read", "approve", "settings/installations/42"} {
+		if !strings.Contains(body.Error, want) {
+			t.Errorf("error = %q, want it to carry %q (the permission, the step, the page)", body.Error, want)
+		}
+	}
+	if strings.Contains(body.Error, "does not implement") {
+		t.Errorf("error = %q reads as a capability miss; the client serves the capability, the installation lacks a grant", body.Error)
+	}
+	if f.refused() == 0 {
+		t.Error("the CI profile must have asked GitHub for checks:read and been refused — the typed error comes from that refusal")
+	}
+
+	// The health probe reports the same gap, so an operator sees it on the
+	// connection before a card ever shows a dead panel.
+	req := forgeReq(superAdminCtx(), "GET", "/api/teams/t1/forge/connections/c-app/health", "", "t1")
+	req.SetPathValue("conn_id", "c-app")
+	w = httptest.NewRecorder()
+	s.handleForgeConnectionHealth(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("health: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var h forgeConnectionHealth
+	if err := json.Unmarshal(w.Body.Bytes(), &h); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.MissingCIPermissions) != 1 || h.MissingCIPermissions[0] != "checks" {
+		t.Errorf("missing_ci_permissions = %v, want [checks] — the grant the card CI panel needs and the installation lacks", h.MissingCIPermissions)
+	}
+	if h.ManageInstallURL == "" {
+		t.Error("the health view must hand over the installation page: it is where the grant is approved")
+	}
+}

--- a/pkg/server/forge_clients_capability_test.go
+++ b/pkg/server/forge_clients_capability_test.go
@@ -59,6 +59,7 @@ func TestForgeAdminForGitHubAppCapabilityMatrix(t *testing.T) {
 	}
 	served := map[string]bool{
 		"IssueClient":        assertsAs[forge.IssueClient](admin),
+		"PullClient":         assertsAs[forge.PullClient](admin),
 		"PermissionClient":   assertsAs[forge.PermissionClient](admin),
 		"ReviewClient":       assertsAs[forge.ReviewClient](admin),
 		"CommitStatusClient": assertsAs[forge.CommitStatusClient](admin),
@@ -71,21 +72,26 @@ func TestForgeAdminForGitHubAppCapabilityMatrix(t *testing.T) {
 			t.Errorf("a github_app connection must serve forge.%s; %T does not", name, admin)
 		}
 	}
-	// PullClient is the KNOWN App-connection gap, asserted so it cannot
-	// change in either direction unnoticed. The App client serves
-	// GetPullRequest but not the list/create/merge/CI half, so the board
-	// card's PR panel (GET|POST /api/v1/native/issues/{id}/pulls,
-	// .../pulls/{n}/ci, .../pulls/{n}/merge) answers 501 on a github_app
-	// connection while it works on a PAT one.
-	//
-	// It is not the same shape of fix as IssueClient: GetCIStatus reads
-	// /commits/{ref}/check-runs, which needs `checks: read` — a permission
-	// neither the runtime baseline nor the App manifest requests, so closing
-	// the gap means a manifest change and an org re-approval per
-	// installation, not a delegation. When that lands, delete this assertion.
-	if assertsAs[forge.PullClient](admin) {
-		t.Errorf("forge.PullClient is now served on github_app (%T) — the gap closed: "+
-			"drop this assertion and the 501 note it pins", admin)
+	// Two capabilities are deliberate non-implementations on an App, not gaps:
+	// forge.ReviewerAssigner (an App cannot be asked to review a PR) and
+	// forge.AvatarSetter (GitHub has no App-logo API; the studio hands the file
+	// over). Both callers treat the miss as a documented degrade, never a 501.
+}
+
+// The card's PR panel — GET|POST /api/v1/native/issues/{id}/pulls,
+// .../pulls/{n}/ci, .../pulls/{n}/merge — reads forge.PullClient through
+// pullClientForConn. A github_app connection must serve it: it is the shape
+// the connect wizard creates by default, and answering 501 there left the
+// panel dead on the ordinary connection kind while a PAT connection worked.
+func TestForgeAdminForGitHubAppIsAPullClient(t *testing.T) {
+	s, conn := appConnectionFixture(t)
+	admin, err := s.forgeAdminFor(context.Background(), conn)
+	if err != nil {
+		t.Fatalf("forgeAdminFor: %v", err)
+	}
+	if _, ok := admin.(forge.PullClient); !ok {
+		t.Fatalf("a %s connection yields %T, which does not implement forge.PullClient: "+
+			"the card's PR/CI panel answers 501 on this connection kind", conn.Kind, admin)
 	}
 }
 

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -155,6 +155,12 @@ type forgeConnectionHealth struct {
 	// hasn't approved it — the fix is the ManageInstallURL page.
 	SecurityReadEnabled        bool     `json:"security_read_enabled"`
 	MissingSecurityPermissions []string `json:"missing_security_permissions,omitempty"`
+	// MissingCIPermissions names the grants the board card's CI panel reads
+	// through this connection (checks, statuses) that the installation has
+	// not approved. An installation approved before `checks: read` was
+	// requested shows exactly that here — and the panel answers 422 naming
+	// it — until an owner approves the pending request on ManageInstallURL.
+	MissingCIPermissions []string `json:"missing_ci_permissions,omitempty"`
 }
 
 // syncGrantedPermissions persists the installation's live grant onto the
@@ -193,6 +199,16 @@ func missingDeliveryFor(conn forge.Connection, granted map[string]string) []stri
 		return nil
 	}
 	return forgegithub.MissingDeliveryPermissions(granted)
+}
+
+// missingCIFor is missingDeliveryFor's twin for the card CI panel's grants: a
+// watch-only connection never serves a card, so its absent checks/statuses
+// are not a defect either.
+func missingCIFor(conn forge.Connection, granted map[string]string) []string {
+	if conn.IsSecurityReadOnly() {
+		return nil
+	}
+	return forgegithub.MissingCIPermissions(granted)
 }
 
 func samePermissions(a, b map[string]string) bool {
@@ -247,6 +263,7 @@ func (s *Server) handleForgeConnectionHealth(w http.ResponseWriter, r *http.Requ
 				h.GrantedPermissions = inst.Permissions
 				h.MissingPermissions = missingDeliveryFor(conn, inst.Permissions)
 				h.MissingSecurityPermissions = forgegithub.MissingSecurityPermissions(inst.Permissions)
+				h.MissingCIPermissions = missingCIFor(conn, inst.Permissions)
 				// Keep the stored grant in step with the live one: the mint
 				// reads it, and an owner may approve (or revoke) a permission
 				// long after the install.

--- a/pkg/server/forge_refresh_route.go
+++ b/pkg/server/forge_refresh_route.go
@@ -53,17 +53,18 @@ func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Req
 	s.syncGrantedPermissions(r.Context(), conn, inst.Permissions, inst.Login)
 
 	out := forgeConnectionHealth{
-		Status:              string(conn.Status),
-		StatusReason:        conn.StatusReason,
-		Provider:            string(conn.Provider),
-		Kind:                string(conn.Kind),
-		AccountLogin:        conn.AccountLogin,
-		AppSlug:             conn.AppSlug,
-		InstallationID:      conn.InstallationID,
-		InstallationAccount: inst.Login,
-		ManageInstallURL:    inst.HTMLURL,
-		GrantedPermissions:  inst.Permissions,
-		MissingPermissions:  missingDeliveryFor(conn, inst.Permissions),
+		Status:               string(conn.Status),
+		StatusReason:         conn.StatusReason,
+		Provider:             string(conn.Provider),
+		Kind:                 string(conn.Kind),
+		AccountLogin:         conn.AccountLogin,
+		AppSlug:              conn.AppSlug,
+		InstallationID:       conn.InstallationID,
+		InstallationAccount:  inst.Login,
+		ManageInstallURL:     inst.HTMLURL,
+		GrantedPermissions:   inst.Permissions,
+		MissingPermissions:   missingDeliveryFor(conn, inst.Permissions),
+		MissingCIPermissions: missingCIFor(conn, inst.Permissions),
 	}
 	// Force a fresh token mint so the observability reflects the new grants
 	// (forgeAdminFor builds a fresh client → rest() mints on first use).

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6256,6 +6256,7 @@ export interface components {
             kind: string;
             live_error?: string;
             manage_install_url?: string;
+            missing_ci_permissions?: string[];
             missing_permissions?: string[];
             missing_security_permissions?: string[];
             provider: string;


### PR DESCRIPTION
Closes #777.

`pkg/server/board_forge.go` asserts `forge.PullClient` on the connection's admin client; `forgegithub.AppClient` did not implement it, so on a GitHub-App connection `GET|POST /api/v1/native/issues/{id}/pulls`, `…/pulls/{n}/ci` and `…/pulls/{n}/merge` answered **501** while they worked on a PAT. The card's PR/CI panel was dead for the ordinary connection kind.

## What changes
- **`AppClient` implements the 7 `PullClient` methods** through `scopedREST` (the #776 pattern), one minimal permission profile per method, verified against GitHub's published server-to-server permission table:

  | profile (+ `metadata:read`) | methods |
  |---|---|
  | `pull_requests:read` | ListPullRequests |
  | `pull_requests:read, contents:read` | GetPullRequest (moved off the management token — a narrowing; the merge gate still reads its head SHA) |
  | `pull_requests:write` | CreatePull, UpdatePull |
  | `contents:write, pull_requests:read` | MergePull (GitHub gates the merge on `contents:write`) |
  | `checks:read, statuses:read` | GetCIStatus |
  | `checks:read` | ListCIHistory |
- **The permission gap is explicit, never a 501 and never an opaque 403.** New `forge.PermissionError{Provider, Op, Missing, Remedy}`: a 422 "permissions not granted" at mint, or a 403 "Resource not accessible by integration|personal access token" on the call, becomes a typed error naming the withheld grants (one App-JWT `InstallationInfo` probe on the failure path) and the install page. The board endpoints answer **422** with that message (the create-repo / security-read precedent); `errors.Is(ErrPermissionsNotGranted)` / `errors.Is(ErrForbidden)` keep holding for existing callers.
- **`checks: read` is requested by `BuildAppManifest`** and by the per-call profiles — deliberately NOT by `RuntimeInstallationPermissions()`: that baseline mints the management token and the run token, every existing installation lacks `checks`, and a baseline asking for it would 422 every mint on those installations (and `rest()`'s only fallback drops `statuses`, which would kill the merge gate). Same pattern as `statuses:write`; pinned by `TestPullPermissionProfiles`.
- **Health reports the gap**: `missing_ci_permissions` on `GET /api/teams/{id}/forge/connections/{conn}/health` and on the refresh route; `iterion remote forge connections refresh <id>` prints the delivery and CI gaps (it printed neither before). OpenAPI + studio schema regenerated. `docs/forge-permissions.md` lists the manifest permissions truthfully and carries the re-approval step.

## Operator step — existing installations must re-approve `checks: read`
1. On each App created before this change (the per-org manifest Apps and the platform `ITERION_FORGE_GITHUB_APP_*` App): App settings → **Permissions & events** → Repository permissions → **Checks: Read-only** → save. GitHub has no API for this.
2. GitHub then raises a pending permission request on every installation: an org owner approves it at org **Settings → GitHub Apps → <app> → Configure** (the URL the health endpoint returns as `manage_install_url`).

Until then the PR list/open/merge halves of the panel work; the CI half answers `422 … missing permission checks:read — approve checks:read on the GitHub App installation (<url>)`, the health endpoint shows `missing_ci_permissions: ["checks"]`, and the CLI refresh prints the same line. Apps created after the deploy request it up front. The runtime token is never minted with it, so nothing else on the connection changes.

## Tests (red first)
- `TestBuildAppManifest` (checks perm), `TestForgeAdminForGitHubAppCapabilityMatrix` / `…IsAPullClient`, `pkg/forge/github/pulls_app_test.go` (compile-time interface assertion, per-method profile + PAT-parity, token cache, mint-422 typed error, 403-body typed error on PAT and App, rate-limit 403 stays plain, `MissingCIPermissions`), `pkg/server/board_forge_pulls_app_test.go` (real handlers on a `github_app` connection against a fake GitHub: fully-granted install → 200/200; pre-`checks` install → list 200, CI 422 naming `checks:read` + the install URL, health `missing_ci_permissions: [checks]`).
- `go build ./...` · `go test ./pkg/forge/... ./pkg/server/ ./pkg/webhooks/... ./pkg/dispatcher/... ./pkg/cli/... ./pkg/runner/...` green · `go test -race ./pkg/forge/...` green · `task lint` 0 issues · `task openapi:check` exit 0.

## Capability-assertion sweep (every `.(forge.X)` on `forgeAdminFor`'s result)
`IssueClient` (#776), `PermissionClient`, `RepoCreator`, `CommitStatusLister`, `ReviewClient`, the local gate/commenter/preflighter interfaces: satisfied. `ReviewerAssigner`: neither GitHub client implements it (caller degrades, documented). `AvatarSetter`: GitHub has no App-logo API (docs/brand.md), left as is.

## Left as separate findings (not in this PR)
`forge/transport.go:80` maps every 404 to `ErrHookNotFound` (a missing PR reads "hook not found"); `github/ci.go:193/221` treat a 404 on check-runs as "no CI" (silent for a fine-grained PAT short of the grant); `board_forge.go:771` swallows a failed `ListCIHistory`; the studio renders none of the `missing_*_permissions` fields; a follow-up may add `checks: read` to the RUN token once granted so a bot's `gh pr checks` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
