### PR TITLE
fix(server): a live 401 marks the connection revoked; only a forge that answered "no" earns the vouch

### DIFF
--- a/docs/brand.md
+++ b/docs/brand.md
@@ -56,8 +56,8 @@ Apply state on a connection: `account_kind`, `avatar_applied_at`, `avatar_error`
 (`GET /api/teams/{id}/forge/connections`). The action:
 `POST /api/teams/{id}/forge/connections/{conn_id}/avatar` `{variant?: plain|circle, force?}`
 — 422 with `logo_url` + `logo_circle_url` on GitHub (plus `manage_url` when
-the App is one iterion created), 422 on a revoked connection (reconnect
-first), 409 `needs_force` on an account the forge does not flag as a bot —
+the App is one iterion created), 422 on a revoked connection or a token the
+forge rejects at apply time (reconnect first), 409 `needs_force` on an account the forge does not flag as a bot —
 or would not describe at all (a token without the scope): iterion cannot
 vouch, the operator can — 502 with the forge's reason when the upload is
 refused. Audit event on both the automatic and

--- a/docs/brand.md
+++ b/docs/brand.md
@@ -56,11 +56,14 @@ Apply state on a connection: `account_kind`, `avatar_applied_at`, `avatar_error`
 (`GET /api/teams/{id}/forge/connections`). The action:
 `POST /api/teams/{id}/forge/connections/{conn_id}/avatar` `{variant?: plain|circle, force?}`
 — 422 with `logo_url` + `logo_circle_url` on GitHub (plus `manage_url` when
-the App is one iterion created), 422 on a revoked connection or a token the
-forge rejects at apply time (reconnect first), 409 `needs_force` on an account the forge does not flag as a bot —
-or would not describe at all (a token without the scope): iterion cannot
-vouch, the operator can — 502 with the forge's reason when the upload is
-refused. Audit event on both the automatic and
+the App is one iterion created); 422 on a revoked connection, or on a token
+the forge rejects at apply time (the connection is marked `revoked` with the
+reason — reconnect first); 409 `needs_force` on an account the forge does
+not flag as a bot, or would not describe at all (a token without the scope):
+iterion cannot vouch, the operator can; 502 when the forge did not answer
+the identity read (unreachable, timeout, 5xx, no user endpoint at that base
+URL — no upload was attempted) or when it refused the upload — the message
+says which. Audit event on both the automatic and
 the explicit path: `forge.connection.avatar_applied` (`automatic: true` at
 connect time).
 

--- a/docs/cloud-rest-api.md
+++ b/docs/cloud-rest-api.md
@@ -205,7 +205,7 @@ requires membership. Sources:
 | `DELETE` | `/api/teams/{id}/forge/connections/{conn_id}` | team admin | Remove a connection |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/health` | team member | Connection health / token probe |
 | `POST` | `/api/teams/{id}/forge/connections/{conn_id}/refresh` | team member | GitHub App only: re-probe live installation grants, persist them, and force a fresh token mint |
-| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person), on GitHub (no API — names the App's settings page) and on a token the forge rejects (reconnect first), 409 `needs_force` on an account the forge does not flag as a bot, or would not describe at all. See [brand.md](brand.md) |
+| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person), on GitHub (no API — names the App's settings page) and on a token the forge rejects (the connection is marked `revoked`; reconnect first), 409 `needs_force` on an account the forge does not flag as a bot or would not describe at all, 502 when the forge did not answer the identity read or refused the upload. See [brand.md](brand.md) |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/repos` | team member | Repos visible to the connection |
 | `GET` | `/api/teams/{id}/forge/repos` | team member | Team's forge-linked repos |
 | `POST` | `/api/teams/{id}/forge/repos` | team admin | Create a repo (opt-in `RepoCreator` capability) |

