### PR TITLE
fix(git,pluginsource,runview): a git command iterion runs into a directory it disposes of leaves nothing running

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -158,6 +158,39 @@ func SanitizeEnv(env []string) []string {
 	return out
 }
 
+// autoMaintenanceOff is the config that keeps a git command from spawning
+// automatic maintenance.
+//
+// Since git 2.48 a command that WRITES to a repository — fetch, commit, merge,
+// rebase, am — ends by running `git maintenance run --auto --detach`, and that
+// process DAEMONIZES: it forks, the parent exits, the child calls setsid() and
+// closes stdin/stdout/stderr (git's setup.c daemonize()). The parent's exit and
+// the closed pipes are exactly what os/exec waits for, so CombinedOutput
+// returns while the maintenance child is still alive, still holding
+// `<repo>/.git/objects/maintenance.lock` and still writing under
+// `.git/objects`. The caller has no handle on it: it cannot be waited for, and
+// removing the checkout races it.
+//
+// `maintenance.auto=false` refuses the spawn outright (git ≥ 2.48).
+// `gc.auto=0` is the knob older git reads — there the detaching process is
+// `git gc --auto` — and is also the fallback git ≥ 2.48 consults when
+// maintenance.auto is unset.
+var autoMaintenanceOff = []string{"-c", "maintenance.auto=false", "-c", "gc.auto=0"}
+
+// NoAutoMaintenance returns args prefixed with the config above, for a git
+// command run against a directory iterion owns and disposes of: a cache
+// checkout, a disposable server-side clone, a scratch repository a test
+// builds under t.TempDir(). Such a directory has nothing to maintain, and a
+// maintenance process outliving the command that started it is a process
+// nothing can wait for.
+//
+// Exported for the same reason SanitizeEnv is: this package is not the only
+// place that shells out to git, and a caller assembling its own argv cannot
+// get it from run() below.
+func NoAutoMaintenance(args ...string) []string {
+	return append(slices.Clone(autoMaintenanceOff), args...)
+}
+
 func gitEnv() []string {
 	return append(SanitizeEnv(os.Environ()), "LC_ALL=C", "LANG=C")
 }

--- a/pkg/git/no_auto_maintenance_test.go
+++ b/pkg/git/no_auto_maintenance_test.go
@@ -1,0 +1,30 @@
+package git
+
+import (
+	"slices"
+	"testing"
+)
+
+// The config must precede the subcommand — `git fetch -c gc.auto=0` is a fetch
+// flag error, not a config override — and one call must not be able to corrupt
+// the next: a shared backing array would let the first caller's args leak into
+// a second caller's command line.
+func TestNoAutoMaintenance(t *testing.T) {
+	got := NoAutoMaintenance("fetch", "--depth", "1")
+	want := []string{"-c", "maintenance.auto=false", "-c", "gc.auto=0", "fetch", "--depth", "1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("NoAutoMaintenance = %q, want %q", got, want)
+	}
+
+	second := NoAutoMaintenance("checkout", "--force")
+	if !slices.Equal(got, want) {
+		t.Errorf("a second call rewrote the first call's args: %q", got)
+	}
+	if slices.Equal(second, got) {
+		t.Errorf("both calls returned the same command line: %q", second)
+	}
+
+	if bare := NoAutoMaintenance(); !slices.Equal(bare, want[:4]) {
+		t.Errorf("NoAutoMaintenance() = %q, want just the config %q", bare, want[:4])
+	}
+}

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -160,15 +160,22 @@ func (f *Fetcher) lockKey(ctx context.Context, key string) (func(), error) {
 	}
 }
 
