### PR TITLE
fix(delegate): a terminal verdict on the formatting pass is returned, not retried; a structured answer is an answer; a 403 is a refusal

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -49,6 +49,18 @@ type ClaudeCodeBackend struct {
 	Command string
 	// Logger is the leveled logger for diagnostic output.
 	Logger *iterlog.Logger
+	// formatOutputFn replaces the CLI-spawning formatting pass in tests: the
+	// loop around it — retry, terminal verdict, usage, cost — is where the
+	// accounting defects lived, and it had no seam to be exercised through.
+	formatOutputFn func(ctx context.Context, task Task, sessionID string) (*claudesdk.ResultMessage, error)
+}
+
+// formatPass runs one formatting pass: the CLI, or the test seam.
+func (b *ClaudeCodeBackend) formatPass(ctx context.Context, task Task, sessionID string) (*claudesdk.ResultMessage, error) {
+	if b.formatOutputFn != nil {
+		return b.formatOutputFn(ctx, task, sessionID)
+	}
+	return b.formatOutput(ctx, task, sessionID)
 }
 
 // Execute runs the claude CLI with the given task using the Claude Agent SDK.
@@ -505,6 +517,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	if (len(output) == 0 || fallback) && len(task.OutputSchema) > 0 && rm.SessionID != "" {
 		var rerr error
 		if recoveryRM, rerr = b.runRecoveryFormatterPass(ctx, task, rm.SessionID, &result, &totalIn, &totalOut); rerr != nil {
+			if result.Output == nil {
+				result.Output = map[string]any{}
+			}
+			annotateCost(&result, task, totalIn, totalOut, rm, recoveryRM)
 			return result, rerr
 		}
 	}
@@ -534,8 +550,13 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	// (parseSDKOutput ships exactly it), so the two cannot diverge. No
 	// evidence is filed from a shipped answer: a false bench of the
 	// credential costs more than a reading the next pass files anyway.
-	if obj, _, found := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 {
-		return nil
+	// The CLI's render form ("API Error: …") is never an answer, whatever it
+	// carries after the prefix — a fenced JSON inside a relayed error body
+	// must not satisfy the exemption.
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(*rm.Result)), "api error") {
+		if obj, _, found := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 {
+			return nil
+		}
 	}
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
 	// 5h caps can come back as the result text (subtype=success, IsError=true)
@@ -786,7 +807,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 	var lastFmtErr error
 	for attempt := 1; attempt <= maxFmtAttempts; attempt++ {
 		b.Logger.Debug("claude-code [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, rm.SessionID)
-		fmtRM, fmtErr := b.formatOutput(ctx, task, rm.SessionID)
+		fmtRM, fmtErr := b.formatPass(ctx, task, rm.SessionID)
 		if fmtErr == nil {
 			// The pass ran and was billed, whatever its result says: its
 			// usage counts on every path out of here, the typed ones too.
@@ -802,7 +823,13 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 				if !renderRetryable(rerr) {
 					// A credential, model or window verdict is terminal: a
 					// second attempt re-spends the pass against a provider
-					// that just refused and re-files the same evidence.
+					// that just refused and re-files the same evidence. The
+					// cost is stamped on the map (allocated: the annotation
+					// writes nothing into a nil one, and the spend of a node
+					// that failed here must still reach the caps).
+					if result.Output == nil {
+						result.Output = map[string]any{}
+					}
 					annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
 					return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr)
 				}
@@ -819,6 +846,9 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 			// by the fast path above with the same arguments, so there is
 			// nothing left to recover from it: the delegation fails typed.
 			if fmtRM != nil {
+				if result.Output == nil {
+					result.Output = map[string]any{}
+				}
 				annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
 			}
 			return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr)
@@ -879,26 +909,29 @@ func (b *ClaudeCodeBackend) setupCredsAndSession(ctx context.Context, task Task,
 // output, which the schema then judges); a pass that RENDERS an upstream
 // failure is returned typed — the executor routes it, instead of shipping
 // Pass 1's fallback text to an opaque schema failure. Returns the pass's own
-// ResultMessage (nil when it did not run) so the caller's cost annotation
-// sees its CLI-reported cost, not just Pass 1's.
+// ResultMessage whenever it ran (with the verdict too — a billed pass is a
+// billed pass), nil when it did not, so the caller's cost annotation sees
+// its CLI-reported cost, not just Pass 1's.
 func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task Task, sessionID string, result *Result, totalIn, totalOut *int) (*claudesdk.ResultMessage, error) {
 	b.Logger.Debug("claude-code: empty output with schema — attempting recovery formatting pass (session=%s)", sessionID)
-	fmtRM, fmtErr := b.formatOutput(ctx, task, sessionID)
+	fmtRM, fmtErr := b.formatPass(ctx, task, sessionID)
 	if fmtErr != nil {
 		b.Logger.Warn("claude-code: recovery formatting pass failed: %v", fmtErr)
 		return nil, nil
 	}
-	// A render on the recovery pass is typed and returned, never parsed as
-	// the output nor swallowed into an opaque schema failure.
-	if rerr := b.renderedFailure(fmtRM, task, "recovery formatting pass"); rerr != nil {
-		return nil, rerr
-	}
+	// The pass ran and was billed, whatever its result says.
 	if fmtRM.Usage != nil {
 		*totalIn += fmtRM.Usage.InputTokens
 		*totalOut += fmtRM.Usage.OutputTokens
 		result.Tokens = *totalIn + *totalOut
 	}
 	result.FormattingPassUsed = true
+	// A render on the recovery pass is typed and returned, never parsed as
+	// the output nor swallowed into an opaque schema failure — with its
+	// message, so the caller's cost annotation sees the billed pass.
+	if rerr := b.renderedFailure(fmtRM, task, "recovery formatting pass"); rerr != nil {
+		return fmtRM, rerr
+	}
 	fmtOutput, fmtRawLen, fmtFallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)
 	if len(fmtOutput) > 0 {
 		result.Output = fmtOutput

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -527,10 +527,14 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	if rm == nil || rm.Result == nil {
 		return nil
 	}
-	// A result that carries a structured object is an answer, whatever its
-	// text says: the CLI never renders an upstream failure alongside one,
-	// and a short JSON answer about quotas must not read as a quota notice.
-	if obj, ok := rm.StructuredOutput.(map[string]any); ok && len(obj) > 0 {
+	// A result that already yields a structured answer — the SDK's object,
+	// or a JSON object in the text — is an answer whatever else its text
+	// says: a short JSON answer about quotas must not read as a quota notice
+	// on any pass. structuredObject is the one definition of that answer
+	// (parseSDKOutput ships exactly it), so the two cannot diverge. No
+	// evidence is filed from a shipped answer: a false bench of the
+	// credential costs more than a reading the next pass files anyway.
+	if obj, _, found := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 {
 		return nil
 	}
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
@@ -571,17 +575,6 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 		b.Logger.Error("[%s#%d/claude-code %s] authentication failed — failing fast: %.160s",
 			task.NodeID, task.Iteration, pass, redactAuthRender(strings.TrimSpace(*rm.Result)))
 		return authErr
-	}
-
-	// Refusal guard. A 403 is the upstream refusing the request — a facade
-	// or CDN block, a policy refusal — which a retry will not change, but
-	// which is no verdict on the credential either (a dead token renders
-	// 401): fail fast, legibly, without the credential remedy.
-	if isRefusedRequestResult(*rm.Result) {
-		detail := strings.TrimSpace(*rm.Result)
-		b.Logger.Error("[%s#%d/claude-code %s] upstream refused the request — failing fast: %.160s",
-			task.NodeID, task.Iteration, pass, detail)
-		return fmt.Errorf("claude-code: upstream refused the request (403) — not transient, not retried, not a credential verdict: %s", detail)
 	}
 
 	// Model-unavailable guard. An invalid/unauthorized `--model` does NOT fail
@@ -625,13 +618,20 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 }
 
 // renderRetryable reports whether a rendered failure is one a repeat of the
-// same pass can recover from: only the transient class (5xx, overload, a
-// bare throttle, connectivity). A credential, model or window verdict is
-// terminal for this delegation — retrying it re-spends the pass against a
+// same pass can recover from: the transient class (5xx, overload,
+// connectivity) and a bare throttle. The throttle is safe by construction —
+// classifyRateLimit returns RateLimitKindTransient only together with an
+// empty window, and the usagecap write is gated on a named window, so a
+// repeat cannot re-file evidence. A credential, model or usage-window verdict
+// is terminal for this delegation — retrying it re-spends the pass against a
 // provider that just refused and re-files the same usage evidence.
 func renderRetryable(err error) bool {
 	var tr *ErrTransient
-	return errors.As(err, &tr)
+	if errors.As(err, &tr) {
+		return true
+	}
+	var rl *ErrRateLimited
+	return errors.As(err, &rl) && rl.Kind == RateLimitKindTransient
 }
 
 // annotateCost stamps `_tokens` / `_model` / `_cost_usd` on the delegation
@@ -788,6 +788,14 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 		b.Logger.Debug("claude-code [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, rm.SessionID)
 		fmtRM, fmtErr := b.formatOutput(ctx, task, rm.SessionID)
 		if fmtErr == nil {
+			// The pass ran and was billed, whatever its result says: its
+			// usage counts on every path out of here, the typed ones too.
+			if fmtRM.Usage != nil {
+				*totalIn += fmtRM.Usage.InputTokens
+				*totalOut += fmtRM.Usage.OutputTokens
+				result.Tokens = *totalIn + *totalOut
+			}
+			result.FormattingPassUsed = true
 			// The formatter's result is read through the same predicate as
 			// pass 1: a render here would otherwise be parsed as the output.
 			if rerr := b.renderedFailure(fmtRM, task, fmt.Sprintf("formatting pass %d/%d", attempt, maxFmtAttempts)); rerr != nil {
@@ -795,6 +803,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 					// A credential, model or window verdict is terminal: a
 					// second attempt re-spends the pass against a provider
 					// that just refused and re-files the same evidence.
+					annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
 					return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr)
 				}
 				fmtErr = rerr
@@ -806,32 +815,14 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 				b.Logger.Warn("claude-code [formatting pass %d/%d] failed, retrying: %v", attempt, maxFmtAttempts, fmtErr)
 				continue
 			}
-			// Both attempts exhausted. Before failing the whole delegation,
-			// try parsing Pass 1's free-form output: agents typically emit
-			// a fenced ```json block matching the schema as their final
-			// message, and parseSDKOutput already extracts that. This
-			// recovers from the common infra failure where the sandbox
-			// container dies mid-formatting (observed: container SIGKILL
-			// at formatting-pass invocation → claude exits 137 →
-			// "container is not running" on retry → whole delegation
-			// fails despite Pass 1 having produced shippable output).
-			output, rawLen, fallback := parseSDKOutput(rm.Result, rm.StructuredOutput, task.OutputSchema)
-			if len(output) > 0 && !fallback {
-				b.Logger.Warn("claude-code [formatting pass] failed (%v); recovered structured output from Pass 1 free-form result", fmtErr)
-				result.Output = output
-				result.RawOutputLen = rawLen
-				result.ParseFallback = false
-				annotateCost(&result, task, *totalIn, *totalOut, rm)
-				return true, result, nil
+			// Both attempts exhausted. Pass 1's own output was already tried
+			// by the fast path above with the same arguments, so there is
+			// nothing left to recover from it: the delegation fails typed.
+			if fmtRM != nil {
+				annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
 			}
 			return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr)
 		}
