### PR TITLE
fix(server): a refused launch gives the board card back and retries with a backoff; the attempt cap files it blocked with the reason

### DIFF
--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -288,14 +288,37 @@ column it was taken from under the machine provenance `unlaunchable`
 it), and the claim is freed. It is never parked `blocked` — that column
 is a verdict on the card's work, and reaching it here parked 36 roadmap
 tickets in one pass and pushed *Blocked* onto the operator's GitHub
-board. Real launch failures — the publisher refusing the run (quota,
-sealing), a run that started and failed — keep filing `blocked`.
+board. A run that started and failed keeps filing `blocked`: that is
+the run's verdict.
 
-Each refusal is logged **once per card and reason** (the card is listed
-again every tick for as long as it stays broken), and every watchdog
+**A launch the run service refuses is a third class — transient, and
+retried with a backoff.** Every error out of `runs.Launch` means no run
+was started (a credential-sealing failure, a queue outage, the server
+draining, a bot that does not compile, an invalid spec), so the card is
+returned to its column under the machine provenance `launch_refused`
+and its **launch-refusal ledger** (`launch_refusal` on the card:
+attempts, last reason, last instant, `not_before`) is advanced. The
+dispatch listing skips a card until its `not_before` — 1m after the
+first refusal, then 2m, 4m, … capped at 30m — so a refused card costs
+one attempt per backoff, not one per 5s tick, and queues behind the
+cards not tried yet (its `updated_at` moves). The server draining
+consumes no attempt: another replica claims the card on its next tick.
+
+After `ITERION_BOARD_LAUNCH_ATTEMPTS` consecutive refusals (default 8,
+about an hour and a half of retries; an unparsable value keeps the
+default and is logged once at startup) the card is filed `blocked` under
+the **descriptive** provenance `launch_given_up`, with the last refusal
+on its ledger and a give-up stamp naming it — reflected onto a bound
+external board on purpose: a human has to decide now. A successful
+launch (any run stamped on the card) clears the ledger, and so does an
+operator's *Reopen*, so a card reopened after the cap starts its retries
+afresh.
+
+Each verdict is logged **once per card and reason**, and every watchdog
 pass logs one tally line — `N refused at admission, M returned to their
-column after a claim` — so the ongoing cost of a broken card stays
-visible after its first line.
+column after a claim, K launches refused by the run service, G filed
+blocked after the launch attempt cap` — so the ongoing cost of a broken
+card stays visible after its first line.
 
 ## Retry queue
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -46,8 +46,16 @@ bug until you know it is a decision:
 2. **It never reopens a closed card.** Leaving a terminal column (`done`,
    `blocked`) is a *reopen* — an operator gesture with a dependents check and
    an audit trail. Dragging a card out of *Done* on GitHub is reported
-   (`refused_terminal`) and the two boards stay divergent until a human reopens
-   the card in iterion.
+   (`refused_terminal`, and the log line `project import: state write refused
+   … is terminal — leaving it requires an explicit reopen`) and the two boards
+   stay divergent until a human reopens the card in iterion. **The sanctioned
+   reopen is the API transition** — `iterion remote issues transition
+   <card-id> <state>`, or the studio move — because `SetStateOrReopen`
+   treats a transition OUT of a terminal state through the HTTP surface as
+   the explicit reopen the sink demands, while the project import
+   deliberately does not take that path. Whether a human's move on the
+   GitHub board should count as that reopen is an open decision:
+   [#839](https://github.com/SocialGouv/iterion/issues/839).
 3. **Unmapped states are inert.** A card in `review` or `waiting_deps` leaves
    the board showing the last true thing it was told, rather than being
    collapsed onto *In progress* — which the next pass would read back and undo.
@@ -253,17 +261,26 @@ The roadmap follows two kinds of native move and ignores a third:
 |---|---|
 | a **person** (studio, CLI, a bot's `board.move` tool) | yes |
 | a **run's verdict** — the dispatcher filing `in_progress` at launch, `done` after a finished run, `blocked` after a failed one, `awaiting_input` on a pause | yes |
-| **iterion on its own authority** — the claim watchdog parking a card, a column rename/delete, the dispatcher giving back a card it could not launch | **no** |
+| **iterion on its own authority** — the claim watchdog parking a card, a column rename/delete, the dispatcher giving back a card it could not launch or whose launch the run service refused | **no** |
 
 The third kind is *machine provenance*: the store stamps it on the card
 (`state_reason`, the same value the card's state event carries — `watchdog`,
-`state_rename`, `unlaunchable`, …) at every transition, on both the filesystem
-and the Mongo board, and both reflect paths read it off the card. Such a
-column says nothing about the card's work, so pushing it would show on the
-operator's board as if someone had decided it. The pass counts what it left
-alone as `reflect_machine`; the fast path materializes no projection row for
-a machine-caused move at all. The trigger spine applies the same
-`tracker.IsMachineReason` set to *launches*, for the same reason.
+`state_rename`, `unlaunchable`, `launch_refused`, …) at every transition, on
+both the filesystem and the Mongo board, and both reflect paths read it off
+the card. Such a column says nothing about the card's work, so pushing it
+would show on the operator's board as if someone had decided it. The pass
+counts what it left alone as `reflect_machine`; the fast path materializes no
+projection row for a machine-caused move at all. The trigger spine applies
+the same `tracker.IsMachineReason` set to *launches*, for the same reason.
+
+One machine-caused sequence ends in a move the roadmap DOES show: a card
+whose launch the run service keeps refusing is given back and retried with a
+backoff (`launch_refused`, machine), and once the attempts run out it is
+filed `blocked` under `launch_given_up` — **descriptive**, reflected on
+purpose, because the retries are over and a human has to decide. The card
+carries the last refusal (`launch_refusal.last_reason`) and a give-up stamp;
+reopening it in iterion starts the retries afresh. See
+[dispatcher.md](dispatcher.md#claim-selection-on-the-cloud-board--what-is-never-claimed).
 
 The card and the board therefore stay legitimately divergent after a machine
 park — a watchdog-filed `blocked` while GitHub still says *Planned* — until a
@@ -401,7 +418,9 @@ repository under a supported one is the fix.
 Check the column is in the map (`iterion remote board show` — a `!` marks a
 mapped column the board lacks). Then check it is not a terminal card:
 `refused_terminal > 0` means automation declined to resurrect a closed card,
-which is by design — reopen it in iterion.
+which is by design — reopen it in iterion: `iterion remote issues transition
+<card-id> <state>` (or the studio move) is the explicit reopen the terminal
+sink accepts; see [What syncs](#what-syncs-and-which-way), item 2, and #839.
 
 **A card moved in iterion but not on GitHub.**
 Five causes, in order of likelihood: the state is unmapped (`review`,

--- a/openapi.json
+++ b/openapi.json
@@ -1102,6 +1102,9 @@
           "last_workdir": {
             "type": "string"
           },
+          "launch_refusal": {
+            "$ref": "#/components/schemas/LaunchRefusal"
+          },
           "parent_id": {
             "type": "string"
           },
@@ -1138,6 +1141,29 @@
           "state",
           "created_at",
           "updated_at"
+        ],
+        "type": "object"
+      },
+      "LaunchRefusal": {
+        "properties": {
+          "attempts": {
+            "type": "integer"
+          },
+          "last_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_reason": {
+            "type": "string"
+          },
+          "not_before": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "attempts",
+          "last_at"
         ],
         "type": "object"
       },

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -250,6 +250,103 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 		t.Fatalf("StateReason: restore state: %v", err)
 	}
 
+	// Issue.LaunchRefusal is the dispatcher's retry ledger for a launch the
+	// run service refused before any run started (#814). Both twins owe:
+	// a fenced write (a foreign token is refused), a faithful round trip,
+	// survival across the give-back transition, and the two clears — a run
+	// stamped on the card (a launch happened) and an operator Reopen.
+	// On its OWN card: the scenario stamps runs, and the run-history rows
+	// further down read `created`'s history from empty.
+	lrCard, err := store.Create(native.Issue{Title: "launch-refusal ledger", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("LaunchRefusal: create: %v", err)
+	}
+	ledgerOf := func(what string) *native.LaunchRefusal {
+		got, err := store.Get(lrCard.ID)
+		if err != nil {
+			t.Fatalf("LaunchRefusal/%s: Get: %v", what, err)
+		}
+		return got.LaunchRefusal
+	}
+	dispTok, err := store.Claim(lrCard.ID, "board-dispatcher:pod-1")
+	if err != nil {
+		t.Fatalf("LaunchRefusal: claim: %v", err)
+	}
+	notBefore := time.Now().UTC().Add(4 * time.Minute).Truncate(time.Millisecond)
+	ledger := &native.LaunchRefusal{Attempts: 2, LastAt: notBefore.Add(-2 * time.Minute), NotBefore: notBefore, LastReason: "queue unavailable"}
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, ledger, tracker.ClaimToken{Marker: "somebody-else", Epoch: dispTok.Epoch}); !errors.Is(err, tracker.ErrClaimConflict) {
+		t.Errorf("LaunchRefusal: a foreign token wrote the ledger: err=%v, want ErrClaimConflict", err)
+	}
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, ledger, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: owned write: %v", err)
+	}
+	if got := ledgerOf("after the owned write"); got == nil || got.Attempts != 2 || !got.NotBefore.Equal(notBefore) || got.LastReason != "queue unavailable" {
+		t.Fatalf("LaunchRefusal round trip = %+v, want %+v", got, ledger)
+	}
+	// The give-back transition keeps the ledger — it is what bounds the
+	// NEXT attempt.
+	if _, err := store.SetStateOwned(lrCard.ID, native.StateInProgress, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: start: %v", err)
+	}
+	if _, err := store.SetStateOwnedReason(lrCard.ID, native.StateReady, dispTok, tracker.ReasonLaunchRefused); err != nil {
+		t.Fatalf("LaunchRefusal: give back: %v", err)
+	}
+	if got := ledgerOf("after a give-back"); got == nil || got.Attempts != 2 {
+		t.Errorf("LaunchRefusal after the give-back transition = %+v, want it kept", got)
+	}
+	if !mustGetIssue(t, store, lrCard.ID).StateByMachine() {
+		t.Error("StateByMachine after a launch_refused give-back = false, want true")
+	}
+	// A run stamped on the card means a launch happened: the ledger is over.
+	if err := store.SetLastRunOwned(lrCard.ID, "run-after-refusals", "/wt/x", dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: SetLastRunOwned: %v", err)
+	}
+	if got := ledgerOf("after SetLastRunOwned"); got != nil {
+		t.Errorf("LaunchRefusal survived a stamped run: %+v — a launch happened, the retry ledger no longer describes the card", got)
+	}
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, ledger, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: re-write: %v", err)
+	}
+	if err := store.SetLastRun(lrCard.ID, "run-after-refusals-2", "/wt/y"); err != nil {
+		t.Fatalf("LaunchRefusal: SetLastRun: %v", err)
+	}
+	if got := ledgerOf("after SetLastRun"); got != nil {
+		t.Errorf("LaunchRefusal survived an unfenced run stamp: %+v", got)
+	}
+	// nil clears explicitly too.
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, ledger, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: re-write: %v", err)
+	}
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, nil, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: clear: %v", err)
+	}
+	if got := ledgerOf("after an explicit clear"); got != nil {
+		t.Errorf("LaunchRefusal after nil = %+v, want cleared", got)
+	}
+	// An operator Reopen clears it: the card filed blocked after the cap
+	// starts its retries afresh when a human reopens it.
+	if err := store.SetLaunchRefusalOwned(lrCard.ID, ledger, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: re-write: %v", err)
+	}
+	if _, err := store.SetStateOwnedReason(lrCard.ID, native.StateBlocked, dispTok, tracker.ReasonLaunchGivenUp); err != nil {
+		t.Fatalf("LaunchRefusal: file blocked: %v", err)
+	}
+	if mustGetIssue(t, store, lrCard.ID).StateByMachine() {
+		t.Error("StateByMachine after launch_given_up = true, want false — the roadmap must show the filing")
+	}
+	if err := store.ReleaseOwned(lrCard.ID, dispTok); err != nil {
+		t.Fatalf("LaunchRefusal: release: %v", err)
+	}
+	if _, err := store.Reopen(lrCard.ID, native.StateReady); err != nil {
+		t.Fatalf("LaunchRefusal: Reopen: %v", err)
+	}
+	if got := ledgerOf("after Reopen"); got != nil {
+		t.Errorf("LaunchRefusal survived an operator Reopen: %+v", got)
+	}
+	if err := store.Delete(lrCard.ID); err != nil {
+		t.Fatalf("LaunchRefusal: delete: %v", err)
+	}
+
 	// Claim: idempotent same marker; conflict on a different marker; release.
 	if _, err := store.Claim(created.ID, "runner-A"); err != nil {
 		t.Fatalf("Claim: %v", err)
@@ -1347,6 +1444,58 @@ func TestMongoStore_Conformance(t *testing.T) {
 	}
 	if !dispTitles["ready-a"] || !dispTitles["ready-b"] {
 		t.Errorf("ListDispatchable must list the launchable ready cards: %v", dispTitles)
+	}
+	// A card inside its launch-refusal backoff is not dispatchable until
+	// NotBefore has passed (#814) — the predicate is in the query, like the
+	// bot filter, for the same batch-starvation reason.
+	{
+		st := coord.StoreFor("ca")
+		held, cerr := st.Create(native.Issue{Title: "held-back", State: native.StateReady, Bot: "feature-dev"})
+		if cerr != nil {
+			t.Fatalf("coord create held-back: %v", cerr)
+		}
+		tok, cerr := st.Claim(held.ID, "board-dispatcher:pod-1")
+		if cerr != nil {
+			t.Fatalf("claim held-back: %v", cerr)
+		}
+		listed := func(what string) bool {
+			t.Helper()
+			d, derr := coord.ListDispatchable(ctx, []string{native.StateReady}, 50)
+			if derr != nil {
+				t.Fatalf("ListDispatchable (%s): %v", what, derr)
+			}
+			for _, c := range d {
+				if c.Issue.ID == held.ID {
+					return true
+				}
+			}
+			return false
+		}
+		if err := st.SetLaunchRefusalOwned(held.ID, &native.LaunchRefusal{Attempts: 1, LastAt: time.Now().UTC(), NotBefore: time.Now().UTC().Add(time.Hour), LastReason: "x"}, tok); err != nil {
+			t.Fatalf("ledger held-back: %v", err)
+		}
+		if err := st.ReleaseOwned(held.ID, tok); err != nil {
+			t.Fatalf("release held-back: %v", err)
+		}
+		if listed("inside the backoff") {
+			t.Error("ListDispatchable listed a card inside its launch-refusal backoff")
+		}
+		tok, cerr = st.Claim(held.ID, "board-dispatcher:pod-1")
+		if cerr != nil {
+			t.Fatalf("re-claim held-back: %v", cerr)
+		}
+		if err := st.SetLaunchRefusalOwned(held.ID, &native.LaunchRefusal{Attempts: 1, LastAt: time.Now().UTC(), NotBefore: time.Now().UTC().Add(-time.Second), LastReason: "x"}, tok); err != nil {
+			t.Fatalf("ledger held-back (expired): %v", err)
+		}
+		if err := st.ReleaseOwned(held.ID, tok); err != nil {
+			t.Fatalf("release held-back: %v", err)
+		}
+		if !listed("after the backoff") {
+			t.Error("ListDispatchable must list a card once its NotBefore has passed")
+		}
+		if err := st.Delete(held.ID); err != nil {
+			t.Fatalf("delete held-back: %v", err)
+		}
 	}
 	elig, eerr := coord.ListEligible(ctx, []string{native.StateReady}, 50, false)
 	if eerr != nil {

--- a/pkg/dispatcher/boardmongo/coordinator.go
+++ b/pkg/dispatcher/boardmongo/coordinator.go
@@ -122,6 +122,15 @@ func (c *Coordinator) ListDispatchable(ctx context.Context, eligible []string, l
 		"issue.state": bson.M{"$in": eligible},
 		"issue.claim": bson.M{"$in": bson.A{"", nil}},
 		"issue.bot":   bson.M{"$gt": ""},
+		// A card inside its launch-refusal backoff is not a candidate until
+		// NotBefore has passed — in the query for the same starvation
+		// reason as the bot filter. Measured against this replica's clock:
+		// a backoff is a pacing, not a lease, so a few seconds of skew
+		// between pods only moves a retry slightly.
+		"$or": bson.A{
+			bson.M{"issue.launchrefusal": nil},
+			bson.M{"issue.launchrefusal.notbefore": bson.M{"$lte": time.Now().UTC()}},
+		},
 	}, opt)
 	if err != nil {
 		return nil, fmt.Errorf("boardmongo: list dispatchable: %w", err)
@@ -207,6 +216,12 @@ func (c *Coordinator) ReleaseOwned(_ context.Context, tenant, id string, tok tra
 // a filing was ITS decision (a pruned pointer), not a human's.
 func (c *Coordinator) SetGaveUpOwned(_ context.Context, tenant, id string, g *native.GiveUp, tok tracker.ClaimToken) error {
 	return c.StoreFor(tenant).SetGaveUpOwned(id, g, tok)
+}
+
+// SetLaunchRefusalOwned is the fenced launch-refusal ledger write — the
+// dispatcher's retry bound on a launch the run service refused.
+func (c *Coordinator) SetLaunchRefusalOwned(_ context.Context, tenant, id string, r *native.LaunchRefusal, tok tracker.ClaimToken) error {
+	return c.StoreFor(tenant).SetLaunchRefusalOwned(id, r, tok)
 }
 
 // ExpiredCandidate is one cross-tenant reap candidate.

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -797,8 +797,9 @@ func (s *Store) SetLastRun(id, runID, workdir string) error {
 	iss.LastRunID = runID
 	iss.LastWorkdir = workdir
 	iss.Runs = native.AppendRunRef(iss.Runs, runID, workdir, now)
+	iss.LaunchRefusal = nil // a launch happened: the retry ledger no longer describes the card
 	iss.UpdatedAt = now
-	if err := s.replace(ctx, iss, "lastrunid", "lastworkdir", "runs"); err != nil {
+	if err := s.replace(ctx, iss, "lastrunid", "lastworkdir", "runs", "launchrefusal"); err != nil {
 		return err
 	}
 	return s.emit(native.Event{Type: native.EvtIssueLastRun, IssueID: id, Payload: map[string]any{"run_id": runID, "workdir": workdir}})

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -364,10 +364,11 @@ func (s *Store) SetLastRunOwned(id, runID, workdir string, tok tracker.ClaimToke
 	now := time.Now().UTC()
 	runs := native.AppendRunRef(iss.Runs, runID, workdir, now)
 	res, err := s.issues.UpdateOne(ctx, s.ownedFilter(id, tok), bson.M{"$set": bson.M{
-		"issue.lastrunid":   runID,
-		"issue.lastworkdir": workdir,
-		"issue.runs":        runs,
-		"issue.updatedat":   now,
+		"issue.lastrunid":     runID,
+		"issue.lastworkdir":   workdir,
+		"issue.runs":          runs,
+		"issue.launchrefusal": nil, // a launch happened: the retry ledger no longer describes the card
+		"issue.updatedat":     now,
 	}})
 	if err != nil {
 		return fmt.Errorf("boardmongo: set last run owned: %w", err)
@@ -401,6 +402,27 @@ func (s *Store) SetAwaitingInputOwned(id string, v bool, tok tracker.ClaimToken)
 	}
 	return s.emit(native.Event{Type: native.EvtIssueUpdated, IssueID: id,
 		Payload: map[string]any{"awaiting_input": v}})
+}
+
+// SetLaunchRefusalOwned — see native.BoardStore. ONE conditional write:
+// the ownership check and the ledger ride the same UpdateOne.
+func (s *Store) SetLaunchRefusalOwned(id string, r *native.LaunchRefusal, tok tracker.ClaimToken) error {
+	ctx, cancel := ctxWithTimeout()
+	defer cancel()
+	stamped := r.Clone()
+	res, err := s.issues.UpdateOne(ctx, s.ownedFilter(id, tok), bson.M{"$set": bson.M{
+		"issue.launchrefusal": stamped,
+		// UpdatedAt moves on purpose: the dispatch listing is oldest-updated
+		// first, so a refused card queues behind the cards not tried yet.
+		"issue.updatedat": time.Now().UTC(),
+	}})
+	if err != nil {
+		return fmt.Errorf("boardmongo: set launch refusal owned: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return s.ownedRefused(ctx, id, tok)
+	}
+	return s.emit(native.Event{Type: native.EvtIssueLaunchRefused, IssueID: id, Payload: native.LaunchRefusalPayload(stamped)})
 }
 
 // SetGaveUpOwned is SetGaveUp fenced on the claim token. The stamp's
@@ -672,9 +694,13 @@ func (s *Store) Reopen(id, toState string) (*native.Issue, error) {
 	// back to the caller (SetStateOrReopen, via the board HTTP handlers) —
 	// so returning the snapshot read above told the studio the reopened
 	// card still carried the give-up flag that "Needs attention" reads.
+	// An operator gesture: the park's provenance no longer describes the
+	// card, and its launch retries start afresh.
+	reopenSet := stateSet(toState, "")
+	reopenSet["issue.launchrefusal"] = nil
 	res := s.issues.FindOneAndUpdate(ctx,
 		bson.M{"_id": id, "tenant_id": s.tenant, "issue.state": iss.State},
-		bson.M{"$set": stateSet(toState, "")}, // an operator gesture: the park's provenance no longer describes the card
+		bson.M{"$set": reopenSet},
 		options.FindOneAndUpdate().SetReturnDocument(options.After))
 	if res.Err() != nil {
 		if !isNoDocuments(res.Err()) {

--- a/pkg/dispatcher/launchrefusal.go
+++ b/pkg/dispatcher/launchrefusal.go
@@ -1,0 +1,101 @@
+package dispatcher
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// The launch-refusal retry policy of the cloud board dispatcher.
+//
+// A card whose launch the run service refuses before any run exists (a
+// sealing failure, a queue outage, a bot that does not compile, …) is not a
+// failed card: the same launch succeeds ten minutes later, or never. The
+// dispatcher gives the card back to its column and tries again — but not on
+// every 5s tick, and not for ever: an exponential backoff spaces the
+// attempts, and an attempt cap turns a permanent refusal into a `blocked`
+// filing that names the last refusal, which is the point where a human has
+// to decide.
+
+const (
+	launchRefusalBackoffBase = time.Minute
+	launchRefusalBackoffMax  = 30 * time.Minute
+	// launchAttemptsEnv overrides the attempt cap per deployment. 0 or an
+	// unparsable value leaves the default in force (and is logged once at
+	// startup, see LaunchAttemptCapMisspelling).
+	launchAttemptsEnv     = "ITERION_BOARD_LAUNCH_ATTEMPTS"
+	defaultLaunchAttempts = 8
+)
+
+// LaunchRefusalBackoff is how long the dispatch listing skips a card after
+// its n-th consecutive refusal: 1m, 2m, 4m, … doubling, capped at 30m. With
+// the default cap of 8 attempts a permanently refused card is filed after
+// roughly an hour and a half.
+func LaunchRefusalBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := launchRefusalBackoffBase
+	for i := 1; i < attempt && d < launchRefusalBackoffMax; i++ {
+		d *= 2
+	}
+	if d > launchRefusalBackoffMax {
+		d = launchRefusalBackoffMax
+	}
+	return d
+}
+
+// LaunchAttemptCap is the number of consecutive launch refusals after which
+// the card is filed blocked instead of given back once more.
+func LaunchAttemptCap() int {
+	cap, _ := launchAttemptSetting()
+	return cap
+}
+
+// LaunchAttemptCapEnvName is the override's env var, for the startup log.
+func LaunchAttemptCapEnvName() string { return launchAttemptsEnv }
+
+// LaunchAttemptCapMisspelling returns a diagnostic when the override is set
+// to a value that is not a positive integer, and "" otherwise — the default
+// stays in force, and the operator must be able to see that it did.
+func LaunchAttemptCapMisspelling() string {
+	_, raw := launchAttemptSetting()
+	if raw == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s=%q is not a positive integer — the launch attempt cap stays at its default of %d",
+		launchAttemptsEnv, raw, defaultLaunchAttempts)
+}
+
+func launchAttemptSetting() (cap int, unrecognised string) {
+	raw := strings.TrimSpace(os.Getenv(launchAttemptsEnv))
+	if raw == "" {
+		return defaultLaunchAttempts, ""
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return defaultLaunchAttempts, raw
+	}
+	return n, ""
+}
+
+// NextLaunchRefusal folds one more refusal into a card's ledger: attempts
+// advance, NotBefore is pushed out by the backoff for the NEW attempt count,
+// and the reason and instant are recorded for the operator. prev may be nil
+// (first refusal).
+func NextLaunchRefusal(prev *native.LaunchRefusal, now time.Time, reason string) *native.LaunchRefusal {
+	attempts := 1
+	if prev != nil {
+		attempts = prev.Attempts + 1
+	}
+	return &native.LaunchRefusal{
+		Attempts:   attempts,
+		LastAt:     now,
+		NotBefore:  now.Add(LaunchRefusalBackoff(attempts)),
+		LastReason: reason,
+	}
+}

--- a/pkg/dispatcher/launchrefusal_test.go
+++ b/pkg/dispatcher/launchrefusal_test.go
@@ -1,0 +1,55 @@
+package dispatcher
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLaunchRefusalBackoff_DoublesAndCaps(t *testing.T) {
+	for attempt, want := range map[int]time.Duration{
+		0: time.Minute, 1: time.Minute, 2: 2 * time.Minute, 3: 4 * time.Minute,
+		5: 16 * time.Minute, 6: 30 * time.Minute, 7: 30 * time.Minute, 40: 30 * time.Minute,
+	} {
+		if got := LaunchRefusalBackoff(attempt); got != want {
+			t.Errorf("backoff(%d) = %s, want %s", attempt, got, want)
+		}
+	}
+}
+
+func TestNextLaunchRefusal_AdvancesTheLedger(t *testing.T) {
+	now := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	first := NextLaunchRefusal(nil, now, "queue unavailable")
+	if first.Attempts != 1 || !first.NotBefore.Equal(now.Add(time.Minute)) || first.LastReason != "queue unavailable" || !first.LastAt.Equal(now) {
+		t.Fatalf("first refusal = %+v", first)
+	}
+	second := NextLaunchRefusal(first, now.Add(time.Minute), "still down")
+	if second.Attempts != 2 || !second.NotBefore.Equal(now.Add(time.Minute).Add(2*time.Minute)) || second.LastReason != "still down" {
+		t.Fatalf("second refusal = %+v", second)
+	}
+	if first.Attempts != 1 {
+		t.Fatal("NextLaunchRefusal mutated its input")
+	}
+}
+
+func TestLaunchAttemptCap_EnvOverride(t *testing.T) {
+	t.Setenv(launchAttemptsEnv, "")
+	if got := LaunchAttemptCap(); got != defaultLaunchAttempts {
+		t.Fatalf("default cap = %d, want %d", got, defaultLaunchAttempts)
+	}
+	t.Setenv(launchAttemptsEnv, "3")
+	if got := LaunchAttemptCap(); got != 3 {
+		t.Fatalf("cap from env = %d, want 3", got)
+	}
+	if msg := LaunchAttemptCapMisspelling(); msg != "" {
+		t.Fatalf("a valid override reported a misspelling: %s", msg)
+	}
+	for _, bad := range []string{"0", "-2", "many", "1.5"} {
+		t.Setenv(launchAttemptsEnv, bad)
+		if got := LaunchAttemptCap(); got != defaultLaunchAttempts {
+			t.Errorf("cap with %q = %d, want the default %d", bad, got, defaultLaunchAttempts)
+		}
+		if msg := LaunchAttemptCapMisspelling(); msg == "" {
+			t.Errorf("no diagnostic for %q — the default silently won", bad)
+		}
+	}
+}

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -79,6 +79,12 @@ type BoardStore interface {
 	SetLastRunOwned(id, runID, workdir string, tok tracker.ClaimToken) error
 	SetAwaitingInputOwned(id string, v bool, tok tracker.ClaimToken) error
 	SetGaveUpOwned(id string, g *GiveUp, tok tracker.ClaimToken) error
+	// SetLaunchRefusalOwned writes (nil clears) the launch-refusal ledger
+	// of a card the token owns — the dispatcher's own record, so fenced
+	// like every owner write. Both twins clear it themselves when a run is
+	// stamped (SetLastRun / SetLastRunOwned: a launch happened) and on
+	// Reopen (an operator gesture).
+	SetLaunchRefusalOwned(id string, r *LaunchRefusal, tok tracker.ClaimToken) error
 	// The reaper half — MANDATORY for the same reason as the lease: an
 	// optional watchdog is silently inert exactly where it matters (the
 	// cloud). ListExpiredClaimCandidates never lists a legacy claim;

--- a/pkg/dispatcher/native/event.go
+++ b/pkg/dispatcher/native/event.go
@@ -20,6 +20,11 @@ const (
 	// state change on a ticket that no human asked for, so it gets its own
 	// audit record rather than an anonymous issue_updated.
 	EvtIssueGaveUp EventType = "issue_gave_up"
+	// EvtIssueLaunchRefused is emitted when the dispatcher's launch-refusal
+	// ledger is written or cleared on an issue (see Issue.LaunchRefusal).
+	// Payload: {refused: bool, attempts, not_before, reason}. An audit
+	// record, not a card event: the trigger spine does not consume it.
+	EvtIssueLaunchRefused EventType = "issue_launch_refused"
 	// EvtIssueBlockersUpdated is emitted when an issue's blockers list changes
 	// (create-with-blockers, Update patch). Payload: {blockers: []string}.
 	EvtIssueBlockersUpdated EventType = "issue_blockers_updated"

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -84,6 +84,15 @@ type Issue struct {
 	// construction (see GiveUp.Current). The one case that needs an explicit
 	// clear is an operator filing the ticket into the state it is already in.
 	GaveUp *GiveUp `json:"gave_up,omitempty"`
+	// LaunchRefusal is the cloud dispatcher's record of a claimed card whose
+	// launch the run service REFUSED before any run started (a sealing
+	// failure, a queue outage, a bot that does not compile, …): nothing ran,
+	// so no verdict belongs on the card and it went back to its column. It
+	// is what bounds the retry — the dispatch listing skips the card until
+	// NotBefore, and the attempt cap turns a permanent refusal into a
+	// `blocked` filing the operator can read (LastReason). Cleared when a
+	// launch succeeds (SetLastRun) and when an operator reopens the card.
+	LaunchRefusal *LaunchRefusal `json:"launch_refusal,omitempty"`
 	// LastWorkdir is the absolute filesystem path the last run
 	// executed in — either the per-issue dispatcher workspace or,
 	// when `worktree: auto` was used, the run's git worktree path.
@@ -200,6 +209,27 @@ type GiveUp struct {
 	Reason string `json:"reason,omitempty"`
 	// At is when the give-up was stamped (UTC).
 	At time.Time `json:"at"`
+}
+
+// LaunchRefusal is the retry ledger of a card whose launch keeps being
+// refused before a run exists (see Issue.LaunchRefusal). Attempts counts
+// the consecutive refusals; NotBefore is the earliest instant the dispatch
+// tick may claim the card again; LastAt / LastReason say when and why, for
+// the operator who finds the card filed blocked once the attempts run out.
+type LaunchRefusal struct {
+	Attempts   int       `json:"attempts"`
+	LastAt     time.Time `json:"last_at"`
+	NotBefore  time.Time `json:"not_before,omitempty"`
+	LastReason string    `json:"last_reason,omitempty"`
+}
+
+// Clone returns a copy, nil-safe.
+func (r *LaunchRefusal) Clone() *LaunchRefusal {
+	if r == nil {
+		return nil
+	}
+	c := *r
+	return &c
 }
 
 // Current reports whether the stamp still describes the issue as it stands:

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -191,6 +191,7 @@ func cloneIssue(in *Issue) *Issue {
 		g := *in.GaveUp
 		c.GaveUp = &g
 	}
+	c.LaunchRefusal = in.LaunchRefusal.Clone()
 	if in.Labels != nil {
 		c.Labels = append([]string(nil), in.Labels...)
 	}
@@ -501,7 +502,8 @@ func (s *Store) Reopen(id, toState string) (updated *Issue, err error) {
 	}
 	old := iss.State
 	iss.State = toState
-	iss.StateReason = "" // an operator gesture: whatever parked the card no longer describes it
+	iss.StateReason = ""    // an operator gesture: whatever parked the card no longer describes it
+	iss.LaunchRefusal = nil // …and its launch retries start afresh
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -136,6 +136,53 @@ func (s *Store) SetGaveUpOwned(id string, g *GiveUp, tok tracker.ClaimToken) (er
 	return s.setGaveUpLocked(iss, g)
 }
 
+// SetLaunchRefusalOwned — see BoardStore.
+func (s *Store) SetLaunchRefusalOwned(id string, r *LaunchRefusal, tok tracker.ClaimToken) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("SetLaunchRefusalOwned", &err)
+	iss, err := s.ownedIssueLocked(id, tok)
+	if err != nil {
+		return err
+	}
+	return s.setLaunchRefusalLocked(iss, r)
+}
+
+func (s *Store) setLaunchRefusalLocked(iss *Issue, r *LaunchRefusal) error {
+	if r == nil && iss.LaunchRefusal == nil {
+		return nil
+	}
+	iss.LaunchRefusal = r.Clone()
+	// UpdatedAt moves on purpose: the dispatch listing is oldest-updated
+	// first, so a refused card takes its place behind the cards that have
+	// not been tried yet.
+	iss.UpdatedAt = time.Now().UTC()
+	if err := s.writeIssueLocked(iss); err != nil {
+		return err
+	}
+	s.index[iss.ID] = cloneIssue(iss)
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtIssueLaunchRefused,
+		IssueID: iss.ID,
+		Payload: LaunchRefusalPayload(iss.LaunchRefusal),
+	})
+}
+
+// LaunchRefusalPayload is the EvtIssueLaunchRefused body, shared by both
+// twins: {refused: false} for a clear, else the ledger's attempts, next
+// instant and reason.
+func LaunchRefusalPayload(r *LaunchRefusal) map[string]any {
+	if r == nil {
+		return map[string]any{"refused": false}
+	}
+	return map[string]any{
+		"refused":    true,
+		"attempts":   r.Attempts,
+		"not_before": r.NotBefore,
+		"reason":     r.LastReason,
+	}
+}
+
 // ReleaseOwned is Release fenced on the claim token. Idempotent when
 // the claim is already gone (an unclaimed issue is the desired state);
 // a claim held by ANOTHER epoch or marker refuses — releasing someone
@@ -186,6 +233,7 @@ func (s *Store) setLastRunLocked(iss *Issue, runID, workdir string) error {
 	iss.LastRunID = runID
 	iss.LastWorkdir = workdir
 	iss.Runs = AppendRunRef(iss.Runs, runID, workdir, now)
+	iss.LaunchRefusal = nil // a launch happened: the retry ledger no longer describes the card
 	iss.UpdatedAt = now
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err

--- a/pkg/dispatcher/tracker/tracker.go
+++ b/pkg/dispatcher/tracker/tracker.go
@@ -251,6 +251,18 @@ const (
 	// an audit surface must not sign it with the assignee's name, and an
 	// external roadmap must not read it as a move.
 	ReasonUnlaunchable = "unlaunchable"
+	// ReasonLaunchRefused is the dispatcher returning a card whose launch
+	// the run service refused before any run started (sealing, a queue
+	// outage, a bot that does not compile, …) to the column it took it
+	// from, to try again after a backoff. Machine provenance for the same
+	// reasons as ReasonUnlaunchable: nothing about the card's work was
+	// judged.
+	ReasonLaunchRefused = "launch_refused"
+	// ReasonLaunchGivenUp is the dispatcher filing a card whose launch was
+	// refused on every attempt it allows itself: a decision a human now has
+	// to take, so DESCRIPTIVE, not machine — the external roadmap shows
+	// it, and the card carries the last refusal for the operator to read.
+	ReasonLaunchGivenUp = "launch_given_up"
 )
 
 // IsMachineReason reports whether a board-event `reason` names iterion
@@ -261,7 +273,8 @@ const (
 // field's mere presence silently disarmed them.
 func IsMachineReason(reason string) bool {
 	switch reason {
-	case ReasonWatchdog, ReasonStateRename, ReasonStateDelete, ReasonFieldRename, ReasonFieldDelete, ReasonUnlaunchable:
+	case ReasonWatchdog, ReasonStateRename, ReasonStateDelete, ReasonFieldRename, ReasonFieldDelete,
+		ReasonUnlaunchable, ReasonLaunchRefused:
 		return true
 	}
 	return false

--- a/pkg/server/board_project_reflect_test.go
+++ b/pkg/server/board_project_reflect_test.go
@@ -814,3 +814,33 @@ func TestSyncProjectBoardReflectsARunVerdict(t *testing.T) {
 		t.Fatalf("run verdict: reflected=%d writes=%+v, want one Done write", res.Reflected, bc.writes)
 	}
 }
+
+// TestSyncProjectBoardReflectsALaunchGiveUp (#814): the filing that ends a
+// card's launch retries is a decision for a human, so it IS reflected —
+// while the give-backs that preceded it (launch_refused) were machinery.
+func TestSyncProjectBoardReflectsALaunchGiveUp(t *testing.T) {
+	at := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+	board := newTestBoard(t)
+	id := seedSynced(t, board, 814, native.StateReady, "Planned", at)
+	tok, err := board.Claim(id, "board-dispatcher:pod-1")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if _, err := board.SetStateOwnedReason(id, native.StateBlocked, tok, tracker.ReasonLaunchGivenUp); err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	if mustGet(t, board, id).StateByMachine() {
+		t.Fatal("fixture: launch_given_up must not read as machine provenance")
+	}
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 814, statusValue("Planned", at)),
+	}}}
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board,
+		&ProjectImportOptions{Binding: testBinding()})
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if res.Reflected != 1 || len(bc.writes) != 1 || bc.writes[0].OptionID != optionID(t, testProject(), "Blocked") {
+		t.Fatalf("launch give-up: reflected=%d writes=%+v, want one Blocked write — the operator's board must show the card that needs them", res.Reflected, bc.writes)
+	}
+}

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	"github.com/SocialGouv/iterion/pkg/errtrack"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -60,6 +61,9 @@ type boardCoordinator interface {
 	// SetGaveUpOwned stamps the watchdog's give-up on a card it filed on
 	// its own authority (a pruned pointer) — fenced like every owner write.
 	SetGaveUpOwned(ctx context.Context, tenant, id string, g *native.GiveUp, tok tracker.ClaimToken) error
+	// SetLaunchRefusalOwned writes (nil clears) a card's launch-refusal
+	// ledger — the retry bound of a launch the run service refused.
+	SetLaunchRefusalOwned(ctx context.Context, tenant, id string, r *native.LaunchRefusal, tok tracker.ClaimToken) error
 	// The reaper pair (the cloud half of the claim watchdog — the hole
 	// boarddispatch itself documented as R5ceb26: "no TTL and no reaper
 	// exists yet"). List is cross-tenant; Reclaim is a CAS TRANSFER.
@@ -94,6 +98,16 @@ var errCardContinuable = errors.New("board dispatcher: run continuable")
 //     bot the resolver cannot find, carries malformed reserved bot-args, or
 //     the run service is not wired. Card back to its column, claim freed,
 //     one Warn per (card, reason) edge.
+//   - errCardLaunchRefused — the run service refused the launch before any
+//     run existed (a sealing failure, a queue outage, the server draining,
+//     a bot that does not compile, an invalid spec): transient, retryable.
+//     Card back to its column under the machine ReasonLaunchRefused, the
+//     card's launch-refusal ledger advanced (the dispatch listing skips it
+//     for a backoff), one Warn per (card, reason) edge — and past the
+//     attempt cap, filed `blocked` under the DESCRIPTIVE
+//     ReasonLaunchGivenUp with the last refusal on the card, reflected on
+//     purpose: a human has to decide. The server draining consumes no
+//     attempt (another replica picks the card up next tick).
 //   - errCardPaused — the run parked on a human/operator gate → the
 //     awaiting-input column.
 //   - errCardContinuable — the run ended failed_resumable / cancelled → the
@@ -103,6 +117,39 @@ var errCardContinuable = errors.New("board dispatcher: run continuable")
 //   - anything else — the run was launched and ended in a terminal failure,
 //     or the publisher refused the launch (quota, sealing, …) → `blocked`.
 var errCardUnlaunchable = errors.New("board dispatcher: card cannot be launched")
+
+// errCardLaunchRefused marks a launch the run service refused before any run
+// started — see the taxonomy above. Typed at the ONE boundary where it is
+// decidable without reading an error's prose: every error returned by
+// runview.Service.Launch means no run was started.
+var errCardLaunchRefused = errors.New("board dispatcher: launch refused")
+
+// launchRefusal is the typed form processBoardCard returns for an error out
+// of runs.Launch: errors.Is(err, errCardLaunchRefused) for the class,
+// errors.Is through Cause for the typed refusals underneath (the server
+// draining), and Cause's own text for the ledger the operator reads — never
+// the class wrapper's.
+type launchRefusal struct {
+	cardID string
+	cause  error
+}
+
+func (e *launchRefusal) Error() string {
+	return fmt.Sprintf("card %s launch refused: %v", e.cardID, e.cause)
+}
+func (e *launchRefusal) Is(target error) bool { return target == errCardLaunchRefused }
+func (e *launchRefusal) Unwrap() error        { return e.cause }
+
+// launchRefusalReason is the refusal's own text — what the card's ledger and
+// the give-up stamp record — falling back to the whole error for a refusal
+// that did not come through the typed form.
+func launchRefusalReason(err error) string {
+	var lr *launchRefusal
+	if errors.As(err, &lr) && lr.cause != nil {
+		return lr.cause.Error()
+	}
+	return err.Error()
+}
 
 // pollDisposition maps a TERMINAL polled status to the poll's verdict:
 // finished = clean; failed = the one filing-worthy failure; everything
@@ -215,6 +262,11 @@ type boardDispatcher struct {
 	unlaunchMu     sync.Mutex
 	unlaunchWarned map[string]unlaunchNote
 	unlaunchTally  unlaunchableTally
+
+	// launchAttemptCap is how many consecutive launch refusals a card may
+	// collect before it is filed blocked (dispatcher.LaunchAttemptCap by
+	// default; tests lower it).
+	launchAttemptCap int
 }
 
 // unlaunchNote is one card's last unlaunchable verdict: the reason said, and
@@ -232,18 +284,19 @@ func newBoardDispatcher(coord boardCoordinator, process func(context.Context, st
 		concurrency = 4
 	}
 	return &boardDispatcher{
-		coord:           coord,
-		process:         process,
-		marker:          marker,
-		eligible:        []string{native.StateReady},
-		inProgressState: native.StateInProgress,
-		doneState:       native.StateDone,
-		blockedState:    native.StateBlocked,
-		awaitingState:   native.StateAwaitingInput,
-		interval:        5 * time.Second,
-		reapEvery:       dispatcher.ClaimReaperInterval(),
-		sem:             make(chan struct{}, concurrency),
-		logger:          logger,
+		coord:            coord,
+		process:          process,
+		marker:           marker,
+		eligible:         []string{native.StateReady},
+		inProgressState:  native.StateInProgress,
+		doneState:        native.StateDone,
+		blockedState:     native.StateBlocked,
+		awaitingState:    native.StateAwaitingInput,
+		interval:         5 * time.Second,
+		reapEvery:        dispatcher.ClaimReaperInterval(),
+		sem:              make(chan struct{}, concurrency),
+		logger:           logger,
+		launchAttemptCap: dispatcher.LaunchAttemptCap(),
 	}
 }
 
@@ -275,7 +328,7 @@ func (d *boardDispatcher) tick(ctx context.Context) int {
 			if err := d.admit(ctx, c.Tenant, c.Issue); err != nil {
 				<-d.sem
 				if errors.Is(err, errCardUnlaunchable) {
-					d.noteUnlaunchable(c.Tenant, c.Issue.ID, c.Issue.State, err, false)
+					d.noteHeld(heldAtAdmission, c.Tenant, c.Issue.ID, c.Issue.State, err)
 				} else {
 					d.warn("card %s/%s admission: %v — retried next tick", c.Tenant, c.Issue.ID, err)
 				}
@@ -332,8 +385,11 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	runErr := d.process(cardCtx, c.Tenant, c.Issue)
 	final := d.doneState
 	// finalReason is the provenance the final write carries; empty for a
-	// run's own verdict (the ordinary fenced move).
+	// run's own verdict (the ordinary fenced move). ledger / giveUp are the
+	// launch-refusal writes that accompany it, when the class calls for them.
 	finalReason := ""
+	var ledger *native.LaunchRefusal
+	var giveUp *native.GiveUp
 	switch {
 	case runErr != nil && errors.Is(runErr, errCardUnlaunchable):
 		// Nothing ran (the taxonomy on errCardUnlaunchable): no verdict
@@ -344,7 +400,33 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 		// makes this the race case (the card changed between the listing
 		// and the launch); it is still never `blocked`.
 		final, finalReason = c.Issue.State, tracker.ReasonUnlaunchable
-		d.noteUnlaunchable(c.Tenant, c.Issue.ID, c.Issue.State, runErr, true)
+		d.noteHeld(heldAfterClaim, c.Tenant, c.Issue.ID, c.Issue.State, runErr)
+	case runErr != nil && errors.Is(runErr, errCardLaunchRefused):
+		// The run service refused the launch before any run existed (the
+		// taxonomy above): transient, not a verdict. Back to the column the
+		// tick took it from under machine provenance, and the card's ledger
+		// advanced so the dispatch listing spaces the retries — unless the
+		// refusal is the server draining, which says nothing about the card:
+		// another replica claims it next tick with a clean count. Past the
+		// attempt cap the retries are over: the card is filed blocked under
+		// the DESCRIPTIVE launch_given_up (the roadmap shows it, on purpose)
+		// with the last refusal on the card and a give-up stamp, so the
+		// operator reads why instead of guessing.
+		final, finalReason = c.Issue.State, tracker.ReasonLaunchRefused
+		kind := heldLaunchRefused
+		if !errors.Is(runErr, runtime.ErrServerDraining) {
+			ledger = dispatcher.NextLaunchRefusal(c.Issue.LaunchRefusal, time.Now().UTC(), launchRefusalReason(runErr))
+			if ledger.Attempts >= d.launchAttemptCap {
+				final, finalReason = d.blockedState, tracker.ReasonLaunchGivenUp
+				giveUp = &native.GiveUp{
+					State:    d.blockedState,
+					Attempts: ledger.Attempts,
+					Reason:   fmt.Sprintf("the launch was refused %d times; last refusal: %s", ledger.Attempts, ledger.LastReason),
+				}
+				kind = heldLaunchGivenUp
+			}
+		}
+		d.noteHeld(kind, c.Tenant, c.Issue.ID, final, runErr)
 	case runErr != nil && errors.Is(runErr, errCardPaused):
 		// A pause is not a failure: route the card to the awaiting-input
 		// column so the operator answers it there, not to blocked.
@@ -384,6 +466,13 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	// too, while the release below is the write the drain exists FOR.
 	finCtx, finCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer finCancel()
+	if ledger != nil {
+		// Before the state write: the ledger is what keeps the next tick
+		// from claiming the card again the moment it is back in its column.
+		if err := d.coord.SetLaunchRefusalOwned(finCtx, c.Tenant, c.Issue.ID, ledger, tok); err != nil {
+			d.warn("card %s/%s launch-refusal ledger: %v", c.Tenant, c.Issue.ID, err)
+		}
+	}
 	if final != "" {
 		var err error
 		if finalReason != "" {
@@ -393,6 +482,13 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 		}
 		if err != nil {
 			d.warn("card %s/%s → %s: %v", c.Tenant, c.Issue.ID, final, err)
+		}
+	}
+	if giveUp != nil {
+		// After the filing: the stamp only lands on a card sitting in the
+		// state it names (GiveUpToRecord), which is the write just above.
+		if err := d.coord.SetGaveUpOwned(finCtx, c.Tenant, c.Issue.ID, giveUp, tok); err != nil {
+			d.warn("card %s/%s launch give-up stamp: %v", c.Tenant, c.Issue.ID, err)
 		}
 	}
 	// Announce the release BEFORE it lands (the local twin's rule, see
@@ -717,6 +813,9 @@ func (d *boardDispatcher) run(ctx context.Context) {
 	// the operator's only other feedback at the cutover is cards that
 	// stay stuck.
 	if msg := dispatcher.ClaimReaperMisspelling(); msg != "" {
+		d.warn("%s", msg)
+	}
+	if msg := dispatcher.LaunchAttemptCapMisspelling(); msg != "" {
 		d.warn("%s", msg)
 	}
 	reaperOn := dispatcher.ClaimReaperEnabled()
@@ -1395,6 +1494,10 @@ func (d *boardDispatcher) fileReapedCard(ctx context.Context, cand boardmongo.Ex
 // blocked — that is the point of counting them apart from failures.
 type unlaunchableTally struct {
 	refused, released int
+	// launchRefused counts launches the run service refused (the card
+	// given back, its ledger advanced); launchGivenUp the cards filed
+	// blocked because the refusals reached the attempt cap.
+	launchRefused, launchGivenUp int
 }
 
 // unlaunchableCounts returns the running tally (test seam).
@@ -1404,12 +1507,31 @@ func (d *boardDispatcher) unlaunchableCounts() unlaunchableTally {
 	return d.unlaunchTally
 }
 
-// noteUnlaunchable records one unlaunchable verdict on a card and says it
-// ONCE per (card, reason) edge: the card is listed again on every tick for
-// as long as it stays broken, and the line has to be findable, not buried
-// under 17k copies of itself a day. column is where the card stays (or
-// returns to); afterClaim tells the belt's give-back from admission's skip.
-func (d *boardDispatcher) noteUnlaunchable(tenant, id, column string, err error, afterClaim bool) {
+// heldKind is why a card was held back from running: the four verdicts
+// that leave a card without a run — none of them a filing, except the last.
+type heldKind int
+
+const (
+	// heldAtAdmission: a precondition failed before the claim; the card is
+	// skipped in its column.
+	heldAtAdmission heldKind = iota
+	// heldAfterClaim: a precondition failed after the claim; the card is
+	// returned to its column.
+	heldAfterClaim
+	// heldLaunchRefused: the run service refused the launch; the card is
+	// returned to its column and retried after a backoff.
+	heldLaunchRefused
+	// heldLaunchGivenUp: the refusals reached the attempt cap; the card is
+	// filed blocked with the last refusal on it.
+	heldLaunchGivenUp
+)
+
+// noteHeld records one such verdict on a card and says it ONCE per (card,
+// reason) edge: the card is listed again on every tick (or after every
+// backoff) for as long as it stays broken, and the line has to be findable,
+// not buried under 17k copies of itself a day. column is where the card
+// stays, returns to, or — for a give-up — was filed.
+func (d *boardDispatcher) noteHeld(kind heldKind, tenant, id, column string, err error) {
 	key := tenant + "/" + id
 	reason := err.Error()
 	d.unlaunchMu.Lock()
@@ -1418,22 +1540,34 @@ func (d *boardDispatcher) noteUnlaunchable(tenant, id, column string, err error,
 	}
 	said := d.unlaunchWarned[key].reason == reason
 	d.unlaunchWarned[key] = unlaunchNote{reason: reason, at: time.Now()}
-	if afterClaim {
-		d.unlaunchTally.released++
-	} else {
+	switch kind {
+	case heldAtAdmission:
 		d.unlaunchTally.refused++
+	case heldAfterClaim:
+		d.unlaunchTally.released++
+	case heldLaunchRefused:
+		d.unlaunchTally.launchRefused++
+	case heldLaunchGivenUp:
+		d.unlaunchTally.launchGivenUp++
 	}
 	d.unlaunchMu.Unlock()
-	if said {
-		return
+	if said && kind != heldLaunchGivenUp {
+		return // a give-up is a filing: always said, once per card
 	}
-	if afterClaim {
+	switch kind {
+	case heldAtAdmission:
+		d.warn("card %s/%s cannot be launched — left in %q, not claimed (said once until the reason changes): %v",
+			tenant, id, column, err)
+	case heldAfterClaim:
 		d.warn("card %s/%s could not be launched after the claim — returned to %q, claim freed, not filed (said once until the reason changes): %v",
 			tenant, id, column, err)
-		return
+	case heldLaunchRefused:
+		d.warn("card %s/%s launch refused by the run service — returned to %q, claim freed, retried after a backoff (said once until the reason changes): %v",
+			tenant, id, column, err)
+	case heldLaunchGivenUp:
+		d.warn("card %s/%s launch refused on every attempt allowed (%s=%d) — filed %q with the last refusal on the card; a human decides now: %v",
+			tenant, id, dispatcher.LaunchAttemptCapEnvName(), d.launchAttemptCap, column, err)
 	}
-	d.warn("card %s/%s cannot be launched — left in %q, not claimed (said once until the reason changes): %v",
-		tenant, id, column, err)
 }
 
 // clearUnlaunchable forgets a card's memo entry once it launched, so a later
@@ -1459,11 +1593,11 @@ func (d *boardDispatcher) reportUnlaunchable(now time.Time) {
 		}
 	}
 	d.unlaunchMu.Unlock()
-	if t.refused == 0 && t.released == 0 {
+	if t == (unlaunchableTally{}) {
 		return
 	}
-	d.warn("unlaunchable cards since the last watchdog pass: %d refused at admission (never claimed), %d returned to their column after a claim — none filed blocked; each card is named once above",
-		t.refused, t.released)
+	d.warn("cards held back since the last watchdog pass: %d refused at admission (never claimed), %d returned to their column after a claim, %d launches refused by the run service (retried after a backoff), %d filed blocked after the launch attempt cap — each card is named once above",
+		t.refused, t.released, t.launchRefused, t.launchGivenUp)
 }
 
 func (d *boardDispatcher) warn(format string, args ...any) {
@@ -1726,7 +1860,9 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 	lb.Stamp(&spec)
 	res, err := s.runs.Launch(ctx, spec)
 	if err != nil {
-		return err
+		// Every error out of Launch means no run was started — the class is
+		// decidable here, at the boundary, without reading the error's text.
+		return &launchRefusal{cardID: iss.ID, cause: err}
 	}
 	runID := res.RunID
 	// Stamp the launched run onto the card immediately (not after the run

--- a/pkg/server/boarddispatch_launchrefusal_test.go
+++ b/pkg/server/boarddispatch_launchrefusal_test.go
@@ -1,0 +1,233 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A launch the run service REFUSES before any run exists — a sealing
+// failure, a queue outage, a bot that does not compile — is not a verdict on
+// the card (#814). The card goes back to its column under machine
+// provenance, its retry is bounded by a backoff + an attempt cap, and only a
+// permanently refused card is filed blocked — with the reason, and reflected
+// on purpose.
+
+func refusedLaunch(iss native.Issue) error {
+	return &launchRefusal{cardID: iss.ID, cause: errors.New("cloudpublisher: seal run bundle: kms unavailable")}
+}
+
+// TestBoardDispatcher_LaunchRefusalGivesTheCardBack: one refusal → the card
+// is back in `ready` under ReasonLaunchRefused (machine: no chain fires, no
+// reflect), its ledger reads one attempt with a NotBefore in the future, the
+// claim is freed, the next tick does NOT re-claim it, and the refusal is
+// said once and counted.
+func TestBoardDispatcher_LaunchRefusalGivesTheCardBack(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, func(_ context.Context, _ string, iss native.Issue) error {
+		return refusedLaunch(iss)
+	}, "replica-A", 4, iterlog.New(iterlog.LevelWarn, &buf))
+	d.launchAttemptCap = 3
+
+	before := time.Now()
+	for i := 0; i < 2; i++ {
+		d.tick(context.Background())
+		d.wg.Wait()
+	}
+	if got := f.states["native:1"]; got != native.StateReady {
+		t.Errorf("a refused launch ended the card in %q, want %q — the column it was taken from", got, native.StateReady)
+	}
+	if got := f.reasons["native:1"]; got != tracker.ReasonLaunchRefused {
+		t.Errorf("the give-back carried provenance %q, want %q", got, tracker.ReasonLaunchRefused)
+	}
+	rec := f.refusals["native:1"]
+	if rec == nil || rec.Attempts != 1 || !rec.NotBefore.After(before) || !strings.Contains(rec.LastReason, "kms unavailable") {
+		t.Fatalf("launch-refusal ledger = %+v, want attempts=1, a NotBefore in the future and the refusal as reason", rec)
+	}
+	if f.claimCalls != 1 {
+		t.Errorf("Claim was attempted %d time(s) over 2 ticks, want 1 — a card inside its backoff is not listed", f.claimCalls)
+	}
+	if len(f.claimed) != 0 {
+		t.Errorf("the claim must be freed after the give-back: %v", f.claimed)
+	}
+	if got := d.unlaunchableCounts(); got.launchRefused != 1 || got.launchGivenUp != 0 {
+		t.Errorf("tally = %+v, want 1 launch refused, 0 given up", got)
+	}
+	if got := linesMentioning(buf.String(), "native:1"); got != 1 {
+		t.Errorf("the refusal was logged %d time(s), want exactly 1:\n%s", got, buf.String())
+	}
+	if _, stamped := f.gaveUps["native:1"]; stamped {
+		t.Error("a single refusal stamped a give-up — that is the attempt cap's job")
+	}
+}
+
+// TestBoardDispatcher_LaunchRefusalIsBounded: the refusal that reaches the
+// attempt cap files the card blocked under the DESCRIPTIVE
+// ReasonLaunchGivenUp (reflected on purpose — a human decides now), with the
+// last refusal readable on the card and a give-up stamp naming it.
+func TestBoardDispatcher_LaunchRefusalIsBounded(t *testing.T) {
+	card := readyCard("native:1", "feature-dev")
+	card.Issue.LaunchRefusal = &native.LaunchRefusal{
+		Attempts: 2, LastAt: time.Now().Add(-time.Hour), NotBefore: time.Now().Add(-time.Minute), LastReason: "earlier refusal",
+	}
+	f := newFakeBoardCoord(card)
+	d := newBoardDispatcher(f, func(_ context.Context, _ string, iss native.Issue) error {
+		return refusedLaunch(iss)
+	}, "replica-A", 4, iterlog.Nop())
+	d.launchAttemptCap = 3
+
+	d.tick(context.Background())
+	d.wg.Wait()
+	if got := f.states["native:1"]; got != native.StateBlocked {
+		t.Fatalf("after the attempt cap the card is %q, want %q — a permanently refused launch has to surface", got, native.StateBlocked)
+	}
+	if got := f.reasons["native:1"]; got != tracker.ReasonLaunchGivenUp {
+		t.Errorf("the filing carried provenance %q, want %q (descriptive — the roadmap must show it)", got, tracker.ReasonLaunchGivenUp)
+	}
+	if tracker.IsMachineReason(tracker.ReasonLaunchGivenUp) {
+		t.Error("launch_given_up must not be machine provenance — the operator's board must show the card")
+	}
+	rec := f.refusals["native:1"]
+	if rec == nil || rec.Attempts != 3 || !strings.Contains(rec.LastReason, "kms unavailable") {
+		t.Fatalf("ledger = %+v, want attempts=3 with the last refusal", rec)
+	}
+	g := f.gaveUps["native:1"]
+	if g == nil || g.State != native.StateBlocked || g.Attempts != 3 || !strings.Contains(g.Reason, "kms unavailable") {
+		t.Fatalf("give-up stamp = %+v, want blocked/3 attempts/the last refusal", g)
+	}
+	if len(f.claimed) != 0 {
+		t.Errorf("the claim must be freed after the filing: %v", f.claimed)
+	}
+	if got := d.unlaunchableCounts(); got.launchGivenUp != 1 {
+		t.Errorf("tally = %+v, want 1 given up", got)
+	}
+}
+
+// TestBoardDispatcher_DrainingLaunchRefusalConsumesNoAttempt: the server
+// draining refuses every launch, which says nothing about the card — it is
+// given back with no ledger advance, so another replica claims it on its
+// next tick with a clean count.
+func TestBoardDispatcher_DrainingLaunchRefusalConsumesNoAttempt(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	d := newBoardDispatcher(f, func(_ context.Context, _ string, iss native.Issue) error {
+		return &launchRefusal{cardID: iss.ID, cause: fmt.Errorf("runview: %w", runtime.ErrServerDraining)}
+	}, "replica-A", 4, iterlog.Nop())
+
+	d.tick(context.Background())
+	d.wg.Wait()
+	if got := f.states["native:1"]; got != native.StateReady {
+		t.Errorf("state = %q, want %q", got, native.StateReady)
+	}
+	if got := f.reasons["native:1"]; got != tracker.ReasonLaunchRefused {
+		t.Errorf("provenance = %q, want %q", got, tracker.ReasonLaunchRefused)
+	}
+	if rec := f.refusals["native:1"]; rec != nil {
+		t.Errorf("a draining refusal advanced the ledger to %+v — it must consume no attempt", rec)
+	}
+}
+
+// TestBoardDispatcher_RunFailureStillFilesBlocked pins what did NOT change:
+// a run that started and failed is a verdict on the card — blocked, under
+// no machine reason, reflected as before.
+func TestBoardDispatcher_RunFailureStillFilesBlocked(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		return errors.New("run r1 ended failed")
+	}, "replica-A", 4, iterlog.Nop())
+	d.tick(context.Background())
+	d.wg.Wait()
+	if got := f.states["native:1"]; got != native.StateBlocked {
+		t.Errorf("a failed run's card is %q, want %q", got, native.StateBlocked)
+	}
+	if got := f.reasons["native:1"]; got != "" {
+		t.Errorf("a run failure carried provenance %q, want none — the roadmap follows a run's verdict", got)
+	}
+	if rec := f.refusals["native:1"]; rec != nil {
+		t.Errorf("a run failure touched the launch-refusal ledger: %+v", rec)
+	}
+}
+
+// TestBoardDispatcher_DispatchListingHonoursTheBackoff: a card inside its
+// NotBefore is not a candidate; once the instant has passed it is listed
+// again with its ledger on the candidate (the fake mirrors the Mongo query;
+// the real one is pinned by the conformance suite).
+func TestBoardDispatcher_DispatchListingHonoursTheBackoff(t *testing.T) {
+	card := readyCard("native:1", "feature-dev")
+	card.Issue.LaunchRefusal = &native.LaunchRefusal{Attempts: 1, NotBefore: time.Now().Add(time.Hour)}
+	f := newFakeBoardCoord(card)
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Error("a card inside its backoff must not be dispatched")
+		return nil
+	}, "replica-A", 4, iterlog.Nop())
+	if n := d.tick(context.Background()); n != 0 {
+		t.Fatalf("tick claimed %d card(s) inside the backoff, want 0", n)
+	}
+	d.wg.Wait()
+}
+
+// refusingPublisher is a cloud publisher whose every SubmitLaunch is refused
+// — the shape a sealing failure or a queue outage takes at the run service.
+type refusingPublisher struct{ err error }
+
+func (p refusingPublisher) SubmitLaunch(context.Context, string, runview.LaunchSpec, *ir.Workflow, string) (int, error) {
+	return 0, p.err
+}
+func (refusingPublisher) CancelRun(context.Context, string) error { return nil }
+func (refusingPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
+	return nil
+}
+func (refusingPublisher) SubmitResume(context.Context, runview.ResumeSpec, *ir.Workflow, string) error {
+	return nil
+}
+
+// TestProcessBoardCard_LaunchRefusalIsTyped pins the taxonomy at its source:
+// an error out of runs.Launch — here the publisher refusing the launch — is
+// errCardLaunchRefused, never a run failure, so processCard gives the card
+// back instead of parking it.
+func TestProcessBoardCard_LaunchRefusalIsTyped(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(
+		"schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"yes\"}'`\n  output: probe_out\n\nworkflow board_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs),
+		runview.WithLaunchPublisher(refusingPublisher{err: errors.New("cloudpublisher: seal run bundle: kms unavailable")}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+	err = s.processBoardCard(context.Background(), "team1", native.Issue{ID: "native:1", Bot: "probe"})
+	if !errors.Is(err, errCardLaunchRefused) {
+		t.Fatalf("processBoardCard = %v, want errCardLaunchRefused — no run started, no verdict belongs on the card", err)
+	}
+	if errors.Is(err, errCardUnlaunchable) {
+		t.Fatal("a launch refusal must not read as a precondition failure: it is transient and retried with a backoff")
+	}
+	if !strings.Contains(err.Error(), "kms unavailable") {
+		t.Fatalf("the refusal lost the publisher's reason: %v", err)
+	}
+	_ = boardmongo.Candidate{}
+}

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -49,6 +49,10 @@ type fakeBoardCoord struct {
 	reasons map[string]string
 	// gaveUps records the fenced give-up stamps, keyed by issue id.
 	gaveUps map[string]*native.GiveUp
+	// refusals records the fenced launch-refusal ledgers, keyed by issue
+	// id; ListDispatchable honours their NotBefore like the real query,
+	// and hands the recorded ledger back on the candidate.
+	refusals map[string]*native.LaunchRefusal
 	// renewHook, when set, runs at the start of RenewClaim OUTSIDE the
 	// lock — a test parks a heartbeat in flight with it while the owner's
 	// own release lands.
@@ -98,8 +102,20 @@ func (f *fakeBoardCoord) ListDispatchable(ctx context.Context, states []string, 
 		return nil, err
 	}
 	var out []boardmongo.Candidate
+	now := time.Now()
 	for _, c := range all {
 		if c.Issue.Bot == "" {
+			continue
+		}
+		// A recorded ledger wins over the seeded one, like a SetState wins
+		// over the seeded state — and a card inside its backoff is not
+		// listed, the real query's $or on not_before.
+		f.mu.Lock()
+		if rec, ok := f.refusals[c.Issue.ID]; ok {
+			c.Issue.LaunchRefusal = rec
+		}
+		f.mu.Unlock()
+		if r := c.Issue.LaunchRefusal; r != nil && r.NotBefore.After(now) {
 			continue
 		}
 		if limit > 0 && len(out) == limit {
@@ -108,6 +124,28 @@ func (f *fakeBoardCoord) ListDispatchable(ctx context.Context, states []string, 
 		out = append(out, c)
 	}
 	return out, nil
+}
+
+// SetLaunchRefusalOwned honours the fence and records the ledger (nil
+// clears), like the real twins.
+func (f *fakeBoardCoord) SetLaunchRefusalOwned(ctx context.Context, _, id string, r *native.LaunchRefusal, tok tracker.ClaimToken) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.claimed[id] != tok.Marker {
+		return tracker.ErrClaimConflict
+	}
+	if f.refusals == nil {
+		f.refusals = map[string]*native.LaunchRefusal{}
+	}
+	if r == nil {
+		delete(f.refusals, id)
+		return nil
+	}
+	f.refusals[id] = r.Clone()
+	return nil
 }
 
 func (f *fakeBoardCoord) Claim(_ context.Context, _, id, marker string) (tracker.ClaimToken, error) {

--- a/pkg/trigger/effects_projection_test.go
+++ b/pkg/trigger/effects_projection_test.go
@@ -119,7 +119,7 @@ func TestMaterializeEffects_ProjectionOnlyWhereItIsOwed(t *testing.T) {
 // column of rows that each retire with nothing to write sits FIFO ahead of
 // the next genuine reflect. The launch rows stay declined too.
 func TestMaterializeEffects_MachineCausedOwesNoProjection(t *testing.T) {
-	for _, reason := range []string{tracker.ReasonWatchdog, tracker.ReasonStateRename, tracker.ReasonUnlaunchable} {
+	for _, reason := range []string{tracker.ReasonWatchdog, tracker.ReasonStateRename, tracker.ReasonUnlaunchable, tracker.ReasonLaunchRefused} {
 		t.Run(reason, func(t *testing.T) {
 			ev := movedEvent()
 			ev.Payload = map[string]any{"reason": reason}

--- a/pkg/trigger/provenance_wiring_test.go
+++ b/pkg/trigger/provenance_wiring_test.go
@@ -138,6 +138,12 @@ func TestMachineCaused_EnumeratedSet(t *testing.T) {
 		// ran, so the return to the column is machinery — a subscription
 		// armed on that column must not re-fire on it (#798).
 		tracker.ReasonUnlaunchable: true,
+		// A launch the run service refused before any run started, given
+		// back to retry after a backoff: machinery too (#814) — while the
+		// filing that ends the retries is a decision for a human, so it is
+		// descriptive and reaches the roadmap.
+		tracker.ReasonLaunchRefused: true,
+		tracker.ReasonLaunchGivenUp: false,
 		// Descriptive provenance — the cascade of an operator gesture —
 		// keeps its triggers. This row is what died under `reason != ""`.
 		tracker.ReasonUnblocked: false,

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5752,6 +5752,7 @@ export interface components {
             labels?: string[];
             last_run_id?: string;
             last_workdir?: string;
+            launch_refusal?: components["schemas"]["LaunchRefusal"];
             parent_id?: string;
             priority?: number;
             runs?: components["schemas"]["RunRef"][];
@@ -5762,6 +5763,14 @@ export interface components {
             title: string;
             /** Format: date-time */
             updated_at: string;
+        };
+        LaunchRefusal: {
+            attempts: number;
+            /** Format: date-time */
+            last_at: string;
+            last_reason?: string;
+            /** Format: date-time */
+            not_before?: string;
         };
         MembershipView: {
             personal?: boolean;


### PR DESCRIPTION
Closes #814. Follow-up to #813.

`processCard`'s `case runErr != nil: final = d.blockedState` also caught a LAUNCH REFUSAL — `s.runs.Launch` failing on the publisher/admission side — so a card whose run never existed was parked `blocked` under the dispatcher's fenced write with no machine reason, and reflected onto the operator's GitHub board as a bad outcome.

## Refusal taxonomy (what reaches `processBoardCard`)
| source | error | typed? | disposition |
|---|---|---|---|
| `Service.Launch` | `runtime.ErrServerDraining` | typed | give back, no attempt consumed |
| `Service.Launch` | branch / budget / supervisors / routing-policy validation, `compileForLaunch` | prose | give back + backoff; cap → blocked |
| `SubmitLaunch` | required secrets unresolved | typed | same |
| `SubmitLaunch` | `SealRunBundle`, `SaveRun` | prose | same |
| `SubmitLaunch` → publish | queue outage (`QueueUnavailableError`) | typed | same |

Typed at source by this change, at the one decidable boundary: every error out of `runs.Launch` means no run was started → `launchRefusal{cardID, cause}` (`Is(errCardLaunchRefused)`, `Unwrap` → cause, so `errors.Is(err, runtime.ErrServerDraining)` still holds). No string matching. Two facts found on the way and filed separately: the org launch gate is never applied on the board-dispatch path, and "no LLM credential" is queued rather than refused.

## Mechanism
- **Ledger on the card, both store twins**: `native.Issue.LaunchRefusal{Attempts, LastAt, NotBefore, LastReason}`, written fenced through the new `BoardStore.SetLaunchRefusalOwned`, kept across the give-back, cleared by any stamped run and by `Reopen`; `EvtIssueLaunchRefused` audit event. OpenAPI + studio schema regenerated.
- **Backoff / cap** (`pkg/dispatcher/launchrefusal.go`): `NotBefore = now + 1m·2^(n-1)`, capped at 30 m; `ITERION_BOARD_LAUNCH_ATTEMPTS` (default 8 ≈ 1h30 of retries; unparsable → default + one startup Warn). `Coordinator.ListDispatchable` skips `not_before > now` IN THE QUERY (the same starvation argument as the bot filter of #813).
- **`processCard` arm**: give back under machine `ReasonLaunchRefused` (in the enumerated machine set → no chain fires, no projection row, `reflect_machine` in the pass); at the cap: `blocked` under descriptive `ReasonLaunchGivenUp` (reflected on purpose) + `GaveUp{Attempts, Reason: "the launch was refused N times; last refusal: …"}`. One Warn per (card, reason) edge; the watchdog tally counts `launchRefused` / `launchGivenUp`.
- **Runbook**: `docs/github-board-sync.md` names the sanctioned reopen of a terminal card (`iterion remote issues transition <card> <state>` — the HTTP transition path is the explicit reopen the sink demands; the project import deliberately is not) and links #839; `docs/dispatcher.md` documents the refusal ledger and the retry bound.

## Tests (red first — failing line, then green)
`boarddispatch_launchrefusal_test.go:54` (`ended the card in "blocked", want "ready"`), `:57` (provenance), `:61` (ledger nil), `:101`/`:108` (give-up at the cap), `:135` (draining consumes no attempt), `:222` (real `runview.Service` + a refusing `LaunchPublisher` → `errCardLaunchRefused`); trigger `machineCaused(reason="launch_refused")`; conformance (a foreign token cannot write the ledger; round trip). `TestBoardDispatcher_RunFailureStillFilesBlocked` pins the unchanged run-failure arm; `TestSyncProjectBoardReflectsALaunchGiveUp` pins the reflected give-up. `go build ./...` · `task lint` 0 issues · `go test ./pkg/server/... ./pkg/dispatcher/... ./pkg/trigger/...` ok · `task test:e2e` ok (395 s) · **Mongo conformance run locally against a real `mongo:8.0` replica set: PASS**.

## Left as separate findings (filed)
Board-dispatched launches bypass the org launch gate (`gateLaunch` is HTTP/webhook only); "no LLM credential" is queued, not refused, and files the card `blocked` as a run failure; a launch give-up (no `RunID`) never shows in the pipeline board's *Needs attention* lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