-// git runs one git command. The credential is injected via an askpass helper
-// (never argv, never the URL) so it cannot leak into a process listing, git's
-// own logs, or an error message — the same use-by-reference discipline the
-// mounted run secrets follow.
+// git runs one git command, and its return is the END of that command: nothing
+// it spawned is still running. gitlib.NoAutoMaintenance is what makes that
+// true — without it a fetch leaves a DETACHED `git maintenance run --auto`
+// behind, writing under the checkout's `.git/objects` after this function has
+// returned, past FetchTimeout, and into a cache directory the caller may
+// already be deleting.
+//
+// The credential is injected via an askpass helper (never argv, never the URL)
+// so it cannot leak into a process listing, git's own logs, or an error
+// message — the same use-by-reference discipline the mounted run secrets
+// follow.
 func (f *Fetcher) git(ctx context.Context, dir, cred string, args ...string) error {
 	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	// SanitizeEnv first: cmd.Dir names the checkout, and an inherited GIT_DIR
 	// or GIT_INDEX_FILE would silently redirect the fetch away from it.

--- a/pkg/pluginsource/fetch_maintenance_test.go
+++ b/pkg/pluginsource/fetch_maintenance_test.go
@@ -1,0 +1,85 @@
+package pluginsource
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A fetch must leave NOTHING running. Since git 2.48 every command that writes
+// to a repository ends by detaching `git maintenance run --auto`: that process
+// calls setsid() and closes its standard descriptors, which is exactly what
+// os/exec waits for, so CombinedOutput returns while it still holds
+// `.git/objects/maintenance.lock` and writes under `.git/objects`. The cache
+// checkout is the caller's to delete, and the detached writer is not waitable —
+// it raced `t.TempDir()`'s cleanup into a merge-queue ejection (#821).
+//
+// The oracle is the argv git receives, not a timing observation: what iterion
+// controls is the config it passes, and a run on git < 2.48 would show nothing
+// either way.
+func TestFetch_RunsGitWithoutAutoMaintenance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the recording shim is a POSIX shell script")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available")
+	}
+
+	origin := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(realGit, args...)
+		cmd.Dir = origin
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, gerr := cmd.CombinedOutput(); gerr != nil {
+			t.Fatalf("git %v: %v: %s", args, gerr, out)
+		}
+	}
+	runGit("init", "--quiet", "-b", "main")
+	if err := os.WriteFile(filepath.Join(origin, "plugin.yaml"),
+		[]byte("name: p\nversion: 0.1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "-A")
+	runGit("commit", "-m", "seed")
+	runGit("tag", "v0.1.0")
+
+	// The shim records the argv and delegates, so the fetch really runs and the
+	// recorded arguments are the ones git actually got.
+	shimDir := t.TempDir()
+	argvLog := filepath.Join(shimDir, "argv.log")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '" + argvLog + "'\nexec '" + realGit + "' \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	f := &Fetcher{CacheDir: t.TempDir()}
+	if _, err := f.Fetch(context.Background(), PluginSource{
+		ID: "ps-1", TenantID: "team-a", Name: "p", GitURL: origin, Ref: "v0.1.0", Enabled: true,
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	recorded, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("the shim recorded nothing — the fetch did not go through PATH: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+	// init, remote add, fetch, checkout: fewer means the assertion below is
+	// vouching for invocations that never happened.
+	if len(lines) < 4 {
+		t.Fatalf("expected the fetch's four git invocations, recorded %d: %q", len(lines), lines)
+	}
+	for _, argv := range lines {
+		if !strings.Contains(argv, "-c maintenance.auto=false") || !strings.Contains(argv, "-c gc.auto=0") {
+			t.Errorf("git invocation may spawn a detached maintenance process that outlives the fetch: %q", argv)
+		}
+	}
+}

--- a/pkg/pluginsource/pluginsource_test.go
+++ b/pkg/pluginsource/pluginsource_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 )
 
 func validSource() PluginSource {
@@ -149,7 +151,7 @@ func TestFetcher_FetchesAndCachesPinnedRef(t *testing.T) {
 	origin := t.TempDir()
 	run := func(dir string, args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
@@ -362,7 +364,7 @@ func TestFetcher_MovingRefSwapsInTheNewTree(t *testing.T) {
 
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
@@ -419,7 +421,7 @@ func TestResolver_ResolvesTeamSourcesFromGit(t *testing.T) {
 	origin := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = origin
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")

--- a/pkg/runview/merge_remote.go
+++ b/pkg/runview/merge_remote.go
@@ -81,10 +81,16 @@ func mergeGitAuthArgs(token string) []string {
 
 // runMergeGit executes one git command for the merge clone, with the
 // forge header injected and the token redacted from any error output.
+//
+// NoAutoMaintenance keeps the command's lifetime whole: fetch, merge and
+// commit each end by DETACHING a `git maintenance run --auto` that keeps
+// writing under `.git/objects`, and this clone is removed the moment the
+// merge lands (removeRepoTargetedMergeRoot) — a partially removed tree that
+// still has a `.git` reads as a materialised clone to the next request.
 func runMergeGit(ctx context.Context, dir, token string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, mergeGitTimeout)
 	defer cancel()
-	full := append(mergeGitAuthArgs(token), args...)
+	full := gitlib.NoAutoMaintenance(append(mergeGitAuthArgs(token), args...)...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	if dir != "" {
 		cmd.Dir = dir

--- a/pkg/server/cloudpublisher/plugin_source_quarantine_test.go
+++ b/pkg/server/cloudpublisher/plugin_source_quarantine_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/pluginsource"
 	"github.com/SocialGouv/iterion/pkg/queue"
@@ -65,9 +66,13 @@ func TestSubmitLaunch_BrokenPluginSourceIsSkippedNotFatal(t *testing.T) {
 		t.Skip("git not available")
 	}
 	origin := t.TempDir()
+	// NoAutoMaintenance: `git commit` below otherwise detaches a
+	// `git maintenance run --auto` that writes under this origin's
+	// `.git/objects` after the command returned — into a directory
+	// t.TempDir()'s cleanup is about to remove.
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = origin
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")

--- a/pkg/server/plugin_sources_routes_test.go
+++ b/pkg/server/plugin_sources_routes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/identity"
 	"github.com/SocialGouv/iterion/pkg/pluginsource"
 )
@@ -30,7 +31,7 @@ const fixedPluginManifest = "name: deploy-onyxia\nversion: 0.1.1\ndescription: \
 
 func gitRunIn(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")


### PR DESCRIPTION
Closes #821.

## The flake, and why it only bites in CI
Merge-queue build of #813, job `race`: `TestSubmitLaunch_BrokenPluginSourceIsSkippedNotFatal` — `TempDir RemoveAll cleanup: unlinkat …/.git/objects: directory not empty`. It never reproduces locally (0/30 with `-race -count=30`, 0/200 under `GOMAXPROCS=2` stress) because **the host runs git 2.43 and the CI runner git 2.55**, and the mechanism was introduced in git 2.48.

## The writer
Not iterion code — **git's own automatic maintenance**: every writing command (`fetch`, `commit`, `merge`, `rebase`, `am`) runs `git maintenance run --auto --detach` (`run-command.c prepare_auto_maintenance`; `maintenance.auto` and `maintenance.autoDetach`/`gc.autoDetach` default true). `builtin/gc.c` takes `.git/objects/maintenance.lock` then **daemonizes** (`fork`, parent exits, child `setsid` + closes stdio). The parent's exit and the closed pipes are exactly what `os/exec` waits for, so `Fetcher.git` returns while the maintenance child is alive, unwaitable, and still writing under `.git/objects` of the checkout `t.TempDir()` was deleting. Measured with `strace -f -e trace=execve` on the failing test: **2 `git maintenance run --auto` processes before the fix, 0 after** (the test helper's `git commit` and the fetcher's `git fetch` — the path in the CI failure).

## The fix — production semantics
A shared chokepoint beside `SanitizeEnv`: `gitlib.NoAutoMaintenance(args...)` (`pkg/git/git.go`) prepends `-c maintenance.auto=false -c gc.auto=0` (the second is what git < 2.48 reads and the fallback git ≥ 2.48 consults). Contract, stated in the code: a git command run against a directory iterion owns and disposes of must leave nothing running — such a directory has nothing to maintain, and a maintenance process outliving its command is a process nothing can wait for. No sleep, no timing. Applied at `pkg/pluginsource/fetch.go` (the incident; its `FetchTimeout` only bounds the command if nothing escapes it) and `pkg/runview/merge_remote.go` (the disposable server-side merge clone — a half-removed tree that still has a `.git` reads as materialised to the next request).

Red first: `pkg/pluginsource/fetch_maintenance_test.go` — a PATH shim records the argv and delegates to the real git, so the fetch really runs; the oracle is the argv git receives (a timing assertion proves nothing on git < 2.48). RED before the fix: all 4 invocations flagged (`init`, `remote add`, `fetch`, `checkout`); green after. Plus `pkg/git/no_auto_maintenance_test.go` (arg order, slice aliasing). Test helpers fixed in the same change: `pkg/pluginsource/pluginsource_test.go`, `plugin_source_quarantine_test.go` (the incident's own helper — the second latent instance in the same test), `pkg/server/plugin_sources_routes_test.go`.

## Class grep
| site | disposition |
|---|---|
| `pkg/pluginsource/fetch.go`, `pkg/runview/merge_remote.go` | fixed |
| `pkg/runner/loop_gitws.go:449` — 3 × `git fetch` into `<WorkDir>/repos/<RunID>`, later `os.RemoveAll`'d | same shape in production on the runner pod — **filed separately** (file next to another PR in flight) |
| `pkg/runtime/worktree.go:54` | left deliberately: finalize commits into the OPERATOR's own repo — its `objects/` is not a directory iterion deletes, and disabling maintenance there overrides the operator's own choice |
| `status` / `rev-parse` / `show` / `log` / `worktree` callers, `git clone` (not in git's `run_auto_maintenance` set, verified against the source) | inert, left |
| 28 other test helpers building repos under `t.TempDir()` with a maintenance-triggering command | filed separately (one line each; a sweep would collide with the packages under concurrent work) |

## Verification
`go test -race -count=30 -run TestSubmitLaunch_BrokenPluginSourceIsSkippedNotFatal ./pkg/server/cloudpublisher/` ok (0/30) · stress 8 × `-count=25` under `GOMAXPROCS=2` ok (0/200) · `go test ./pkg/git/... ./pkg/pluginsource/... ./pkg/runview/... ./pkg/server/...` ok · `task test` (whole module) exit 0 · `task lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