-		if fmtRM.Usage != nil {
-			*totalIn += fmtRM.Usage.InputTokens
-			*totalOut += fmtRM.Usage.OutputTokens
-			result.Tokens = *totalIn + *totalOut
-		}
-		result.FormattingPassUsed = true
 
 		output, rawLen, fallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)
 		if fallback && attempt < maxFmtAttempts {

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -53,6 +53,27 @@ type ClaudeCodeBackend struct {
 	// loop around it — retry, terminal verdict, usage, cost — is where the
 	// accounting defects lived, and it had no seam to be exercised through.
 	formatOutputFn func(ctx context.Context, task Task, sessionID string) (*claudesdk.ResultMessage, error)
+	// formatRetryDelay overrides the pause before a repeated formatting
+	// attempt: zero means the default, negative means none (tests). Per
+	// backend, not package-wide, so parallel tests cannot race on it.
+	formatRetryDelay time.Duration
+}
+
+// defaultFormatRetryDelay is the pause before a formatting attempt is
+// repeated after a retryable render: a throttle answered immediately is a
+// throttle again.
+const defaultFormatRetryDelay = 2 * time.Second
+
+// retryDelay is the pause this backend takes before repeating a formatting
+// attempt.
+func (b *ClaudeCodeBackend) retryDelay() time.Duration {
+	switch {
+	case b.formatRetryDelay < 0:
+		return 0
+	case b.formatRetryDelay == 0:
+		return defaultFormatRetryDelay
+	}
+	return b.formatRetryDelay
 }
 
 // formatPass runs one formatting pass: the CLI, or the test seam.
@@ -497,7 +518,8 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// the formatting passes: a render is never an answer, on any pass. The
 	// session was billed all the same: its cost goes out with the verdict.
 	if err := b.renderedFailure(rm, task, "pass 1"); err != nil {
-		return result, typedFailure(&result, task, totalIn, totalOut, err, rm)
+		typed := typedFailure(&result, task, totalIn, totalOut, err, rm)
+		return result, typed
 	}
 
 	if needsTwoPass && rm.SessionID != "" {
@@ -518,7 +540,8 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	if (len(output) == 0 || fallback) && len(task.OutputSchema) > 0 && rm.SessionID != "" {
 		var rerr error
 		if recoveryRM, rerr = b.runRecoveryFormatterPass(ctx, task, rm.SessionID, &result, &totalIn, &totalOut); rerr != nil {
-			return result, typedFailure(&result, task, totalIn, totalOut, rerr, rm, recoveryRM)
+			typed := typedFailure(&result, task, totalIn, totalOut, rerr, rm, recoveryRM)
+			return result, typed
 		}
 	}
 
@@ -653,21 +676,25 @@ func looksRendered(text string) bool {
 		isModelUnavailableResult(text) || isTransientAPIErrorResult(text)
 }
 
-// errorBodyObject reports an object that is only an error envelope — a raw
-// {"error": …} body a facade could relay as the result text — which is not
-// an answer even though it parses as one.
+// errorBodyObject reports an object that is only an error envelope — a bare
+// {"error": …} body, or the provider's own {"type":"error","error":{…}} —
+// relayed verbatim as the result text: not an answer even though it parses
+// as one. A legitimate answer that carries an `error` field beside real data
+// stays an answer.
 func errorBodyObject(obj map[string]any) bool {
-	if len(obj) != 1 {
+	if _, ok := obj["error"]; !ok {
 		return false
 	}
-	_, ok := obj["error"]
-	return ok
+	return len(obj) == 1 || (len(obj) == 2 && obj["type"] == "error")
 }
 
 // typedFailure returns err with the delegation's spend stamped on the result
 // first: a typed failure still spent Pass 1 and whatever passes ran, and the
 // caps, the fallback chain's carried spend and a donor's ledger read the
-// cost from the output map — an unallocated map records nothing.
+// cost from the output map — an unallocated map records nothing. Callers
+// hoist the call into its own statement before returning `result`: Go leaves
+// the order between a plain operand and a call in one return list
+// unspecified, and the stamp must land before the copy is taken.
 func typedFailure(result *Result, task Task, totalIn, totalOut int, err error, rms ...*claudesdk.ResultMessage) error {
 	if result.Output == nil {
 		result.Output = map[string]any{}
@@ -675,11 +702,6 @@ func typedFailure(result *Result, task Task, totalIn, totalOut int, err error, r
 	annotateCost(result, task, totalIn, totalOut, rms...)
 	return err
 }
-
-// formatRetryDelay is the pause before a formatting attempt is repeated after
-// a retryable render: a throttle answered immediately is a throttle again.
-// A variable so the seam tests run without it.
-var formatRetryDelay = 2 * time.Second
 
 // renderRetryable reports whether a rendered failure is one a repeat of the
 // same pass can recover from: the transient class (5xx, overload,
@@ -867,8 +889,9 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 					// A credential, model or window verdict is terminal: a
 					// second attempt re-spends the pass against a provider
 					// that just refused and re-files the same evidence.
-					return true, result, typedFailure(&result, task, *totalIn, *totalOut,
+					typed := typedFailure(&result, task, *totalIn, *totalOut,
 						fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr), rm, fmtRM)
+					return true, result, typed
 				}
 				fmtErr = rerr
 			}
@@ -880,11 +903,14 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 				// A throttle or an overload answered at once is the same
 				// answer again: a short pause before the repeat, bounded by
 				// the run's context.
-				if formatRetryDelay > 0 {
+				if d := b.retryDelay(); d > 0 {
 					select {
 					case <-ctx.Done():
-						return true, result, typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, fmtRM)
-					case <-time.After(formatRetryDelay):
+						// Cancellation wins over the typed cause: a run being
+						// cancelled must not read as rate-limited downstream.
+						typed := typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, fmtRM)
+						return true, result, typed
+					case <-time.After(d):
 					}
 				}
 				continue
@@ -894,8 +920,9 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 			// nothing left to recover from it: the delegation fails typed —
 			// with Pass 1's cost whether or not the last attempt produced a
 			// message (annotateCost skips a nil one).
-			return true, result, typedFailure(&result, task, *totalIn, *totalOut,
+			typed := typedFailure(&result, task, *totalIn, *totalOut,
 				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), rm, fmtRM)
+			return true, result, typed
 		}
 
 		output, rawLen, fallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -3,6 +3,7 @@ package delegate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -526,6 +527,12 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	if rm == nil || rm.Result == nil {
 		return nil
 	}
+	// A result that carries a structured object is an answer, whatever its
+	// text says: the CLI never renders an upstream failure alongside one,
+	// and a short JSON answer about quotas must not read as a quota notice.
+	if obj, ok := rm.StructuredOutput.(map[string]any); ok && len(obj) > 0 {
+		return nil
+	}
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
 	// 5h caps can come back as the result text (subtype=success, IsError=true)
 	// with no assistant text block for the stream classifier to catch — re-check
@@ -566,6 +573,17 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 		return authErr
 	}
 
+	// Refusal guard. A 403 is the upstream refusing the request — a facade
+	// or CDN block, a policy refusal — which a retry will not change, but
+	// which is no verdict on the credential either (a dead token renders
+	// 401): fail fast, legibly, without the credential remedy.
+	if isRefusedRequestResult(*rm.Result) {
+		detail := strings.TrimSpace(*rm.Result)
+		b.Logger.Error("[%s#%d/claude-code %s] upstream refused the request — failing fast: %.160s",
+			task.NodeID, task.Iteration, pass, detail)
+		return fmt.Errorf("claude-code: upstream refused the request (403) — not transient, not retried, not a credential verdict: %s", detail)
+	}
+
 	// Model-unavailable guard. An invalid/unauthorized `--model` does NOT fail
 	// the stream (subtype=success, IsError=false): the claude CLI renders its
 	// model-error sentence AS the result text (e.g. "There's an issue with the
@@ -604,6 +622,16 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	}
 
 	return nil
+}
+
+// renderRetryable reports whether a rendered failure is one a repeat of the
+// same pass can recover from: only the transient class (5xx, overload, a
+// bare throttle, connectivity). A credential, model or window verdict is
+// terminal for this delegation — retrying it re-spends the pass against a
+// provider that just refused and re-files the same usage evidence.
+func renderRetryable(err error) bool {
+	var tr *ErrTransient
+	return errors.As(err, &tr)
 }
 
 // annotateCost stamps `_tokens` / `_model` / `_cost_usd` on the delegation
