### PR TITLE
fix(server): the board dispatcher never claims a card it cannot launch, and a column iterion wrote on its own authority is not reflected onto the bound board

### DIFF
--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -545,14 +545,42 @@ Everything else follows the shipped doctrine:
   truth from the board and the cards on every run, so a missed transition costs
   a delay of at most one interval, never a permanent divergence. That is why it
   has a named owner (§10) rather than a sentence in a doc.
-- **A machine-caused move still reaches the roadmap.** The trigger spine
-  declines `tracker.IsMachineReason` events (watchdog, state/field rename) for
-  *launches*, because they must not spend budget. The pass form needs no
-  exemption for that gate: it reads the card's CURRENT column, so a watchdog
-  filing a card in `blocked` is reflected like any other move — which is
-  precisely what the roadmap must show. The projection arm added by the
-  addendum below states that exemption explicitly instead of inheriting it,
-  since it *does* ride the shared admission prelude.
+- **A machine-caused move does NOT reach the roadmap** (superseded by the
+  #798 addendum below; the original text exempted the projection from the
+  `tracker.IsMachineReason` decline and let a watchdog park be reflected like
+  any other move). The roadmap follows people and run verdicts; iterion's own
+  bookkeeping — a watchdog park, a column rename, a card given back after a
+  launch that never happened — is left alone and counted (`reflect_machine`).
+
+#### Addendum (issue #798) — machine provenance is persisted on the card, and never projected
+
+The pilot on SocialGouv/203 moved 36 *Planned* tickets to `ready`; the cloud
+board dispatcher claimed every one, failed "card has no bot", parked them
+`blocked`, and the reflect pushed *Blocked* onto 30 roadmap tickets as if a
+human had moved them. Two decisions follow:
+
+1. **The reflect judges the CARD's provenance, not the event.** The store now
+   stamps `Issue.StateReason` at every transition on both twins — the same
+   value the state event's `reason` carries (`native.StateProvenance`, one
+   derivation), so the two cannot disagree — and `Issue.StateByMachine()` is
+   the enumerated `tracker.IsMachineReason` over it. `reflectNativeState`, the
+   ONE reflect both callers share, refuses such a card (counted, not warned,
+   like `reflect_no_column`); `projectionOwed` materializes no row for a
+   machine-caused event. The pass, which sees no event, needed the marker on
+   the card; the fast path reads the same marker so a row queued before the
+   card's provenance was known retires through the same answer.
+2. **What stays reflected is what the ADR was written for**: the dispatcher's
+   own fenced moves carry no machine reason — `in_progress` at launch, `done`
+   after a finished run, `blocked` after a failed one — and a person's move
+   never does. The Context's motivating case ("a bot moves a native card to
+   `done`; the board still shows *Planned*") still holds.
+
+The cause itself is closed upstream of the reflect: the dispatcher's candidate
+query requires a bot (`ListDispatchable`), its tick checks the launch
+preconditions before the claim, and a card that still cannot be launched after
+the claim is returned to its column under the machine `unlaunchable`
+provenance — never parked `blocked` (docs/dispatcher.md, *Claim selection on
+the cloud board*).
 
 ### 11. Permissions, stated up front
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -262,6 +262,41 @@ Each tick (`polling.interval_ms`, default 30s):
 6. **Broadcast snapshot.** Publish to the WS bridge so the dashboard
    shows the new state.
 
