### PR TITLE
fix(runner): the per-run clone's git commands leave no maintenance process behind

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -158,6 +158,39 @@ func SanitizeEnv(env []string) []string {
 	return out
 }
 
+// autoMaintenanceOff is the config that keeps a git command from spawning
+// automatic maintenance.
+//
+// Since git 2.48 a command that WRITES to a repository — fetch, commit, merge,
+// rebase, am — ends by running `git maintenance run --auto --detach`, and that
+// process DAEMONIZES: it forks, the parent exits, the child calls setsid() and
+// closes stdin/stdout/stderr (git's setup.c daemonize()). The parent's exit and
+// the closed pipes are exactly what os/exec waits for, so CombinedOutput
+// returns while the maintenance child is still alive, still holding
+// `<repo>/.git/objects/maintenance.lock` and still writing under
+// `.git/objects`. The caller has no handle on it: it cannot be waited for, and
+// removing the checkout races it.
+//
+// `maintenance.auto=false` refuses the spawn outright (git ≥ 2.48).
+// `gc.auto=0` is the knob older git reads — there the detaching process is
+// `git gc --auto` — and is also the fallback git ≥ 2.48 consults when
+// maintenance.auto is unset.
+var autoMaintenanceOff = []string{"-c", "maintenance.auto=false", "-c", "gc.auto=0"}
+
+// NoAutoMaintenance returns args prefixed with the config above, for a git
+// command run against a directory iterion owns and disposes of: a cache
+// checkout, a disposable server-side clone, a scratch repository a test
+// builds under t.TempDir(). Such a directory has nothing to maintain, and a
+// maintenance process outliving the command that started it is a process
+// nothing can wait for.
+//
+// Exported for the same reason SanitizeEnv is: this package is not the only
+// place that shells out to git, and a caller assembling its own argv cannot
+// get it from run() below.
+func NoAutoMaintenance(args ...string) []string {
+	return append(slices.Clone(autoMaintenanceOff), args...)
+}
+
 func gitEnv() []string {
 	return append(SanitizeEnv(os.Environ()), "LC_ALL=C", "LANG=C")
 }

--- a/pkg/git/no_auto_maintenance_test.go
+++ b/pkg/git/no_auto_maintenance_test.go
@@ -1,0 +1,30 @@
+package git
+
+import (
+	"slices"
+	"testing"
+)
+
+// The config must precede the subcommand — `git fetch -c gc.auto=0` is a fetch
+// flag error, not a config override — and one call must not be able to corrupt
+// the next: a shared backing array would let the first caller's args leak into
+// a second caller's command line.
+func TestNoAutoMaintenance(t *testing.T) {
+	got := NoAutoMaintenance("fetch", "--depth", "1")
+	want := []string{"-c", "maintenance.auto=false", "-c", "gc.auto=0", "fetch", "--depth", "1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("NoAutoMaintenance = %q, want %q", got, want)
+	}
+
+	second := NoAutoMaintenance("checkout", "--force")
+	if !slices.Equal(got, want) {
+		t.Errorf("a second call rewrote the first call's args: %q", got)
+	}
+	if slices.Equal(second, got) {
+		t.Errorf("both calls returned the same command line: %q", second)
+	}
+
+	if bare := NoAutoMaintenance(); !slices.Equal(bare, want[:4]) {
+		t.Errorf("NoAutoMaintenance() = %q, want just the config %q", bare, want[:4])
+	}
+}

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -160,15 +160,22 @@ func (f *Fetcher) lockKey(ctx context.Context, key string) (func(), error) {
 	}
 }
 