@@ -762,7 +790,15 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 		if fmtErr == nil {
 			// The formatter's result is read through the same predicate as
 			// pass 1: a render here would otherwise be parsed as the output.
-			fmtErr = b.renderedFailure(fmtRM, task, fmt.Sprintf("formatting pass %d/%d", attempt, maxFmtAttempts))
+			if rerr := b.renderedFailure(fmtRM, task, fmt.Sprintf("formatting pass %d/%d", attempt, maxFmtAttempts)); rerr != nil {
+				if !renderRetryable(rerr) {
+					// A credential, model or window verdict is terminal: a
+					// second attempt re-spends the pass against a provider
+					// that just refused and re-files the same evidence.
+					return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr)
+				}
+				fmtErr = rerr
+			}
 		}
 		if fmtErr != nil {
 			lastFmtErr = fmtErr
@@ -847,10 +883,13 @@ func (b *ClaudeCodeBackend) setupCredsAndSession(ctx context.Context, task Task,
 // wrapper, resume the session for one formatting pass to extract structured
 // output. Catches agents that did real work (tools, code changes) but whose
 // structured output the SDK didn't capture (e.g. backends where tools are
-// implicit). Mutates result and the running token totals in place; failures
-// are logged and left non-fatal (the caller keeps Pass 1's output). Returns
-// the pass's own ResultMessage (nil on failure) so the caller's cost
-// annotation sees its CLI-reported cost, not just Pass 1's.
+// implicit). Mutates result and the running token totals in place. A pass
+// that fails to run is logged and left non-fatal (the caller keeps Pass 1's
+// output, which the schema then judges); a pass that RENDERS an upstream
+// failure is returned typed — the executor routes it, instead of shipping
+// Pass 1's fallback text to an opaque schema failure. Returns the pass's own
+// ResultMessage (nil when it did not run) so the caller's cost annotation
+// sees its CLI-reported cost, not just Pass 1's.
 func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task Task, sessionID string, result *Result, totalIn, totalOut *int) (*claudesdk.ResultMessage, error) {
 	b.Logger.Debug("claude-code: empty output with schema — attempting recovery formatting pass (session=%s)", sessionID)
 	fmtRM, fmtErr := b.formatOutput(ctx, task, sessionID)

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -563,21 +563,21 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	if rm == nil || rm.Result == nil {
 		return nil
 	}
-	// A structured answer is an answer — structuredObject is its one
-	// definition, the one parseSDKOutput ships — but on two conditions. An
-	// object the TEXT itself is (direct or fenced) is the answer, whatever
+	// An object the TEXT itself is (direct or fenced) is the answer, whatever
 	// words it contains: a short JSON answer about quotas must not read as a
-	// quota notice. An object the SDK carried BESIDE a text is trusted only
-	// when that text is not a render the guards below would recognise: a
-	// resumed pass could echo a prior turn's object next to a refusal, and
-	// a window verdict shipped as an answer is the class this predicate
-	// closes. The CLI's render form ("API Error: …") is never an answer,
-	// whatever it carries after the prefix; an object that is only an error
-	// body ({"error": …}) is not one either. No evidence is filed from a
-	// shipped answer: a false bench costs more than a reading the next pass
-	// files anyway.
-	if obj, _, found, fromText := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 &&
-		!errorBodyObject(obj) && (fromText || !looksRendered(*rm.Result)) && !hasRenderPrefix(*rm.Result) {
+	// quota notice — structuredObject is the one definition, the one
+	// parseSDKOutput ships. Two vetoes: the CLI's render form ("API Error:
+	// …") is never an answer, whatever it carries after the prefix; an
+	// error envelope ({"error": …}, {"type":"error", …}) is not one either.
+	// An object the SDK carried BESIDE a text earns no exemption: the text
+	// goes through the guards below like any other — a resumed pass could
+	// echo a prior turn's object next to a refusal, and a window verdict
+	// shipped as an answer is the class this predicate closes; beside plain
+	// prose no guard matches and the answer ships anyway. No evidence is
+	// filed from a shipped answer: a false bench costs more than a reading
+	// the next pass files.
+	if obj, _, found, fromText := structuredObject(rm.Result, rm.StructuredOutput); found && fromText && len(obj) > 0 &&
+		!errorBodyObject(obj) && !hasRenderPrefix(*rm.Result) {
 		return nil
 	}
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
@@ -667,25 +667,17 @@ func hasRenderPrefix(text string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "api error")
 }
 
-// looksRendered reports whether a result text is one of the renders the
-// guards recognise — a quota notice, a credential or model verdict, a
-// transient API error, the render prefix. Used to refuse the structured
-// exemption to an SDK object that sits beside such a text.
-func looksRendered(text string) bool {
-	return hasRenderPrefix(text) || isRateLimitMessage(text) || isAuthErrorResult(text) ||
-		isModelUnavailableResult(text) || isTransientAPIErrorResult(text)
-}
-
-// errorBodyObject reports an object that is only an error envelope — a bare
-// {"error": …} body, or the provider's own {"type":"error","error":{…}} —
-// relayed verbatim as the result text: not an answer even though it parses
-// as one. A legitimate answer that carries an `error` field beside real data
-// stays an answer.
+// errorBodyObject reports an object that is an error envelope — a bare
+// {"error": …} body, or the provider's own {"type":"error","error":{…}}
+// with whatever else it carries (a request id) — relayed verbatim as the
+// result text: not an answer even though it parses as one. A legitimate
+// answer that carries an `error` field beside real data, without the
+// provider's type marker, stays an answer.
 func errorBodyObject(obj map[string]any) bool {
 	if _, ok := obj["error"]; !ok {
 		return false
 	}
-	return len(obj) == 1 || (len(obj) == 2 && obj["type"] == "error")
+	return len(obj) == 1 || obj["type"] == "error"
 }
 
 // typedFailure returns err with the delegation's spend stamped on the result
@@ -870,10 +862,14 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 	}
 	const maxFmtAttempts = 2
 	var lastFmtErr error
+	// The last attempt that produced a message: an earlier billed attempt
+	// must price the delegation when the final one could not even spawn.
+	var lastFmtRM *claudesdk.ResultMessage
 	for attempt := 1; attempt <= maxFmtAttempts; attempt++ {
 		b.Logger.Debug("claude-code [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, rm.SessionID)
 		fmtRM, fmtErr := b.formatPass(ctx, task, rm.SessionID)
 		if fmtErr == nil {
+			lastFmtRM = fmtRM
 			// The pass ran and was billed, whatever its result says: its
 			// usage counts on every path out of here, the typed ones too.
 			if fmtRM.Usage != nil {
@@ -908,7 +904,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 					case <-ctx.Done():
 						// Cancellation wins over the typed cause: a run being
 						// cancelled must not read as rate-limited downstream.
-						typed := typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, fmtRM)
+						typed := typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, lastFmtRM)
 						return true, result, typed
 					case <-time.After(d):
 					}
@@ -918,10 +914,11 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 			// Both attempts exhausted. Pass 1's own output was already tried
 			// by the fast path above with the same arguments, so there is
 			// nothing left to recover from it: the delegation fails typed —
-			// with Pass 1's cost whether or not the last attempt produced a
-			// message (annotateCost skips a nil one).
+			// priced from Pass 1 and from the last attempt that produced a
+			// message, whether or not the final one did (annotateCost takes
+			// the highest CLI figure and skips a nil message).
 			typed := typedFailure(&result, task, *totalIn, *totalOut,
-				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), rm, fmtRM)
+				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), rm, lastFmtRM, fmtRM)
 			return true, result, typed
 		}
 

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -494,9 +494,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	}
 
 	// Every guard on the result TEXT lives in renderedFailure, shared with
-	// the formatting passes: a render is never an answer, on any pass.
+	// the formatting passes: a render is never an answer, on any pass. The
+	// session was billed all the same: its cost goes out with the verdict.
 	if err := b.renderedFailure(rm, task, "pass 1"); err != nil {
-		return result, err
+		return result, typedFailure(&result, task, totalIn, totalOut, err, rm)
 	}
 
 	if needsTwoPass && rm.SessionID != "" {
@@ -517,11 +518,7 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	if (len(output) == 0 || fallback) && len(task.OutputSchema) > 0 && rm.SessionID != "" {
 		var rerr error
 		if recoveryRM, rerr = b.runRecoveryFormatterPass(ctx, task, rm.SessionID, &result, &totalIn, &totalOut); rerr != nil {
-			if result.Output == nil {
-				result.Output = map[string]any{}
-			}
-			annotateCost(&result, task, totalIn, totalOut, rm, recoveryRM)
-			return result, rerr
+			return result, typedFailure(&result, task, totalIn, totalOut, rerr, rm, recoveryRM)
 		}
 	}
 
@@ -543,20 +540,22 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	if rm == nil || rm.Result == nil {
 		return nil
 	}
-	// A result that already yields a structured answer — the SDK's object,
-	// or a JSON object in the text — is an answer whatever else its text
-	// says: a short JSON answer about quotas must not read as a quota notice
-	// on any pass. structuredObject is the one definition of that answer
-	// (parseSDKOutput ships exactly it), so the two cannot diverge. No
-	// evidence is filed from a shipped answer: a false bench of the
-	// credential costs more than a reading the next pass files anyway.
-	// The CLI's render form ("API Error: …") is never an answer, whatever it
-	// carries after the prefix — a fenced JSON inside a relayed error body
-	// must not satisfy the exemption.
-	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(*rm.Result)), "api error") {
-		if obj, _, found := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 {
-			return nil
-		}
+	// A structured answer is an answer — structuredObject is its one
+	// definition, the one parseSDKOutput ships — but on two conditions. An
+	// object the TEXT itself is (direct or fenced) is the answer, whatever
+	// words it contains: a short JSON answer about quotas must not read as a
+	// quota notice. An object the SDK carried BESIDE a text is trusted only
+	// when that text is not a render the guards below would recognise: a
+	// resumed pass could echo a prior turn's object next to a refusal, and
+	// a window verdict shipped as an answer is the class this predicate
+	// closes. The CLI's render form ("API Error: …") is never an answer,
+	// whatever it carries after the prefix; an object that is only an error
+	// body ({"error": …}) is not one either. No evidence is filed from a
+	// shipped answer: a false bench costs more than a reading the next pass
+	// files anyway.
+	if obj, _, found, fromText := structuredObject(rm.Result, rm.StructuredOutput); found && len(obj) > 0 &&
+		!errorBodyObject(obj) && (fromText || !looksRendered(*rm.Result)) && !hasRenderPrefix(*rm.Result) {
+		return nil
 	}
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /
 	// 5h caps can come back as the result text (subtype=success, IsError=true)
@@ -637,6 +636,50 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 
 	return nil
 }
+
+// hasRenderPrefix reports the CLI's own render form of an upstream failure:
+// "API Error: …", whatever follows — a relayed body, fenced or not, is not an
+// answer.
+func hasRenderPrefix(text string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(text)), "api error")
+}
+
+// looksRendered reports whether a result text is one of the renders the
+// guards recognise — a quota notice, a credential or model verdict, a
+// transient API error, the render prefix. Used to refuse the structured
+// exemption to an SDK object that sits beside such a text.
+func looksRendered(text string) bool {
+	return hasRenderPrefix(text) || isRateLimitMessage(text) || isAuthErrorResult(text) ||
+		isModelUnavailableResult(text) || isTransientAPIErrorResult(text)
+}
+
+// errorBodyObject reports an object that is only an error envelope — a raw
+// {"error": …} body a facade could relay as the result text — which is not
+// an answer even though it parses as one.
+func errorBodyObject(obj map[string]any) bool {
+	if len(obj) != 1 {
+		return false
+	}
+	_, ok := obj["error"]
+	return ok
+}
+
+// typedFailure returns err with the delegation's spend stamped on the result
+// first: a typed failure still spent Pass 1 and whatever passes ran, and the
+// caps, the fallback chain's carried spend and a donor's ledger read the
+// cost from the output map — an unallocated map records nothing.
+func typedFailure(result *Result, task Task, totalIn, totalOut int, err error, rms ...*claudesdk.ResultMessage) error {
+	if result.Output == nil {
+		result.Output = map[string]any{}
+	}
+	annotateCost(result, task, totalIn, totalOut, rms...)
+	return err
+}
+
+// formatRetryDelay is the pause before a formatting attempt is repeated after
+// a retryable render: a throttle answered immediately is a throttle again.
+// A variable so the seam tests run without it.
+var formatRetryDelay = 2 * time.Second
 
 // renderRetryable reports whether a rendered failure is one a repeat of the
 // same pass can recover from: the transient class (5xx, overload,
@@ -823,15 +866,9 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 				if !renderRetryable(rerr) {
 					// A credential, model or window verdict is terminal: a
 					// second attempt re-spends the pass against a provider
-					// that just refused and re-files the same evidence. The
-					// cost is stamped on the map (allocated: the annotation
-					// writes nothing into a nil one, and the spend of a node
-					// that failed here must still reach the caps).
-					if result.Output == nil {
-						result.Output = map[string]any{}
-					}
-					annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
-					return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr)
+					// that just refused and re-files the same evidence.
+					return true, result, typedFailure(&result, task, *totalIn, *totalOut,
+						fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr), rm, fmtRM)
 				}
 				fmtErr = rerr
 			}
@@ -840,18 +877,25 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 			lastFmtErr = fmtErr
 			if attempt < maxFmtAttempts {
 				b.Logger.Warn("claude-code [formatting pass %d/%d] failed, retrying: %v", attempt, maxFmtAttempts, fmtErr)
+				// A throttle or an overload answered at once is the same
+				// answer again: a short pause before the repeat, bounded by
+				// the run's context.
+				if formatRetryDelay > 0 {
+					select {
+					case <-ctx.Done():
+						return true, result, typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, fmtRM)
+					case <-time.After(formatRetryDelay):
+					}
+				}
 				continue
 			}
 			// Both attempts exhausted. Pass 1's own output was already tried
 			// by the fast path above with the same arguments, so there is
