### PR TITLE
fix(server,store): the pr_url launches pass the fork guard, a typed PR-closed end reason, a claimed launch_error retry, and gate notices that name a remedy that can reach the run

### DIFF
--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -888,6 +888,14 @@ repeatedly on one revision is a structural signal (a run budget too short for
 the workload, a recurring provider quota, a bot defect), which is a human's
 call.
 
+The synthetic failure states the remedy that applies to the run it replaces.
+A review that died reads `review died (<reason>) — push again or comment the
+bot's command to re-run`; a run whose queue message is parked on the
+dead-letter queue reads `review parked on the DLQ — operator replay needed
+(iterion remote admin dlq)` instead, because a push there launches a fresh run
+and leaves the parked message where it is. Both are the reconciler's own
+marker, so both are repairable and both are ignored by the lane below.
+
 The auto-fix lane ([above](#autofix)) deliberately ignores these synthetic
 failures: `review died` means there are no findings to fix, so the recovery is
 re-running the REVIEWER (this lane), never launching the fixer.

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -888,6 +888,13 @@ repeatedly on one revision is a structural signal (a run budget too short for
 the workload, a recurring provider quota, a bot defect), which is a human's
 call.
 
+A pull request that is **closed or merged** gets no synthetic failure at all:
+it owes nobody a verdict, and "push again to re-run the review" on work that
+already shipped is advice with no object. The check then keeps whatever the
+interrupted run's in-flight claim left on the head — which blocks nothing, and
+which a reopen heals, since the fresh review's claim may overwrite an in-flight
+marker. A provider that reports no state at all is not treated as a closure.
+
 The synthetic failure states the remedy that applies to the run it replaces.
 A review that died reads `review died (<reason>) — push again or comment the
 bot's command to re-run`; a run whose queue message is parked on the

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -402,6 +402,68 @@ integration's launch vars): first review automatic on open, every re-review
 a button click or a `/revi` — see
 [merge-gate.md](merge-gate.md#disabling-the-gate-per-repo--first-review-only-re-review-on-demand).
 
+### <a name="two-identities"></a>Two identities: the App connection reads, a PAT binding writes
+
+An operator who wires BOTH a team **forge App connection** covering the
+repo AND a webhook **`forge_token` PAT binding** on the same webhook gets
+a bot that reads and writes under **two different logins**, and neither
+guard connects them by itself:
+
+- **the server-side read side** — the command gate, the author-trust
+  probe, the reply-thread gate, the PR fetch behind `/revi` — resolves
+  its client through `prforgeReplierAPIFor`
+  ([pkg/server/webhooks_prforge.go](../pkg/server/webhooks_prforge.go)):
+  the covering App connection FIRST (mints an installation token,
+  identity `<app_slug>[bot]`), the webhook's `forge_token` binding only
+  as fallback when the connection cannot serve. The merge-gate commit
+  status is App-only — it rides the connection the publish grant names,
+  with no binding fallback at all;
+- **the bot's runtime write side** — the review comments, the verdict,
+  a `/billy` push, the reply the bot posts inside its own review thread
+  — posts through the `forge_token` PAT the run resolves from its bot
+  binding, identity = whichever user owns that PAT.
+
+`iterionBotLogins` — the shared identity set the bot-author actor guard
+(`isIterionForgeBotAuthor`), the review-request predicate
+(`isIterionBotReviewRequest`) and the per-login classifier
+(`iterionBotAuthorPredicate`) all read
+([pkg/server/webhooks_common.go](../pkg/server/webhooks_common.go)) — is
+built from the connection alone: operator-configured
+`review_request_logins` first, then `<app_slug>[bot]` on GitHub/Forgejo
+Apps, then `AccountLogin` on GitLab only. **The PAT's login is NOT in
+that set unless you list it.** Symptom: on a delivery whose actor is the
+PAT — the bot's own review comment echoing back on the `note` /
+`issue_comment` lane, or a `review_requested` naming the PAT user — the
+actor guard reads the write as a human's and either loops (re-reacts to
+its own comment) or never fires (the reviewer-request button routes
+nowhere).
+
+**What to list.** Add the PAT's login to
+[`review_request_logins`](#other-config-keys-settable-through-the-crud-api)
+on the webhook (with or without the leading `@`). It joins the shared
+identity set both halves read: the actor guard skips the PAT's writes,
+and the "Re-request review" button relaunches when that user is added
+as reviewer.
+
+**How to check the identities.** For the App side,
+`iterion remote forge refresh <conn-id>` re-probes the installation and
+prints the account it acts as (`installation`; `installation_account`
+under `--json`); `iterion remote forge connections` lists every
+connection's `account_login`. For a `forge_token` PAT there is no
+built-in whoami: you named the account when you set the token, or you
+ask the forge directly with the token in hand (`GET /user` on
+GitHub / Forgejo, `GET /api/v4/user` on GitLab).
+
+The reply-thread gate compensates in one place: `reviewReplyGateWithAPI`
+issues a live `WhoAmI` on whatever client it resolved and unions the
+answer into its own bot-identity check, so an in-thread self-reply is
+caught even when the identity is not in `iterionBotLogins`. That union
+is scoped to that one gate; the actor guard on the delivery envelope and
+the reviewer-request predicate stay driven by `iterionBotLogins`, so
+`review_request_logins` remains the knob for those two — and, on a
+setup where the connection SERVES the read side, the WhoAmI returns the
+App login rather than the PAT's, so listing the PAT stays required.
+
 ### Generic (`POST /api/webhooks/generic/{id}`)
 
 Bot-agnostic: the caller picks which bot to launch by name (or relies
@@ -690,7 +752,7 @@ are accepted by `POST` / `PATCH`:
 
 | Key | Default | Meaning |
 |---|---|---|
-| `review_request_logins` | *(empty)* | Logins whose `review_requested` / reviewer-add delivery relaunches the reviewer, IN ADDITION to the identity derived from the connection. **This is what makes the lane work on GitHub**, where only a User account can be a requested reviewer: name a bot user reached through a `pat` connection, so the review is posted by that same account and the forge re-arms the button. Explicit only — never derived from a connection's account, which on the PAT path is typically a maintainer's own, and deriving would turn every reviewer ping addressed to that human into a bot run. The logins join the shared identity set, so the anti-loop actor guard recognises them too. |
+| `review_request_logins` | *(empty)* | Logins whose `review_requested` / reviewer-add delivery relaunches the reviewer, IN ADDITION to the identity derived from the connection. **This is what makes the lane work on GitHub**, where only a User account can be a requested reviewer: name a bot user reached through a `pat` connection, so the review is posted by that same account and the forge re-arms the button. Explicit only — never derived from a connection's account, which on the PAT path is typically a maintainer's own, and deriving would turn every reviewer ping addressed to that human into a bot run. The logins join the shared identity set, so the anti-loop actor guard recognises them too. Also the knob for the [mixed-identity setup](#two-identities) where a webhook rides an App connection for reads and a `forge_token` PAT for writes — list the PAT's login here so both guards recognise the bot's own posts. |
 | `review_on_sync` | `false` | Re-review on each push to a PR head, so a required status re-evaluates on the revision that fixed it. Required for a blocking [merge gate](merge-gate.md). The lane is debounced (`ITERION_WEBHOOK_SYNC_DEBOUNCE`, default `3m`): a push volley costs one review of the final head — see the GitHub section above. |
 | `overlap` | *(empty = allow)* | Concurrency policy for runs this webhook launches, keyed on (webhook, subject, bot) — one PR's reviews, not the whole repo's. `allow` / `skip` / `supersede`. **Empty means allow**, not `pkg/schedgate`'s `skip` default: a webhook is event-driven and every delivery has always launched, so the gate applies only when explicitly set. `supersede` is the one worth setting alongside `review_on_sync` — three pushes in two minutes otherwise launch three runs, two of which review dead commits. |
 | `operator_launch_vars` | — | Vars layered **between** the handler-derived base and a bot's own rule vars (precedence: base < bot rule vars < these). Kept separate from `launch_vars` so co-enabling two bots that declare the same key does not make them share whichever value won. |

--- a/openapi.json
+++ b/openapi.json
@@ -1787,6 +1787,9 @@
           "deployment": {
             "$ref": "#/components/schemas/DeploymentReport"
           },
+          "end_reason": {
+            "type": "string"
+          },
           "error": {
             "type": "string"
           },
@@ -2056,6 +2059,9 @@
           },
           "created_at": {
             "format": "date-time",
+            "type": "string"
+          },
+          "end_reason": {
             "type": "string"
           },
           "error": {

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -287,11 +287,12 @@ func dispositionForStatus(msg *queue.RunMessage, run *store.Run) preconditionOut
 		// operator's explicit resume re-queues it.
 		//
 		// A PR-closed cancel keeps its own line: the redelivered message
-		// does not carry the cancel, and the reason on the doc (via
-		// store.IsPRClosedCancel, which survives CancelRunWithReason's
-		// "(was <status>: <prior>)" wrapping) is the only signal that the PR
-		// is gone.
-		if store.IsPRClosedCancel(run.Error) {
+		// does not carry the cancel, so the reason on the doc is the only
+		// signal that the PR is gone. store.EndedBecausePRClosed reads the
+		// TYPED EndReason the cancel writes, and falls back to the message
+		// for a document cancelled before that field existed — the prose is
+		// a migration carrier here, never the protocol.
+		if store.EndedBecausePRClosed(run) {
 			return preconditionOutcome{
 				finalStatus: "cancelled",
 				op:          "ack-pr-closed-cancel",

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -632,11 +632,12 @@ func TestResolveDeliveryPreconditions(t *testing.T) {
 			t.Fatalf("SaveRun %s: %v", id, err)
 		}
 	}
-	// The exact prefix CancelRunWithReason wraps ("(was <status>: <prior>)"),
-	// so the substring detection has to survive it — that's the WHOLE point of
-	// exposing store.IsPRClosedCancel as a helper.
+	// A document cancelled before EndReason existed: the message, wrapped
+	// as CancelRunWithReason wraps it ("(was <status>: <prior>)"), is the
+	// only carrier — which is what store.EndedBecausePRClosed's migration
+	// half reads.
 	saveErr("run-cancel-pr-closed", store.RunStatusCancelled, &store.Checkpoint{NodeID: "n1"},
-		store.RunEndReasonPRClosed+" (was failed_resumable: node \"campaign\": rate_limited)")
+		store.RunEndReasonPRClosed.Message()+" (was failed_resumable: node \"campaign\": rate_limited)")
 	// An operator cancel of a QUEUED resume: every cloud resume CASes the
 	// doc to queued before publishing, so `cancelled` at admission always
 	// post-dates the publish — whatever the error shape.
@@ -1546,5 +1547,53 @@ func TestAdoptRunningUnderLock_PeerMovedTheDocTakesItsDisposition(t *testing.T) 
 	}
 	if got := loadStatus(t, st, id); got.FailureCode != store.FailureInterrupted {
 		t.Fatalf("FailureCode = %q, want the peer's INTERRUPTED kept — the adoption must not overwrite a cause it did not establish", got.FailureCode)
+	}
+}
+
+// The PR-closed drop is a PROTOCOL between the webhook layer that cancels and
+// the runner that admits. Its carrier is the typed EndReason on the run doc,
+// not the prose in run.Error: a reworded, translated or truncated message must
+// not silently re-arm the redelivery this admission exists to refuse.
+func TestResolveDeliveryPreconditions_PRClosedIsReadFromTheTypedEndReason(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := context.Background()
+	save := func(id string, end store.RunEndReason, errText string) {
+		t.Helper()
+		if err := st.SaveRun(ctx, &store.Run{
+			ID: id, WorkflowName: "wf", Status: store.RunStatusCancelled,
+			Checkpoint: &store.Checkpoint{NodeID: "n1"},
+			EndReason:  end, Error: errText,
+		}); err != nil {
+			t.Fatalf("SaveRun %s: %v", id, err)
+		}
+	}
+	// The typed reason with a message that shares nothing with the constant.
+	save("run-typed", store.RunEndReasonPRClosed, "la pull request est fermée (was running: node \"campaign\")")
+	// A doc written before the field existed: the prose is all there is.
+	save("run-legacy", "", store.RunEndReasonPRClosed.Message()+" (was failed_resumable: node \"campaign\": rate_limited)")
+	// An operator cancel must NOT be mistaken for one.
+	save("run-operator", store.RunEndReasonOperator, "cancelled by user")
+
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+	for _, c := range []struct {
+		name, runID, wantOp string
+	}{
+		{"the typed reason decides", "run-typed", "ack-pr-closed-cancel"},
+		{"a pre-field doc still reads its prose", "run-legacy", "ack-pr-closed-cancel"},
+		{"an operator cancel keeps its own line", "run-operator", "ack-cancelled"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			msg := &queue.RunMessage{RunID: c.runID, TenantID: "team-1", Resume: &queue.ResumeSpec{}}
+			out := r.resolveDeliveryPreconditions(msg)
+			if out.proceed {
+				t.Fatalf("a cancelled run must never proceed (outcome %+v)", out)
+			}
+			if out.op != c.wantOp {
+				t.Fatalf("op = %q, want %q", out.op, c.wantOp)
+			}
+		})
 	}
 }

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -419,6 +419,10 @@ type RunSummary struct {
 	// FailureCode is Error's machine-readable classification (ADR-095);
 	// empty = unknown/legacy.
 	FailureCode store.FailureCode `json:"failure_code,omitempty"`
+	// EndReason is the typed WHY the run ended, of which Error is the
+	// human sentence — what tells "cancelled because its pull request
+	// closed" from an operator's click. Empty = unknown/legacy.
+	EndReason store.RunEndReason `json:"end_reason,omitempty"`
 	// Active reports whether the run is currently held by this
 	// process's manager. A run with status "running" but Active=false
 	// belongs to another process or to a previous boot — Cancel won't

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -33,13 +33,14 @@ func (s *Service) Cancel(runID string) error {
 	return s.manager.Cancel(runID)
 }
 
-// CancelWithReason mirrors Cancel but records WHY on the run (run.Error) —
-// what the run list, board cards and merge-gate synthetic statuses read. An
+// CancelWithReason mirrors Cancel but records WHY on the run: the typed
+// store.RunEndReason the runner admission reads, and the message it derives —
+// what the run list, board cards and merge-gate synthetic statuses show. An
 // automated caller (the webhook supersede lane) must not sign its cancel
 // "cancelled by user". The in-process manager path has no reason plumbing —
 // the engine stamps its own cancellation semantics — so the reason applies
 // on the cloud path, where the bare status flip IS the record.
-func (s *Service) CancelWithReason(runID, reason string) error {
+func (s *Service) CancelWithReason(runID string, reason store.RunEndReason) error {
 	if s.publisher != nil {
 		return s.publisher.CancelRunWithReason(context.Background(), runID, reason)
 	}

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -47,11 +47,13 @@ type LaunchPublisher interface {
 	// flips the Mongo doc to cancelled regardless of whether a runner
 	// is currently holding the lease.
 	CancelRun(ctx context.Context, runID string) error
-	// CancelRunWithReason is CancelRun with an explicit reason recorded
-	// on the run (run.Error). Automated cancellations — the webhook
-	// supersede lane — pass what actually happened; CancelRun stays the
-	// operator-click shape ("cancelled by user").
-	CancelRunWithReason(ctx context.Context, runID, reason string) error
+	// CancelRunWithReason is CancelRun with an explicit, TYPED reason
+	// recorded on the run — the field the runner admission reads, and the
+	// message the run list shows, both derived from it. Automated
+	// cancellations — the webhook supersede, re-queue and closed-PR lanes
+	// — say what actually happened; CancelRun stays the operator-click
+	// shape (store.RunEndReasonOperator).
+	CancelRunWithReason(ctx context.Context, runID string, reason store.RunEndReason) error
 	// SubmitResume republishes a RunMessage with ResumeSpec set so
 	// the runner picks the run back up.
 	SubmitResume(ctx context.Context, spec ResumeSpec, wf *ir.Workflow, hash string) error

--- a/pkg/runview/service_launch_budget_test.go
+++ b/pkg/runview/service_launch_budget_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/store"
+
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -134,7 +136,7 @@ func (p *stubLaunchPublisher) SubmitLaunch(_ context.Context, _ string, spec Lau
 	return 1, nil
 }
 func (p *stubLaunchPublisher) CancelRun(context.Context, string) error { return nil }
-func (p *stubLaunchPublisher) CancelRunWithReason(context.Context, string, string) error {
+func (p *stubLaunchPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
 	return nil
 }
 func (p *stubLaunchPublisher) SubmitResume(context.Context, ResumeSpec, *ir.Workflow, string) error {

--- a/pkg/runview/service_launch_operator_resume_test.go
+++ b/pkg/runview/service_launch_operator_resume_test.go
@@ -21,7 +21,7 @@ func (*operatorResumePublisher) SubmitLaunch(context.Context, string, LaunchSpec
 }
 
 func (*operatorResumePublisher) CancelRun(context.Context, string) error { return nil }
-func (*operatorResumePublisher) CancelRunWithReason(context.Context, string, string) error {
+func (*operatorResumePublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
 	return nil
 }
 

--- a/pkg/runview/service_resume_hash_test.go
+++ b/pkg/runview/service_resume_hash_test.go
@@ -63,7 +63,7 @@ func (*resumeHashPublisher) CancelRun(context.Context, string) error {
 	return nil
 }
 
-func (*resumeHashPublisher) CancelRunWithReason(context.Context, string, string) error {
+func (*resumeHashPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
 	return nil
 }
 

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -265,6 +265,7 @@ func summarizeRun(r *store.Run, active bool) RunSummary {
 		FinishedAt:        r.FinishedAt,
 		Error:             r.Error,
 		FailureCode:       r.FailureCode,
+		EndReason:         r.EndReason,
 		Active:            active,
 		FinalCommit:       r.FinalCommit,
 		FinalBranch:       r.FinalBranch,

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -119,7 +119,11 @@ type RunHeader struct {
 	// FailureCode is Error's machine-readable classification (ADR-095);
 	// empty = unknown/legacy.
 	FailureCode store.FailureCode `json:"failure_code,omitempty"`
-	Checkpoint  *store.Checkpoint `json:"checkpoint,omitempty"`
+	// EndReason is the typed WHY the run ended, of which Error is the
+	// human sentence — what tells "cancelled because its pull request
+	// closed" from an operator's click. Empty = unknown/legacy.
+	EndReason  store.RunEndReason `json:"end_reason,omitempty"`
+	Checkpoint *store.Checkpoint  `json:"checkpoint,omitempty"`
 	// WorkDir is the absolute filesystem path the run executed in
 	// (per-run worktree when Worktree is true, otherwise inherited cwd).
 	// Empty for runs created before this field was persisted; the studio
@@ -1446,6 +1450,7 @@ func headerFromRun(r *store.Run) RunHeader {
 		FinishedAt:           r.FinishedAt,
 		Error:                r.Error,
 		FailureCode:          r.FailureCode,
+		EndReason:            r.EndReason,
 		Checkpoint:           r.Checkpoint,
 		WorkDir:              r.WorkDir,
 		ProjectPath:          r.ProjectPath,

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -1480,8 +1480,14 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 		return fmt.Errorf("card %s: %w", iss.ID, err)
 	}
 	// A card that targets a pull request also needs the repo's launch policy
-	// and a publish grant, neither of which can ride the card itself.
-	lc.Vars = s.applyPRLaunchContext(ctx, tenant, "", iss.Bot, lc.Vars, nil)
+	// and a publish grant, neither of which can ride the card itself — and it
+	// passes the fork guard at CLAIM time: a head repo can vanish between
+	// carding and claiming, and a refused card is filed blocked with the
+	// reason rather than launched against the base repo.
+	lc.Vars, err = s.applyPRLaunchContext(ctx, tenant, "", iss.Bot, lc.Vars, nil)
+	if err != nil {
+		return fmt.Errorf("card %s: %w", iss.ID, err)
+	}
 	spec := runview.LaunchSpec{
 		Vars:            lc.Vars,
 		RepoURL:         lc.RepoURL,

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -679,6 +679,11 @@ func TestProcessBoardCardCarriesPRLaunchContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.cfg.Bots.Paths = []string{botsDir}
+	// The launch proves the PR same-repo through the team connection before
+	// it grants anything; the stub forge answers "same repo".
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return &fakeGateClient{headSHA: "abc"}, nil
+	}
 
 	rs, err := store.New(t.TempDir())
 	if err != nil {
@@ -786,12 +791,21 @@ func TestApplyPRLaunchContextPrecedence(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Every PR-bound launch is proven same-repo before it is granted; the
+	// stub forge answers "same repo" so the precedence under test is reached.
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return &fakeGateClient{headSHA: "abc"}, nil
+	}
+
 	vars := map[string]string{
 		"pr_url":        "https://github.com/o/r/pull/7",
 		"gate_severity": "medium", // pinned on the launch — must survive
 		"gate_context":  "",       // cleared field: absent, not a decision
 	}
-	out := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", vars, nil)
+	out, err := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", vars, nil)
+	if err != nil {
+		t.Fatalf("applyPRLaunchContext: %v", err)
+	}
 	if out["gate_severity"] != "medium" {
 		t.Errorf("repo policy overwrote a launch pin: %q", out["gate_severity"])
 	}
@@ -819,8 +833,11 @@ func TestApplyPRLaunchContextPrecedence(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	out = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer",
+	out, err = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer",
 		map[string]string{"pr_url": "https://github.com/o/r/pull/7"}, nil)
+	if err != nil {
+		t.Fatalf("applyPRLaunchContext: %v", err)
+	}
 	if g, ok := s.forgePublishTokens.lookup(out[forgePublishVarToken]); !ok || g.ConnectionID != "conn1" {
 		t.Errorf("the stale provisioning won the grant: ok=%v g=%+v", ok, g)
 	}
@@ -828,9 +845,13 @@ func TestApplyPRLaunchContextPrecedence(t *testing.T) {
 		t.Errorf("the stale provisioning won the policy: %q", out["gate_context"])
 	}
 
-	// Same slug on another forge is a different repo: no policy, no grant.
-	out = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer",
+	// Same slug on another forge is a different repo: no policy, no grant —
+	// and no connection to prove anything through, so no refusal either.
+	out, err = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer",
 		map[string]string{"pr_url": "https://gitlab.example/o/r/-/merge_requests/7"}, nil)
+	if err != nil {
+		t.Fatalf("a host no connection covers has no pair to guard: %v", err)
+	}
 	if _, ok := out["gate_context"]; ok {
 		t.Errorf("policy applied across forge hosts: %v", out)
 	}
@@ -838,7 +859,10 @@ func TestApplyPRLaunchContextPrecedence(t *testing.T) {
 		t.Error("grant minted for a repo on a host no connection covers")
 	}
 
-	out = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"base_ref": "main"}, nil)
+	out, err = s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"base_ref": "main"}, nil)
+	if err != nil {
+		t.Fatalf("no pr_url: %v", err)
+	}
 	if _, ok := out[forgePublishVarToken]; ok {
 		t.Error("no pr_url: nothing to grant")
 	}
@@ -2712,5 +2736,128 @@ func TestCloudSweep_GateOffReleasesAnAbandonedRecoveryHold(t *testing.T) {
 	}
 	if state != native.StateInProgress {
 		t.Fatalf("state = %q — a release restores the card, it must never ROUTE an operator-cancelled run", state)
+	}
+}
+
+// prLaunchGuardFixture: a team provisioned on o/r through conn1 and a stub
+// forge whose GetPullRequest answers with the head repo the test chooses —
+// the seam the fork guard reads through.
+func prLaunchGuardFixture(t *testing.T, gc forgeGateClient) *Server {
+	t.Helper()
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.PublicURL = "https://iterion.example"
+	s.forgeIntegrations = forge.NewMemoryRepoIntegrationStore()
+	s.webhookConfigs = webhooks.NewMemoryConfigStore()
+	if err := s.forgeIntegrations.Create(context.Background(), forge.RepoIntegration{
+		ID: "ri1", TenantID: "team1", ConnectionID: "conn1", RepoFullName: "o/r",
+		LaunchVars: map[string]string{"gate_context": "iterion/review"},
+		CreatedAt:  time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+	return s
+}
+
+// TestApplyPRLaunchContextForkGuard: the studio/API and board lanes stamp the
+// same launch pair the webhook lanes do — <base>.CloneURL + the PR's head
+// branch — so they inherit the same fail-CLOSED fork guard. A head branch that
+// is not PROVEN to live in the base repo is refused with the webhook lanes'
+// own wording (forkGuardRefusal), never checked out against a same-named
+// branch of the base repo; a resolution failure is an explicit refusal, not
+// a silent launch. Same-repo (case-insensitively) is admitted and granted.
+func TestApplyPRLaunchContextForkGuard(t *testing.T) {
+	const prURL = "https://github.com/o/r/pull/7"
+
+	t.Run("a fork PR is refused with the webhook lanes' wording", func(t *testing.T) {
+		s := prLaunchGuardFixture(t, &fakeGateClient{headSHA: "abc", headRepo: "someone/r"})
+		out, err := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"pr_url": prURL}, nil)
+		if !errors.Is(err, errPRLaunchForkGuard) {
+			t.Fatalf("a fork PR must be refused by the fork guard, got err=%v", err)
+		}
+		if want := forkGuardRefusal(false, false, "someone/r"); !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal must carry the webhook lanes' own wording:\n got %q\nwant %q", err, want)
+		}
+		if tok := out[forgePublishVarToken]; tok != "" {
+			t.Fatalf("a refused launch must not be granted: grant %q minted", tok)
+		}
+	})
+
+	t.Run("an unnamed head repo is refused too — same-repo is proven, never assumed", func(t *testing.T) {
+		s := prLaunchGuardFixture(t, &fakeGateClient{headSHA: "abc", noHeadRepo: true})
+		out, err := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"pr_url": prURL}, nil)
+		if !errors.Is(err, errPRLaunchForkGuard) {
+			t.Fatalf("an unverifiable head repo must be refused by the fork guard, got err=%v", err)
+		}
+		if want := forkGuardRefusal(false, false, ""); !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal must carry the webhook lanes' own wording:\n got %q\nwant %q", err, want)
+		}
+		if tok := out[forgePublishVarToken]; tok != "" {
+			t.Fatalf("a refused launch must not be granted: grant %q minted", tok)
+		}
+	})
+
+	t.Run("a PR the forge cannot resolve is refused, not launched blind", func(t *testing.T) {
+		s := prLaunchGuardFixture(t, &fakeGateClient{getErr: errors.New("502 from the forge")})
+		out, err := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"pr_url": prURL}, nil)
+		if err == nil || !strings.Contains(err.Error(), "502 from the forge") {
+			t.Fatalf("a resolution failure must surface as the refusal, got err=%v", err)
+		}
+		if errors.Is(err, errPRLaunchForkGuard) {
+			t.Fatalf("a forge outage is not a fork verdict — the HTTP lane must answer 502, not 422: %v", err)
+		}
+		if tok := out[forgePublishVarToken]; tok != "" {
+			t.Fatalf("an unresolved PR must not be granted a launch: grant %q minted", tok)
+		}
+	})
+
+	t.Run("a same-repo PR is admitted, case-insensitively, and granted", func(t *testing.T) {
+		s := prLaunchGuardFixture(t, &fakeGateClient{headSHA: "abc", headRepo: "O/R"})
+		out, err := s.applyPRLaunchContext(context.Background(), "team1", "", "fixer", map[string]string{"pr_url": prURL}, nil)
+		if err != nil {
+			t.Fatalf("a same-repo PR must be admitted: %v", err)
+		}
+		if out[forgePublishVarToken] == "" {
+			t.Fatal("a same-repo PR must be granted")
+		}
+		if out["gate_context"] != "iterion/review" {
+			t.Errorf("the repo's policy must still apply: %q", out["gate_context"])
+		}
+	})
+}
+
+// TestProcessBoardCardRefusesAForkPR: the cloud board coordinator is the
+// second door into the same launch pair. A card whose pull request turns out
+// to be a fork (or whose head repo vanished since carding) is refused at
+// claim time — the error files the card blocked with the reason — and no run
+// is created against the base repo.
+func TestProcessBoardCardRefusesAForkPR(t *testing.T) {
+	s := prLaunchGuardFixture(t, &fakeGateClient{headSHA: "abc", headRepo: "someone/r"})
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "fixer.bot"), []byte(
+		"schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"yes\"}'`\n  output: probe_out\n\nworkflow board_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+
+	err = s.processBoardCard(context.Background(), "team1", native.Issue{
+		ID: "card-fork", Bot: "fixer", State: native.StateReady,
+		BotArgs: map[string]string{"pr_url": "https://github.com/o/r/pull/7"},
+	})
+	if !errors.Is(err, errPRLaunchForkGuard) {
+		t.Fatalf("a fork PR card must be refused by the fork guard, got err=%v", err)
+	}
+	if ids, lerr := rs.ListRuns(context.Background()); lerr != nil || len(ids) != 0 {
+		t.Fatalf("a refused card must launch nothing, got runs=%v err=%v", ids, lerr)
 	}
 }

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -29,6 +29,17 @@ import (
 // exists (the studio launch surface): a team's experimental fork must not
 // silently hijack that team's schedules/webhooks. The platform tier applies
 // everywhere — overriding the deployment's catalog is its purpose.
+//
+// That exclusion is a CONTRACT, not an oversight, and it binds the metadata
+// reads below as much as the launch: effectiveEntries* / effectiveFindByName
+// are the tenant-context-FREE view (platform over baked), which is exactly the
+// resolution resolveBotSource performs on the lanes that read them — the
+// webhook hand-off matcher (produces:/consumes:), the command discovery, the
+// gate-var defaults. A team-authored bot is therefore invisible to those
+// lanes, on purpose: describing a fork the launch will never run would seed a
+// run from the wrong manifest. A caller that holds the tier a bot ACTUALLY
+// resolved through — a run's BotSourceTenant, stamped at launch — asks
+// teamBotManifest first instead.
 
 // launchBot is a resolved, launch-ready bot: its source, provenance, and —
 // for a STORED bot (team or platform botsource row) — the materialized
@@ -328,6 +339,33 @@ func (s *Server) botExists(botID string) bool {
 	}
 	_, err := botregistry.ResolveBotPath(botID, s.effectivePaths())
 	return err == nil
+}
+
+// teamBotManifest reads the manifest of a TEAM-authored bot row. It is for
+// callers holding the tier a bot actually resolved through — a run's
+// BotSourceTenant — so that a run's own manifest is read where the run came
+// from. Nil when the tenant names no team row (empty, the platform sentinel,
+// or no such slug), leaving the caller on the platform + baked tiers.
+//
+// Deliberately NOT folded into effectiveFindByName: see the contract at the
+// top of this file — the tenant-context-free lanes must stay blind to a team
+// fork, because their launch is blind to it too.
+func (s *Server) teamBotManifest(ctx context.Context, tenantID, slug string) *bundle.Manifest {
+	slug = strings.TrimSpace(slug)
+	tenantID = strings.TrimSpace(tenantID)
+	if s.botSources == nil || slug == "" || tenantID == "" || tenantID == botsource.PlatformTenantID {
+		return nil
+	}
+	bs, err := s.botSources.GetBySlug(store.WithTenant(ctx, tenantID), tenantID, slug)
+	if err != nil {
+		if !errors.Is(err, botsource.ErrNotFound) {
+			// A store blip is not "this team authored no such bot": say so,
+			// then fall through to the tiers that can still answer.
+			s.logger.Warn("bot source %s/%s: %v — reading the manifest fell through to the platform tier", tenantID, slug, err)
+		}
+		return nil
+	}
+	return bs.Manifest()
 }
 
 // effectiveFindByName returns the effective (platform-overlaid) entry for a

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1899,20 +1899,25 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 //
 // Idempotent: running CancelRun on an already-terminal run is a no-op.
 func (p *Publisher) CancelRun(ctx context.Context, runID string) error {
-	return p.CancelRunWithReason(ctx, runID, "cancelled by user")
+	return p.CancelRunWithReason(ctx, runID, store.RunEndReasonOperator)
 }
 
-// CancelRunWithReason is CancelRun with an explicit reason. The reason lands
-// in run.Error — which the run list, the board cards and the merge-gate
-// synthetic status all read — so an AUTOMATED cancel must say what actually
-// happened instead of masquerading as an operator action: a webhook supersede
-// once overwrote a runner validation error with "cancelled by user", and the
-// PR's synthetic gate then blamed a human who had touched nothing.
+// CancelRunWithReason is CancelRun with an explicit, TYPED reason. It lands on
+// the run twice: as store.Run.EndReason, the field the runner admission reads
+// to drop a redelivery for a dead pull request, and — through
+// RunEndReason.Message — as the run.Error the run list, the board cards and
+// the merge-gate synthetic status all quote. An AUTOMATED cancel must say what
+// actually happened instead of masquerading as an operator action: a webhook
+// supersede once overwrote a runner validation error with "cancelled by user",
+// and the PR's synthetic gate then blamed a human who had touched nothing.
+//
+// One reason, one message: the caller states the reason and the message is
+// derived, so a rewording can never disarm a reader keyed on the meaning.
 //
 // The prior error, when present, is carried forward (same rationale as
 // runview.CancelInactiveCtx): run.Error is the only record in run.json of WHY
 // the run was in its pre-cancel state, and cancelling must not erase it.
-func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason string) error {
+func (p *Publisher) CancelRunWithReason(ctx context.Context, runID string, reason store.RunEndReason) error {
 	// Cancel descends here with a NON-request context (runview.Service.Cancel
 	// takes no ctx), so the mongo tenant filter has no tenant and its
 	// tenant-scoped queries panic. The caller (handleCancelRun / the WS
@@ -1945,13 +1950,12 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 			cancellable = append(cancellable, st)
 		}
 	}
-	if strings.TrimSpace(reason) == "" {
-		reason = "cancelled"
-	}
+	msg := reason.Message()
 	if prior := strings.TrimSpace(r.Error); prior != "" {
-		reason += " (was " + string(r.Status) + ": " + prior + ")"
+		msg += " (was " + string(r.Status) + ": " + prior + ")"
 	}
-	changed, err := p.store.UpdateRunStatusIfCoded(ctx, runID, store.RunStatusCancelled, reason, store.FailureCancelled, cancellable)
+	changed, err := p.store.UpdateRunOutcome(ctx, runID, store.RunStatusCancelled, msg,
+		store.RunOutcomeMeta{Code: store.FailureCancelled, EndReason: reason}, cancellable)
 	if err != nil {
 		return fmt.Errorf("cloudpublisher: flip status: %w", err)
 	}

--- a/pkg/server/cloudpublisher/publisher_auto_resume_test.go
+++ b/pkg/server/cloudpublisher/publisher_auto_resume_test.go
@@ -22,7 +22,7 @@ func TestSubmitResume_AutomaticRefusesCancelled(t *testing.T) {
 	}
 	ctx := store.WithIdentity(context.Background(), "team", "alice")
 	const runID = "run-cancelled-by-stop-on-close"
-	cancelReason := store.RunEndReasonPRClosed + " (was failed_resumable: node \"campaign\": rate_limited)"
+	cancelReason := store.RunEndReasonPRClosed.Message() + " (was failed_resumable: node \"campaign\": rate_limited)"
 	if err := st.SaveRun(ctx, &store.Run{
 		ID: runID, TenantID: "team", OwnerID: "alice",
 		Status: store.RunStatusCancelled, Error: cancelReason,

--- a/pkg/server/cloudpublisher/publisher_cancel_test.go
+++ b/pkg/server/cloudpublisher/publisher_cancel_test.go
@@ -8,11 +8,13 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// A cancel's reason lands in run.Error — what the run list, board cards and
-// merge-gate synthetic statuses all read. Pinned here: an automated cancel
+// A cancel's reason lands on the run twice: as the typed EndReason the runner
+// admission reads, and as the run.Error the run list, board cards and
+// merge-gate synthetic statuses all show. Pinned here: an automated cancel
 // (the webhook supersede lane) records what actually happened instead of
-// "cancelled by user", and the prior error is carried forward rather than
-// erased (a supersede once overwrote a runner validation error, and the PR's
+// "cancelled by user", the message is DERIVED from the reason so the two
+// cannot disagree, and the prior error is carried forward rather than erased
+// (a supersede once overwrote a runner validation error, and the PR's
 // synthetic gate then blamed a human who had touched nothing).
 func TestCancelRunWithReason(t *testing.T) {
 	newPub := func(t *testing.T) (*Publisher, store.RunStore) {
@@ -42,7 +44,7 @@ func TestCancelRunWithReason(t *testing.T) {
 	t.Run("an automated reason is recorded verbatim and keeps the prior error", func(t *testing.T) {
 		p, st := newPub(t)
 		seed(t, st, "run-1", store.RunStatusFailedResumable, `runner: reject repo ref: git: branch name "renovate/npm-(non-major)"`)
-		if err := p.CancelRunWithReason(context.Background(), "run-1", "superseded by a newer delivery for the same subject"); err != nil {
+		if err := p.CancelRunWithReason(context.Background(), "run-1", store.RunEndReasonSuperseded); err != nil {
 			t.Fatalf("CancelRunWithReason: %v", err)
 		}
 		run, err := st.LoadRun(context.Background(), "run-1")
@@ -52,7 +54,10 @@ func TestCancelRunWithReason(t *testing.T) {
 		if run.Status != store.RunStatusCancelled {
 			t.Fatalf("status = %s, want cancelled", run.Status)
 		}
-		if !strings.HasPrefix(run.Error, "superseded by a newer delivery") {
+		if run.EndReason != store.RunEndReasonSuperseded {
+			t.Errorf("end_reason = %q, want %q — the typed reason is what a reader keys on", run.EndReason, store.RunEndReasonSuperseded)
+		}
+		if !strings.HasPrefix(run.Error, store.RunEndReasonSuperseded.Message()) {
 			t.Errorf("error = %q, want the automated reason first", run.Error)
 		}
 		if !strings.Contains(run.Error, "was failed_resumable") || !strings.Contains(run.Error, "reject repo ref") {
@@ -70,8 +75,8 @@ func TestCancelRunWithReason(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if run.Error != "cancelled by user" {
-			t.Errorf("error = %q, want the plain operator shape", run.Error)
+		if run.Error != "cancelled by user" || run.EndReason != store.RunEndReasonOperator {
+			t.Errorf("(error, end_reason) = (%q, %q), want the plain operator shape", run.Error, run.EndReason)
 		}
 	})
 
@@ -83,7 +88,7 @@ func TestCancelRunWithReason(t *testing.T) {
 	t.Run("the runner's engine cancel does not overwrite a recorded reason", func(t *testing.T) {
 		p, st := newPub(t)
 		seed(t, st, "run-4", store.RunStatusRunning, "")
-		if err := p.CancelRunWithReason(context.Background(), "run-4", "superseded by a newer delivery for the same subject"); err != nil {
+		if err := p.CancelRunWithReason(context.Background(), "run-4", store.RunEndReasonSuperseded); err != nil {
 			t.Fatalf("CancelRunWithReason: %v", err)
 		}
 		// The exact write the engine performs on ctx-cancel.
@@ -103,15 +108,17 @@ func TestCancelRunWithReason(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !strings.HasPrefix(run.Error, "superseded by a newer delivery") {
-			t.Errorf("error = %q — the supersede reason did not survive the runner's cancel", run.Error)
+		if !strings.HasPrefix(run.Error, store.RunEndReasonSuperseded.Message()) || run.EndReason != store.RunEndReasonSuperseded {
+			t.Errorf("(error, end_reason) = (%q, %q) — the supersede reason did not survive the runner's cancel", run.Error, run.EndReason)
 		}
 	})
 
-	t.Run("an empty reason still names the fact", func(t *testing.T) {
+	// A reason the vocabulary does not know still names the fact, and never
+	// signs an operator's name to a decision no operator took.
+	t.Run("an unknown reason still names the fact", func(t *testing.T) {
 		p, st := newPub(t)
 		seed(t, st, "run-3", store.RunStatusQueued, "")
-		if err := p.CancelRunWithReason(context.Background(), "run-3", "  "); err != nil {
+		if err := p.CancelRunWithReason(context.Background(), "run-3", store.RunEndReason("  ")); err != nil {
 			t.Fatalf("CancelRunWithReason: %v", err)
 		}
 		run, err := st.LoadRun(context.Background(), "run-3")

--- a/pkg/server/forge_gate_dlq_notice_test.go
+++ b/pkg/server/forge_gate_dlq_notice_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -156,5 +157,61 @@ func TestNoticeGateDLQParked_SilentForANonGatingRun(t *testing.T) {
 
 	if len(c.bodies) != 0 {
 		t.Fatalf("a run owing no verdict posted a DLQ notice: %v", c.bodies)
+	}
+}
+
+// The check is what the developer reads first, and for a DLQ-parked run the
+// dead-review trailer is false advice: a push (or the bot's command) launches
+// a FRESH run while the parked message stays parked, so the check would tell
+// the developer the opposite of what the DLQ comment on the same PR says, and
+// hide the one remedy that reaches the parked message.
+func TestGateReconcile_DLQParkedCheckNamesTheOperatorReplay(t *testing.T) {
+	s, runID, gc, _ := dlqGateFixture(t, nil)
+
+	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1", gc.setCalls)
+	}
+	desc := gc.last.Description
+	if strings.Contains(desc, "push again") || strings.Contains(desc, "comment the bot's command") {
+		t.Fatalf("the DLQ check carries the dead-review trailer — a push wakes no parked message:\n%s", desc)
+	}
+	for _, want := range []string{"DLQ", "iterion remote admin dlq"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("the DLQ check must name the remedy that reaches the parked message, missing %q:\n%s", want, desc)
+		}
+	}
+	// The reconciler must still read its own repair as its own: the second
+	// death on a head escalates, and the auto-fix lane must not send a fixer
+	// hunting for findings behind a review that never ran.
+	if !isSyntheticGateInterruption(desc) {
+		t.Fatalf("the DLQ description is not recognised as a synthetic interruption:\n%s", desc)
+	}
+	if n := utf8.RuneCountInString(desc); n > 140 {
+		t.Fatalf("description is %d runes — a forge truncates commit-status descriptions at 140:\n%s", n, desc)
+	}
+}
+
+// The wording is selected by the persisted FailureCode, the same typed WHY
+// the DLQ notice keys on — never by parsing run.Error.
+func TestGateInterruptedDescriptionFor_DLQParkOutranksTheRunError(t *testing.T) {
+	run := &store.Run{
+		Status:      store.RunStatusFailedResumable,
+		FailureCode: store.FailureDLQParked,
+		Error:       "max deliveries exhausted: runner: prepare repo workspace for 01a0: boom",
+	}
+	got := gateInterruptedDescriptionFor(run)
+	if strings.HasPrefix(got, gateDiedDescriptionPrefix) || strings.Contains(got, "push again") {
+		t.Fatalf("a DLQ park must not be described as a dead review: %q", got)
+	}
+	if !strings.Contains(got, "iterion remote admin dlq") {
+		t.Fatalf("a DLQ park must name the operator replay: %q", got)
+	}
+	// A plain interruption keeps the dead-review wording.
+	plain := gateInterruptedDescriptionFor(&store.Run{Error: "boom"})
+	if !strings.HasPrefix(plain, gateDiedDescriptionPrefix) {
+		t.Fatalf("a non-DLQ interruption must keep the dead-review wording: %q", plain)
 	}
 }

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -70,7 +70,7 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 	//
 	// Read after the target resolves: it walks the bot catalog, which a run
 	// that may not be commented on has no reason to pay for.
-	role := s.pauseNoticeRoleForBot(run.BotID)
+	role := s.pauseNoticeRoleForRun(ctx, run)
 	body := gatePauseNoticeBody(run, role, time.Now().UTC())
 	if _, err := target.commenter.CommentIssue(ctx, target.repo, target.number, body); err != nil {
 		s.gateNoticeDebug(run, "pause notice", "%v", err)
@@ -121,16 +121,25 @@ const (
 	pauseNoticeRoleFixer
 )
 
-// pauseNoticeRoleForBot classifies the bot behind a parked run. A bot that
+// pauseNoticeRoleForRun classifies the bot behind a parked run. A bot that
 // PRODUCES a review is a reviewer (Revi and any peer); one that CONSUMES a
-// review to answer it is a fixer (Billy and any peer). Consumes wins over
-// produces on the (unlikely) both — a bot that produces its own review of
-// its own fixes is a fixer, and the fixer notice's push-back warning is the
-// one that matters. Missing bot / entry / catalog → unknown (silent).
-func (s *Server) pauseNoticeRoleForBot(botID string) pauseNoticeRole {
-	botID = strings.TrimSpace(botID)
+// review to answer it is a fixer (Billy and any peer). Missing bot / entry /
+// catalog → unknown (neutral notice).
+//
+// The manifest is read AT THE TIER THE RUN CAME FROM: a team-authored bot
+// resolves through the team's own bot-source row at launch, and the run
+// records which (BotSourceTenant), so reading only the platform + baked
+// catalog would find nothing and hand a team's reviewer the neutral notice.
+// The team lookup is keyed on the run's own provenance, never on an ambient
+// tenant — the tenant-context-free lanes stay blind to team forks by
+// contract (see bot_resolver.go).
+func (s *Server) pauseNoticeRoleForRun(ctx context.Context, run *store.Run) pauseNoticeRole {
+	botID := strings.TrimSpace(run.BotID)
 	if botID == "" {
 		return pauseNoticeRoleUnknown
+	}
+	if m := s.teamBotManifest(ctx, run.BotSourceTenant, botID); m != nil {
+		return pauseNoticeRoleFor(m.Produces, m.Consumes)
 	}
 	entry, ok, err := s.effectiveFindByName(botID)
 	if err != nil {
@@ -145,12 +154,21 @@ func (s *Server) pauseNoticeRoleForBot(botID string) pauseNoticeRole {
 	if !ok {
 		return pauseNoticeRoleUnknown
 	}
-	for _, c := range entry.Consumes {
+	return pauseNoticeRoleFor(entry.Produces, entry.Consumes)
+}
+
+// pauseNoticeRoleFor is the classification itself, over the two hand-off
+// declaration lists whichever tier supplied them. Consumes wins over produces
+// on the (unlikely) both — a bot that produces its own review of its own
+// fixes is a fixer, and the fixer notice's push-back warning is the one that
+// matters.
+func pauseNoticeRoleFor(produces []bundle.ProducedArtifact, consumes []bundle.ConsumedArtifact) pauseNoticeRole {
+	for _, c := range consumes {
 		if c.Kind == bundle.HandoffKindReview {
 			return pauseNoticeRoleFixer
 		}
 	}
-	for _, p := range entry.Produces {
+	for _, p := range produces {
 		if p.Kind == bundle.HandoffKindReview {
 			return pauseNoticeRoleReviewer
 		}

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -46,20 +46,13 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 	if s == nil || run == nil || run.RetryState == nil || run.RetryState.RetryAfter == nil {
 		return
 	}
-	if s.forgePublishTokens == nil || s.forgeConnections == nil {
-		return
-	}
-	prURL := strings.TrimSpace(runInputString(run, "pr_url"))
-	token := strings.TrimSpace(runInputString(run, forgePublishVarToken))
-	if prURL == "" || token == "" {
-		return // holds no publish grant: nothing to tell anyone
-	}
-	// Holding a grant is NOT enough to warrant a notice — the server mints
-	// one for ANY bot launched with a pr_url (the brancher, the docs
-	// amender, and every fixer). And a run whose repo pinned the gate off
-	// isn't blocking a merge, so a park there tells nobody nothing useful.
-	// Filter both classes: no gate_context OR the operator disabled the gate.
-	if strings.TrimSpace(runInputString(run, "gate_context")) == "" || runGateDisabled(run) {
+	// Where iterion may speak, and through whom, is ONE walk — the run's
+	// publish grant and its (repo, tenant, host) scope — shared with the DLQ
+	// notice. Both comment on a pull request under iterion's forge identity,
+	// so both are bounded by the same rule: a grant for repo A must not let
+	// that identity speak on any repo B the connection reaches.
+	target, ok := s.gateNoticeTarget(ctx, run, "pause notice")
+	if !ok {
 		return
 	}
 	// Derive the run's ROLE from its bot manifest, never from a bot id —
@@ -74,60 +67,18 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 	// re-reads the branch, so a push in between collides with what it
 	// pushes back). Unknown: says the pause exists and when it resumes,
 	// makes no push-side claim either way.
+	//
+	// Read after the target resolves: it walks the bot catalog, which a run
+	// that may not be commented on has no reason to pay for.
 	role := s.pauseNoticeRoleForBot(run.BotID)
-	debugf := func(format string, args ...any) {
-		if s.logger != nil {
-			s.logger.Debug("forge gate: pause notice for run %s on %s not posted: "+format,
-				append([]any{run.ID, prURL}, args...)...)
-		}
-	}
-	grant, ok := s.forgePublishTokens.lookup(token)
-	if !ok {
-		debugf("its publish grant is expired or revoked")
-		return
-	}
-	host, repo, number, err := forge.ParsePullURL(prURL)
-	if err != nil {
-		debugf("its pr_url does not parse: %v", err)
-		return
-	}
-	// pr_url is a LAUNCH VAR and injectForgePublishVars honours a
-	// caller-pinned token, so the grant's scope has to be re-enforced here
-	// exactly as the publish endpoint and the reconciler enforce it —
-	// repo, tenant, host. Without the REPO half a run holding a legitimate
-	// grant for repo A could park on a quota and have iterion's forge
-	// identity comment on any repo B the connection reaches (for a GitHub
-	// App installation, typically the whole org).
-	if !strings.EqualFold(strings.TrimSpace(repo), strings.TrimSpace(grant.Repo)) {
-		debugf("its grant covers %s — refusing to comment outside the grant's repo", grant.Repo)
-		return
-	}
-	conn, err := s.forgeConnections.Get(store.WithoutTenantFilter(ctx), grant.ConnectionID)
-	if err != nil {
-		debugf("its connection %s is unreadable: %v", grant.ConnectionID, err)
-		return
-	}
-	if conn.TenantID != grant.TeamID {
-		debugf("its connection %s belongs to another tenant", grant.ConnectionID)
-		return
-	}
-	if connHost := hostOfURL(conn.BaseURL()); connHost == "" || !strings.EqualFold(connHost, host) {
-		debugf("its connection points at %q, not %q", hostOfURL(conn.BaseURL()), host)
-		return
-	}
-	commenter, err := s.issueCommenterFor(ctx, conn)
-	if err != nil || commenter == nil {
-		debugf("no comment client for %s: %v", conn.Provider, err)
-		return
-	}
 	body := gatePauseNoticeBody(run, role, time.Now().UTC())
-	if _, err := commenter.CommentIssue(ctx, repo, number, body); err != nil {
-		debugf("%v", err)
+	if _, err := target.commenter.CommentIssue(ctx, target.repo, target.number, body); err != nil {
+		s.gateNoticeDebug(run, "pause notice", "%v", err)
 		return
 	}
 	if s.logger != nil {
 		s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
-			run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
+			run.ID, target.prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
 	}
 }
 

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/botsource"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -434,5 +435,58 @@ func TestGateNotices_ShareOneAuthorizationWalk(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// A run's manifest is read at the TIER the run came from. A team-authored
+// bot resolves through the team botsource row at launch (run.BotSourceTenant
+// records which), so reading its produces:/consumes: from the platform +
+// baked catalog alone finds nothing and the reviewer silently gets the
+// role-neutral notice — the wrong etiquette for the one surface a developer
+// reads while their PR waits.
+func TestGatePausedNotice_TeamAuthoredBotKeepsItsRole(t *testing.T) {
+	s := newForgeGateTestServer(t, nil)
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = st
+	s.botSources = botsource.NewMemoryStore()
+	registerPublishToken(t, s, "tok-gate", ForgePublishGrant{
+		TeamID: "team1", ConnectionID: "conn1", Repo: "o/r", Bot: "acme-reviewer",
+	})
+	c := &stubCommenter{}
+	s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) { return c, nil }
+
+	// A reviewer the TEAM authored: it exists in no catalog, only in the
+	// team's own bot-source row.
+	ctx := store.WithTenant(context.Background(), "team1")
+	if _, err := s.botSources.Create(ctx, botsource.BotSource{
+		TenantID: "team1", Slug: "acme-reviewer",
+		Files: map[string]string{
+			botsource.MainBotFile: "workflow acme_reviewer:\n  entry: done\n",
+			"manifest.yaml": "name: acme-reviewer\nversion: 0.1.0\n" +
+				"produces:\n  - kind: review\n    node: publish\n",
+		},
+	}); err != nil {
+		t.Fatalf("seed the team bot: %v", err)
+	}
+
+	at := time.Now().UTC().Add(time.Hour)
+	run := &store.Run{
+		ID: "run-team", BotID: "acme-reviewer", BotSourceTenant: "team1",
+		TenantID: "team1", Status: store.RunStatusFailedResumable,
+		Inputs:     gatingInputs(),
+		RetryState: &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"},
+		Error:      "rate_limited: You've hit your weekly limit",
+	}
+
+	s.noticeGatePausedForRetry(context.Background(), run)
+
+	if len(c.bodies) != 1 {
+		t.Fatalf("want exactly one notice, got %d", len(c.bodies))
+	}
+	if !strings.Contains(c.bodies[0], "Review paused") {
+		t.Fatalf("a team-authored reviewer must get the reviewer notice; got:\n%s", c.bodies[0])
 	}
 }

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -333,3 +333,106 @@ func TestGatePausedNoticePostsOnThePR(t *testing.T) {
 		}
 	})
 }
+
+// Both gate notices — the quota pause and the DLQ park — comment on a pull
+// request under iterion's forge identity, so both are bounded by the same
+// authorization walk: the run's publish grant, the grant's repo, its tenant,
+// its host, and whether the run owes a verdict at all. gateNoticeTarget IS
+// that walk. This table drives BOTH notices through every refusal reason on
+// one world, so a rule at the choke point cannot reach only half the callers
+// and a second spelling of the walk cannot drift away from the first.
+func TestGateNotices_ShareOneAuthorizationWalk(t *testing.T) {
+	// One run satisfying both notices' own preconditions at once: an armed
+	// retry (what the pause notice keys on) and a DLQ park (what the DLQ
+	// notice keys on). Whatever the walk then refuses, it refuses for both.
+	world := func(t *testing.T) (*Server, *stubCommenter, *store.Run) {
+		t.Helper()
+		st, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatalf("store: %v", err)
+		}
+		s := newForgeGateTestServer(t, st)
+		registerPublishToken(t, s, "tok-gate", ForgePublishGrant{
+			TeamID: "team1", ConnectionID: "conn1", Repo: "o/r", Bot: "review-pr",
+		})
+		c := &stubCommenter{}
+		s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+			return c, nil
+		}
+		at := time.Now().UTC().Add(time.Hour)
+		run := &store.Run{
+			ID:          "run-gating",
+			BotID:       "review-pr",
+			Status:      store.RunStatusFailedResumable,
+			Inputs:      gatingInputs(),
+			FailureCode: store.FailureDLQParked,
+			RetryState:  &store.RunRetryState{RetryAfter: &at, Reason: "usage_window", Attempts: 1},
+			Error:       "rate_limited: You've hit your weekly limit",
+		}
+		return s, c, run
+	}
+
+	cases := []struct {
+		name   string
+		break_ func(t *testing.T, s *Server, run *store.Run)
+		want   int
+	}{
+		{"a grant on the PR's own repo posts", func(*testing.T, *Server, *store.Run) {}, 1},
+		{"an expired or revoked grant posts nothing", func(_ *testing.T, s *Server, _ *store.Run) {
+			s.forgePublishTokens.Revoke("tok-gate")
+		}, 0},
+		{"a grant covering another repo posts nothing", func(t *testing.T, s *Server, _ *store.Run) {
+			registerPublishToken(t, s, "tok-gate", ForgePublishGrant{
+				TeamID: "team1", ConnectionID: "conn1", Repo: "o/other", Bot: "review-pr",
+			})
+		}, 0},
+		{"a connection owned by another tenant posts nothing", func(t *testing.T, s *Server, _ *store.Run) {
+			registerPublishToken(t, s, "tok-gate", ForgePublishGrant{
+				TeamID: "team2", ConnectionID: "conn1", Repo: "o/r", Bot: "review-pr",
+			})
+		}, 0},
+		{"a connection pointing at another host posts nothing", func(t *testing.T, s *Server, _ *store.Run) {
+			if err := s.forgeConnections.Create(context.Background(), forge.Connection{
+				ID: "conn-elsewhere", TenantID: "team1", Provider: forge.ProviderGitHub,
+				ForgeBaseURL: "https://github.example.internal",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			registerPublishToken(t, s, "tok-gate", ForgePublishGrant{
+				TeamID: "team1", ConnectionID: "conn-elsewhere", Repo: "o/r", Bot: "review-pr",
+			})
+		}, 0},
+		{"a run holding no grant posts nothing", func(_ *testing.T, _ *Server, run *store.Run) {
+			delete(run.Inputs, forgePublishVarToken)
+		}, 0},
+		{"a run owing no verdict posts nothing", func(_ *testing.T, _ *Server, run *store.Run) {
+			delete(run.Inputs, "gate_context")
+		}, 0},
+		{"a run whose launch pinned the gate off posts nothing", func(_ *testing.T, _ *Server, run *store.Run) {
+			run.Inputs["gate_enabled"] = "false"
+		}, 0},
+		{"a provider with no comment client posts nothing", func(_ *testing.T, s *Server, _ *store.Run) {
+			s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+				return nil, nil
+			}
+		}, 0},
+	}
+
+	notices := map[string]func(*Server, context.Context, *store.Run){
+		"pause notice": func(s *Server, ctx context.Context, run *store.Run) { s.noticeGatePausedForRetry(ctx, run) },
+		"DLQ notice":   func(s *Server, ctx context.Context, run *store.Run) { s.noticeGateDLQParked(ctx, run) },
+	}
+	for _, tc := range cases {
+		for noticeName, post := range notices {
+			t.Run(tc.name+"/"+noticeName, func(t *testing.T) {
+				s, c, run := world(t)
+				tc.break_(t, s, run)
+				post(s, context.Background(), run)
+				if len(c.bodies) != tc.want {
+					t.Fatalf("%s posted %d comments, want %d — both notices answer the same authorization walk (gateNoticeTarget); bodies: %v",
+						noticeName, len(c.bodies), tc.want, c.bodies)
+				}
+			})
+		}
+	}
+}

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -57,11 +57,26 @@ var gateReasonWrappers = []*regexp.Regexp{
 	regexp.MustCompile(`^git: `),
 }
 
+// gateDLQDescription is what a run parked on the dead-letter queue leaves on
+// the head. The generic trailer below would be false advice here: a push, or
+// the bot's command, launches a FRESH run and leaves the parked message
+// parked, so the check would contradict the DLQ comment on the same pull
+// request and hide the one remedy that reaches the message. Reason-free on
+// purpose — the DLQ comment carries the cause and the status links to the run,
+// so the 140 characters a forge allows go to the remedy.
+const gateDLQDescription = "review parked on the DLQ — operator replay needed (iterion remote admin dlq)"
+
 // gateInterruptedDescriptionFor prefixes the remedy with WHY the run died when
 // the run doc can say (budget exceeded, provider error, …). GitHub truncates
 // commit-status descriptions at 140 characters, so the reason is bounded and
 // the remedy — the part the operator cannot reconstruct — keeps priority.
+//
+// The remedy is selected by the persisted FailureCode, the same typed WHY the
+// DLQ notice keys on, never by parsing run.Error.
 func gateInterruptedDescriptionFor(run *store.Run) string {
+	if run != nil && run.FailureCode == store.FailureDLQParked {
+		return gateDLQDescription
+	}
 	reason := ""
 	if run != nil {
 		reason = strings.TrimSpace(run.Error)
@@ -104,7 +119,8 @@ const gateDiedDescriptionPrefix = "review died ("
 // there are no findings behind a synthetic failure for a fixer to address.
 func isSyntheticGateInterruption(description string) bool {
 	d := strings.TrimSpace(description)
-	return d == gateInterruptedDescription || strings.HasPrefix(d, gateDiedDescriptionPrefix)
+	return d == gateInterruptedDescription || d == gateDLQDescription ||
+		strings.HasPrefix(d, gateDiedDescriptionPrefix)
 }
 
 // startGateReconciler attaches the reconciler to the event spine. It rides the

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -343,6 +343,30 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 	if strings.TrimSpace(pr.HeadSHA) == "" {
 		return abstain("the forge returned no head sha")
 	}
+	// A pull request that is closed or merged owes nobody a verdict: painting
+	// "review died — push again" there tells a developer to re-run a review of
+	// work that already shipped, and the relaunch below stands down on the
+	// same state anyway. Reachable from every terminal outcome such a run can
+	// have — the retry sweeper's abandon republishes one deliberately, the
+	// stop-on-close cancel IS one, and the sweep re-offers the run for its
+	// whole lookback.
+	//
+	// Same predicate the relaunch and auto-fix lanes use: an EMPTY state is a
+	// provider that does not report one, not a closure, so a verdict is never
+	// suppressed on a guess. Debug rather than abstain(): a pull request
+	// closed while its review ran is ordinary, not an anomaly.
+	//
+	// What this leaves behind is an in-flight claim nothing repairs. It blocks
+	// nothing — the pull request is already merged or closed — and a reopen
+	// heals it, because the fresh review's own claim may overwrite an
+	// in-flight marker (markGateInFlight).
+	if pr.State != "" && pr.State != "open" {
+		if s.logger != nil {
+			s.logger.Debug("forge gate: run %s owed %s on %s, but the pull request is %s — a closed pull request needs no verdict",
+				runID, gateCtx, prURL, pr.State)
+		}
+		return nil
+	}
 	// Only the revision this run was reviewing. Between its start and its
 	// death the head routinely moves — the author pushes a fix, a brancher
 	// commits, review_on_sync already has a fresh review in flight. Painting

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -377,3 +377,49 @@ func TestGateReconcile_DoesNotSpeakForAHeadItNeverReviewed(t *testing.T) {
 		t.Fatalf("the head it DID review must still get its verdict (%d writes)", gc.setCalls)
 	}
 }
+
+// A pull request that is closed or merged owes nobody a verdict. The
+// reconciler used to paint its synthetic failure there anyway — a red
+// "review died — push again or comment the bot's command to re-run" on a
+// pull request already merged, telling a developer to re-run a review of
+// work that shipped. Reachable from every terminal outcome on such a run:
+// the retry sweeper's abandon republishes the outcome deliberately, the
+// stop-on-close cancel is itself a terminal outcome, and the sweep re-offers
+// the run for its whole lookback.
+//
+// Same predicate the relaunch and auto-fix lanes already use: an EMPTY state
+// (a provider that does not report one) is not a closure, so a verdict is
+// never suppressed on an unknown.
+func TestGateReconcile_ClosedPullRequestGetsNoSyntheticFailure(t *testing.T) {
+	for _, tc := range []struct {
+		state string
+		want  int
+	}{
+		{"open", 1},
+		{"", 1}, // unknown state: never suppress a verdict on a guess
+		{"closed", 0},
+		{"merged", 0},
+	} {
+		t.Run("state="+tc.state, func(t *testing.T) {
+			gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef", state: tc.state}}
+			s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+			run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			run.Status = store.RunStatusCancelled
+			run.Error = "auto-retry abandoned: monthly_run_quota_exceeded"
+			if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			if gc.setCalls != tc.want {
+				t.Fatalf("pull request %q: posted %d statuses, want %d (last: %q %q)",
+					tc.state, gc.setCalls, tc.want, gc.last.State, gc.last.Description)
+			}
+		})
+	}
+}

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -333,8 +333,8 @@ func TestGateReconcile_ReasonStripsMechanicalWrappers(t *testing.T) {
 	}
 }
 
-// The synthetic marker must be recognized in both its shapes and must never
-// swallow a real verdict.
+// The synthetic marker must be recognized in every shape the reconciler
+// writes and must never swallow a real verdict.
 func TestGateReconcile_SyntheticMarker(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
@@ -342,6 +342,7 @@ func TestGateReconcile_SyntheticMarker(t *testing.T) {
 	}{
 		{gateInterruptedDescription, true},
 		{"review died (budget exceeded: duration…) — push again or comment the bot's command to re-run", true},
+		{gateDLQDescription, true},
 		{"no blocking findings (≥high); 4 total", false},
 		{"supply-chain audit clean; no alignment needed, build verified", false},
 		{"", false},

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -674,12 +675,17 @@ func (s *Server) injectForgePublishVars(ctx context.Context, teamID, preferredCo
 // authenticated team surfaces, and the grant is scoped to the (team,
 // connection, repo) the team is provisioned on and re-enforced at the publish
 // endpoint.
-func (s *Server) applyPRLaunchContext(ctx context.Context, teamID, preferredConnID, botID string, vars map[string]string, r *http.Request) map[string]string {
+//
+// The fork guard, however, IS shared with the webhook lanes: the launch pair
+// is the same (<base>.CloneURL + the PR's head branch), so a PR whose head
+// is not proven to live in the base repo is refused here too — the returned
+// error carries the refusal, and the caller launches nothing.
+func (s *Server) applyPRLaunchContext(ctx context.Context, teamID, preferredConnID, botID string, vars map[string]string, r *http.Request) (map[string]string, error) {
 	prURL := strings.TrimSpace(vars["pr_url"])
 	if prURL == "" {
-		return vars
+		return vars, nil
 	}
-	if host, repo, _, err := forge.ParsePullURL(prURL); err == nil {
+	if host, repo, number, err := forge.ParsePullURL(prURL); err == nil {
 		if ri, ok := s.repoIntegrationFor(ctx, teamID, host, repo); ok {
 			if preferredConnID == "" {
 				// Pin the grant to the connection the policy came from.
@@ -687,8 +693,65 @@ func (s *Server) applyPRLaunchContext(ctx context.Context, teamID, preferredConn
 			}
 			fillVarGaps(vars, s.repoLaunchPolicy(ctx, ri, botID))
 		}
+		conn, proven, err := s.prLaunchForkGuard(ctx, teamID, preferredConnID, prURL, host, repo, number)
+		if err != nil {
+			return vars, err
+		}
+		if proven {
+			// The grant is minted on the connection the PR was proven
+			// through, so the identity that read the head is the one that
+			// posts the verdict.
+			preferredConnID = conn.ID
+		}
 	}
-	return s.injectForgePublishVars(ctx, teamID, preferredConnID, botID, vars, r)
+	return s.injectForgePublishVars(ctx, teamID, preferredConnID, botID, vars, r), nil
+}
+
+// errPRLaunchForkGuard marks a launch the fork guard refused — the operator's
+// pull request is not admissible, as opposed to a forge that could not be
+// asked — so the HTTP lane answers 422 rather than 502.
+var errPRLaunchForkGuard = errors.New("fork guard")
+
+// prLaunchForkGuard is the fork guard of the launch surfaces that hold no
+// webhook payload — the studio/API launch and the cloud board coordinator —
+// over the same launch pair the webhook lanes guard: <base>.CloneURL + the
+// PR's head branch. It reads the PR through the team connection covering the
+// PR's host+repo (the one the publish grant is minted on) and requires the
+// head branch to be PROVEN to live in the base repo, refused with the webhook
+// lanes' own wording (forkGuardRefusal): on a fork PR the checkout misses, or
+// worse hits a same-named branch of the BASE repo and a code-pushing bot
+// commits onto it. Fail-CLOSED on resolution: a PR the forge cannot answer
+// for is refused, never launched on a guess.
+//
+// Returns the connection the proof was read through (proven=true), or
+// proven=false with no error when no team connection covers the PR's host:
+// the server then makes no launch pair for that host — a repo-targeted
+// launch needs a connection on the repo's host, and a board card's repo rides
+// the webhook lane that already guarded it — so there is nothing to decide
+// and the launch keeps its shape (no policy, no grant), said at Debug.
+func (s *Server) prLaunchForkGuard(ctx context.Context, teamID, preferredConnID, prURL, host, repo string, number int) (forge.Connection, bool, error) {
+	conn, ok := s.forgeConnectionForPR(ctx, teamID, preferredConnID, host, repo)
+	if !ok {
+		if s.logger != nil {
+			s.logger.Debug("fork guard: no team %s connection covers %s/%s — nothing to prove for %s", teamID, host, repo, prURL)
+		}
+		return forge.Connection{}, false, nil
+	}
+	gc, err := s.gateClientFor(ctx, conn)
+	if err != nil {
+		return conn, false, fmt.Errorf("fork guard: %s: cannot read the pull request through connection %s: %w", prURL, conn.ID, err)
+	}
+	if gc == nil {
+		return conn, false, fmt.Errorf("fork guard: %s: provider %s cannot read pull requests, so same-repo cannot be proven", prURL, conn.Provider)
+	}
+	pr, err := gc.GetPullRequest(ctx, repo, number)
+	if err != nil {
+		return conn, false, fmt.Errorf("fork guard: %s: PR resolution: %w", prURL, err)
+	}
+	if reason := forkGuardRefusal(pr.SameRepoAs(repo), false, pr.HeadRepoFullName); reason != "" {
+		return conn, false, fmt.Errorf("%w: %s: %s", errPRLaunchForkGuard, prURL, reason)
+	}
+	return conn, true, nil
 }
 
 // repoLaunchPolicy composes a repo's launch-var layers for ONE bot, in the

--- a/pkg/server/forge_publish_gate_test.go
+++ b/pkg/server/forge_publish_gate_test.go
@@ -68,14 +68,19 @@ type fakeGateClient struct {
 	// same-repo PR), so pre-#642 fixtures pass the fork-guard fail-CLOSED
 	// check without editing every callsite; a fork test sets it explicitly.
 	headRepo string
+	// noHeadRepo returns an EMPTY HeadRepoFullName — the shape a provider
+	// emits once a fork was deleted or blocked (head.repo: null).
+	noHeadRepo bool
+	// state is the PR state the stub reports; empty reads as open.
+	state string
 }
 
 func (f *fakeGateClient) GetPullRequest(_ context.Context, repo string, _ int) (forge.PullRef, error) {
 	head := f.headRepo
-	if head == "" {
+	if head == "" && !f.noHeadRepo {
 		head = repo
 	}
-	return forge.PullRef{HeadSHA: f.headSHA, HeadRepoFullName: head}, f.getErr
+	return forge.PullRef{HeadSHA: f.headSHA, HeadRepoFullName: head, State: f.state}, f.getErr
 }
 
 func (f *fakeGateClient) SetCommitStatus(_ context.Context, _, sha string, st forge.CommitStatus) error {

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -213,7 +213,7 @@ func TestSweepDueRetries_ResumeRefusedIfRunCancelledBeforeRead(t *testing.T) {
 	st.loadRun["run-cancelled"] = &store.Run{
 		ID:     "run-cancelled",
 		Status: store.RunStatusCancelled,
-		Error:  store.RunEndReasonPRClosed + " (was failed_resumable: node \"campaign\": rate_limited)",
+		Error:  store.RunEndReasonPRClosed.Message() + " (was failed_resumable: node \"campaign\": rate_limited)",
 	}
 	resumer := &fakeResumer{}
 	s := newRetrySweeperServer(t, st, resumer)

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -436,7 +436,21 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 	// workspace-mounted token. Same composition as the board lane — a launch
 	// from the studio form must gate under the same context a webhook does.
 	if launchID, _ := auth.FromContext(r.Context()); launchID.TeamID != "" {
-		req.Vars = s.applyPRLaunchContext(r.Context(), launchID.TeamID, req.ConnectionID, req.BotID, req.Vars, r)
+		vars, err := s.applyPRLaunchContext(r.Context(), launchID.TeamID, req.ConnectionID, req.BotID, req.Vars, r)
+		if err != nil {
+			// The fork guard refuses the operator's pull request (422); a
+			// forge that could not be asked is an upstream failure (502).
+			// Either way nothing launches: the same door the webhook lanes
+			// keep closed is not left open for a hand-picked PR.
+			code := http.StatusBadGateway
+			if errors.Is(err, errPRLaunchForkGuard) {
+				code = http.StatusUnprocessableEntity
+			}
+			s.httpErrorFor(w, r, code, "%v", err)
+			span.SetStatus(codes.Error, "pr launch refused")
+			return
+		}
+		req.Vars = vars
 	}
 
 	// Detach lifecycle from the HTTP request context so a client

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -30,7 +30,7 @@ func (p *queueOutageTestPublisher) SubmitLaunch(context.Context, string, runview
 
 func (*queueOutageTestPublisher) CancelRun(context.Context, string) error { return nil }
 
-func (*queueOutageTestPublisher) CancelRunWithReason(context.Context, string, string) error {
+func (*queueOutageTestPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
 	return nil
 }
 

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -911,10 +911,11 @@ func (s *Server) webhookRunLive(ctx context.Context, runID string) bool {
 	return false
 }
 
-// supersededRunReason is recorded as the run error of a run cancelled by the
-// overlap=supersede lane. Kept short: the merge-gate synthetic description
-// quotes it within a 60-rune budget.
-const supersededRunReason = "superseded by a newer delivery for the same subject"
+// supersededRunReason names the cancel of a run replaced by the
+// overlap=supersede lane. Its message is kept short in the store's
+// vocabulary: the merge-gate synthetic description quotes it within a
+// 60-rune budget.
+const supersededRunReason = store.RunEndReasonSuperseded
 
 // scheduleForgeBoardProjection kicks the near-real-time forge→board refresh
 // for a repo. Once per DELIVERY, never once per bot: a fan-out would otherwise
@@ -1212,10 +1213,10 @@ func (s *Server) launchWebhookTarget(
 // prClosedRunReason names the cancel so the run list, and the merge-gate
 // synthetic status that quotes run.Error, say WHY. "cancelled by user"
 // there once sent operators hunting for a human who did nothing.
-// The exact text is store.RunEndReasonPRClosed so the runner admission can
-// detect it in preRun.Error (via store.IsPRClosedCancel) and drop a redelivered
-// message even when it carries an explicit resume — the runner never imports
-// the webhook layer, so the vocabulary lives in the store, not here.
+// It is the TYPED store.RunEndReasonPRClosed, which is what the runner
+// admission reads to drop a redelivered message even when that message carries
+// an explicit resume — the runner never imports the webhook layer, so the
+// vocabulary lives in the store, not here.
 const prClosedRunReason = store.RunEndReasonPRClosed
 
 // forkGuardRefusal is the fork guard of the unattended payload-side lanes
@@ -1243,7 +1244,7 @@ func forkGuardRefusal(sameRepoProven, withheld bool, headRepo string) string {
 // prRequeuedRunReason names the auto-heal cancel for the same reason: a
 // reader finding a stopped fixer run has to learn that the queue took the
 // pull request back, not that someone gave up on it.
-const prRequeuedRunReason = "pull request re-entered the merge queue — the heal has nothing left to carry"
+const prRequeuedRunReason = store.RunEndReasonPRRequeued
 
 // healIdempotencyKey is the identity of ONE auto-heal attempt: this
 // webhook, this pull request, this head. Both halves of the loop derive
@@ -1288,7 +1289,7 @@ func (s *Server) stopHealRunForRequeuedPR(ctx context.Context, cfg webhooks.Conf
 	// Disarm before cancelling, like the closed-PR stop: a retry left armed
 	// would resume the very run we just stopped.
 	if retries := store.AsRunRetryStore(s.cfg.Store); retries != nil {
-		if aerr := retries.AbandonRunRetry(ctx, d.RunID, prRequeuedRunReason); aerr != nil && s.logger != nil {
+		if aerr := retries.AbandonRunRetry(ctx, d.RunID, prRequeuedRunReason.Message()); aerr != nil && s.logger != nil {
 			s.logger.Debug("webhooks: could not disarm the retry of heal run %s on a re-queued PR: %v", d.RunID, aerr)
 		}
 	}
@@ -1390,7 +1391,7 @@ func (s *Server) stopRunsForDeadPR(ctx context.Context, cfg webhooks.Config, met
 		// leaves the promise standing, and the sweeper would resume the
 		// run we just cancelled.
 		if retries != nil {
-			if aerr := retries.AbandonRunRetry(ctx, d.RunID, prClosedRunReason); aerr != nil && s.logger != nil {
+			if aerr := retries.AbandonRunRetry(ctx, d.RunID, prClosedRunReason.Message()); aerr != nil && s.logger != nil {
 				s.logger.Debug("webhooks: could not disarm the retry of run %s on a closed PR: %v", d.RunID, aerr)
 			}
 		}

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -1095,17 +1095,36 @@ func (s *Server) launchWebhookTarget(
 	delivery.Attempts = 1
 	if reusePriorFailure != nil {
 		// Retry: keep the prior row's identity + received-at, count the
-		// attempt, clear the error, and UPDATE it (Insert would
-		// ErrDuplicate on the idemKey).
+		// attempt, clear the error, and CLAIM it (Insert would ErrDuplicate
+		// on the idemKey). A claim rather than a plain update because the
+		// row was READ in step 1: two redeliveries of the same failed event
+		// both find it there, and an unconditional write would let both go
+		// on to launch a run for one event — the storm shape a redelivery
+		// burst has. The loser answers as a duplicate, exactly as the
+		// concurrent-insert loser below does.
 		delivery.ID = reusePriorFailure.ID
 		delivery.ReceivedAt = reusePriorFailure.ReceivedAt
 		delivery.Attempts = reusePriorFailure.Attempts + 1
 		if s.webhookDeliveries != nil {
-			if err := s.webhookDeliveries.Update(ctx, delivery); err != nil {
+			claimed, err := s.webhookDeliveries.ClaimFailedRetry(ctx, delivery, reusePriorFailure.Attempts)
+			if err != nil {
 				adm.rollback(s.logger)
 				out.Status = webhooks.StatusLaunchError
 				out.Error = fmt.Sprintf("reset failed delivery: %v", err)
 				out.httpStatus = http.StatusInternalServerError
+				return out
+			}
+			if !claimed {
+				// Somebody else is retrying this event right now. Release
+				// this delivery's metered quota unit — the same reason the
+				// Insert loser does — and echo the row that won.
+				adm.rollback(s.logger)
+				s.markWebhookOutcome(cfg.Provider, webhooks.StatusDuplicate)
+				out.Status = webhooks.StatusDuplicate
+				out.DeliveryID = reusePriorFailure.ID
+				if existing, gerr := s.webhookDeliveries.GetByIdempotencyKey(ctx, idemKey); gerr == nil {
+					out.RunID, out.DeliveryID = existing.RunID, existing.ID
+				}
 				return out
 			}
 		}

--- a/pkg/server/webhooks_launch_retry_claim_test.go
+++ b/pkg/server/webhooks_launch_retry_claim_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// barrierDeliveryStore holds every idempotency-key read until n of them are
+// in flight, then releases them together. It reproduces the window the
+// launch_error retry lives in: two redeliveries of the same event both find
+// the failed row before either has taken it over.
+type barrierDeliveryStore struct {
+	webhooks.DeliveryStore
+	mu   sync.Mutex
+	once sync.Once
+	seen int
+	n    int
+	open chan struct{}
+}
+
+func newBarrierDeliveryStore(inner webhooks.DeliveryStore, n int) *barrierDeliveryStore {
+	return &barrierDeliveryStore{DeliveryStore: inner, open: make(chan struct{}), n: n}
+}
+
+func (s *barrierDeliveryStore) GetByIdempotencyKey(ctx context.Context, key string) (webhooks.Delivery, error) {
+	d, err := s.DeliveryStore.GetByIdempotencyKey(ctx, key)
+	s.mu.Lock()
+	s.seen++
+	held := s.seen <= s.n
+	if s.seen >= s.n {
+		s.once.Do(func() { close(s.open) })
+	}
+	s.mu.Unlock()
+	// Only the first n reads wait: the claim LOSER re-reads the winning row
+	// on its way out, and holding that read too would deadlock the test on
+	// the very branch it exists to exercise.
+	if held {
+		select {
+		case <-s.open:
+		case <-time.After(5 * time.Second):
+		}
+	}
+	return d, err
+}
+
+// A prior launch_error row is deliberately RETRYABLE: a redelivery of the same
+// event must be able to relaunch it. Taking it over is therefore a CLAIM, not
+// a read followed by a write — two redeliveries arriving together both find
+// the failed row, and without the claim both go on to launch a run for one
+// event, which is the storm shape a redelivery burst has.
+func TestLaunchWebhookTarget_FailedRowRetryIsClaimedOnce(t *testing.T) {
+	s := newWebhookTestServer(t)
+	const idemKey = "idem-retry-claim"
+	inner := webhooks.NewMemoryDeliveryStore()
+	cfg := webhooks.Config{ID: "wh1", TenantID: "team1", Provider: webhooks.ProviderGitHub}
+	meta := webhookEventMeta{ProjectPath: "o/r", SubjectID: "pr:7", Kind: "pull_request"}
+
+	prior := newWebhookDelivery(cfg, meta, webhooks.StatusLaunchError, "hash", "1.2.3.4")
+	prior.IdempotencyKey = idemKey
+	prior.BotID = "review-pr"
+	prior.Attempts = 1
+	prior.Error = "boom"
+	if err := inner.Insert(context.Background(), prior); err != nil {
+		t.Fatalf("seed the failed row: %v", err)
+	}
+	s.webhookDeliveries = newBarrierDeliveryStore(inner, 2)
+
+	var mu sync.Mutex
+	launches := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		launches++
+		return "run-launched", nil
+	}
+
+	// A super-admin identity: the launch gate is not what this pins.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u", TeamID: "team1", IsSuperAdmin: true})
+	target := forgeLaunchTarget{IdemKey: idemKey, BotID: "review-pr", Vars: map[string]string{}}
+	results := make([]webhookLaunchResult, 2)
+	var wg sync.WaitGroup
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = s.launchWebhookTarget(ctx, nil, cfg, meta, target, "hash", "1.2.3.4")
+		}(i)
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := launches
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("two redeliveries of one failed event launched %d runs, want 1 — the retry must be claimed, not read-then-written (results: %+v)", got, results)
+	}
+	// The loser answers as a duplicate, never as a launch: an event that
+	// launched nothing here has one run, and the caller must be told which.
+	launched, duplicates := 0, 0
+	for _, res := range results {
+		switch res.Status {
+		case webhooks.StatusLaunched:
+			launched++
+		case webhooks.StatusDuplicate:
+			duplicates++
+		}
+	}
+	if launched != 1 || duplicates != 1 {
+		t.Fatalf("results = %+v, want exactly one launched and one duplicate", results)
+	}
+	// The claim counts the attempt exactly once.
+	row, err := inner.GetByIdempotencyKey(context.Background(), idemKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Attempts != 2 {
+		t.Fatalf("attempts = %d, want 2 — one retry happened, not two", row.Attempts)
+	}
+}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -251,6 +251,7 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	// A concurrent write refuses the replacement.
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
+		r.EndReason = ""
 	}
 	// Same discipline for the pause pointer: a full-document write on a
 	// non-carrying status must not resurrect consumed interaction
@@ -912,6 +913,16 @@ func statusTransitionSet(status store.RunStatus, runErr string, meta store.RunOu
 			bson.M{"$ifNull": bson.A{"$failure_code", "$$REMOVE"}}}}
 	default:
 		set["failure_code"] = "$$REMOVE"
+	}
+	// The end reason follows the same discipline, on the same statuses.
+	switch {
+	case status.CarriesFailureCode() && meta.EndReason != "":
+		set["end_reason"] = bson.M{"$literal": string(meta.EndReason)}
+	case status.CarriesFailureCode():
+		set["end_reason"] = bson.M{"$cond": bson.A{statusChanged, "$$REMOVE",
+			bson.M{"$ifNull": bson.A{"$end_reason", "$$REMOVE"}}}}
+	default:
+		set["end_reason"] = "$$REMOVE"
 	}
 	// The pause pointer is a consumable (store.CarriesPausePointer):
 	// strip it off the SURVIVING checkpoint via $unsetField, guarded on

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -125,22 +125,74 @@ func (s RunStatus) IsPaused() bool {
 	return s == RunStatusPausedWaitingHuman || s == RunStatusPausedOperator
 }
 
-// RunEndReasonPRClosed is the exact reason prefix written to run.Error when
-// the stop-on-close webhook lane cancels a run because its pull request was
-// closed or merged. Consumers detect it via strings.Contains — CancelRunWithReason
-// wraps the reason as "<reason> (was <status>: <prior>)", so a match on this
-// prefix survives that wrapping. Shared vocabulary between the webhook layer
-// (writer) and the runner admission (reader), so a redelivery that arrived
-// after the cancel does not resurrect a dead PR's review.
-const RunEndReasonPRClosed = "pull request closed or merged — nothing left to review"
+// RunEndReason is the typed WHY a run ENDED, persisted on the run doc beside
+// FailureCode. It is the protocol between the surface that ends a run and the
+// surfaces that must recognise the ending — above all the runner admission,
+// which drops a redelivery for a run whose pull request is gone.
+//
+// It exists because run.Error cannot be that protocol: it is a human message,
+// wrapped by the cancel path as "<message> (was <status>: <prior>)", quoted on
+// the run list, on board cards and inside the merge-gate synthetic status. Any
+// rewording, translation or truncation of a message read by a strings.Contains
+// would silently disarm the check that reads it.
+//
+// The message is DERIVED from the reason (Message below), so a writer states
+// the reason alone and the two can never disagree.
+type RunEndReason string
 
-// IsPRClosedCancel reports whether run.Error carries the PR-closed cancel
-// reason (RunEndReasonPRClosed). Used by the runner admission to drop a
-// redelivered message — including an explicit-resume one — for a run whose
-// PR is gone: nothing the review would say can matter, and continuing burns
-// provider quota on a diff no one will merge. Empty string → false.
+const (
+	// RunEndReasonOperator: a human asked for the run to stop.
+	RunEndReasonOperator RunEndReason = "operator"
+	// RunEndReasonPRClosed: the stop-on-close webhook lane ended the run
+	// because its pull request was closed or merged. The runner admission
+	// drops every redelivery for such a run — including one carrying an
+	// explicit resume: nothing the review would say can matter now, and
+	// continuing burns provider quota on a diff no one will merge.
+	RunEndReasonPRClosed RunEndReason = "pr_closed"
+	// RunEndReasonPRRequeued: the merge queue took the pull request back,
+	// so the auto-heal run has nothing left to carry.
+	RunEndReasonPRRequeued RunEndReason = "pr_requeued"
+	// RunEndReasonSuperseded: a newer delivery for the same subject
+	// replaced this run.
+	RunEndReasonSuperseded RunEndReason = "superseded"
+)
+
+// Message is the human sentence a reason writes into run.Error — what the run
+// list, the board cards and the merge-gate synthetic status quote. An unknown
+// or empty reason reads as a bare "cancelled": an automated stop that cannot
+// name itself must not sign an operator's name to its own decision.
+func (r RunEndReason) Message() string {
+	switch r {
+	case RunEndReasonOperator:
+		return "cancelled by user"
+	case RunEndReasonPRClosed:
+		return "pull request closed or merged — nothing left to review"
+	case RunEndReasonPRRequeued:
+		return "pull request re-entered the merge queue — the heal has nothing left to carry"
+	case RunEndReasonSuperseded:
+		return "superseded by a newer delivery for the same subject"
+	default:
+		return "cancelled"
+	}
+}
+
+// IsPRClosedCancel reports whether run.Error carries the PR-closed message.
+// It is the MIGRATION reader, for run documents written before EndReason
+// existed and which therefore say why in prose alone; a run carrying the typed
+// reason is recognised by that field. Empty string → false.
 func IsPRClosedCancel(runError string) bool {
-	return runError != "" && strings.Contains(runError, RunEndReasonPRClosed)
+	return runError != "" && strings.Contains(runError, RunEndReasonPRClosed.Message())
+}
+
+// EndedBecausePRClosed answers the admission's question over BOTH carriers:
+// the typed reason on the doc, and — for a document written before the field
+// existed — the message it wrapped. One predicate, so a caller cannot honour
+// half the answer.
+func EndedBecausePRClosed(r *Run) bool {
+	if r == nil {
+		return false
+	}
+	return r.EndReason == RunEndReasonPRClosed || IsPRClosedCancel(r.Error)
 }
 
 // ---------------------------------------------------------------------------
@@ -572,7 +624,15 @@ type Run struct {
 	// rollback text — the code classifies the restored state, not the
 	// rollback message. See lifecycle.go (ADR-095) for the vocabulary
 	// and the open-world contract.
-	FailureCode   FailureCode    `json:"failure_code,omitempty" bson:"failure_code,omitempty"`
+	FailureCode FailureCode `json:"failure_code,omitempty" bson:"failure_code,omitempty"`
+	// EndReason is the typed WHY the run ended — the protocol half of
+	// Error, whose prose it derives (RunEndReason.Message). It carries on
+	// the same statuses as FailureCode and is cleared by the same
+	// transitions, so a resumed run never keeps claiming why it once
+	// ended. Empty means UNKNOWN, and for a run cancelled before this
+	// field existed the message is the only carrier there is — read the
+	// pair through EndedBecausePRClosed rather than either half alone.
+	EndReason     RunEndReason   `json:"end_reason,omitempty" bson:"end_reason,omitempty"`
 	Checkpoint    *Checkpoint    `json:"checkpoint,omitempty" bson:"checkpoint,omitempty"`
 	ArtifactIndex map[string]int `json:"artifact_index,omitempty" bson:"artifact_index,omitempty"` // node_id → latest version written
 	// WorkDir is the absolute filesystem path the run executes in
@@ -1041,6 +1101,12 @@ const (
 type RunOutcomeMeta struct {
 	Code         FailureCode
 	Continuation ContinuationState
+	// EndReason is the typed WHY the run ended. It follows the FailureCode
+	// discipline exactly — persisted only on the statuses that carry an
+	// outcome (RunStatus.CarriesFailureCode), cleared by every transition
+	// out of them, preserved across a same-status rewrite that states none
+	// — so a resumed run cannot keep claiming why it once ended.
+	EndReason RunEndReason
 }
 
 // MergeStatus enumerates the lifecycle of the merge step independently

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -147,6 +147,7 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	// A concurrent write is refused at writeRun, before replacing the file.
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
+		r.EndReason = ""
 	}
 	// Same discipline for the pause pointer: a full-document write on a
 	// non-carrying status must not resurrect consumed interaction
@@ -275,13 +276,19 @@ func healRun(r *Run) bool {
 		r.FinishedAt = nil
 		changed = true
 	}
-	// A failure code may only persist on a failure status. The
-	// transition machinery clears it and SaveRun normalizes, so the
-	// remaining sources are historical rows written before those
-	// guards and hand-edited run.json — heal on read.
-	if r.FailureCode != "" && !r.Status.CarriesFailureCode() {
-		r.FailureCode = ""
-		changed = true
+	// A failure code, and the end reason beside it, may only persist on a
+	// status that carries an outcome. The transition machinery clears them
+	// and SaveRun normalizes, so the remaining sources are historical rows
+	// written before those guards and hand-edited run.json — heal on read.
+	if !r.Status.CarriesFailureCode() {
+		if r.FailureCode != "" {
+			r.FailureCode = ""
+			changed = true
+		}
+		if r.EndReason != "" {
+			r.EndReason = ""
+			changed = true
+		}
 	}
 	return changed
 }
@@ -655,6 +662,17 @@ func (s *FilesystemRunStore) applyStatusTransitionOutcome(r *Run, status RunStat
 		}
 	default:
 		r.FailureCode = ""
+	}
+	// The end reason follows the same discipline, on the same statuses.
+	switch {
+	case status.CarriesFailureCode() && meta.EndReason != "":
+		r.EndReason = meta.EndReason
+	case status.CarriesFailureCode():
+		if transition {
+			r.EndReason = ""
+		}
+	default:
+		r.EndReason = ""
 	}
 	switch status {
 	case RunStatusFinished, RunStatusFailed, RunStatusFailedResumable, RunStatusCancelled:

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1307,6 +1307,13 @@ func testEndReasonLifecycle(t *testing.T, s store.RunStore) {
 		}
 		return r
 	}
+	// The twins start a run differently on purpose — the filesystem store goes
+	// straight to running, the cloud one to queued (Opts.InitialStatus models
+	// it) — so the row states the status it CASes from instead of inheriting
+	// either default. What is under test is the end reason, not CreateRun.
+	if err := s.UpdateRunStatus(ctx, "run_er", store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
 	// The cancel writes reason and status in ONE outcome write.
 	changed, err := s.UpdateRunOutcome(ctx, "run_er", store.RunStatusCancelled,
 		store.RunEndReasonPRClosed.Message(),

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -67,6 +67,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("ParallelCheckpointRoundTrip", func(t *testing.T) { testParallelCheckpointRoundTrip(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
+	t.Run("EndReasonLifecycle", func(t *testing.T) { testEndReasonLifecycle(t, factory(t)) })
 	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
 	t.Run("FinalContinuationDisarmsRetry", func(t *testing.T) { testFinalContinuationDisarmsRetry(t, factory(t)) })
 	t.Run("TombstoneRefusesWriters", func(t *testing.T) { testTombstoneRefusesWriters(t, factory(t)) })
@@ -1283,6 +1284,75 @@ func testFailureCodeLifecycle(t *testing.T, s store.RunStore) {
 	r, _ = s.LoadRun(ctx, "run_fc")
 	if r.FailureCode != "SOME_FUTURE_CODE_V9" {
 		t.Fatalf("unknown code mangled: %q", r.FailureCode)
+	}
+}
+
+// testEndReasonLifecycle pins the typed end-reason discipline on BOTH
+// store twins. It is the protocol the runner admission reads to drop a
+// redelivery for a run whose pull request closed, so it has to persist on
+// the same statuses as FailureCode, survive a same-status rewrite that
+// states none, and be cleared by every transition out of them — a resumed
+// run that still claimed "pr_closed" would be refused admission forever.
+func testEndReasonLifecycle(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "run_er", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	load := func() *store.Run {
+		t.Helper()
+		r, err := s.LoadRun(ctx, "run_er")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+	// The cancel writes reason and status in ONE outcome write.
+	changed, err := s.UpdateRunOutcome(ctx, "run_er", store.RunStatusCancelled,
+		store.RunEndReasonPRClosed.Message(),
+		store.RunOutcomeMeta{Code: store.FailureCancelled, EndReason: store.RunEndReasonPRClosed},
+		[]store.RunStatus{store.RunStatusRunning})
+	if err != nil || !changed {
+		t.Fatalf("cancel outcome: changed=%v err=%v", changed, err)
+	}
+	if r := load(); r.EndReason != store.RunEndReasonPRClosed || r.FailureCode != store.FailureCancelled {
+		t.Fatalf("after the cancel: end_reason=%q failure_code=%q", r.EndReason, r.FailureCode)
+	}
+	// A same-status rewrite that states no reason keeps the one the
+	// transition wrote — an untyped writer must not erase it.
+	if err := s.UpdateRunStatusCoded(ctx, "run_er", store.RunStatusCancelled, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if r := load(); r.EndReason != store.RunEndReasonPRClosed {
+		t.Fatalf("a same-status rewrite erased the end reason: %q", r.EndReason)
+	}
+	// Any transition out of the carrying statuses clears it: an operator
+	// resume must not leave the run claiming why it once ended.
+	if _, err := s.UpdateRunStatusIf(ctx, "run_er", store.RunStatusQueued, "", []store.RunStatus{store.RunStatusCancelled}); err != nil {
+		t.Fatal(err)
+	}
+	if r := load(); r.EndReason != "" {
+		t.Fatalf("queued must clear the end reason, got %q", r.EndReason)
+	}
+	// Open-world, like FailureCode: an unknown reason round-trips.
+	if _, err := s.UpdateRunOutcome(ctx, "run_er", store.RunStatusFailed, "boom",
+		store.RunOutcomeMeta{Code: store.FailureExecutionFailed, EndReason: store.RunEndReason("some_future_reason")},
+		[]store.RunStatus{store.RunStatusQueued}); err != nil {
+		t.Fatal(err)
+	}
+	if r := load(); r.EndReason != "some_future_reason" {
+		t.Fatalf("unknown reason mangled: %q", r.EndReason)
+	}
+	// A full-document write on a non-carrying status cannot resurrect it,
+	// and a document that already carries one is healed on read.
+	r := load()
+	r.Status = store.RunStatusRunning
+	r.EndReason = store.RunEndReasonPRClosed
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatal(err)
+	}
+	if got := load(); got.EndReason != "" {
+		t.Fatalf("SaveRun resurrected an end reason on a running run: %q", got.EndReason)
 	}
 }
 

--- a/pkg/webhooks/delivery_attempts_test.go
+++ b/pkg/webhooks/delivery_attempts_test.go
@@ -52,6 +52,14 @@ func TestDeliveryStore_AttemptsAndFailedAtRoundTrip(t *testing.T) {
 		}
 	}
 
+	onDeliveryStoreTwins(t, run)
+}
+
+// onDeliveryStoreTwins runs one delivery-store contract against both twins.
+// The Mongo half skips without ITERION_TEST_MONGO_URI (the CI
+// mongo-conformance job supplies it).
+func onDeliveryStoreTwins(t *testing.T, run func(*testing.T, DeliveryStore)) {
+	t.Helper()
 	t.Run("memory", func(t *testing.T) { run(t, NewMemoryDeliveryStore()) })
 
 	t.Run("mongo", func(t *testing.T) {
@@ -78,5 +86,63 @@ func TestDeliveryStore_AttemptsAndFailedAtRoundTrip(t *testing.T) {
 			t.Fatalf("EnsureSchema: %v", err)
 		}
 		run(t, NewMongoStores(db).Deliveries)
+	})
+}
+
+// A prior launch_error row is retryable, so taking it over is a CLAIM: both
+// twins must let exactly ONE caller past, or two redeliveries of the same
+// event each launch a run for it.
+func TestDeliveryStore_ClaimFailedRetry(t *testing.T) {
+	onDeliveryStoreTwins(t, func(t *testing.T, st DeliveryStore) {
+		ctx := context.Background()
+		seed := func(t *testing.T, id string, status string, attempts int) Delivery {
+			t.Helper()
+			d := Delivery{
+				ID: id, TenantID: "t1", WebhookID: "w1", Provider: ProviderGitHub,
+				IdempotencyKey: "key-" + id, Status: status, Attempts: attempts,
+				ReceivedAt: time.Date(2026, 9, 6, 8, 0, 0, 0, time.UTC),
+			}
+			if err := st.Insert(ctx, d); err != nil {
+				t.Fatalf("Insert %s: %v", id, err)
+			}
+			return d
+		}
+
+		// Two callers read the same failed row; only the first claim lands.
+		d := seed(t, "d-race", StatusLaunchError, 1)
+		first, second := d, d
+		first.Status, first.Attempts = StatusAccepted, 2
+		second.Status, second.Attempts = StatusAccepted, 2
+		claimed, err := st.ClaimFailedRetry(ctx, first, 1)
+		if err != nil || !claimed {
+			t.Fatalf("first claim = (%v, %v), want (true, nil)", claimed, err)
+		}
+		claimed, err = st.ClaimFailedRetry(ctx, second, 1)
+		if err != nil {
+			t.Fatalf("second claim errored: %v", err)
+		}
+		if claimed {
+			t.Fatal("both callers claimed the same failed row — two runs would launch for one event")
+		}
+		got, err := st.GetByIdempotencyKey(ctx, "key-d-race")
+		if err != nil || got.Attempts != 2 || got.Status != StatusAccepted {
+			t.Fatalf("row after the claim = %+v (%v), want status accepted / attempts 2", got, err)
+		}
+
+		// A row that is not a launch failure is never claimable.
+		live := seed(t, "d-live", StatusLaunched, 1)
+		live.Attempts = 2
+		if claimed, err := st.ClaimFailedRetry(ctx, live, 1); err != nil || claimed {
+			t.Fatalf("claim of a launched row = (%v, %v), want (false, nil)", claimed, err)
+		}
+
+		// A failed row that never counted an attempt carries no attempts
+		// field at all on Mongo (omitempty): claiming it at 0 must still work,
+		// or a first retry could never be taken over.
+		zero := seed(t, "d-zero", StatusLaunchError, 0)
+		zero.Status, zero.Attempts = StatusAccepted, 1
+		if claimed, err := st.ClaimFailedRetry(ctx, zero, 0); err != nil || !claimed {
+			t.Fatalf("claim of an attempt-less failed row = (%v, %v), want (true, nil)", claimed, err)
+		}
 	})
 }

--- a/pkg/webhooks/memory.go
+++ b/pkg/webhooks/memory.go
@@ -76,6 +76,18 @@ func (s *MemoryDeliveryStore) Update(_ context.Context, d Delivery) error {
 	return s.kit.Replace(d.ID, d)
 }
 
+// ClaimFailedRetry is the compare-and-set take-over of a failed row (see
+// DeliveryStore). Keep its semantics in lock-step with the Mongo twin.
+func (s *MemoryDeliveryStore) ClaimFailedRetry(_ context.Context, d Delivery, expectAttempts int) (bool, error) {
+	return s.kit.Mutate(d.ID, func(cur *Delivery) bool {
+		if cur.Status != StatusLaunchError || cur.Attempts != expectAttempts {
+			return false
+		}
+		*cur = d
+		return true
+	})
+}
+
 func (s *MemoryDeliveryStore) ListByWebhook(_ context.Context, tenantID, webhookID string, limit int) ([]Delivery, error) {
 	out := s.kit.List(func(d Delivery) bool {
 		return d.TenantID == tenantID && d.WebhookID == webhookID

--- a/pkg/webhooks/mongo.go
+++ b/pkg/webhooks/mongo.go
@@ -120,6 +120,25 @@ func (s *MongoDeliveryStore) Update(ctx context.Context, d Delivery) error {
 	return s.kit.Replace(ctx, d.ID, d, nil, "update delivery")
 }
 
+// ClaimFailedRetry is the compare-and-set take-over of a failed row (see
+// DeliveryStore). Keep its semantics in lock-step with the memory twin.
+func (s *MongoDeliveryStore) ClaimFailedRetry(ctx context.Context, d Delivery, expectAttempts int) (bool, error) {
+	// attempts is omitempty, so a row that never counted one carries NO
+	// field — and {attempts: 0} does not match a missing field. Match both
+	// spellings of "none yet", or a first retry could never be claimed.
+	attempts := bson.M{"$eq": expectAttempts}
+	if expectAttempts == 0 {
+		attempts = bson.M{"$in": bson.A{0, nil}}
+	}
+	res, err := s.kit.Coll().ReplaceOne(ctx, bson.M{
+		"_id": d.ID, "status": StatusLaunchError, "attempts": attempts,
+	}, d)
+	if err != nil {
+		return false, fmt.Errorf("webhooks: claim failed delivery %s: %w", d.ID, err)
+	}
+	return res.MatchedCount > 0, nil
+}
+
 func (s *MongoDeliveryStore) ListByWebhook(ctx context.Context, tenantID, webhookID string, limit int) ([]Delivery, error) {
 	if limit <= 0 {
 		limit = 50

--- a/pkg/webhooks/store.go
+++ b/pkg/webhooks/store.go
@@ -33,6 +33,18 @@ type DeliveryStore interface {
 	Insert(ctx context.Context, d Delivery) error
 	GetByIdempotencyKey(ctx context.Context, key string) (Delivery, error)
 	Update(ctx context.Context, d Delivery) error
+	// ClaimFailedRetry takes over a delivery row left in StatusLaunchError so
+	// that ONE caller retries the event. A prior launch failure is
+	// deliberately retryable — a redelivery of the same event must be able to
+	// relaunch it — which makes the take-over a claim, not a read followed by
+	// a write: two redeliveries arriving together both find the failed row,
+	// and both would otherwise go on to launch a run for one event.
+	//
+	// The replacement lands iff the stored row is STILL that failure at the
+	// attempt count the caller read. claimed=false with a NIL error means
+	// another caller got there first, and the loser must answer as a
+	// duplicate rather than launch. ErrNotFound when the row is gone.
+	ClaimFailedRetry(ctx context.Context, d Delivery, expectAttempts int) (claimed bool, err error)
 	ListByWebhook(ctx context.Context, tenantID, webhookID string, limit int) ([]Delivery, error)
 	// CountLaunched counts the deliveries of one event kind on one subject
 	// that actually launched a run (RunID set). This is a CEILING query —

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5956,6 +5956,7 @@ export interface components {
             /** Format: date-time */
             current_run_start?: string;
             deployment?: components["schemas"]["DeploymentReport"];
+            end_reason?: string;
             error?: string;
             failure_code?: string;
             fallbacks_used?: components["schemas"]["FallbackUsage"][];
@@ -6044,6 +6045,7 @@ export interface components {
             bundle_name?: string;
             /** Format: date-time */
             created_at: string;
+            end_reason?: string;
             error?: string;
             failure_code?: string;
             file_path?: string;


### PR DESCRIPTION
Closes #702. Closes #715. Closes #713. Closes #721. Closes #722. Closes #712.

## #702 — SECURITY: the studio/API/MCP and board `pr_url` launches had no fork guard
The five webhook lanes were made fail-closed by #683; two doors into the same launch pair were not: `runs_launch.go` → `applyPRLaunchContext` (studio, remote CLI, MCP) and the cloud board coordinator (`boarddispatch.go`, at claim time). Both now refuse a head branch that does not live in the base repo with the lanes' own `forkGuardRefusal` (422 on refusal, 502 on an unreachable forge, nothing launches; the board files the card blocked with the reason). Confirmed as needing no guard: the custom-ingress board path (carries `pr_url` onto `BotArgs`, re-guarded at claim) and the trigger evaluator (skips any event carrying `launched_run_id`).

| entry point | before | after |
|---|---|---|
| GitHub PR-event lane, prforge PR/comment lane, GitLab MR lane, gate relaunch, gate auto-fix | guarded (#683) | unchanged |
| studio / remote CLI / MCP launch (`applyPRLaunchContext`) | **none** | guarded |
| cloud board coordinator (claim) | **none** | guarded |

## #722 — one authorization walk for both gate notices
`noticeGatePausedForRetry` re-implemented `gateNoticeTarget`'s walk byte for byte. Red by canary (a rule added to `gateNoticeTarget` only: `pause notice posted 1 comments, want 0`); the committed test is a table over both notices × 9 refusal reasons + the positive control.

## #721 — a DLQ-parked run's check names a remedy that reaches it
`gateInterruptedDescriptionFor` branches on `FailureCode == FailureDLQParked`: `review parked on the DLQ — operator replay needed (iterion remote admin dlq)` instead of "push again or comment the bot's command". Class grep: `isSyntheticGateInterruption` learnt the third shape — otherwise the reconciler would read the repair as a real verdict, the pending path would refuse to overwrite it and the auto-fix lane would send a fixer hunting behind a review that never ran. Deviation, stated: the issue's "make the DLQ path independent of the publish-grant lookup" is not implementable — the grant supplies the connection AND the repo scope; with no grant there is no client and no boundary (and the DLQ comment itself goes through that grant).

## #713 — the PR-closed end reason is a typed field
`store.RunEndReason` (`operator` / `pr_closed` / `pr_requeued` / `superseded`) with `Message()` deriving the prose; `CancelRunWithReason` takes the typed reason; `store.EndedBecausePRClosed(run)` is the one predicate the admission asks (typed field, or the message for pre-field docs only). Class grep (`CarriesFailureCode`): five sites, not two — the transition tail on each store twin, the `SaveRun` guard on each twin, and the FS heal-on-read — all honour `EndReason`, or a full-document `SaveRun` could resurrect a stale `pr_closed` and refuse the run's admission forever. Conformance row `EndReasonLifecycle` (red on the old store: `end_reason="" failure_code="CANCELLED"`); `openapi.json` + studio schema regenerated.

## #715 — launch-tail residues
1. **`launch_error` retry is claimed, not re-read**: `DeliveryStore.ClaimFailedRetry(d, expectAttempts)` on both twins; two redeliveries of one failed event launch ONE run (red: `launched 2 runs, want 1`, deterministic via a barrier store); the loser answers `duplicate` and rolls back its metered quota unit. Mongo twin filters `attempts` as `$in [0, null]` (the field is `omitempty`, so `{attempts: 0}` never matched a first retry).
2. **A run's manifest is read at the run's own tier** (`teamBotManifest` keyed on the recorded `BotSourceTenant`) — a team-authored reviewer now gets the reviewer notice. Deviation, stated: the issue's first option ("resolve the team tier for hand-offs") contradicts the code — every webhook/board/schedule/trigger launch resolves platform → baked (`resolveBotTiered(ctx, "", …)`), so the hand-off resolver reading the same tiers already IS the launch's resolution; the exclusion is now a stated contract at the resolver.
3. **Hypothesis CONFIRMED and broader**: the reconciler painted `review died (auto-retry abandoned …) — push again …` on a **merged** pull request (probe over open/closed/merged: one status write each). Fixed with the predicate the sibling lanes use (`pr.State != "" && pr.State != "open"` → stand down); an unreported state is never read as a closure. Known consequence, documented: the dead run's pending claim stays on the head of a closed PR (blocks nothing; a reopen heals it).

## #712 — docs
`docs/webhooks.md` § "Two identities: the App connection reads, a PAT binding writes", with two corrections to the issue's premises: the merge-gate commit status is App-connection-only (no binding fallback), and there is no `iterion remote forge whoami` — the section names the two commands that exist.

## Verification
`go build ./...` · `go test ./pkg/server/... ./pkg/store/... ./pkg/runner/... ./pkg/webhooks/...` ok · `task lint` 0 issues · `task openapi:gen` + `openapi:check` exit 0. Mongo conformance (`EndReasonLifecycle`, `TestDeliveryStore_ClaimFailedRetry` Mongo halves) skipped locally — CI's `mongo-conformance` job runs them.

## Left as separate findings (filed)
Neither `gateNoticeTarget` nor the reconciler's grant walk checks that the publish grant belongs to the run's own tenant; `ForgePublishGrant.Bot`'s comment describes a mechanism the reconciler does not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