-// git runs one git command. The credential is injected via an askpass helper
-// (never argv, never the URL) so it cannot leak into a process listing, git's
-// own logs, or an error message — the same use-by-reference discipline the
-// mounted run secrets follow.
+// git runs one git command, and its return is the END of that command: nothing
+// it spawned is still running. gitlib.NoAutoMaintenance is what makes that
+// true — without it a fetch leaves a DETACHED `git maintenance run --auto`
+// behind, writing under the checkout's `.git/objects` after this function has
+// returned, past FetchTimeout, and into a cache directory the caller may
+// already be deleting.
+//
+// The credential is injected via an askpass helper (never argv, never the URL)
+// so it cannot leak into a process listing, git's own logs, or an error
+// message — the same use-by-reference discipline the mounted run secrets
+// follow.
 func (f *Fetcher) git(ctx context.Context, dir, cred string, args ...string) error {
 	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	// SanitizeEnv first: cmd.Dir names the checkout, and an inherited GIT_DIR
 	// or GIT_INDEX_FILE would silently redirect the fetch away from it.

--- a/pkg/pluginsource/fetch_maintenance_test.go
+++ b/pkg/pluginsource/fetch_maintenance_test.go
@@ -1,0 +1,85 @@
+package pluginsource
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// A fetch must leave NOTHING running. Since git 2.48 every command that writes
+// to a repository ends by detaching `git maintenance run --auto`: that process
+// calls setsid() and closes its standard descriptors, which is exactly what
+// os/exec waits for, so CombinedOutput returns while it still holds
+// `.git/objects/maintenance.lock` and writes under `.git/objects`. The cache
+// checkout is the caller's to delete, and the detached writer is not waitable —
+// it raced `t.TempDir()`'s cleanup into a merge-queue ejection (#821).
+//
+// The oracle is the argv git receives, not a timing observation: what iterion
+// controls is the config it passes, and a run on git < 2.48 would show nothing
+// either way.
+func TestFetch_RunsGitWithoutAutoMaintenance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the recording shim is a POSIX shell script")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available")
+	}
+
+	origin := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(realGit, args...)
+		cmd.Dir = origin
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, gerr := cmd.CombinedOutput(); gerr != nil {
+			t.Fatalf("git %v: %v: %s", args, gerr, out)
+		}
+	}
+	runGit("init", "--quiet", "-b", "main")
+	if err := os.WriteFile(filepath.Join(origin, "plugin.yaml"),
+		[]byte("name: p\nversion: 0.1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "-A")
+	runGit("commit", "-m", "seed")
+	runGit("tag", "v0.1.0")
+
+	// The shim records the argv and delegates, so the fetch really runs and the
+	// recorded arguments are the ones git actually got.
+	shimDir := t.TempDir()
+	argvLog := filepath.Join(shimDir, "argv.log")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '" + argvLog + "'\nexec '" + realGit + "' \"$@\"\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	f := &Fetcher{CacheDir: t.TempDir()}
+	if _, err := f.Fetch(context.Background(), PluginSource{
+		ID: "ps-1", TenantID: "team-a", Name: "p", GitURL: origin, Ref: "v0.1.0", Enabled: true,
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	recorded, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("the shim recorded nothing — the fetch did not go through PATH: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+	// init, remote add, fetch, checkout: fewer means the assertion below is
+	// vouching for invocations that never happened.
+	if len(lines) < 4 {
+		t.Fatalf("expected the fetch's four git invocations, recorded %d: %q", len(lines), lines)
+	}
+	for _, argv := range lines {
+		if !strings.Contains(argv, "-c maintenance.auto=false") || !strings.Contains(argv, "-c gc.auto=0") {
+			t.Errorf("git invocation may spawn a detached maintenance process that outlives the fetch: %q", argv)
+		}
+	}
+}

--- a/pkg/pluginsource/pluginsource_test.go
+++ b/pkg/pluginsource/pluginsource_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 )
 
 func validSource() PluginSource {
@@ -149,7 +151,7 @@ func TestFetcher_FetchesAndCachesPinnedRef(t *testing.T) {
 	origin := t.TempDir()
 	run := func(dir string, args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = dir
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
@@ -362,7 +364,7 @@ func TestFetcher_MovingRefSwapsInTheNewTree(t *testing.T) {
 
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
@@ -419,7 +421,7 @@ func TestResolver_ResolvesTeamSourcesFromGit(t *testing.T) {
 	origin := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = origin
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")

--- a/pkg/runner/gitws_no_auto_maintenance_test.go
+++ b/pkg/runner/gitws_no_auto_maintenance_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The runner's git commands must leave NOTHING running. Since git 2.48 a
+// `git fetch` ends by detaching `git maintenance run --auto`: that process
+// calls setsid() and closes stdin/stdout/stderr — exactly what os/exec waits
+// on — so runGitOutEnv returns while it is still holding
+// `.git/objects/maintenance.lock` and writing under `.git/objects`. The
+// per-run clone at `<WorkDir>/repos/<RunID>` is removed when the run returns
+// and again at the next attempt, so that removal would race a process the
+// runner has no handle on, and gitOpTimeout would bound nothing that escaped
+// it (#828 item 1; the mechanism is measured in #821).
+//
+// The oracle is the argv git receives, recorded by a PATH shim that delegates
+// to the real binary: what iterion controls is the config it passes, and a
+// run on git < 2.48 would show nothing either way. The two bank-family fetch
+// paths are driven for real; the third (prepareRepoWorkspace) needs a public
+// forge host, and rides the same single chokepoint — runGitOutEnv is the only
+// place this package builds a git subprocess.
+func TestRunnerGitRunsWithoutAutoMaintenance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the recording shim is a POSIX shell script")
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not available")
+	}
+
+	r, msg, work, _, _ := bankFixture(t)
+	branch := "iterion/run-" + msg.RunID
+	gitOut(t, work, "commit", "--allow-empty", "-m", "earlier attempt")
+	oldHead := gitOut(t, work, "rev-parse", "HEAD")
+	gitOut(t, work, "push", "origin", "HEAD:refs/heads/"+branch)
+	gitOut(t, work, "commit", "--allow-empty", "-m", "finished attempt")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	// The shim goes on PATH only now, so the log holds the runner's own
+	// invocations and not the fixture's.
+	shimDir := t.TempDir()
+	argvLog := filepath.Join(shimDir, "argv.log")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '" + argvLog + "'\nexec '" + realGit + "' \"$@\"\n"
+	if werr := os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o755); werr != nil {
+		t.Fatal(werr)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx := context.Background()
+	if !r.bankSupersedes(ctx, msg, work, "", branch, oldHead, head) {
+		t.Fatalf("precondition: the finished head contains the earlier one, so the bank must be allowed")
+	}
+	r.preserveSupersededChain(ctx, msg, work, "", branch, oldHead, head)
+
+	recorded, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("the shim recorded nothing — the runner's git did not go through PATH: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+	fetches := 0
+	for _, argv := range lines {
+		// The subcommand as a token, never a substring of the whole line: a
+		// count that only matches once the config prefix is there would be
+		// vouched for by the very fix it is meant to guard.
+		if slices.Contains(strings.Fields(argv), "fetch") {
+			fetches++
+		}
+		if !strings.Contains(argv, "-c maintenance.auto=false") || !strings.Contains(argv, "-c gc.auto=0") {
+			t.Errorf("git invocation may spawn a detached maintenance process that outlives the command: %q", argv)
+		}
+	}
+	// One per exercised path: fewer means the assertion above vouched for
+	// invocations that never ran.
+	if fetches < 2 {
+		t.Fatalf("expected both bank-family fetches, recorded %d in %q", fetches, lines)
+	}
+}

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -440,13 +440,23 @@ func (r *Runner) runGitEnv(ctx context.Context, dir, tok string, extraEnv []stri
 // runGitOutEnv is runGitEnv returning the command's combined output —
 // for the callers that need to READ git (ls-remote, rev-list), with the
 // same timeout, cancellation hardening and token redaction.
+//
+// It is the ONE place this package builds a git subprocess, so the
+// guarantees below hold for every git command the runner runs.
+// NoAutoMaintenance is what makes the return of this function the END of
+// the command: a `git fetch` otherwise detaches `git maintenance run
+// --auto`, which closes its descriptors — the very thing CombinedOutput
+// waits on — and keeps writing under `.git/objects` of the per-run clone.
+// That clone is deleted when the run returns (and again at the next
+// attempt), so the removal would race a process nothing here can wait for,
+// and gitOpTimeout would bound nothing that escaped it.
 func (r *Runner) runGitOutEnv(ctx context.Context, dir, tok string, extraEnv []string, args ...string) (string, error) {
 	if gitOpTimeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, gitOpTimeout)
 		defer cancel()
 	}
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, "git", gitlib.NoAutoMaintenance(args...)...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/pkg/runview/merge_remote.go
+++ b/pkg/runview/merge_remote.go
@@ -81,10 +81,16 @@ func mergeGitAuthArgs(token string) []string {
 
 // runMergeGit executes one git command for the merge clone, with the
 // forge header injected and the token redacted from any error output.
+//
+// NoAutoMaintenance keeps the command's lifetime whole: fetch, merge and
+// commit each end by DETACHING a `git maintenance run --auto` that keeps
+// writing under `.git/objects`, and this clone is removed the moment the
+// merge lands (removeRepoTargetedMergeRoot) — a partially removed tree that
+// still has a `.git` reads as a materialised clone to the next request.
 func runMergeGit(ctx context.Context, dir, token string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, mergeGitTimeout)
 	defer cancel()
-	full := append(mergeGitAuthArgs(token), args...)
+	full := gitlib.NoAutoMaintenance(append(mergeGitAuthArgs(token), args...)...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	if dir != "" {
 		cmd.Dir = dir

--- a/pkg/server/cloudpublisher/plugin_source_quarantine_test.go
+++ b/pkg/server/cloudpublisher/plugin_source_quarantine_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/pluginsource"
 	"github.com/SocialGouv/iterion/pkg/queue"
@@ -65,9 +66,13 @@ func TestSubmitLaunch_BrokenPluginSourceIsSkippedNotFatal(t *testing.T) {
 		t.Skip("git not available")
 	}
 	origin := t.TempDir()
+	// NoAutoMaintenance: `git commit` below otherwise detaches a
+	// `git maintenance run --auto` that writes under this origin's
+	// `.git/objects` after the command returned — into a directory
+	// t.TempDir()'s cleanup is about to remove.
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 		cmd.Dir = origin
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")

--- a/pkg/server/plugin_sources_routes_test.go
+++ b/pkg/server/plugin_sources_routes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/identity"
 	"github.com/SocialGouv/iterion/pkg/pluginsource"
 )
@@ -30,7 +31,7 @@ const fixedPluginManifest = "name: deploy-onyxia\nversion: 0.1.1\ndescription: \
 
 func gitRunIn(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := exec.Command("git", gitlib.NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")


### PR DESCRIPTION
Refs #828 (item 1 — the runner site; item 2, the test-helper sweep, stays open for after today's merges).

Since git 2.48 every writing command spawns `git maintenance run --auto --detach`, which daemonizes and keeps writing under `.git/objects` after the command returned (the mechanism measured in #821 / PR #827). The runner's three `git fetch` invocations run into `<WorkDir>/repos/<RunID>`, a directory the runner `os.RemoveAll`s at the end of the attempt — a detached maintenance process can make that removal fail or resurrect objects under a half-removed tree, and the fetch's `FetchTimeout` bounds nothing that escaped it.

## The fix
The guard goes on `runGitOutEnv` (`pkg/runner/loop_gitws.go`), the ONLY `exec.Command*("git"` in `pkg/runner`'s production code (grep-verified), now `exec.CommandContext(ctx, "git", gitlib.NoAutoMaintenance(args...)...)` — one chokepoint covering the three fetches and any writing command added later, instead of three copies that would drift. A present-tense comment states why the function's return is the end of the command.

The branch carries PR #827's commit (cherry-picked whole, byte-identical) because `origin/main` does not yet have `gitlib.NoAutoMaintenance`; the queue's rebase drops the duplicate once #827 lands — the diff against main after that is the single commit on `loop_gitws.go` + its test.

## Red then green
`TestRunnerGitRunsWithoutAutoMaintenance` drives the two bank-family fetch paths for real (`bankSupersedes`, `preserveSupersededChain`) against a real bare origin + clone, with a PATH shim recording argv and exec'ing the real git. Red with the fix reverted: `gitws_no_auto_maintenance_test.go:77: git invocation may spawn a detached maintenance process that outlives the command: "fetch origin 745470f2…"` (both fetches + both `merge-base`). Green with it. The anti-vacuity guard counts fetches with `slices.Contains(strings.Fields(argv), "fetch")` — a first version using `strings.Contains(argv, " fetch ")` matched 0 in the unfixed state (the leading space only exists once the `-c` prefix is there), i.e. it was vouched for by the fix it guarded; corrected and re-verified red. The third fetch (`prepareRepoWorkspace`) needs a public forge host and rides the same chokepoint.

`go build ./...` · `go test ./pkg/runner/... ./pkg/git/...` ok · `task lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
