### PR TITLE
fix(sandbox): a sandboxed claw node relays its tools, retries and turns

### DIFF
--- a/cmd/iterion/claw_runner.go
+++ b/cmd/iterion/claw_runner.go
@@ -161,9 +161,9 @@ func runClawRunner(ctx context.Context, stdin io.Reader, stdout, stderr io.Write
 	// client from the standard ITERION_*_KEY env vars, which the
 	// sandbox driver inherits from the host (subject to the env
 	// scrubbing the engine applies before container start). Its event
-	// hooks relay the per-step LLM observations to the launcher, which
-	// re-fires them through its own hooks — what meters a sandboxed claw
-	// node like an in-process one.
+	// hooks relay what this loop observes to the launcher, which re-fires
+	// them through its own hooks — what makes a sandboxed claw node
+	// metered, auditable and forkable like an in-process one.
 	registry := model.NewRegistry()
 	backend := model.NewClawBackend(registry, relayEventHooks(dispatcher, stderr), model.RetryPolicy{})
 
@@ -195,10 +195,12 @@ func runClawRunner(ctx context.Context, stdin io.Reader, stdout, stderr io.Write
 }
 
 // relayEventHooks builds the event hooks the runner installs on its claw
-// backend: llm_request and llm_step_finished cross the IPC as `event`
-// envelopes on the dispatcher's writer (see [model.SandboxRelayHooks]). A
-// failed write is reported on stderr, which the launcher captures into the
-// node's error when the channel is dead.
+// backend: every observation of the in-container loop — its LLM steps,
+// the tools it executes here, its retries and compactions, its per-turn
+// fork anchors — crosses the IPC as an `event` envelope on the
+// dispatcher's writer (see [model.SandboxRelayHooks]). A failed write is
+// reported on stderr, which the launcher captures into the node's error
+// when the channel is dead.
 func relayEventHooks(d *proxyDispatcher, stderr io.Writer) model.EventHooks {
 	return model.SandboxRelayHooks(d.write, func(err error) {
 		fmt.Fprintf(stderr, "iterion-claw-runner: %v\n", err)

--- a/cmd/iterion/claw_runner_relay_test.go
+++ b/cmd/iterion/claw_runner_relay_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+)
+
+// TestClawRunner_RelayHooksCarryTheContainersToolAndLoopEvents (#811):
+// the in-container backend executes its builtins, its retries and its
+// compaction itself, so the hooks the runner installs must carry them —
+// otherwise the launcher's timeline shows LLM steps and nothing else,
+// and `iterion fork --turn` has no anchor for the node.
+func TestClawRunner_RelayHooksCarryTheContainersToolAndLoopEvents(t *testing.T) {
+	runnerStdinR, _ := io.Pipe()
+	runnerStdoutR, runnerStdoutW := io.Pipe()
+	defer runnerStdinR.Close()
+
+	var stderr strings.Builder
+	hooks := relayEventHooks(newProxyDispatcher(runnerStdinR, runnerStdoutW), &stderr)
+	for name, wired := range map[string]bool{
+		"tool_started":     hooks.OnToolStarted != nil,
+		"tool_called":      hooks.OnToolCall != nil,
+		"llm_retry":        hooks.OnLLMRetry != nil,
+		"llm_compacted":    hooks.OnLLMCompacted != nil,
+		"llm_turn_capture": hooks.OnLLMTurnCapture != nil,
+	} {
+		if !wired {
+			t.Fatalf("the runner's claw backend has no %s hook: that observation dies in the container", name)
+		}
+	}
+
+	go func() {
+		hooks.OnToolStarted("campaign", model.LLMToolStartedInfo{
+			ToolName: "bash", ToolUseID: "tu_1", InputSize: 12, Input: json.RawMessage(`{"command":"ls"}`),
+		})
+		hooks.OnToolCall("campaign", model.LLMToolCallInfo{
+			ToolName: "bash", ToolUseID: "tu_1", Output: "main.go\n",
+		})
+		hooks.OnLLMRetry("campaign", model.RetryInfo{Attempt: 1, Error: errors.New("429"), StatusCode: 429})
+		hooks.OnLLMCompacted("campaign", model.LLMCompactInfo{BeforeMessages: 40, AfterMessages: 8})
+		hooks.OnLLMTurnCapture("campaign", model.LLMTurnCaptureInfo{Step: 1, FinishReason: "tool_use"})
+		_ = runnerStdoutW.Close()
+	}()
+
+	reader := delegate.NewEnvelopeReader(runnerStdoutR)
+	var got []string
+	for {
+		env, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read envelope: %v", err)
+		}
+		if env.Type != delegate.EnvelopeEvent {
+			t.Fatalf("envelope type = %q, want %q", env.Type, delegate.EnvelopeEvent)
+		}
+		var ed delegate.EventData
+		if err := json.Unmarshal(env.Data, &ed); err != nil {
+			t.Fatalf("decode event data: %v", err)
+		}
+		got = append(got, ed.Type)
+	}
+	want := []string{"tool_started", "tool_called", "llm_retry", "llm_compacted", "llm_turn_capture"}
+	if len(got) != len(want) {
+		t.Fatalf("relayed events = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("relayed events = %v, want %v", got, want)
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want nothing on a healthy channel", stderr.String())
+	}
+}

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -637,9 +637,60 @@ across the channel.
   with the steps relayed, the delegation total is a summary and is not
   counted again — see [quotas-and-limits.md](quotas-and-limits.md#per-credential-usage--what-did-this-key-cost)
   for what a run whose container carries an older, non-relaying runner
-  is charged. Not relayed: `tool_started` / `tool_called` for the
-  builtins executed inside the container, `llm_retry`, and the per-turn
-  `llm_turn_capture` checkpoints — those stay in the container.
+  is charged.
+- ✅ **Tool, retry, compaction and turn observability.** The same relay
+  carries everything else the in-container loop observes, so a sandboxed
+  claw node is not a blind spot on any consumer:
+  `tool_started` / `tool_called` for the builtins it executes **inside**
+  the container (tool name, correlation id, input, result, duration —
+  and, for a failed call, `tool_error` carrying the reason, which is what
+  makes an in-container permission denial auditable); `llm_retry`
+  (including the context-window force-compaction recovery, which the
+  in-process path also reports as a retry); `llm_compacted`; and the
+  per-turn `llm_turn_capture` checkpoints, so the studio timeline and
+  `iterion fork --turn` anchor on a sandboxed node exactly as on an
+  in-process one. Every one of them re-fires the launcher's own hooks, so
+  the studio timeline, the `EventObservers` a supervisor's `tool_*`
+  monitors ride, and the permission audit see what the in-process path
+  produces.
+
+  Two properties of that channel are worth knowing:
+
+  - **Nothing is dropped in silence.** A relayed NDJSON line over
+    `delegate.MaxEnvelopeLineBytes` (4 MiB) would fail the launcher's
+    reader and with it the whole IPC, so the relay cuts *before* it
+    writes, always visibly: a text field over 1 MiB (a tool result, an
+    assistant text) is truncated with a marker naming the byte count that
+    stayed in the container, and a JSON field over it (a `write_file`
+    input) is replaced by a `{"_iterion_sandbox_relay_omitted_bytes":N}`
+    marker — a document cut mid-way would not be JSON the host can
+    decode. `input_size` keeps the size the container measured, so the
+    honest number always travels beside the cut. An event whose fields
+    are each in budget but whose SUM is not (a step dispatching six large
+    `write_file` calls at once) keeps its **numbers** and loses its bulk,
+    every cut marked — the token counts are what the run is metered on. A
+    payload still over the cap after that (thousands of short strings,
+    nothing left to cut) is refused and reported on the runner's stderr,
+    which the launcher folds into the node's error: one lost
+    observation, never a dead channel, and never a silent one.
+  - **A turn's conversation crosses whole or not at all.** The snapshot a
+    fork replays is relayed up to 2 MiB (a full 200k-token context, with
+    room under the line cap); a larger one is left out and the turn
+    crosses carrying its size, which the launcher logs as a warning
+    naming the node and the turn. The turn still anchors the timeline; a
+    fork from it starts that node fresh. It crosses on the wire rather
+    than being written to a run directory the host reads back because
+    there is no such directory to rely on: the kubernetes driver refuses
+    `host_state: auto` (no host filesystem in a pod), `host_state: none`
+    is the recommended posture for a multi-tenant runner, a store nested
+    in the workspace is skipped by the host-state bind, and a cloud run's
+    store is Mongo + S3, which no bind-mount reaches.
+
+  One observation of the in-container loop deliberately stays there:
+  `OnLLMResponse` (per-call latency). The host's own store hooks leave
+  that callback nil — the same numbers reach `llm_step_finished` with
+  per-step detail — so relaying it would fire nothing; its single
+  optional consumer is the `--metrics` Prometheus latency histogram.
 
 ### MCP tools in a sandbox
 

--- a/pkg/backend/delegate/envelope.go
+++ b/pkg/backend/delegate/envelope.go
@@ -161,11 +161,14 @@ type AskUserAnswerData struct {
 }
 
 // EventData is the payload of an [EnvelopeEvent]. The runner forwards
-// observability events that belong in the run's events.jsonl — its
-// per-step LLM observations, `llm_request` and `llm_step_finished`, whose
-// payloads are the wire forms defined beside model.SandboxRelayHooks — and
-// the launcher re-fires them through its own event hooks, so they are
-// persisted, priced and metered exactly like an in-process node's.
+// what its own loop observes and the launcher otherwise could not see:
+// the per-step LLM observations (`llm_request`, `llm_step_finished`), the
+// tools it executes inside the container (`tool_started`, `tool_called`),
+// its `llm_retry` and `llm_compacted` rounds, and its per-turn
+// `llm_turn_capture` anchors — each payload a wire form defined beside
+// model.SandboxRelayHooks. The launcher re-fires them through its own
+// event hooks, so they are persisted, priced and metered exactly like an
+// in-process node's.
 type EventData struct {
 	Type    string         `json:"type"`
 	Payload map[string]any `json:"payload,omitempty"`

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1323,10 +1323,11 @@ func (b *ClawBackend) multiplexerHandler(ctx context.Context, task delegate.Task
 			_ = hostStore.SaveSnapshot(hostRunID, task.NodeID, snapshot)
 		},
 		OnEvent: func(eventType string, payload map[string]any) {
-			// The runner's per-step LLM observations (llm_request,
-			// llm_step_finished), re-fired through THIS process's hooks so
-			// a sandboxed claw node is persisted, priced and metered like
-			// an in-process one — see sandbox_relay.go.
+			// What the in-container loop observed — its LLM steps, the
+			// tools it ran, its retries and compactions, its per-turn
+			// anchors — re-fired through THIS process's hooks so a
+			// sandboxed claw node is persisted, priced, metered and
+			// forkable like an in-process one — see sandbox_relay.go.
 			handled, err := ApplyRelayedEvent(b.hooks, task.NodeID, eventType, payload)
 			if b.logger == nil {
 				return

--- a/pkg/backend/model/events.go
+++ b/pkg/backend/model/events.go
@@ -207,6 +207,13 @@ type LLMTurnCaptureInfo struct {
 	// passes it to `claude --resume <id> --fork-session` for the
 	// claude_code rehydration path.
 	SessionID string
+	// ConversationOmittedBytes is non-zero when the turn crossed the
+	// sandbox IPC without its snapshot, the snapshot being larger than
+	// one relayed line may carry (relayConversationBudget): the turn is
+	// still an anchor for the timeline, but a fork from it replays
+	// nothing, and this names how much stayed inside the container.
+	// Always zero on the in-process path.
+	ConversationOmittedBytes int
 	// conversation holds the unmarshalled message slice the runtime
 	// captures for the fork rehydration path. Kept unexported so
 	// observers must call MarshalConversation to materialise the JSON

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -763,6 +763,13 @@ func (h *storeHooks) onLLMTurnCapture(nodeID string, info LLMTurnCaptureInfo) {
 		// user + every tool result) and feeds the Fork API — scrub
 		// secrets before it lands on disk.
 		turn.Messages = h.guard.RedactBytes(conv)
+	} else if info.ConversationOmittedBytes > 0 {
+		// A sandboxed node whose snapshot was too large for one IPC
+		// line: the turn anchors the timeline, a fork from it starts
+		// the node fresh. Said here, where the size is known, rather
+		// than discovered as an empty conversation at fork time.
+		h.logger.Warn("turn capture [%s] step %d: the sandbox runner could not relay the %d-byte conversation — this turn anchors the timeline, but forking from it replays no conversation",
+			nodeID, info.Step, info.ConversationOmittedBytes)
 	}
 	if err := h.turnSink.WriteTurn(h.ctx, turn); err != nil {
 		h.logger.Warn("turn capture [%s] step %d: %v", nodeID, info.Step, err)

--- a/pkg/backend/model/sandbox_relay.go
+++ b/pkg/backend/model/sandbox_relay.go
@@ -2,27 +2,51 @@ package model
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // The sandboxed claw path runs the LLM loop in `iterion __claw-runner`
 // inside the container, a process with no event hooks of its own. Left
-// there, the per-step observations — which model a call went to, what it
-// consumed — never reach the host: the run store carries no llm_request /
-// llm_step_finished for the node, no usage_progress can be derived for a
-// supervisor's cost_gt monitor, and the runner's metering sees the
-// delegation total alone.
+// there, everything that loop observes — which model a call went to, what
+// it consumed, which tools it ran and how they answered, when it retried
+// or compacted, where each turn ended — never reaches the host: the run
+// store carries no llm_request / llm_step_finished / tool_* for the node,
+// no usage_progress can be derived for a supervisor's cost_gt monitor, an
+// in-container permission denial leaves no audit, `iterion fork --turn`
+// has no anchor, and the runner's metering sees the delegation total
+// alone.
 //
 // This file is the relay across that boundary, on the IPC channel the
 // runner already has: the runner installs SandboxRelayHooks, which encode
-// the two hooks as `event` envelopes; the launcher's multiplexer handler
+// each hook as an `event` envelope; the launcher's multiplexer handler
 // decodes them with ApplyRelayedEvent and re-fires its own EventHooks, so a
-// sandboxed claw node produces the same events, log lines and derived usage
-// samples as an in-process one, through the same code.
+// sandboxed claw node produces the same events, turn checkpoints, log lines
+// and derived usage samples as an in-process one, through the same code.
+//
+// One generation callback deliberately does NOT cross: OnLLMResponse.
+// The host's own store hooks leave it nil — per-call latency and usage
+// surface on llm_step_finished with richer detail — so relaying it would
+// fire nothing on the shipped wiring. Its one optional consumer is the
+// `--metrics` Prometheus latency histogram, chained through ExtraHooks.
+//
+// Why the turn SNAPSHOT crosses the wire rather than being written to a
+// run directory the host reads back: there is no run directory the
+// container can rely on. The host-state bind is the only one that could
+// carry `~/.iterion`, and it is absent exactly where the sandbox is
+// mandatory — the kubernetes driver REFUSES host_state=auto (no host
+// filesystem in a pod), `host_state: none` is the recommended posture for
+// a multi-tenant runner, collectHostStateMounts skips a store nested in
+// the workspace, and a cloud run's store is Mongo + S3, which no
+// bind-mount reaches. The IPC is the one channel every driver and every
+// store backend share.
 
 // relayedLLMRequest is the wire form of LLMRequestInfo.
 type relayedLLMRequest struct {
@@ -56,13 +80,199 @@ type relayedToolCall struct {
 	Input json.RawMessage `json:"input,omitempty"`
 }
 
+// relayedToolStarted is the wire form of LLMToolStartedInfo. InputSize is
+// the size the container measured, kept whole even when Input itself is
+// clamped: the studio reads it as "how big was this call".
+type relayedToolStarted struct {
+	ToolName  string          `json:"tool"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	InputSize int             `json:"input_size"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Iteration int             `json:"iteration"`
+}
+
+// relayedToolFinished is the wire form of LLMToolCallInfo. Error crosses
+// as its message — the host rebuilds an error from it, which is what
+// routes the event to tool_error and makes an in-container permission
+// denial auditable. Duration crosses in milliseconds, the only precision
+// the persisted event keeps.
+type relayedToolFinished struct {
+	ToolName   string `json:"tool"`
+	ToolUseID  string `json:"tool_use_id,omitempty"`
+	InputSize  int    `json:"input_size"`
+	Output     string `json:"output,omitempty"`
+	DurationMs int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// relayedRetry is the wire form of RetryInfo.
+type relayedRetry struct {
+	Attempt    int    `json:"attempt"`
+	Error      string `json:"error,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+	DelayMs    int64  `json:"delay_ms"`
+}
+
+// relayedCompact is the wire form of LLMCompactInfo.
+type relayedCompact struct {
+	BeforeMessages      int `json:"before_messages"`
+	AfterMessages       int `json:"after_messages"`
+	RemovedMessageCount int `json:"removed_message_count"`
+	Iteration           int `json:"iteration"`
+}
+
+// relayedTurnCapture is the wire form of LLMTurnCaptureInfo — the
+// fork-from-here anchor. Conversation is the JSON-encoded []api.Message
+// the container's loop had accumulated; when it is over
+// relayConversationBudget it is left out and ConversationOmittedBytes
+// names its size, because half a conversation is not one.
+type relayedTurnCapture struct {
+	Step                     int               `json:"step"`
+	Text                     string            `json:"text,omitempty"`
+	ToolCalls                []relayedToolCall `json:"tool_calls,omitempty"`
+	FinishReason             string            `json:"finish_reason,omitempty"`
+	InputTokens              int               `json:"input_tokens"`
+	OutputTokens             int               `json:"output_tokens"`
+	CacheReadTokens          int               `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens         int               `json:"cache_write_tokens,omitempty"`
+	Iteration                int               `json:"iteration"`
+	Backend                  string            `json:"backend,omitempty"`
+	SessionID                string            `json:"session_id,omitempty"`
+	Conversation             json.RawMessage   `json:"conversation,omitempty"`
+	ConversationOmittedBytes int               `json:"conversation_omitted_bytes,omitempty"`
+}
+
+// relayTurnCaptureType names the turn capture on the wire. Unlike its
+// siblings it is not a store.EventType: a captured turn is persisted as a
+// store.TurnCheckpoint, not appended to events.jsonl — the IPC still
+// needs a name for it, and both sides key on this one.
+const relayTurnCaptureType = "llm_turn_capture"
+
+// A relayed line is one NDJSON line, and the launcher's reader refuses a
+// line over delegate.MaxEnvelopeLineBytes by failing the WHOLE channel
+// (delegate.ErrEnvelopeLineTooLong) — which would turn an observability
+// feature into a run-killer. The container holds payloads no cap bounds:
+// a write_file input, a `go test ./...` output, a full conversation. So
+// the relay cuts before it writes, always visibly:
+//
+//   - a text field over relayFieldBudget is truncated and marked, with
+//     the original size named in the marker;
+//   - a JSON field over it is replaced by a marker OBJECT, since a
+//     document cut mid-way is not JSON the host can decode;
+//   - a conversation over relayConversationBudget is omitted whole and
+//     its size named (relayedTurnCapture.ConversationOmittedBytes);
+//   - an event whose fields are each in budget but whose SUM is not (a
+//     step dispatching six large write_file calls at once) keeps its
+//     numbers and loses its bulk: relayShrinkValue cuts every long
+//     string in the encoded payload, marking each. The token counts are
+//     what the run is metered on — dropping the event would bill the
+//     node wrong;
+//   - anything still over the line cap after that is refused and
+//     REPORTED (stderr → the node's error), never written: one lost
+//     observation beats a dead channel, and neither is silent.
+const (
+	// relayFieldBudget is the ceiling the host's own hooks already apply
+	// to a tool payload they cannot spill to a sidecar blob
+	// (maxFieldSize); several of them still fit under the line cap.
+	relayFieldBudget = maxFieldSize
+	// relayConversationBudget holds a full 200k-token context with room
+	// to spare under the 4 MiB line cap.
+	relayConversationBudget = 2 * 1024 * 1024
+	// relayEnvelopeOverhead covers the `{"type":"event","data":…}\n`
+	// wrapper around the payload when checking the line cap.
+	relayEnvelopeOverhead = 64
+	// relayShrinkFloor is what a string keeps when the whole payload has
+	// to be shrunk to fit one line — enough to recognise the content,
+	// small enough that hundreds of them fit.
+	relayShrinkFloor = 4 * 1024
+)
+
+// relayClampText cuts a text field to relayFieldBudget, marking the cut
+// and naming the original size — a reader must be able to tell a short
+// answer from one the relay could not carry.
+func relayClampText(s string) string {
+	if len(s) <= relayFieldBudget {
+		return s
+	}
+	return fmt.Sprintf("%s [iterion sandbox relay: cut, %d bytes in the container]",
+		iterlog.Truncate(s, relayFieldBudget), len(s))
+}
+
+// relayClampJSON replaces a JSON field over relayFieldBudget with a
+// marker object naming what stayed behind. A tool input is a document the
+// host and the studio parse, so it crosses whole or as this marker —
+// never as a fragment.
+func relayClampJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) <= relayFieldBudget {
+		return raw
+	}
+	return json.RawMessage(fmt.Sprintf(`{"_iterion_sandbox_relay_omitted_bytes":%d}`, len(raw)))
+}
+
+// relayShrinkValue cuts every string past relayShrinkFloor anywhere in an
+// already-encoded payload, marking each cut, and reports whether it
+// changed anything. It works on the DECODED tree, so a nested document
+// (a tool input) stays valid JSON — cutting its raw text would not.
+func relayShrinkValue(v any) (any, bool) {
+	switch t := v.(type) {
+	case string:
+		if len(t) <= relayShrinkFloor {
+			return t, false
+		}
+		return fmt.Sprintf("%s [iterion sandbox relay: dropped to fit one IPC line, %d bytes in the container]",
+			iterlog.Truncate(t, relayShrinkFloor), len(t)), true
+	case map[string]any:
+		shrunk := false
+		for k, val := range t {
+			nv, changed := relayShrinkValue(val)
+			if changed {
+				t[k] = nv
+				shrunk = true
+			}
+		}
+		return t, shrunk
+	case []any:
+		shrunk := false
+		for i, val := range t {
+			nv, changed := relayShrinkValue(val)
+			if changed {
+				t[i] = nv
+				shrunk = true
+			}
+		}
+		return t, shrunk
+	}
+	return v, false
+}
+
+// relayLineSize is the NDJSON line an envelope will occupy.
+func relayLineSize(env delegate.Envelope) int {
+	return len(env.Data) + relayEnvelopeOverhead
+}
+
+// relayClampToolCalls converts a step's tool calls to their wire form,
+// clamping each input. Shared by the step and the turn capture, which
+// carry the same slice.
+func relayClampToolCalls(calls []ToolCallEntry) []relayedToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	out := make([]relayedToolCall, len(calls))
+	for i, tc := range calls {
+		out[i] = relayedToolCall{Name: tc.Name, Input: relayClampJSON(tc.Input)}
+	}
+	return out
+}
+
 // SandboxRelayHooks returns the EventHooks the in-container claw runner
-// installs: OnLLMRequest and OnLLMStepFinish are encoded as `event`
-// envelopes and handed to write, the runner's IPC writer. A hook cannot
-// return an error, so a failed write is passed to report (nil-safe); a
-// channel that fails here fails the result envelope right after, loudly.
+// installs: every observation its own loop produces — the LLM steps, the
+// tools it executes locally, its retries, its compaction rounds and its
+// per-turn fork anchors — is encoded as an `event` envelope and handed to
+// write, the runner's IPC writer. A hook cannot return an error, so a
+// failed write is passed to report (nil-safe); a channel that fails here
+// fails the result envelope right after, loudly.
 func SandboxRelayHooks(write func(delegate.Envelope) error, report func(error)) EventHooks {
-	send := func(eventType store.EventType, payload any) {
+	send := func(eventType string, payload any) {
 		env, err := relayEnvelope(eventType, payload)
 		if err == nil {
 			err = write(env)
@@ -73,20 +283,13 @@ func SandboxRelayHooks(write func(delegate.Envelope) error, report func(error)) 
 	}
 	return EventHooks{
 		OnLLMRequest: func(_ string, info LLMRequestInfo) {
-			send(store.EventLLMRequest, relayedLLMRequest(info))
+			send(string(store.EventLLMRequest), relayedLLMRequest(info))
 		},
 		OnLLMStepFinish: func(_ string, step LLMStepInfo) {
-			var calls []relayedToolCall
-			if len(step.ToolCalls) > 0 {
-				calls = make([]relayedToolCall, len(step.ToolCalls))
-				for i, tc := range step.ToolCalls {
-					calls[i] = relayedToolCall(tc)
-				}
-			}
-			send(store.EventLLMStepFinished, relayedLLMStep{
+			send(string(store.EventLLMStepFinished), relayedLLMStep{
 				Number:           step.Number,
-				Text:             step.Text,
-				ToolCalls:        calls,
+				Text:             relayClampText(step.Text),
+				ToolCalls:        relayClampToolCalls(step.ToolCalls),
 				FinishReason:     step.FinishReason,
 				InputTokens:      step.InputTokens,
 				OutputTokens:     step.OutputTokens,
@@ -94,17 +297,85 @@ func SandboxRelayHooks(write func(delegate.Envelope) error, report func(error)) 
 				CacheWriteTokens: step.CacheWriteTokens,
 				ReasoningTokens:  step.ReasoningTokens,
 				ThinkingMs:       step.ThinkingMs,
-				Thinking:         step.Thinking,
+				Thinking:         relayClampText(step.Thinking),
 				Iteration:        step.Iteration,
 			})
+		},
+		OnToolStarted: func(_ string, info LLMToolStartedInfo) {
+			send(string(store.EventToolStarted), relayedToolStarted{
+				ToolName:  info.ToolName,
+				ToolUseID: info.ToolUseID,
+				InputSize: info.InputSize,
+				Input:     relayClampJSON(info.Input),
+				Iteration: info.Iteration,
+			})
+		},
+		OnToolCall: func(_ string, info LLMToolCallInfo) {
+			var errMsg string
+			if info.Error != nil {
+				errMsg = relayClampText(info.Error.Error())
+			}
+			send(string(store.EventToolCalled), relayedToolFinished{
+				ToolName:   info.ToolName,
+				ToolUseID:  info.ToolUseID,
+				InputSize:  info.InputSize,
+				Output:     relayClampText(info.Output),
+				DurationMs: info.Duration.Milliseconds(),
+				Error:      errMsg,
+			})
+		},
+		OnLLMRetry: func(_ string, info RetryInfo) {
+			var errMsg string
+			if info.Error != nil {
+				errMsg = relayClampText(info.Error.Error())
+			}
+			send(string(store.EventLLMRetry), relayedRetry{
+				Attempt:    info.Attempt,
+				Error:      errMsg,
+				StatusCode: info.StatusCode,
+				DelayMs:    info.Delay.Milliseconds(),
+			})
+		},
+		OnLLMCompacted: func(_ string, info LLMCompactInfo) {
+			send(string(store.EventLLMCompacted), relayedCompact(info))
+		},
+		OnLLMTurnCapture: func(_ string, info LLMTurnCaptureInfo) {
+			turn := relayedTurnCapture{
+				Step:             info.Step,
+				Text:             relayClampText(info.Text),
+				ToolCalls:        relayClampToolCalls(info.ToolCalls),
+				FinishReason:     info.FinishReason,
+				InputTokens:      info.InputTokens,
+				OutputTokens:     info.OutputTokens,
+				CacheReadTokens:  info.CacheReadTokens,
+				CacheWriteTokens: info.CacheWriteTokens,
+				Iteration:        info.Iteration,
+				Backend:          info.Backend,
+				SessionID:        info.SessionID,
+			}
+			// The snapshot is what a fork replays, so it crosses whole or
+			// not at all — and when it cannot, the turn still crosses,
+			// naming what stayed in the container.
+			if conv := info.MarshalConversation(); len(conv) > 0 {
+				if len(conv) <= relayConversationBudget {
+					turn.Conversation = conv
+				} else {
+					turn.ConversationOmittedBytes = len(conv)
+				}
+			}
+			send(relayTurnCaptureType, turn)
 		},
 	}
 }
 
 // relayEnvelope encodes a typed payload as an event envelope. EventData
 // carries its payload as a map, so the typed form goes through JSON once
-// here and once again on the host — two small encodes per LLM step.
-func relayEnvelope(eventType store.EventType, payload any) (delegate.Envelope, error) {
+// here and once again on the host — two small encodes per LLM step. A
+// payload the field clamps could not bring under the IPC's per-line cap
+// is refused HERE: writing it would fail the launcher's reader and with
+// it the whole channel, so the caller reports one lost observation
+// instead of losing the node.
+func relayEnvelope(eventType string, payload any) (delegate.Envelope, error) {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return delegate.Envelope{}, err
@@ -113,7 +384,26 @@ func relayEnvelope(eventType store.EventType, payload any) (delegate.Envelope, e
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return delegate.Envelope{}, err
 	}
-	return delegate.NewEventEnvelope(string(eventType), m)
+	env, err := delegate.NewEventEnvelope(eventType, m)
+	if err != nil {
+		return delegate.Envelope{}, err
+	}
+	if relayLineSize(env) <= delegate.MaxEnvelopeLineBytes {
+		return env, nil
+	}
+	// Fields each in budget, sum over the cap: keep the numbers, cut the
+	// bulk, mark every cut.
+	if _, shrunk := relayShrinkValue(m); shrunk {
+		if env, err = delegate.NewEventEnvelope(eventType, m); err != nil {
+			return delegate.Envelope{}, err
+		}
+		if relayLineSize(env) <= delegate.MaxEnvelopeLineBytes {
+			return env, nil
+		}
+	}
+	return delegate.Envelope{}, fmt.Errorf(
+		"payload is %d bytes with every field already cut, over the %d-byte IPC line cap: refused rather than written, which would fail the channel",
+		relayLineSize(env), delegate.MaxEnvelopeLineBytes)
 }
 
 // ApplyRelayedEvent re-fires one relayed event through h, for nodeID (the
@@ -124,8 +414,8 @@ func relayEnvelope(eventType store.EventType, payload any) (delegate.Envelope, e
 // defect on one side of the wire, not a version skew, and the node's
 // metering is incomplete without it.
 func ApplyRelayedEvent(h EventHooks, nodeID, eventType string, payload map[string]any) (handled bool, err error) {
-	switch store.EventType(eventType) {
-	case store.EventLLMRequest:
+	switch eventType {
+	case string(store.EventLLMRequest):
 		var r relayedLLMRequest
 		if err := decodeRelayed(payload, &r); err != nil {
 			return true, err
@@ -134,7 +424,7 @@ func ApplyRelayedEvent(h EventHooks, nodeID, eventType string, payload map[strin
 			h.OnLLMRequest(nodeID, LLMRequestInfo(r))
 		}
 		return true, nil
-	case store.EventLLMStepFinished:
+	case string(store.EventLLMStepFinished):
 		var s relayedLLMStep
 		if err := decodeRelayed(payload, &s); err != nil {
 			return true, err
@@ -162,6 +452,107 @@ func ApplyRelayedEvent(h EventHooks, nodeID, eventType string, payload map[strin
 				Iteration:        s.Iteration,
 			})
 		}
+		return true, nil
+	case string(store.EventToolStarted):
+		var ts relayedToolStarted
+		if err := decodeRelayed(payload, &ts); err != nil {
+			return true, err
+		}
+		if h.OnToolStarted != nil {
+			h.OnToolStarted(nodeID, LLMToolStartedInfo{
+				ToolName:  ts.ToolName,
+				ToolUseID: ts.ToolUseID,
+				InputSize: ts.InputSize,
+				Input:     ts.Input,
+				Iteration: ts.Iteration,
+			})
+		}
+		return true, nil
+	case string(store.EventToolCalled):
+		var tc relayedToolFinished
+		if err := decodeRelayed(payload, &tc); err != nil {
+			return true, err
+		}
+		if h.OnToolCall != nil {
+			info := LLMToolCallInfo{
+				ToolName:  tc.ToolName,
+				ToolUseID: tc.ToolUseID,
+				InputSize: tc.InputSize,
+				Output:    tc.Output,
+				Duration:  time.Duration(tc.DurationMs) * time.Millisecond,
+			}
+			// A failed call is a tool_error host-side — the shape a
+			// permission denial or a tool crash is audited under.
+			if tc.Error != "" {
+				info.Error = errors.New(tc.Error)
+			}
+			h.OnToolCall(nodeID, info)
+		}
+		return true, nil
+	case string(store.EventLLMRetry):
+		var r relayedRetry
+		if err := decodeRelayed(payload, &r); err != nil {
+			return true, err
+		}
+		if h.OnLLMRetry != nil {
+			info := RetryInfo{
+				Attempt:    r.Attempt,
+				StatusCode: r.StatusCode,
+				Delay:      time.Duration(r.DelayMs) * time.Millisecond,
+			}
+			if r.Error != "" {
+				info.Error = errors.New(r.Error)
+			}
+			h.OnLLMRetry(nodeID, info)
+		}
+		return true, nil
+	case string(store.EventLLMCompacted):
+		var c relayedCompact
+		if err := decodeRelayed(payload, &c); err != nil {
+			return true, err
+		}
+		if h.OnLLMCompacted != nil {
+			h.OnLLMCompacted(nodeID, LLMCompactInfo(c))
+		}
+		return true, nil
+	case relayTurnCaptureType:
+		var t relayedTurnCapture
+		if err := decodeRelayed(payload, &t); err != nil {
+			return true, err
+		}
+		if h.OnLLMTurnCapture == nil {
+			return true, nil
+		}
+		info := LLMTurnCaptureInfo{
+			Step:                     t.Step,
+			Text:                     t.Text,
+			FinishReason:             t.FinishReason,
+			InputTokens:              t.InputTokens,
+			OutputTokens:             t.OutputTokens,
+			CacheReadTokens:          t.CacheReadTokens,
+			CacheWriteTokens:         t.CacheWriteTokens,
+			Iteration:                t.Iteration,
+			Backend:                  t.Backend,
+			SessionID:                t.SessionID,
+			ConversationOmittedBytes: t.ConversationOmittedBytes,
+		}
+		if len(t.ToolCalls) > 0 {
+			info.ToolCalls = make([]ToolCallEntry, len(t.ToolCalls))
+			for i, tc := range t.ToolCalls {
+				info.ToolCalls[i] = ToolCallEntry(tc)
+			}
+		}
+		// The snapshot re-enters the host as the message slice the
+		// in-process path holds, so the turn it persists — and the
+		// conversation a fork replays from it — is the same artifact.
+		if len(t.Conversation) > 0 {
+			var msgs []api.Message
+			if err := json.Unmarshal(t.Conversation, &msgs); err != nil {
+				return true, fmt.Errorf("decode relayed conversation: %w", err)
+			}
+			info.conversation = msgs
+		}
+		h.OnLLMTurnCapture(nodeID, info)
 		return true, nil
 	}
 	return false, nil

--- a/pkg/backend/model/sandbox_relay_test.go
+++ b/pkg/backend/model/sandbox_relay_test.go
@@ -20,6 +20,21 @@ import (
 // events the studio, the report and the runner's metering read.
 func relayHost(t *testing.T, runID string) (*ClawBackend, func() []*store.Event) {
 	t.Helper()
+	b, st := relayHostStore(t, runID)
+	return b, func() []*store.Event {
+		evts, err := st.LoadEvents(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("LoadEvents: %v", err)
+		}
+		return evts
+	}
+}
+
+// relayHostStore is relayHost with the run store itself, for the
+// assertions whose oracle is not events.jsonl (the turn checkpoints the
+// Fork API reads).
+func relayHostStore(t *testing.T, runID string, observers ...func(store.Event)) (*ClawBackend, *store.FilesystemRunStore) {
+	t.Helper()
 	st, err := store.New(t.TempDir())
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
@@ -28,15 +43,40 @@ func relayHost(t *testing.T, runID string) (*ClawBackend, func() []*store.Event)
 	if _, err := st.CreateRun(ctx, runID, "wf", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	hooks := NewStoreEventHooks(ctx, st, runID, iterlog.Nop(), nil)
-	b := NewClawBackend(NewRegistry(), hooks, RetryPolicy{})
-	return b, func() []*store.Event {
-		evts, err := st.LoadEvents(ctx, runID)
-		if err != nil {
-			t.Fatalf("LoadEvents: %v", err)
-		}
-		return evts
+	hooks := NewStoreEventHooks(ctx, st, runID, iterlog.Nop(), nil, observers...)
+	return NewClawBackend(NewRegistry(), hooks, RetryPolicy{}), st
+}
+
+// runRelay drives one full runner→launcher exchange: fire builds the
+// runner-side hooks' calls, the real Multiplexer carries their envelopes,
+// and the launcher's handler re-fires the host's own hooks. Returns
+// whatever the runner-side relay reported as a failed write.
+func runRelay(t *testing.T, b *ClawBackend, task delegate.Task, fire func(EventHooks)) []error {
+	t.Helper()
+	handler := b.multiplexerHandler(context.Background(), task)
+	if handler.OnEvent == nil {
+		t.Fatal("the launcher's multiplexer handler has no OnEvent: every event envelope the runner emits is dropped")
 	}
+	_, runnerStdinW := io.Pipe()
+	runnerStdoutR, runnerStdoutW := io.Pipe()
+	mux := delegate.NewMultiplexer(runnerStdoutR, runnerStdinW, handler)
+
+	var relayErrs []error
+	writer := delegate.NewEnvelopeWriter(runnerStdoutW)
+	relay := SandboxRelayHooks(writer.Write, func(err error) { relayErrs = append(relayErrs, err) })
+	go func() {
+		defer runnerStdoutW.Close()
+		fire(relay)
+		resEnv, _ := delegate.NewResultEnvelope(delegate.IOResult{})
+		_ = writer.Write(resEnv)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := mux.Run(ctx); err != nil {
+		t.Fatalf("multiplexer: %v", err)
+	}
+	return relayErrs
 }
 
 func eventsOfType(evts []*store.Event, typ store.EventType) []*store.Event {
@@ -168,7 +208,7 @@ func TestApplyRelayedEvent_UnknownIsDroppedMalformedIsAnError(t *testing.T) {
 	var fired int
 	hooks := EventHooks{OnLLMStepFinish: func(string, LLMStepInfo) { fired++ }}
 
-	handled, err := ApplyRelayedEvent(hooks, "n", "tool_called", map[string]any{"name": "bash"})
+	handled, err := ApplyRelayedEvent(hooks, "n", "an_event_a_newer_runner_relays", map[string]any{"name": "bash"})
 	if handled || err != nil {
 		t.Fatalf("unknown type: handled=%v err=%v, want dropped without error", handled, err)
 	}

--- a/pkg/backend/model/sandbox_relay_tools_test.go
+++ b/pkg/backend/model/sandbox_relay_tools_test.go
@@ -1,0 +1,405 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// relayCarries reports whether the runner-side relay wires the hooks pick
+// asks for. Checked before firing, so a hook the relay does not carry
+// fails with a message instead of a nil-call panic in the runner
+// goroutine.
+func relayCarries(pick func(EventHooks) bool) bool {
+	return pick(SandboxRelayHooks(func(delegate.Envelope) error { return nil }, nil))
+}
+
+// #811 — the tool half of a sandboxed claw node. Its builtins execute
+// INSIDE the container, so tool_started / tool_called fire on the runner's
+// hooks: without the relay the studio timeline of that node shows LLM
+// steps and no tools, the permission gate's denials leave no audit, and a
+// supervisor's tool monitor never arms.
+func TestSandboxRelay_ToolEventsCrossTheWireIntoTheHostStore(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnToolStarted != nil && h.OnToolCall != nil }) {
+		t.Fatal("the runner's relay carries no tool hooks: the in-container builtins are invisible to the host")
+	}
+	b, load := relayHost(t, "run-relay-tools")
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnToolStarted("campaign", LLMToolStartedInfo{
+			ToolName:  "bash",
+			ToolUseID: "tu_1",
+			InputSize: 42,
+			Input:     json.RawMessage(`{"command":"go test ./..."}`),
+			Iteration: 3,
+		})
+		relay.OnToolCall("campaign", LLMToolCallInfo{
+			ToolName:  "bash",
+			ToolUseID: "tu_1",
+			InputSize: 42,
+			Output:    "ok\n",
+			Duration:  1500 * time.Millisecond,
+		})
+		relay.OnToolCall("campaign", LLMToolCallInfo{
+			ToolName:  "bash",
+			ToolUseID: "tu_2",
+			InputSize: 20,
+			Output:    "Permission denied: Bash(rm:*)",
+			Error:     errors.New("Permission denied: Bash(rm:*)"),
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v", errs)
+	}
+
+	evts := load()
+	started := eventsOfType(evts, store.EventToolStarted)
+	if len(started) != 1 {
+		t.Fatalf("tool_started events = %d, want 1 (events: %+v)", len(started), evts)
+	}
+	if started[0].NodeID != "campaign" {
+		t.Errorf("tool_started node = %q, want the launcher's task node", started[0].NodeID)
+	}
+	if started[0].Data["tool"] != "bash" || started[0].Data["tool_use_id"] != "tu_1" ||
+		started[0].Data["input_size"] != float64(42) || started[0].Data["input"] != `{"command":"go test ./..."}` {
+		t.Errorf("tool_started data = %v, want the name, correlation id, size and input intact", started[0].Data)
+	}
+
+	called := eventsOfType(evts, store.EventToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("tool_called events = %d, want 1", len(called))
+	}
+	if called[0].Data["tool"] != "bash" || called[0].Data["tool_use_id"] != "tu_1" ||
+		called[0].Data["duration_ms"] != float64(1500) || called[0].Data["output"] != "ok\n" {
+		t.Errorf("tool_called data = %v, want the result and duration intact", called[0].Data)
+	}
+
+	// A tool the in-container permission gate refused: the host must
+	// persist tool_error carrying the denial, which is the audit.
+	failed := eventsOfType(evts, store.EventToolError)
+	if len(failed) != 1 {
+		t.Fatalf("tool_error events = %d, want 1 — a refused tool leaves no audit otherwise", len(failed))
+	}
+	if !strings.Contains(fmt.Sprint(failed[0].Data["error"]), "Permission denied") {
+		t.Errorf("tool_error data = %v, want the denial reason", failed[0].Data)
+	}
+}
+
+// #811 — the two loop-health observations of a sandboxed claw node. The
+// in-container backend runs its own retry loop and its own compactor, so
+// both fire on the runner's hooks; without the relay a run that retried
+// three times or compacted its history reads as a silent gap.
+func TestSandboxRelay_RetryAndCompactionCrossTheWireIntoTheHostStore(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnLLMRetry != nil && h.OnLLMCompacted != nil }) {
+		t.Fatal("the runner's relay carries neither llm_retry nor llm_compacted: the in-container loop's health is invisible")
+	}
+	b, load := relayHost(t, "run-relay-loop")
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnLLMRetry("campaign", RetryInfo{
+			Attempt:    2,
+			Error:      errors.New("overloaded_error"),
+			StatusCode: 529,
+			Delay:      4 * time.Second,
+		})
+		relay.OnLLMCompacted("campaign", LLMCompactInfo{
+			BeforeMessages: 80, AfterMessages: 12, RemovedMessageCount: 68, Iteration: 1,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v", errs)
+	}
+
+	evts := load()
+	retries := eventsOfType(evts, store.EventLLMRetry)
+	if len(retries) != 1 {
+		t.Fatalf("llm_retry events = %d, want 1 (events: %+v)", len(retries), evts)
+	}
+	if retries[0].Data["attempt"] != float64(2) || retries[0].Data["delay_ms"] != float64(4000) ||
+		retries[0].Data["status_code"] != float64(529) || retries[0].Data["error"] != "overloaded_error" {
+		t.Errorf("llm_retry data = %v, want attempt/delay/status/error intact", retries[0].Data)
+	}
+
+	compacts := eventsOfType(evts, store.EventLLMCompacted)
+	if len(compacts) != 1 {
+		t.Fatalf("llm_compacted events = %d, want 1", len(compacts))
+	}
+	if compacts[0].Data["before_messages"] != float64(80) || compacts[0].Data["after_messages"] != float64(12) ||
+		compacts[0].Data["removed_message_count"] != float64(68) {
+		t.Errorf("llm_compacted data = %v, want the message counts intact", compacts[0].Data)
+	}
+}
+
+// clawTurnConversation is a two-message claw conversation, the shape the
+// turn snapshot carries for the Fork API's rehydration.
+func clawTurnConversation() []api.Message {
+	return []api.Message{
+		{Role: "user", Content: []api.ContentBlock{{Type: "text", Text: "ship the feature"}}},
+		{Role: "assistant", Content: []api.ContentBlock{
+			{Type: "text", Text: "reading the tests first"},
+			{Type: "tool_use", ID: "tu_1", Name: "read_file", Input: map[string]any{"path": "main.go"}},
+		}},
+	}
+}
+
+// #811 — the fork anchor of a sandboxed claw node. The turn capture is
+// written by the in-container loop; relayed, the host persists the same
+// store.TurnCheckpoint an in-process node writes — the record
+// `iterion fork --turn` resolves and rehydrates from.
+func TestSandboxRelay_TurnCaptureCrossesIntoTheRunsTurnStore(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnLLMTurnCapture != nil }) {
+		t.Fatal("the runner's relay carries no turn capture: `iterion fork --turn` has nothing to anchor on for a sandboxed claw node")
+	}
+	const runID = "run-relay-turn"
+	b, st := relayHostStore(t, runID)
+	conv := clawTurnConversation()
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnLLMTurnCapture("campaign", LLMTurnCaptureInfo{
+			Step:         2,
+			Text:         "reading the tests first",
+			ToolCalls:    []ToolCallEntry{{Name: "read_file", Input: json.RawMessage(`{"path":"main.go"}`)}},
+			FinishReason: "tool_use",
+			InputTokens:  9000,
+			OutputTokens: 120,
+			Iteration:    1,
+			conversation: conv,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v", errs)
+	}
+
+	ctx := context.Background()
+	turn, err := store.AsTurnStore(st).LatestTurn(ctx, runID, "campaign")
+	if err != nil {
+		t.Fatalf("LatestTurn (the seam `iterion fork --turn` resolves): %v", err)
+	}
+	if turn.LoopIter != 1 || turn.TurnIndex != 1 {
+		t.Errorf("turn anchored at loop_iter=%d turn_index=%d, want 1/1 (step 2 of iteration 1)", turn.LoopIter, turn.TurnIndex)
+	}
+	if turn.Backend != delegate.BackendClaw || turn.FinishReason != "tool_use" {
+		t.Errorf("turn = %+v, want the claw backend and its finish reason", turn)
+	}
+	if len(turn.ToolCalls) != 1 || turn.ToolCalls[0].Name != "read_file" {
+		t.Errorf("turn.ToolCalls = %+v, want the step's call", turn.ToolCalls)
+	}
+	if turn.Usage.InputTokens != 9000 || turn.Usage.OutputTokens != 120 {
+		t.Errorf("turn.Usage = %+v, want the step's tokens", turn.Usage)
+	}
+	if turn.MessagesRef == "" {
+		t.Fatal("turn carries no MessagesRef: Fork would rehydrate the child with no conversation")
+	}
+	msgs, err := store.AsTurnStore(st).LoadTurnMessages(ctx, runID, "campaign", turn.LoopIter, turn.TurnIndex)
+	if err != nil {
+		t.Fatalf("LoadTurnMessages: %v", err)
+	}
+	var got []api.Message
+	if err := json.Unmarshal(msgs, &got); err != nil {
+		t.Fatalf("the persisted snapshot is not a claw conversation: %v", err)
+	}
+	if len(got) != len(conv) || got[0].Content[0].Text != "ship the feature" ||
+		got[1].Content[1].Name != "read_file" {
+		t.Fatalf("rehydrated conversation = %+v, want the snapshot the container captured", got)
+	}
+}
+
+// #811, decision (a) — the IPC refuses a line over
+// delegate.MaxEnvelopeLineBytes by killing the channel, so an oversize
+// payload is CUT with a marker the consumer can read, never dropped in
+// silence and never written as a line the launcher cannot parse. The
+// event still lands, and the honest size travels beside the cut.
+func TestSandboxRelay_OversizeToolPayloadsAreMarkedNotDropped(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnToolStarted != nil && h.OnToolCall != nil }) {
+		t.Fatal("the runner's relay carries no tool hooks: nothing to size-check")
+	}
+	const runID = "run-relay-oversize"
+	b, st := relayHostStore(t, runID)
+	load := func() []*store.Event {
+		evts, err := st.LoadEvents(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("LoadEvents: %v", err)
+		}
+		return evts
+	}
+	hugeOutput := strings.Repeat("x", 3*1024*1024)
+	hugeInput := json.RawMessage(`{"content":"` + strings.Repeat("y", 3*1024*1024) + `"}`)
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnToolStarted("campaign", LLMToolStartedInfo{
+			ToolName: "write_file", ToolUseID: "tu_1", InputSize: len(hugeInput), Input: hugeInput,
+		})
+		relay.OnToolCall("campaign", LLMToolCallInfo{
+			ToolName: "bash", ToolUseID: "tu_1", InputSize: len(hugeInput), Output: hugeOutput,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v — an oversize payload must be cut, not fail the channel", errs)
+	}
+
+	evts := load()
+	started := eventsOfType(evts, store.EventToolStarted)
+	if len(started) != 1 {
+		t.Fatalf("tool_started events = %d, want 1 — the oversize input dropped the whole event", len(started))
+	}
+	if started[0].Data["input_size"] != float64(len(hugeInput)) {
+		t.Errorf("tool_started input_size = %v, want the ORIGINAL %d bytes", started[0].Data["input_size"], len(hugeInput))
+	}
+	// The input is a JSON document the studio parses: cut, it must stay
+	// valid JSON and name what was left behind.
+	inline := fmt.Sprint(started[0].Data["input"]) + fmt.Sprint(started[0].Data["input_preview"])
+	if !strings.Contains(inline, "relay") {
+		t.Errorf("tool_started input = %.200q, want a marker naming the sandbox relay as the cutter", inline)
+	}
+
+	called := eventsOfType(evts, store.EventToolCalled)
+	if len(called) != 1 {
+		t.Fatalf("tool_called events = %d, want 1 — the oversize output dropped the whole event", len(called))
+	}
+	// The cut output is what the host persisted: shorter than the
+	// original, and ending on a marker that names the relay as the
+	// cutter — a reader must never mistake it for the tool's real answer.
+	body, total, _, err := st.ReadToolBlob(context.Background(), runID, "tu_1", "output", 0, 0)
+	if err != nil {
+		t.Fatalf("ReadToolBlob: %v", err)
+	}
+	if total >= int64(len(hugeOutput)) {
+		t.Errorf("persisted output = %d bytes, want less than the %d the container held", total, len(hugeOutput))
+	}
+	if tail := string(body[max(0, len(body)-200):]); !strings.Contains(tail, "relay") {
+		t.Errorf("persisted output ends %.200q, want a marker naming the sandbox relay as the cutter", tail)
+	}
+}
+
+// #811, decision (b) — a conversation snapshot bigger than the relay can
+// carry is OMITTED whole (a truncated one is not a conversation), and the
+// turn still lands, naming the bytes that stayed in the container.
+func TestSandboxRelay_OversizeConversationIsOmittedAndNamed(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnLLMTurnCapture != nil }) {
+		t.Fatal("the runner's relay carries no turn capture: nothing to size-check")
+	}
+	const runID = "run-relay-oversize-conv"
+	b, st := relayHostStore(t, runID)
+	huge := make([]api.Message, 0, 400)
+	for i := 0; i < 400; i++ {
+		huge = append(huge, api.Message{Role: "user", Content: []api.ContentBlock{
+			{Type: "text", Text: strings.Repeat("z", 8*1024)},
+		}})
+	}
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnLLMTurnCapture("campaign", LLMTurnCaptureInfo{
+			Step: 1, FinishReason: "tool_use", InputTokens: 800000, conversation: huge,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v — an oversize conversation must degrade, not fail the channel", errs)
+	}
+	turn, err := store.AsTurnStore(st).LatestTurn(context.Background(), runID, "campaign")
+	if err != nil {
+		t.Fatalf("LatestTurn: %v — the turn itself must survive its conversation not fitting", err)
+	}
+	if turn.MessagesRef != "" {
+		t.Errorf("turn.MessagesRef = %q, want empty: a truncated conversation must never be presented as one", turn.MessagesRef)
+	}
+	if turn.FinishReason != "tool_use" || turn.Usage.InputTokens != 800000 {
+		t.Errorf("turn = %+v, want the metadata intact", turn)
+	}
+}
+
+// #811 — the plan checklist the studio renders is built from the INPUT of
+// the agent's `todo_write` calls, which the tool-started hook captures. On
+// a sandboxed claw node that call happens in the container, so the plan
+// store stays empty until the relay carries the input across.
+func TestSandboxRelay_RelayedTodoWriteFeedsThePlanStore(t *testing.T) {
+	if !relayCarries(func(h EventHooks) bool { return h.OnToolStarted != nil }) {
+		t.Fatal("the runner's relay carries no tool_started: a sandboxed node's plan never reaches the studio")
+	}
+	const runID = "run-relay-plan"
+	b, st := relayHostStore(t, runID)
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnToolStarted("campaign", LLMToolStartedInfo{
+			ToolName:  "todo_write",
+			ToolUseID: "tu_9",
+			Input:     json.RawMessage(`{"todos":[{"content":"wire the relay","status":"in_progress"}]}`),
+			Iteration: 2,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v", errs)
+	}
+	snaps, err := st.ListPlanSnapshots(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListPlanSnapshots: %v", err)
+	}
+	if len(snaps) != 1 {
+		t.Fatalf("plan snapshots = %d, want 1 — the container's todo_write left no plan", len(snaps))
+	}
+	if len(snaps[0].Todos) != 1 || snaps[0].Todos[0].Content != "wire the relay" || snaps[0].Iteration != 2 {
+		t.Errorf("plan snapshot = %+v, want the container's todo at iteration 2", snaps[0])
+	}
+}
+
+// #811, decision (a) again — the numbers a step carries are what the run
+// is METERED on, so an event whose bulk pushes the line past the cap must
+// still cross: the relay drops the bulk, marks the drop, and delivers the
+// counts. Losing the whole event here would leave the node billed from
+// the delegation total the launcher deliberately stops counting once it
+// has seen steps.
+func TestSandboxRelay_ABulkyStepStillDeliversItsTokenCounts(t *testing.T) {
+	b, load := relayHost(t, "run-relay-bulky-step")
+	// Six tool inputs, each just under the per-field budget: no single
+	// field is clamped, their sum is past the IPC's per-line cap.
+	fat := json.RawMessage(`{"content":"` + strings.Repeat("w", 900*1024) + `"}`)
+	calls := make([]ToolCallEntry, 6)
+	for i := range calls {
+		calls[i] = ToolCallEntry{Name: "write_file", Input: fat}
+	}
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnLLMStepFinish("campaign", LLMStepInfo{
+			Number: 4, ToolCalls: calls, FinishReason: "tool_use",
+			InputTokens: 31000, OutputTokens: 4200, Iteration: 1,
+		})
+	})
+	if len(errs) != 0 {
+		t.Fatalf("relay reported %v — the step's tokens must reach the host even when its payloads cannot", errs)
+	}
+	steps := eventsOfType(load(), store.EventLLMStepFinished)
+	if len(steps) != 1 {
+		t.Fatalf("llm_step_finished events = %d, want 1 — the node is metered from this event", len(steps))
+	}
+	if steps[0].Data["input_tokens"] != float64(31000) || steps[0].Data["output_tokens"] != float64(4200) ||
+		steps[0].Data["tool_calls"] != float64(6) {
+		t.Errorf("llm_step_finished data = %v, want the token counts and call count intact", steps[0].Data)
+	}
+}
+
+// #811, decision (a), last rung — a payload made of many SHORT strings
+// has no bulk to cut, so it cannot be brought under the line cap. It is
+// refused rather than written (writing it would fail the launcher's
+// reader and with it the run's whole IPC) and the refusal is REPORTED on
+// the runner's stderr, which the launcher folds into the node's error.
+// The one lossy case in the relay is never a silent one.
+func TestSandboxRelay_AnUnshrinkablePayloadIsRefusedAndReported(t *testing.T) {
+	b, load := relayHost(t, "run-relay-unshrinkable")
+	calls := make([]ToolCallEntry, 60000)
+	for i := range calls {
+		calls[i] = ToolCallEntry{Name: strings.Repeat("t", 60), Input: json.RawMessage(`{"a":"bbbbbbbb"}`)}
+	}
+	errs := runRelay(t, b, delegate.Task{NodeID: "campaign"}, func(relay EventHooks) {
+		relay.OnLLMStepFinish("campaign", LLMStepInfo{Number: 1, ToolCalls: calls, InputTokens: 10})
+	})
+	if len(errs) != 1 {
+		t.Fatalf("reported = %v, want exactly one refusal — a dropped observation must leave a trace", errs)
+	}
+	if !strings.Contains(errs[0].Error(), "llm_step_finished") || !strings.Contains(errs[0].Error(), "line cap") {
+		t.Errorf("reported = %q, want the event type and the reason", errs[0])
+	}
+	if evts := eventsOfType(load(), store.EventLLMStepFinished); len(evts) != 0 {
+		t.Errorf("llm_step_finished events = %d, want 0 — the line was refused, not truncated on the wire", len(evts))
+	}
+}

--- a/pkg/runview/fork_sandboxed_claw_test.go
+++ b/pkg/runview/fork_sandboxed_claw_test.go
@@ -1,0 +1,97 @@
+package runview
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #811 — `iterion fork --turn` on a run whose claw node executed inside a
+// sandbox. The tool loop, and with it every turn capture, runs in the
+// container; the host learns of a turn only through the `__claw-runner`
+// relay. This drives the host half of that relay (the decode the
+// multiplexer handler performs on each `event` envelope) into the run's
+// own store hooks, then forks through the very API `iterion fork` calls —
+// so a missing relay shows up as "no turn checkpoint", and a relay that
+// drops the snapshot shows up as a child with no conversation.
+func TestFork_SandboxedClawTurnRelayedFromTheContainer(t *testing.T) {
+	dir := t.TempDir()
+	logger := iterlog.Nop()
+	st, err := store.New(dir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := context.Background()
+	const parentID = "run-sandboxed-claw"
+	if _, err := st.CreateRun(ctx, parentID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	parent, err := st.LoadRun(ctx, parentID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	parent.Checkpoint = &store.Checkpoint{NodeID: "campaign"}
+	parent.Status = store.RunStatusCancelled
+	if err := st.SaveRun(ctx, parent); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	// One turn capture as it arrives from the container: the payload of
+	// the `event` envelope the in-container relay writes (see
+	// model.SandboxRelayHooks and its round-trip test
+	// TestSandboxRelay_TurnCaptureCrossesIntoTheRunsTurnStore).
+	const relayed = `{
+		"step": 1,
+		"text": "patching the handler",
+		"finish_reason": "tool_use",
+		"input_tokens": 12000,
+		"output_tokens": 300,
+		"iteration": 0,
+		"conversation": [
+			{"role":"user","content":[{"type":"text","text":"ship the feature"}]},
+			{"role":"assistant","content":[{"type":"text","text":"patching the handler"}]}
+		]
+	}`
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(relayed), &payload); err != nil {
+		t.Fatalf("decode relayed payload: %v", err)
+	}
+	hooks := model.NewStoreEventHooks(ctx, st, parentID, logger, nil)
+	handled, err := model.ApplyRelayedEvent(hooks, "campaign", "llm_turn_capture", payload)
+	if err != nil {
+		t.Fatalf("ApplyRelayedEvent: %v", err)
+	}
+	if !handled {
+		t.Fatal("the host drops a relayed llm_turn_capture: a sandboxed claw run has no fork anchor at all")
+	}
+
+	svc, err := NewService(dir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	result, err := svc.Fork(ctx, ForkSpec{RunID: parentID, NodeID: "campaign", TurnIndex: -1})
+	if err != nil {
+		t.Fatalf("Fork on the relayed turn: %v", err)
+	}
+	child, err := st.LoadRun(ctx, result.NewRunID)
+	if err != nil {
+		t.Fatalf("load child: %v", err)
+	}
+	if child.Checkpoint == nil || child.Checkpoint.BackendName != "claw" {
+		t.Fatalf("child checkpoint = %+v, want the claw backend the relayed turn named", child.Checkpoint)
+	}
+	if len(child.Checkpoint.BackendConversation) == 0 {
+		t.Fatal("child carries no BackendConversation: the fork replays nothing the sandboxed node had said")
+	}
+	var msgs []map[string]any
+	if err := json.Unmarshal(child.Checkpoint.BackendConversation, &msgs); err != nil {
+		t.Fatalf("child conversation is not a message list: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0]["role"] != "user" || msgs[1]["role"] != "assistant" {
+		t.Fatalf("child conversation = %+v, want the two messages the container captured", msgs)
+	}
+}

--- a/pkg/supervise/relayed_tool_event_test.go
+++ b/pkg/supervise/relayed_tool_event_test.go
@@ -1,0 +1,93 @@
+package supervise
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #811 — a supervisor's tool monitor must arm on a SANDBOXED claw node
+// exactly as on an in-process one. Tool events fire inside the container,
+// reach the host only through the `__claw-runner` relay, and the hub is
+// fed by the same store hooks (ExecutorSpec.EventObservers) that carry
+// the in-process ones. Without the relay this hub stays silent for the
+// whole node and a `tool_error` monitor never fires.
+func TestRelayedToolEventArmsAToolMonitor(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "run-supervised-sandbox"
+	if _, err := st.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	hub := NewEventHub()
+	events, release, err := hub.ObserveRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("ObserveRun: %v", err)
+	}
+	defer release()
+	hostHooks := model.NewStoreEventHooks(ctx, st, runID, iterlog.Nop(), nil, hub.Publish)
+
+	// The runner half, inside the container: the failing tool call fires
+	// on the relay hooks, which encode it as an `event` envelope.
+	var wire []delegate.Envelope
+	relay := model.SandboxRelayHooks(func(env delegate.Envelope) error {
+		wire = append(wire, env)
+		return nil
+	}, func(err error) { t.Errorf("relay: %v", err) })
+	if relay.OnToolCall == nil {
+		t.Fatal("the runner's relay carries no tool hook: a supervisor watching a sandboxed claw node sees no tool at all")
+	}
+	relay.OnToolCall("implement", model.LLMToolCallInfo{
+		ToolName:  "bash",
+		ToolUseID: "tu_7",
+		Output:    "FAIL\texit status 1",
+		Duration:  900 * time.Millisecond,
+		Error:     errors.New("exit status 1"),
+	})
+
+	// The launcher half: decode each envelope and re-fire the host's own
+	// hooks — what the multiplexer handler's OnEvent does in production.
+	for _, env := range wire {
+		if env.Type != delegate.EnvelopeEvent {
+			continue
+		}
+		var ed delegate.EventData
+		if err := json.Unmarshal(env.Data, &ed); err != nil {
+			t.Fatalf("decode event envelope: %v", err)
+		}
+		handled, err := model.ApplyRelayedEvent(hostHooks, "implement", ed.Type, ed.Payload)
+		if err != nil || !handled {
+			t.Fatalf("ApplyRelayedEvent(%s) = handled %v, err %v", ed.Type, handled, err)
+		}
+	}
+
+	monitor := Monitor{EventType: string(store.EventToolError), ToolName: "bash"}
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case evt := <-events:
+			if evt == nil {
+				t.Fatal("hub closed before the relayed tool event arrived")
+			}
+			if !monitor.matches(evt) {
+				continue
+			}
+			if evt.NodeID != "implement" {
+				t.Errorf("matched event node = %q, want implement", evt.NodeID)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no event the tool monitor matches: a sandboxed claw node's failing bash never reaches its supervisor")
+		}
+	}
+}


### PR DESCRIPTION
Closes #811.

PR #810 made the `__claw-runner` relay carry `llm_request` and `llm_step_finished`; everything else a claw node observes in-process still stopped at the container boundary. Now every callback the in-container loop can fire crosses the SAME seam (`SandboxRelayHooks` on the runner side, `ApplyRelayedEvent` on the host, re-firing the host's own store hooks) — no second channel.

| observation | before | after |
|---|---|---|
| `llm_request`, `llm_step_finished` (+ derived `assistant_text`, `usage_progress`) | relayed (#810) | relayed |
| `tool_started` | no | relayed |
| `tool_called` / `tool_error` (incl. the 4 refusal paths: unknown tool, malformed input, PreToolUse block, permission gate — the permission AUDIT) | no | relayed |
| `plan_written` + plan snapshots | absent | derived host-side from the relayed `todo_write` |
| `llm_retry` (retry loop AND context-window force-compaction) | no | relayed |
| `llm_compacted` | no | relayed |
| `llm_turn_capture` → `store.TurnCheckpoint` (fork anchors) | no | relayed |
| `llm_response` | no | still not — the host's store hooks leave `OnLLMResponse` nil by design (the data rides `llm_step_finished`); named in code + `docs/sandbox.md` |

No double-firing: on the sandboxed path the in-container loop is the only producer of tool events.

## The two decisions
**(a) IPC line cap** — `delegate.MaxEnvelopeLineBytes` is 4 MiB and the reader fails the WHOLE channel on a longer line, so the cut happens before the write, in three rungs: a text field over 1 MiB (the host's own inline ceiling) is truncated with a marker naming the container-side byte count; a JSON field over 1 MiB becomes `{"_iterion_sandbox_relay_omitted_bytes":N}` while `input_size` keeps the measured size (a document cut mid-way is not JSON); an event whose fields are each in budget but whose sum is not keeps its numbers and loses its bulk (the token counts are what the run is metered on). Only a payload of thousands of short strings is refused, and the refusal reaches the node's error through the runner's stderr — never a silent drop, never a broken line.
**(b) Turn snapshots cross the wire** — there is no run directory the container can rely on (the k8s driver hard-errors on `host_state: auto`, `host_state: none` is the multi-tenant posture, a cloud store is Mongo + S3). The conversation is relayed up to 2 MiB; larger, it is omitted WHOLE (half a conversation is not one), the turn still lands, and the host warns naming node/turn/bytes.

## Tests (red first — failing line, then green)
`TestSandboxRelay_ToolEventsCrossTheWireIntoTheHostStore` (`:33 the runner's relay carries no tool hooks`), `…RetryAndCompactionCrossTheWire…` (`:102`), `…TurnCaptureCrossesIntoTheRunsTurnStore` (`:158 iterion fork --turn has nothing to anchor on`), `…Oversize{ToolPayloadsAreMarkedNotDropped,ConversationIsOmittedAndNamed}` (`:220`/`:267`), `…ABulkyStepStillDeliversItsTokenCounts` (`:369 … over the 4194304-byte IPC line cap` → drove the shrink pass); consumers: `pkg/supervise/relayed_tool_event_test.go:48` (a supervisor watching a sandboxed claw node saw no tool), `pkg/runview/fork_sandboxed_claw_test.go:69` (forks through `runview.Service.Fork`, asserts the child's `BackendConversation`), `cmd/iterion/claw_runner_relay_test.go:34`. Written after the fix and said so: the `todo_write` → plan store test and the unshrinkable-payload refusal test. One #810 test adjusted (its "unknown type" fixture was `tool_called`, now a known type).
`go build ./...` · `go test ./pkg/backend/model/... ./pkg/runner/... ./pkg/supervise/... ./cmd/... ./pkg/cli/...` ok · full `task test` no FAIL · `task test:e2e` ok (395 s) · `task lint` 0 issues.

## Left as separate findings (filed)
`ChainHooks` (`pkg/backend/model/executor_hooks.go`) composes 18 of the 22 hook fields — `OnAssistantText`, `OnUsageCap`, `OnUsageProgress`, `OnOrchestrationStall` are dropped, so a run launched with an `ExtraHooks` entry (the Prometheus exporter) silently loses those events; the launcher→runner `tool_result` envelope has no clamp for a >4 MiB host-side tool output; a stale `TurnWriter` comment says Mongo does not implement it (it does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
