### PR TITLE
fix(delegate): a facade's bracketed API-error render is an API error, not a node's answer

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -480,81 +480,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 		}
 	}
 
-	// Overload/5xx guard. The claude CLI sometimes completes the stream
-	// "successfully" (subtype=success, IsError=false) but renders an
-	// unrecoverable upstream API failure AS the result text — e.g.
-	// "API Error: 529 Overloaded". Left untouched, that string becomes the
-	// node's output AND poisons any downstream session that inherits this
-	// one (observed in a test-coverage dogfood: a 529 on the `plan` node
-	// flowed a non-plan into `act`). Re-type it as ErrTransient so the
-	// executor's retry loop rides the outage out — exactly as it does for a
-	// connectivity drop surfaced on stderr (retypeNetworkError). Only
-	// transient classes (429/5xx/overload/connectivity) retry; a 4xx
-	// client/auth error falls through as the visible node output.
-	if rm.Result != nil && isTransientAPIErrorResult(*rm.Result) {
-		detail := strings.TrimSpace(*rm.Result)
-		b.Logger.Warn("[%s#%d/claude-code] upstream API-error result text detected — flagging for retry: %.120s",
-			task.NodeID, task.Iteration, detail)
-		return result, &ErrTransient{Provider: BackendClaudeCode, Reason: "api_error_result", Detail: detail}
-	}
-
-	// Model-unavailable guard. An invalid/unauthorized `--model` does NOT fail
-	// the stream (subtype=success, IsError=false): the claude CLI renders its
-	// model-error sentence AS the result text (e.g. "There's an issue with the
-	// selected model (openai/gpt-5.5). It may not exist or you may not have
-	// access to it."). Left untouched that prose flows into the formatting
-	// passes and finally surfaces as an opaque "missing required field" schema
-	// error, masking the real cause. Fail fast with a legible error naming the
-	// offending model. Non-transient (unlike the API-error guard above) — a
-	// retry can't fix a bad/unauthorized model; the usual cause is a
-	// claude_code node pinned to a non-Anthropic model (e.g. the shared
-	// ITERION_SEC_AUDIT_BACKEND/MODEL override dragging detect_tech onto
-	// openai/gpt-5.5).
-	if rm.Result != nil && isModelUnavailableResult(*rm.Result) {
-		detail := strings.TrimSpace(*rm.Result)
-		b.Logger.Error("[%s#%d/claude-code] model %q unavailable to the CLI — failing fast: %.160s",
-			task.NodeID, task.Iteration, task.Model, detail)
-		return result, fmt.Errorf("claude-code: model %q is unavailable or unauthorized (check the node's backend/model — a claude_code node cannot run a non-Anthropic model): %s", task.Model, detail)
-	}
-
-	// Auth-failure guard. A dead/expired forfait token (or a rejected API key)
-	// does NOT fail the stream (subtype=success, IsError=true): the claude CLI
-	// renders the auth error AS the result text (e.g. "Failed to authenticate.
-	// API Error: 401 Invalid bearer token"). Left untouched it flows into the
-	// formatting passes and finally surfaces as an opaque "missing required
-	// field" schema error — the exact masking that turns a dead credential into
-	// a wild goose chase through the structured-output machinery. Fail fast with
-	// a legible auth error. Non-transient (a retry can't revive a dead token).
-	if authErr := authFailureFast(rm.Result, task); authErr != nil {
-		b.Logger.Error("[%s#%d/claude-code] authentication failed — failing fast: %.160s",
-			task.NodeID, task.Iteration, redactAuthRender(strings.TrimSpace(*rm.Result)))
-		return result, authErr
-	}
-
-	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
-	// 5h caps can come back as the result text (subtype=success, IsError=true)
-	// with no assistant text block for the stream classifier to catch — re-check
-	// here so the notice becomes a typed, resumable rate-limit error instead of
-	// flowing into structured-output validation as a misleading "missing
-	// required field". Usage-window → resumable after reset; a plain throttle →
-	// the executor's transient retry.
-	if rm.Result != nil && isRateLimitMessage(*rm.Result) {
-		detail := strings.TrimSpace(*rm.Result)
-		kind, window, resetAt := classifyRateLimit(detail, time.Now())
-		b.Logger.Warn("[%s#%d/claude-code] provider quota/rate-limit result (%s) — failing: %.120s",
-			task.NodeID, task.Iteration, kind, detail)
-		// Same evidence duty as the stream path: a text-relayed refusal
-		// that names a meter window must reach the store, or the
-		// credential-tier skip stays blind to it.
-		if window != "" && task.Hooks.OnUsageWindow != nil {
-			_ = task.Hooks.OnUsageWindow(usagecap.Reading{
-				Window:     window,
-				Status:     usagecap.StatusRejected,
-				ObservedAt: time.Now().UTC(),
-				ResetsAt:   resetAt,
-			})
-		}
-		return result, &ErrRateLimited{Provider: BackendClaudeCode, Detail: detail, Kind: kind, ResetAt: resetAt}
+	// Every guard on the result TEXT lives in renderedFailure, shared with
+	// the formatting passes: a render is never an answer, on any pass.
+	if err := b.renderedFailure(rm, task, "pass 1"); err != nil {
+		return result, err
 	}
 
 	if needsTwoPass && rm.SessionID != "" {
@@ -573,11 +502,108 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// try one recovery formatting pass via session resume (see helper).
 	var recoveryRM *claudesdk.ResultMessage
 	if (len(output) == 0 || fallback) && len(task.OutputSchema) > 0 && rm.SessionID != "" {
-		recoveryRM = b.runRecoveryFormatterPass(ctx, task, rm.SessionID, &result, &totalIn, &totalOut)
+		var rerr error
+		if recoveryRM, rerr = b.runRecoveryFormatterPass(ctx, task, rm.SessionID, &result, &totalIn, &totalOut); rerr != nil {
+			return result, rerr
+		}
 	}
 
 	annotateCost(&result, task, totalIn, totalOut, rm, recoveryRM)
 	return result, nil
+}
+
+// renderedFailure re-types a result whose TEXT is the CLI's render of an
+// upstream failure — a quota window, a rejected credential, an unavailable
+// model, a transient API error — into the typed error the executor knows how
+// to route. One predicate for every result message the delegation reads:
+// pass 1, each formatting pass, the recovery pass. A render that reaches
+// parseSDKOutput becomes the node's answer, and the graph continues on it
+// (measured: a campaign node "rendered" an upstream 500 and the next node
+// spent 283 minutes on it). Order is the most specific verdict first: a
+// window notice carries evidence the generic retry would lose, and a dead
+// credential must not be retried at all.
+func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Task, pass string) error {
+	if rm == nil || rm.Result == nil {
+		return nil
+	}
+	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
+	// 5h caps can come back as the result text (subtype=success, IsError=true)
+	// with no assistant text block for the stream classifier to catch — re-check
+	// here so the notice becomes a typed, resumable rate-limit error instead of
+	// flowing into structured-output validation as a misleading "missing
+	// required field". Usage-window → resumable after reset; a plain throttle →
+	// the executor's transient retry.
+	if rm.Result != nil && isRateLimitMessage(*rm.Result) {
+		detail := strings.TrimSpace(*rm.Result)
+		kind, window, resetAt := classifyRateLimit(detail, time.Now())
+		b.Logger.Warn("[%s#%d/claude-code %s] provider quota/rate-limit result (%s) — failing: %.120s",
+			task.NodeID, task.Iteration, pass, kind, detail)
+		// Same evidence duty as the stream path: a text-relayed refusal
+		// that names a meter window must reach the store, or the
+		// credential-tier skip stays blind to it.
+		if window != "" && task.Hooks.OnUsageWindow != nil {
+			_ = task.Hooks.OnUsageWindow(usagecap.Reading{
+				Window:     window,
+				Status:     usagecap.StatusRejected,
+				ObservedAt: time.Now().UTC(),
+				ResetsAt:   resetAt,
+			})
+		}
+		return &ErrRateLimited{Provider: BackendClaudeCode, Detail: detail, Kind: kind, ResetAt: resetAt}
+	}
+
+	// Auth-failure guard. A dead/expired forfait token (or a rejected API key)
+	// does NOT fail the stream (subtype=success, IsError=true): the claude CLI
+	// renders the auth error AS the result text (e.g. "Failed to authenticate.
+	// API Error: 401 Invalid bearer token"). Left untouched it flows into the
+	// formatting passes and finally surfaces as an opaque "missing required
+	// field" schema error — the exact masking that turns a dead credential into
+	// a wild goose chase through the structured-output machinery. Fail fast with
+	// a legible auth error. Non-transient (a retry can't revive a dead token).
+	if authErr := authFailureFast(rm.Result, task); authErr != nil {
+		b.Logger.Error("[%s#%d/claude-code %s] authentication failed — failing fast: %.160s",
+			task.NodeID, task.Iteration, pass, redactAuthRender(strings.TrimSpace(*rm.Result)))
+		return authErr
+	}
+
+	// Model-unavailable guard. An invalid/unauthorized `--model` does NOT fail
+	// the stream (subtype=success, IsError=false): the claude CLI renders its
+	// model-error sentence AS the result text (e.g. "There's an issue with the
+	// selected model (openai/gpt-5.5). It may not exist or you may not have
+	// access to it."). Left untouched that prose flows into the formatting
+	// passes and finally surfaces as an opaque "missing required field" schema
+	// error, masking the real cause. Fail fast with a legible error naming the
+	// offending model. Non-transient (unlike the API-error guard above) — a
+	// retry can't fix a bad/unauthorized model; the usual cause is a
+	// claude_code node pinned to a non-Anthropic model (e.g. the shared
+	// ITERION_SEC_AUDIT_BACKEND/MODEL override dragging detect_tech onto
+	// openai/gpt-5.5).
+	if rm.Result != nil && isModelUnavailableResult(*rm.Result) {
+		detail := strings.TrimSpace(*rm.Result)
+		b.Logger.Error("[%s#%d/claude-code %s] model %q unavailable to the CLI — failing fast: %.160s",
+			task.NodeID, task.Iteration, pass, task.Model, detail)
+		return fmt.Errorf("claude-code: model %q is unavailable or unauthorized (check the node's backend/model — a claude_code node cannot run a non-Anthropic model): %s", task.Model, detail)
+	}
+
+	// Overload/5xx guard. The claude CLI sometimes completes the stream
+	// "successfully" (subtype=success, IsError=false) but renders an
+	// unrecoverable upstream API failure AS the result text — e.g.
+	// "API Error: 529 Overloaded". Left untouched, that string becomes the
+	// node's output AND poisons any downstream session that inherits this
+	// one (observed in a test-coverage dogfood: a 529 on the `plan` node
+	// flowed a non-plan into `act`). Re-type it as ErrTransient so the
+	// executor's retry loop rides the outage out — exactly as it does for a
+	// connectivity drop surfaced on stderr (retypeNetworkError). Only
+	// transient classes (429/5xx/overload/connectivity) retry; a 4xx
+	// client/auth error falls through as the visible node output.
+	if rm.Result != nil && isTransientAPIErrorResult(*rm.Result) {
+		detail := strings.TrimSpace(*rm.Result)
+		b.Logger.Warn("[%s#%d/claude-code %s] upstream API-error result text detected — flagging for retry: %.120s",
+			task.NodeID, task.Iteration, pass, detail)
+		return &ErrTransient{Provider: BackendClaudeCode, Reason: "api_error_result", Detail: detail}
+	}
+
+	return nil
 }
 
 // annotateCost stamps `_tokens` / `_model` / `_cost_usd` on the delegation