-			// nothing left to recover from it: the delegation fails typed.
-			if fmtRM != nil {
-				if result.Output == nil {
-					result.Output = map[string]any{}
-				}
-				annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
-			}
-			return true, result, fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr)
+			// nothing left to recover from it: the delegation fails typed —
+			// with Pass 1's cost whether or not the last attempt produced a
+			// message (annotateCost skips a nil one).
+			return true, result, typedFailure(&result, task, *totalIn, *totalOut,
+				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), rm, fmtRM)
 		}
 
 		output, rawLen, fallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -576,7 +576,10 @@ func (b *ClaudeCodeBackend) renderedFailure(rm *claudesdk.ResultMessage, task Ta
 	// prose no guard matches and the answer ships anyway. No evidence is
 	// filed from a shipped answer: a false bench costs more than a reading
 	// the next pass files.
-	if obj, _, found, fromText := structuredObject(rm.Result, rm.StructuredOutput); found && fromText && len(obj) > 0 &&
+	// Read from the text alone: with the SDK object passed too, a populated
+	// structured_output — the normal shape on a schema pass — answers first
+	// and hides that the text is that very object.
+	if obj, _, found, fromText := structuredObject(rm.Result, nil); found && fromText && len(obj) > 0 &&
 		!errorBodyObject(obj) && !hasRenderPrefix(*rm.Result) {
 		return nil
 	}
@@ -862,14 +865,15 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 	}
 	const maxFmtAttempts = 2
 	var lastFmtErr error
-	// The last attempt that produced a message: an earlier billed attempt
-	// must price the delegation when the final one could not even spawn.
-	var lastFmtRM *claudesdk.ResultMessage
+	// Every attempt that produced a message: each was billed, and the
+	// pricing takes the highest CLI figure among them — an earlier attempt
+	// must count when a later one could not spawn, or answered.
+	var ranRMs []*claudesdk.ResultMessage
 	for attempt := 1; attempt <= maxFmtAttempts; attempt++ {
 		b.Logger.Debug("claude-code [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, rm.SessionID)
 		fmtRM, fmtErr := b.formatPass(ctx, task, rm.SessionID)
 		if fmtErr == nil {
-			lastFmtRM = fmtRM
+			ranRMs = append(ranRMs, fmtRM)
 			// The pass ran and was billed, whatever its result says: its
 			// usage counts on every path out of here, the typed ones too.
 			if fmtRM.Usage != nil {
@@ -886,7 +890,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 					// second attempt re-spends the pass against a provider
 					// that just refused and re-files the same evidence.
 					typed := typedFailure(&result, task, *totalIn, *totalOut,
-						fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr), rm, fmtRM)
+						fmt.Errorf("delegate: claude-code formatting pass failed: %w", rerr), append([]*claudesdk.ResultMessage{rm}, ranRMs...)...)
 					return true, result, typed
 				}
 				fmtErr = rerr
@@ -904,7 +908,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 					case <-ctx.Done():
 						// Cancellation wins over the typed cause: a run being
 						// cancelled must not read as rate-limited downstream.
-						typed := typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), rm, lastFmtRM)
+						typed := typedFailure(&result, task, *totalIn, *totalOut, ctx.Err(), append([]*claudesdk.ResultMessage{rm}, ranRMs...)...)
 						return true, result, typed
 					case <-time.After(d):
 					}
@@ -918,7 +922,7 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 			// message, whether or not the final one did (annotateCost takes
 			// the highest CLI figure and skips a nil message).
 			typed := typedFailure(&result, task, *totalIn, *totalOut,
-				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), rm, lastFmtRM, fmtRM)
+				fmt.Errorf("delegate: claude-code formatting pass failed: %w", fmtErr), append([]*claudesdk.ResultMessage{rm}, ranRMs...)...)
 			return true, result, typed
 		}
 
