### PR TITLE
fix(secrets,server,cli): the OAuth token endpoints are env-overridable, a refused personal OAuth credential is audited, and `iterion secret set` shape-checks what it stores

### DIFF
--- a/cmd/iterion/secret.go
+++ b/cmd/iterion/secret.go
@@ -19,10 +19,17 @@ keyed by a master key held in the OS keychain (fallback: ~/.iterion/secrets.key,
 ` + "`{{secrets.NAME}}`" + `; the value is injected at tool/shell exec time and
 never enters the agent's context. Values are never printed by any subcommand.
 
+A stored value is shape-checked at ingestion, the same gate the cloud API
+runs: a bearer token is one run of visible characters, so a pasted terminal
+transcript is refused at the paste instead of surfacing as a provider 401
+mid-run. The shape is read off the value (a PEM header, a JSON opener, else
+a token) or named with ` + "`--kind`" + `; ` + "`--kind raw`" + ` stores anything.
+
 Examples:
   iterion secret set GITHUB_TOKEN                 # masked prompt
   iterion secret set STRIPE_KEY --from-env SK     # import from an env var
   iterion secret set DB_URL --project --hosts db.internal
+  iterion secret set DB_PASSPHRASE --kind raw     # not a token/JSON/PEM
   iterion secret list
   iterion secret rm GITHUB_TOKEN`,
 }
@@ -62,6 +69,7 @@ func init() {
 	secretCmd.PersistentFlags().BoolVar(&secretOpts.Project, "project", false, "Target the per-project store (overrides global by name)")
 	secretSetCmd.Flags().StringVar(&secretOpts.FromEnv, "from-env", "", "Read the value from this environment variable instead of prompting")
 	secretSetCmd.Flags().StringSliceVar(&secretOpts.Hosts, "hosts", nil, "Egress host allowlist for the secret (comma-separated); empty = unrestricted")
+	secretSetCmd.Flags().StringVar(&secretOpts.Kind, "kind", "", "Shape to validate the value against: token|json|pem|raw (default: inferred from the value; raw skips the check)")
 
 	secretCmd.AddCommand(secretSetCmd, secretListCmd, secretRmCmd)
 	rootCmd.AddCommand(secretCmd)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -579,11 +579,12 @@ iterion server webpush-keys        # mint a VAPID keypair for Web Push
 
 ### `iterion secret`
 
-Subcommands are `set`, `list`, and `rm`; `--project` selects the per-project store. Values are never printed.
+Subcommands are `set`, `list`, and `rm`; `--project` selects the per-project store. Values are never printed. `set` shape-checks the value at ingestion against the kind read off it (token / JSON / PEM), or the one `--kind` names; `--kind raw` stores it unchecked.
 
 ```bash
 iterion secret set GITHUB_TOKEN
 iterion secret set DB_URL --project --hosts db.internal
+iterion secret set DB_PASSPHRASE --kind raw
 iterion secret list
 ```
 

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -141,6 +141,11 @@ was found (#627). The gate is
   expiry or a scope).
 - **Codex `auth.json`**: the token-shape check on `tokens.access_token`.
 
+The **local** store has the same door: `iterion secret set` runs the matching
+rule for the value's shape (token / JSON / PEM), with `--kind` to name it and
+`--kind raw` to opt out — see
+[secrets.md](secrets.md#ingestion-shape-gate---kind).
+
 A refusal answers `400` with the reason, and leaves a trace an operator can
 find after the fact: a `Warn` in the server log and an audit event naming the
 field and the reason — never the value. Nothing is stored on a refusal. Which

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -142,9 +142,23 @@ was found (#627). The gate is
 - **Codex `auth.json`**: the token-shape check on `tokens.access_token`.
 
 A refusal answers `400` with the reason, and leaves a trace an operator can
-find after the fact: a `Warn` in the server log and an audit event
-(`byok.refused`, `oauth.org.refused`, `platform.llm_*.refused`) naming the
-field and the reason — never the value. Nothing is stored on a refusal.
+find after the fact: a `Warn` in the server log and an audit event naming the
+field and the reason — never the value. Nothing is stored on a refusal. Which
+log the event lands in follows the credential's owner:
+
+| Owner | Action | Readable by |
+| --- | --- | --- |
+| Team / org credential | `byok.refused`, `oauth.org.refused` | the team's admins (`/api/teams/{id}/audit`) |
+| Platform fallback | `platform.llm_key.refused`, `platform.llm_oauth.refused` | super-admins (`/api/admin/audit`) |
+| **Personal (`/me`)** | `byok.refused`, `oauth.personal.refused` | the admins of the **caller's active team** |
+
+A personal refusal crosses into the team's log on purpose: a personal forfait
+can be pledged to the org's [credential pool](credential-pool.md), so a
+refused rotation of it stops funding runs the org depends on. Only the
+refusal crosses — a successful personal connect is never audited — and the
+row carries the field and the reason class, never the material. With no
+active team on the session there is no tenant to key the row on, and the
+server-log `Warn` is the only trace.
 
 ## Provisioning cookbook (via `iterion remote`, authenticated)
 

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -365,6 +365,28 @@ Semantics worth knowing:
   leisure. An empty platform store keeps today's behaviour byte-identical.
 - Every mutation lands in the platform audit log (`/api/admin/audit`).
 
+## Re-pointing the OAuth endpoints (OEM CLI, proxy, air-gapped IdP)
+
+The forfait flow talks to a reverse-engineered vendor surface, so every
+endpoint it uses is env-overridable per deployment. **Move them as a set** —
+the first three drive the browser connect, the fourth drives what happens
+after it, and a deployment that moves three of four connects against one host
+and refreshes against another (each is read at the call site through
+[`envOr`](../pkg/secrets/oauth_authcode.go), so nothing is cached across a
+restart):
+
+| Env var | Default |
+| --- | --- |
+| `ITERION_OAUTH_FORFAIT_ANTHROPIC_AUTHORIZE_URL` | `https://claude.ai/oauth/authorize` |
+| `ITERION_OAUTH_FORFAIT_ANTHROPIC_REDIRECT_URI` | `https://platform.claude.com/oauth/code/callback` |
+| `ITERION_OAUTH_FORFAIT_ANTHROPIC_SCOPES` | `user:profile user:inference user:sessions:claude_code user:mcp_servers` |
+| `ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL` | `https://console.anthropic.com/v1/oauth/token` — the auth-code exchange **and** the refresh worker |
+| `ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL` | `https://auth.openai.com/oauth/token` |
+
+The two client ids (`ITERION_OAUTH_FORFAIT_{ANTHROPIC,CODEX}_CLIENT_ID`) ride
+the config loader rather than the call site; full table in
+[oauth-forfait.md](oauth-forfait.md#configuration).
+
 ## Related
 
 - Backends + provider routing + the OpenAI-via-ChatGPT-forfait section:

--- a/docs/oauth-forfait.md
+++ b/docs/oauth-forfait.md
@@ -74,6 +74,14 @@ values are overridable per deployment:
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_AUTHORIZE_URL` | Override the authorize endpoint (default `https://claude.ai/oauth/authorize`). |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_REDIRECT_URI` | Override the headless redirect (default `https://platform.claude.com/oauth/code/callback`). |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_SCOPES` | Override the requested scopes. |
+| `ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL` | Override the token endpoint (default `https://console.anthropic.com/v1/oauth/token`). Used by BOTH the auth-code exchange and the server-side refresh. |
+| `ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL` | Override the Codex token endpoint (default `https://auth.openai.com/oauth/token`). |
+
+Re-pointing an OEM-repackaged CLI takes the whole family: the authorize
+URL, the redirect URI and the scopes drive the browser connect, and the
+token URL drives what happens after it — a deployment that moves the
+first three and not the fourth connects against one host and refreshes
+against another.
 
 The browser connect flow is available whenever the OAuth store is wired
 (cloud mode) — the client id is defaulted, so no extra config is needed.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -314,9 +314,33 @@ never from `argv`, and never printed back):
 iterion secret set GITHUB_TOKEN                 # masked prompt
 iterion secret set STRIPE_KEY --from-env SK     # import from an env var
 iterion secret set DB_URL --project --hosts db.internal
+iterion secret set DB_PASSPHRASE --kind raw     # not a token / JSON / PEM
 iterion secret list                             # names + last4 + scope only
 iterion secret rm GITHUB_TOKEN
 ```
+
+#### Ingestion shape gate (`--kind`)
+
+`secret set` refuses, at the paste, a value that could not possibly
+authenticate — the same rule the cloud API runs on BYOK keys and OAuth blobs
+([`pkg/secrets/credential_shape.go`](../pkg/secrets/credential_shape.go)), so
+a terminal transcript pasted into the prompt fails here instead of surfacing
+as a provider `401` in the middle of a run.
+
+The local store is name-keyed and carries no kind of its own, so the shape is
+either **read off the value** — a `-----BEGIN ` header → `pem`, a leading `{`
+or `[` → `json`, anything else → `token` — or **named with `--kind`**:
+
+| `--kind` | Rule |
+| --- | --- |
+| `token` | One run of visible characters: no white-space (ASCII or not), no control/format/non-printing rune, valid UTF-8. |
+| `json` | Parses as a top-level JSON object or array, and carries at least one member. |
+| `pem` | At least one complete `-----BEGIN`/`-----END` block decodes. |
+| `raw` | No check — the explicit opt-out for a passphrase, a connection string, a blob. |
+
+The refusal names the secret, the reason and the kind it was read as, and
+never the value; `--kind raw` is in the message, so the remedy travels with
+it. An unknown `--kind` is an error, not a silent pass-through to no checking.
 
 Studio: the **Secrets** view (gated on `server_info.secrets_enabled`) offers
 the same CRUD over `/api/local/secrets` (unauthenticated single-operator

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,7 @@ import (
 // layer over the machine-global one for set/remove.
 type SecretOptions struct {
 	Name     string
+	Kind     string
 	FromEnv  string
 	Project  bool
 	Hosts    []string
@@ -75,6 +77,9 @@ func RunSecretSet(p *Printer, opts SecretOptions) error {
 	if value == "" {
 		return fmt.Errorf("empty secret value")
 	}
+	if err := validateSecretShape(opts.Kind, name, value); err != nil {
+		return err
+	}
 
 	st, sealer, err := buildLocalSecrets(opts)
 	if err != nil {
@@ -100,6 +105,35 @@ func RunSecretSet(p *Printer, opts SecretOptions) error {
 		verb = "Stored"
 	}
 	p.Line("%s secret %q (%s scope, last4 %s)", verb, name, scope, rec.Last4)
+	return nil
+}
+
+// validateSecretShape is the CLI's half of the ingestion gate the API
+// paths run (secrets.ValidateAPIKeyShape / ValidateTokenShape): a value
+// that could not possibly authenticate is refused at the paste, not
+// discovered as a provider 401 in the middle of a run hours later.
+//
+// The local store is name-keyed and carries no kind of its own, so the
+// shape is what the operator names with --kind, or what the value itself
+// says (a PEM header, a JSON opener, else a bare token). `--kind raw` is
+// the explicit opt-out for a value that is none of the three — the
+// refusal names it, so the remedy travels with the message.
+func validateSecretShape(kind, name, value string) error {
+	shape := secrets.InferSecretShapeKind(value)
+	if strings.TrimSpace(kind) != "" {
+		parsed, err := secrets.ParseSecretShapeKind(kind)
+		if err != nil {
+			return err
+		}
+		shape = parsed
+	}
+	if err := secrets.ValidateSecretShape(shape, name, value); err != nil {
+		var se *secrets.ShapeError
+		if errors.As(err, &se) {
+			return fmt.Errorf("%s (read as --kind %s; pass --kind raw to store it unchecked)", se.Error(), shape)
+		}
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cli/secret_shape_test.go
+++ b/pkg/cli/secret_shape_test.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// isolatedSecretStore points the local store and its master key at a
+// throwaway directory, so a test never reads the operator's own
+// ~/.iterion/secrets.json nor their OS keychain.
+func isolatedSecretStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("ITERION_HOME", dir)
+	t.Setenv("ITERION_SECRETS_KEY", base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{9}, 32)))
+	return dir
+}
+
+// setSecret runs the CLI set path with the value handed over in an env
+// var (never argv, never stdin).
+func setSecret(t *testing.T, name, kind, value string) error {
+	t.Helper()
+	t.Setenv("ITER_TEST_SECRET_VALUE", value)
+	p := &Printer{W: &bytes.Buffer{}, Format: OutputHuman}
+	return RunSecretSet(p, SecretOptions{Name: name, Kind: kind, FromEnv: "ITER_TEST_SECRET_VALUE"})
+}
+
+// storedSecret reports whether the local store holds name.
+func storedSecret(t *testing.T, name string) bool {
+	t.Helper()
+	st, err := LocalSecretStores("")
+	if err != nil {
+		t.Fatalf("open local store: %v", err)
+	}
+	_, ok := st.Global().GetByName(name)
+	return ok
+}
+
+// The API paths refuse credential material whose shape cannot
+// authenticate; `iterion secret set` is the same door one over. A
+// transcript pasted under a credential name must be refused at
+// ingestion, with the wording the API gives — not sealed and discovered
+// as a provider 401 at the first run.
+func TestRunSecretSet_RefusesATranscriptPaste(t *testing.T) {
+	isolatedSecretStore(t)
+
+	value := "\x1b[32mWelcome to Claude Code\x1b[0m\nsk-ant-oat01-secret"
+	err := setSecret(t, "ANTHROPIC_AUTH_TOKEN", "", value)
+	if err == nil {
+		t.Fatal("a terminal transcript was accepted as a token")
+	}
+	// The reason is the API's, verbatim — one rule, two doors.
+	want := secrets.ValidateTokenShape("ANTHROPIC_AUTH_TOKEN", value)
+	if want == nil {
+		t.Fatal("fixture no longer trips the shape gate")
+	}
+	if !strings.Contains(err.Error(), want.(*secrets.ShapeError).Reason) {
+		t.Fatalf("error = %q, want the API's reason %q", err, want.(*secrets.ShapeError).Reason)
+	}
+	// The remedy has to be reachable from the message alone.
+	if !strings.Contains(err.Error(), "--kind raw") {
+		t.Fatalf("error = %q, want it to name the explicit opt-out", err)
+	}
+	if storedSecret(t, "ANTHROPIC_AUTH_TOKEN") {
+		t.Fatal("a refused value was stored")
+	}
+}
+
+// The gate must not turn the generic store into a token-only store: it
+// legitimately holds PEM keys and JSON documents, and `--kind raw` is
+// the explicit opt-out for anything else.
+func TestRunSecretSet_AcceptsTheShapesTheStoreIsFor(t *testing.T) {
+	isolatedSecretStore(t)
+
+	pem := "-----BEGIN OPENSSH PRIVATE KEY-----\nZmFrZS1rZXktbWF0ZXJpYWw=\n-----END OPENSSH PRIVATE KEY-----"
+	cases := []struct {
+		name  string
+		kind  string
+		value string
+	}{
+		{"BEARER_TOKEN", "", "sk-test-0123456789abcdef"},
+		{"DEPLOY_KEY", "", pem},
+		{"SERVICE_ACCOUNT", "", `{"type":"service_account","project_id":"p"}`},
+		{"PASSPHRASE", "raw", "correct horse battery staple"},
+		{"EXPLICIT_PEM", "pem", pem},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := setSecret(t, tc.name, tc.kind, tc.value); err != nil {
+				t.Fatalf("set %s: %v", tc.name, err)
+			}
+			if !storedSecret(t, tc.name) {
+				t.Fatalf("%s was accepted but not stored", tc.name)
+			}
+		})
+	}
+}
+
+// An explicit --kind overrides the inference: `--kind token` is how an
+// operator says "this one really is a bare token" about a value the
+// inference would have waved through as a JSON document.
+func TestRunSecretSet_ExplicitKindOverridesTheInference(t *testing.T) {
+	isolatedSecretStore(t)
+
+	// A pasted credentials.json — which the inference reads as json and
+	// accepts — is refused once the operator says it is a token.
+	pastedFile := "{\n  \"claudeAiOauth\": {\n    \"accessToken\": \"sk-ant-oat01-x\"\n  }\n}"
+	if err := setSecret(t, "STILL_JSON", "", pastedFile); err != nil {
+		t.Fatalf("guard: the inference must accept the file as json: %v", err)
+	}
+	if err := setSecret(t, "NOT_A_TOKEN", "token", pastedFile); err == nil {
+		t.Fatal("--kind token accepted a multi-line JSON document")
+	}
+	if err := setSecret(t, "TRUNCATED_JSON", "json", `{"tokens":{"acce`); err == nil {
+		t.Fatal("--kind json accepted a truncated paste")
+	}
+	if err := setSecret(t, "NOT_A_PEM", "pem", "sk-test-0123456789abcdef"); err == nil {
+		t.Fatal("--kind pem accepted a bare token")
+	}
+	for _, n := range []string{"NOT_A_TOKEN", "TRUNCATED_JSON", "NOT_A_PEM"} {
+		if storedSecret(t, n) {
+			t.Fatalf("%s was refused but stored", n)
+		}
+	}
+}
+
+// An unknown --kind is a typo, not a silent pass-through to no checking.
+func TestRunSecretSet_RefusesAnUnknownKind(t *testing.T) {
+	isolatedSecretStore(t)
+
+	err := setSecret(t, "SOME_SECRET", "tokne", "sk-test-0123456789abcdef")
+	if err == nil {
+		t.Fatal("an unknown --kind was accepted — the gate silently did nothing")
+	}
+	if !strings.Contains(err.Error(), "token") || !strings.Contains(err.Error(), "raw") {
+		t.Fatalf("error = %q, want it to list the accepted kinds", err)
+	}
+	if storedSecret(t, "SOME_SECRET") {
+		t.Fatal("a secret with an unknown kind was stored")
+	}
+}

--- a/pkg/secrets/credential_shape.go
+++ b/pkg/secrets/credential_shape.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"strings"
 	"unicode"
@@ -74,19 +75,130 @@ func ValidateAPIKeyShape(provider Provider, value string) error {
 	if !provider.CredentialIsJSON() {
 		return ValidateTokenShape("api-key secret", value)
 	}
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
+	if strings.TrimSpace(value) == "" {
 		return &ShapeError{Field: "api-key secret", Reason: "is empty"}
 	}
-	var doc map[string]json.RawMessage
-	if !strings.HasPrefix(trimmed, "{") || json.Unmarshal([]byte(trimmed), &doc) != nil {
+	fields, kind := jsonDocument(value)
+	if kind != jsonObject {
 		return &ShapeError{Field: "api-key secret", Reason: fmt.Sprintf("must be a JSON credential object for provider %s (an AWS-style credential document, a service-account file), not a bearer token", provider)}
 	}
 	// An EMPTY object parses and carries nothing: a credential that cannot
 	// authenticate is refused at ingestion like any other, rather than
 	// discovered at the first call.
-	if len(doc) == 0 {
+	if fields == 0 {
 		return &ShapeError{Field: "api-key secret", Reason: fmt.Sprintf("is an empty JSON object — a %s credential document must carry its fields", provider)}
 	}
 	return nil
+}
+
+// jsonDocumentKind classifies what a value parses as at the top level.
+type jsonDocumentKind int
+
+const (
+	jsonNotADocument jsonDocumentKind = iota
+	jsonObject
+	jsonArray
+)
+
+// jsonDocument parses value as a top-level JSON object or array and
+// returns how many members it carries. Shared by every ingestion gate so
+// "is this a JSON credential document" has one answer: a scalar, a
+// truncated paste or trailing garbage is not a document.
+func jsonDocument(value string) (members int, kind jsonDocumentKind) {
+	trimmed := strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(trimmed, "{"):
+		var doc map[string]json.RawMessage
+		if json.Unmarshal([]byte(trimmed), &doc) != nil {
+			return 0, jsonNotADocument
+		}
+		return len(doc), jsonObject
+	case strings.HasPrefix(trimmed, "["):
+		var doc []json.RawMessage
+		if json.Unmarshal([]byte(trimmed), &doc) != nil {
+			return 0, jsonNotADocument
+		}
+		return len(doc), jsonArray
+	}
+	return 0, jsonNotADocument
+}
+
+// SecretShapeKind names the shape a stored secret's value must have. The
+// generic secret store legitimately holds a PEM key or a JSON document
+// as well as bearer tokens, so the bare-token rule cannot be the only
+// one — the kind selects which gate applies, and SecretShapeRaw opts out
+// explicitly for a value that is none of the three (a passphrase, a
+// connection string, a blob).
+type SecretShapeKind string
+
+const (
+	SecretShapeToken SecretShapeKind = "token"
+	SecretShapeJSON  SecretShapeKind = "json"
+	SecretShapePEM   SecretShapeKind = "pem"
+	SecretShapeRaw   SecretShapeKind = "raw"
+)
+
+// SecretShapeKinds lists the accepted kinds, in the order an operator
+// meets them in the help text.
+var SecretShapeKinds = []SecretShapeKind{SecretShapeToken, SecretShapeJSON, SecretShapePEM, SecretShapeRaw}
+
+// ParseSecretShapeKind resolves an operator-supplied kind. An empty
+// string means "infer from the value" and is the caller's business
+// (InferSecretShapeKind); an unrecognised one is an error, never a
+// silent pass-through to no checking.
+func ParseSecretShapeKind(s string) (SecretShapeKind, error) {
+	k := SecretShapeKind(strings.ToLower(strings.TrimSpace(s)))
+	for _, known := range SecretShapeKinds {
+		if k == known {
+			return k, nil
+		}
+	}
+	names := make([]string, 0, len(SecretShapeKinds))
+	for _, known := range SecretShapeKinds {
+		names = append(names, string(known))
+	}
+	return "", fmt.Errorf("unknown secret kind %q (want one of: %s)", s, strings.Join(names, "|"))
+}
+
+// InferSecretShapeKind reads the shape off the value itself: a PEM
+// header, a JSON document opener, else a bare token. It never returns
+// SecretShapeRaw — opting out of the check is a decision an operator
+// takes, not one a heuristic takes for them.
+func InferSecretShapeKind(value string) SecretShapeKind {
+	trimmed := strings.TrimSpace(value)
+	switch {
+	case strings.HasPrefix(trimmed, "-----BEGIN "):
+		return SecretShapePEM
+	case strings.HasPrefix(trimmed, "{"), strings.HasPrefix(trimmed, "["):
+		return SecretShapeJSON
+	}
+	return SecretShapeToken
+}
+
+// ValidateSecretShape is the ingestion gate for a stored secret whose
+// shape the operator named (or that InferSecretShapeKind read off the
+// value). field phrases the refusal — pass the secret's name so an
+// operator sees WHICH secret was rejected; the value never appears.
+func ValidateSecretShape(kind SecretShapeKind, field, value string) error {
+	switch kind {
+	case SecretShapeRaw:
+		return nil
+	case SecretShapeToken:
+		return ValidateTokenShape(field, value)
+	case SecretShapeJSON:
+		members, docKind := jsonDocument(value)
+		if docKind == jsonNotADocument {
+			return &ShapeError{Field: field, Reason: "is not a JSON document — it opens like one but does not parse, which is what a truncated or partially-copied paste looks like"}
+		}
+		if members == 0 {
+			return &ShapeError{Field: field, Reason: "is an empty JSON document — it carries nothing to authenticate with"}
+		}
+		return nil
+	case SecretShapePEM:
+		if block, _ := pem.Decode([]byte(value)); block == nil {
+			return &ShapeError{Field: field, Reason: "is not a PEM block — it opens with a PEM header but no complete -----BEGIN/-----END block decodes, which is what a truncated paste looks like"}
+		}
+		return nil
+	}
+	return fmt.Errorf("secrets: unknown secret shape kind %q", kind)
 }

--- a/pkg/secrets/credential_shape_test.go
+++ b/pkg/secrets/credential_shape_test.go
@@ -102,3 +102,99 @@ func TestValidateAPIKeyShape_PerProvider(t *testing.T) {
 		t.Fatal("bearer providers must not be JSON-credential providers")
 	}
 }
+
+const testPEM = "-----BEGIN OPENSSH PRIVATE KEY-----\nZmFrZS1rZXktbWF0ZXJpYWw=\n-----END OPENSSH PRIVATE KEY-----\n"
+
+// The generic secret store holds PEM keys and JSON documents as well as
+// bearer tokens, so the shape read off a value decides which gate runs.
+func TestInferSecretShapeKind(t *testing.T) {
+	cases := []struct {
+		value string
+		want  SecretShapeKind
+	}{
+		{"sk-ant-0123456789", SecretShapeToken},
+		{testPEM, SecretShapePEM},
+		{"  " + testPEM, SecretShapePEM},
+		{`{"type":"service_account"}`, SecretShapeJSON},
+		{"\n[\"a\",\"b\"]", SecretShapeJSON},
+		// A transcript is not a document, and must fall to the token rule
+		// that refuses it — never to raw.
+		{"Welcome to Claude Code\nsk-ant-0123", SecretShapeToken},
+	}
+	for _, tc := range cases {
+		if got := InferSecretShapeKind(tc.value); got != tc.want {
+			t.Errorf("InferSecretShapeKind(%.20q) = %q, want %q", tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestParseSecretShapeKind(t *testing.T) {
+	for _, want := range SecretShapeKinds {
+		got, err := ParseSecretShapeKind(strings.ToUpper(string(want)))
+		if err != nil || got != want {
+			t.Errorf("ParseSecretShapeKind(%q) = (%q, %v), want %q", want, got, err, want)
+		}
+	}
+	// An unknown kind is a typo, never a silent pass-through to no check.
+	_, err := ParseSecretShapeKind("tokne")
+	if err == nil {
+		t.Fatal("an unknown kind was accepted")
+	}
+	for _, k := range SecretShapeKinds {
+		if !strings.Contains(err.Error(), string(k)) {
+			t.Fatalf("error %q must list %q so the typo is fixable from the message", err, k)
+		}
+	}
+	// The empty string is "infer" — the caller's business, not an error
+	// this function invents a default for.
+	if _, err := ParseSecretShapeKind(""); err == nil {
+		t.Fatal("the empty kind must be rejected here; inference is the caller's decision")
+	}
+}
+
+func TestValidateSecretShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    SecretShapeKind
+		value   string
+		wantErr string
+	}{
+		{"token: clean", SecretShapeToken, "sk-ant-0123456789", ""},
+		{"token: transcript", SecretShapeToken, "Welcome\nsk-ant-0123", "newline"},
+		{"json: object", SecretShapeJSON, `{"type":"service_account"}`, ""},
+		{"json: array", SecretShapeJSON, `["a"]`, ""},
+		{"json: truncated", SecretShapeJSON, `{"tokens":{"acce`, "not a JSON document"},
+		{"json: empty object", SecretShapeJSON, `{}`, "empty JSON document"},
+		{"json: empty array", SecretShapeJSON, `[]`, "empty JSON document"},
+		{"json: a bare token", SecretShapeJSON, "sk-ant-0123", "not a JSON document"},
+		{"pem: block", SecretShapePEM, testPEM, ""},
+		{"pem: truncated", SecretShapePEM, "-----BEGIN OPENSSH PRIVATE KEY-----\nZmFrZQ==", "not a PEM block"},
+		// raw is the explicit opt-out: it must accept what every other
+		// gate refuses, or it is not an escape hatch.
+		{"raw: a whole transcript", SecretShapeRaw, "\x1b[32mWelcome\x1b[0m\nanything at all", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSecretShape(tc.kind, "MY_SECRET", tc.value)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("refused: %v", err)
+				}
+				return
+			}
+			var se *ShapeError
+			if !errors.As(err, &se) {
+				t.Fatalf("got %v (%T), want a *ShapeError", err, err)
+			}
+			if se.Field != "MY_SECRET" {
+				t.Errorf("field = %q, want the secret's name so the operator knows which one", se.Field)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q, want it to mention %q", err, tc.wantErr)
+			}
+			if strings.Contains(err.Error(), tc.value) {
+				t.Fatalf("the refusal echoed the value: %q", err)
+			}
+		})
+	}
+}

--- a/pkg/secrets/oauth_authcode.go
+++ b/pkg/secrets/oauth_authcode.go
@@ -30,7 +30,10 @@ import (
 //
 // All values are env-overridable because this is an undocumented,
 // reverse-engineered surface: if Anthropic rotates the client/flow,
-// an operator can re-point it without a rebuild.
+// an operator can re-point it without a rebuild. The family is
+// ITERION_OAUTH_FORFAIT_ANTHROPIC_{CLIENT_ID,AUTHORIZE_URL,
+// REDIRECT_URI,SCOPES,TOKEN_URL} — the token endpoint (shared with the
+// refresh, pkg/secrets/oauth_refresh.go) included.
 // DefaultAnthropicOAuthClientID is the public Claude Code OAuth client
 // id. It is a PUBLIC PKCE client (no client secret), the same id the
 // `claude` CLI embeds — not a confidential value. Shipping it as a
@@ -132,7 +135,7 @@ func ExchangeAnthropicCode(ctx context.Context, hc *http.Client, clientID, code,
 	if state != "" {
 		form.Set("state", state)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicTokenURL(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return RefreshResult{}, fmt.Errorf("secrets: build code-exchange req: %w", err)
 	}

--- a/pkg/secrets/oauth_authcode_test.go
+++ b/pkg/secrets/oauth_authcode_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 )
 
@@ -77,6 +78,24 @@ func TestExchangeAnthropicCode_HappyPath(t *testing.T) {
 	}
 	if gotForm["code_verifier"] != "the-verifier" {
 		t.Errorf("code_verifier: got %q", gotForm["code_verifier"])
+	}
+}
+
+// The auth-code exchange POSTs to the same token endpoint as the
+// refresh, so an operator who re-points the deployment must move both
+// halves of the flow with one variable — not the authorize URL alone.
+func TestExchangeAnthropicCode_HonoursTokenURLOverride(t *testing.T) {
+	freshRetrySchedule(t)
+	srv := newFakeOAuthServer(`{"access_token":"sk-ant-exchanged1234567890abcd","refresh_token":"rf-x","expires_in":3600}`, http.StatusOK)
+	defer srv.Close()
+	t.Setenv("ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL", srv.URL+"/v1/oauth/token")
+
+	_, err := ExchangeAnthropicCode(context.Background(), pinnedClient(t, srv.URL), "client-xyz", "the-code", "the-verifier", "https://example.test/cb", "state-abc")
+	if err != nil {
+		t.Fatalf("ExchangeAnthropicCode: %v", err)
+	}
+	if got := atomic.LoadInt32(&srv.hits); got != 1 {
+		t.Fatalf("overridden endpoint hits = %d, want 1", got)
 	}
 }
 

--- a/pkg/secrets/oauth_refresh.go
+++ b/pkg/secrets/oauth_refresh.go
@@ -17,12 +17,25 @@ import (
 // rotated server-side before its access_token expires.
 //
 // The values are the documented endpoints at the time of writing
-// (2026-05). Operators can override via env on a per-deployment
-// basis when an OEM repackages the CLI.
+// (2026-05).
 const (
-	anthropicTokenURL = "https://console.anthropic.com/v1/oauth/token"
-	codexTokenURL     = "https://auth.openai.com/oauth/token"
+	defaultAnthropicTokenURL = "https://console.anthropic.com/v1/oauth/token"
+	defaultCodexTokenURL     = "https://auth.openai.com/oauth/token"
 )
+
+// anthropicTokenURL is the endpoint both halves of the Anthropic flow
+// POST to — the auth-code exchange and the server-side refresh. It goes
+// through envOr like its three siblings (authorize URL, redirect URI,
+// scopes) so an OEM-repackaged CLI or a proxying deployment moves the
+// whole flow, not three quarters of it.
+func anthropicTokenURL() string {
+	return envOr("ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL", defaultAnthropicTokenURL)
+}
+
+// codexTokenURL is the Codex half of the same override family.
+func codexTokenURL() string {
+	return envOr("ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL", defaultCodexTokenURL)
+}
 
 // ErrNotRefreshable marks a credential whose sealed payload carries no
 // refresh token: no refresh exchange can ever succeed for it, so callers
@@ -58,7 +71,7 @@ func RefreshAnthropic(ctx context.Context, hc *http.Client, clientID, refreshTok
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("client_id", clientID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicTokenURL(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return RefreshResult{}, fmt.Errorf("secrets: build refresh req: %w", err)
 	}
@@ -251,7 +264,7 @@ func RefreshCodex(ctx context.Context, hc *http.Client, clientID, refreshToken s
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("client_id", clientID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, codexTokenURL, strings.NewReader(form.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, codexTokenURL(), strings.NewReader(form.Encode()))
 	if err != nil {
 		return RefreshResult{}, fmt.Errorf("secrets: build codex refresh req: %w", err)
 	}

--- a/pkg/secrets/oauth_refresh_test.go
+++ b/pkg/secrets/oauth_refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -459,5 +460,82 @@ func TestDoWithRetry_ClosesAbandoned5xxBodyOnRetrySuccess(t *testing.T) {
 	}
 	if atomic.LoadInt32(&secondClosed) != 1 {
 		t.Error("successful response body was not closed")
+	}
+}
+
+// -----------------------------------------------------------------
+// Token-endpoint env override
+// -----------------------------------------------------------------
+
+// hostPinnedTransport refuses any request aimed somewhere other than
+// want, so a test asserting that an endpoint override reaches a local
+// server never leaves the machine when the override is not honoured: it
+// fails naming the host that was actually dialled.
+type hostPinnedTransport struct {
+	want string
+	base http.RoundTripper
+}
+
+func (t *hostPinnedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != t.want {
+		return nil, fmt.Errorf("request went to %q, want the overridden endpoint %q", req.URL.Host, t.want)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// pinnedClient dials host and nothing else.
+func pinnedClient(t *testing.T, rawURL string) *http.Client {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse %q: %v", rawURL, err)
+	}
+	return &http.Client{Transport: &hostPinnedTransport{want: u.Host, base: http.DefaultTransport}}
+}
+
+// The three sibling Anthropic endpoints (authorize URL, redirect URI,
+// scopes) are env-overridable; the token endpoint the refresh POSTs to
+// must be too, or an OEM-repackaged CLI moves three of four and the
+// refresh worker keeps hitting the vendor's host.
+func TestRefreshAnthropic_HonoursTokenURLOverride(t *testing.T) {
+	freshRetrySchedule(t)
+	body := `{"access_token":"sk-ant-newaccess1234567890abcdef","refresh_token":"rf-new","expires_in":3600}`
+	srv := newFakeOAuthServer(body, http.StatusOK)
+	defer srv.Close()
+	t.Setenv("ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL", srv.URL+"/v1/oauth/token")
+
+	if _, err := RefreshAnthropic(context.Background(), pinnedClient(t, srv.URL), "client-id", "rf-old"); err != nil {
+		t.Fatalf("RefreshAnthropic: %v", err)
+	}
+	if got := atomic.LoadInt32(&srv.hits); got != 1 {
+		t.Fatalf("overridden endpoint hits = %d, want 1", got)
+	}
+}
+
+// Same promise for the Codex token endpoint, which shares the comment.
+func TestRefreshCodex_HonoursTokenURLOverride(t *testing.T) {
+	freshRetrySchedule(t)
+	body := `{"access_token":"codex-newaccess1234567890","refresh_token":"rf-new","expires_in":3600}`
+	srv := newFakeOAuthServer(body, http.StatusOK)
+	defer srv.Close()
+	t.Setenv("ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL", srv.URL+"/oauth/token")
+
+	if _, err := RefreshCodex(context.Background(), pinnedClient(t, srv.URL), "client-id", "rf-old"); err != nil {
+		t.Fatalf("RefreshCodex: %v", err)
+	}
+	if got := atomic.LoadInt32(&srv.hits); got != 1 {
+		t.Fatalf("overridden endpoint hits = %d, want 1", got)
+	}
+}
+
+// Unset env keeps the published endpoint: the override is opt-in.
+func TestTokenURLs_DefaultToThePublishedEndpoints(t *testing.T) {
+	t.Setenv("ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL", "")
+	t.Setenv("ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL", "")
+	if got := anthropicTokenURL(); got != defaultAnthropicTokenURL {
+		t.Errorf("anthropicTokenURL() = %q, want %q", got, defaultAnthropicTokenURL)
+	}
+	if got := codexTokenURL(); got != defaultCodexTokenURL {
+		t.Errorf("codexTokenURL() = %q, want %q", got, defaultCodexTokenURL)
 	}
 }

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -123,15 +123,31 @@ func (s *Server) handleDeleteOAuth(w http.ResponseWriter, r *http.Request) {
 // to check on admins must not lie). Placed inside the shared helpers,
 // after the write, so team AND platform surfaces audit identically:
 // keeping the audit at each caller meant it fired even on a 400/404/500
-// return from the helper. A personal (/me) owner key is not audited —
-// unchanged from the per-user endpoints, which never did. verb is
-// "connected" or "deleted".
+// return from the helper. verb is "connected", "deleted" or "refused".
+//
+// A personal (/me) owner key is audited for a REFUSAL only, on the
+// caller's active team — pkg/audit has no user scope, and the sibling
+// personal credential door already writes there (/api/me/api-keys
+// refuses through refuseApiKey -> auditApiKey(r, id.TeamID, "refused")).
+// A refusal is an operational signal an org admin needs: a personal
+// forfait can be pledged to the org's credential pool, and a refused
+// rotation of it stops funding runs the org depends on. The row names
+// the field and the reason class, never the material — and a successful
+// personal connect stays the user's own business, unaudited. With no
+// active team there is no tenant to key the row on (a tenant-less row is
+// readable by nobody), so the Warn at the refusal site is the trace.
 func (s *Server) auditOAuthByOwner(r *http.Request, ownerKey, verb string, kind secrets.OAuthKind, meta map[string]any) {
 	switch {
 	case ownerKey == secrets.PlatformOwnerKey:
 		s.auditPlatform(r, "", "platform.llm_oauth."+verb, "platform_llm_oauth", string(kind), meta)
 	case strings.HasPrefix(ownerKey, secrets.OrgOwnerPrefix):
 		s.auditTenant(r, strings.TrimPrefix(ownerKey, secrets.OrgOwnerPrefix), "oauth.org."+verb, "oauth_forfait", string(kind), meta)
+	case verb == "refused":
+		id, _ := auth.FromContext(r.Context())
+		if id.TeamID == "" {
+			return
+		}
+		s.auditTenant(r, id.TeamID, "oauth.personal.refused", "oauth_forfait", string(kind), meta)
 	}
 }
 

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -735,6 +735,91 @@ func TestOAuthCredentialIngestion_RefusalLeavesATrace(t *testing.T) {
 	}
 }
 
+// A refusal on a PERSONAL connection is audited too, on the caller's
+// active team. There is no user-scoped audit log (pkg/audit has exactly
+// two scopes), and the sibling personal credential door already writes
+// there: /api/me/api-keys refuses a bad paste through refuseApiKey ->
+// auditApiKey(r, id.TeamID, "refused", ...). A personal forfait can also
+// be pledged to the org's credential pool, so an org admin has to be able
+// to see that a rotation of it was refused.
+func TestOAuthCredentialIngestion_PersonalRefusalIsAudited(t *testing.T) {
+	srv, hs, signer, oauthStore := oauthTestServer(t)
+	auditStore := audit.NewMemoryStore()
+	srv.auditStore = auditStore
+	tok, _, err := signer.IssueAccess(auth.Identity{UserID: "alice", Email: "alice@x", TeamID: "team-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good\nWelcome to Claude Code","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+	code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", tok, blob)
+	if code != http.StatusBadRequest {
+		t.Fatalf("upload = %d body=%s, want 400", code, body)
+	}
+	if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+		t.Fatal("a refused credential was stored")
+	}
+
+	// The audit insert is detached; poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		events, err := auditStore.ListByTenant(t.Context(), "team-a", audit.Page{Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range events {
+			if e.Action != "oauth.personal.refused" {
+				continue
+			}
+			if e.ActorID != "alice" || e.TargetID != string(secrets.OAuthKindClaudeCode) {
+				t.Fatalf("audit event = %+v, want the actor and the kind", e)
+			}
+			if e.Meta["field"] != "claudeAiOauth.accessToken" || e.Meta["reason"] == nil {
+				t.Fatalf("audit event = %+v, want the field and the reason class", e)
+			}
+			if strings.Contains(fmt.Sprint(e.Meta), "sk-ant-oat01-good") {
+				t.Fatalf("the audit row carried the material: %+v", e)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no oauth.personal.refused audit event; got %+v", events)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// Only the REFUSAL crosses into the team's log: a personal connect that
+// succeeds stays the user's own business, as it always has.
+func TestOAuthCredentialIngestion_PersonalSuccessIsNotAudited(t *testing.T) {
+	srv, hs, signer, oauthStore := oauthTestServer(t)
+	auditStore := audit.NewMemoryStore()
+	srv.auditStore = auditStore
+	tok, _, err := signer.IssueAccess(auth.Identity{UserID: "alice", Email: "alice@x", TeamID: "team-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-clean-token","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+	code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", tok, blob)
+	if code != http.StatusOK {
+		t.Fatalf("upload = %d body=%s, want 200", code, body)
+	}
+	if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err != nil {
+		t.Fatalf("stored record: %v", err)
+	}
+	// The insert would be detached: give it the same window the refusal
+	// test gives, then require the log to still be empty.
+	time.Sleep(200 * time.Millisecond)
+	events, err := auditStore.ListByTenant(t.Context(), "team-a", audit.Page{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("a personal connect was audited on the team log: %+v", events)
+	}
+}
+
 // A whole terminal transcript pasted into the box is the shape #627 was
 // filed on. It fails to PARSE, which is not a ShapeError — so the refusal
 // branch let it through with no Warn and no audit entry, exactly the


### PR DESCRIPTION
Closes #725. Closes #726. Closes #727.

## #725 — the token endpoints join their siblings' env override
The Anthropic token URL was a `const` under a comment promising a per-deployment env override, while the authorize URL, scopes and redirect URI already went through `envOr(…)`. The Codex token URL had the same shape in the same comment block. Both now read through the same helper at the same call sites: `ITERION_OAUTH_FORFAIT_ANTHROPIC_TOKEN_URL`, `ITERION_OAUTH_FORFAIT_CODEX_TOKEN_URL` (documented in `docs/oauth-forfait.md` + `docs/cloud-llm-credentials.md`). Endpoint class swept in `pkg/secrets`: the xAI base URL already honours `XAI_BASE_URL`; the z.ai default carries no override promise (a same-class asymmetry one package over is filed separately).
Red: `oauth_authcode_test.go:95` / `oauth_refresh_test.go:508,524` — the exchange and both refreshes dialled the vendor with the override set (host-pinned transport, so an unhonoured override fails locally naming the host). Green: 4 PASS.

## #726 — decision: audit, not confirm
`pkg/audit` has two scopes only (tenant, platform) — no user-scoped log exists. The decisive precedent: the sibling personal credential door already audits — `handleCreateMyApiKey` resolves the caller's team and `refuseApiKey` records `refused` on it. A transcript pasted into a personal BYOK key was visible to team admins; the same paste into a personal OAuth connection was not: one class, two behaviours. Now only the REFUSAL crosses (`oauth.personal.refused`, keyed on the caller's active team, meta = field + reason class, never the material); a successful personal connect stays unaudited (pinned by `TestOAuthCredentialIngestion_PersonalSuccessIsNotAudited`); with no active team the Warn is the trace (stated at the helper). Class re-grepped: the two credential-refusal audit sites are now consistent.
Red: `oauth_routes_test.go:786: no oauth.personal.refused audit event; got []`. Green: both new tests + the 5 pre-existing ingestion tests.

## #727 — `iterion secret set` shape-checks at ingestion
The local generic store is name-keyed only (no reserved credential names, no kind on bindings), so the discriminator is `--kind token|json|pem|raw`, defaulting to the shape read off the value (`-----BEGIN ` → pem, leading `{`/`[` → json, else token). `--kind raw` is the explicit opt-out; an unknown kind is an error; the refusal message names `--kind raw` so the remedy travels with it. No `--force`: the API has no equivalent. Deviation, stated: the `json` kind accepts a top-level object OR array, because inference keys on both and refusing an inferred array would be a trap; empty documents are refused. The JSON-document parse is one shared helper (`jsonDocument`) that `ValidateAPIKeyShape` also uses, so the two doors cannot drift. Docs: `docs/secrets.md`, `docs/cli-reference.md`, `docs/cloud-llm-credentials.md`.
Red: `secret_shape_test.go:54: a terminal transcript was accepted as a token` / `:110` / `:131 an unknown --kind was accepted — the gate silently did nothing`. Green: 4 tests + 5 subtests; `e2e/cli_secret_test.go` still green.

## Verification
`go build ./...` · `go test ./pkg/secrets/... ./pkg/server/... ./pkg/cli/... ./pkg/audit/... ./e2e/... ./cmd/...` ok · `task lint` 0 issues · `task openapi:gen` byte-identical (no response struct changed).

## Left as separate findings (filed)
A tenant-provisioned z.ai key hardcodes `ANTHROPIC_BASE_URL` to the default with no override (`pkg/backend/delegate/claude_code_creds.go`), the env-key branches honour the operator's; the studio's local Secrets view is a second ungated door into the same store (its request carries no kind — gating it needs the UI to carry one); `docs/forge-security-read.md` documents `iterion secret set <name> '<json>'` with the value as a positional argument, which the command does not accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
