### PR TITLE
fix(runner): a sandboxed claw node meters from its relayed steps, on the credential that served it

### DIFF
--- a/cmd/iterion/claw_runner.go
+++ b/cmd/iterion/claw_runner.go
@@ -160,9 +160,12 @@ func runClawRunner(ctx context.Context, stdin io.Reader, stdout, stderr io.Write
 	// Build a minimal ClawBackend. The registry resolves the API
 	// client from the standard ITERION_*_KEY env vars, which the
 	// sandbox driver inherits from the host (subject to the env
-	// scrubbing the engine applies before container start).
+	// scrubbing the engine applies before container start). Its event
+	// hooks relay the per-step LLM observations to the launcher, which
+	// re-fires them through its own hooks — what meters a sandboxed claw
+	// node like an in-process one.
 	registry := model.NewRegistry()
-	backend := model.NewClawBackend(registry, model.EventHooks{}, model.RetryPolicy{})
+	backend := model.NewClawBackend(registry, relayEventHooks(dispatcher, stderr), model.RetryPolicy{})
 
 	start := time.Now()
 	result, err := backend.Execute(ctx, task)
@@ -189,6 +192,17 @@ func runClawRunner(ctx context.Context, stdin io.Reader, stdout, stderr io.Write
 		return err
 	}
 	return nil
+}
+
+// relayEventHooks builds the event hooks the runner installs on its claw
+// backend: llm_request and llm_step_finished cross the IPC as `event`
+// envelopes on the dispatcher's writer (see [model.SandboxRelayHooks]). A
+// failed write is reported on stderr, which the launcher captures into the
+// node's error when the channel is dead.
+func relayEventHooks(d *proxyDispatcher, stderr io.Writer) model.EventHooks {
+	return model.SandboxRelayHooks(d.write, func(err error) {
+		fmt.Fprintf(stderr, "iterion-claw-runner: %v\n", err)
+	})
 }
 
 // unmarshalTaskEnvelope decodes a [delegate.EnvelopeTask] envelope

--- a/cmd/iterion/claw_runner_proxy_test.go
+++ b/cmd/iterion/claw_runner_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 )
 
 // TestProxyDispatcher_RoundTripsToolCall is the V2-2 acceptance-level
@@ -212,6 +213,80 @@ func TestProxyDispatcher_PreservesErrAskUserAcrossWire(t *testing.T) {
 	}
 	if !strings.Contains(string(askErr.Conversation), "messages") {
 		t.Errorf("Conversation should round-trip; got %s", askErr.Conversation)
+	}
+}
+
+// TestClawRunner_RelayHooksCrossTheWireAsEventEnvelopes: the hooks the
+// runner installs on its claw backend write llm_request / llm_step_finished
+// on the dispatcher's stdout as `event` envelopes — the same channel and
+// the same serialised writer the tool proxies use, so a step's usage
+// leaves the container on the wire the launcher already reads.
+func TestClawRunner_RelayHooksCrossTheWireAsEventEnvelopes(t *testing.T) {
+	runnerStdinR, _ := io.Pipe()
+	runnerStdoutR, runnerStdoutW := io.Pipe()
+	defer runnerStdinR.Close()
+
+	var stderr strings.Builder
+	dispatcher := newProxyDispatcher(runnerStdinR, runnerStdoutW)
+	hooks := relayEventHooks(dispatcher, &stderr)
+	if hooks.OnLLMRequest == nil || hooks.OnLLMStepFinish == nil {
+		t.Fatal("the runner's claw backend has no step hooks: its per-step usage stays inside the container")
+	}
+
+	go func() {
+		hooks.OnLLMRequest("plan_review", model.LLMRequestInfo{Model: "gpt-5.6-sol", MessageCount: 2})
+		hooks.OnLLMStepFinish("plan_review", model.LLMStepInfo{Number: 1, InputTokens: 1234, OutputTokens: 56, CacheReadTokens: 7})
+		_ = runnerStdoutW.Close()
+	}()
+
+	reader := delegate.NewEnvelopeReader(runnerStdoutR)
+	var got []delegate.EventData
+	for {
+		env, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read envelope: %v", err)
+		}
+		if env.Type != delegate.EnvelopeEvent {
+			t.Fatalf("envelope type = %q, want %q", env.Type, delegate.EnvelopeEvent)
+		}
+		var ed delegate.EventData
+		if err := json.Unmarshal(env.Data, &ed); err != nil {
+			t.Fatalf("decode event data: %v", err)
+		}
+		got = append(got, ed)
+	}
+	if len(got) != 2 || got[0].Type != "llm_request" || got[1].Type != "llm_step_finished" {
+		t.Fatalf("relayed events = %+v, want [llm_request llm_step_finished]", got)
+	}
+	if got[0].Payload["model"] != "gpt-5.6-sol" || got[0].Payload["message_count"] != float64(2) {
+		t.Errorf("llm_request payload = %v", got[0].Payload)
+	}
+	step := got[1].Payload
+	if step["input_tokens"] != float64(1234) || step["output_tokens"] != float64(56) || step["cache_read_tokens"] != float64(7) || step["step"] != float64(1) {
+		t.Errorf("llm_step_finished payload = %v, want the token counts intact", step)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want nothing on a healthy channel", stderr.String())
+	}
+}
+
+// TestClawRunner_RelayReportsADeadChannelOnStderr: a hook cannot return an
+// error, so a relay write that fails is written to stderr — which the
+// launcher captures into the node's error — instead of vanishing.
+func TestClawRunner_RelayReportsADeadChannelOnStderr(t *testing.T) {
+	runnerStdinR, _ := io.Pipe()
+	runnerStdoutR, runnerStdoutW := io.Pipe()
+	defer runnerStdinR.Close()
+	_ = runnerStdoutR.Close() // the launcher is gone
+
+	var stderr strings.Builder
+	hooks := relayEventHooks(newProxyDispatcher(runnerStdinR, runnerStdoutW), &stderr)
+	hooks.OnLLMStepFinish("n", model.LLMStepInfo{InputTokens: 1})
+	if !strings.Contains(stderr.String(), "relay llm_step_finished") {
+		t.Fatalf("stderr = %q, want the failed relay named", stderr.String())
 	}
 }
 

--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -172,6 +172,35 @@ The `tier` (`team` | `pool` | `platform`) is part of the meter identity, not
 a label: the same key lent through the pool and used by its owner are two
 different economic facts.
 