@@ -733,6 +759,11 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 	for attempt := 1; attempt <= maxFmtAttempts; attempt++ {
 		b.Logger.Debug("claude-code [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, rm.SessionID)
 		fmtRM, fmtErr := b.formatOutput(ctx, task, rm.SessionID)
+		if fmtErr == nil {
+			// The formatter's result is read through the same predicate as
+			// pass 1: a render here would otherwise be parsed as the output.
+			fmtErr = b.renderedFailure(fmtRM, task, fmt.Sprintf("formatting pass %d/%d", attempt, maxFmtAttempts))
+		}
 		if fmtErr != nil {
 			lastFmtErr = fmtErr
 			if attempt < maxFmtAttempts {
@@ -820,12 +851,17 @@ func (b *ClaudeCodeBackend) setupCredsAndSession(ctx context.Context, task Task,
 // are logged and left non-fatal (the caller keeps Pass 1's output). Returns
 // the pass's own ResultMessage (nil on failure) so the caller's cost
 // annotation sees its CLI-reported cost, not just Pass 1's.
-func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task Task, sessionID string, result *Result, totalIn, totalOut *int) *claudesdk.ResultMessage {
+func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task Task, sessionID string, result *Result, totalIn, totalOut *int) (*claudesdk.ResultMessage, error) {
 	b.Logger.Debug("claude-code: empty output with schema — attempting recovery formatting pass (session=%s)", sessionID)
 	fmtRM, fmtErr := b.formatOutput(ctx, task, sessionID)
 	if fmtErr != nil {
 		b.Logger.Warn("claude-code: recovery formatting pass failed: %v", fmtErr)
-		return nil
+		return nil, nil
+	}
+	// A render on the recovery pass is typed and returned, never parsed as
+	// the output nor swallowed into an opaque schema failure.
+	if rerr := b.renderedFailure(fmtRM, task, "recovery formatting pass"); rerr != nil {
+		return nil, rerr
 	}
 	if fmtRM.Usage != nil {
 		*totalIn += fmtRM.Usage.InputTokens
@@ -841,7 +877,7 @@ func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task T
 	} else {
 		b.Logger.Warn("claude-code: recovery formatting pass also produced empty output")
 	}
-	return fmtRM
+	return fmtRM, nil
 }
 
 // hostSpawnEnv returns the process environment with the per-task env entries

--- a/pkg/backend/delegate/claude_code_apierror_test.go
+++ b/pkg/backend/delegate/claude_code_apierror_test.go
@@ -31,6 +31,18 @@ func TestIsTransientAPIErrorResult(t *testing.T) {
 		{"facade bracketed 429", "API Error: [429][Rate limit reached][2026090610430471b2ed5a5eaa4de7]", true},
 		{"facade bracketed 529", "API Error: [529][Overloaded][abc]", true},
 		{"facade bracketed, no space", "API Error:[503][Service unavailable]", true},
+		// A CDN or proxy in front of the facade: 5xx outside any allow-list,
+		// and a 4xx whose text carries a connectivity marker — both were
+		// retried through the marker fallback before the status parsed.
+		{"proxy bracketed 524", "API Error: [524][Gateway timeout][2026090610430471b2ed5a5eaa4de7]", true},
+		{"proxy bracketed 522", "API Error: [522][Connection timed out][abc]", true},
+		{"proxy bracketed 530", "API Error: [530][Service unavailable][abc]", true},
+		{"proxy bracketed 499 with marker", "API Error: [499][Connection error][abc]", true},
+		{"bare unlisted 5xx", "API Error: 520 Bad gateway", true},
+		// No connectivity marker in the text: only the 5xx rule can retry
+		// these — an allow-list would ship them as the node's answer.
+		{"bare unlisted 5xx without a marker", "API Error: 598 Upstream hiccup", true},
+		{"proxy bracketed 526 without a marker", "API Error: [526][Invalid SSL certificate][abc]", true},
 
 		// Non-transient client/auth errors — must surface, not loop.
 		{"400 bad request", "API Error: 400 Bad Request", false},
@@ -41,6 +53,7 @@ func TestIsTransientAPIErrorResult(t *testing.T) {
 		{"facade bracketed 400", "API Error: [400][Invalid request][abc]", false},
 		{"facade bracketed 401", "API Error: [401][Unauthorized][abc]", false},
 		{"four digits are not a status", "API Error: [5000][x]", false},
+		{"facade bracketed 404", "API Error: [404][Not found][abc]", false},
 
 		// Genuine assistant output — must never be mistaken for an error.
 		{"empty", "", false},

--- a/pkg/backend/delegate/claude_code_apierror_test.go
+++ b/pkg/backend/delegate/claude_code_apierror_test.go
@@ -25,6 +25,12 @@ func TestIsTransientAPIErrorResult(t *testing.T) {
 		{"leading/trailing space", "  API Error: 503 Service Unavailable\n", true},
 		{"no code but connectivity marker", "API Error: Connection error.", true},
 		{"case-insensitive prefix", "api error: 500 boom", true},
+		// The bracketed render of an Anthropic-shaped facade: measured as a
+		// node's "answer" once, the graph continued on it.
+		{"facade bracketed 500", "API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]", true},
+		{"facade bracketed 429", "API Error: [429][Rate limit reached][2026090610430471b2ed5a5eaa4de7]", true},
+		{"facade bracketed 529", "API Error: [529][Overloaded][abc]", true},
+		{"facade bracketed, no space", "API Error:[503][Service unavailable]", true},
 
 		// Non-transient client/auth errors — must surface, not loop.
 		{"400 bad request", "API Error: 400 Bad Request", false},
@@ -32,6 +38,9 @@ func TestIsTransientAPIErrorResult(t *testing.T) {
 		{"403 forbidden", "API Error: 403 Forbidden", false},
 		{"404 not found", "API Error: 404 Not Found", false},
 		{"422 unprocessable", "API Error: 422 Unprocessable Entity", false},
+		{"facade bracketed 400", "API Error: [400][Invalid request][abc]", false},
+		{"facade bracketed 401", "API Error: [401][Unauthorized][abc]", false},
+		{"four digits are not a status", "API Error: [5000][x]", false},
 
 		// Genuine assistant output — must never be mistaken for an error.
 		{"empty", "", false},

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -19,6 +19,10 @@ func TestIsAuthErrorResult(t *testing.T) {
 		"invalid api key",
 		"OAuth token has expired",
 		"Not logged in \u00b7 Please run /login",
+		// A facade's bracketed 401 and a bare 403: the status is the
+		// provider's verdict, whatever prose follows it.
+		"API Error: [401][Unauthorized][2026090610430471b2ed5a5eaa4de7]",
+		"API Error: 403 Forbidden",
 	}
 	for _, s := range authy {
 		if !isAuthErrorResult(s) {
@@ -38,6 +42,8 @@ func TestIsAuthErrorResult(t *testing.T) {
 			"to reproduce it, clear the cookie jar, reload the dashboard, and assert the banner text in the e2e spec so a regression is caught early.",
 		// A rate-limit notice is a DIFFERENT class (handled by isRateLimitMessage).
 		"You've hit your weekly limit · resets 9pm (Europe/Paris)",
+		// A server error is the transient class, never a credential verdict.
+		"API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]",
 	}
 	for _, s := range notAuthy {
 		if isAuthErrorResult(s) {

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -12,8 +12,14 @@ import (
 
 // apiErrorResultStatusRe extracts the HTTP-ish status code the claude CLI
 // prints when it renders an upstream API failure AS its result text, e.g.
-// "API Error: 529 Overloaded" or "API Error: 503 {...}".
-var apiErrorResultStatusRe = regexp.MustCompile(`(?i)^api error:?\s+(\d{3})\b`)
+// "API Error: 529 Overloaded" or "API Error: 503 {...}" — and the bracketed
+// form an Anthropic-shaped facade relays, "API Error: [500][Operation
+// failed][<request id>]". The bracketed status went unparsed once, so the
+// render fell through to the connectivity markers, matched none, and became
+// the node's output: the graph continued on an error message for 283
+// minutes. Exactly three digits, closed by a bracket or a word boundary — a
+// longer number is not a status and still falls through.
+var apiErrorResultStatusRe = regexp.MustCompile(`(?i)^api error:?\s*\[?(\d{3})(?:\]|\b)`)
 
 // isTransientAPIErrorResult reports whether a claude CLI "successful" result
 // string is actually a rendered upstream API failure of a TRANSIENT class

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -31,10 +31,12 @@ var apiErrorResultStatusRe = regexp.MustCompile(`(?i)^api error:?\s*\[?(\d{3})(?
 // Precision matters — a genuine assistant answer must not be mistaken for an
 // error. Two guards keep false positives near-zero: the text must be SHORT
 // (the CLI's bare error render is; a real answer that merely discusses an API
-// error is longer and embedded) and must BEGIN with "api error". A parseable
-// 4xx client/auth status returns false so it surfaces as the visible output
-// (a retry won't fix a misconfig); 429/5xx/529 and bare connectivity markers
-// return true.
+// error is longer and embedded) and must BEGIN with "api error". Every 5xx
+// and the retryable 4xx (408/409/425/429) return true; another 4xx
+// client/auth status returns false so it surfaces as the visible output (a
+// retry won't fix a misconfig) — unless its text carries a connectivity
+// marker, which classified it before the status was parsed; a render with no
+// status at all falls back to those markers.
 func isTransientAPIErrorResult(s string) bool {
 	t := strings.TrimSpace(s)
 	if t == "" || len(t) >= 400 {
@@ -45,12 +47,20 @@ func isTransientAPIErrorResult(s string) bool {
 		return false
 	}
 	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil {
-		switch m[1] {
-		case "408", "409", "425", "429", "500", "502", "503", "504", "529":
+		switch {
+		case m[1][0] == '5':
+			// Every 5xx, not an allow-list: a CDN or proxy in front of a
+			// facade renders 520-530 and the like, and an unlisted server
+			// status that fell out of an allow-list here became the node's
+			// answer.
 			return true
-		default:
-			return false // 4xx client/auth error — a retry won't fix it
+		case m[1] == "408" || m[1] == "409" || m[1] == "425" || m[1] == "429":
+			return true
 		}
+		// A 4xx client/auth error — a retry won't fix it — unless the text
+		// itself carries a connectivity marker ("[499][Connection error]"):
+		// parsing the status must not lose what the marker already said.
+		return MatchesNetworkSignature(low)
 	}
 	// No parseable status code (e.g. "API Error: Connection error.") → fall
 	// back to the shared connectivity-marker classifier.
@@ -101,6 +111,14 @@ func isAuthErrorResult(s string) bool {
 	// keeps an agent discussing auth in a long answer from false-positiving.
 	if t == "" || len(t) > 200 {
 		return false
+	}
+	// A 401/403 status is the provider's own verdict on the credential,
+	// whatever prose (or none) follows it: a facade renders "API Error:
+	// [401][Unauthorized][<id>]", which matches no signature below and would
+	// otherwise flow on as the node's answer. Prefix-anchored by the regex,
+	// short by the cap.
+	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil && (m[1] == "401" || m[1] == "403") {
+		return true
 	}
 	low := strings.ToLower(t)
 	for _, sig := range []string{

--- a/pkg/backend/delegate/claude_code_rendered_failure_test.go
+++ b/pkg/backend/delegate/claude_code_rendered_failure_test.go
@@ -1,0 +1,85 @@
+package delegate
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// TestRenderedFailure pins the one predicate every result message goes
+// through — pass 1, the formatting passes, the recovery pass — and its
+// order: a window notice is a rate-limit verdict (with evidence) before it
+// is a transient 429; a credential verdict is never retried; a server error
+// is transient; an answer is an answer.
+func TestRenderedFailure(t *testing.T) {
+	b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+	task := Task{NodeID: "n", Iteration: 1, Model: "claude-fable-5"}
+	str := func(s string) *string { return &s }
+
+	t.Run("nil result is not a failure", func(t *testing.T) {
+		if err := b.renderedFailure(nil, task, "pass 1"); err != nil {
+			t.Fatalf("nil message: %v", err)
+		}
+		if err := b.renderedFailure(&claudesdk.ResultMessage{}, task, "pass 1"); err != nil {
+			t.Fatalf("nil result: %v", err)
+		}
+	})
+	t.Run("an answer is an answer", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("Here is the plan: three lots, one gate each.")}
+		if err := b.renderedFailure(rm, task, "pass 1"); err != nil {
+			t.Fatalf("answer re-typed: %v", err)
+		}
+	})
+	t.Run("a facade's bracketed 500 is transient, on every pass", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]")}
+		for _, pass := range []string{"pass 1", "formatting pass 1/2", "recovery formatting pass"} {
+			var tr *ErrTransient
+			err := b.renderedFailure(rm, task, pass)
+			if !errors.As(err, &tr) || tr.Reason != "api_error_result" {
+				t.Fatalf("%s: want ErrTransient{api_error_result}, got %v", pass, err)
+			}
+		}
+	})
+	t.Run("a bracketed 429 naming a window is a rate-limit verdict, not a retry", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("API Error: [429][Usage limit reached for 5 hour. Your limit will reset at 3pm][abc]")}
+		var rl *ErrRateLimited
+		var tr *ErrTransient
+		err := b.renderedFailure(rm, task, "pass 1")
+		if errors.As(err, &tr) {
+			t.Fatalf("window notice retried as transient: %v", err)
+		}
+		if !errors.As(err, &rl) {
+			t.Fatalf("want ErrRateLimited, got %v", err)
+		}
+	})
+	t.Run("a bare 429 with no window is transient", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("API Error: 429 Too Many Requests")}
+		var tr *ErrTransient
+		if err := b.renderedFailure(rm, task, "pass 1"); !errors.As(err, &tr) {
+			t.Fatalf("want ErrTransient, got %v", err)
+		}
+	})
+	t.Run("a bracketed 401 is a credential verdict, never retried", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("API Error: [401][Unauthorized][2026090610430471b2ed5a5eaa4de7]")}
+		var auth *ErrAuthFailed
+		var tr *ErrTransient
+		err := b.renderedFailure(rm, task, "pass 1")
+		if errors.As(err, &tr) {
+			t.Fatalf("credential verdict retried: %v", err)
+		}
+		if !errors.As(err, &auth) {
+			t.Fatalf("want ErrAuthFailed, got %v", err)
+		}
+	})
+	t.Run("a model the CLI cannot use fails fast", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{Result: str("There's an issue with the selected model (x/y). It may not exist or you may not have access to it.")}
+		err := b.renderedFailure(rm, task, "pass 1")
+		var tr *ErrTransient
+		if err == nil || errors.As(err, &tr) {
+			t.Fatalf("want a fast, non-transient failure, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Measured

A golden-master run behind an Anthropic-shaped facade: the campaign node finished in 2.5 minutes with its structured output built from

```
API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]
```

— the CLI's render of an upstream 500, also its last assistant text. The node had acted nothing, yet it counted as rendered: the graph continued into the next node for 283 minutes and its budget, on a request that was never acted, and the run ended unconverged.

## Fix

`isTransientAPIErrorResult` is the choke point that re-types a rendered upstream failure as `ErrTransient` (the `claude_code` backend, and `pi` through the same predicate), so the executor's retry loop rides it out instead of handing the text downstream. Its status regex required bare digits after the prefix (`API Error: 529 Overloaded`, `API Error: 503 {...}`); the facade's bracketed status went unparsed, the text fell through to the connectivity markers, matched none, and became the node's output.

The regex now accepts the bracketed form: exactly three digits closed by a bracket or a word boundary, so a longer number is still not a status and still falls through. The classes are unchanged — 408/409/425/429/5xx/529 retry, a 4xx client or auth error surfaces as before.

## Proof

- `TestIsTransientAPIErrorResult`: the measured string, and the bracketed 429/529/503 (with and without a space) retry; the bracketed 400/401 and a four-digit number do not.
- Mutant: the previous regex put back turns the new cases red.
- `go test ./pkg/backend/delegate/` green; `golangci-lint` 0 issues.

## Limit, stated

A bracketed 429 is retried as transient like any other; it does not arm the credential-skip evidence the way the relayed `Request rejected (429)` shape does (`rateLimitSignals`). Adding a substring there aborts the node and benches the credential on a false positive, so that shape is left for its own change with its own measurement.


## Second round (one finding, reproduced; four questions answered in code)

- **The widened regex intercepted statuses the marker used to retry** (medium): the switch it fed was an allow-list whose `default` arm returned false without the connectivity fallback, so `[524][Gateway timeout]`, `[522][Connection timed out]`, `[499][Connection error]` — retried through the marker while the bracketed status never parsed — were now shipped as the node's answer; on the pi backend the same flip lost the `unavailable` fallback route. Now every 5xx is transient (a CDN or proxy in front of a facade renders 520-530 and the like; an allow-list here is where the incident comes back), the retryable 4xx (408/409/425/429) stay, and any other status falls back to the connectivity markers it had before. Tests: marker-free 5xx (`598`, `[526]`) retry only through the 5xx rule, `[499]` keeps its retry through the marker, `[404]` does not retry. Mutants: the old allow-list back — red on the marker-free 5xx; the fallback dropped — red on `[499]`.

Open questions, answered:

- *Does a render on the formatting pass become the output?* It did: `runTwoPassFormatting` and `runRecoveryFormatterPass` parsed their own result message straight into the output, so an upstream failure there became the answer (or an opaque schema failure). The four result-text guards now live in one method, `renderedFailure`, read on pass 1, on each formatting attempt (a render counts as a failed attempt: retried once, then the pass-1 free-form recovery, then the typed error) and on the recovery pass (typed and returned, no longer swallowed). `TestRenderedFailure` pins the predicate on the three pass labels.
- *A bracketed 429 that names a window?* The order inside the predicate is the most specific verdict first: rate-limit (with its `OnUsageWindow` evidence write), then credential, then model, then the generic transient — so `[429][Usage limit reached for 5 hour…]` is `ErrRateLimited`, never a retry inside a shut window; a bare `429 Too Many Requests` stays transient. Mutant: the rate-limit gate no longer first — red.
- *The bracketed 401/403?* Not observed on the facade yet, and it was the same hole: `[401][Unauthorized][<id>]` matched none of the auth prose signatures and would have flowed on as the answer. A 401/403 status, bare or bracketed, is now the provider's verdict on the credential whatever prose follows (`isAuthErrorResult`, under its length cap and prefix anchor) — a fast, typed failure. It stays out of `isHighConfidenceAuthRender`, so it does not bench the credential fleet-wide. Mutant: the rule dropped — red.
- *codex?* It reads its own result through a prefix-anchored error envelope (`hasCodexTerminalErrorEnvelope`: `api error:` among others), independent of the status shape — not exposed to the bracketed render.

Not claimed: the wiring of the formatting passes has no subprocess harness in this package, so it is covered by the predicate's test and by reading, not by a mutant of the call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