+### Claim selection on the cloud board — what is never claimed
+
+The cloud board dispatcher (one per server replica, over the Mongo
+board) has no configured default bot: a card is launchable only if it
+**names a bot**. Its candidate query therefore lists unclaimed cards in
+the launch column **that carry a bot** — the filter is in the query, not
+a skip after the listing, because the batch is capped and bot-less cards
+(never written, so always the oldest) would otherwise fill every batch
+and starve the launchable ones. A `ready` card with no bot is roadmap
+content, typically one a project-board sync moved there (the default map
+lands every *Planned* ticket in `ready`, see
+[github-board-sync.md](github-board-sync.md#dispatching-from-the-board));
+it is neither claimed nor moved until something stamps a bot on it.
+
+Before claiming a listed card, the tick runs the **launch
+preconditions** — a run service, a bot, a bot the resolver can find,
+reserved bot-args that parse — and skips a card that fails them in its
+column, without claiming it (the local dispatcher's `resolveExplicitBot`
+shape). The same preconditions guard the launch itself, so a card that
+changed between the listing and the launch is caught there too; nothing
+ran, so **no verdict is written on it**: the card is returned to the
+column it was taken from under the machine provenance `unlaunchable`
+(no subscription re-fires on the return, no external board reflects
+it), and the claim is freed. It is never parked `blocked` — that column
+is a verdict on the card's work, and reaching it here parked 36 roadmap
+tickets in one pass and pushed *Blocked* onto the operator's GitHub
+board. Real launch failures — the publisher refusing the run (quota,
+sealing), a run that started and failed — keep filing `blocked`.
+
+Each refusal is logged **once per card and reason** (the card is listed
+again every tick for as long as it stays broken), and every watchdog
+pass logs one tally line — `N refused at admission, M returned to their
+column after a claim` — so the ongoing cost of a broken card stays
+visible after its first line.
+
 ## Retry queue
 
 | Trigger                       | Delay                                                  |

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -245,11 +245,30 @@ settle it:
   different one. The import owns the join (it hydrates cards, it never creates
   them from items), so the reflect waits for it.
 
-A **machine-caused** move — a claim watchdog filing a card in `blocked`, a
-column rename — is reflected like any other. The trigger spine declines those
-events for *launches* (they must not spend LLM budget); a projection starts no
-run, so it is explicitly exempt. Your roadmap shows what actually happened to
-the card.
+## What is projected — people and run verdicts, never the machinery
+
+The roadmap follows two kinds of native move and ignores a third:
+
+| the card's column was written by | reflected? |
+|---|---|
+| a **person** (studio, CLI, a bot's `board.move` tool) | yes |
+| a **run's verdict** — the dispatcher filing `in_progress` at launch, `done` after a finished run, `blocked` after a failed one, `awaiting_input` on a pause | yes |
+| **iterion on its own authority** — the claim watchdog parking a card, a column rename/delete, the dispatcher giving back a card it could not launch | **no** |
+
+The third kind is *machine provenance*: the store stamps it on the card
+(`state_reason`, the same value the card's state event carries — `watchdog`,
+`state_rename`, `unlaunchable`, …) at every transition, on both the filesystem
+and the Mongo board, and both reflect paths read it off the card. Such a
+column says nothing about the card's work, so pushing it would show on the
+operator's board as if someone had decided it. The pass counts what it left
+alone as `reflect_machine`; the fast path materializes no projection row for
+a machine-caused move at all. The trigger spine applies the same
+`tracker.IsMachineReason` set to *launches*, for the same reason.
+
+The card and the board therefore stay legitimately divergent after a machine
+park — a watchdog-filed `blocked` while GitHub still says *Planned* — until a
+person or a run moves the card again. Reopening the card in iterion, or
+dragging it on GitHub, both clear the divergence on the next pass.
 
 > Setting `--sync-every 0` leaves the fast path running with **no net under
 > it**: a move the outbox dead-letters, or one made while the binding was
@@ -280,7 +299,7 @@ permanent divergence.
 ```
 board sync: team=t_123 board=SocialGouv/203 items=214 moved=2 reflected=1 \
   labelled=3 conflicts=0 refused_terminal=0 reflect_failed=0 reflect_no_column=0 \
-  skipped_no_card=4 skipped_archived=3 skipped=11 took=812ms
+  reflect_machine=0 skipped_no_card=4 skipped_archived=3 skipped=11 took=812ms
 ```
 
 A failed pass logs `Warn` and **does not block the next tick**; one team's
@@ -341,6 +360,17 @@ The dispatcher can take its workflow state from the board instead of labels —
 `tracker.github.project` in the config. Full reference:
 [dispatcher.md](dispatcher.md#board-mode--states-from-a-projects-v2-board-adr-097).
 
+**The default map makes every *Planned* ticket a `ready` card**, and `ready`
+is the column the cloud board dispatcher dispatches from. What keeps a bound
+roadmap from being launched wholesale is the **bot**: the dispatcher only
+claims a `ready` card that names one (there is no default bot on cloud), so a
+roadmap ticket the sync moved to `ready` is roadmap content until something —
+a triage bot via `set_bot`, an operator, a board trigger — stamps a bot on
+it. A card the dispatcher claimed but could not launch after all (its bot was
+cleared or cannot be resolved in between) is given back to its column, never
+parked `blocked`; see
+[dispatcher.md](dispatcher.md#claim-selection-on-the-cloud-board--what-is-never-claimed).
+
 ---
 
 ## Troubleshooting
@@ -374,15 +404,19 @@ mapped column the board lacks). Then check it is not a terminal card:
 which is by design — reopen it in iterion.
 
 **A card moved in iterion but not on GitHub.**
-Four causes, in order of likelihood: the state is unmapped (`review`,
-`waiting_deps`, `awaiting_input`, `backlog` are inert); the binding has
-`sync_every: 0`; the board has no column for that state — `reflect_no_column >
-0`, and `iterion remote board show` says which (a `!` on a mapped column, or a
-`degraded` reason when a column was deleted after the bind, see [Editing a
-bound board's columns](#editing-a-bound-boards-columns)); or the credential
-lacks the write grant — `reflect_failed > 0` with a `403 Resource not
-accessible by integration` in the log means the App's *Projects: Read and
-write* is not approved.
+Five causes, in order of likelihood: the state is unmapped (`review`,
+`waiting_deps`, `awaiting_input`, `backlog` are inert); the move was
+**iterion's own** — a watchdog park, a column rename, a card given back after
+a failed launch — which the roadmap never follows (`reflect_machine > 0`; the
+card's `state_reason` names it, see [What is
+projected](#what-is-projected--people-and-run-verdicts-never-the-machinery));
+the binding has `sync_every: 0`; the board has no column for that state —
+`reflect_no_column > 0`, and `iterion remote board show` says which (a `!` on
+a mapped column, or a `degraded` reason when a column was deleted after the
+bind, see [Editing a bound board's columns](#editing-a-bound-boards-columns));
+or the credential lacks the write grant — `reflect_failed > 0` with a `403
+Resource not accessible by integration` in the log means the App's *Projects:
+Read and write* is not approved.
 
 **A card moved in iterion and reached GitHub, but only minutes later.**
 The [projection effect](#how-fast-a-native-move-reaches-the-board) declined and

--- a/openapi.json
+++ b/openapi.json
@@ -1121,6 +1121,9 @@
             "format": "date-time",
             "type": "string"
           },
+          "state_reason": {
+            "type": "string"
+          },
           "title": {
             "type": "string"
           },

--- a/pkg/dispatcher/boardmongo/admin.go
+++ b/pkg/dispatcher/boardmongo/admin.go
@@ -66,6 +66,7 @@ func (s *Store) migrateState(ctx context.Context, from, to, reason string) (int,
 			continue
 		}
 		iss.State = to
+		iss.StateReason = reason
 		iss.UpdatedAt = time.Now().UTC()
 		if err := s.replace(ctx, &iss, "state"); err != nil {
 			return touched, fmt.Errorf("boardmongo: write %s during state migration: %w", iss.ID, err)

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -41,6 +41,17 @@ func lastStatePayload(t *testing.T, s native.BoardStore, id string) map[string]a
 	return last
 }
 
+// mustGetIssue is Get or Fatal, for the provenance rows that read a method
+// off the record.
+func mustGetIssue(t *testing.T, s native.BoardStore, id string) *native.Issue {
+	t.Helper()
+	got, err := s.Get(id)
+	if err != nil {
+		t.Fatalf("Get %s: %v", id, err)
+	}
+	return got
+}
+
 // runBoardStoreSuite exercises the native.BoardStore contract. It runs against
 // both the filesystem native.Store (always — proving the suite) and the Mongo
 // store (gated on ITERION_TEST_MONGO_URI), so the two implementations are held
@@ -147,6 +158,96 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	}
 	if _, err := store.SetState(created.ID, native.StateReady); err != nil {
 		t.Fatalf("StateAt: restore state: %v", err)
+	}
+
+	// Issue.StateReason is the provenance of the card's last TRANSITION —
+	// the `reason` its state event carried — persisted so a reader of the
+	// card alone (the project-board reflect, which sees no event) can tell a
+	// column iterion wrote on its own authority from one a person, or a
+	// run's verdict, put it in (#798). Both twins owe: stamped from the SAME
+	// inputs as the event's reason, overwritten or cleared by the next
+	// transition, untouched by an edit or a same-state no-op.
+	reasonOf := func(what string) string {
+		got, err := store.Get(created.ID)
+		if err != nil {
+			t.Fatalf("StateReason/%s: Get: %v", what, err)
+		}
+		return got.StateReason
+	}
+	if got := reasonOf("after an operator SetState"); got != "" {
+		t.Errorf("StateReason after a tokenless SetState = %q, want empty (an unattributed gesture)", got)
+	}
+	watchdogTok, err := store.Claim(created.ID, tracker.ReaperMarkerPrefix+"host-1")
+	if err != nil {
+		t.Fatalf("StateReason: reaper claim: %v", err)
+	}
+	if _, err := store.SetStateOwned(created.ID, native.StateBlocked, watchdogTok); err != nil {
+		t.Fatalf("StateReason: watchdog park: %v", err)
+	}
+	if got := reasonOf("after a watchdog park"); got != tracker.ReasonWatchdog {
+		t.Errorf("StateReason after a reaper-marker write = %q, want %q (marker-derived, like the event)", got, tracker.ReasonWatchdog)
+	}
+	if got, _ := lastStatePayload(t, store, created.ID)["reason"].(string); got != tracker.ReasonWatchdog {
+		t.Fatalf("event reason after a watchdog park = %q, want %q — the card and the event must agree", got, tracker.ReasonWatchdog)
+	}
+	if !mustGetIssue(t, store, created.ID).StateByMachine() {
+		t.Error("StateByMachine after a watchdog park = false, want true")
+	}
+	pr3 := 3
+	if _, err := store.Update(created.ID, native.Patch{Priority: &pr3}); err != nil {
+		t.Fatalf("StateReason: Update: %v", err)
+	}
+	if got := reasonOf("after a non-state Update"); got != tracker.ReasonWatchdog {
+		t.Errorf("StateReason cleared by a priority edit: %q — an edit is not a transition", got)
+	}
+	if _, err := store.SetStateOwned(created.ID, native.StateBlocked, watchdogTok); err != nil {
+		t.Fatalf("StateReason: same-state no-op: %v", err)
+	}
+	if got := reasonOf("after a same-state write"); got != tracker.ReasonWatchdog {
+		t.Errorf("StateReason changed by a same-state no-op: %q", got)
+	}
+	if err := store.ReleaseOwned(created.ID, watchdogTok); err != nil {
+		t.Fatalf("StateReason: release reaper claim: %v", err)
+	}
+	// Reopen is an operator gesture: it clears the machine provenance.
+	if _, err := store.Reopen(created.ID, native.StateReady); err != nil {
+		t.Fatalf("StateReason: Reopen: %v", err)
+	}
+	if got := reasonOf("after Reopen"); got != "" {
+		t.Errorf("StateReason after an operator Reopen = %q, want empty — the machine's park no longer describes the card", got)
+	}
+	// An explicit reason travels verbatim; an owner's ordinary fenced move
+	// carries none (a run's own lifecycle is not machine provenance).
+	ownerTok, err := store.Claim(created.ID, "runner-X")
+	if err != nil {
+		t.Fatalf("StateReason: owner claim: %v", err)
+	}
+	if _, err := store.SetStateOwned(created.ID, native.StateInProgress, ownerTok); err != nil {
+		t.Fatalf("StateReason: owner start: %v", err)
+	}
+	if got := reasonOf("after an owner's fenced move"); got != "" {
+		t.Errorf("StateReason after an ordinary owner write = %q, want empty", got)
+	}
+	if _, err := store.SetStateOwnedReason(created.ID, native.StateReady, ownerTok, tracker.ReasonUnlaunchable); err != nil {
+		t.Fatalf("StateReason: give back: %v", err)
+	}
+	if got := reasonOf("after a give-back"); got != tracker.ReasonUnlaunchable {
+		t.Errorf("StateReason after SetStateOwnedReason(unlaunchable) = %q, want %q", got, tracker.ReasonUnlaunchable)
+	}
+	if !mustGetIssue(t, store, created.ID).StateByMachine() {
+		t.Error("StateByMachine after a give-back = false, want true")
+	}
+	if err := store.ReleaseOwned(created.ID, ownerTok); err != nil {
+		t.Fatalf("StateReason: release owner claim: %v", err)
+	}
+	if _, moved, err := store.SetStateFrom(created.ID, native.StateReady, native.StateInProgress); err != nil || !moved {
+		t.Fatalf("StateReason: SetStateFrom: moved=%v err=%v", moved, err)
+	}
+	if got := reasonOf("after a tokenless CAS move"); got != "" {
+		t.Errorf("StateReason after SetStateFrom = %q, want empty — the previous machine provenance must not survive a transition", got)
+	}
+	if _, err := store.SetState(created.ID, native.StateReady); err != nil {
+		t.Fatalf("StateReason: restore state: %v", err)
 	}
 
 	// Claim: idempotent same marker; conflict on a different marker; release.
@@ -1214,7 +1315,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 		{"cb", "claimed", native.StateReady, true}, // eligible state but claimed
 	} {
 		st := coord.StoreFor(tc.tenant)
-		iss, cerr := st.Create(native.Issue{Title: tc.title, State: tc.state})
+		iss, cerr := st.Create(native.Issue{Title: tc.title, State: tc.state, Bot: "feature-dev"})
 		if cerr != nil {
 			t.Fatalf("coord create %s: %v", tc.title, cerr)
 		}
@@ -1224,10 +1325,46 @@ func TestMongoStore_Conformance(t *testing.T) {
 			}
 		}
 	}
+	// A ready+unclaimed card with NO bot is roadmap content (#798): the
+	// sweeps' ListEligible still sees it, the dispatch tick's
+	// ListDispatchable never does — the bot predicate is in the query.
+	if _, cerr := coord.StoreFor("ca").Create(native.Issue{Title: "roadmap-no-bot", State: native.StateReady}); cerr != nil {
+		t.Fatalf("coord create roadmap-no-bot: %v", cerr)
+	}
+	disp, derr0 := coord.ListDispatchable(ctx, []string{native.StateReady}, 50)
+	if derr0 != nil {
+		t.Fatalf("ListDispatchable: %v", derr0)
+	}
+	dispTitles := map[string]bool{}
+	for _, c := range disp {
+		if c.Issue.Title == "roadmap-no-bot" {
+			t.Error("ListDispatchable listed a ready card with no bot — the tick would claim what it cannot launch")
+		}
+		if c.Issue.Bot == "" {
+			t.Errorf("ListDispatchable listed %q with an empty bot", c.Issue.Title)
+		}
+		dispTitles[c.Issue.Title] = true
+	}
+	if !dispTitles["ready-a"] || !dispTitles["ready-b"] {
+		t.Errorf("ListDispatchable must list the launchable ready cards: %v", dispTitles)
+	}
 	elig, eerr := coord.ListEligible(ctx, []string{native.StateReady}, 50, false)
 	if eerr != nil {
 		t.Fatalf("ListEligible: %v", eerr)
 	}
+	sawRoadmap := false
+	kept := elig[:0:0]
+	for _, c := range elig {
+		if c.Issue.Title == "roadmap-no-bot" {
+			sawRoadmap = true
+			continue // keep the ordering assertions below on their two-card population
+		}
+		kept = append(kept, c)
+	}
+	if !sawRoadmap {
+		t.Error("ListEligible (the sweeps' listing) must still see a bot-less card — a sweep judges by the recorded run")
+	}
+	elig = kept
 	// The Coordinator is cross-tenant BY DESIGN, and this suite shares one
 	// database: ready+unclaimed residue from the earlier per-tenant suites
 	// (tenant-1's cards) legitimately shows up here. Scope the assertions
@@ -1274,7 +1411,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 	}
 	var descOwn []boardmongo.Candidate
 	for _, c := range desc {
-		if coordTenants[c.Tenant] {
+		if coordTenants[c.Tenant] && c.Issue.Title != "roadmap-no-bot" {
 			descOwn = append(descOwn, c)
 		}
 	}

--- a/pkg/dispatcher/boardmongo/coordinator.go
+++ b/pkg/dispatcher/boardmongo/coordinator.go
@@ -55,17 +55,18 @@ func (c *Coordinator) DistinctEffectTenants(ctx context.Context) ([]string, erro
 	return vals, nil
 }
 
-// ListEligible returns up to `limit` UNCLAIMED issues whose state is in
-// `eligible`, across every tenant, in the requested update order:
-// oldest-updated first (newestFirst=false) for the dispatch tick — FIFO
-// fairness — or newest-updated first for the stranded-card sweeps, whose
-// capped window must always contain the freshest strandings (a stranding
-// bumps UpdatedAt, and a sweep that leaves a card in place does not, so
-// under oldest-first a saturated board's forgotten pile occupies the window
-// permanently and starves exactly the cards the sweep exists to rescue).
-// (v1 assumes the default-board eligibility passed by the caller; a
-// per-tenant custom board schema is a future refinement. Blocker gating is
-// left to the per-issue processor.)
+// ListEligible is the SWEEPS' listing: up to `limit` UNCLAIMED issues whose
+// state is in `eligible`, across every tenant, with no bot filter (a sweep
+// judges a card by its recorded run — the dispatch tick lists through
+// ListDispatchable), in the requested update order: oldest-updated first
+// (newestFirst=false), or newest-updated first for the stranded-card
+// sweeps, whose capped window must always contain the freshest strandings
+// (a stranding bumps UpdatedAt, and a sweep that leaves a card in place
+// does not, so under oldest-first a saturated board's forgotten pile
+// occupies the window permanently and starves exactly the cards the sweep
+// exists to rescue). (v1 assumes the default-board eligibility passed by
+// the caller; a per-tenant custom board schema is a future refinement.
+// Blocker gating is left to the per-issue processor.)
 func (c *Coordinator) ListEligible(ctx context.Context, eligible []string, limit int, newestFirst bool) ([]Candidate, error) {
 	if len(eligible) == 0 {
 		return nil, nil
@@ -88,6 +89,46 @@ func (c *Coordinator) ListEligible(ctx context.Context, eligible []string, limit
 	var docs []issueDoc
 	if err := cur.All(ctx, &docs); err != nil {
 		return nil, fmt.Errorf("boardmongo: decode eligible: %w", err)
+	}
+	out := make([]Candidate, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, Candidate{Tenant: d.Tenant, Issue: d.Issue})
+	}
+	return out, nil
+}
+
+// ListDispatchable is the dispatch tick's candidate query: up to `limit`
+// UNCLAIMED issues in an `eligible` state that CARRY A BOT, across every
+// tenant, oldest-updated first (FIFO fairness). The cloud dispatcher has
+// no default bot, so a card without one is not launchable — it is roadmap
+// content (a project-board sync lands every "Planned" ticket in `ready`),
+// and listing it only buys a claim, a failed launch and a park. The bot
+// filter lives in the QUERY because the batch cap does too: bot-less cards
+// are never written, so they are the oldest, so they would fill every
+// oldest-first batch and starve the launchable ones behind them.
+//
+// Same index as ListEligible (eligible_by_updated): the bot predicate is a
+// residual filter on that scan, which is what keeps the sweeps' sort
+// index-served — a bot key between claim and updatedat would not.
+func (c *Coordinator) ListDispatchable(ctx context.Context, eligible []string, limit int) ([]Candidate, error) {
+	if len(eligible) == 0 {
+		return nil, nil
+	}
+	opt := options.Find().SetSort(bson.D{{Key: "issue.updatedat", Value: 1}})
+	if limit > 0 {
+		opt.SetLimit(int64(limit))
+	}
+	cur, err := c.coll.Find(ctx, bson.M{
+		"issue.state": bson.M{"$in": eligible},
+		"issue.claim": bson.M{"$in": bson.A{"", nil}},
+		"issue.bot":   bson.M{"$gt": ""},
+	}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("boardmongo: list dispatchable: %w", err)
+	}
+	var docs []issueDoc
+	if err := cur.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("boardmongo: decode dispatchable: %w", err)
 	}
 	out := make([]Candidate, 0, len(docs))
 	for _, d := range docs {

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -231,7 +231,8 @@ func (s *Store) Create(in native.Issue) (*native.Issue, error) {
 	now := time.Now().UTC()
 	in.CreatedAt = now
 	in.UpdatedAt = now
-	in.StateAt = now // the card's column was decided now (the FS twin derives the same)
+	in.StateAt = now    // the card's column was decided now (the FS twin derives the same)
+	in.StateReason = "" // derived by the store at every transition, never supplied
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
 	if _, err := s.issues.InsertOne(ctx, issueDoc{ID: in.ID, Tenant: s.tenant, Issue: in}); err != nil {
@@ -400,7 +401,12 @@ func (s *Store) replaceGuarded(ctx context.Context, iss *native.Issue, guard bso
 	// writeIssueLocked derivation.
 	if slices.Contains(changed, "state") {
 		iss.StateAt = time.Now().UTC()
-		changed = append(changed, "state_at")
+		// The provenance rides with the transition too: the caller set
+		// iss.StateReason for THIS write (or left it empty for an
+		// unattributed move), and naming the key here is what writes it —
+		// a state writer cannot leave the previous transition's reason on
+		// the card by forgetting the key.
+		changed = append(changed, "state_at", "state_reason")
 	}
 	hadGaveUp := iss.GaveUp != nil
 	expireGiveUp(iss)
@@ -580,6 +586,7 @@ func (s *Store) setStateReason(id, newState, reason string) (*native.Issue, erro
 		}
 		old = iss.State
 		iss.State = newState
+		iss.StateReason = native.StateProvenance("", reason)
 		iss.UpdatedAt = time.Now().UTC()
 		matched, err := s.replaceGuarded(ctx, iss, bson.M{"issue.state": old}, "state")
 		if err != nil {
@@ -598,11 +605,8 @@ func (s *Store) setStateReason(id, newState, reason string) (*native.Issue, erro
 		}
 		iss = fresh
 	}
-	payload := map[string]any{"from": old, "to": newState}
-	if reason != "" {
-		payload["reason"] = reason
-	}
-	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: iss.ID, Payload: payload}); err != nil {
+	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: iss.ID,
+		Payload: native.StateEventPayload(old, newState, "", reason)}); err != nil {
 		return nil, err
 	}
 	if newState == native.StateDone {

--- a/pkg/dispatcher/boardmongo/store_launch.go
+++ b/pkg/dispatcher/boardmongo/store_launch.go
@@ -43,7 +43,7 @@ func (s *Store) ClaimForLaunch(id string) (*native.Issue, bool, error) {
 			"issue.state": native.StateReady,
 			"issue.claim": bson.M{"$in": bson.A{"", nil}},
 		},
-		bson.M{"$set": stateSetAt(native.StateInProgress, time.Now().UTC())},
+		bson.M{"$set": stateSetAt(native.StateInProgress, "", time.Now().UTC())},
 		options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
 		if !isNoDocuments(res.Err()) {

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -118,17 +118,25 @@ func (s *Store) ReleaseOwned(id string, tok tracker.ClaimToken) error {
 // package added would otherwise leave a card reading "the dispatcher gave
 // up" after something moved it on. The stamp only describes the state it
 // was taken in — a card that left that state has no give-up to show.
-func stateSet(newState string) bson.M { return stateSetAt(newState, time.Now().UTC()) }
+//
+// reason is the transition's provenance (native.StateProvenance — the value
+// the event carries), persisted on the card as Issue.StateReason: written
+// on EVERY transition, so a cleared reason overwrites the previous one and
+// a card never keeps the provenance of a column it has left.
+func stateSet(newState, reason string) bson.M {
+	return stateSetAt(newState, reason, time.Now().UTC())
+}
 
 // stateSetAt is stateSet with the write's timestamp supplied, so a caller
 // that must ALSO return the updated issue can report exactly what it
 // wrote instead of a pre-write snapshot.
-func stateSetAt(newState string, at time.Time) bson.M {
+func stateSetAt(newState, reason string, at time.Time) bson.M {
 	return bson.M{
-		"issue.state":     newState,
-		"issue.stateat":   at,
-		"issue.gaveup":    nil,
-		"issue.updatedat": at,
+		"issue.state":       newState,
+		"issue.statereason": reason,
+		"issue.stateat":     at,
+		"issue.gaveup":      nil,
+		"issue.updatedat":   at,
 	}
 }
 
@@ -184,9 +192,10 @@ func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 	// the retry below re-reads it the same way. writtenAt lets the return
 	// value below still describe what was WRITTEN rather than the
 	// pre-write snapshot.
+	prov := native.StateProvenance(tok.Marker, reason)
 	writtenAt := time.Now().UTC()
 	res := s.issues.FindOneAndUpdate(ctx, filter,
-		bson.M{"$set": stateSetAt(newState, writtenAt)},
+		bson.M{"$set": stateSetAt(newState, prov, writtenAt)},
 		options.FindOneAndUpdate().SetReturnDocument(options.Before))
 	if res.Err() != nil && isNoDocuments(res.Err()) {
 		// Zero match has three causes and they must not be conflated: the
@@ -214,7 +223,7 @@ func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 		// still holds.
 		writtenAt = time.Now().UTC()
 		res = s.issues.FindOneAndUpdate(ctx, filter,
-			bson.M{"$set": stateSetAt(newState, writtenAt)},
+			bson.M{"$set": stateSetAt(newState, prov, writtenAt)},
 			options.FindOneAndUpdate().SetReturnDocument(options.Before))
 		if res.Err() != nil && isNoDocuments(res.Err()) {
 			// Still nothing, with ownership just verified: the card is
@@ -242,16 +251,12 @@ func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 	// value that still carries the old ones describes a card that no
 	// longer exists.
 	updated.State = newState
+	updated.StateReason = prov
 	updated.GaveUp = nil
 	updated.UpdatedAt = writtenAt
 	if old != newState {
 		if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: id,
-			Payload: func() map[string]any {
-				if reason != "" {
-					return map[string]any{"from": old, "to": newState, "reason": reason}
-				}
-				return native.StateChangePayload(old, newState, tok.Marker)
-			}()}); err != nil {
+			Payload: native.StateEventPayload(old, newState, tok.Marker, reason)}); err != nil {
 			return nil, err
 		}
 		if newState == native.StateDone {
@@ -297,7 +302,7 @@ func (s *Store) SetStateOwnedFrom(id, from, to string, tok tracker.ClaimToken) (
 	filter["issue.state"] = from
 	writtenAt := time.Now().UTC()
 	res := s.issues.FindOneAndUpdate(ctx, filter,
-		bson.M{"$set": stateSetAt(to, writtenAt)},
+		bson.M{"$set": stateSetAt(to, native.StateProvenance(tok.Marker, ""), writtenAt)},
 		options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
 		if !isNoDocuments(res.Err()) {
@@ -669,7 +674,7 @@ func (s *Store) Reopen(id, toState string) (*native.Issue, error) {
 	// card still carried the give-up flag that "Needs attention" reads.
 	res := s.issues.FindOneAndUpdate(ctx,
 		bson.M{"_id": id, "tenant_id": s.tenant, "issue.state": iss.State},
-		bson.M{"$set": stateSet(toState)},
+		bson.M{"$set": stateSet(toState, "")}, // an operator gesture: the park's provenance no longer describes the card
 		options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
 		if !isNoDocuments(res.Err()) {
@@ -717,7 +722,7 @@ func (s *Store) SetStateFromReason(id, from, to, reason string) (*native.Issue, 
 	}
 	res := s.issues.FindOneAndUpdate(ctx,
 		bson.M{"_id": id, "tenant_id": s.tenant, "issue.state": from},
-		bson.M{"$set": stateSet(to)},
+		bson.M{"$set": stateSet(to, native.StateProvenance("", reason))},
 		options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
 		if !isNoDocuments(res.Err()) {
@@ -734,11 +739,8 @@ func (s *Store) SetStateFromReason(id, from, to, reason string) (*native.Issue, 
 		return nil, false, fmt.Errorf("boardmongo: set state from decode: %w", err)
 	}
 	updated := doc.Issue
-	payload := map[string]any{"from": from, "to": to}
-	if reason != "" {
-		payload["reason"] = reason
-	}
-	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: id, Payload: payload}); err != nil {
+	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: id,
+		Payload: native.StateEventPayload(from, to, "", reason)}); err != nil {
 		return nil, false, err
 	}
 	if to == native.StateDone {

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -60,6 +60,13 @@ type BoardStore interface {
 	// of clobbering the new owner's state.
 	ReleaseOwned(id string, tok tracker.ClaimToken) error
 	SetStateOwned(id, newState string, tok tracker.ClaimToken) (*Issue, error)
+	// SetStateOwnedReason is SetStateOwned with an EXPLICIT provenance
+	// overriding the marker-derived one — the watchdog's terminal filings
+	// carry the run's own verdict (run_finished / run_failed), the
+	// dispatcher's give-back of a card it could not launch carries the
+	// machine ReasonUnlaunchable. The reason lands on the event AND on the
+	// card (Issue.StateReason), on both twins.
+	SetStateOwnedReason(id, newState string, tok tracker.ClaimToken, reason string) (*Issue, error)
 	// SetStateOwnedFrom is SetStateOwned with a source-state precondition:
 	// ONE CAS on (claim, claim_epoch, state == from). changed=false when
 	// the state drifted (somebody moved the card while its owner was

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -1,6 +1,10 @@
 package native
 
-import "time"
+import (
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
 
 // Issue is the native tracker's source-of-truth issue record. The
 // dispatcher consumes a normalized view via tracker.Issue (see
@@ -109,6 +113,19 @@ type Issue struct {
 	// ClaimedAt. A reader wanting a transition time for such a card has to
 	// say what it falls back to.
 	StateAt time.Time `json:"state_at,omitempty"`
+	// StateReason is the provenance of the card's LAST column change — the
+	// `reason` its state event carried (a tracker.Reason* constant), empty
+	// for an unattributed write (an operator surface, a bot's board tool,
+	// the project import, a create). It is what lets a reader of the CARD
+	// alone — the periodic project-board reflect, which sees no event —
+	// tell a column iterion wrote on its own authority (StateByMachine)
+	// from one a person, or a run's verdict, put the card in.
+	//
+	// Stamped by the store at every state write, on both twins, from the
+	// same inputs that build the event's `reason`: it cannot disagree with
+	// the event, and it is overwritten (or cleared) by the next transition,
+	// so it never describes a column the card has left.
+	StateReason string `json:"state_reason,omitempty"`
 	// External links this card to an issue on an external forge — set when
 	// the card is mirrored FROM a forge (one-way forge→board sync) or pushed
 	// TO one (push-to-forge). It is metadata: the card's column stays
@@ -119,6 +136,17 @@ type Issue struct {
 	// IssueModal, and — once the comment-trigger wiring lands — to carry
 	// operator `/command` requests and the resulting MR/PR back-links.
 	Comments []Comment `json:"comments,omitempty"`
+}
+
+// StateByMachine reports whether the card's current column was written by
+// iterion acting on its own authority — a watchdog repair, a schema
+// migration, the dispatcher returning a card it could not launch — rather
+// than by a person or by a run's verdict. The predicate is the enumerated
+// tracker.IsMachineReason over the persisted provenance, the same contract
+// the trigger spine applies to the event: a descriptive reason (unblocked,
+// run_finished) reads as a gesture here too.
+func (i *Issue) StateByMachine() bool {
+	return i != nil && tracker.IsMachineReason(i.StateReason)
 }
 
 // RunRef is one entry in an issue's run history (Issue.Runs). RunID is

--- a/pkg/dispatcher/native/store_board.go
+++ b/pkg/dispatcher/native/store_board.go
@@ -102,6 +102,7 @@ func (s *Store) migrateStateLocked(from, to, reason string) (int, error) {
 		// goroutines holding earlier defensive copies.
 		next := cloneIssue(iss)
 		next.State = to
+		next.StateReason = reason
 		next.UpdatedAt = time.Now().UTC()
 		if err := s.writeIssueLocked(next); err != nil {
 			return touched, fmt.Errorf("native store: write %s during state migration: %w", id, err)

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -109,6 +109,7 @@ func (s *Store) createLocked(in Issue) (created *Issue, err error) {
 	now := time.Now().UTC()
 	in.CreatedAt = now
 	in.UpdatedAt = now
+	in.StateReason = "" // derived by the store at every transition, never supplied — like StateAt
 	if err := s.writeIssueLocked(&in); err != nil {
 		return nil, err
 	}
@@ -500,6 +501,7 @@ func (s *Store) Reopen(id, toState string) (updated *Issue, err error) {
 	}
 	old := iss.State
 	iss.State = toState
+	iss.StateReason = "" // an operator gesture: whatever parked the card no longer describes it
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err
@@ -589,6 +591,9 @@ func (s *Store) setStateReasonLocked(iss *Issue, newState, byMarker, reason stri
 	}
 	old := iss.State
 	iss.State = newState
+	// The card records the same provenance the event carries — derived
+	// once, here, from the same two inputs, so the two cannot disagree.
+	iss.StateReason = StateProvenance(byMarker, reason)
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err
@@ -597,13 +602,7 @@ func (s *Store) setStateReasonLocked(iss *Issue, newState, byMarker, reason stri
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueState,
 		IssueID: iss.ID,
-		Payload: func() map[string]any {
-			p := StateChangePayload(old, newState, byMarker)
-			if reason != "" {
-				p["reason"] = reason
-			}
-			return p
-		}(),
+		Payload: StateEventPayload(old, newState, byMarker, reason),
 	}); err != nil {
 		return nil, err
 	}
@@ -641,6 +640,7 @@ func (s *Store) ClaimForLaunch(id string) (claimed *Issue, won bool, err error) 
 		return nil, false, nil
 	}
 	iss.State = StateInProgress
+	iss.StateReason = "" // the admission loop launching a run: a lifecycle move, not machine bookkeeping
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, false, err
@@ -704,6 +704,7 @@ func (s *Store) promoteUnblockedDependentsLocked(closedID string) error {
 		// Mutate a clone then write — index holds shared pointers.
 		next := cloneIssue(iss)
 		next.State = target
+		next.StateReason = tracker.ReasonUnblocked
 		next.UpdatedAt = time.Now().UTC()
 		if err := s.writeIssueLocked(next); err != nil {
 			return err
@@ -822,21 +823,42 @@ func stampStateAtLocked(prev, next *Issue) {
 	next.StateAt = time.Now().UTC()
 }
 
-// StateChangePayload builds the state-change event body, stamping the
-// provenance when the WRITER is a watchdog. byMarker is the writer's own
-// claim marker — the token a fenced write presented — never the marker
-// the card happens to carry: an operator moving a card the watchdog is
-// conserving is still an operator gesture. Downstream consumers launch
-// bots and spend one-shot label gates on these events, and a machine
-// repairing a dead owner is not the operator gesture they are written
-// for. Exported for the Mongo twin, which builds the same event from
-// its own CAS.
-func StateChangePayload(from, to, byMarker string) map[string]any {
-	p := map[string]any{"from": from, "to": to}
+// StateProvenance is the ONE derivation of a state write's provenance —
+// the value that lands on the event's `reason` AND on the card
+// (Issue.StateReason): the explicit reason when the writer gave one, else
+// the machine ReasonWatchdog when the WRITER is a watchdog, else none.
+// byMarker is the writer's own claim marker — the token a fenced write
+// presented — never the marker the card happens to carry: an operator
+// moving a card the watchdog is conserving is still an operator gesture.
+// Downstream consumers launch bots, spend one-shot label gates and reflect
+// columns onto external boards from this value, and a machine repairing a
+// dead owner is not the operator gesture they are written for. Exported
+// for the Mongo twin, which builds the same event from its own CAS.
+func StateProvenance(byMarker, reason string) string {
+	if reason != "" {
+		return reason
+	}
 	if tracker.IsReaperMarker(byMarker) {
-		p["reason"] = tracker.ReasonWatchdog
+		return tracker.ReasonWatchdog
+	}
+	return ""
+}
+
+// StateEventPayload builds the state-change event body carrying
+// StateProvenance(byMarker, reason) — omitted when empty, so an
+// unattributed move keeps the bare {from, to} shape its consumers expect.
+func StateEventPayload(from, to, byMarker, reason string) map[string]any {
+	p := map[string]any{"from": from, "to": to}
+	if prov := StateProvenance(byMarker, reason); prov != "" {
+		p["reason"] = prov
 	}
 	return p
+}
+
+// StateChangePayload is StateEventPayload for a write with no explicit
+// reason — the ordinary fenced move.
+func StateChangePayload(from, to, byMarker string) map[string]any {
+	return StateEventPayload(from, to, byMarker, "")
 }
 
 // expireGiveUp drops a give-up stamp that no longer describes the state the

--- a/pkg/dispatcher/tracker/tracker.go
+++ b/pkg/dispatcher/tracker/tracker.go
@@ -243,6 +243,14 @@ const (
 	// under the machine ReasonWatchdog.
 	ReasonRunFinished = "run_finished"
 	ReasonRunFailed   = "run_failed"
+	// ReasonUnlaunchable is the dispatcher returning a card it claimed but
+	// could not launch (no bot, an unresolvable bot, malformed launch
+	// context) to the column it took it from. Nothing ran, so nothing
+	// about the card's work was judged: machine provenance — a
+	// subscription armed on that column must not re-fire on the return,
+	// an audit surface must not sign it with the assignee's name, and an
+	// external roadmap must not read it as a move.
+	ReasonUnlaunchable = "unlaunchable"
 )
 
 // IsMachineReason reports whether a board-event `reason` names iterion
@@ -253,7 +261,7 @@ const (
 // field's mere presence silently disarmed them.
 func IsMachineReason(reason string) bool {
 	switch reason {
-	case ReasonWatchdog, ReasonStateRename, ReasonStateDelete, ReasonFieldRename, ReasonFieldDelete:
+	case ReasonWatchdog, ReasonStateRename, ReasonStateDelete, ReasonFieldRename, ReasonFieldDelete, ReasonUnlaunchable:
 		return true
 	}
 	return false

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -125,6 +125,14 @@ type ProjectImportResult struct {
 	// ReflectFailed is the reflects the forge refused. Counted rather than
 	// fatal: one card's failed write must not abandon the rest of the board.
 	ReflectFailed int `json:"reflect_failed,omitempty"`
+	// ReflectMachine is the cards whose current column iterion wrote on its
+	// own authority (Issue.StateByMachine — a watchdog park, a schema
+	// migration, a card given back after a failed launch) and therefore did
+	// NOT push onto the board: the roadmap follows people and run verdicts,
+	// never the machinery's own bookkeeping. Counted per pass, like
+	// ReflectNoColumn — the same cards stay unreflectable until someone or
+	// some run moves them.
+	ReflectMachine int `json:"reflect_machine,omitempty"`
 	// Labelled is the cards whose project-derived labels changed.
 	Labelled int `json:"labelled"`
 	// Conflicts is the items where both sides had moved since the last sync.
@@ -572,6 +580,13 @@ func applyProjectItem(
 // "who moved?" oracle and the echo suppressor, which is why neither direction
 // needs a per-write "last mover" flag.
 //
+// What it does need is WHO made the native move: a column iterion wrote on
+// its own authority (Issue.StateByMachine — a watchdog park, a column rename,
+// a card given back after a launch that never happened) is not a move the
+// roadmap follows, and is left alone and counted (ReflectMachine). A person's
+// move and a run's verdict — the dispatcher filing `in_progress` at launch,
+// `done` after a finished run, `blocked` after a failed one — are reflected.
+//
 // A failed write is counted and logged, never fatal: one card's 403 must not
 // abandon the rest of the board.
 //
@@ -608,6 +623,18 @@ func reflectNativeState(
 	}
 	if strings.EqualFold(strings.TrimSpace(want), strings.TrimSpace(boardStatus)) {
 		return reflectNothingToWrite // already there — the idempotence that keeps a pass free
+	}
+	if card.StateByMachine() {
+		// The card's column was written by iterion on its own authority — a
+		// watchdog park, a schema migration, a card given back after a launch
+		// that never happened — not by a person and not by a run's verdict.
+		// The roadmap follows the latter two and never the machinery's own
+		// bookkeeping: a park that says nothing about the card's work must
+		// not read, on the operator's board, as if someone had decided it.
+		// Counted like ReflectNoColumn, not warned: the same card stays
+		// unreflectable on every pass until a person or a run moves it.
+		res.ReflectMachine++
+		return reflectNothingToWrite
 	}
 	option, ok := binding.OptionForState(card.State)
 	if !ok || repair.lostState(card.State) {

--- a/pkg/server/board_project_reflect_test.go
+++ b/pkg/server/board_project_reflect_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -694,5 +695,122 @@ func TestSyncProjectBoardConvergesWhenTheReflectCannotWrite(t *testing.T) {
 					res2.Conflicts, res2)
 			}
 		})
+	}
+}
+
+// TestSyncProjectBoardDoesNotReflectAMachineTransition (#798): a column
+// iterion wrote on its OWN authority — here the claim watchdog parking a card
+// in `blocked` under its reaper marker — is not a move the roadmap follows.
+// The pass counts it (reflect_machine) and pushes nothing, while the same
+// park performed by a person is reflected like any other move. The rule
+// reads the CARD's persisted provenance, not the event: the pass sees no
+// event, and the card must decide.
+func TestSyncProjectBoardDoesNotReflectAMachineTransition(t *testing.T) {
+	at := time.Date(2026, 9, 5, 20, 55, 0, 0, time.UTC)
+	park := map[string]func(t *testing.T, board *native.Store, id string){
+		"watchdog": func(t *testing.T, board *native.Store, id string) {
+			tok, err := board.Claim(id, tracker.ReaperMarkerPrefix+"host-1")
+			if err != nil {
+				t.Fatalf("claim: %v", err)
+			}
+			if _, err := board.SetStateOwned(id, native.StateBlocked, tok); err != nil {
+				t.Fatalf("park: %v", err)
+			}
+		},
+		"given back after a failed launch": func(t *testing.T, board *native.Store, id string) {
+			tok, err := board.Claim(id, "board-dispatcher:pod-1")
+			if err != nil {
+				t.Fatalf("claim: %v", err)
+			}
+			if _, err := board.SetStateOwned(id, native.StateInProgress, tok); err != nil {
+				t.Fatalf("start: %v", err)
+			}
+			if _, err := board.SetStateOwnedReason(id, native.StateReady, tok, tracker.ReasonUnlaunchable); err != nil {
+				t.Fatalf("give back: %v", err)
+			}
+		},
+	}
+	for name, parkFn := range park {
+		t.Run(name, func(t *testing.T) {
+			board := newTestBoard(t)
+			id := seedSynced(t, board, 798, native.StateReady, "Planned", at)
+			parkFn(t, board, id)
+			if !mustGet(t, board, id).StateByMachine() {
+				t.Fatalf("fixture: the card's provenance is %q, want a machine reason", mustGet(t, board, id).StateReason)
+			}
+			bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+				item("PVTI_1", 798, statusValue("Planned", at)),
+			}}}
+			res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+				&ProjectImportOptions{Binding: testBinding()})
+			if err != nil {
+				t.Fatalf("ImportProjectBoard: %v", err)
+			}
+			if len(bc.writes) != 0 {
+				t.Fatalf("writes = %+v, want none — a machine-written column is not a move the roadmap follows", bc.writes)
+			}
+			if res.Reflected != 0 {
+				t.Errorf("Reflected = %d, want 0 (%+v)", res.Reflected, res)
+			}
+			if mustGet(t, board, id).State == native.StateBlocked && res.ReflectMachine != 1 {
+				t.Errorf("ReflectMachine = %d, want 1 — the pass must explain the card it left alone (%+v)", res.ReflectMachine, res)
+			}
+		})
+	}
+
+	t.Run("a person's park is reflected", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedSynced(t, board, 798, native.StateReady, "Planned", at)
+		if _, err := board.SetState(id, native.StateBlocked); err != nil {
+			t.Fatalf("park: %v", err)
+		}
+		if mustGet(t, board, id).StateByMachine() {
+			t.Fatal("fixture: an operator move must not read as machine provenance")
+		}
+		bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+			item("PVTI_1", 798, statusValue("Planned", at)),
+		}}}
+		res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+			&ProjectImportOptions{Binding: testBinding()})
+		if err != nil {
+			t.Fatalf("ImportProjectBoard: %v", err)
+		}
+		if res.Reflected != 1 || len(bc.writes) != 1 || bc.writes[0].OptionID != optionID(t, testProject(), "Blocked") {
+			t.Fatalf("a person's park: reflected=%d writes=%+v, want one Blocked write", res.Reflected, bc.writes)
+		}
+	})
+}
+
+// TestSyncProjectBoardReflectsARunVerdict pins the other half of the rule,
+// the one ADR-097 was written for: the dispatcher filing a run's OUTCOME
+// (`done` after a finished run, under its fenced claim) is what actually
+// happened to the card, and the roadmap follows it.
+func TestSyncProjectBoardReflectsARunVerdict(t *testing.T) {
+	at := time.Date(2026, 9, 5, 20, 55, 0, 0, time.UTC)
+	board := newTestBoard(t)
+	id := seedSynced(t, board, 613, native.StateReady, "Planned", at)
+	tok, err := board.Claim(id, "board-dispatcher:pod-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if _, err := board.SetStateOwned(id, native.StateInProgress, tok); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if _, err := board.SetStateOwned(id, native.StateDone, tok); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+	if mustGet(t, board, id).StateByMachine() {
+		t.Fatal("fixture: a run verdict filed by its owner must not read as machine provenance")
+	}
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Planned", at)),
+	}}}
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.Reflected != 1 || len(bc.writes) != 1 || bc.writes[0].OptionID != optionID(t, testProject(), "Done") {
+		t.Fatalf("run verdict: reflected=%d writes=%+v, want one Done write", res.Reflected, bc.writes)
 	}
 }

--- a/pkg/server/board_projection_effect_machine_test.go
+++ b/pkg/server/board_projection_effect_machine_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+)
+
+// TestBoardProjection_DoesNotReflectAMachineTransition (#798): the fast path
+// runs the same reflect as the pass, so a column iterion wrote on its own
+// authority is refused here too — and refused on the CARD's persisted
+// provenance, not on the event: a row that reaches the worker without its
+// reason (or after a later machine write on the same card) must still leave
+// the roadmap alone.
+func TestBoardProjection_DoesNotReflectAMachineTransition(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 5, 20, 55, 0, 0, time.UTC)
+	id := seedSynced(t, board, 798, native.StateReady, "Planned", at)
+	tok, err := board.Claim(id, tracker.ReaperMarkerPrefix+"host-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if _, err := board.SetStateOwned(id, native.StateBlocked, tok); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if !mustGet(t, board, id).StateByMachine() {
+		t.Fatalf("fixture: provenance %q is not machine", mustGet(t, board, id).StateReason)
+	}
+	bc := &fakeBoardClient{project: testProject()}
+	p, _ := projectionEffectWorld(t, bc, board)
+
+	// With the event's provenance…
+	ev := movedCardEvent(id, native.StateReady)
+	ev.Payload["reason"] = tracker.ReasonWatchdog
+	if err := p.ReflectCard(context.Background(), ev); err != nil {
+		t.Fatalf("ReflectCard: %v", err)
+	}
+	// …and without it (a row queued by an older binary).
+	if err := p.ReflectCard(context.Background(), movedCardEvent(id, native.StateReady)); err != nil {
+		t.Fatalf("ReflectCard (bare event): %v", err)
+	}
+	if len(bc.writes) != 0 {
+		t.Fatalf("writes = %+v, want none — a watchdog park is not a move the roadmap follows", bc.writes)
+	}
+	if rec := mustGet(t, board, id).External.Project.Status; rec != "Planned" {
+		t.Fatalf("recorded status = %q, want %q untouched — nothing was pushed, so nothing may be recorded", rec, "Planned")
+	}
+}

--- a/pkg/server/board_sync_worker.go
+++ b/pkg/server/board_sync_worker.go
@@ -211,9 +211,9 @@ func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, own
 		w.warn("board sync: team=%s board=%s failed after %s: %v", b.TenantID, b.Ref(), took.Round(time.Millisecond), err)
 		return false
 	}
-	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d reflect_no_column=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
+	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d reflect_no_column=%d reflect_machine=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
 		b.TenantID, b.Ref(), res.Items, res.Moved, res.Reflected, res.Labelled,
-		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.ReflectNoColumn,
+		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.ReflectNoColumn, res.ReflectMachine,
 		res.SkippedNoCard, res.SkippedArchived, res.Skipped,
 		took.Round(time.Millisecond))
 	return true

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -22,6 +22,20 @@ import (
 // boardCoordinator is the cross-tenant board view the cloud dispatcher needs.
 // *boardmongo.Coordinator satisfies it; tests pass a fake.
 type boardCoordinator interface {
+	// ListDispatchable is the dispatch tick's candidate query: unclaimed
+	// cards in a launch column that CARRY A BOT, oldest-updated first. The
+	// cloud dispatcher has no default bot, so a card without one cannot be
+	// launched — it is roadmap content (a project-board sync lands every
+	// "Planned" ticket in `ready`), and claiming it only to fail is the
+	// claim + failed launch + park this listing exists to make impossible.
+	// The filter is part of the QUERY, not a post-listing skip: the batch
+	// is capped, and bot-less cards — never written, so always the oldest
+	// — would otherwise fill every batch and starve the launchable ones.
+	ListDispatchable(ctx context.Context, eligible []string, limit int) ([]boardmongo.Candidate, error)
+	// ListEligible is the sweeps' listing — unclaimed cards in the given
+	// states, either order, with NO bot filter: a sweep judges a card by
+	// its recorded run, and a card whose bot was cleared after its run is
+	// still the sweep's to file.
 	ListEligible(ctx context.Context, eligible []string, limit int, newestFirst bool) ([]boardmongo.Candidate, error)
 	Claim(ctx context.Context, tenant, id, marker string) (tracker.ClaimToken, error)
 	SetState(ctx context.Context, tenant, id, state string) error
@@ -67,6 +81,29 @@ var errCardPaused = errors.New("board dispatcher: run paused awaiting input")
 // blocked, the flag no reconciler lifts.
 var errCardContinuable = errors.New("board dispatcher: run continuable")
 
+// errCardUnlaunchable marks a launch PRECONDITION failure: nothing ran, so
+// nothing about the card's work was judged and no verdict belongs on it.
+// processCard returns such a card to the column the tick took it from and
+// frees the claim — never `blocked`, which reads as a verdict on the work
+// and, on a team bound to an external board, is projected onto the
+// operator's roadmap as one.
+//
+// The failure taxonomy of processBoardCard, which processCard routes on:
+//
+//   - errCardUnlaunchable — a precondition: the card names no bot, names a
+//     bot the resolver cannot find, carries malformed reserved bot-args, or
+//     the run service is not wired. Card back to its column, claim freed,
+//     one Warn per (card, reason) edge.
+//   - errCardPaused — the run parked on a human/operator gate → the
+//     awaiting-input column.
+//   - errCardContinuable — the run ended failed_resumable / cancelled → the
+//     card stays where it is; the retry machinery or the operator continues.
+//   - a cancelled parent context — this replica is draining → the card
+//     stays where it is, the claim is released.
+//   - anything else — the run was launched and ended in a terminal failure,
+//     or the publisher refused the launch (quota, sealing, …) → `blocked`.
+var errCardUnlaunchable = errors.New("board dispatcher: card cannot be launched")
+
 // pollDisposition maps a TERMINAL polled status to the poll's verdict:
 // finished = clean; failed = the one filing-worthy failure; everything
 // else terminal (failed_resumable, cancelled) is continuable — the retry
@@ -91,7 +128,13 @@ func pollDisposition(runID string, st store.RunStatus) error {
 type boardDispatcher struct {
 	coord   boardCoordinator
 	process func(ctx context.Context, tenant string, iss native.Issue) error
-	marker  string
+	// admit checks a listed card's launch preconditions BEFORE it is
+	// claimed (the local dispatcher's resolveExplicitBot shape): a card
+	// that cannot be launched is skipped in its column, not claimed, moved
+	// and given back every tick. Optional; an errCardUnlaunchable is the
+	// only refusal — any other error is a transient the tick retries.
+	admit  func(ctx context.Context, tenant string, iss native.Issue) error
+	marker string
 
 	eligible        []string
 	inProgressState string
@@ -162,6 +205,25 @@ type boardDispatcher struct {
 	// so the abstention it causes is reported on its edges rather than
 	// once per candidate per pass.
 	runReadFailure bool
+
+	// The unlaunchable bookkeeping is shared by the tick (admission, run
+	// loop goroutine) and the processCard goroutines (the post-claim belt),
+	// hence its own lock. unlaunchWarned dedups the per-card Warn on its
+	// (card, reason) edge — a card that cannot be launched is listed on
+	// every tick, and one line per 5s per card is the storm that hides the
+	// next real signal; unlaunchTally is reported once per watchdog pass.
+	unlaunchMu     sync.Mutex
+	unlaunchWarned map[string]unlaunchNote
+	unlaunchTally  unlaunchableTally
+}
+
+// unlaunchNote is one card's last unlaunchable verdict: the reason said, and
+// when it was last seen — a card that stops being listed (deleted, fixed and
+// launched elsewhere) drops out of the memo after a pass, so the memo is
+// bounded by the live population and a card that comes back warns again.
+type unlaunchNote struct {
+	reason string
+	at     time.Time
 }
 
 // newBoardDispatcher wires a cloud board dispatcher with sensible defaults.
@@ -188,9 +250,12 @@ func newBoardDispatcher(coord boardCoordinator, process func(context.Context, st
 // tick claims as many eligible cards as there are free slots and dispatches
 // each in a detached goroutine. Returns the number it claimed this tick.
 func (d *boardDispatcher) tick(ctx context.Context) int {
-	cands, err := d.coord.ListEligible(ctx, d.eligible, cap(d.sem)*2, false)
+	// The dispatch listing, not the sweeps' one: a card that names no bot
+	// is never a candidate (the query filters it), so the tick cannot claim
+	// what it has no way to launch.
+	cands, err := d.coord.ListDispatchable(ctx, d.eligible, cap(d.sem)*2)
 	if err != nil {
-		d.warn("list eligible: %v", err)
+		d.warn("list dispatchable: %v", err)
 		return 0
 	}
 	claimed := 0
@@ -199,6 +264,23 @@ func (d *boardDispatcher) tick(ctx context.Context) int {
 		case d.sem <- struct{}{}: // acquired a slot
 		default:
 			return claimed // no free slots; the rest wait for the next tick
+		}
+		// Admission BEFORE the claim (the local dispatcher's
+		// resolveExplicitBot shape): a card whose launch preconditions fail
+		// is skipped in its column — not claimed, moved into the running
+		// column and given back a tick later, over and over. Only
+		// errCardUnlaunchable refuses; any other error is a transient the
+		// next tick retries.
+		if d.admit != nil {
+			if err := d.admit(ctx, c.Tenant, c.Issue); err != nil {
+				<-d.sem
+				if errors.Is(err, errCardUnlaunchable) {
+					d.noteUnlaunchable(c.Tenant, c.Issue.ID, c.Issue.State, err, false)
+				} else {
+					d.warn("card %s/%s admission: %v — retried next tick", c.Tenant, c.Issue.ID, err)
+				}
+				continue
+			}
 		}
 		tok, err := d.coord.Claim(ctx, c.Tenant, c.Issue.ID, d.marker)
 		if err != nil {
@@ -249,7 +331,20 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	}
 	runErr := d.process(cardCtx, c.Tenant, c.Issue)
 	final := d.doneState
+	// finalReason is the provenance the final write carries; empty for a
+	// run's own verdict (the ordinary fenced move).
+	finalReason := ""
 	switch {
+	case runErr != nil && errors.Is(runErr, errCardUnlaunchable):
+		// Nothing ran (the taxonomy on errCardUnlaunchable): no verdict
+		// belongs on the card. Back to the column the tick took it from —
+		// under machine provenance, so the return re-fires no subscription
+		// armed on that column and is not projected onto an external board
+		// as a move — and the claim is freed below. The pre-claim admission
+		// makes this the race case (the card changed between the listing
+		// and the launch); it is still never `blocked`.
+		final, finalReason = c.Issue.State, tracker.ReasonUnlaunchable
+		d.noteUnlaunchable(c.Tenant, c.Issue.ID, c.Issue.State, runErr, true)
 	case runErr != nil && errors.Is(runErr, errCardPaused):
 		// A pause is not a failure: route the card to the awaiting-input
 		// column so the operator answers it there, not to blocked.
@@ -277,6 +372,11 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 		final = d.blockedState
 		d.warn("card %s/%s run failed: %v", c.Tenant, c.Issue.ID, runErr)
 	}
+	if finalReason == "" {
+		// The card ran (or is running): whatever kept it from launching
+		// before is over, and a later refusal must be said again.
+		d.clearUnlaunchable(c.Tenant, c.Issue.ID)
+	}
 	// Final writes on a DETACHED ctx: a superseded claim cancelled
 	// cardCtx (the fenced writes must still run to be REFUSED loudly —
 	// typed conflict in the log — rather than die on a dead ctx reading
@@ -285,7 +385,13 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	finCtx, finCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer finCancel()
 	if final != "" {
-		if err := d.coord.SetStateOwned(finCtx, c.Tenant, c.Issue.ID, final, tok); err != nil {
+		var err error
+		if finalReason != "" {
+			err = d.coord.SetStateOwnedReason(finCtx, c.Tenant, c.Issue.ID, final, tok, finalReason)
+		} else {
+			err = d.coord.SetStateOwned(finCtx, c.Tenant, c.Issue.ID, final, tok)
+		}
+		if err != nil {
 			d.warn("card %s/%s → %s: %v", c.Tenant, c.Issue.ID, final, err)
 		}
 	}
@@ -660,6 +766,7 @@ func (d *boardDispatcher) run(ctx context.Context) {
 			d.sweepAbandonedRecoveryClaims(ctx, now, verdict)
 			d.sweepUnleasedClaims(ctx, now, verdict)
 			verdict.report(d)
+			d.reportUnlaunchable(now)
 		}
 		select {
 		case <-ctx.Done():
@@ -1282,6 +1389,83 @@ func (d *boardDispatcher) fileReapedCard(ctx context.Context, cand boardmongo.Ex
 	return true
 }
 
+// unlaunchableTally counts the cards the dispatcher could not launch since
+// the last watchdog pass: refused at admission (never claimed) and released
+// after a claim (given back to their column). Neither is a card filed
+// blocked — that is the point of counting them apart from failures.
+type unlaunchableTally struct {
+	refused, released int
+}
+
+// unlaunchableCounts returns the running tally (test seam).
+func (d *boardDispatcher) unlaunchableCounts() unlaunchableTally {
+	d.unlaunchMu.Lock()
+	defer d.unlaunchMu.Unlock()
+	return d.unlaunchTally
+}
+
+// noteUnlaunchable records one unlaunchable verdict on a card and says it
+// ONCE per (card, reason) edge: the card is listed again on every tick for
+// as long as it stays broken, and the line has to be findable, not buried
+// under 17k copies of itself a day. column is where the card stays (or
+// returns to); afterClaim tells the belt's give-back from admission's skip.
+func (d *boardDispatcher) noteUnlaunchable(tenant, id, column string, err error, afterClaim bool) {
+	key := tenant + "/" + id
+	reason := err.Error()
+	d.unlaunchMu.Lock()
+	if d.unlaunchWarned == nil {
+		d.unlaunchWarned = map[string]unlaunchNote{}
+	}
+	said := d.unlaunchWarned[key].reason == reason
+	d.unlaunchWarned[key] = unlaunchNote{reason: reason, at: time.Now()}
+	if afterClaim {
+		d.unlaunchTally.released++
+	} else {
+		d.unlaunchTally.refused++
+	}
+	d.unlaunchMu.Unlock()
+	if said {
+		return
+	}
+	if afterClaim {
+		d.warn("card %s/%s could not be launched after the claim — returned to %q, claim freed, not filed (said once until the reason changes): %v",
+			tenant, id, column, err)
+		return
+	}
+	d.warn("card %s/%s cannot be launched — left in %q, not claimed (said once until the reason changes): %v",
+		tenant, id, column, err)
+}
+
+// clearUnlaunchable forgets a card's memo entry once it launched, so a later
+// refusal of the same card is said again.
+func (d *boardDispatcher) clearUnlaunchable(tenant, id string) {
+	d.unlaunchMu.Lock()
+	delete(d.unlaunchWarned, tenant+"/"+id)
+	d.unlaunchMu.Unlock()
+}
+
+// reportUnlaunchable folds the pass's tally into ONE line — the per-card
+// lines above are edge-triggered, so without this a broken card's ongoing
+// cost (one refused listing per tick) is invisible after its first tick —
+// and prunes memo entries no tick has refreshed for a pass (the card was
+// deleted, or fixed and launched by another replica).
+func (d *boardDispatcher) reportUnlaunchable(now time.Time) {
+	d.unlaunchMu.Lock()
+	t := d.unlaunchTally
+	d.unlaunchTally = unlaunchableTally{}
+	for key, note := range d.unlaunchWarned {
+		if now.Sub(note.at) > 2*d.reapEvery {
+			delete(d.unlaunchWarned, key)
+		}
+	}
+	d.unlaunchMu.Unlock()
+	if t.refused == 0 && t.released == 0 {
+		return
+	}
+	d.warn("unlaunchable cards since the last watchdog pass: %d refused at admission (never claimed), %d returned to their column after a claim — none filed blocked; each card is named once above",
+		t.refused, t.released)
+}
+
 func (d *boardDispatcher) warn(format string, args ...any) {
 	if d.logger != nil {
 		d.logger.Warn("board dispatcher: "+format, args...)
@@ -1457,19 +1641,26 @@ func (s *Server) boardIssueRuns(ctx context.Context, tenant, issueID string) ([]
 	return runs, nil
 }
 
-func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native.Issue) error {
+// boardLaunchPreconditions is everything a cloud card must satisfy BEFORE a
+// run can exist: a run service, a bot, a bot the resolver can find, and
+// reserved bot-args that parse. Every refusal wraps errCardUnlaunchable —
+// nothing ran, so the card keeps (or gets back) its column instead of being
+// filed blocked; a transient resolver error takes the same exit on purpose,
+// since the next tick retries a card that kept its column and never retries
+// one parked blocked. ONE helper for the tick's pre-claim admission and for
+// the launch itself, so the two cannot drift.
+func (s *Server) boardLaunchPreconditions(ctx context.Context, tenant string, iss native.Issue) (*launchBot, boardLaunchContext, error) {
 	if s.runs == nil {
-		return errors.New("run service unavailable")
+		return nil, boardLaunchContext{}, fmt.Errorf("run service unavailable: %w", errCardUnlaunchable)
 	}
 	if iss.Bot == "" {
-		return fmt.Errorf("card %s has no bot", iss.ID)
+		return nil, boardLaunchContext{}, fmt.Errorf("card %s has no bot: %w", iss.ID, errCardUnlaunchable)
 	}
 	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
 	lb, err := s.resolveBotSource(ctx, iss.Bot)
 	if err != nil {
-		return err
+		return nil, boardLaunchContext{}, fmt.Errorf("card %s names bot %q: %w: %w", iss.ID, iss.Bot, err, errCardUnlaunchable)
 	}
-	defer lb.Cleanup()
 	// A webhook-launched card carries its launch context (repo + the webhook's
 	// BYOK key / secret overrides) in reserved BotArgs keys (ensureBoardCard) —
 	// the coordinator otherwise has none of it. Lift it into the LaunchSpec so
@@ -1477,8 +1668,33 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 	// reserved keys from the bot's vars.
 	lc, err := liftBoardLaunchContext(iss.BotArgs)
 	if err != nil {
-		return fmt.Errorf("card %s: %w", iss.ID, err)
+		lb.Cleanup()
+		return nil, boardLaunchContext{}, fmt.Errorf("card %s: %w: %w", iss.ID, err, errCardUnlaunchable)
 	}
+	return lb, lc, nil
+}
+
+// admitBoardCard is the dispatcher's pre-claim admission for a cloud card:
+// the launch preconditions, and nothing else. It resolves the bot a second
+// time when the launch follows (processBoardCard resolves for itself) — one
+// extra catalog/store read per launch, paid so that a card that cannot be
+// launched is never claimed, moved and given back on every tick.
+func (s *Server) admitBoardCard(ctx context.Context, tenant string, iss native.Issue) error {
+	lb, _, err := s.boardLaunchPreconditions(ctx, tenant, iss)
+	if err != nil {
+		return err
+	}
+	lb.Cleanup()
+	return nil
+}
+
+func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native.Issue) error {
+	lb, lc, err := s.boardLaunchPreconditions(ctx, tenant, iss)
+	if err != nil {
+		return err
+	}
+	defer lb.Cleanup()
+	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
 	// A card that targets a pull request also needs the repo's launch policy
 	// and a publish grant, neither of which can ride the card itself.
 	lc.Vars = s.applyPRLaunchContext(ctx, tenant, "", iss.Bot, lc.Vars, nil)

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -26,16 +26,19 @@ import (
 )
 
 type fakeBoardCoord struct {
-	mu       sync.Mutex
-	cands    []boardmongo.Candidate
-	claimed  map[string]string
-	states   map[string]string
-	claimErr map[string]error
-	stateErr map[string]error
-	renews   map[string]int
-	epochs   map[string]int64
-	expired  []boardmongo.ExpiredCandidate
-	unleased []boardmongo.ExpiredCandidate
+	mu    sync.Mutex
+	cands []boardmongo.Candidate
+	// claimCalls counts Claim attempts — the oracle for "refused BEFORE
+	// the claim" (a released claim leaves no trace in `claimed`).
+	claimCalls int
+	claimed    map[string]string
+	states     map[string]string
+	claimErr   map[string]error
+	stateErr   map[string]error
+	renews     map[string]int
+	epochs     map[string]int64
+	expired    []boardmongo.ExpiredCandidate
+	unleased   []boardmongo.ExpiredCandidate
 	// recoveryLists counts ListAbandonedRecoveryClaims calls — the
 	// periodicity oracle for the repair-sweep cadence.
 	recoveryLists int
@@ -77,7 +80,29 @@ func (f *fakeBoardCoord) ListEligible(_ context.Context, states []string, limit 
 		if f.claimed[c.Issue.ID] != "" || !slices.Contains(states, state) {
 			continue
 		}
-		if len(out) == limit {
+		if limit > 0 && len(out) == limit { // limit <= 0 is unbounded, like the real coordinator
+			break
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+// ListDispatchable honours the dispatch tick's contract on top of
+// ListEligible's: a card with NO bot is never listed, however eligible its
+// column — the real query filters on issue.bot, and a fake that listed it
+// would certify a tick that claims what it cannot launch (#798).
+func (f *fakeBoardCoord) ListDispatchable(ctx context.Context, states []string, limit int) ([]boardmongo.Candidate, error) {
+	all, err := f.ListEligible(ctx, states, 0, false)
+	if err != nil {
+		return nil, err
+	}
+	var out []boardmongo.Candidate
+	for _, c := range all {
+		if c.Issue.Bot == "" {
+			continue
+		}
+		if limit > 0 && len(out) == limit {
 			break
 		}
 		out = append(out, c)
@@ -88,6 +113,7 @@ func (f *fakeBoardCoord) ListEligible(_ context.Context, states []string, limit 
 func (f *fakeBoardCoord) Claim(_ context.Context, _, id, marker string) (tracker.ClaimToken, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.claimCalls++
 	if err := f.claimErr[id]; err != nil {
 		return tracker.ClaimToken{}, err
 	}
@@ -2596,7 +2622,7 @@ func (s *stolenClaimCoord) SetStateOwned(context.Context, string, string, string
 // later fenced write (the final state, the release) is refused too.
 func TestCloudProcessCard_ClaimConflictAbortsTheLaunch(t *testing.T) {
 	f := newFakeBoardCoord(boardmongo.Candidate{
-		Tenant: "t1", Issue: native.Issue{ID: "c-stolen", State: native.StateReady},
+		Tenant: "t1", Issue: native.Issue{ID: "c-stolen", State: native.StateReady, Bot: "feature-dev"},
 	})
 	var processed atomic.Bool
 	d := newBoardDispatcher(&stolenClaimCoord{fakeBoardCoord: f},

--- a/pkg/server/boarddispatch_unlaunchable_test.go
+++ b/pkg/server/boarddispatch_unlaunchable_test.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The cloud board dispatcher must not claim what it cannot launch (#798).
+//
+// A `ready` card with no bot is roadmap content, not dispatchable work — the
+// cloud dispatcher has no default bot — and a project-board sync lands every
+// "Planned" ticket in `ready`. The prod shape: 36 such cards were claimed,
+// each failed "card has no bot", each was parked `blocked`, and the reflect
+// pushed Blocked onto 30 roadmap tickets as if a human had moved them.
+
+// TestBoardDispatcher_NeverClaimsACardWithoutABot pins the choke point: the
+// tick's candidate query excludes a bot-less card, so it is never claimed,
+// launched or moved.
+func TestBoardDispatcher_NeverClaimsACardWithoutABot(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:roadmap", ""), readyCard("native:work", "feature-dev"))
+	var pmu sync.Mutex
+	processed := map[string]int{}
+	d := newBoardDispatcher(f, func(_ context.Context, _ string, iss native.Issue) error {
+		pmu.Lock()
+		processed[iss.ID]++
+		pmu.Unlock()
+		if iss.Bot == "" {
+			return fmt.Errorf("card %s has no bot", iss.ID)
+		}
+		return nil
+	}, "replica-A", 4, iterlog.Nop())
+
+	if n := d.tick(context.Background()); n != 1 {
+		t.Fatalf("tick claimed %d card(s), want 1 — only the card that names a bot is dispatchable", n)
+	}
+	d.wg.Wait()
+	if f.claimCalls != 1 {
+		t.Errorf("Claim was attempted %d time(s), want 1 — a bot-less card must never be claimed", f.claimCalls)
+	}
+	if processed["native:roadmap"] != 0 {
+		t.Errorf("the bot-less card was processed %d time(s), want 0", processed["native:roadmap"])
+	}
+	if got, moved := f.states["native:roadmap"]; moved {
+		t.Errorf("the bot-less card was moved to %q, want it left in %q untouched", got, native.StateReady)
+	}
+	if f.states["native:work"] != native.StateDone {
+		t.Errorf("the launchable card ended %q, want %q", f.states["native:work"], native.StateDone)
+	}
+}
+
+// TestBoardDispatcher_AdmissionRefusesBeforeTheClaim: the launch
+// preconditions are checked BEFORE the claim (the local dispatcher's
+// resolveExplicitBot shape), so a card that cannot be launched is skipped in
+// its column — no claim, no in_progress move, no give-back — and the refusal
+// is said once per (card, reason), not once per 5s tick.
+func TestBoardDispatcher_AdmissionRefusesBeforeTheClaim(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:ghost", "ghost-bot"))
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Error("a card refused at admission must never reach process")
+		return nil
+	}, "replica-A", 4, iterlog.New(iterlog.LevelWarn, &buf))
+	d.admit = func(_ context.Context, _ string, iss native.Issue) error {
+		return fmt.Errorf("card %s names bot %q which cannot be resolved: %w", iss.ID, iss.Bot, errCardUnlaunchable)
+	}
+
+	for i := 0; i < 3; i++ {
+		if n := d.tick(context.Background()); n != 0 {
+			t.Fatalf("tick %d claimed %d card(s), want 0", i, n)
+		}
+	}
+	d.wg.Wait()
+	if f.claimCalls != 0 {
+		t.Errorf("Claim was attempted %d time(s), want 0 — admission runs before the claim", f.claimCalls)
+	}
+	if got, moved := f.states["native:ghost"]; moved {
+		t.Errorf("a card refused at admission was moved to %q — it must keep its column", got)
+	}
+	if got := linesMentioning(buf.String(), "native:ghost"); got != 1 {
+		t.Errorf("the refusal was logged %d time(s) over 3 ticks, want exactly 1 (once per card+reason edge):\n%s", got, buf.String())
+	}
+	if got := d.unlaunchableCounts(); got.refused != 3 || got.released != 0 {
+		t.Errorf("unlaunchable counts = %+v, want 3 refused at admission, 0 released after claim", got)
+	}
+}
+
+// TestBoardDispatcher_UnlaunchableCardKeepsItsColumn is the belt under the
+// choke point: when a precondition still fails AFTER the claim (the card
+// changed between the listing and the launch), nothing ran, so no verdict
+// belongs on the card. It goes back to the column the tick took it from —
+// under machine provenance, so the return re-fires no subscription and is
+// not projected as a move — and the claim is freed. Never `blocked`.
+func TestBoardDispatcher_UnlaunchableCardKeepsItsColumn(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, func(_ context.Context, _ string, iss native.Issue) error {
+		return fmt.Errorf("card %s has no bot: %w", iss.ID, errCardUnlaunchable)
+	}, "replica-A", 4, iterlog.New(iterlog.LevelWarn, &buf))
+
+	for i := 0; i < 2; i++ {
+		d.tick(context.Background())
+		d.wg.Wait()
+	}
+	if got := f.states["native:1"]; got != native.StateReady {
+		t.Errorf("an unlaunchable card ended in %q, want %q — the column it was taken from, never blocked", got, native.StateReady)
+	}
+	if got := f.reasons["native:1"]; got != tracker.ReasonUnlaunchable {
+		t.Errorf("the give-back carried provenance %q, want %q (machine — no chain fires, no reflect)", got, tracker.ReasonUnlaunchable)
+	}
+	if len(f.claimed) != 0 {
+		t.Errorf("the claim must be freed after the give-back: %v", f.claimed)
+	}
+	if got := linesMentioning(buf.String(), "native:1"); got != 1 {
+		t.Errorf("the give-back was logged %d time(s) over 2 ticks, want exactly 1:\n%s", got, buf.String())
+	}
+	if got := d.unlaunchableCounts(); got.released != 2 {
+		t.Errorf("unlaunchable counts = %+v, want 2 released after claim", got)
+	}
+}
+
+// TestProcessBoardCard_PreconditionsAreUnlaunchable pins the taxonomy at its
+// source: every failure that happens BEFORE a run exists — no bot, an
+// unresolvable bot, malformed reserved bot-args, no run service — is
+// errCardUnlaunchable, so processCard gives the card back instead of parking
+// it. The publisher refusing an actual launch is deliberately NOT in this
+// class: that is a verdict on the launch, and keeps its filing.
+func TestProcessBoardCard_PreconditionsAreUnlaunchable(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.Bots.Paths = []string{t.TempDir()}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name string
+		iss  native.Issue
+	}{
+		{"no bot", native.Issue{ID: "native:nobot"}},
+		{"unresolvable bot", native.Issue{ID: "native:ghost", Bot: "no-such-bot-anywhere"}},
+		{"malformed reserved bot-args", native.Issue{ID: "native:bad", Bot: "no-such-bot-anywhere",
+			BotArgs: map[string]string{boardKeyOverridesKey: "{not json"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.processBoardCard(ctx, "team1", tc.iss)
+			if !errors.Is(err, errCardUnlaunchable) {
+				t.Fatalf("processBoardCard = %v, want errCardUnlaunchable — nothing ran, no verdict belongs on the card", err)
+			}
+		})
+	}
+	t.Run("run service unwired", func(t *testing.T) {
+		s.runs = nil
+		if err := s.processBoardCard(ctx, "team1", native.Issue{ID: "native:x", Bot: "b"}); !errors.Is(err, errCardUnlaunchable) {
+			t.Fatalf("processBoardCard = %v, want errCardUnlaunchable", err)
+		}
+	})
+}
+
+// linesMentioning counts the LOG LINES naming a card — one line names it
+// twice (the dispatcher's own prefix and the wrapped error), so a substring
+// count would read one warn as two.
+func linesMentioning(log, needle string) int {
+	n := 0
+	for _, line := range strings.Split(log, "\n") {
+		if strings.Contains(line, needle) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestServerAdmitBoardCard: the pre-claim admission shares processBoardCard's
+// precondition set — one helper, so the two cannot drift — and refuses with
+// the same sentinel.
+func TestServerAdmitBoardCard(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.Bots.Paths = []string{t.TempDir()}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+	if err := s.admitBoardCard(context.Background(), "team1", native.Issue{ID: "native:nobot"}); !errors.Is(err, errCardUnlaunchable) {
+		t.Fatalf("admit(no bot) = %v, want errCardUnlaunchable", err)
+	}
+	if err := s.admitBoardCard(context.Background(), "team1", native.Issue{ID: "native:ghost", Bot: "no-such-bot"}); !errors.Is(err, errCardUnlaunchable) {
+		t.Fatalf("admit(unresolvable bot) = %v, want errCardUnlaunchable", err)
+	}
+}

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -420,6 +420,9 @@ func (s *Server) ListenAndServe() error {
 				cancel()
 			}()
 			d := newBoardDispatcher(s.cfg.CloudBoardCoordinator, s.processBoardCard, marker, 4, s.logger)
+			// Pre-claim admission: a card that cannot be launched is skipped
+			// in its column, never claimed and parked.
+			d.admit = s.admitBoardCard
 			// Parked-card sweep wiring: read a run's status tenant-scoped,
 			// and clear the denormalized ⏸ badge when the sweep moves a card.
 			d.statusFor = s.boardRunStatus

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -111,24 +111,49 @@ func TestMaterializeEffects_ProjectionOnlyWhereItIsOwed(t *testing.T) {
 	}
 }
 
-// TestMaterializeEffects_ProjectionExemptFromTheMachineDecline is the point of
-// the whole exercise: the machine-caused decline guards LAUNCH admission (a
-// column rename must not mass-launch), and a watchdog filing a card in
-// `blocked` is EXACTLY what the external roadmap has to show. The launch rows
-// stay declined; the projection row is owed.
-func TestMaterializeEffects_ProjectionExemptFromTheMachineDecline(t *testing.T) {
-	ev := movedEvent()
-	ev.Payload = map[string]any{"reason": tracker.ReasonWatchdog}
-	if !machineCaused(ev) {
-		t.Fatalf("fixture is not machine-caused — reason %q", ev.Payload["reason"])
+// TestMaterializeEffects_MachineCausedOwesNoProjection (#798): a move iterion
+// made on its own authority — a watchdog park, a column rename, a card given
+// back after a failed launch — is not a move the external roadmap follows,
+// so no projection row is owed for it. Declined at materialization for the
+// reason launches are: a schema migration emits one event per card, and a
+// column of rows that each retire with nothing to write sits FIFO ahead of
+// the next genuine reflect. The launch rows stay declined too.
+func TestMaterializeEffects_MachineCausedOwesNoProjection(t *testing.T) {
+	for _, reason := range []string{tracker.ReasonWatchdog, tracker.ReasonStateRename, tracker.ReasonUnlaunchable} {
+		t.Run(reason, func(t *testing.T) {
+			ev := movedEvent()
+			ev.Payload = map[string]any{"reason": reason}
+			if !machineCaused(ev) {
+				t.Fatalf("fixture is not machine-caused — reason %q", reason)
+			}
+			rows, err := MaterializeEffects(context.Background(), projectionSubs(t),
+				&stubBindings{bound: map[string]bool{"t1": true}}, ev, time.Now().UTC())
+			if err != nil {
+				t.Fatalf("materialize: %v", err)
+			}
+			if len(rows) != 0 {
+				t.Fatalf("machine-caused move materialized %+v, want no row at all — not a launch, not a projection", rows)
+			}
+		})
 	}
+	// A DESCRIPTIVE reason is a gesture (or a run's verdict) and still owes
+	// its projection: the watchdog filing a finished run's `done` is what
+	// the roadmap must show.
+	ev := movedEvent()
+	ev.Payload = map[string]any{"reason": tracker.ReasonRunFinished}
 	rows, err := MaterializeEffects(context.Background(), projectionSubs(t),
 		&stubBindings{bound: map[string]bool{"t1": true}}, ev, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("materialize: %v", err)
 	}
-	if len(rows) != 1 || !rows[0].IsProjection() {
-		t.Fatalf("machine-caused move materialized %+v, want exactly one projection row and no launch", rows)
+	var proj int
+	for _, r := range rows {
+		if r.IsProjection() {
+			proj++
+		}
+	}
+	if proj != 1 {
+		t.Fatalf("a run-verdict move materialized %d projection row(s), want 1 (%+v)", proj, rows)
 	}
 }
 
@@ -232,19 +257,26 @@ func TestEffectWorker_ProjectionReflectsAndCompletes(t *testing.T) {
 	}
 }
 
-// TestEffectWorker_ProjectionIsExemptFromTheMachineDecline is the exemption
-// at its own line: `applyEffect` declines a machine-caused event for every
-// LAUNCH arm, and must not for a projection. A watchdog move that never
-// reaches the external board is the one divergence the reflect exists to
-// prevent.
-func TestEffectWorker_ProjectionIsExemptFromTheMachineDecline(t *testing.T) {
+// TestEffectWorker_ProjectionArmStillExecutesAQueuedRow: the projection arm
+// does not re-derive the machine decline from the event — a row that IS in
+// the outbox reaches the reflect, which judges the CARD's persisted
+// provenance (the one authority both callers share). A row queued by an
+// older binary for a machine move therefore retires through the reflect's
+// own refusal, never as a dead-letter.
+func TestEffectWorker_ProjectionArmStillExecutesAQueuedRow(t *testing.T) {
 	ev := movedEvent()
-	ev.Payload = map[string]any{"reason": tracker.ReasonWatchdog}
 	proj := &stubProjection{}
 	w, out := projectionWorld(t, ev, proj)
+	// Stamp the provenance AFTER materialization: the row exists; only its
+	// execution is under test.
+	row, _ := out.Row(ProjectionEffectID(ev.ID))
+	row.Event.Payload = map[string]any{"reason": tracker.ReasonWatchdog}
+	if err := out.UpsertPending(context.Background(), []EffectRow{row}); err != nil {
+		t.Fatal(err)
+	}
 	w.Tick(context.Background(), 10)
 	if len(proj.cards) != 1 {
-		t.Fatalf("a machine-caused move reflected %d times, want 1 — the decline leaked into the projection arm", len(proj.cards))
+		t.Fatalf("a queued projection row reached the reflect %d times, want 1 — the arm hands every row to the reflect, which decides on the card", len(proj.cards))
 	}
 	if row, _ := out.Row(ProjectionEffectID(ev.ID)); row.State != EffectDone {
 		t.Fatalf("projection row state = %q, want %q", row.State, EffectDone)

--- a/pkg/trigger/effects_worker.go
+++ b/pkg/trigger/effects_worker.go
@@ -178,11 +178,11 @@ type ProjectionBindings interface {
 // case no projection row is ever owed.
 func MaterializeEffects(ctx context.Context, subs SubscriptionStore, bindings ProjectionBindings, ev Event, now time.Time) ([]EffectRow, error) {
 	var rows []EffectRow
-	// The projection is computed BEFORE — and outside of —
-	// matchingSubscriptions, deliberately: that prelude declines
-	// machine-caused events to protect the fleet from mass LAUNCHES, and a
-	// watchdog filing a card in `blocked` is exactly what the external
-	// roadmap must show. A projection spends no budget and starts no run.
+	// The projection is computed outside of matchingSubscriptions: it is
+	// owed to the tenant's board binding, never to a subscription, and it
+	// spends no budget and starts no run. It shares that prelude's
+	// machine-caused decline all the same (projectionOwed): a column
+	// iterion wrote on its own authority is not a move the roadmap follows.
 	owed, err := projectionOwed(ctx, bindings, ev)
 	if err != nil {
 		return nil, err
@@ -226,6 +226,16 @@ func projectionOwed(ctx context.Context, bindings ProjectionBindings, ev Event) 
 	// name, for a tenant a binding can be resolved for.
 	if bindings == nil || ev.Source != SourceBoard || ev.Kind != KindCardMoved ||
 		ev.Subject.ID == "" || ev.TenantID == "" {
+		return false, nil
+	}
+	// A machine-caused move — a watchdog park, a column rename, a card given
+	// back after a failed launch — is iterion's own bookkeeping, not a move
+	// the operator's roadmap follows: no row. Declined HERE, not only in the
+	// reflect (which judges the card's persisted provenance and refuses
+	// too), for the reason launches are: a schema migration emits one event
+	// per card, and a column of durable rows that each retire with nothing
+	// to write sits FIFO ahead of the next genuine reflect.
+	if machineCaused(ev) {
 		return false, nil
 	}
 	bound, err := bindings.HasBoardBinding(ctx, ev.TenantID)

--- a/pkg/trigger/evaluator.go
+++ b/pkg/trigger/evaluator.go
@@ -159,17 +159,15 @@ func machineCaused(ev Event) bool {
 // (the bus path warns and moves on, the outbox path retries).
 
 func (e *Evaluator) applyEffect(ctx context.Context, sub Subscription, ev Event, opts effectOpts) error {
-	// The PROJECTION arm, deliberately ahead of the machine-caused decline
-	// below — this is the exemption ADR-097 §10 named, stated at the one line
-	// that grants it rather than left to fall out of the wiring.
-	//
-	// That decline protects LAUNCH admission: a schema migration emits one
-	// event per card, and one run per card is the fan-out it refuses. A
-	// projection starts no run, spends no budget and consumes no one-shot —
-	// it copies a column the native board already holds onto the external
-	// board bound to it. Declining it there would make iterion's OWN moves (a
-	// watchdog filing a card in `blocked`) the only ones the roadmap never
-	// hears about, which is the divergence the reflect exists to close.
+	// The PROJECTION arm, ahead of the machine-caused decline below: the
+	// decline here reads the EVENT, and a projection row is judged on the
+	// CARD — the reflect refuses a column iterion wrote on its own authority
+	// from the card's persisted provenance, the one authority the fast path
+	// and the periodic pass share. A row that is in the outbox (materialized
+	// before the event was known to be machine-caused, or by an older
+	// binary) therefore reaches the reflect and retires through its answer,
+	// never as a dead-letter. projectionOwed already declines the row at
+	// materialization for a machine-caused event.
 	//
 	// `sub` is the zero value here: a projection is owed to the tenant's board
 	// binding, never to a subscription.

--- a/pkg/trigger/provenance_wiring_test.go
+++ b/pkg/trigger/provenance_wiring_test.go
@@ -134,6 +134,10 @@ func TestMachineCaused_EnumeratedSet(t *testing.T) {
 		tracker.ReasonStateRename: true,
 		tracker.ReasonStateDelete: true,
 		tracker.ReasonFieldRename: true,
+		// The dispatcher giving back a card it could not launch: nothing
+		// ran, so the return to the column is machinery — a subscription
+		// armed on that column must not re-fire on it (#798).
+		tracker.ReasonUnlaunchable: true,
 		// Descriptive provenance — the cascade of an operator gesture —
 		// keeps its triggers. This row is what died under `reason != ""`.
 		tracker.ReasonUnblocked: false,

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5758,6 +5758,7 @@ export interface components {
             state: string;
             /** Format: date-time */
             state_at?: string;
+            state_reason?: string;
             title: string;
             /** Format: date-time */
             updated_at: string;


### PR DESCRIPTION
Closes #798.

## What happened (prod, 2026-09-05 20:55Z, the #613 pilot)
With a team bound to GitHub Projects board SocialGouv/203 (ADR-097, default map `Planned → ready`), the project pass moved 36 native cards to `ready`. Ten seconds later the cloud board dispatcher claimed every one of them, failed "card has no bot", parked them `blocked` — and the reflect pushed "Blocked" onto 30 roadmap tickets as if a human had moved them.

## Defect 1 — the dispatcher never claims what it cannot launch
- **Choke point**: `boardmongo.Coordinator.ListDispatchable` — unclaimed + launch column + `issue.bot > ""` in the query itself (the batch is capped; bot-less cards are the oldest and would starve every batch). `ListEligible` stays the sweeps' listing (they judge by `LastRunID`). The tick uses the new listing; the test fake honours the same contract.
- **Admission before the claim** (`boarddispatch.go` `tick`): the launch preconditions run before `Claim`, so a broken card is skipped in its column — no claim, no `in_progress` move, no give-back per tick.
- **Belt in `processCard`**: an explicit taxonomy, `errCardUnlaunchable` (no bot / unresolvable bot / malformed reserved bot-args / run service unwired), all produced by ONE helper `boardLaunchPreconditions` shared by admission and `processBoardCard`. Such a card goes back to the column the tick took it from (`SetStateOwnedReason(…, ReasonUnlaunchable)` — machine provenance, so no subscription re-fires and nothing is reflected) and the claim is freed. Never `blocked`. One Warn per (card, reason) edge + one tally per watchdog pass. Publisher/quota refusals and real run failures keep today's `blocked` semantics.

## Defect 2 — a column iterion wrote on its own authority is not projected
- **Marker**: `native.Issue.StateReason` (`state_reason`) + `Issue.StateByMachine()`, stamped on **both store twins** at every state write from the same inputs as the event's `reason` (one derivation, `native.StateProvenance`); `ReasonUnlaunchable` joins the enumerated machine set; `SetStateOwnedReason` joins the `BoardStore` contract.
- **Rule**, in the ONE reflect both callers share (`reflectNativeState`): a card whose current column carries machine provenance is left alone and counted (`reflect_machine` in the pass line); `projectionOwed` materializes no row for a machine-caused event.
- **Deliberately NOT excluded**: the dispatcher's fenced `in_progress` / `done` / `blocked`-after-a-real-failure — ADR-097's own motivating case ("a bot moves a card to done; the board still shows Planned") and the runbook promise the roadmap follows run verdicts. Excluded = transitions iterion performs on its own authority (watchdog park / give-up / ceiling park, column rename, the unlaunchable give-back); reflected = a person's move and a run's verdict. ADR-097 carries a `#798` addendum superseding its "a machine-caused move is reflected like any other" bullet; `docs/github-board-sync.md` gains "What is projected"; `docs/dispatcher.md` documents the admission.

## Tests (red first — failing line, then green)
`boarddispatch_unlaunchable_test.go:45` (`tick claimed 2 card(s), want 1`), `:116` (`ended in "blocked", want "ready"`), `:119` (provenance), `:128` (tallies), `:80` (admission: `tick 0 claimed 1, want 0`); `board_project_reflect_test.go:739` and `board_projection_effect_machine_test.go:30` (machine provenance fixtures); `effects_projection_test.go:135` (`machine-caused move materialized …, want no row`); `provenance_wiring_test.go:155`; conformance build failure on the missing `SetStateOwnedReason` (added). All PASS. `go test ./pkg/server/... ./pkg/dispatcher/... ./pkg/trigger/... ./pkg/cli/...` ok · `task lint` 0 issues · `task test:e2e` ok (416 s) · `TestNativeStore_Conformance` PASS on the new rows · `task openapi:gen` (`state_reason`). `TestMongoStore_Conformance` skipped locally (no `ITERION_TEST_MONGO_URI`) — CI's `mongo-conformance` job runs the Mongo half.

## Class sweep
Automation parks to `blocked`: `processCard` real-failure arm (kept), `sweepParked` hard-fail (kept — run verdict), `reconcileDeadPointer` terminal (kept) and settled-resumable (`ReasonWatchdog` → excluded from the reflect via the marker), `reapOne` StuckFail (descriptive, reflected), lifetime-ceiling repark + `giveUpReapedCard` (watchdog → excluded). Candidate builders: `ListEligible` (sweeps), `ListDispatchable` (tick), native `Adapter.ListCandidates` (local, has a default bot), studio `ClaimForLaunch` (already 409 on a bot-less ticket). Reflect entry points: `applyProjectItem` and `ReflectCard` → both `reflectNativeState`.

## Left as separate findings
A publisher/admission refusal (quota, sealing) in `processCard`'s real-failure arm still parks the card `blocked` with no run and IS reflected — filed separately. `iterion remote board bind` does not yet warn that the default `Planned → ready` map feeds the cloud dispatcher (documented in the runbook). `docs/github-board-sync.md` lines 13–21 carry a pre-existing duplicated table fragment (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