--- a/docs/cloud-rest-api.md
+++ b/docs/cloud-rest-api.md
@@ -205,7 +205,7 @@ requires membership. Sources:
 | `DELETE` | `/api/teams/{id}/forge/connections/{conn_id}` | team admin | Remove a connection |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/health` | team member | Connection health / token probe |
 | `POST` | `/api/teams/{id}/forge/connections/{conn_id}/refresh` | team member | GitHub App only: re-probe live installation grants, persist them, and force a fresh token mint |
-| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person) and GitHub (no API — names the App's settings page), 409 `needs_force` on an account the forge does not flag as a bot, or would not describe at all. See [brand.md](brand.md) |
+| `POST` | `/api/teams/{id}/forge/connections/{conn_id}/avatar` | team admin | Upload the iterion-bot avatar onto the account behind a PAT connection (`{variant?, force?}`); 422 on OAuth (a person), on GitHub (no API — names the App's settings page) and on a token the forge rejects (reconnect first), 409 `needs_force` on an account the forge does not flag as a bot, or would not describe at all. See [brand.md](brand.md) |
 | `GET` | `/api/teams/{id}/forge/connections/{conn_id}/repos` | team member | Repos visible to the connection |
 | `GET` | `/api/teams/{id}/forge/repos` | team member | Team's forge-linked repos |
 | `POST` | `/api/teams/{id}/forge/repos` | team admin | Create a repo (opt-in `RepoCreator` capability) |

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -325,8 +325,9 @@ var (
 	// the studio can prompt for re-auth with broader scope or a PAT.
 	ErrForbidden = errors.New("forge: insufficient scope")
 	// ErrUnauthorized is returned when the credential is rejected outright
-	// (revoked / expired). The refresh worker flips the connection to
-	// StatusRevoked on this.
+	// (revoked / expired). The refresh worker marks a refreshable connection
+	// StatusNeedsReauth on it; an avatar apply meeting it on a PAT — which
+	// nothing else probes — marks the connection StatusRevoked.
 	ErrUnauthorized = errors.New("forge: credential rejected")
 	// ErrPermissionsNotGranted is returned when minting a GitHub-App
 	// installation token fails with a PERMANENT permission mismatch — the

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -110,8 +110,8 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("connection kind %q cannot carry an avatar", conn.Kind)}
 	case conn.Status == forge.StatusRevoked:
-		// A dead credential would come back as a 401 recorded on AvatarError,
-		// dressing a reconnect problem as an avatar one.
+		// The forge already rejected this token (a live 401 met by an apply
+		// below): a reconnect problem, never an avatar one.
 		return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 			msg: fmt.Sprintf("%s rejected this connection's token (status %s) — reconnect it first", conn.Host(), conn.Status)}
 	}
@@ -163,13 +163,29 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		switch {
 		case err == nil:
 			conn.AccountKind, learned = ident.Kind, ident.Kind
+		case ctx.Err() != nil:
+			// The apply's budget is spent, whatever the forge managed to send:
+			// the upload would only fail on the dead context and stamp a
+			// misleading reason on the connection.
+			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
 		case errors.Is(err, forge.ErrUnauthorized):
-			// The credential itself is rejected: the reconnect problem the
-			// revoked-status rung above catches once the health probe has
-			// seen it. No force can carry an upload the forge would refuse
-			// the same way.
+			// The credential itself is rejected. Nothing else probes a PAT,
+			// so this is where the connection learns it: mark it revoked so
+			// the card and every later apply say so, and refuse — no force
+			// can carry an upload the forge would refuse the same way.
+			if updated, rerr := record(func(c *forge.Connection) {
+				c.Status, c.StatusReason = forge.StatusRevoked, "the forge rejected the token on an avatar apply (HTTP 401)"
+			}); rerr == nil {
+				conn = updated
+			} else if s.logger != nil {
+				s.logger.Error("forge avatar: mark connection %s revoked: %v", conn.ID, rerr)
+			}
 			return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 				msg: fmt.Sprintf("%s rejected this connection's token — reconnect it first", conn.Host())}
+		case errors.Is(err, forge.ErrHookNotFound):
+			// StatusErr maps every 404 onto the hook sentinel; here the user
+			// endpoint is what is missing, i.e. the base URL is wrong.
+			return conn, "", fmt.Errorf("could not read the account behind connection %s: %s does not serve the user endpoint (HTTP 404) — check the forge base URL", conn.ID, conn.Host())
 		case errors.Is(err, forge.ErrForbidden) && force:
 			// The forge answered but would not describe the account: the
 			// operator's word carries the apply, the kind stays unknown.
@@ -183,9 +199,9 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 				msg:    fmt.Sprintf("%s would not say whether @%s is a bot account (%v)%s", conn.Host(), conn.AccountLogin, err, avatarForceHint),
 				fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
 		default:
-			// Not an answer — a spent budget, an unreachable forge, a 5xx:
-			// nothing to vouch for, and the upload would only fail the same
-			// way and stamp a misleading reason on the connection.
+			// Not an answer — an unreachable forge, a 5xx, a body that is not
+			// JSON: nothing to vouch for, and the upload would only fail the
+			// same way and stamp a misleading reason on the connection.
 			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
 		}
 	}

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -163,17 +163,30 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		switch {
 		case err == nil:
 			conn.AccountKind, learned = ident.Kind, ident.Kind
-		case ctx.Err() != nil:
-			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
-		case !force:
-			// The forge would not describe the account (a token without the
-			// scope, a forge without the field): iterion cannot vouch for it,
-			// the operator can — the same rung as an unflagged account, so
-			// every surface offers the forced retry instead of a 502 that
-			// records nothing and repeats on the next attempt.
+		case errors.Is(err, forge.ErrUnauthorized):
+			// The credential itself is rejected: the reconnect problem the
+			// revoked-status rung above catches once the health probe has
+			// seen it. No force can carry an upload the forge would refuse
+			// the same way.
+			return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
+				msg: fmt.Sprintf("%s rejected this connection's token — reconnect it first", conn.Host())}
+		case errors.Is(err, forge.ErrForbidden) && force:
+			// The forge answered but would not describe the account: the
+			// operator's word carries the apply, the kind stays unknown.
+		case errors.Is(err, forge.ErrForbidden):
+			// iterion cannot vouch for an account the forge will not
+			// describe (a token without the scope) — the operator can: the
+			// same rung as an unflagged account, so every surface offers the
+			// forced retry instead of a 502 that records nothing and repeats
+			// on the next attempt.
 			return conn, "", &avatarRefusal{status: http.StatusConflict,
 				msg:    fmt.Sprintf("%s would not say whether @%s is a bot account (%v)%s", conn.Host(), conn.AccountLogin, err, avatarForceHint),
 				fields: map[string]any{"needs_force": true, "account_login": conn.AccountLogin}}
+		default:
+			// Not an answer — a spent budget, an unreachable forge, a 5xx:
+			// nothing to vouch for, and the upload would only fail the same
+			// way and stamp a misleading reason on the connection.
+			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
 		}
 	}
 	if conn.AccountKind != forge.AccountKindBot && !force {

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -603,3 +603,51 @@ func TestForgeConnectionAvatar_UnreadableAccountAsksForTheWord(t *testing.T) {
 		t.Fatalf("the operator's word carries the apply: code=%d uploads=%d body=%s", w.Code, uploads, w.Body.String())
 	}
 }
+
+// A token the forge rejects outright is a reconnect problem, whatever the
+// connection's recorded status says: no vouch is offered, no force carries
+// it, and nothing lands on the record.
+func TestForgeConnectionAvatar_RejectedCredentialIsAReconnectProblem(t *testing.T) {
+	s := newForgeTestServer(t)
+	uploads := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) })
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		uploads++
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-dead-token", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL}) // AccountKind empty, status still active
+	for _, body := range []string{"", `{"force":true}`} {
+		w := avatarReq(s, "c-dead-token", body)
+		if w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "reconnect it first") || strings.Contains(w.Body.String(), "needs_force") {
+			t.Fatalf("body %q: code=%d body=%s", body, w.Code, w.Body.String())
+		}
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-dead-token")
+	if uploads != 0 || stored.AccountKind != "" || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("a rejected credential must upload and record nothing: uploads=%d stored=%+v", uploads, stored)
+	}
+}
+
+// A forge that does not answer at all is not a vouch matter either: the
+// unforced apply is a plain failure naming the identity, never a 409 that
+// would invite the operator to vouch for an upload that cannot land.
+func TestForgeConnectionAvatar_UnreachableForgeIsNotAVouchMatter(t *testing.T) {
+	s := newForgeTestServer(t)
+	gone := httptest.NewServer(http.NotFoundHandler())
+	url := gone.URL
+	gone.Close() // connection refused from here on
+	seedAvatarConn(t, s, forge.Connection{ID: "c-unreachable", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: url})
+	for _, body := range []string{"", `{"force":true}`} {
+		w := avatarReq(s, "c-unreachable", body)
+		if w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "could not read the account") {
+			t.Fatalf("body %q: code=%d body=%s", body, w.Code, w.Body.String())
+		}
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-unreachable")
+	if stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("an unreachable forge must record nothing: %+v", stored)
+	}
+}

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -606,12 +606,13 @@ func TestForgeConnectionAvatar_UnreadableAccountAsksForTheWord(t *testing.T) {
 
 // A token the forge rejects outright is a reconnect problem, whatever the
 // connection's recorded status says: no vouch is offered, no force carries
-// it, and nothing lands on the record.
+// it, and the connection — which nothing else probes — is marked revoked
+// with the reason, so the card says so and the next apply refuses up front.
 func TestForgeConnectionAvatar_RejectedCredentialIsAReconnectProblem(t *testing.T) {
 	s := newForgeTestServer(t)
-	uploads := 0
+	uploads, whoami := 0, 0
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) })
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) { whoami++; w.WriteHeader(http.StatusUnauthorized) })
 	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
 		uploads++
 		w.WriteHeader(http.StatusUnauthorized)
@@ -619,15 +620,52 @@ func TestForgeConnectionAvatar_RejectedCredentialIsAReconnectProblem(t *testing.
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	seedAvatarConn(t, s, forge.Connection{ID: "c-dead-token", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL}) // AccountKind empty, status still active
+	w := avatarReq(s, "c-dead-token", "")
+	if w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "reconnect it first") || strings.Contains(w.Body.String(), "needs_force") {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-dead-token")
+	if stored.Status != forge.StatusRevoked || !strings.Contains(stored.StatusReason, "401") {
+		t.Fatalf("a live 401 must mark the connection revoked with the reason: status=%q reason=%q", stored.Status, stored.StatusReason)
+	}
+	if uploads != 0 || stored.AccountKind != "" || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("a rejected credential must upload nothing and touch no avatar field: uploads=%d stored=%+v", uploads, stored)
+	}
+	// Forced or not, the next apply is refused before the forge is asked.
+	if w := avatarReq(s, "c-dead-token", `{"force":true}`); w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "reconnect it first") || whoami != 1 || uploads != 0 {
+		t.Fatalf("forced apply on a revoked connection: code=%d whoami=%d uploads=%d body=%s", w.Code, whoami, uploads, w.Body.String())
+	}
+}
+
+// A forge that sends its refusal's headers and then stalls has spent the
+// apply's budget: that outranks the answer it managed to send — no 409 to
+// vouch into, no forced upload on a dead context.
+func TestForgeConnectionAvatar_SpentBudgetOutranksTheForgesAnswer(t *testing.T) {
+	s := newForgeTestServer(t)
+	uploads := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done() // the body never completes
+	})
+	mux.HandleFunc("PUT /api/v4/user/avatar", func(w http.ResponseWriter, r *http.Request) {
+		uploads++
+		_ = json.NewEncoder(w).Encode(map[string]any{"avatar_url": "https://gl/u.png"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-stalled-403", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL})
+	s.avatarApplyTimeout = 200 * time.Millisecond
 	for _, body := range []string{"", `{"force":true}`} {
-		w := avatarReq(s, "c-dead-token", body)
-		if w.Code != http.StatusUnprocessableEntity || !strings.Contains(w.Body.String(), "reconnect it first") || strings.Contains(w.Body.String(), "needs_force") {
+		w := avatarReq(s, "c-stalled-403", body)
+		if w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "could not read the account") {
 			t.Fatalf("body %q: code=%d body=%s", body, w.Code, w.Body.String())
 		}
 	}
-	stored, _ := s.forgeConnections.Get(context.Background(), "c-dead-token")
-	if uploads != 0 || stored.AccountKind != "" || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
-		t.Fatalf("a rejected credential must upload and record nothing: uploads=%d stored=%+v", uploads, stored)
+	stored, _ := s.forgeConnections.Get(context.Background(), "c-stalled-403")
+	if uploads != 0 || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
+		t.Fatalf("uploaded on a dead context or recorded a misleading reason: uploads=%d stored=%+v", uploads, stored)
 	}
 }
 
@@ -649,5 +687,13 @@ func TestForgeConnectionAvatar_UnreachableForgeIsNotAVouchMatter(t *testing.T) {
 	stored, _ := s.forgeConnections.Get(context.Background(), "c-unreachable")
 	if stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
 		t.Fatalf("an unreachable forge must record nothing: %+v", stored)
+	}
+	// A forge that answers 404 to /user is a wrong base URL, and says so —
+	// not the hook sentinel StatusErr maps every 404 onto.
+	noUser := httptest.NewServer(http.NotFoundHandler())
+	defer noUser.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-wrong-base", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: noUser.URL})
+	if w := avatarReq(s, "c-wrong-base", ""); w.Code != http.StatusBadGateway || !strings.Contains(w.Body.String(), "does not serve the user endpoint") || strings.Contains(w.Body.String(), "hook") {
+		t.Fatalf("404 on /user: code=%d body=%s", w.Code, w.Body.String())
 	}
 }

--- a/studio/src/api/client.ts
+++ b/studio/src/api/client.ts
@@ -44,12 +44,22 @@ function tryRefreshSession(): Promise<boolean> {
 export class ApiError extends Error {
   status: number;
   errorCode?: string;
-  constructor(status: number, message: string, errorCode?: string) {
+  // The server's own message, without the "API error <status>: " prefix the
+  // transport puts on `message` — for a surface that quotes the reason.
+  detail?: string;
+  constructor(status: number, message: string, errorCode?: string, detail?: string) {
     super(message);
     this.status = status;
     this.errorCode = errorCode;
+    this.detail = detail;
     this.name = "ApiError";
   }
+}
+
+// apiErrorFrom is the error every non-2xx response throws. Exported so a test
+// can hand a caller the exact shape production produces, prefix included.
+export function apiErrorFrom(status: number, detail: ExtractedErrorDetail): ApiError {
+  return new ApiError(status, `API error ${status}: ${detail.message}`, detail.errorCode, detail.message);
 }
 
 // is404 reports whether a thrown value represents an HTTP 404. Prefers
@@ -142,12 +152,7 @@ export async function apiRequest<T>(
     onUnauthorized();
   }
   if (!res.ok) {
-    const detail = await extractErrorDetail(res);
-    throw new ApiError(
-      res.status,
-      `API error ${res.status}: ${detail.message}`,
-      detail.errorCode,
-    );
+    throw apiErrorFrom(res.status, await extractErrorDetail(res));
   }
   // 204 No Content (e.g. DELETE endpoints) has an empty body. Don't
   // try to parse it — return undefined and let the typed caller cast.

--- a/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
+++ b/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/api/bots", async () => {
   return { ...actual, listBots: vi.fn(async () => []) };
 });
 
-import { ApiError, apiErrorFrom } from "@/api/client";
+import { apiErrorFrom } from "@/api/client";
 import * as forgeApi from "@/api/forgeConnections";
 import IntegrationsTab from "../IntegrationsTab";
 
@@ -136,12 +136,13 @@ describe("ConnectionCard — iterion-bot avatar", () => {
   it("refetches AND keeps the reason when the apply fails", async () => {
     vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: "bot" })]);
     vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
-      new ApiError(502, "gitlab: avatar rejected (HTTP 400): boom"),
+      apiErrorFrom(502, { message: "gitlab: avatar rejected (HTTP 400): boom" }),
     );
     renderTab();
     const before = vi.mocked(forgeApi.listForgeConnections).mock.calls.length;
     fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
-    await screen.findByText(/avatar rejected \(HTTP 400\): boom/);
+    await screen.findByText(/^gitlab: avatar rejected \(HTTP 400\): boom$/);
+    expect(screen.queryByText(/API error/)).toBeNull();
     await waitFor(() =>
       expect(vi.mocked(forgeApi.listForgeConnections).mock.calls.length).toBeGreaterThan(before),
     );

--- a/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
+++ b/studio/src/views/teams/tabs/__tests__/IntegrationsTab.oauthApps.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/api/bots", async () => {
   return { ...actual, listBots: vi.fn(async () => []) };
 });
 
-import { ApiError } from "@/api/client";
+import { ApiError, apiErrorFrom } from "@/api/client";
 import * as forgeApi from "@/api/forgeConnections";
 import IntegrationsTab from "../IntegrationsTab";
 
@@ -150,7 +150,10 @@ describe("ConnectionCard — iterion-bot avatar", () => {
   it("tries an account of unknown kind as-is, and vouches only on a 409", async () => {
     vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: undefined })]);
     vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
-      new ApiError(409, "gitlab.example.com does not flag @group_1_bot_x as a bot account"),
+      apiErrorFrom(409, {
+        message:
+          "gitlab.example.com does not flag @group_1_bot_x as a bot account; if it is a dedicated account for iterion (not a person's), apply with force",
+      }),
     );
     renderTab();
     fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
@@ -167,15 +170,19 @@ describe("ConnectionCard — iterion-bot avatar", () => {
   it("offers the vouch when the forge would not describe the account, naming the reason", async () => {
     vi.mocked(forgeApi.listForgeConnections).mockResolvedValue([conn({ account_kind: undefined })]);
     vi.mocked(forgeApi.applyForgeConnectionAvatar).mockRejectedValueOnce(
-      new ApiError(
-        409,
-        "gitlab.example.com would not say whether @group_1_bot_x is a bot account (gitlab: HTTP 403); if it is a dedicated account for iterion (not a person's), apply with force",
-      ),
+      apiErrorFrom(409, {
+        message:
+          "gitlab.example.com would not say whether @group_1_bot_x is a bot account (forge: insufficient scope); if it is a dedicated account for iterion (not a person's), apply with force",
+      }),
     );
     renderTab();
     fireEvent.click(await screen.findByRole("button", { name: "Apply iterion-bot avatar" }));
-    // The dialog carries the forge's own answer, and is the forced retry itself.
-    await screen.findByText(/would not say whether @group_1_bot_x is a bot account \(gitlab: HTTP 403\)\./);
+    // The dialog carries the forge's own answer — without the transport's
+    // "API error 409:" prefix or the CLI wording — and is the forced retry.
+    await screen.findByText(
+      /^gitlab.example.com would not say whether @group_1_bot_x is a bot account \(forge: insufficient scope\)\./,
+    );
+    expect(screen.queryByText(/API error/)).toBeNull();
     expect(screen.queryByText(/apply with force/)).toBeNull();
     fireEvent.click(await screen.findByRole("button", { name: "Apply the avatar" }));
     await waitFor(() =>

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -265,7 +265,8 @@ function AvatarRow({
   // this order.
   const fail = (e: unknown) => {
     onChanged();
-    onError(errorMessage(e));
+    // The banner quotes the server's reason, not the transport's prefix.
+    onError(e instanceof ApiError && e.detail ? e.detail : errorMessage(e));
   };
   const apply = async () => {
     // A known non-bot account needs the operator's word up front. An account

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -257,7 +257,8 @@ function AvatarRow({
     });
   // A 409 reads "<why iterion cannot vouch>; if it is a dedicated account …,
   // apply with force": the dialog shows the why and is the force itself.
-  const refusalReason = (e: ApiError) => e.message.replace(/;\s*if it is a dedicated account.*$/, "");
+  const refusalReason = (e: ApiError) =>
+    (e.detail ?? e.message).replace(/;\s*if it is a dedicated account.*$/, "");
   // A refusal still taught the server something (the account's kind, a forge
   // error kept on the record): refetch, then show the reason. onChanged clears
   // the banner synchronously and onError re-sets it in the same batch — keep


### PR DESCRIPTION
Follow-up to #808 — its two medium findings (`Re2e5af`, `R65ef34`), plus five defects an adversarial pass found on the fix's own lines before this PR was opened.

**R65ef34 — a failed WhoAmI now takes three shapes instead of one.** A credential the forge rejects outright (`forge.ErrUnauthorized`) is a reconnect problem: a 422, forced or not, because no force can carry an upload the forge would refuse the same way. A forge that answered but would not describe the account (`forge.ErrForbidden`) is the one case the operator can vouch for: a 409 unforced, tolerated under force. Anything else — a spent budget, an unreachable forge, a 5xx, a non-JSON body — is not an answer: a plain 502 naming the identity, never an invitation to vouch for an upload that cannot land.

**Re2e5af — the vouch dialog quoted the transport, not the server.** `ApiError.message` carries the `API error <status>:` prefix; the server's own message now travels on `ApiError.detail`, built at the one choke point every non-2xx response goes through (`apiErrorFrom`, exported), and the studio tests hand the card that exact shape. The card's failure banner quotes `detail` too.

**From the adversarial pass.**
- The pre-existing "revoked" rung read a status *nothing in production wrote* (the refresh worker writes `needs_reauth`, and a PAT is never refreshed). A live 401 met by an apply now records `StatusRevoked` with the reason, so the card shows it and the next apply refuses up front — the 422 alone had removed the only durable trace a dead PAT used to leave.
- The `ctx.Err()` guard is back at the head of the switch: a forge that sends a 403 and then stalls has spent the budget, and that outranks the answer it managed to send (no 409 to vouch into, no forced upload on a dead context).
- A 404 on `/user` names the wrong base URL instead of the hook sentinel `StatusErr` maps every 404 onto.
- The docs describe the two 502s an operator can now meet (identity read vs. upload).

**Tests.** `RejectedCredentialIsAReconnectProblem` (401 → 422, status revoked + reason persisted, no upload, the forced retry refused before the forge is asked), `SpentBudgetOutranksTheForgesAnswer` (403 headers then a stalled body under a 200 ms budget → 502 both ways, nothing uploaded or recorded), `UnreachableForgeIsNotAVouchMatter` (connection refused → 502 both ways; 404 → "does not serve the user endpoint"), `UnreadableAccountAsksForTheWord` unchanged. Studio: the three avatar-error specs build their errors through `apiErrorFrom` and assert no transport prefix reaches the dialog or the banner.

Evidence: `pkg/server` + `pkg/cli` + `pkg/forge/...` suites, `golangci-lint` (0 issues) and `task studio:check` (1332 tests) green on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)