@@ -930,7 +934,8 @@ func (b *ClaudeCodeBackend) runTwoPassFormatting(ctx context.Context, task Task,
 		result.Output = output
 		result.RawOutputLen = rawLen
 		result.ParseFallback = fallback
-		annotateCost(&result, task, *totalIn, *totalOut, rm, fmtRM)
+		// Priced from every attempt that ran, the one that answered included.
+		annotateCost(&result, task, *totalIn, *totalOut, append([]*claudesdk.ResultMessage{rm}, ranRMs...)...)
 		return true, result, nil
 	}
 	// Defensive: loop fell through without returning. Shouldn't happen

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -19,9 +19,11 @@ func TestIsAuthErrorResult(t *testing.T) {
 		"invalid api key",
 		"OAuth token has expired",
 		"Not logged in \u00b7 Please run /login",
-		// A facade's bracketed 401: the status is the provider's verdict on
-		// the credential, whatever prose follows it.
+		// A facade's bracketed 401 and a bare 403: the status is the
+		// provider's verdict on the credential, whatever prose follows it.
 		"API Error: [401][Unauthorized][2026090610430471b2ed5a5eaa4de7]",
+		"API Error: 403 Forbidden",
+		"API Error: [403][Request blocked][abc]",
 	}
 	for _, s := range authy {
 		if !isAuthErrorResult(s) {
@@ -43,9 +45,6 @@ func TestIsAuthErrorResult(t *testing.T) {
 		"You've hit your weekly limit · resets 9pm (Europe/Paris)",
 		// A server error is the transient class, never a credential verdict.
 		"API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]",
-		// A 403 is a refusal (isRefusedRequestResult), not a dead token.
-		"API Error: 403 Forbidden",
-		"API Error: [403][Request blocked][abc]",
 	}
 	for _, s := range notAuthy {
 		if isAuthErrorResult(s) {

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -19,10 +19,9 @@ func TestIsAuthErrorResult(t *testing.T) {
 		"invalid api key",
 		"OAuth token has expired",
 		"Not logged in \u00b7 Please run /login",
-		// A facade's bracketed 401 and a bare 403: the status is the
-		// provider's verdict, whatever prose follows it.
+		// A facade's bracketed 401: the status is the provider's verdict on
+		// the credential, whatever prose follows it.
 		"API Error: [401][Unauthorized][2026090610430471b2ed5a5eaa4de7]",
-		"API Error: 403 Forbidden",
 	}
 	for _, s := range authy {
 		if !isAuthErrorResult(s) {
@@ -44,6 +43,9 @@ func TestIsAuthErrorResult(t *testing.T) {
 		"You've hit your weekly limit · resets 9pm (Europe/Paris)",
 		// A server error is the transient class, never a credential verdict.
 		"API Error: [500][Operation failed][2026090610430471b2ed5a5eaa4de7]",
+		// A 403 is a refusal (isRefusedRequestResult), not a dead token.
+		"API Error: 403 Forbidden",
+		"API Error: [403][Request blocked][abc]",
 	}
 	for _, s := range notAuthy {
 		if isAuthErrorResult(s) {

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -112,13 +112,15 @@ func isAuthErrorResult(s string) bool {
 	if t == "" || len(t) > 200 {
 		return false
 	}
-	// A 401 status is the provider's own verdict on the credential, whatever
-	// prose (or none) follows it: a facade renders "API Error:
+	// A 401/403 status is the provider's own verdict on the credential,
+	// whatever prose (or none) follows it: a facade renders "API Error:
 	// [401][Unauthorized][<id>]", which matches no signature below and would
 	// otherwise flow on as the node's answer. Prefix-anchored by the regex,
-	// short by the cap. A 403 is a refusal, not a credential verdict — see
-	// isRefusedRequestResult.
-	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil && m[1] == "401" {
+	// short by the cap. 403 is in the class as the pi backend mints it from
+	// the upstream status: a permission error is per-key and the pool's
+	// rotation is the right first move; a facade block fails the next key
+	// the same way and surfaces then, no worse than surfacing now.
+	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil && (m[1] == "401" || m[1] == "403") {
 		return true
 	}
 	low := strings.ToLower(t)
@@ -141,20 +143,6 @@ func isAuthErrorResult(s string) bool {
 		}
 	}
 	return false
-}
-
-// isRefusedRequestResult detects a 403 render, bare or bracketed: the
-// upstream refused the request — a facade or CDN block, a policy refusal —
-// which a retry will not change, but which is not a verdict on the
-// credential either (a dead token renders 401). Same brevity and prefix
-// guards as the transient classifier.
-func isRefusedRequestResult(s string) bool {
-	t := strings.TrimSpace(s)
-	if t == "" || len(t) >= 400 {
-		return false
-	}
-	m := apiErrorResultStatusRe.FindStringSubmatch(t)
-	return m != nil && m[1] == "403"
 }
 
 // redactAuthRender strips the quoted credential out of an auth render:

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -112,12 +112,13 @@ func isAuthErrorResult(s string) bool {
 	if t == "" || len(t) > 200 {
 		return false
 	}
-	// A 401/403 status is the provider's own verdict on the credential,
-	// whatever prose (or none) follows it: a facade renders "API Error:
+	// A 401 status is the provider's own verdict on the credential, whatever
+	// prose (or none) follows it: a facade renders "API Error:
 	// [401][Unauthorized][<id>]", which matches no signature below and would
 	// otherwise flow on as the node's answer. Prefix-anchored by the regex,
-	// short by the cap.
-	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil && (m[1] == "401" || m[1] == "403") {
+	// short by the cap. A 403 is a refusal, not a credential verdict — see
+	// isRefusedRequestResult.
+	if m := apiErrorResultStatusRe.FindStringSubmatch(t); m != nil && m[1] == "401" {
 		return true
 	}
 	low := strings.ToLower(t)
@@ -140,6 +141,20 @@ func isAuthErrorResult(s string) bool {
 		}
 	}
 	return false
+}
+
+// isRefusedRequestResult detects a 403 render, bare or bracketed: the
+// upstream refused the request — a facade or CDN block, a policy refusal —
+// which a retry will not change, but which is not a verdict on the
+// credential either (a dead token renders 401). Same brevity and prefix
+// guards as the transient classifier.
+func isRefusedRequestResult(s string) bool {
+	t := strings.TrimSpace(s)
+	if t == "" || len(t) >= 400 {
+		return false
+	}
+	m := apiErrorResultStatusRe.FindStringSubmatch(t)
+	return m != nil && m[1] == "403"
 }
 
 // redactAuthRender strips the quoted credential out of an auth render:

--- a/pkg/backend/delegate/claude_code_formatting_pass_test.go
+++ b/pkg/backend/delegate/claude_code_formatting_pass_test.go
@@ -162,6 +162,29 @@ func TestFormattingPassVerdicts(t *testing.T) {
 			t.Fatalf("an object beside plain prose re-typed: %v", err)
 		}
 	})
+	t.Run("a JSON answer text beside a populated SDK object is an answer, whatever its words", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		rm := &claudesdk.ResultMessage{
+			Result:           str(`{"reason":"usage limit reached","count":1}`),
+			StructuredOutput: map[string]any{"reason": "usage limit reached", "count": 1},
+		}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
+			t.Fatalf("a structured answer about quotas re-typed because the SDK object answered first: %v", err)
+		}
+	})
+	t.Run("a billed throttle attempt still prices the delegation when the next attempt answers", func(t *testing.T) {
+		answer := &claudesdk.ResultMessage{Result: str(`{"answer":"done","count":2}`), SessionID: "s1",
+			Usage: &claudesdk.Usage{InputTokens: 40, OutputTokens: 4}, TotalCostUSD: f(0.05)}
+		b, _ := newBackend(render("API Error: 429 rate limit exceeded", 0.50), answer)
+		in, out := 100, 10
+		_, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		if err != nil {
+			t.Fatalf("want a shipped answer, got %v", err)
+		}
+		if got, _ := res.Output["_cost_usd"].(float64); got < 0.50 {
+			t.Fatalf("the billed throttle attempt's CLI figure was lost on the success path: _cost_usd=%v (want >= 0.50)", res.Output["_cost_usd"])
+		}
+	})
 	t.Run("a raw error body is not an answer, the provider's two-key envelope neither", func(t *testing.T) {
 		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
 		for _, text := range []string{

--- a/pkg/backend/delegate/claude_code_formatting_pass_test.go
+++ b/pkg/backend/delegate/claude_code_formatting_pass_test.go
@@ -1,0 +1,114 @@
+package delegate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// TestFormattingPassVerdicts drives the formatting loop through the test seam:
+// a terminal verdict returns at once with the billed pass counted and its
+// cost stamped; a throttle is retried and the second attempt's answer ships
+// with both passes' usage; a transient render exhausts the attempts typed;
+// the recovery pass returns its message with the verdict.
+func TestFormattingPassVerdicts(t *testing.T) {
+	str := func(s string) *string { return &s }
+	f := func(v float64) *float64 { return &v }
+	schema := json.RawMessage(`{"type":"object","required":["answer","count"],"properties":{"answer":{"type":"string"},"count":{"type":"integer"}}}`)
+	task := Task{NodeID: "n", Iteration: 1, Model: "claude-fable-5", OutputSchema: schema}
+	pass1 := &claudesdk.ResultMessage{Result: str("I looked at the code and here is my free-form conclusion."), SessionID: "s1",
+		Usage: &claudesdk.Usage{InputTokens: 100, OutputTokens: 10}, TotalCostUSD: f(0.10)}
+	newBackend := func(replies ...*claudesdk.ResultMessage) (*ClaudeCodeBackend, *int) {
+		calls := 0
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		b.formatOutputFn = func(context.Context, Task, string) (*claudesdk.ResultMessage, error) {
+			i := calls
+			calls++
+			if i >= len(replies) {
+				t.Fatalf("formatting pass called %d times, only %d replies scripted", calls, len(replies))
+			}
+			return replies[i], nil
+		}
+		return b, &calls
+	}
+	render := func(text string, cost float64) *claudesdk.ResultMessage {
+		return &claudesdk.ResultMessage{Result: str(text), SessionID: "s1",
+			Usage: &claudesdk.Usage{InputTokens: 50, OutputTokens: 5}, TotalCostUSD: f(cost)}
+	}
+
+	t.Run("a credential verdict ends the loop after one billed pass, cost stamped", func(t *testing.T) {
+		b, calls := newBackend(render("API Error: [401][Unauthorized][abc]", 0.25))
+		in, out := 100, 10
+		handled, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		var auth *ErrAuthFailed
+		if !handled || !errors.As(err, &auth) {
+			t.Fatalf("want handled + ErrAuthFailed, got handled=%v err=%v", handled, err)
+		}
+		if *calls != 1 {
+			t.Fatalf("formatting pass called %d times, want 1", *calls)
+		}
+		if res.Tokens != 165 || !res.FormattingPassUsed {
+			t.Fatalf("billed pass not counted: tokens=%d used=%v", res.Tokens, res.FormattingPassUsed)
+		}
+		if res.Output == nil || res.Output["_cost_usd"] == nil || res.Output["_tokens"] == nil {
+			t.Fatalf("cost not stamped on the terminal path: %v", res.Output)
+		}
+	})
+	t.Run("a throttle is retried; the second attempt's answer ships with both passes counted", func(t *testing.T) {
+		answer := &claudesdk.ResultMessage{Result: str(`{"answer":"done","count":2}`), SessionID: "s1",
+			Usage: &claudesdk.Usage{InputTokens: 40, OutputTokens: 4}, TotalCostUSD: f(0.30)}
+		b, calls := newBackend(render("API Error: 429 rate limit exceeded", 0.20), answer)
+		in, out := 100, 10
+		handled, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		if !handled || err != nil {
+			t.Fatalf("want a shipped answer, got handled=%v err=%v", handled, err)
+		}
+		if *calls != 2 {
+			t.Fatalf("formatting pass called %d times, want 2", *calls)
+		}
+		if res.Output["answer"] != "done" || res.ParseFallback {
+			t.Fatalf("answer not shipped: %v fallback=%v", res.Output, res.ParseFallback)
+		}
+		if res.Tokens != 110+55+44 {
+			t.Fatalf("both passes must count: tokens=%d", res.Tokens)
+		}
+	})
+	t.Run("a transient render exhausts the attempts, typed", func(t *testing.T) {
+		b, calls := newBackend(render("API Error: [500][Operation failed][x]", 0.2), render("API Error: [500][Operation failed][y]", 0.3))
+		in, out := 100, 10
+		handled, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		var tr *ErrTransient
+		if !handled || !errors.As(err, &tr) {
+			t.Fatalf("want handled + ErrTransient, got handled=%v err=%v", handled, err)
+		}
+		if *calls != 2 || res.Tokens != 220 || res.Output["_cost_usd"] == nil {
+			t.Fatalf("exhausted path: calls=%d tokens=%d output=%v", *calls, res.Tokens, res.Output)
+		}
+	})
+	t.Run("the recovery pass returns its billed message with the verdict", func(t *testing.T) {
+		b, calls := newBackend(render("API Error: [429][Usage limit reached for 5 hour. Your limit will reset at 3pm][abc]", 0.4))
+		in, out := 100, 10
+		res := Result{Tokens: 110}
+		fmtRM, err := b.runRecoveryFormatterPass(context.Background(), task, "s1", &res, &in, &out)
+		var rl *ErrRateLimited
+		if !errors.As(err, &rl) || fmtRM == nil {
+			t.Fatalf("want the message with ErrRateLimited, got rm=%v err=%v", fmtRM, err)
+		}
+		if *calls != 1 || res.Tokens != 165 || !res.FormattingPassUsed {
+			t.Fatalf("billed recovery pass not counted: calls=%d tokens=%d", *calls, res.Tokens)
+		}
+	})
+	t.Run("a render carrying a fenced JSON is still a render", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		rm := &claudesdk.ResultMessage{Result: str("API Error: 503 ```json\n{\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\"}}\n```")}
+		var tr *ErrTransient
+		if err := b.renderedFailure(rm, task, "pass 1"); !errors.As(err, &tr) {
+			t.Fatalf("render with a fenced body exempted as an answer: %v", err)
+		}
+	})
+}

--- a/pkg/backend/delegate/claude_code_formatting_pass_test.go
+++ b/pkg/backend/delegate/claude_code_formatting_pass_test.go
@@ -17,6 +17,9 @@ import (
 // with both passes' usage; a transient render exhausts the attempts typed;
 // the recovery pass returns its message with the verdict.
 func TestFormattingPassVerdicts(t *testing.T) {
+	prevDelay := formatRetryDelay
+	formatRetryDelay = 0
+	t.Cleanup(func() { formatRetryDelay = prevDelay })
 	str := func(s string) *string { return &s }
 	f := func(v float64) *float64 { return &v }
 	schema := json.RawMessage(`{"type":"object","required":["answer","count"],"properties":{"answer":{"type":"string"},"count":{"type":"integer"}}}`)
@@ -101,6 +104,53 @@ func TestFormattingPassVerdicts(t *testing.T) {
 		}
 		if *calls != 1 || res.Tokens != 165 || !res.FormattingPassUsed {
 			t.Fatalf("billed recovery pass not counted: calls=%d tokens=%d", *calls, res.Tokens)
+		}
+	})
+	t.Run("a pass that could not run still prices the delegation on the exhausted path", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		calls := 0
+		b.formatOutputFn = func(context.Context, Task, string) (*claudesdk.ResultMessage, error) {
+			calls++
+			return nil, errors.New("container is not running")
+		}
+		in, out := 100, 10
+		handled, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		if !handled || err == nil || calls != 2 {
+			t.Fatalf("want handled + error after 2 attempts, got handled=%v err=%v calls=%d", handled, err, calls)
+		}
+		if res.Output == nil || res.Output["_cost_usd"] == nil {
+			t.Fatalf("Pass 1's cost dropped when the last attempt produced no message: %v", res.Output)
+		}
+	})
+	t.Run("a typed failure carries the delegation's spend", func(t *testing.T) {
+		res := Result{}
+		err := typedFailure(&res, task, 100, 10, errors.New("x"), pass1)
+		if err == nil || res.Output == nil || res.Output["_cost_usd"] == nil || res.Output["_tokens"] == nil {
+			t.Fatalf("typed failure without its spend: err=%v output=%v", err, res.Output)
+		}
+	})
+	t.Run("an SDK object beside a render is not an answer; beside plain prose it is", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		obj := map[string]any{"answer": "done", "count": 1}
+		rm := &claudesdk.ResultMessage{Result: str("API Error: [429][Usage limit reached for 5 hour. Your limit will reset at 3pm][abc]"), StructuredOutput: obj}
+		var rl *ErrRateLimited
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); !errors.As(err, &rl) {
+			t.Fatalf("window verdict shipped as an answer beside an echoed object: %v", err)
+		}
+		rm = &claudesdk.ResultMessage{Result: str("Claude AI usage limit reached|1757200000"), StructuredOutput: obj}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); !errors.As(err, &rl) {
+			t.Fatalf("non-bracketed refusal shipped as an answer beside an object: %v", err)
+		}
+		rm = &claudesdk.ResultMessage{Result: str("Done: the report lists the quota policy and the two remaining lots."), StructuredOutput: obj}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
+			t.Fatalf("an object beside plain prose re-typed: %v", err)
+		}
+	})
+	t.Run("a raw error body is not an answer", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		rm := &claudesdk.ResultMessage{Result: str(`{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`)}
+		if err := b.renderedFailure(rm, task, "pass 1"); err == nil {
+			t.Fatalf("a raw error body shipped as an answer")
 		}
 	})
 	t.Run("a render carrying a fenced JSON is still a render", func(t *testing.T) {

--- a/pkg/backend/delegate/claude_code_formatting_pass_test.go
+++ b/pkg/backend/delegate/claude_code_formatting_pass_test.go
@@ -119,6 +119,25 @@ func TestFormattingPassVerdicts(t *testing.T) {
 			t.Fatalf("Pass 1's cost dropped when the last attempt produced no message: %v", res.Output)
 		}
 	})