+**Where a route's model comes from.** The runner's metrics emitter names each
+node's route from three events, in order: `delegate_started.declared_model`
+(the node's spec, provider included — every backend emits it), then each
+`llm_request` (the id the call actually went to), then
+`delegate_finished.effective_model` when the backend reports one. A backend
+reports the id it CALLED, and claw strips the provider before the request —
+so a claw step reports `gpt-5.6-sol`, not `openai/gpt-5.6-sol`. A bare id
+names no provider and would fall to the backend's default wire (anthropic for
+claw), charging an OpenAI model's tokens to the Claude forfait; when the
+reported id is the declared model without its prefix, the route keeps the
+declared, provider-qualified name. A different id (a fallback element) is kept
+as reported.
+
+**claw inside a sandbox.** The LLM loop runs in `iterion __claw-runner` in the
+container, and the runner relays its per-step `llm_request` /
+`llm_step_finished` to the launcher over the IPC ([sandbox.md](sandbox.md#claw-backend-in-sandbox)),
+so a sandboxed claw node is metered from its steps exactly like an in-process
+one — and the `delegate_finished` total, a summary of those steps, is not
+counted again (cost or tokens). When a run's container carries an older
+runner that relays nothing, that total is the only observation: it is booked
+on the route and, when the event carries no `cost_usd`, priced from the table
+at the model's **input** rate — a floor, since one aggregate count cannot be
+split into input and output — or left unpriced when no source knows the
+model. Zero is unknown, never free.
+
+A route iterion cannot attribute is logged at **warn** by the runner, once per
+route per attempt (`no credential iterion can name`): the decline is
+definitive for that attempt, so it has to be visible.
+
 ```sh
 # This team's credentials, this month
 iterion remote usage --by-credential

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -622,6 +622,24 @@ across the channel.
   envelope, the runner stashes the snapshot, then loads it into its
   local store once the task arrives so applySessionMessages
   prepends the replayed prior messages to the LLM's first call.
+- ✅ **Per-step LLM observability — metering parity.** The in-container
+  runner's claw backend carries [model.SandboxRelayHooks], which emit
+  each `llm_request` and `llm_step_finished` (model, input / output /
+  cache token counts, response text, thinking) as an `event` envelope;
+  the launcher's [delegate.MultiplexerHandler.OnEvent] decodes them
+  ([model.ApplyRelayedEvent]) and re-fires its OWN event hooks. A
+  sandboxed claw node therefore writes the same `llm_request` /
+  `llm_step_finished` / `assistant_text` events as an in-process one, the
+  host derives the same `usage_progress` samples from them (a
+  supervisor's `cost_gt` monitor works), and the runner pod's org,
+  per-credential and pool metering read the steps the same way. The
+  launcher still emits `delegate_started` / `delegate_finished` itself;
+  with the steps relayed, the delegation total is a summary and is not
+  counted again — see [quotas-and-limits.md](quotas-and-limits.md#per-credential-usage--what-did-this-key-cost)
+  for what a run whose container carries an older, non-relaying runner
+  is charged. Not relayed: `tool_started` / `tool_called` for the
+  builtins executed inside the container, `llm_retry`, and the per-turn
+  `llm_turn_capture` checkpoints — those stay in the container.
 
 ### MCP tools in a sandbox
 

--- a/pkg/backend/cost/cost.go
+++ b/pkg/backend/cost/cost.go
@@ -52,7 +52,7 @@ import (
 // observability — operators concerned with hard budget tracking should
 // pull the authoritative rates from their provider invoices.
 //
-// Last reviewed: 2026-07-28, against models.dev via `iterion models pricing`.
+// Last reviewed: 2026-09-06, against models.dev via `iterion models pricing`.
 // Run that command to see where this table and the published rates diverge;
 // it reports and never rewrites, because a price is a budget decision.
 //
@@ -82,6 +82,12 @@ var (
 	sonnetRate     = modelPricing{3.00, 15.00}
 	sonnet5Rate    = modelPricing{2.00, 10.00}
 	haikuRate      = modelPricing{1.00, 5.00}
+	// OpenAI's gpt-5.6 line ships three sizes at three rates (standard tier,
+	// developers.openai.com/api/docs/pricing); the bare `gpt-5.6` alias routes
+	// to sol, so it carries sol's rate.
+	gpt56SolRate   = modelPricing{4.00, 20.00}
+	gpt56TerraRate = modelPricing{2.00, 12.00}
+	gpt56LunaRate  = modelPricing{0.20, 1.20}
 )
 
 var modelPriceTable = map[string]modelPricing{
@@ -101,21 +107,25 @@ var modelPriceTable = map[string]modelPricing{
 	"claude-sonnet-4":           sonnetRate,
 	"claude-haiku-4-5":          haikuRate,
 	"claude-haiku-4-5-20251001": haikuRate,
-	// OpenAI — gpt-5.5+ are priced higher than gpt-5; mini/nano variants
-	// are roughly an order of magnitude cheaper. Numbers below are best
-	// effort against the known list; refresh against the OpenAI pricing
+	// OpenAI — each gpt-5.x generation carries its own rate; mini/nano
+	// variants are roughly an order of magnitude cheaper. Numbers below are
+	// best effort against the known list; refresh against the OpenAI pricing
 	// page when a new tier ships.
-	"gpt-5":        {1.25, 10.00},
-	"gpt-5-mini":   {0.25, 2.00},
-	"gpt-5.4":      {2.50, 15.00},
-	"gpt-5.4-pro":  {30.00, 180.00},
-	"gpt-5.4-mini": {0.75, 4.50},
-	"gpt-5.4-nano": {0.20, 1.25},
-	"gpt-5.5":      {5.00, 30.00},
-	"gpt-5.5-pro":  {30.00, 180.00},
-	"o3":           {2.00, 8.00},
-	"gpt-4o":       {2.50, 10.00},
-	"gpt-4o-mini":  {0.15, 0.60},
+	"gpt-5":         {1.25, 10.00},
+	"gpt-5-mini":    {0.25, 2.00},
+	"gpt-5.4":       {2.50, 15.00},
+	"gpt-5.4-pro":   {30.00, 180.00},
+	"gpt-5.4-mini":  {0.75, 4.50},
+	"gpt-5.4-nano":  {0.20, 1.25},
+	"gpt-5.5":       {5.00, 30.00},
+	"gpt-5.5-pro":   {30.00, 180.00},
+	"gpt-5.6":       gpt56SolRate,
+	"gpt-5.6-sol":   gpt56SolRate,
+	"gpt-5.6-terra": gpt56TerraRate,
+	"gpt-5.6-luna":  gpt56LunaRate,
+	"o3":            {2.00, 8.00},
+	"gpt-4o":        {2.50, 10.00},
+	"gpt-4o-mini":   {0.15, 0.60},
 }
 
 // EstimateUSD returns a rough cost estimate for the given token usage on

--- a/pkg/backend/cost/cost_test.go
+++ b/pkg/backend/cost/cost_test.go
@@ -266,3 +266,28 @@ func TestGLMIsPricedByTheLiveRegistryNotTheTable(t *testing.T) {
 		t.Errorf("effective rate %v/%v: output tokens cost more than input on every provider", in, out)
 	}
 }
+
+// The gpt-5.6 line is the model the campaign bots' cross-family plan review
+// runs on (openai/gpt-5.6-sol), and a sandboxed runner prices from a cold
+// container where neither live source has a cache yet — so the committed
+// table must carry it. Rates are OpenAI's published standard tier
+// (developers.openai.com/api/docs/pricing); the bare `gpt-5.6` alias routes
+// to sol and carries sol's rate.
+func TestStaticTable_PricesTheGPT56Family(t *testing.T) {
+	cases := map[string][2]float64{
+		"gpt-5.6-sol":   {4.00, 20.00},
+		"gpt-5.6":       {4.00, 20.00},
+		"gpt-5.6-terra": {2.00, 12.00},
+		"gpt-5.6-luna":  {0.20, 1.20},
+	}
+	for model, want := range cases {
+		in, out, ok := StaticRate("openai/" + model)
+		if !ok {
+			t.Errorf("%s: no committed rate — a cold sandboxed runner prices it at nothing", model)
+			continue
+		}
+		if in != want[0] || out != want[1] {
+			t.Errorf("%s: committed rate %v/%v, want %v/%v", model, in, out, want[0], want[1])
+		}
+	}
+}

--- a/pkg/backend/delegate/envelope.go
+++ b/pkg/backend/delegate/envelope.go
@@ -161,9 +161,11 @@ type AskUserAnswerData struct {
 }
 
 // EventData is the payload of an [EnvelopeEvent]. The runner forwards
-// observability events that belong in the run's events.jsonl
-// (tool_called, llm_request, …) — the launcher persists them via the
-// engine's normal emit path.
+// observability events that belong in the run's events.jsonl — its
+// per-step LLM observations, `llm_request` and `llm_step_finished`, whose
+// payloads are the wire forms defined beside model.SandboxRelayHooks — and
+// the launcher re-fires them through its own event hooks, so they are
+// persisted, priced and metered exactly like an in-process node's.
 type EventData struct {
 	Type    string         `json:"type"`
 	Payload map[string]any `json:"payload,omitempty"`

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1322,6 +1322,24 @@ func (b *ClawBackend) multiplexerHandler(ctx context.Context, task delegate.Task
 			// snapshot behind but the next capture will reconcile.
 			_ = hostStore.SaveSnapshot(hostRunID, task.NodeID, snapshot)
 		},
+		OnEvent: func(eventType string, payload map[string]any) {
+			// The runner's per-step LLM observations (llm_request,
+			// llm_step_finished), re-fired through THIS process's hooks so
+			// a sandboxed claw node is persisted, priced and metered like
+			// an in-process one — see sandbox_relay.go.
+			handled, err := ApplyRelayedEvent(b.hooks, task.NodeID, eventType, payload)
+			if b.logger == nil {
+				return
+			}
+			switch {
+			case err != nil:
+				b.logger.Warn("[%s#%d/claw] the sandbox runner relayed a %s event this host cannot decode — the node's per-step metering is incomplete: %v",
+					task.NodeID, task.Iteration, eventType, err)
+			case !handled:
+				b.logger.Debug("[%s#%d/claw] the sandbox runner relayed a %s event this host does not consume",
+					task.NodeID, task.Iteration, eventType)
+			}
+		},
 	}
 }
 

--- a/pkg/backend/model/sandbox_relay.go
+++ b/pkg/backend/model/sandbox_relay.go
@@ -1,0 +1,180 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The sandboxed claw path runs the LLM loop in `iterion __claw-runner`
+// inside the container, a process with no event hooks of its own. Left
+// there, the per-step observations — which model a call went to, what it
+// consumed — never reach the host: the run store carries no llm_request /
+// llm_step_finished for the node, no usage_progress can be derived for a
+// supervisor's cost_gt monitor, and the runner's metering sees the
+// delegation total alone.
+//
+// This file is the relay across that boundary, on the IPC channel the
+// runner already has: the runner installs SandboxRelayHooks, which encode
+// the two hooks as `event` envelopes; the launcher's multiplexer handler
+// decodes them with ApplyRelayedEvent and re-fires its own EventHooks, so a
+// sandboxed claw node produces the same events, log lines and derived usage
+// samples as an in-process one, through the same code.
+
+// relayedLLMRequest is the wire form of LLMRequestInfo.
+type relayedLLMRequest struct {
+	Model           string    `json:"model"`
+	MessageCount    int       `json:"message_count"`
+	ToolCount       int       `json:"tool_count"`
+	ReasoningEffort string    `json:"reasoning_effort,omitempty"`
+	Timestamp       time.Time `json:"timestamp"`
+	Iteration       int       `json:"iteration"`
+}
+
+// relayedLLMStep is the wire form of LLMStepInfo.
+type relayedLLMStep struct {
+	Number           int               `json:"step"`
+	Text             string            `json:"text,omitempty"`
+	ToolCalls        []relayedToolCall `json:"tool_calls,omitempty"`
+	FinishReason     string            `json:"finish_reason,omitempty"`
+	InputTokens      int               `json:"input_tokens"`
+	OutputTokens     int               `json:"output_tokens"`
+	CacheReadTokens  int               `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int               `json:"cache_write_tokens,omitempty"`
+	ReasoningTokens  int               `json:"thinking_tokens,omitempty"`
+	ThinkingMs       int               `json:"thinking_ms,omitempty"`
+	Thinking         string            `json:"thinking,omitempty"`
+	Iteration        int               `json:"iteration"`
+}
+
+// relayedToolCall is the wire form of ToolCallEntry.
+type relayedToolCall struct {
+	Name  string          `json:"name"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// SandboxRelayHooks returns the EventHooks the in-container claw runner
+// installs: OnLLMRequest and OnLLMStepFinish are encoded as `event`
+// envelopes and handed to write, the runner's IPC writer. A hook cannot
+// return an error, so a failed write is passed to report (nil-safe); a
+// channel that fails here fails the result envelope right after, loudly.
+func SandboxRelayHooks(write func(delegate.Envelope) error, report func(error)) EventHooks {
+	send := func(eventType store.EventType, payload any) {
+		env, err := relayEnvelope(eventType, payload)
+		if err == nil {
+			err = write(env)
+		}
+		if err != nil && report != nil {
+			report(fmt.Errorf("relay %s event to the launcher: %w", eventType, err))
+		}
+	}
+	return EventHooks{
+		OnLLMRequest: func(_ string, info LLMRequestInfo) {
+			send(store.EventLLMRequest, relayedLLMRequest(info))
+		},
+		OnLLMStepFinish: func(_ string, step LLMStepInfo) {
+			var calls []relayedToolCall
+			if len(step.ToolCalls) > 0 {
+				calls = make([]relayedToolCall, len(step.ToolCalls))
+				for i, tc := range step.ToolCalls {
+					calls[i] = relayedToolCall(tc)
+				}
+			}
+			send(store.EventLLMStepFinished, relayedLLMStep{
+				Number:           step.Number,
+				Text:             step.Text,
+				ToolCalls:        calls,
+				FinishReason:     step.FinishReason,
+				InputTokens:      step.InputTokens,
+				OutputTokens:     step.OutputTokens,
+				CacheReadTokens:  step.CacheReadTokens,
+				CacheWriteTokens: step.CacheWriteTokens,
+				ReasoningTokens:  step.ReasoningTokens,
+				ThinkingMs:       step.ThinkingMs,
+				Thinking:         step.Thinking,
+				Iteration:        step.Iteration,
+			})
+		},
+	}
+}
+
+// relayEnvelope encodes a typed payload as an event envelope. EventData
+// carries its payload as a map, so the typed form goes through JSON once
+// here and once again on the host — two small encodes per LLM step.
+func relayEnvelope(eventType store.EventType, payload any) (delegate.Envelope, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return delegate.Envelope{}, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return delegate.Envelope{}, err
+	}
+	return delegate.NewEventEnvelope(string(eventType), m)
+}
+
+// ApplyRelayedEvent re-fires one relayed event through h, for nodeID (the
+// host's own node id, never the wire's). handled is false for an event type
+// this host does not relay — a newer runner may forward more, and the
+// multiplexer's contract for an envelope the launcher does not know is to
+// drop it. The error is for a known type whose payload does not decode: a
+// defect on one side of the wire, not a version skew, and the node's
+// metering is incomplete without it.
+func ApplyRelayedEvent(h EventHooks, nodeID, eventType string, payload map[string]any) (handled bool, err error) {
+	switch store.EventType(eventType) {
+	case store.EventLLMRequest:
+		var r relayedLLMRequest
+		if err := decodeRelayed(payload, &r); err != nil {
+			return true, err
+		}
+		if h.OnLLMRequest != nil {
+			h.OnLLMRequest(nodeID, LLMRequestInfo(r))
+		}
+		return true, nil
+	case store.EventLLMStepFinished:
+		var s relayedLLMStep
+		if err := decodeRelayed(payload, &s); err != nil {
+			return true, err
+		}
+		if h.OnLLMStepFinish != nil {
+			var calls []ToolCallEntry
+			if len(s.ToolCalls) > 0 {
+				calls = make([]ToolCallEntry, len(s.ToolCalls))
+				for i, tc := range s.ToolCalls {
+					calls[i] = ToolCallEntry(tc)
+				}
+			}
+			h.OnLLMStepFinish(nodeID, LLMStepInfo{
+				Number:           s.Number,
+				Text:             s.Text,
+				ToolCalls:        calls,
+				FinishReason:     s.FinishReason,
+				InputTokens:      s.InputTokens,
+				OutputTokens:     s.OutputTokens,
+				CacheReadTokens:  s.CacheReadTokens,
+				CacheWriteTokens: s.CacheWriteTokens,
+				ReasoningTokens:  s.ReasoningTokens,
+				ThinkingMs:       s.ThinkingMs,
+				Thinking:         s.Thinking,
+				Iteration:        s.Iteration,
+			})
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// decodeRelayed reads a relayed payload map back into its typed wire form.
+func decodeRelayed(payload map[string]any, into any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("re-encode payload: %w", err)
+	}
+	if err := json.Unmarshal(raw, into); err != nil {
+		return fmt.Errorf("decode payload: %w", err)
+	}
+	return nil
+}

--- a/pkg/backend/model/sandbox_relay_test.go
+++ b/pkg/backend/model/sandbox_relay_test.go
@@ -1,0 +1,208 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// relayHost builds the launcher half of the sandbox IPC over a real run
+// store: a ClawBackend whose hooks are the production store hooks, and a
+// loader for what those hooks persisted. The store is the oracle — the
+// events the studio, the report and the runner's metering read.
+func relayHost(t *testing.T, runID string) (*ClawBackend, func() []*store.Event) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	hooks := NewStoreEventHooks(ctx, st, runID, iterlog.Nop(), nil)
+	b := NewClawBackend(NewRegistry(), hooks, RetryPolicy{})
+	return b, func() []*store.Event {
+		evts, err := st.LoadEvents(ctx, runID)
+		if err != nil {
+			t.Fatalf("LoadEvents: %v", err)
+		}
+		return evts
+	}
+}
+
+func eventsOfType(evts []*store.Event, typ store.EventType) []*store.Event {
+	var out []*store.Event
+	for _, e := range evts {
+		if e.Type == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// #805 — the relay boundary, end to end on the real wire: the runner-side
+// hooks encode llm_request / llm_step_finished as `event` envelopes, a
+// real Multiplexer carries them to the launcher's handler, and the
+// launcher's own store hooks persist them — with the same payload the
+// in-process path writes, plus what those hooks derive from it (the
+// assistant_text narration of a tool-bearing step, the usage_progress
+// sample a supervisor's cost_gt monitor arms on). Before the relay, a
+// sandboxed claw node left none of these on the host.
+func TestSandboxRelay_StepEventsCrossTheWireIntoTheHostStore(t *testing.T) {
+	b, load := relayHost(t, "run-relay")
+	handler := b.multiplexerHandler(context.Background(), delegate.Task{NodeID: "plan_review", Model: "openai/gpt-5.6-sol"})
+	if handler.OnEvent == nil {
+		t.Fatal("the launcher's multiplexer handler has no OnEvent: every event envelope the runner emits is dropped")
+	}
+
+	// Only the runner→launcher direction carries traffic here: no tool_call
+	// or ask_user asks for a reply, so the launcher→runner pipe is never
+	// written and needs no reader.
+	_, runnerStdinW := io.Pipe()
+	runnerStdoutR, runnerStdoutW := io.Pipe()
+	mux := delegate.NewMultiplexer(runnerStdoutR, runnerStdinW, handler)
+
+	// The runner half: the hooks the in-container claw backend fires,
+	// writing on its IPC stdout.
+	var relayErrs []error
+	go func() {
+		defer runnerStdoutW.Close()
+		writer := delegate.NewEnvelopeWriter(runnerStdoutW)
+		relay := SandboxRelayHooks(writer.Write, func(err error) { relayErrs = append(relayErrs, err) })
+		relay.OnLLMRequest("plan_review", LLMRequestInfo{
+			Model: "gpt-5.6-sol", MessageCount: 3, ToolCount: 4, ReasoningEffort: "high", Iteration: 2, Timestamp: time.Now(),
+		})
+		relay.OnLLMStepFinish("plan_review", LLMStepInfo{
+			Number:           1,
+			Text:             "Reading the plan before I judge it.",
+			ToolCalls:        []ToolCallEntry{{Name: "read_file", Input: json.RawMessage(`{"path":"PLAN.md"}`)}},
+			FinishReason:     "tool_use",
+			InputTokens:      20000,
+			OutputTokens:     300,
+			CacheReadTokens:  1500,
+			CacheWriteTokens: 250,
+			ReasoningTokens:  120,
+			ThinkingMs:       900,
+			Thinking:         "The plan skips the migration.",
+			Iteration:        2,
+		})
+		resEnv, _ := delegate.NewResultEnvelope(delegate.IOResult{Tokens: 20300})
+		_ = writer.Write(resEnv)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mux.Run(ctx); err != nil {
+		t.Fatalf("multiplexer: %v", err)
+	}
+	if len(relayErrs) != 0 {
+		t.Fatalf("relay reported %v", relayErrs)
+	}
+
+	evts := load()
+	reqs := eventsOfType(evts, store.EventLLMRequest)
+	if len(reqs) != 1 {
+		t.Fatalf("llm_request events = %d, want 1 (events: %+v)", len(reqs), evts)
+	}
+	req := reqs[0]
+	if req.NodeID != "plan_review" {
+		t.Errorf("llm_request node = %q, want the launcher's task node", req.NodeID)
+	}
+	if req.Data["model"] != "gpt-5.6-sol" || req.Data["message_count"] != float64(3) ||
+		req.Data["tool_count"] != float64(4) || req.Data["reasoning_effort"] != "high" {
+		t.Errorf("llm_request data = %v, want model/message_count/tool_count/reasoning_effort intact", req.Data)
+	}
+
+	steps := eventsOfType(evts, store.EventLLMStepFinished)
+	if len(steps) != 1 {
+		t.Fatalf("llm_step_finished events = %d, want 1", len(steps))
+	}
+	step := steps[0]
+	want := map[string]any{
+		"step":               float64(1),
+		"input_tokens":       float64(20000),
+		"output_tokens":      float64(300),
+		"cache_read_tokens":  float64(1500),
+		"cache_write_tokens": float64(250),
+		"thinking_tokens":    float64(120),
+		"thinking_ms":        float64(900),
+		"finish_reason":      "tool_use",
+		"tool_calls":         float64(1),
+		"response_text":      "Reading the plan before I judge it.",
+	}
+	for k, v := range want {
+		if step.Data[k] != v {
+			t.Errorf("llm_step_finished %s = %v, want %v", k, step.Data[k], v)
+		}
+	}
+	if _, present := step.Data["thinking"]; present {
+		t.Error("thinking text persisted on the event — the in-process hook keeps it out of events.jsonl")
+	}
+
+	// Derived by the host hooks from the relayed step, exactly as in-process.
+	if narr := eventsOfType(evts, store.EventAssistantText); len(narr) != 1 || narr[0].Data["text"] != "Reading the plan before I judge it." {
+		t.Errorf("assistant_text events = %+v, want the tool-bearing step's narration", narr)
+	}
+	ups := eventsOfType(evts, store.EventUsageProgress)
+	if len(ups) != 1 {
+		t.Fatalf("usage_progress events = %d, want 1 — a 22k-token step is past the sampling floor", len(ups))
+	}
+	if ups[0].Data["tokens"] != float64(20000+300+1500+250) || ups[0].Data["model"] != "gpt-5.6-sol" {
+		t.Errorf("usage_progress data = %v, want the step's tokens priced on the relayed model", ups[0].Data)
+	}
+}
+
+// A payload a newer runner may relay and this host does not consume is
+// dropped, never fatal; a payload of a known type that does not decode is
+// an error the caller must surface — the node's metering is incomplete.
+func TestApplyRelayedEvent_UnknownIsDroppedMalformedIsAnError(t *testing.T) {
+	var fired int
+	hooks := EventHooks{OnLLMStepFinish: func(string, LLMStepInfo) { fired++ }}
+
+	handled, err := ApplyRelayedEvent(hooks, "n", "tool_called", map[string]any{"name": "bash"})
+	if handled || err != nil {
+		t.Fatalf("unknown type: handled=%v err=%v, want dropped without error", handled, err)
+	}
+	handled, err = ApplyRelayedEvent(hooks, "n", string(store.EventLLMStepFinished), map[string]any{"input_tokens": "twelve"})
+	if !handled || err == nil {
+		t.Fatalf("malformed known type: handled=%v err=%v, want an error", handled, err)
+	}
+	if fired != 0 {
+		t.Fatalf("hook fired %d time(s) on a malformed payload", fired)
+	}
+}
+
+// The launcher-side handler surfaces a decode failure instead of dropping
+// it: the run log names the node and the event type.
+func TestSandboxRelay_HostWarnsOnAnUndecodableRelayedEvent(t *testing.T) {
+	var logBuf strings.Builder
+	b := NewClawBackend(NewRegistry(), EventHooks{}, RetryPolicy{}, WithClawLogger(iterlog.New(iterlog.LevelWarn, &logBuf)))
+	handler := b.multiplexerHandler(context.Background(), delegate.Task{NodeID: "plan_review"})
+	handler.OnEvent(string(store.EventLLMRequest), map[string]any{"model": 42})
+	if !strings.Contains(logBuf.String(), "plan_review") || !strings.Contains(logBuf.String(), "llm_request") {
+		t.Fatalf("no warning naming the node and event type, log: %q", logBuf.String())
+	}
+}
+
+// A write that fails is reported, not swallowed: the runner cannot return
+// an error from a hook, and a dead channel must leave a trace.
+func TestSandboxRelayHooks_ReportsAFailedWrite(t *testing.T) {
+	var reported []error
+	hooks := SandboxRelayHooks(
+		func(delegate.Envelope) error { return errors.New("broken pipe") },
+		func(err error) { reported = append(reported, err) },
+	)
+	hooks.OnLLMRequest("n", LLMRequestInfo{Model: "m"})
+	if len(reported) != 1 || !strings.Contains(reported[0].Error(), "llm_request") || !strings.Contains(reported[0].Error(), "broken pipe") {
+		t.Fatalf("reported = %v, want one error naming the event and the cause", reported)
+	}
+}

--- a/pkg/runner/cred_spend_test.go
+++ b/pkg/runner/cred_spend_test.go
@@ -1,7 +1,9 @@
 package runner
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,5 +178,95 @@ func TestRecordCredentialSpend_IsInertWithoutACounterOrCredentials(t *testing.T)
 	r2.recordCredentialSpend(context.Background(), &queue.RunMessage{RunID: "x"}, usage, time.Now())
 	if rows, _ := counter.List(context.Background(), time.Now(), ""); len(rows) != 0 {
 		t.Fatalf("rows = %+v, want none", rows)
+	}
+}
+
+// #805 — the production shape: a claw plan-review node served by the
+// platform's codex forfait, executed inside the sandbox, observed by the
+// runner as delegate_started + delegate_finished only. The run also holds the
+// team's claude_code forfait. The codex slot must be the one charged — the
+// tokens used to land on the claude forfait's fingerprint, because an
+// unnamed model fell to claw's default (anthropic) wire.
+func TestRecordCredentialSpend_SandboxedClawChargesTheCodexSlot(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	r := &Runner{cfg: Config{Logger: iterlog.Nop(), CredUsage: counter}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{
+			delegate.BackendClaudeCode:     "/tmp/oauth-claude",
+			string(secrets.OAuthKindCodex): "/tmp/oauth-codex",
+		},
+		PlatformSourced: map[string]bool{string(secrets.OAuthKindCodex): true},
+		Fingerprints: map[string]string{
+			delegate.BackendClaudeCode:     "fp-claude-forfait",
+			string(secrets.OAuthKindCodex): "fp-codex-platform",
+		},
+	})
+	usage := newMetricsEmitter(nil, nil)
+	usage.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "plan_review",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "plan_review",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol", "tokens": float64(25000)}})
+
+	now := time.Now().UTC()
+	r.recordCredentialSpend(ctx, &queue.RunMessage{RunID: "run-805", TenantID: "team-a"}, usage, now)
+
+	rows, err := counter.List(ctx, now, "team-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("recorded %d credential rows, want exactly the codex forfait's: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Fingerprint != "fp-codex-platform" {
+		t.Fatalf("charged fingerprint %q, want fp-codex-platform — the OpenAI tokens landed on the Anthropic credential", row.Fingerprint)
+	}
+	if row.InputTokens != 25000 {
+		t.Errorf("input tokens = %d, want 25000", row.InputTokens)
+	}
+	if row.CostUSD <= 0 {
+		t.Errorf("cost = %v, want > 0 — a priced model's delegation is not a free call", row.CostUSD)
+	}
+	if row.Tier != credusage.TierPlatform || row.Nature != credusage.NatureEstimate {
+		t.Errorf("tier/nature = %s/%s, want platform/estimate (a subscription's would-have-cost figure)", row.Tier, row.Nature)
+	}
+	if len(row.Backends) != 1 || row.Backends[0] != "claw" {
+		t.Errorf("backends = %v, want [claw]", row.Backends)
+	}
+}
+
+// A route iterion cannot attribute is declined for good at the end of the
+// attempt, so the decline is a WARN — a debug line is silent on a production
+// runner and left the misattribution unseen for a week. Once per route.
+func TestRecordCredentialSpend_WarnsOnceOnAnUnattributableRoute(t *testing.T) {
+	var logBuf bytes.Buffer
+	counter := credusage.NewMemoryCounter()
+	r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelWarn, &logBuf), CredUsage: counter}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:      map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-a"},
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): "fp-a"},
+	})
+	usage := newMetricsEmitter(nil, nil)
+	usage.observe(store.Event{Type: store.EventLLMRequest, NodeID: "n",
+		Data: map[string]any{"model": "google/gemini-3"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "pi", "tokens": float64(10), "cost_usd": 0.5}})
+
+	now := time.Now().UTC()
+	msg := &queue.RunMessage{RunID: "run-warn", TenantID: "team-c"}
+	r.recordCredentialSpend(ctx, msg, usage, now)
+	r.recordCredentialSpend(ctx, msg, usage, now)
+
+	logged := logBuf.String()
+	if n := strings.Count(logged, "no credential iterion can name"); n != 1 {
+		t.Fatalf("decline logged %d time(s) at warn, want exactly 1:\n%s", n, logged)
+	}
+	for _, want := range []string{"run-warn", "pi/google/gemini-3"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("warn line does not name %q:\n%s", want, logged)
+		}
+	}
+	if rows, _ := counter.List(ctx, now, "team-c"); len(rows) != 0 {
+		t.Fatalf("rows = %+v, want none: the decline must not charge anybody", rows)
 	}
 }

--- a/pkg/runner/loop_cred_spend.go
+++ b/pkg/runner/loop_cred_spend.go
@@ -49,9 +49,13 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 	for route, totals := range routes {
 		slot := credentialSlotForRoute(creds, route.backend, route.model)
 		if slot == "" {
-			if r.cfg.Logger != nil {
-				r.cfg.Logger.Debug("runner: run %s spent on %s/%s with no credential iterion can name — not metered per credential",
-					msg.RunID, route.backend, route.model)
+			// Declined for good: the attempt is over and nothing will name
+			// this route's credential later, so the decline is a warning —
+			// a debug line is silent on a production runner. Once per route.
+			if r.cfg.Logger != nil && usage.noteDeclinedRoute(route) {
+				r.cfg.Logger.Warn("runner: run %s spent %d tokens ($%.4f) on %s/%s with no credential iterion can name (wire %q) — not metered per credential",
+					msg.RunID, totals.inputTokens+totals.outputTokens, totals.costUSD,
+					route.backend, route.model, wireForRoute(route.backend, route.model))
 			}
 			continue
 		}

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/SocialGouv/iterion/pkg/backend/cost"
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -26,19 +27,36 @@ type metricsEmitter struct {
 	inner model.EventEmitter
 	reg   *metrics.Registry
 
-	// modelByNode caches the last model name reported by an
-	// llm_request event for a given node, so the subsequent
-	// llm_step_finished events can be labelled even though the step
-	// payload itself doesn't repeat the model field.
+	// modelByNode names the model each node's route is keyed on. Seeded by
+	// delegate_started (the node's declared spec, provider included),
+	// refined by llm_request (the id the call actually went to) and by
+	// delegate_finished's effective_model — each re-qualified with the
+	// declared provider when a backend reports the same model bare, see
+	// routeModel. The step events carry no model of their own; this is
+	// where they read it.
+	//
+	// declaredByNode keeps the declared spec beside it, because a bare
+	// reported id needs the provider the declaration carried.
+	//
+	// stepsSeen marks a node whose CURRENT attempt produced
+	// llm_step_finished events (each delegate_started opens a new attempt).
+	// It decides whether a claw delegation total is a summary of steps
+	// already counted or the only observation there is.
 	//
 	// priceByModel caches the resolved per-token rates so the
 	// cost.EstimateUSD path (which hits claw's live registry — a disk
 	// read + JSON parse each call) doesn't fire on every step event.
 	// A workflow with 50 steps × 10 parallel branches would otherwise
 	// serialise 500 disk hits through the metrics emitter mutex.
-	mu           sync.Mutex
-	modelByNode  map[string]string
-	priceByModel map[string]modelRate
+	mu             sync.Mutex
+	modelByNode    map[string]string
+	declaredByNode map[string]string
+	stepsSeen      map[string]bool
+	priceByModel   map[string]modelRate
+
+	// declinedRoutes remembers the routes recordCredentialSpend could name
+	// no credential for, so that decline is warned once per route.
+	declinedRoutes map[routeKey]bool
 
 	// Per-run accumulation for org metering. Covers both claw steps and
 	// delegate calls; a node whose model the price table cannot price
@@ -89,12 +107,51 @@ type routeTotals struct {
 
 func newMetricsEmitter(inner model.EventEmitter, reg *metrics.Registry) *metricsEmitter {
 	return &metricsEmitter{
-		inner:        inner,
-		reg:          reg,
-		modelByNode:  make(map[string]string),
-		priceByModel: make(map[string]modelRate),
-		byRoute:      make(map[routeKey]routeTotals),
+		inner:          inner,
+		reg:            reg,
+		modelByNode:    make(map[string]string),
+		declaredByNode: make(map[string]string),
+		stepsSeen:      make(map[string]bool),
+		priceByModel:   make(map[string]modelRate),
+		byRoute:        make(map[routeKey]routeTotals),
+		declinedRoutes: make(map[routeKey]bool),
 	}
+}
+
+// routeModel names the model a node's route is keyed on, from the spec the
+// node declared and the id a backend reported. Backends report the id they
+// CALLED — claw strips the provider prefix before the request, so its
+// llm_request carries a bare id — and a bare id names no provider: keyed on
+// it, the route falls to the backend's default wire and an OpenAI model's
+// tokens are charged to the Anthropic credential. When the report is the
+// declared model without its prefix, the declared spec names the route; a
+// different id (a fallback element) is kept as reported.
+func routeModel(declared, reported string) string {
+	switch {
+	case reported == "":
+		return declared
+	case declared == "" || strings.Contains(reported, "/"):
+		return reported
+	case delegate.SameModelID(declared, reported):
+		return declared
+	}
+	return reported
+}
+
+// noteDeclinedRoute records that no credential could be named for a route
+// and reports whether this is the first time — the warning it gates is
+// written once per route per attempt.
+func (m *metricsEmitter) noteDeclinedRoute(k routeKey) (first bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.declinedRoutes[k] {
+		return false
+	}
+	if m.declinedRoutes == nil {
+		m.declinedRoutes = make(map[routeKey]bool)
+	}
+	m.declinedRoutes[k] = true
+	return true
 }
 
 // addRouteLocked folds one observation into its (backend, model) bucket.
@@ -219,10 +276,24 @@ func (m *metricsEmitter) RecordNodeServed(ctx context.Context, runID, nodeID str
 
 func (m *metricsEmitter) observe(evt store.Event) {
 	switch evt.Type {
+	case store.EventDelegateStarted:
+		if evt.NodeID == "" {
+			return
+		}
+		declared, _ := evt.Data["declared_model"].(string)
+		m.mu.Lock()
+		// A new attempt of the node: whether its steps are observed is
+		// decided afresh.
+		delete(m.stepsSeen, evt.NodeID)
+		if declared != "" {
+			m.declaredByNode[evt.NodeID] = declared
+			m.modelByNode[evt.NodeID] = declared
+		}
+		m.mu.Unlock()
 	case store.EventLLMRequest:
 		if model, _ := evt.Data["model"].(string); model != "" && evt.NodeID != "" {
 			m.mu.Lock()
-			m.modelByNode[evt.NodeID] = model
+			m.modelByNode[evt.NodeID] = routeModel(m.declaredByNode[evt.NodeID], model)
 			m.mu.Unlock()
 		}
 	case store.EventLLMStepFinished:
@@ -237,6 +308,9 @@ func (m *metricsEmitter) observe(evt store.Event) {
 		// the addTokens helper run AFTER the unlock — counter Add is
 		// atomic on the vec, addTokens reads only its locals.
 		m.mu.Lock()
+		if evt.NodeID != "" {
+			m.stepsSeen[evt.NodeID] = true
+		}
 		modelName := m.modelByNode[evt.NodeID]
 		if modelName == "" {
 			modelName = "unknown"
@@ -301,37 +375,58 @@ func (m *metricsEmitter) observe(evt store.Event) {
 			backend = "delegate"
 		}
 		tokensF := toFloat(evt.Data["tokens"])
-		// The delegate already priced this call (its own CLI figure, or the
-		// token estimate a subscription session falls back to) and carries
-		// the result on the event. Accumulating it here is what keeps a
-		// claude_code run from reporting $0 spend for the whole attempt —
-		// which is what every downstream consumer of RunTotals (org monthly
-		// cost cap, credential-pool quota) is metering on. Absent key = the
-		// price table didn't know the model, so nothing is recorded.
-		//
-		// claw is excluded. It is an in-process backend but still dispatches
-		// through the same observability hook, so it emits BOTH a
-		// llm_step_finished per step (priced above, off the same table) and
-		// this delegation total — counting both would charge every claw run
-		// twice, tripping an org's monthly cap at half its budget and
-		// draining a lending donor at twice the rate they agreed to.
-		var costDelta float64
-		if backend != "claw" {
-			costDelta = toFloat(evt.Data["cost_usd"])
-		}
+		effective, _ := evt.Data["effective_model"].(string)
 
 		// Single critical section: resolve the per-node model name and
 		// accumulate the aggregated token count. Prometheus write
 		// happens after the unlock via addTokens (counter Add is atomic).
 		m.mu.Lock()
+		if effective != "" && evt.NodeID != "" {
+			m.modelByNode[evt.NodeID] = routeModel(m.declaredByNode[evt.NodeID], effective)
+		}
 		modelName := m.modelByNode[evt.NodeID]
-		m.runInputTokens += int64(tokensF)
-		m.runCostUSD += costDelta
-		// The delegate reports one aggregated token count; booked as input
-		// here for the same reason addTokens labels it that way, so a sum
-		// across directions stays meaningful.
-		m.addRouteLocked(backend, modelName, costDelta, int64(tokensF), 0)
+		// claw dispatches through the same observability hook as the CLI
+		// delegates, so when its LLM loop has been observed step by step
+		// (llm_step_finished, counted and priced above) this delegation
+		// total is the SUM of those steps: counting it again would charge
+		// every claw run twice — an org's monthly cap tripping at half its
+		// budget, a lending donor drained at twice the rate they agreed to.
+		// The steps are the evidence, not the backend name: a claw loop in a
+		// sandbox container relays them across the IPC, and an in-container
+		// runner too old to relay them leaves this total as the only
+		// observation there is — which is then booked like any delegate's.
+		summarised := backend == "claw" && m.stepsSeen[evt.NodeID]
+		var costDelta float64
+		if !summarised {
+			// The delegate already priced this call (its own CLI figure, the
+			// token estimate a subscription session falls back to, or claw's
+			// in-container annotation) and carries the result on the event;
+			// accumulating it is what keeps a claude_code run from reporting
+			// $0 for the whole attempt — the number every consumer of
+			// RunTotals (org monthly cost cap, credential-pool quota) meters
+			// on. An absent key means the delegate's price sources did not
+			// know the model. claw's sources were consulted in the container,
+			// where no cache may exist yet, so the host prices the aggregate
+			// off its own — at the INPUT rate, a floor: one aggregate count
+			// cannot be split into input and output, and output is dearer. A
+			// model no source prices stays at zero: unknown, never free.
+			costDelta = toFloat(evt.Data["cost_usd"])
+			if costDelta == 0 && backend == "claw" && tokensF > 0 && modelName != "" {
+				if rate := m.rateForLocked(modelName); rate.known {
+					costDelta = tokensF * rate.inputUSDPerToken
+				}
+			}
+			m.runInputTokens += int64(tokensF)
+			m.runCostUSD += costDelta
+			// The delegate reports one aggregated token count; booked as
+			// input here for the same reason addTokens labels it that way,
+			// so a sum across directions stays meaningful.
+			m.addRouteLocked(backend, modelName, costDelta, int64(tokensF), 0)
+		}
 		m.mu.Unlock()
+		if summarised {
+			return
+		}
 
 		// Delegate events report a single aggregated token count;
 		// label as input so a sum across directions stays meaningful.

--- a/pkg/runner/metrics_test.go
+++ b/pkg/runner/metrics_test.go
@@ -2,12 +2,14 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -380,9 +382,14 @@ func TestMetricsEmitter_clawCostIsNotCountedTwice(t *testing.T) {
 		Data: map[string]any{"backend": "claw", "tokens": float64(1500), "cost_usd": perStep},
 	})
 
-	total, _, _ := usage.RunTotals()
+	total, in, out := usage.RunTotals()
 	if total != perStep {
 		t.Errorf("cost = %v after the delegation total, want %v — claw was charged twice", total, perStep)
+	}
+	// The delegation total is the SUM of the steps already counted: booking
+	// it again doubles the token figure on the org bucket and the ledger.
+	if in != 1000 || out != 500 {
+		t.Errorf("tokens = %d in / %d out after the delegation total, want 1000 / 500 — claw's tokens were counted twice", in, out)
 	}
 }
 
@@ -396,5 +403,196 @@ func TestMetricsEmitter_cliDelegateCostIsStillCounted(t *testing.T) {
 	})
 	if cost, _, _ := usage.RunTotals(); cost != 0.42 {
 		t.Errorf("cost = %v, want 0.42", cost)
+	}
+}
+
+// #805 — the production shape of a sandboxed claw node. The LLM loop runs in
+// `iterion __claw-runner` inside the container; an in-container runner that
+// relays no per-step events leaves the host with the delegation pair alone:
+// delegate_started names the model, delegate_finished carries one aggregate
+// token count and, when the container could not price the call, no cost. The
+// route must still be the node's provider-qualified model — an empty or bare
+// model falls to the backend's default wire and charges an OpenAI forfait's
+// tokens to the Anthropic credential — with the tokens booked and a price
+// taken off the table rather than the $0 the claw double-count guard used to
+// leave (a pool donor "reads $0 forever").
+func TestMetricsEmitter_sandboxedClaw_delegateOnlyIsPricedAndRouted(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	ctx := context.Background()
+
+	_, _ = usage.AppendEvent(ctx, "run-1", store.Event{
+		Type: store.EventDelegateStarted, RunID: "run-1", NodeID: "plan_review",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"},
+	})
+	_, _ = usage.AppendEvent(ctx, "run-1", store.Event{
+		Type: store.EventDelegateFinished, RunID: "run-1", NodeID: "plan_review",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol", "tokens": float64(25000)},
+	})
+
+	routes := usage.RouteTotals()
+	got, ok := routes[routeKey{backend: "claw", model: "openai/gpt-5.6-sol"}]
+	if !ok {
+		t.Fatalf("routes = %v, want one keyed (claw, openai/gpt-5.6-sol) — the declared model must name the route", routes)
+	}
+	if got.inputTokens != 25000 {
+		t.Errorf("route input tokens = %d, want 25000", got.inputTokens)
+	}
+	if got.costUSD <= 0 {
+		t.Errorf("route cost = %v, want > 0: the table prices gpt-5.6-sol, and a delegation the guard excluded is not a free call", got.costUSD)
+	}
+	cost, in, _ := usage.RunTotals()
+	if cost != got.costUSD || in != 25000 {
+		t.Errorf("RunTotals = ($%v, %d) — must mirror the route (%+v)", cost, in, got)
+	}
+}
+
+// The delegation's own figure is exact (the container split input from output
+// when it priced the call); the host-side table price is only for a delegation
+// that carries none.
+func TestMetricsEmitter_sandboxedClaw_delegateCostWinsOverTheTable(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	usage.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "tokens": float64(25000), "cost_usd": 0.1234}})
+	if cost, in, _ := usage.RunTotals(); cost != 0.1234 || in != 25000 {
+		t.Fatalf("RunTotals = ($%v, %d), want ($0.1234, 25000)", cost, in)
+	}
+}
+
+// Zero is unknown, never free: a delegation no source can price books its
+// tokens on the route and leaves the cost at zero — no fabricated figure.
+func TestMetricsEmitter_sandboxedClaw_unknownModelStaysUnpriced(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	usage.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-99-nowhere"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "tokens": float64(400)}})
+	cost, in, _ := usage.RunTotals()
+	if cost != 0 {
+		t.Errorf("cost = %v for a model no source prices, want 0 (unknown)", cost)
+	}
+	if in != 400 {
+		t.Errorf("input tokens = %d, want 400 — the tokens are known even when the price is not", in)
+	}
+	if _, ok := usage.RouteTotals()[routeKey{backend: "claw", model: "openai/gpt-99-nowhere"}]; !ok {
+		t.Errorf("routes = %v, want the unpriced route present so the credential still sees its tokens", usage.RouteTotals())
+	}
+}
+
+// The in-process shape of the same class. claw strips the provider before the
+// call, so its llm_request reports the BARE id; keyed on that, the route of a
+// claw node on an OpenAI model falls to the anthropic wire exactly like the
+// sandboxed one did. The declared model supplies the provider the report
+// dropped — for the same model only; a different id (a fallback element) is
+// kept as reported.
+func TestMetricsEmitter_bareStepModelKeepsTheDeclaredProvider(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	usage.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}})
+	usage.observe(store.Event{Type: store.EventLLMRequest, NodeID: "n",
+		Data: map[string]any{"model": "gpt-5.6-sol"}})
+	usage.observe(store.Event{Type: store.EventLLMStepFinished, NodeID: "n",
+		Data: map[string]any{"input_tokens": float64(1000), "output_tokens": float64(100)}})
+	routes := usage.RouteTotals()
+	if _, ok := routes[routeKey{backend: "claw", model: "openai/gpt-5.6-sol"}]; !ok {
+		t.Fatalf("routes = %v, want (claw, openai/gpt-5.6-sol): the bare step id must inherit the declared provider", routes)
+	}
+
+	other := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	other.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}})
+	other.observe(store.Event{Type: store.EventLLMRequest, NodeID: "n",
+		Data: map[string]any{"model": "claude-opus-5"}})
+	other.observe(store.Event{Type: store.EventLLMStepFinished, NodeID: "n",
+		Data: map[string]any{"input_tokens": float64(10), "output_tokens": float64(1)}})
+	if _, ok := other.RouteTotals()[routeKey{backend: "claw", model: "claude-opus-5"}]; !ok {
+		t.Fatalf("routes = %v, want (claw, claude-opus-5): a different model than declared is not re-labelled", other.RouteTotals())
+	}
+}
+
+// delegate_finished.effective_model is what the provider reports it ran; when
+// present it names the route over the declared model.
+func TestMetricsEmitter_effectiveModelNamesTheRoute(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	usage.observe(store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claude_code", "declared_model": "anthropic/claude-opus-5"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "claude_code", "declared_model": "anthropic/claude-opus-5",
+			"effective_model": "claude-sonnet-4-6", "tokens": float64(900), "cost_usd": 0.42}})
+	routes := usage.RouteTotals()
+	if r, ok := routes[routeKey{backend: "claude_code", model: "claude-sonnet-4-6"}]; !ok || r.costUSD != 0.42 {
+		t.Fatalf("routes = %v, want (claude_code, claude-sonnet-4-6) carrying $0.42", routes)
+	}
+}
+
+// The sandboxed shape WITH the relay, through the production hooks on both
+// sides: the in-container runner's hooks encode each step, the host decodes
+// and re-fires them through its store hooks — whose emitter is this metrics
+// emitter on a runner pod — around the delegation pair the host emits
+// itself. The route is named by the declared spec, the tokens are the
+// steps' exact input/output split, the cost is the steps' price, and the
+// delegation total (a summary of those steps) is not booked again.
+func TestMetricsEmitter_relayedSandboxedClawStepsMeterLikeInProcess(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	host := model.NewStoreEventHooks(context.Background(), usage, "run-relay", iterlog.New(iterlog.LevelError, nil), nil)
+	relay := model.SandboxRelayHooks(func(env delegate.Envelope) error {
+		var ed delegate.EventData
+		if err := json.Unmarshal(env.Data, &ed); err != nil {
+			return err
+		}
+		_, err := model.ApplyRelayedEvent(host, "plan_review", ed.Type, ed.Payload)
+		return err
+	}, func(err error) { t.Errorf("relay: %v", err) })
+
+	host.OnDelegateStarted("plan_review", model.DelegateInfo{BackendName: "claw", DeclaredModel: "openai/gpt-5.6-sol"})
+	relay.OnLLMRequest("plan_review", model.LLMRequestInfo{Model: "gpt-5.6-sol"})
+	relay.OnLLMStepFinish("plan_review", model.LLMStepInfo{Number: 1, InputTokens: 20000, OutputTokens: 3000})
+	relay.OnLLMStepFinish("plan_review", model.LLMStepInfo{Number: 2, InputTokens: 20000, OutputTokens: 3000})
+	stepsCost, _, _ := usage.RunTotals()
+	if stepsCost <= 0 {
+		t.Fatalf("the relayed steps priced to %v — gpt-5.6-sol is in the table", stepsCost)
+	}
+	host.OnDelegateFinished("plan_review", model.DelegateInfo{BackendName: "claw", DeclaredModel: "openai/gpt-5.6-sol", Tokens: 46000, CostUSD: 0.5})
+
+	routes := usage.RouteTotals()
+	got, ok := routes[routeKey{backend: "claw", model: "openai/gpt-5.6-sol"}]
+	if !ok {
+		t.Fatalf("routes = %v, want (claw, openai/gpt-5.6-sol)", routes)
+	}
+	if got.inputTokens != 40000 || got.outputTokens != 6000 {
+		t.Errorf("route tokens = %d in / %d out, want 40000 / 6000 — the steps' split, counted once", got.inputTokens, got.outputTokens)
+	}
+	if got.costUSD != stepsCost {
+		t.Errorf("route cost = %v, want the steps' %v — the delegation total was re-priced", got.costUSD, stepsCost)
+	}
+	if len(routes) != 1 {
+		t.Errorf("routes = %v, want the one route", routes)
+	}
+	if cost, in, out := usage.RunTotals(); cost != stepsCost || in != 40000 || out != 6000 {
+		t.Errorf("RunTotals = ($%v, %d, %d), want ($%v, 40000, 6000)", cost, in, out, stepsCost)
+	}
+}
+
+// A node's second attempt (a loop iteration, a retry) opens with a fresh
+// delegate_started; whether its steps were seen is decided per attempt, so a
+// relayed first pass never hides an unrelayed second one.
+func TestMetricsEmitter_newAttemptResetsTheStepGuard(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	start := store.Event{Type: store.EventDelegateStarted, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}}
+	usage.observe(start)
+	usage.observe(store.Event{Type: store.EventLLMStepFinished, NodeID: "n",
+		Data: map[string]any{"input_tokens": float64(1000), "output_tokens": float64(0)}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "tokens": float64(1000)}})
+	if _, in, _ := usage.RunTotals(); in != 1000 {
+		t.Fatalf("after a summarised first attempt: input tokens = %d, want 1000", in)
+	}
+	usage.observe(start)
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": "claw", "tokens": float64(500)}})
+	if _, in, _ := usage.RunTotals(); in != 1500 {
+		t.Fatalf("after an unrelayed second attempt: input tokens = %d, want 1500 — the guard must reset per attempt", in)
 	}
 }


### PR DESCRIPTION
Closes #805.

## Measured
On ovh-prod, the campaign bots' `plan_review` peer ran 37 times in 7 days on `claw` / `openai/gpt-5.6-sol` (33 served, 4 skipped on the forfait's 429). The per-credential counter had **no row for the codex forfait**, every claw delegation was booked at **$0**, and its tokens landed on the **claude** forfait's fingerprint.

## Root cause — one level deeper than the issue
- The in-container claw (`cmd/iterion/claw_runner.go`) was built with empty `EventHooks{}`, and the host `multiplexerHandler` (`pkg/backend/model/claw_backend.go`) wired no `OnEvent`: the IPC `event` envelope existed in the protocol and nothing ever flowed through it. Correction to the issue text: `usage_progress` / `tool_*` / `assistant_text` did **not** come back for sandboxed claw nodes either — the ones seen in the 68 runs came from the claude_code nodes.
- The runner's emitter then excluded the claw delegation cost (its double-count guard assumes per-step events), never learnt the node's model (only `llm_request` set it), and `wireForRoute("claw", "")` fell to the anthropic wire.
- Same class in-process: `llm_request.model` is the **bare** id (claw strips the provider before the call), so an unsandboxed claw node on `openai/gpt-5.6-sol` produced route `(claw, gpt-5.6-sol)` → anthropic wire too — and claw's tokens were **counted twice** (steps + delegation total; only the cost was excluded).

## What changes
1. **Relay** (`pkg/backend/model/sandbox_relay.go`, new): the runner side encodes `llm_request` + `llm_step_finished` as `event` envelopes on the existing IPC writer; the host side re-fires its own store hooks from them — same events, same `assistant_text` / `usage_progress` derivation, same code. Undecodable known payload → Warn in the run log; unknown type → dropped (forward-compat); write failure → stderr (captured into the node error).
2. **Emitter belt** (`pkg/runner/loop_metrics.go`): the node's model is seeded from `delegate_started.declared_model`, refined by `llm_request` and `effective_model`; a backend reporting the same model bare keeps the declared provider-qualified name. The claw exclusion is now evidence-based (`stepsSeen` per attempt, reset on `delegate_started`): steps seen → the delegation total is skipped for cost AND tokens; none seen → booked on the route, priced from the event's `cost_usd`, else from the host table at the input rate (a documented floor), else left at 0 — unknown is never free.
3. **`loop_cred_spend.go`**: an unattributable route is a **Warn**, once per route per attempt, naming run, tokens, cost, `backend/model` and wire.
4. **Pricing**: static entries for the `gpt-5.6` family (`gpt-5.6` alias → `-sol` 4.00/20.00, `-terra` 2.00/12.00, `-luna` 0.20/1.20), verified against https://developers.openai.com/api/docs/pricing and the model page; the aggregator's bare-id consensus is zeroed by reseller quotes and a cold container has no cache, which is why 24/33 prod delegations carried no price. `iterion models pricing`: four `gpt-5.6*` rows `ok`, `0 model(s) need a decision`.
5. **Docs**: `docs/sandbox.md` (what the `__claw-runner` now relays and what it still does not) and `docs/quotas-and-limits.md` (route-model provenance, the sandboxed-claw contract incl. the input-rate floor, the Warn).

## Relay table (runner → host)
| event | before | after |
|---|---|---|
| `llm_request`, `llm_step_finished` | never crossed | relayed with their data |
| `usage_progress`, `assistant_text` | absent for sandboxed claw | derived host-side from the relayed steps |
| `delegate_started/finished` | host-emitted | unchanged |
| in-container `tool_started/tool_called`, `llm_retry`, `llm_compacted`, `llm_turn_capture` | not relayed | still not relayed — documented gap, separate ticket |

## Tests (red first — failing line, then green)
`TestMetricsEmitter_sandboxedClaw_delegateOnlyIsPricedAndRouted` (`routes = map[{claw }:{0 25000 0}]`), `…_delegateCostWinsOverTheTable`, `…_unknownModelStaysUnpriced`, `TestMetricsEmitter_bareStepModelKeepsTheDeclaredProvider`, `…_effectiveModelNamesTheRoute`, `…_newAttemptResetsTheStepGuard`, `…_clawCostIsNotCountedTwice` (extended: `tokens = 2500 in, want 1000`), `TestRecordCredentialSpend_SandboxedClawChargesTheCodexSlot` (`charged "fp-claude-forfait", want fp-codex-platform`), `…_WarnsOnceOnAnUnattributableRoute`, `TestStaticTable_PricesTheGPT56Family`, `TestSandboxRelay_StepEventsCrossTheWireIntoTheHostStore` (real multiplexer → handler → store hooks; red: "the launcher's multiplexer handler has no OnEvent"), `…_relayedSandboxedClawStepsMeterLikeInProcess`, `TestClawRunner_RelayHooksCrossTheWireAsEventEnvelopes` + `…_RelayReportsADeadChannelOnStderr`.
`go build ./...` · `go test ./pkg/runner/... ./pkg/backend/model/... ./pkg/backend/cost/... ./cmd/...` green · `task lint` 0 issues.

## Consumers now seeing claw spend in the sandboxed shape
`recordOrgSpend` (org bucket, once), `recordCredentialSpend` (codex slot; Warn on decline), `recordPoolSpend` (donor ledger no longer $0), subbot child runs (same emitter), Prometheus `LLMTokensTotal` / `LLMCostUSDTotal` (model label instead of `unknown`, no double count).

## Left as separate findings
Tool observability of a sandboxed claw node is absent end to end (in-container builtins fire no `tool_*`; `llm_turn_capture` / `llm_retry` never cross — the same seam would carry them, the 4 MiB line cap needs a decision); a claw fallback element served on a different bare model than declared still keys the route on the bare id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