+	t.Run("a billed first attempt prices the delegation when the second could not spawn", func(t *testing.T) {
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}), formatRetryDelay: -1}
+		calls := 0
+		b.formatOutputFn = func(context.Context, Task, string) (*claudesdk.ResultMessage, error) {
+			calls++
+			if calls == 1 {
+				return render("API Error: 429 rate limit exceeded", 0.45), nil
+			}
+			return nil, errors.New("container is not running")
+		}
+		in, out := 100, 10
+		_, res, err := b.runTwoPassFormatting(context.Background(), task, pass1, Result{Tokens: 110}, &in, &out)
+		if err == nil || calls != 2 {
+			t.Fatalf("want an error after 2 attempts, got err=%v calls=%d", err, calls)
+		}
+		if got, _ := res.Output["_cost_usd"].(float64); got < 0.45 {
+			t.Fatalf("the billed first attempt's CLI figure was lost: _cost_usd=%v (want >= 0.45)", res.Output["_cost_usd"])
+		}
+	})
 	t.Run("a typed failure carries the delegation's spend", func(t *testing.T) {
 		res := Result{}
 		err := typedFailure(&res, task, 100, 10, errors.New("x"), pass1)
@@ -148,6 +167,7 @@ func TestFormattingPassVerdicts(t *testing.T) {
 		for _, text := range []string{
 			`{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
 			`{"type":"error","error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+			`{"type":"error","error":{"type":"rate_limit_error","message":"rate limit exceeded"},"request_id":"req_123"}`,
 		} {
 			rm := &claudesdk.ResultMessage{Result: str(text)}
 			if err := b.renderedFailure(rm, task, "pass 1"); err == nil {

--- a/pkg/backend/delegate/claude_code_formatting_pass_test.go
+++ b/pkg/backend/delegate/claude_code_formatting_pass_test.go
@@ -17,9 +17,6 @@ import (
 // with both passes' usage; a transient render exhausts the attempts typed;
 // the recovery pass returns its message with the verdict.
 func TestFormattingPassVerdicts(t *testing.T) {
-	prevDelay := formatRetryDelay
-	formatRetryDelay = 0
-	t.Cleanup(func() { formatRetryDelay = prevDelay })
 	str := func(s string) *string { return &s }
 	f := func(v float64) *float64 { return &v }
 	schema := json.RawMessage(`{"type":"object","required":["answer","count"],"properties":{"answer":{"type":"string"},"count":{"type":"integer"}}}`)
@@ -28,7 +25,7 @@ func TestFormattingPassVerdicts(t *testing.T) {
 		Usage: &claudesdk.Usage{InputTokens: 100, OutputTokens: 10}, TotalCostUSD: f(0.10)}
 	newBackend := func(replies ...*claudesdk.ResultMessage) (*ClaudeCodeBackend, *int) {
 		calls := 0
-		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}), formatRetryDelay: -1}
 		b.formatOutputFn = func(context.Context, Task, string) (*claudesdk.ResultMessage, error) {
 			i := calls
 			calls++
@@ -107,7 +104,7 @@ func TestFormattingPassVerdicts(t *testing.T) {
 		}
 	})
 	t.Run("a pass that could not run still prices the delegation on the exhausted path", func(t *testing.T) {
-		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}), formatRetryDelay: -1}
 		calls := 0
 		b.formatOutputFn = func(context.Context, Task, string) (*claudesdk.ResultMessage, error) {
 			calls++
@@ -146,11 +143,29 @@ func TestFormattingPassVerdicts(t *testing.T) {
 			t.Fatalf("an object beside plain prose re-typed: %v", err)
 		}
 	})
-	t.Run("a raw error body is not an answer", func(t *testing.T) {
+	t.Run("a raw error body is not an answer, the provider's two-key envelope neither", func(t *testing.T) {
 		b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
-		rm := &claudesdk.ResultMessage{Result: str(`{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`)}
-		if err := b.renderedFailure(rm, task, "pass 1"); err == nil {
-			t.Fatalf("a raw error body shipped as an answer")
+		for _, text := range []string{
+			`{"error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+			`{"type":"error","error":{"type":"rate_limit_error","message":"rate limit exceeded"}}`,
+		} {
+			rm := &claudesdk.ResultMessage{Result: str(text)}
+			if err := b.renderedFailure(rm, task, "pass 1"); err == nil {
+				t.Fatalf("%s: an error envelope shipped as an answer", text)
+			}
+		}
+		// An answer that carries an `error` field beside real data stays one.
+		rm := &claudesdk.ResultMessage{Result: str(`{"answer":"rate limit exceeded on the third call","error":null,"count":3}`)}
+		if err := b.renderedFailure(rm, task, "pass 1"); err != nil {
+			t.Fatalf("an answer with an error field re-typed: %v", err)
+		}
+	})
+	t.Run("the retry pause is per backend, off when negative, default when zero", func(t *testing.T) {
+		if (&ClaudeCodeBackend{formatRetryDelay: -1}).retryDelay() != 0 {
+			t.Fatal("negative must disable the pause")
+		}
+		if (&ClaudeCodeBackend{}).retryDelay() != defaultFormatRetryDelay {
+			t.Fatal("zero must mean the default")
 		}
 	})
 	t.Run("a render carrying a fenced JSON is still a render", func(t *testing.T) {

--- a/pkg/backend/delegate/claude_code_rendered_failure_test.go
+++ b/pkg/backend/delegate/claude_code_rendered_failure_test.go
@@ -74,7 +74,7 @@ func TestRenderedFailure(t *testing.T) {
 			t.Fatalf("want ErrAuthFailed, got %v", err)
 		}
 	})
-	t.Run("a structured answer is an answer, whatever its text says", func(t *testing.T) {
+	t.Run("an answer is an answer, whatever its text says — the SDK object or JSON text", func(t *testing.T) {
 		rm := &claudesdk.ResultMessage{
 			Result:           str("quota exceeded"),
 			StructuredOutput: map[string]any{"status": "quota exceeded", "ok": false},
@@ -82,31 +82,44 @@ func TestRenderedFailure(t *testing.T) {
 		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
 			t.Fatalf("structured answer re-typed: %v", err)
 		}
-		rm.StructuredOutput = map[string]any{}
+		// The formatting pass may deliver its answer as JSON in the text
+		// with an empty structured object: the same definition applies.
+		rm = &claudesdk.ResultMessage{
+			Result:           str(`{"status": "usage limit reached", "ok": false}`),
+			StructuredOutput: map[string]any{},
+		}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
+			t.Fatalf("JSON-text answer re-typed: %v", err)
+		}
+		rm = &claudesdk.ResultMessage{Result: str("quota exceeded"), StructuredOutput: map[string]any{}}
 		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err == nil {
-			t.Fatalf("an empty structured object is not an answer: want the quota verdict")
+			t.Fatalf("a bare quota notice with an empty object is not an answer: want the quota verdict")
 		}
 	})
-	t.Run("a 403 is a refusal: terminal, not transient, not a credential verdict", func(t *testing.T) {
+	t.Run("a 403 is a credential verdict, as the pi backend mints it — never retried", func(t *testing.T) {
 		for _, text := range []string{"API Error: 403 Forbidden", "API Error: [403][Request blocked][abc]"} {
 			rm := &claudesdk.ResultMessage{Result: str(text)}
 			err := b.renderedFailure(rm, task, "pass 1")
-			var tr *ErrTransient
 			var auth *ErrAuthFailed
-			if err == nil || errors.As(err, &tr) || errors.As(err, &auth) {
-				t.Fatalf("%q: want a terminal refusal, got %v", text, err)
+			if !errors.As(err, &auth) {
+				t.Fatalf("%q: want ErrAuthFailed, got %v", text, err)
 			}
 			if renderRetryable(err) {
-				t.Fatalf("%q: a refusal must not be retried", text)
+				t.Fatalf("%q: a credential verdict must not be retried", text)
 			}
 		}
 	})
-	t.Run("only the transient class is retried on a formatting attempt", func(t *testing.T) {
-		if !renderRetryable(&ErrTransient{Provider: BackendClaudeCode, Reason: "api_error_result"}) {
-			t.Fatal("transient not retryable")
+	t.Run("the transient class and a bare throttle are retried on a formatting attempt; verdicts are not", func(t *testing.T) {
+		for _, err := range []error{
+			&ErrTransient{Provider: BackendClaudeCode, Reason: "api_error_result"},
+			&ErrRateLimited{Provider: BackendClaudeCode, Kind: RateLimitKindTransient},
+		} {
+			if !renderRetryable(err) {
+				t.Fatalf("%v: retryable class treated as terminal", err)
+			}
 		}
 		for _, err := range []error{
-			&ErrRateLimited{Provider: BackendClaudeCode, Kind: "usage_window"},
+			&ErrRateLimited{Provider: BackendClaudeCode, Kind: RateLimitKindUsageWindow},
 			&ErrAuthFailed{Provider: BackendClaudeCode},
 			errors.New("claude-code: model unavailable"),
 		} {

--- a/pkg/backend/delegate/claude_code_rendered_failure_test.go
+++ b/pkg/backend/delegate/claude_code_rendered_failure_test.go
@@ -75,12 +75,19 @@ func TestRenderedFailure(t *testing.T) {
 		}
 	})
 	t.Run("an answer is an answer, whatever its text says — the SDK object or JSON text", func(t *testing.T) {
+		// An SDK object beside a text that is itself a quota render is NOT
+		// an answer (a resumed pass may echo a prior turn's object next to
+		// a refusal); beside plain prose it is.
 		rm := &claudesdk.ResultMessage{
 			Result:           str("quota exceeded"),
 			StructuredOutput: map[string]any{"status": "quota exceeded", "ok": false},
 		}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err == nil {
+			t.Fatalf("an SDK object beside a quota render shipped as an answer")
+		}
+		rm.Result = str("Here is the quota summary you asked for.")
 		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
-			t.Fatalf("structured answer re-typed: %v", err)
+			t.Fatalf("structured answer beside prose re-typed: %v", err)
 		}
 		// The formatting pass may deliver its answer as JSON in the text
 		// with an empty structured object: the same definition applies.

--- a/pkg/backend/delegate/claude_code_rendered_failure_test.go
+++ b/pkg/backend/delegate/claude_code_rendered_failure_test.go
@@ -74,6 +74,47 @@ func TestRenderedFailure(t *testing.T) {
 			t.Fatalf("want ErrAuthFailed, got %v", err)
 		}
 	})
+	t.Run("a structured answer is an answer, whatever its text says", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{
+			Result:           str("quota exceeded"),
+			StructuredOutput: map[string]any{"status": "quota exceeded", "ok": false},
+		}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err != nil {
+			t.Fatalf("structured answer re-typed: %v", err)
+		}
+		rm.StructuredOutput = map[string]any{}
+		if err := b.renderedFailure(rm, task, "formatting pass 1/2"); err == nil {
+			t.Fatalf("an empty structured object is not an answer: want the quota verdict")
+		}
+	})
+	t.Run("a 403 is a refusal: terminal, not transient, not a credential verdict", func(t *testing.T) {
+		for _, text := range []string{"API Error: 403 Forbidden", "API Error: [403][Request blocked][abc]"} {
+			rm := &claudesdk.ResultMessage{Result: str(text)}
+			err := b.renderedFailure(rm, task, "pass 1")
+			var tr *ErrTransient
+			var auth *ErrAuthFailed
+			if err == nil || errors.As(err, &tr) || errors.As(err, &auth) {
+				t.Fatalf("%q: want a terminal refusal, got %v", text, err)
+			}
+			if renderRetryable(err) {
+				t.Fatalf("%q: a refusal must not be retried", text)
+			}
+		}
+	})
+	t.Run("only the transient class is retried on a formatting attempt", func(t *testing.T) {
+		if !renderRetryable(&ErrTransient{Provider: BackendClaudeCode, Reason: "api_error_result"}) {
+			t.Fatal("transient not retryable")
+		}
+		for _, err := range []error{
+			&ErrRateLimited{Provider: BackendClaudeCode, Kind: "usage_window"},
+			&ErrAuthFailed{Provider: BackendClaudeCode},
+			errors.New("claude-code: model unavailable"),
+		} {
+			if renderRetryable(err) {
+				t.Fatalf("%v: terminal verdict retried", err)
+			}
+		}
+	})
 	t.Run("a model the CLI cannot use fails fast", func(t *testing.T) {
 		rm := &claudesdk.ResultMessage{Result: str("There's an issue with the selected model (x/y). It may not exist or you may not have access to it.")}
 		err := b.renderedFailure(rm, task, "pass 1")

--- a/pkg/backend/delegate/parse.go
+++ b/pkg/backend/delegate/parse.go
@@ -19,17 +19,18 @@ import (
 // missing — a non-map structured value that round-trips to a non-empty
 // object, or a JSON object in the result text, direct or in a fenced block.
 // found is false when there is none; rawLen is the text's length when the
-// object came from the text.
-func structuredObject(resultText *string, structuredOutput any) (obj map[string]any, rawLen int, found bool) {
+// object came from the text, and fromText says so — the render guards trust
+// an object the text itself is more than one the SDK carried beside a text.
+func structuredObject(resultText *string, structuredOutput any) (obj map[string]any, rawLen int, found, fromText bool) {
 	if structuredOutput != nil {
 		if m, ok := structuredOutput.(map[string]any); ok {
 			if len(m) > 0 {
-				return m, 0, true
+				return m, 0, true, false
 			}
 		} else if b, err := json.Marshal(structuredOutput); err == nil {
 			var m map[string]any
 			if json.Unmarshal(b, &m) == nil && len(m) > 0 {
-				return m, len(b), true
+				return m, len(b), true, false
 			}
 		}
 	}
@@ -37,20 +38,20 @@ func structuredObject(resultText *string, structuredOutput any) (obj map[string]
 		text := *resultText
 		var m map[string]any
 		if json.Unmarshal([]byte(text), &m) == nil {
-			return m, len(text), true
+			return m, len(text), true, true
 		}
 		if extracted := extractJSONFromMarkdown(text); extracted != "" {
 			if json.Unmarshal([]byte(extracted), &m) == nil {
-				return m, len(text), true
+				return m, len(text), true, true
 			}
 		}
 	}
-	return nil, 0, false
+	return nil, 0, false, false
 }
 
 func parseSDKOutput(resultText *string, structuredOutput any, outputSchema json.RawMessage) (output map[string]any, rawLen int, fallback bool) {
 	// Priority 1 and 2: a structured answer, from the SDK object or the text.
-	if obj, n, found := structuredObject(resultText, structuredOutput); found {
+	if obj, n, found, _ := structuredObject(resultText, structuredOutput); found {
 		return obj, n, false
 	}
 

--- a/pkg/backend/delegate/parse.go
+++ b/pkg/backend/delegate/parse.go
@@ -10,50 +10,54 @@ import (
 // parseSDKOutput converts SDK result fields into a delegate Result.Output map.
 // It prioritizes structuredOutput over resultText, falling back to JSON extraction
 // from markdown and finally plain text wrapping.
-func parseSDKOutput(resultText *string, structuredOutput any, outputSchema json.RawMessage) (output map[string]any, rawLen int, fallback bool) {
-	// Priority 1: structured output from SDK — only when non-empty.
-	// claude-code's stream-json emits `structured_output: {}` for
-	// tool-using sessions where no second-pass formatter ran (i.e.
-	// the sandboxed two-pass case where formatOutput can't resume the
-	// in-container session). Treating an empty map as a valid result
-	// wedged the runtime into "raw_output_len=0, parse_fallback=false"
-	// with all required fields missing — fall through to the
-	// resultText path so the assistant's final markdown JSON block
-	// can be extracted instead.
+// structuredObject is THE definition of a structured answer, shared by
+// parseSDKOutput (which ships it) and the render guards (which exempt it):
+// the SDK's structured object when non-empty — claude-code's stream-json
+// emits `structured_output: {}` for tool-using sessions where no second-pass
+// formatter ran, and treating that as a result once wedged the runtime into
+// "raw_output_len=0, parse_fallback=false" with every required field
+// missing — a non-map structured value that round-trips to a non-empty
+// object, or a JSON object in the result text, direct or in a fenced block.
+// found is false when there is none; rawLen is the text's length when the
+// object came from the text.
+func structuredObject(resultText *string, structuredOutput any) (obj map[string]any, rawLen int, found bool) {
 	if structuredOutput != nil {
-		if obj, ok := structuredOutput.(map[string]any); ok {
-			if len(obj) > 0 {
-				return obj, 0, false
+		if m, ok := structuredOutput.(map[string]any); ok {
+			if len(m) > 0 {
+				return m, 0, true
 			}
-		} else {
-			// Non-map types: round-trip via JSON.
-			b, err := json.Marshal(structuredOutput)
-			if err == nil {
-				var obj map[string]any
-				if json.Unmarshal(b, &obj) == nil && len(obj) > 0 {
-					return obj, len(b), false
-				}
+		} else if b, err := json.Marshal(structuredOutput); err == nil {
+			var m map[string]any
+			if json.Unmarshal(b, &m) == nil && len(m) > 0 {
+				return m, len(b), true
 			}
 		}
 	}
+	if resultText != nil && *resultText != "" {
+		text := *resultText
+		var m map[string]any
+		if json.Unmarshal([]byte(text), &m) == nil {
+			return m, len(text), true
+		}
+		if extracted := extractJSONFromMarkdown(text); extracted != "" {
+			if json.Unmarshal([]byte(extracted), &m) == nil {
+				return m, len(text), true
+			}
+		}
+	}
+	return nil, 0, false
+}
 
-	// Priority 2: parse result text.
+func parseSDKOutput(resultText *string, structuredOutput any, outputSchema json.RawMessage) (output map[string]any, rawLen int, fallback bool) {
+	// Priority 1 and 2: a structured answer, from the SDK object or the text.
+	if obj, n, found := structuredObject(resultText, structuredOutput); found {
+		return obj, n, false
+	}
+
+	// Priority 3: the result text as text.
 	if resultText != nil && *resultText != "" {
 		text := *resultText
 		rawLen = len(text)
-
-		// Try direct JSON object parse.
-		var obj map[string]any
-		if json.Unmarshal([]byte(text), &obj) == nil {
-			return obj, rawLen, false
-		}
-
-		// Try extracting JSON from markdown code blocks.
-		if extracted := extractJSONFromMarkdown(text); extracted != "" {
-			if json.Unmarshal([]byte(extracted), &obj) == nil {
-				return obj, rawLen, false
-			}
-		}
 
 		// Fallback: wrap raw text. If the output schema expects exactly one
 		// required field of type "string" (e.g. shell_result {result}), a


### PR DESCRIPTION
## Follow-up of #818 — its second review round, landed here because the queue had locked the branch

#818 made a facade's bracketed API-error render an API error instead of a node's answer, and put every result message — pass 1, the formatting passes, the recovery pass — through one predicate. Revi's second round found one thing in that wiring and asked six questions; the branch was already locked in the merge queue, so the answers land here.

## The finding, reproduced

The formatting loop assigned every rendered verdict to `fmtErr` and retried the attempt once. A dead credential, an unavailable model or an exhausted window therefore bought a **second CLI spawn** against a provider that had just refused — and `renderedFailure` re-ran its side effects, filing the same `usagecap.Reading` twice for one refusal. Only the transient class (5xx, overload, a bare throttle, connectivity) is a case a repeat can recover. `renderRetryable(err)` says which; everything else returns typed at once, as the recovery pass already did. Mutant: every failure retried — red.

## The questions, answered in code where they were code

- *Guard order flipped for non-bracketed shapes too?* Yes, and it is behaviour-preserving where it matters: a render matching both a quota phrase and a transient status ("API Error: 503 … quota exceeded") is now `ErrRateLimited`; without a window it is a plain throttle, which the executor already treats as its transient retry, and with a window it carries the evidence the generic retry would have lost.
- *`isRateLimitMessage` is unanchored, and now runs on the formatting pass.* A result that carries a **non-empty structured object is an answer whatever its text says** — the CLI never renders an upstream failure alongside one — so a short JSON answer about quotas cannot abort the node as rate-limited, on any pass. An empty object is not an answer. Mutant: the exemption dropped — red.
- *`runRecoveryFormatterPass`'s doc was stale.* It now says what it returns: a pass that fails to run stays non-fatal (Pass 1's output is judged by the schema), a pass that renders an upstream failure is returned typed instead of shipping Pass 1's fallback text to an opaque schema failure.
- *The Pass-1 recovery in the exhausted branch looks unreachable.* It is, as far as this reading goes: the fast path at the top tests the same call. Pre-existing, not widened here.
- *Every 403 as a credential verdict?* Not observed on the facade; 401 is the measured shape. A 403 is now a **refusal**: the upstream will repeat it, so it is terminal and legible, but it is no verdict on the credential (a dead token renders 401) and no longer carries the token remedy. Mutants: 403 back to auth; the 403 guard dropped — both red.
- *pi shares the predicate.* Intentional: pi's `errorMessage` gets the same 5xx rule and bracketed parse; a pi 5xx that surfaced as deterministic before now retries. pi mints its own credential verdicts from the upstream status (`pi.go`), so the 401/403 change does not touch its auth path.

## Proof

`TestRenderedFailure`: the four classes through `renderRetryable`; a structured answer with "quota exceeded" as text passes, an empty object does not; bare and bracketed 403 are terminal, not transient, not auth. `go test ./pkg/backend/delegate/` green, `golangci-lint` 0 issues. Not claimed: the formatting-loop wiring has no subprocess harness in this package — it is covered by the predicate's tests and by reading.


## Second round (one finding, reproduced; six questions answered in code)

- **A bare throttle was terminal on the formatting pass** (medium): `renderRetryable` named the throttle in its contract but matched only `ErrTransient`; a plain 429 render — the most common transient refusal — went from one resumed formatting call to a re-run of the whole delegation, Pass 1's tool calls and file edits included. A throttle is safe to repeat by construction: `classifyRateLimit` returns the transient kind only with an empty window, and the evidence write is gated on a window. Mutant: the throttle terminal again — red.

Open questions, answered:

- *The exemption rests on "the CLI never renders a failure alongside a structured object" — measured or inferred?* Inferred, and it is no longer the ground: the exemption now keys on **a structured answer** by the one definition, `structuredObject` (the SDK object, a round-tripped value, or a JSON object in the text, direct or fenced), which `parseSDKOutput` ships and the render guards exempt — the two cannot diverge. A late refusal render beside an early structured object ships the answer and files no evidence: a false bench of the credential costs more than the reading the next pass files anyway.
- *"Is an answer" defined twice (map vs. round-trip)?* Not any more — see above. Mutant: the shared definition dropping fenced JSON — red on the parser's own tests.
- *JSON in `fmtRM.Result` with an empty structured object?* Covered by the same definition: a formatting pass answering as JSON text is an answer. Test: `{"status": "usage limit reached", …}` with an empty object passes; a bare notice with an empty object is the quota verdict. Mutant: the exemption keyed on the SDK map only — red.
- *403 → `FallbackUnclassified` changes routing.* Reverted: 403 stays in the credential class, as the pi backend mints it from the upstream status — a permission error is per-key and the pool's rotation is the right first move; a facade block fails the next key the same way and surfaces then, no worse than surfacing now.
- *The dead Pass-1 recovery in the exhausted branch.* Deleted: the fast path had already tried the same parse with the same arguments, so there were two paths to keep in sync for nothing.
- *A billed formatting pass on the terminal path went unaccounted.* Its usage now counts on every path out of the loop, the typed ones too, and the cost is annotated before a terminal return.


## Third round (two findings, reproduced; four questions answered)

- **The cost annotation on the terminal path wrote nothing** (medium): `result.Output` was still nil there, so the annotation returned early — tokens survived, the cost half did not, and a node that spent Pass 1 plus a formatting pass before a credential or window verdict reported zero to the fallback chain, the run budget and the monthly cap. The map is now allocated before annotating on both terminal paths of the loop.
- **The recovery pass had the same hole from the other side** (medium): its usage was counted after the guard that returned, and it returned nil with the verdict, so the caller could not annotate. It now counts its usage before the guard, returns its message with the verdict, and the caller annotates before returning it.
- **A seam, since both defects sat in the untested wiring**: `formatOutputFn` replaces the CLI spawn in tests, and `TestFormattingPassVerdicts` drives the loop — a credential verdict ends after one billed pass with the cost stamped; a throttle is retried and the second attempt's answer ships with both passes counted; a transient render exhausts the attempts typed; the recovery pass returns its billed message with the verdict. Mutants, each red: the terminal path annotating into a nil map; the recovery usage counted after the guard; the recovery pass dropping its message; the render-prefix guard removed.

Open questions, answered:

- *A facade rendering a refusal as a JSON body would now satisfy the exemption on pass 1.* Not observed: the CLI renders every upstream failure in its text form, `API Error: <status> <body>`, and a body after that prefix is neither a direct object nor a fenced block. The exemption now also refuses that form outright — a text starting with `API Error` is never an answer, a fenced JSON inside it included (test: a 503 render carrying a fenced error body is still transient).
- *Is `Usage` per-invocation, given the cost is session-cumulative?* The standing assumption of this code, unchanged here: usage is summed and the CLI-reported cost is taken as a maximum. This change extends the sum to a retried attempt that ran and was billed, which is what a per-invocation figure means; it is not re-measured in this PR.
- *A formatting-pass verdict fails the node and a `fallbacks:` chain re-runs Pass 1 on the next route.* The verdict types are the ones pass 1 already returns for the same renders, so the routing is the executor's existing routing; the formatting pass merely stops masking them. Resuming the session for the formatting pass alone is a separate feature.
- *A fake `formatOutput` seam?* Added, see above.


## Fourth round (one finding, reproduced; five questions answered)

- **The exhausted path priced the delegation only when the last attempt had produced a message** (medium): a pass that could not run — the container gone at formatting time — left Pass 1's whole session unpriced, $0 to the caps and the fallback chain. `typedFailure` is now the one place a typed failure leaves through: it allocates the output map and annotates the spend from every message that ran (a nil one is skipped) — on pass 1, on both terminal paths of the loop, on the recovery caller. Test: a pass that could not run still prices the delegation. Mutants: the exhausted path pricing only with a message; `typedFailure` no longer stamping — both red.

Open questions, answered:

- *Can a resumed pass echo a prior turn's `structured_output` beside a refusal render?* Inferred impossible before, not measured — so the exemption no longer rests on it: an object the SDK carried **beside** a text is trusted only when that text is not a render the guards recognise (`looksRendered`); an object the **text itself is** (direct or fenced) is the answer whatever words it contains. Test: an object beside a bracketed window refusal or a bare "usage limit reached" render is the verdict, beside plain prose it is the answer. Mutant: the exemption back beside a render — red.
- *The asymmetry between the `API Error` prefix and the other refusal shapes.* Gone with the rule above: every shape the guards recognise refuses the exemption for an SDK-carried object.
- *Pass 1's terminal return dropped the session's cost.* Same class, same fix: it leaves through `typedFailure` too.
- *A bare 429 re-spawned the formatting pass with no backoff.* A retried attempt now waits two seconds first (`formatRetryDelay`, bounded by the run's context, zero in the seam tests): a throttle answered at once is the same answer again. The executor's backoff still governs the delegation-level retry.
- *A facade relaying a raw JSON error body as the result text.* Not observed — the CLI prefixes every upstream failure — and refused anyway: an object that is only an error envelope (`{"error": …}`) is not an answer. Mutant: the error body counted as an answer — red.


## Fifth round (two findings, reproduced; six questions answered)

- **`return result, typedFailure(&result, …)` relied on an unspecified evaluation order** (medium): Go leaves the order between a plain operand and a call in one return list unspecified; the current toolchain runs the call first, so it was correct today, and an order flip would have handed back a nil output map in silence at the two `Execute` sites no test drives. The call is hoisted into its own statement at all five sites, so the stamp lands before the copy.
- **`errorBodyObject` refused only the single-key body** (medium): the provider's own envelope is `{"type":"error","error":{…}}`, two keys, and relayed verbatim as the result text it was exempted as an answer. Both shapes are refused; an answer carrying an `error` field beside real data stays an answer. Test: both shapes, plus the legitimate answer. Mutant: the two-key envelope exempted again — red.

Open questions, answered:

- *`handleCLIErrorSubtype`'s fatal path and `buildStreamErrorResult` still return a nil output.* Pre-existing and out of this PR's surface (a CLI error subtype and a stream error are not rendered results); the same helper applies there and it is a follow-up, not a deliberate exclusion.
- *In-place retries overwrite `result`, so the stamped spend survives only on the last attempt.* Executor-side, a second hole on the same ledger: follow-up, not scoped here on purpose — this PR closes the delegate's half, where the spend was never stamped at all.
- *`annotateCost` takes the max `TotalCostUSD`, on a resumed session too.* The standing assumption of the existing code (session-cumulative reporting), unchanged and not re-measured here.
- *A render as bare JSON or a fenced block without the `API Error` prefix?* Never observed; the CLI prefixes every upstream failure. The provider envelope is now refused even so.
- *The retry-delay `select` returns a bare `ctx.Err()`.* On purpose, now said in code: a run being cancelled must not read as rate-limited downstream; the typed cause was already logged by the attempt.
- *`formatRetryDelay` as a package variable.* Moved onto the backend beside the seam (zero = the default, negative = none), so parallel tests cannot race on it.


## Sixth round (no finding; six questions, three answered in code)

- *Can a failed node now be charged twice by the runner?* No: the runner's cost accumulator reads `cost_usd` from `delegate_finished` events only, and the error event carries none. A failed attempt's spend reaches the totals through the chain's carried `_cost_usd`, folded once. The other side of that coin: a node that fails with no further route still reports its spend only in the error event (tokens), so the runner's totals do not add it — a runner-side follow-up, out of this PR.
- *Only the last attempt's message priced the exhausted path.* Fixed: the last message that ran is carried across attempts, so a billed first attempt (a throttle, the higher session-cumulative figure) prices the delegation when the second could not spawn. Test and mutant.
- *The two other terminal returns outside `typedFailure`.* Next slice, named above.
- *The provider's envelope carries a `request_id`, three keys.* Fixed: an object with an `error` key and the provider's `"type":"error"` marker is an envelope whatever else it carries; a bare `{"error": …}` too; an answer with an `error` field beside real data and no marker stays an answer. Test and mutant. The prefix remains the first guard for the CLI's own relay; the envelope test is for a facade that relays the body without it.
- *`!looksRendered` was inert.* Yes — when no guard matches the text the predicate returns nil anyway. The SDK-object half of the exemption is gone; what remains is the load-bearing rule: an object the text itself is, minus the render prefix and the envelope.
- *Is `Usage` per-invocation?* The standing assumption of the summing code, unchanged and unmeasured here; over-counting a retried attempt would be conservative for the caps.


## Seventh round (one finding, reproduced; five questions answered)

- **The exemption was unreachable beside a populated SDK object** (medium): `structuredObject` answers from the SDK object first whenever it is populated — the normal shape on a schema pass — and stamps it as not-from-text, so a JSON answer text about quotas beside its own object fell through to the quota guard and died as a usage-window verdict, parking the run and cooling the route for a valid answer. The exemption now reads the text alone. Test: a JSON text beside a populated object is an answer whatever its words. Mutant: the SDK object read first again — red.

Open questions, answered:

- *`Usage` per-invocation or cumulative on a resumed session?* Unmeasured here, as said before; the summing convention is the existing code's.
- *A whole chain failing emits no `cost_usd` on the error event.* Runner-side follow-up, as said in the previous round: the error event carries tokens, the runner's totals read `delegate_finished` only.
- *The success path priced only the answering attempt.* Fixed: every attempt that produced a message is kept, and each exit of the loop — the answer, the terminal verdict, the exhausted attempts, a cancellation — prices from all of them. Test: a billed throttle attempt still prices the delegation when the next attempt answers. Mutant: the success path pricing only the answering attempt — red.
- *No override for the two-second pause.* Deliberately below the bar for a knob until a measurement asks for one; it is a per-backend field for tests.
- *Has the `API Error:` prefix been verified across every facade path?* Only on the Anthropic-shaped facade this PR measured; the envelope veto covers a relay without the prefix, and a bare JSON quota phrase with neither is the residual, unobserved shape.


## Eighth round (no finding; six questions answered, no code)

- *A refusal that parses as JSON, does not start with `API Error` and is not an envelope?* Not observed on any facade; it is the residual shape, named as such since the fifth round.
- *A schema pass whose SDK object is a good answer but whose final text trips the unanchored quota guard?* The trade taken in the fourth round: beside a recognised refusal render the object earns no exemption, because a resumed pass can echo a prior turn's object next to a real window verdict, and shipping that verdict as an answer is the class this PR closes. The exposure is a final message quoting a provider-shaped phrase verbatim under 200 characters; not measured, judged rarer and cheaper (a visible failure) than the reverse.
- *Settling the usage-vs-cost convention?* A CLI run comparing pass 2's reported input tokens against pass 1's would settle it; not done here.
- *`claudesdk.Prompt` dropping a parsed result when a later read fails.* The SDK's residual of the same class, out of this package; not measured whether the CLI ever writes after the result line.
- *Does any consumer branch on a failed result's non-nil output?* Checked: the chain's `applyTo` only folds spend into a non-nil map, and the `action: skip` terminal builds its own empty map; nothing reads a failed result's map as output.
- *A bare `context.Canceled` from the retry pause.* It lands where every in-delegate cancellation lands: the chain's terminal short-circuit on `ctx.Err()`, the same path as a cancellation raised outside the delegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
