### PR TITLE
fix(forge,webhooks): one App client per connection with its real slug, tokens minted from the recorded grant, a 403 that arms the preflight, a connection-first reply gate, and a GitLab fork MR that names its source

### DIFF
--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -32,7 +32,12 @@ entries there:
   still without forge I/O (`isIterionForgeBotAuthor` — the bot's
   own answer echoes back as this very event), requires the converse
   bot in the webhook scope (`roleBots().ReviConverse` +
-  `cfg.AllowsBot`), then gates: the thread is fetched
+  `cfg.AllowsBot`), then gates: the forge client is resolved the way
+  every GitHub/Forgejo lane resolves it (`prforgeReplierAPIFor`) — the
+  team connection covering the PR first, its App client reading under a
+  `pull_requests:read` token, the webhook's `forge_token` binding as the
+  fallback — so a connection-only integration serves the lane; the
+  thread is fetched
   (`ListPRReviewComments` — newest-first capped pagination, handed
   back chronological, so a long-lived PR's cap never blinds the gate
   on the thread just replied to) and must contain a

--- a/docs/forge-permissions.md
+++ b/docs/forge-permissions.md
@@ -112,6 +112,19 @@ Prefer narrowing the *connection*, not the user:
   (`iterion remote forge connections refresh <id>` prints the same line), and
   nothing else on the connection is affected — the runtime token is never
   minted with it.
+
+  **One client per connection.** The server keeps a single App client per
+  connection per replica ([`githubAppClientFor`](../pkg/server/forge_clients.go)),
+  so the management token and each scoped profile are minted once per token
+  lifetime (~1h) and reused by every lane and delivery — not minted again by
+  each call. The entry is valid only while the connection state it was built
+  from is unchanged (installation, App id + key, status, granted permissions,
+  slug): a re-provisioned App, a synced grant, a revocation or a key rotation
+  builds a fresh client; deleting the connection or hitting its `refresh`
+  route evicts it. The App's identity — the `<slug>[bot]` login the loop
+  guards compare a commenter against — is the configured slug, else the one
+  `GET /app` answers, resolved once and recorded on the connection (the
+  refresh worker records it too), never a placeholder.
   **Self-service** (no platform App, no manual registration): Integrations →
   "+ Register an OAuth app" → github → **"Create a GitHub App"** (iterion builds
   the scoped App via manifest and captures its private key), then the **"Install"**

--- a/docs/forge-permissions.md
+++ b/docs/forge-permissions.md
@@ -124,7 +124,15 @@ Prefer narrowing the *connection*, not the user:
   route evicts it. The App's identity — the `<slug>[bot]` login the loop
   guards compare a commenter against — is the configured slug, else the one
   `GET /app` answers, resolved once and recorded on the connection (the
-  refresh worker records it too), never a placeholder.
+  refresh worker records it too), never a placeholder. The management token
+  that client mints — the one the server's own calls ride: hooks, the merge
+  gate's commit status, the PR review, the commenter's role — is narrowed to
+  the baseline grants the installation **recorded as approved**
+  (`ManagementPermissionsFor`, the health probe keeps the record in step),
+  plus `statuses:write` when the grant carries it; an installation approved
+  with less than the baseline still mints the intersection, and what it
+  withholds is known before any write (`PreflightFor`) rather than
+  discovered as a 403.
   **Self-service** (no platform App, no manual registration): Integrations →
   "+ Register an OAuth app" → github → **"Create a GitHub App"** (iterion builds
   the scoped App via manifest and captures its private key), then the **"Install"**

--- a/docs/forge-permissions.md
+++ b/docs/forge-permissions.md
@@ -132,7 +132,11 @@ Prefer narrowing the *connection*, not the user:
   plus `statuses:write` when the grant carries it; an installation approved
   with less than the baseline still mints the intersection, and what it
   withholds is known before any write (`PreflightFor`) rather than
-  discovered as a 403.
+  discovered as a 403. A 403 the forge does answer on a commit-status call —
+  a grant revoked after the mint — is recorded on that token too, so the next
+  preflight reports `statuses` withheld and the lane takes its fallback
+  (the webhook's `forge_token` binding) instead of failing the same write
+  for the rest of the token's life.
   **Self-service** (no platform App, no manual registration): Integrations →
   "+ Register an OAuth app" → github → **"Create a GitHub App"** (iterion builds
   the scoped App via manifest and captures its private key), then the **"Install"**

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -95,7 +95,7 @@ Webhook config ([`pkg/webhooks/types.go`](../pkg/webhooks/types.go)):
 | Field | Default | Meaning |
 |-------|---------|---------|
 | `review_on_sync` | `false` | Re-review on each push so the required status re-evaluates on the fixed head. **Required for a blocking gate.** |
-| `block_fork_prs` | `false` | Persisted and returned by the webhook CRUD API, but **no launch path reads it** — the only references are the struct field and the two CRUD assignments. Setting it changes nothing on any provider. See the caution for what actually guards fork PRs. |
+| `block_fork_prs` | `false` | Persisted and returned by the webhook CRUD API, but **no launch path reads it** — the only references are the struct field and the two CRUD assignments. Setting it changes nothing on any provider: the fork guard is unconditional everywhere (see the caution). |
 
 > **Caution — budget with `review_on_sync`.** The sync lane re-runs Revi's
 > selected topology on **every push** (each new head SHA): one LLM reviewer in
@@ -105,25 +105,29 @@ Webhook config ([`pkg/webhooks/types.go`](../pkg/webhooks/types.go)):
 > contributor pushing repeatedly can drive repeated full reviews, bounded only
 > by the org launch gate + webhook rate limit.
 >
-> **Where fork PRs actually stand, per provider.** On **GitHub** and
-> **Forgejo** the guard is unconditional and needs no configuration: an
-> inbound PR event whose head is a fork is filtered before the sync lane
-> is even considered, so the fork re-review exposure above cannot occur
-> there. The `/command` lanes refuse a fork (or an unnamed head repo) too —
-> same-repo only, silently: the fork's work needs a branch in the base repo
-> before any bot runs on it. On **GitLab** the inbound MR (auto-review)
-> lane still has no fork/cross-project guard, so a forked-MR auto-review
-> *is* reachable — bound that lane with an `AuthorAllowlist` /
-> `MinAuthorRole`, since `block_fork_prs` is inert. Every lane that
-> resolves the MR through the API instead — the `/command` note lane,
-> auto-fix, and gate relaunch, all fail-closed on an unproven head repo —
-> does guard on GitLab: a same-project MR qualifies (the MR's source and
-> target project ids agree, so the head lives in the project the lane
-> queried), a fork MR is refused (GitLab's MR payload names the source
-> project's id only, never its path, so the head stays unproven). The
-> note payload itself carries neither id, which is why the `/command`
-> lane resolves the MR via the API purely to prove this, even though the
-> note already carries branch names of its own.
+> **Where fork PRs actually stand, per provider.** The guard is
+> unconditional on every provider and needs no configuration. On
+> **GitHub** and **Forgejo** an inbound PR event whose head is a fork is
+> filtered before the sync lane is even considered, so the fork re-review
+> exposure above cannot occur there. On **GitLab** the inbound MR
+> (auto-review) lane filters a **proven** fork the same way — the MR
+> payload names both projects (`source_project_id`/`target_project_id`
+> and the source project's own path), and the refusal names the fork; a
+> payload naming neither project is not refused as a fork (unproven is not
+> proven), and the lanes below fail closed on it. The `/command` lanes
+> refuse a fork (or an unnamed head repo) too — same-repo only, silently:
+> the fork's work needs a branch in the base repo before any bot runs on
+> it. Every lane that resolves the MR through the API — the `/command`
+> note lane, auto-fix, and gate relaunch, all fail-closed on an unproven
+> head repo — guards on GitLab as well: a same-project MR qualifies (the
+> MR's source and target project ids agree, so the head lives in the
+> project the lane queried); a fork MR has its source project resolved by
+> id (`GET /projects/:id`, cached per instance for an hour), so the head
+> compares by its real path and the refusal names it; a source project the
+> token cannot see (a private fork) stays unproven and is refused as
+> before. The note payload itself carries neither id, which is why the
+> `/command` lane resolves the MR via the API purely to prove this, even
+> though the note already carries branch names of its own.
 
 ## <a name="review-tiers"></a>Review tiers — glance / guard / audit
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -94,7 +94,13 @@ Single URL, two event kinds dispatched on `X-Gitlab-Event`
   [pkg/webhooks/gitlab/parser.go:IsReviewable](../pkg/webhooks/gitlab/parser.go).
   An `update` whose `changes.reviewers` **(re-)requests a review from
   iterion's own bot account** is the exception — the re-request-review
-  button; see <a href="#re-request-review">below</a>.
+  button; see <a href="#re-request-review">below</a>. A **fork MR never
+  auto-launches**, on any action: the payload names both projects
+  (`source_project_id`/`target_project_id` and the source project's own
+  path under `object_attributes.source`), so a proven fork is filtered
+  with a reason naming the fork (`gitlab.Parsed.IsFork`) — the same
+  posture as the GitHub/Forgejo lanes; a payload naming neither project
+  stays on its way, and the API-side lanes fail closed on it.
 - **`Note Hook`** — the generic slash-command and conversation surface.
   A note's first non-whitespace token is the command; quoting "please run
   /revi" mid-text never triggers (anti-oscillation guard —
@@ -114,7 +120,10 @@ Single URL, two event kinds dispatched on `X-Gitlab-Event`
      also resolves the MR via the forge API to prove the fork guard
      (`forge.PullRef.SameRepoAs` — the note payload carries neither
      `source_project_id` nor `target_project_id`, so same-project can
-     only be proven, never assumed from the payload) and carries the
+     only be proven, never assumed from the payload; the adapter resolves
+     a fork's source project by id — `GET /projects/:id`, cached per
+     instance for an hour — so the refusal names the fork's own path, and
+     a source project the token cannot see stays unproven) and carries the
      note's own conversational plumbing (`discussion_id`,
      `trigger_note`/`trigger_command`/`trigger_args`, `replier`) plus a
      best-effort `thread_context` for any command that carries args. A
@@ -699,7 +708,7 @@ are accepted by `POST` / `PATCH`:
 | `secret_overrides` | — | Pins a stored secret per workflow-secret name, so several webhooks for the same bot can post under different forge tokens / bot identities. The secret twin of `key_overrides`. |
 | `retry_usage_window`, `retry_max_attempts`, `retry_max_wait`, `retry_jitter` | *(bot manifest, then machine default)* | The launch-surface layer of the [retry policy](scheduling.md#retry--a-provider-quota-window-is-waited-out-not-re-attempted) for a run that dies on an exhausted provider usage window. Only what is set here overrides the layers below. A webhook-launched run is often one an author is waiting on, so a shorter `max_wait` than a nightly's is usually right. |
 | `forge_base_url` | *(derived)* | Explicit forge base URL for a self-hosted instance. |
-| `block_fork_prs` | `false` | Persisted but **never read** by any launch path — see [merge-gate.md](merge-gate.md) for what actually guards fork PRs, which differs by provider. |
+| `block_fork_prs` | `false` | Persisted but **never read** by any launch path — the fork guard is unconditional on every provider (see [merge-gate.md](merge-gate.md)), so the flag has nothing left to add. |
 
 `authorized_repliers` / `min_replier_role` gate who may talk back to a
 bot in a note thread — see

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -220,7 +220,9 @@ failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
   threads launches the converse bot, which answers **in the same
   thread**. Loop-guarded (the bot's own answer echoes back as this
   event), thread-classified (a human↔human thread never triggers), and
-  replier-gated like every comment lane. Requires the converse bot in
+  replier-gated like every comment lane — through the same client
+  resolution as the other lanes: the team connection covering the PR
+  first, the webhook's `forge_token` binding as the fallback. Requires the converse bot in
   `bot_ids` and the event in `event_allowlist` (a re-provision
   regenerates both from the converse bot's own manifest event
   `pull_request_review_comment` — deliberately separate from

--- a/pkg/forge/forgejo/ci.go
+++ b/pkg/forge/forgejo/ci.go
@@ -24,6 +24,7 @@ type forgejoBranchInfo struct {
 	Sha  string `json:"sha"`
 	Repo *struct {
 		FullName string `json:"full_name"`
+		CloneURL string `json:"clone_url"`
 	} `json:"repo,omitempty"`
 }
 
@@ -63,6 +64,7 @@ func (p forgejoPull) toRef() forge.PullRef {
 		ref.HeadSHA = p.Head.Sha
 		if p.Head.Repo != nil {
 			ref.HeadRepoFullName = p.Head.Repo.FullName
+			ref.HeadCloneURL = p.Head.Repo.CloneURL
 		}
 	}
 	if p.Base != nil {

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -448,6 +448,47 @@ func InstallationInfo(ctx context.Context, httpClient *http.Client, apiBase stri
 	return Installation{Login: out.Account.Login, HTMLURL: out.HTMLURL, Permissions: out.Permissions}, nil
 }
 
+// AppSlug resolves the App's slug via GET /app (App-JWT authenticated). The
+// bot posts as "<slug>[bot]", so the slug is the identity every loop guard
+// compares a commenter against. One round trip; AppClient memoizes it.
+func AppSlug(ctx context.Context, httpClient *http.Client, apiBase string, cfg AppConfig, now time.Time) (string, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	jwt, err := signAppJWT(cfg.AppID, cfg.PrivateKeyPEM, now)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiBase+"/app", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", forge.ErrUnauthorized
+	}
+	if resp.StatusCode/100 != 2 {
+		return "", statusErr("GET /app", resp.StatusCode)
+	}
+	var out struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("github: GET /app: decode: %w", err)
+	}
+	if strings.TrimSpace(out.Slug) == "" {
+		return "", fmt.Errorf("github: GET /app returned no slug for app %d", cfg.AppID)
+	}
+	return strings.TrimSpace(out.Slug), nil
+}
+
 // MintInstallationToken trades the App JWT for a short-lived (≈1h)
 // installation access token. apiBase is the REST API base (APIBaseFor). opts
 // may be nil for an unconstrained (whole-installation) token, or narrow it to
@@ -623,10 +664,17 @@ type AppClient struct {
 	Cfg            AppConfig
 	InstallationID int64
 	Now            func() time.Time
+	// OnSlugResolved, when set, is told the App slug the first time Slug
+	// resolves it over the network (Cfg carried none), so the owner of the
+	// connection record can persist it: iterionBotLogins reads the record,
+	// not this client.
+	OnSlugResolved func(slug string)
 
 	mu    sync.Mutex
 	token string
 	exp   time.Time
+	// slug memoizes the App slug GET /app answered when Cfg carries none.
+	slug string
 	// denied names the permissions the cached token LACKS relative to the
 	// full request: rest() re-mints without the optional ones an
 	// installation withholds, so the token is healthy for every other call
@@ -838,6 +886,11 @@ func permissionSetKey(perms map[string]string) string {
 	return b.String()
 }
 
+// PermissionSetKey renders a grant set as a stable string — the key the
+// scoped-token cache uses — so a caller can tell two grant sets apart
+// without comparing maps.
+func PermissionSetKey(perms map[string]string) string { return permissionSetKey(perms) }
+
 // PreflightFor mints (or reuses) the installation token and nothing else,
 // then reports whether that token carries every permission in need. A caller
 // learns BEFORE acting whether the installation can serve: the client is
@@ -866,12 +919,41 @@ func (a *AppClient) PreflightFor(ctx context.Context, need ...string) error {
 
 func (a *AppClient) Provider() forge.Provider { return forge.ProviderGitHub }
 
+// Slug returns the App's slug: the configured one, else the one GET /app
+// answers, resolved once per client and handed to OnSlugResolved.
+func (a *AppClient) Slug(ctx context.Context) (string, error) {
+	if a.Cfg.AppSlug != "" {
+		return a.Cfg.AppSlug, nil
+	}
+	a.mu.Lock()
+	known := a.slug
+	a.mu.Unlock()
+	if known != "" {
+		return known, nil
+	}
+	slug, err := AppSlug(ctx, a.HTTP, a.apiBase(), a.Cfg, a.clock())
+	if err != nil {
+		return "", err
+	}
+	a.mu.Lock()
+	first := a.slug == ""
+	a.slug = slug
+	cb := a.OnSlugResolved
+	a.mu.Unlock()
+	if first && cb != nil {
+		cb(slug)
+	}
+	return slug, nil
+}
+
 // WhoAmI returns the App identity — an installation token can't call /user,
-// and the bot posts AS the App, so this is the correct "post as" handle.
-func (a *AppClient) WhoAmI(context.Context) (forge.Identity, error) {
-	slug := a.Cfg.AppSlug
-	if slug == "" {
-		slug = "github-app"
+// and the bot posts AS the App, so "<slug>[bot]" is the correct "post as"
+// handle. A slug that cannot be resolved is an error, never a placeholder: a
+// loop guard fed a login that never posts compares against nobody.
+func (a *AppClient) WhoAmI(ctx context.Context) (forge.Identity, error) {
+	slug, err := a.Slug(ctx)
+	if err != nil {
+		return forge.Identity{}, fmt.Errorf("github: resolve the App identity: %w", err)
 	}
 	return forge.Identity{Login: slug + "[bot]", ID: strconv.FormatInt(a.Cfg.AppID, 10), Kind: forge.AccountKindInstallation, Namespace: slug}, nil
 }
@@ -996,7 +1078,19 @@ func (r AppRefresher) Refresh(ctx context.Context, conn forge.Connection, _ stri
 		return forge.RefreshedToken{}, err
 	}
 	RecordRuntimePermissions(conn.InstallationID, opts.Permissions)
-	return forge.RefreshedToken{AccessToken: tok, ExpiresAt: exp}, nil
+	out := forge.RefreshedToken{AccessToken: tok, ExpiresAt: exp}
+	if conn.AppSlug == "" {
+		// A record without the slug names no bot identity (iterionBotLogins
+		// builds "<slug>[bot]" from it). The configured slug serves first, a
+		// GET /app probe otherwise. A failed probe never fails the refresh —
+		// the token is what bots run on — and is retried on the next cycle.
+		if slug := r.Cfg.AppSlug; slug != "" {
+			out.AppSlug = slug
+		} else if slug, serr := AppSlug(ctx, r.HTTP, APIBaseFor(conn.BaseURL()), r.Cfg, now); serr == nil {
+			out.AppSlug = slug
+		}
+	}
+	return out, nil
 }
 
 var _ forge.Admin = (*AppClient)(nil)

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -208,6 +208,17 @@ func PullListInstallationPermissions() map[string]string {
 	}
 }
 
+// PRReviewCommentsInstallationPermissions is the grant set minted for
+// reading a pull request's review-thread comments (the reply gate's thread
+// fetch): pull_requests read plus the metadata baseline — the same set as
+// the listing profile, so the two reads share one cached token by key.
+func PRReviewCommentsInstallationPermissions() map[string]string {
+	return map[string]string{
+		"pull_requests": "read",
+		"metadata":      "read",
+	}
+}
+
 // PullGetInstallationPermissions is the grant set minted for reading ONE pull
 // request. GitHub gates GET /repos/{owner}/{repo}/pulls/{number} on contents
 // read as well as pull_requests read — the object carries content-derived

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -377,6 +377,32 @@ func RuntimePermissionsFor(granted map[string]string) map[string]string {
 	return out
 }
 
+// ManagementPermissionsFor narrows the management token — what the server's
+// own calls through a connection ride: hooks, repos, the commit status, the
+// PR review, the collaborator role — to the baseline grants the installation
+// approved. It is RuntimePermissionsFor without the delivery grants: those
+// belong to the token a RUN pushes with, and a management token carrying
+// workflows:write could rewrite CI from a server-side call. Same contract
+// otherwise: an unknown grant keeps the baseline, and a grant covering
+// nothing recognised keeps it too (an empty map would mint the
+// installation's FULL set).
+func ManagementPermissionsFor(granted map[string]string) map[string]string {
+	base := RuntimeInstallationPermissions()
+	if len(granted) == 0 {
+		return base
+	}
+	out := map[string]string{}
+	for name, level := range base {
+		if _, ok := granted[name]; ok {
+			out[name] = level
+		}
+	}
+	if len(out) == 0 {
+		return base
+	}
+	return out
+}
+
 // InstallationTokenOptions narrows a minted installation token below the
 // installation's full grant (least-privilege). Both fields are optional; a nil
 // field means "don't constrain that dimension" (GitHub returns the
@@ -669,6 +695,12 @@ type AppClient struct {
 	// connection record can persist it: iterionBotLogins reads the record,
 	// not this client.
 	OnSlugResolved func(slug string)
+	// Granted is the installation's approved permission set as the
+	// connection recorded it (nil = unknown). The management token is minted
+	// for the baseline this grant covers (ManagementPermissionsFor), so an
+	// installation approved with less than the baseline still mints — and
+	// what it withholds is denied up front, not discovered at the write.
+	Granted map[string]string
 
 	mu    sync.Mutex
 	token string
@@ -714,31 +746,47 @@ func (a *AppClient) clock() time.Time {
 
 func (a *AppClient) apiBase() string { return APIBaseFor(a.WebBaseURL) }
 
-// rest returns an AdminClient backed by a fresh installation token.
+// rest returns an AdminClient backed by the management token: the baseline
+// grants the connection's recorded grant covers (ManagementPermissionsFor) —
+// never the installation's full set — plus the OPTIONAL statuses:write the
+// merge gate posts its verdict with, asked for only when the grant is unknown
+// or carries it. What the token cannot do — the baseline grants the
+// installation withholds, statuses when it lacks or refuses it — is recorded
+// in denied, so PreflightFor answers without a round trip.
 func (a *AppClient) rest(ctx context.Context) (*AdminClient, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.token == "" || a.clock().After(a.exp.Add(-60*time.Second)) {
-		// Least-privilege: pin the management token to iterion's minimal
-		// permission set (webhook + metadata + code + PR), never the
-		// installation's full grant — plus the OPTIONAL statuses:write the
-		// merge gate needs to post its revi/review commit status.
-		perms := map[string]string{PermissionStatuses: "write"}
-		for k, v := range RuntimeInstallationPermissions() {
-			perms[k] = v
+		base := ManagementPermissionsFor(a.Granted)
+		denied := map[string]bool{}
+		for name := range RuntimeInstallationPermissions() {
+			if _, ok := base[name]; !ok {
+				denied[name] = true
+			}
+		}
+		wantStatuses := len(a.Granted) == 0 || grantCovers(a.Granted, PermissionStatuses, "write")
+		perms := base
+		if wantStatuses {
+			perms = make(map[string]string, len(base)+1)
+			for k, v := range base {
+				perms[k] = v
+			}
+			perms[PermissionStatuses] = "write"
+		} else {
+			denied[PermissionStatuses] = true
 		}
 		tok, exp, err := MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
 			&InstallationTokenOptions{Permissions: perms})
-		var denied map[string]bool
-		if errors.Is(err, forge.ErrPermissionsNotGranted) {
+		if wantStatuses && errors.Is(err, forge.ErrPermissionsNotGranted) {
 			// An installation created before the merge gate (or one that
-			// declined statuses:write) still works — the gate then advises
-			// instead of blocking (SetCommitStatus 403s, non-fatal). Retry with
-			// the core baseline so every other capability keeps functioning,
-			// and remember what this token cannot do.
+			// declined statuses:write) whose recorded grant did not say so
+			// still works — the gate then advises instead of blocking
+			// (SetCommitStatus 403s, non-fatal). Retry with the covered
+			// baseline so every other capability keeps functioning, and
+			// remember what this token cannot do.
 			tok, exp, err = MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
-				&InstallationTokenOptions{Permissions: RuntimeInstallationPermissions()})
-			denied = map[string]bool{PermissionStatuses: true}
+				&InstallationTokenOptions{Permissions: base})
+			denied[PermissionStatuses] = true
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -939,6 +939,20 @@ func permissionSetKey(perms map[string]string) string {
 // without comparing maps.
 func PermissionSetKey(perms map[string]string) string { return permissionSetKey(perms) }
 
+// noteDenied records that the cached management token was refused a
+// permission at a call — a grant revoked after the mint, a repository the
+// installation lost — so PreflightFor reports it withheld for the rest of
+// the token's life, instead of every write failing the same way while a
+// fallback credential sits unused. The next mint starts clean.
+func (a *AppClient) noteDenied(perm string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.denied == nil {
+		a.denied = map[string]bool{}
+	}
+	a.denied[perm] = true
+}
+
 // PreflightFor mints (or reuses) the installation token and nothing else,
 // then reports whether that token carries every permission in need. A caller
 // learns BEFORE acting whether the installation can serve: the client is

--- a/pkg/forge/github/app_denied_test.go
+++ b/pkg/forge/github/app_denied_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// statusRefusingForge mints every token (statuses included) and refuses the
+// commit-status write with GitHub's 403 — the shape of a permission revoked
+// on the installation after the token was minted with it, or a repository
+// the installation lost.
+func statusRefusingForge(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var mints int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/access_tokens"):
+			atomic.AddInt32(&mints, 1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": "ghs_with_statuses", "expires_at": "2099-01-01T00:00:00Z"})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/statuses/"):
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "Resource not accessible by integration"})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"repositories": []any{}})
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &mints
+}
+
+// PreflightFor's denied set was written only at mint time: a token minted
+// WITH statuses that later gets a 403 on SetCommitStatus left it untouched
+// for the token's lifetime, so every subsequent preflight answered "fine" and
+// the caller never switched to the binding it could have used. The 403 now
+// records the denial, keyed on the permission the write needed.
+func TestAppClientRecordsAStatusWriteRefusalForTheNextPreflight(t *testing.T) {
+	srv, mints := statusRefusingForge(t)
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t), AppSlug: "iterion"}, InstallationID: 99}
+	ctx := context.Background()
+	if err := a.PreflightFor(ctx, PermissionStatuses); err != nil {
+		t.Fatalf("a token minted with statuses preflights clean: %v", err)
+	}
+	err := a.SetCommitStatus(ctx, "o/r", "deadbeef", forge.CommitStatus{State: forge.CommitStateSuccess, Context: "revi/review"})
+	if !errors.Is(err, forge.ErrForbidden) {
+		t.Fatalf("SetCommitStatus = %v, want the forge's 403 surfaced", err)
+	}
+	var pe *forge.PermissionError
+	if !errors.As(err, &pe) || len(pe.Missing) != 1 || pe.Missing[0] != "statuses:write" {
+		t.Errorf("the refusal must name the grant the write needed, got %v", err)
+	}
+	if err := a.PreflightFor(ctx, PermissionStatuses); !errors.Is(err, forge.ErrPermissionsNotGranted) {
+		t.Fatalf("PreflightFor(statuses) after the 403 = %v, want ErrPermissionsNotGranted so the caller takes its fallback", err)
+	}
+	// Recording a denial is bookkeeping on the cached token, never a re-mint.
+	if n := atomic.LoadInt32(mints); n != 1 {
+		t.Errorf("mints = %d, want 1: a refusal is noted on the token it happened to, not minted away", n)
+	}
+	// Unrelated permissions are untouched by a statuses refusal.
+	if err := a.PreflightFor(ctx, "contents"); err != nil {
+		t.Errorf("PreflightFor(contents) = %v, want nil: the 403 was about statuses", err)
+	}
+}

--- a/pkg/forge/github/app_grant_test.go
+++ b/pkg/forge/github/app_grant_test.go
@@ -1,0 +1,166 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// grantMintRecorder is a fake GitHub whose installation-token mint applies
+// GitHub's rule — a request outside the installation's grant is refused
+// (422 "permissions not granted") — and serves the one management call the
+// tests make.
+type grantMintRecorder struct {
+	mu      sync.Mutex
+	granted map[string]string // nil = accept every mint
+	mints   []map[string]string
+	srv     *httptest.Server
+}
+
+func newGrantMintRecorder(t *testing.T, granted map[string]string) *grantMintRecorder {
+	t.Helper()
+	r := &grantMintRecorder{granted: granted}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(req.URL.Path, "/access_tokens") {
+			var body struct {
+				Permissions map[string]string `json:"permissions"`
+			}
+			_ = json.NewDecoder(req.Body).Decode(&body)
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			if r.granted != nil {
+				for name, level := range body.Permissions {
+					if !grantCovers(r.granted, name, level) {
+						w.WriteHeader(http.StatusUnprocessableEntity)
+						_ = json.NewEncoder(w).Encode(map[string]any{"message": "The permissions requested are not granted to this installation."})
+						return
+					}
+				}
+			}
+			r.mints = append(r.mints, body.Permissions)
+			_ = json.NewEncoder(w).Encode(map[string]any{"token": "ghs_mgmt", "expires_at": "2099-01-01T00:00:00Z"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"repositories": []map[string]any{{"full_name": "acme/widgets"}}})
+	}))
+	t.Cleanup(r.srv.Close)
+	return r
+}
+
+func (r *grantMintRecorder) snapshot() []map[string]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]map[string]string(nil), r.mints...)
+}
+
+func (r *grantMintRecorder) appClient(t *testing.T, granted map[string]string) *AppClient {
+	t.Helper()
+	return &AppClient{
+		HTTP: r.srv.Client(), WebBaseURL: r.srv.URL,
+		Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t), AppSlug: "iterion"}, InstallationID: 99,
+		Granted: granted,
+	}
+}
+
+// The management token — what every connection lane writes through: publish,
+// the gate reconcilers, /revi approve, hooks — is minted from the grant the
+// connection recorded, not from the constant baseline. An installation whose
+// owner approved LESS than the baseline used to 422 on every mint (and again
+// on the statuses-less retry), so the connection could serve nothing, not
+// even the calls its grant covers.
+func TestAppClientManagementMintNarrowsToTheGrant(t *testing.T) {
+	granted := map[string]string{"contents": "write", "pull_requests": "write", "metadata": "read", "statuses": "write"} // no issues, no repository_hooks
+	r := newGrantMintRecorder(t, granted)
+	a := r.appClient(t, granted)
+	ctx := context.Background()
+	if _, err := a.ListRepos(ctx, forge.RepoQuery{}); err != nil {
+		t.Fatalf("a connection granted a strict subset of the baseline must still mint the intersection: %v", err)
+	}
+	mints := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want exactly 1 (no refused first attempt)", len(mints))
+	}
+	if !reflect.DeepEqual(mints[0], granted) {
+		t.Errorf("minted permissions = %v, want the grant ∩ baseline + statuses = %v", mints[0], granted)
+	}
+	// What the narrowing dropped is denied up front — no round trip needed to
+	// learn it — so a lane that needs it can switch credential before acting.
+	for _, p := range []string{"issues", "repository_hooks"} {
+		if err := a.PreflightFor(ctx, p); !errors.Is(err, forge.ErrPermissionsNotGranted) {
+			t.Errorf("PreflightFor(%s) = %v, want ErrPermissionsNotGranted: the grant lacks it", p, err)
+		}
+	}
+	if err := a.PreflightFor(ctx, PermissionStatuses); err != nil {
+		t.Errorf("PreflightFor(statuses) = %v, want nil: the grant carries it", err)
+	}
+}
+
+// A grant that lacks statuses skips the write request instead of paying a
+// refused mint plus a retry, and PreflightFor reports it withheld.
+func TestAppClientManagementMintSkipsStatusesTheGrantLacks(t *testing.T) {
+	granted := RuntimeInstallationPermissions() // the pre-merge-gate installation shape
+	r := newGrantMintRecorder(t, granted)
+	a := r.appClient(t, granted)
+	ctx := context.Background()
+	if _, err := a.ListRepos(ctx, forge.RepoQuery{}); err != nil {
+		t.Fatal(err)
+	}
+	mints := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want 1 (no refused attempt for a grant known to lack statuses)", len(mints))
+	}
+	if _, ok := mints[0][PermissionStatuses]; ok {
+		t.Errorf("minted permissions = %v, must not ask for statuses the grant lacks", mints[0])
+	}
+	if err := a.PreflightFor(ctx, PermissionStatuses); !errors.Is(err, forge.ErrPermissionsNotGranted) {
+		t.Errorf("PreflightFor(statuses) = %v, want ErrPermissionsNotGranted", err)
+	}
+}
+
+// An unknown grant (a connection stored before grants were recorded) keeps
+// the historical request — baseline plus the optional statuses, retried
+// without statuses when refused — because absence of data is not evidence
+// of a narrower installation.
+func TestAppClientManagementMintUnknownGrantKeepsTheBaseline(t *testing.T) {
+	r := newGrantMintRecorder(t, nil)
+	a := r.appClient(t, nil)
+	if _, err := a.ListRepos(context.Background(), forge.RepoQuery{}); err != nil {
+		t.Fatal(err)
+	}
+	mints := r.snapshot()
+	want := RuntimeInstallationPermissions()
+	want[PermissionStatuses] = "write"
+	if len(mints) != 1 || !reflect.DeepEqual(mints[0], want) {
+		t.Errorf("mints = %v, want one mint of the baseline + statuses:write", mints)
+	}
+}
+
+// ManagementPermissionsFor is the narrowing rule itself.
+func TestManagementPermissionsFor(t *testing.T) {
+	base := RuntimeInstallationPermissions()
+	if got := ManagementPermissionsFor(nil); !reflect.DeepEqual(got, base) {
+		t.Errorf("unknown grant = %v, want the baseline %v", got, base)
+	}
+	granted := map[string]string{"contents": "write", "metadata": "read", "workflows": "write", "packages": "write"}
+	got := ManagementPermissionsFor(granted)
+	if !reflect.DeepEqual(got, map[string]string{"contents": "write", "metadata": "read"}) {
+		t.Errorf("got %v, want the baseline ∩ grant", got)
+	}
+	for _, delivery := range []string{"workflows", "packages"} {
+		if _, ok := got[delivery]; ok {
+			t.Errorf("the management token must not acquire %s: that grant is the RUN token's (RuntimePermissionsFor)", delivery)
+		}
+	}
+	if got := ManagementPermissionsFor(map[string]string{"something_else": "read"}); !reflect.DeepEqual(got, base) {
+		t.Errorf("a grant that covers nothing we recognise keeps the baseline (an empty map would mint the installation's FULL set), got %v", got)
+	}
+}

--- a/pkg/forge/github/app_identity_test.go
+++ b/pkg/forge/github/app_identity_test.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The App's identity is what every loop guard compares a commenter against:
+// the bot posts as "<slug>[bot]". A client whose Cfg carried no slug answered
+// "github-app[bot]" — a login that never posts — so the guard compared
+// against nobody and the App's own comments cleared it. The slug is one
+// App-JWT call away (GET /app); the client resolves it once and keeps it.
+func TestAppClientWhoAmIResolvesTheSlugFromTheApp(t *testing.T) {
+	var appCalls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v3/app" {
+			atomic.AddInt32(&appCalls, 1)
+			if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ey") {
+				t.Errorf("GET /app must be App-JWT authenticated, got %q", r.Header.Get("Authorization"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 42, "slug": "iterion-forge-x", "name": "iterion forge"})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t)}, InstallationID: 99}
+	for i := 0; i < 2; i++ {
+		id, err := a.WhoAmI(context.Background())
+		if err != nil {
+			t.Fatalf("WhoAmI: %v", err)
+		}
+		if id.Login != "iterion-forge-x[bot]" || id.Namespace != "iterion-forge-x" || id.Kind != forge.AccountKindInstallation {
+			t.Fatalf("identity = %+v, want the App's real slug, not a placeholder", id)
+		}
+	}
+	if n := atomic.LoadInt32(&appCalls); n != 1 {
+		t.Errorf("GET /app called %d times over two WhoAmI calls, want once (memoized on the client)", n)
+	}
+}
+
+// A configured slug is authoritative and costs no round trip.
+func TestAppClientWhoAmIUsesTheConfiguredSlugWithoutAProbe(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t), AppSlug: "iterion"}, InstallationID: 99}
+	id, err := a.WhoAmI(context.Background())
+	if err != nil || id.Login != "iterion[bot]" {
+		t.Fatalf("identity = %+v err=%v, want iterion[bot] from the configured slug", id, err)
+	}
+	if atomic.LoadInt32(&calls) != 0 {
+		t.Error("a configured slug must not be re-resolved over the network")
+	}
+}
+
+// No slug configured and GitHub not answering: an error, never a placeholder
+// login — a guard fed a login that never posts is worse than a guard that
+// says it could not resolve one.
+func TestAppClientWhoAmIFailsLoudWithoutASlug(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: testKeyPEMOnce(t)}, InstallationID: 99}
+	id, err := a.WhoAmI(context.Background())
+	if err == nil {
+		t.Fatalf("WhoAmI = %+v, want an error when the slug cannot be resolved", id)
+	}
+	if !strings.Contains(err.Error(), "/app") {
+		t.Errorf("error = %q, want it to name the GET /app probe", err.Error())
+	}
+	if id.Login != "" {
+		t.Errorf("Login = %q, want empty on failure (no placeholder)", id.Login)
+	}
+}

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -33,6 +33,7 @@ type githubPull struct {
 		SHA  string `json:"sha"`
 		Repo struct {
 			FullName string `json:"full_name"`
+			CloneURL string `json:"clone_url"`
 		} `json:"repo"`
 	} `json:"head"`
 	Base struct {
@@ -60,6 +61,7 @@ func (gp githubPull) toRef() forge.PullRef {
 		TargetBranch:     gp.Base.Ref,
 		HeadSHA:          gp.Head.SHA,
 		HeadRepoFullName: gp.Head.Repo.FullName,
+		HeadCloneURL:     gp.Head.Repo.CloneURL,
 		Author:           gp.User.Login,
 		Draft:            gp.Draft,
 		CreatedAt:        gp.CreatedAt,

--- a/pkg/forge/github/pulls_app_test.go
+++ b/pkg/forge/github/pulls_app_test.go
@@ -57,7 +57,13 @@ var githubEndpointGrants = []struct {
 		map[string]string{"checks": "read"}, "list-check-runs-for-a-git-reference"},
 	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/commits/[^/]+/status$`),
 		map[string]string{"statuses": "read"}, "get-the-combined-status-for-a-specific-reference"},
+	{"GET", regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/comments$`),
+		map[string]string{"pull_requests": "read"}, "list-review-comments-on-a-pull-request"},
 }
+
+// pullListOpts is the listing the reply-gate parity test issues after a
+// thread fetch.
+func pullListOpts() forge.PullListOptions { return forge.PullListOptions{State: "all", PerPage: 100} }
 
 // grantsForRequestLine returns GitHub's rule for one recorded request line
 // ("GET /api/v3/repos/o/r/pulls?state=all") and the row's slug, or nil for a
@@ -265,6 +271,13 @@ func newPullMintRecorder(t *testing.T) *pullMintRecorder {
 			return
 		}
 		switch {
+		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/comments"):
+			// Newest first, as GitHub answers sort=created&direction=desc; the
+			// client hands the thread back chronological.
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": 9002, "in_reply_to_id": 9001, "body": "why?", "path": "pkg/x/y.go", "created_at": "2026-09-02T10:05:00Z", "user": map[string]any{"login": "alice"}},
+				{"id": 9001, "body": "the SSRF is reachable", "path": "pkg/x/y.go", "created_at": "2026-09-02T10:00:00Z", "user": map[string]any{"login": "iterion[bot]"}},
+			})
 		case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/check-runs"):
 			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "check_runs": []map[string]any{
 				{"name": "build", "status": "completed", "conclusion": "success", "html_url": "https://gh/o/r/runs/1", "started_at": "2026-01-01T00:00:00Z"},

--- a/pkg/forge/github/reviews.go
+++ b/pkg/forge/github/reviews.go
@@ -126,6 +126,19 @@ func (a *AppClient) CreatePullReview(ctx context.Context, repo string, number in
 	return rest.CreatePullReview(ctx, repo, number, in)
 }
 
+// ListPRReviewComments on an App connection reads the thread under the
+// pull_requests:read profile — the review-thread reply gate resolves its
+// client through the covering connection, which is an App connection by
+// default, so the fetch has to exist here or the lane is dead on the
+// ordinary integration shape.
+func (a *AppClient) ListPRReviewComments(ctx context.Context, repo string, number int) ([]forge.PRReviewComment, error) {
+	c, err := a.scopedREST(ctx, PRReviewCommentsInstallationPermissions())
+	if err != nil {
+		return nil, err
+	}
+	return c.ListPRReviewComments(ctx, repo, number)
+}
+
 // prReviewCommentWire is the list shape of GET /repos/{repo}/pulls/{n}/comments.
 type prReviewCommentWire struct {
 	ID        int64  `json:"id"`

--- a/pkg/forge/github/reviews_app_test.go
+++ b/pkg/forge/github/reviews_app_test.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The review-thread reply gate reads a PR's review comments through the
+// connection covering the repo — an App connection, by default — so the
+// thread fetch must exist on the App client too, under the read profile the
+// endpoint is gated on (pull_requests:read), issuing the PAT client's own
+// requests (newest-first capped pages, handed back chronological).
+func TestAppClientListPRReviewCommentsMintsThePullReadProfile(t *testing.T) {
+	r := newPullMintRecorder(t)
+	ctx := context.Background()
+	fromPAT, err := r.patClient().ListPRReviewComments(ctx, "o/r", 7)
+	if err != nil {
+		t.Fatalf("PAT ListPRReviewComments: %v", err)
+	}
+	a := r.appClient(t)
+	fromApp, err := a.ListPRReviewComments(ctx, "o/r", 7)
+	if err != nil {
+		t.Fatalf("App ListPRReviewComments: %v", err)
+	}
+	if !reflect.DeepEqual(fromApp, fromPAT) || len(fromApp) != 2 || fromApp[0].ID != 9001 {
+		t.Fatalf("App = %+v, PAT = %+v: want the same chronological thread", fromApp, fromPAT)
+	}
+	mints, bearers, paths := r.snapshot()
+	if len(mints) != 1 {
+		t.Fatalf("mints = %d, want exactly 1 (the PAT call mints nothing)", len(mints))
+	}
+	if !reflect.DeepEqual(mints[0], PRReviewCommentsInstallationPermissions()) || mints[0]["pull_requests"] != "read" || len(mints[0]) != 2 {
+		t.Errorf("minted permissions = %v, want exactly pull_requests:read + metadata:read", mints[0])
+	}
+	if len(paths)%2 != 0 || len(paths) == 0 {
+		t.Fatalf("paths = %v, want the App half to mirror the PAT half", paths)
+	}
+	half := len(paths) / 2
+	for i := 0; i < half; i++ {
+		if paths[i] != paths[half+i] {
+			t.Errorf("request %d: PAT %q vs App %q", i, paths[i], paths[half+i])
+		}
+		if bearers[i] != "Bearer ghp_pat" || !strings.HasPrefix(bearers[half+i], "Bearer ghs_scoped_") {
+			t.Errorf("bearers = %v, want the PAT then the minted installation token", bearers)
+		}
+	}
+	// The profile IS the pull-list profile by key, so the two reads share
+	// one cached token: a listing after the thread fetch mints nothing more.
+	if _, err := a.ListPullRequests(ctx, "o/r", pullListOpts()); err != nil {
+		t.Fatal(err)
+	}
+	if mints, _, _ := r.snapshot(); len(mints) != 1 {
+		t.Errorf("mints = %d after a pull listing, want still 1: the thread fetch and the listing share a profile", len(mints))
+	}
+}

--- a/pkg/forge/github/status.go
+++ b/pkg/forge/github/status.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -25,12 +26,12 @@ func (c *AdminClient) SetCommitStatus(ctx context.Context, repo, sha string, st 
 	var out struct {
 		ID int64 `json:"id"`
 	}
-	code, err := c.do(ctx, http.MethodPost, "/repos/"+repo+"/statuses/"+url.PathEscape(sha), body, &out)
+	code, errBody, err := c.doErr(ctx, http.MethodPost, "/repos/"+repo+"/statuses/"+url.PathEscape(sha), body, &out)
 	if err != nil {
 		return err
 	}
 	if code/100 != 2 {
-		return statusErr("set commit status", code)
+		return refusal("set commit status", code, errBody, "statuses:write")
 	}
 	return nil
 }
@@ -38,13 +39,21 @@ func (c *AdminClient) SetCommitStatus(ctx context.Context, repo, sha string, st 
 // SetCommitStatus on an App connection delegates to a management-token
 // AdminClient minted on demand (same live-token rationale as CreatePullReview)
 // — so the merge gate works on the production GitHub App path, not only on
-// raw-token connections.
+// raw-token connections. A 403 on the write is recorded as a statuses denial
+// on the cached token: the grant was revoked after the mint (or the
+// repository left the installation), and PreflightFor must say so for the
+// token's remaining life so the next caller takes its fallback credential
+// instead of failing the same write again.
 func (a *AppClient) SetCommitStatus(ctx context.Context, repo, sha string, st forge.CommitStatus) error {
 	rest, err := a.rest(ctx)
 	if err != nil {
 		return err
 	}
-	return rest.SetCommitStatus(ctx, repo, sha, st)
+	err = rest.SetCommitStatus(ctx, repo, sha, st)
+	if errors.Is(err, forge.ErrForbidden) {
+		a.noteDenied(PermissionStatuses)
+	}
+	return err
 }
 
 // githubCommitState maps the normalized CommitState onto GitHub's wire
@@ -79,12 +88,12 @@ func (c *AdminClient) ListCommitStatuses(ctx context.Context, repo, sha string) 
 			TargetURL   string `json:"target_url"`
 		} `json:"statuses"`
 	}
-	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(sha)+"/status", nil, &out)
+	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(sha)+"/status", nil, &out)
 	if err != nil {
 		return nil, err
 	}
 	if code/100 != 2 {
-		return nil, statusErr("list commit statuses", code)
+		return nil, refusal("list commit statuses", code, errBody, "statuses:read")
 	}
 	sts := make([]forge.CommitStatus, 0, len(out.Statuses))
 	for _, s := range out.Statuses {
@@ -99,11 +108,17 @@ func (c *AdminClient) ListCommitStatuses(ctx context.Context, repo, sha string) 
 }
 
 // ListCommitStatuses on an App connection delegates to a management-token
-// AdminClient, like SetCommitStatus.
+// AdminClient, like SetCommitStatus — and records a 403 the same way: a token
+// refused the READ holds no statuses grant at all, so the write is refused
+// too.
 func (a *AppClient) ListCommitStatuses(ctx context.Context, repo, sha string) ([]forge.CommitStatus, error) {
 	rest, err := a.rest(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return rest.ListCommitStatuses(ctx, repo, sha)
+	out, err := rest.ListCommitStatuses(ctx, repo, sha)
+	if errors.Is(err, forge.ErrForbidden) {
+		a.noteDenied(PermissionStatuses)
+	}
+	return out, err
 }

--- a/pkg/forge/gitlab/capabilities_test.go
+++ b/pkg/forge/gitlab/capabilities_test.go
@@ -220,18 +220,22 @@ func TestListPullRequests_Mapping(t *testing.T) {
 // forge.PullRef.SameRepoAs. GitLab's MR payload carries the source and
 // target PROJECT IDS and never the source project's path: equal ids mean the
 // head branch lives in the project the caller addressed the MR under, so
-// that reference IS the head repo; a fork MR (differing ids) and a payload
-// without the ids leave it empty — not proven same-repo, which those lanes
+// that reference IS the head repo; a fork MR (differing ids) has its source
+// project resolved by id, so the head is the fork's own path — never the
+// addressed project; a source project the token cannot see, and a payload
+// without the ids, leave it empty — not proven same-repo, which those lanes
 // refuse. Both read paths (get + list) must agree.
 func TestPullRequest_HeadRepo(t *testing.T) {
 	cases := []struct {
 		name     string
 		ids      map[string]any
 		wantHead string
+		wantSame bool
 	}{
-		{"same project: the addressed project is the head repo", map[string]any{"source_project_id": 3, "target_project_id": 3}, "g/p"},
-		{"fork MR: the payload names no source project path, head stays unproven", map[string]any{"source_project_id": 5, "target_project_id": 3}, ""},
-		{"payload without project ids proves nothing", map[string]any{}, ""},
+		{"same project: the addressed project is the head repo", map[string]any{"source_project_id": 3, "target_project_id": 3}, "g/p", true},
+		{"fork MR: the source project resolves to the fork's own path", map[string]any{"source_project_id": 5, "target_project_id": 3}, "alice/p", false},
+		{"fork MR: a source project the token cannot see stays unproven", map[string]any{"source_project_id": 7, "target_project_id": 3}, "", false},
+		{"payload without project ids proves nothing", map[string]any{}, "", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -244,11 +248,16 @@ func TestPullRequest_HeadRepo(t *testing.T) {
 				mr[k] = v
 			}
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if strings.HasSuffix(r.URL.EscapedPath(), "/projects/g%2Fp/merge_requests/42") {
+				switch p := r.URL.EscapedPath(); {
+				case strings.HasSuffix(p, "/projects/g%2Fp/merge_requests/42"):
 					_ = json.NewEncoder(w).Encode(mr)
-					return
+				case strings.HasSuffix(p, "/projects/5"):
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 5, "path_with_namespace": "alice/p", "http_url_to_repo": "https://gl/alice/p.git"})
+				case strings.HasSuffix(p, "/projects/7"):
+					w.WriteHeader(http.StatusNotFound)
+				default:
+					_ = json.NewEncoder(w).Encode([]map[string]any{mr})
 				}
-				_ = json.NewEncoder(w).Encode([]map[string]any{mr})
 			}))
 			defer srv.Close()
 			c1 := New(srv.Client(), srv.URL, "tok")
@@ -260,7 +269,7 @@ func TestPullRequest_HeadRepo(t *testing.T) {
 			if got.HeadRepoFullName != c.wantHead {
 				t.Errorf("GetPullRequest HeadRepoFullName = %q, want %q", got.HeadRepoFullName, c.wantHead)
 			}
-			if got.SameRepoAs("g/p") != (c.wantHead != "") {
+			if got.SameRepoAs("g/p") != c.wantSame {
 				t.Errorf("SameRepoAs(g/p) = %v with head %q — the same-repo-only lanes would decide wrongly", got.SameRepoAs("g/p"), got.HeadRepoFullName)
 			}
 			list, err := c1.ListPullRequests(context.Background(), "g/p", forge.PullListOptions{})

--- a/pkg/forge/gitlab/ci.go
+++ b/pkg/forge/gitlab/ci.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -15,8 +16,8 @@ import (
 // addressed by its per-project `iid`; `state` is "opened"/"merged"/"closed",
 // `sha` is the head commit, `work_in_progress`/`draft` flag a draft.
 // `source_project_id`/`target_project_id` name the projects the head and
-// base branches live in — ids only; the payload never carries the source
-// project's path.
+// base branches live in — ids only; the MR object never carries the source
+// project's path, which headProjectFor resolves.
 type gitlabMR struct {
 	IID             int        `json:"iid"`
 	Title           string     `json:"title"`
@@ -35,24 +36,89 @@ type gitlabMR struct {
 	UpdatedAt       time.Time  `json:"updated_at"`
 }
 
-// toRef normalizes a GitLab MR onto forge.PullRef. project is the reference
-// the caller addressed the MR under — an MR lives in its TARGET project.
-// state "opened"→"open", "merged"/"closed" pass through; draft is the OR of
-// the two GitLab flags.
+// headProject is where a merge request's head branch lives, as far as it is
+// proven: the project's path, and — for a fork — its own clone URL. The zero
+// value is UNPROVEN, which every same-project lane reads as a refusal.
+type headProject struct {
+	path     string
+	cloneURL string
+}
+
+// sourceProjectTTL bounds how long a resolved source project is reused: the
+// answer changes only when the project is renamed or transferred.
+const sourceProjectTTL = time.Hour
+
+// sourceProjects caches resolved source projects per (instance, project id)
+// across clients — a bearer client is built per call, so a cache on the
+// client would never hit — so a fork costs one lookup an hour, not one per
+// MR read.
+var sourceProjects = struct {
+	mu sync.Mutex
+	m  map[string]sourceProjectEntry
+}{m: map[string]sourceProjectEntry{}}
+
+type sourceProjectEntry struct {
+	headProject
+	at time.Time
+}
+
+// headProjectFor resolves where a merge request's head branch lives.
+// project is the reference the caller addressed the MR under — an MR lives
+// in its TARGET project. A same-project MR (source and target ids agree) is
+// that same reference, no round trip: a SameRepoAs against the caller's own
+// reference holds by construction, whichever form (path or numeric id) the
+// caller addressed the project by. A fork MR (differing ids) is looked up
+// by its source project id — GET /projects/:id gives the path and clone URL
+// the MR object never carries — so the same-project guards compare real
+// names and a refusal can name the fork.
 //
-// HeadRepoFullName is that same reference when the source and target
-// project ids agree: the head branch then lives in the project the caller
-// queried, and a SameRepoAs against the caller's own reference holds by
-// construction, whichever form (path or numeric id) the caller addressed
-// the project by. A fork MR (differing ids) leaves it empty — the payload
-// names no source project path — and so does a payload without the ids:
-// every same-repo-only lane reads an empty head as "not proven" and
-// refuses, which is the right answer for a fork and for an unknown.
-func (mr gitlabMR) toRef(project string) forge.PullRef {
-	head := ""
-	if mr.SourceProjectID > 0 && mr.SourceProjectID == mr.TargetProjectID {
-		head = strings.TrimSpace(project)
+// Two shapes stay UNPROVEN on purpose rather than failing the read: an MR
+// object without the ids, and a source project the token cannot see (404 /
+// 403 — a private or deleted fork). Every same-project lane refuses an
+// unproven head, which is the right answer for a fork it cannot inspect,
+// and the MR's own fields still serve the lanes that only need its branches.
+func (c *AdminClient) headProjectFor(ctx context.Context, project string, mr gitlabMR) (headProject, error) {
+	switch {
+	case mr.SourceProjectID <= 0 || mr.TargetProjectID <= 0:
+		return headProject{}, nil
+	case mr.SourceProjectID == mr.TargetProjectID:
+		return headProject{path: strings.TrimSpace(project)}, nil
 	}
+	key := c.BaseURL + "#" + strconv.FormatInt(mr.SourceProjectID, 10)
+	sourceProjects.mu.Lock()
+	cached, ok := sourceProjects.m[key]
+	sourceProjects.mu.Unlock()
+	if ok && time.Since(cached.at) < sourceProjectTTL {
+		return cached.headProject, nil
+	}
+	var out struct {
+		PathWithNamespace string `json:"path_with_namespace"`
+		HTTPURLToRepo     string `json:"http_url_to_repo"`
+	}
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+strconv.FormatInt(mr.SourceProjectID, 10), nil, &out)
+	if err != nil {
+		return headProject{}, err
+	}
+	switch {
+	case code == http.StatusNotFound || code == http.StatusForbidden:
+		return headProject{}, nil
+	case code != http.StatusOK:
+		return headProject{}, statusErr("get source project", code)
+	}
+	head := headProject{path: strings.TrimSpace(out.PathWithNamespace), cloneURL: strings.TrimSpace(out.HTTPURLToRepo)}
+	if head.path == "" {
+		return headProject{}, nil
+	}
+	sourceProjects.mu.Lock()
+	sourceProjects.m[key] = sourceProjectEntry{headProject: head, at: time.Now()}
+	sourceProjects.mu.Unlock()
+	return head, nil
+}
+
+// toRef normalizes a GitLab MR onto forge.PullRef. head is where its head
+// branch was proven to live (headProjectFor); state "opened"→"open",
+// "merged"/"closed" pass through; draft is the OR of the two GitLab flags.
+func (mr gitlabMR) toRef(head headProject) forge.PullRef {
 	return forge.PullRef{
 		Number:           mr.IID,
 		Title:            mr.Title,
@@ -61,7 +127,8 @@ func (mr gitlabMR) toRef(project string) forge.PullRef {
 		SourceBranch:     mr.SourceBranch,
 		TargetBranch:     mr.TargetBranch,
 		HeadSHA:          mr.SHA,
-		HeadRepoFullName: head,
+		HeadRepoFullName: head.path,
+		HeadCloneURL:     head.cloneURL,
 		Author:           mr.Author.Username,
 		Draft:            mr.Draft || mr.WorkInProgress,
 		CreatedAt:        mr.CreatedAt,
@@ -124,7 +191,11 @@ func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts fo
 	}
 	out := make([]forge.PullRef, 0, len(mrs))
 	for _, mr := range mrs {
-		out = append(out, mr.toRef(repo))
+		head, err := c.headProjectFor(ctx, repo, mr)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mr.toRef(head))
 	}
 	return out, nil
 }
@@ -139,7 +210,11 @@ func (c *AdminClient) GetPullRequest(ctx context.Context, repo string, number in
 	if code != http.StatusOK {
 		return forge.PullRef{}, statusErr("get merge request", code)
 	}
-	return mr.toRef(repo), nil
+	head, err := c.headProjectFor(ctx, repo, mr)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return mr.toRef(head), nil
 }
 
 // gitlabCommitStatus is one per-job commit status (the GitLab
@@ -313,7 +388,11 @@ func (c *AdminClient) CreatePull(ctx context.Context, repo string, in forge.NewP
 	if code/100 != 2 {
 		return forge.PullRef{}, statusErr("create merge request", code)
 	}
-	return mr.toRef(repo), nil
+	head, err := c.headProjectFor(ctx, repo, mr)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return mr.toRef(head), nil
 }
 
 // UpdatePull applies a partial update. State transitions map onto GitLab's
@@ -345,7 +424,11 @@ func (c *AdminClient) UpdatePull(ctx context.Context, repo string, number int, p
 	if code/100 != 2 {
 		return forge.PullRef{}, statusErr("update merge request", code)
 	}
-	return mr.toRef(repo), nil
+	head, err := c.headProjectFor(ctx, repo, mr)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return mr.toRef(head), nil
 }
 
 // MergePull merges a merge request via PUT /merge_requests/{iid}/merge, which
@@ -376,7 +459,11 @@ func (c *AdminClient) MergePull(ctx context.Context, repo string, number int, op
 	if code/100 != 2 {
 		return forge.PullRef{}, statusErr("merge merge request", code)
 	}
-	return mr.toRef(repo), nil
+	head, err := c.headProjectFor(ctx, repo, mr)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	return mr.toRef(head), nil
 }
 
 var _ forge.PullClient = (*AdminClient)(nil)

--- a/pkg/forge/gitlab/pulls_fork_test.go
+++ b/pkg/forge/gitlab/pulls_fork_test.go
@@ -1,0 +1,136 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// forkForge is a fake GitLab serving one target project's merge requests —
+// two from the same fork (source project 9), one from a private fork the
+// token cannot see (13), one same-project — and the source-project lookup,
+// counting the lookups.
+func forkForge(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var lookups int32
+	mr := func(iid int, branch string, source int64) map[string]any {
+		return map[string]any{
+			"iid": iid, "state": "opened", "title": "t", "web_url": "https://gitlab.example/acme/widgets/-/merge_requests/" + strconv.Itoa(iid),
+			"source_branch": branch, "target_branch": "main", "sha": "abc" + strconv.Itoa(iid),
+			"source_project_id": source, "target_project_id": 42,
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		p := r.URL.EscapedPath()
+		switch {
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/7"):
+			_ = json.NewEncoder(w).Encode(mr(7, "feature/x", 9))
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/8"):
+			_ = json.NewEncoder(w).Encode(mr(8, "feature/y", 42))
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/11"):
+			_ = json.NewEncoder(w).Encode(mr(11, "feature/z", 13))
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests"):
+			_ = json.NewEncoder(w).Encode([]map[string]any{mr(7, "feature/x", 9), mr(9, "feature/w", 9), mr(8, "feature/y", 42)})
+		case p == "/api/v4/projects/9":
+			atomic.AddInt32(&lookups, 1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 9, "path_with_namespace": "mallory/widgets", "http_url_to_repo": "https://gitlab.example/mallory/widgets.git"})
+		case p == "/api/v4/projects/13":
+			atomic.AddInt32(&lookups, 1)
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "404 Project Not Found"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &lookups
+}
+
+func heads(list []forge.PullRef) []string {
+	out := make([]string, 0, len(list))
+	for _, pr := range list {
+		out = append(out, pr.HeadRepoFullName)
+	}
+	return out
+}
+
+// GitLab's MR object names the source project by id only; a fork MR left
+// HeadRepoFullName empty, which every same-project lane read as "not
+// proven" and refused without being able to say what it refused. The source
+// project is one call away: GET /projects/:id gives its path and clone URL,
+// cached per instance and id, so the guards compare real names and a
+// refusal names the fork.
+func TestGitLabGetPullRequestResolvesTheForkSourceProject(t *testing.T) {
+	srv, lookups := forkForge(t)
+	ctx := context.Background()
+	c := New(srv.Client(), srv.URL, "tok")
+	pr, err := c.GetPullRequest(ctx, "acme/widgets", 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.HeadRepoFullName != "mallory/widgets" || pr.HeadCloneURL != "https://gitlab.example/mallory/widgets.git" {
+		t.Fatalf("fork MR head = %q clone=%q, want the source project resolved by id", pr.HeadRepoFullName, pr.HeadCloneURL)
+	}
+	if pr.SameRepoAs("acme/widgets") {
+		t.Fatal("a fork MR must not read as same-project once its head is named")
+	}
+	// Cached per (instance, project id): a second read, and another client on
+	// the same instance, do not look the project up again.
+	if _, err := c.GetPullRequest(ctx, "acme/widgets", 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(srv.Client(), srv.URL, "tok2").GetPullRequest(ctx, "acme/widgets", 7); err != nil {
+		t.Fatal(err)
+	}
+	if n := atomic.LoadInt32(lookups); n != 1 {
+		t.Errorf("source project looked up %d times over three reads, want 1 (cached)", n)
+	}
+	// A same-project MR needs no lookup: the head is the project queried.
+	same, err := c.GetPullRequest(ctx, "acme/widgets", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same.HeadRepoFullName != "acme/widgets" || !same.SameRepoAs("acme/widgets") || same.HeadCloneURL != "" {
+		t.Errorf("same-project MR = %+v, want the queried project as head and no clone URL of its own", same)
+	}
+	if n := atomic.LoadInt32(lookups); n != 1 {
+		t.Errorf("a same-project MR must not look its own project up, lookups = %d", n)
+	}
+	// A listing resolves each distinct fork once (here from the cache).
+	list, err := c.ListPullRequests(ctx, "acme/widgets", forge.PullListOptions{State: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 3 || list[0].HeadRepoFullName != "mallory/widgets" || list[1].HeadRepoFullName != "mallory/widgets" || list[2].HeadRepoFullName != "acme/widgets" {
+		t.Errorf("listing heads = %v, want the two fork MRs named and the same-project one on its own project", heads(list))
+	}
+	if n := atomic.LoadInt32(lookups); n != 1 {
+		t.Errorf("lookups after the listing = %d, want still 1", n)
+	}
+}
+
+// A source project the token cannot see (a private fork, a deleted one)
+// answers 404: the head stays UNPROVEN — every same-project guard refuses,
+// as it did — and the read itself does not fail, so the MR is still served
+// to the lanes that only need its branches.
+func TestGitLabForkSourceProjectTheTokenCannotSeeStaysUnproven(t *testing.T) {
+	srv, _ := forkForge(t)
+	pr, err := New(srv.Client(), srv.URL, "tok").GetPullRequest(context.Background(), "acme/widgets", 11)
+	if err != nil {
+		t.Fatalf("an invisible source project must not fail the MR read: %v", err)
+	}
+	if pr.HeadRepoFullName != "" || pr.HeadCloneURL != "" || pr.SameRepoAs("acme/widgets") {
+		t.Errorf("MR = %+v, want an unproven head (empty) that every guard refuses", pr)
+	}
+	if pr.SourceBranch != "feature/z" || pr.HeadSHA != "abc11" {
+		t.Errorf("the MR's own fields must still be served: %+v", pr)
+	}
+}

--- a/pkg/forge/issues.go
+++ b/pkg/forge/issues.go
@@ -110,6 +110,10 @@ type PullRef struct {
 	// fork guard on lanes that resolve a PR via the forge API and therefore
 	// cannot rely on the webhook payload's own head.repo field.
 	HeadRepoFullName string `json:"head_repo_full_name,omitempty"`
+	// HeadCloneURL is the head repo's own clone URL when the provider reports
+	// it — a fork's, on a fork PR; empty when unknown. It is what a lane that
+	// chooses to work on a fork's code would clone; no launch lane does today.
+	HeadCloneURL string `json:"head_clone_url,omitempty"`
 	// LinkedIssues are issue numbers this PR references / closes, best-effort
 	// parsed from the title/body ("fixes #12", "Closes #7", "!?").
 	LinkedIssues []int `json:"linked_issues,omitempty"`

--- a/pkg/forge/refresh.go
+++ b/pkg/forge/refresh.go
@@ -30,6 +30,10 @@ type RefreshedToken struct {
 	RefreshToken string // may be rotated by the provider; empty = keep current
 	ExpiresAt    time.Time
 	Scopes       []string
+	// AppSlug is the GitHub App's slug when the refresher resolved it for a
+	// record that lacked it; the worker persists it so the "<slug>[bot]"
+	// identity the loop guards read exists on every App connection.
+	AppSlug string
 }
 
 // RefreshWorker keeps OAuth-app and GitHub-App connection tokens fresh and
@@ -196,6 +200,14 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 	}
 	if len(out.Scopes) > 0 {
 		conn.Scopes = out.Scopes
+	}
+	if out.AppSlug != "" && conn.AppSlug != out.AppSlug {
+		conn.AppSlug = out.AppSlug
+		// The connect flow derives the account login from the slug; a record
+		// made without one carries the bare "[bot]", which names nobody.
+		if conn.AccountLogin == "" || conn.AccountLogin == "[bot]" {
+			conn.AccountLogin = out.AppSlug + "[bot]"
+		}
 	}
 	conn.UpdatedAt = now
 	if err := w.Connections.Update(ctx, conn); err != nil {

--- a/pkg/forge/refresh_slug_test.go
+++ b/pkg/forge/refresh_slug_test.go
@@ -1,0 +1,67 @@
+package forge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// slugRefresher is a refresher that, like the GitHub App one, also reports
+// the App's slug when the connection record lacks it.
+type slugRefresher struct {
+	fakeRefresher
+	slug string
+}
+
+func (r slugRefresher) Refresh(ctx context.Context, conn Connection, tok string) (RefreshedToken, error) {
+	out, err := r.fakeRefresher.Refresh(ctx, conn, tok)
+	if err == nil && conn.AppSlug == "" {
+		out.AppSlug = r.slug
+	}
+	return out, nil
+}
+
+// The slug a refresher resolves is persisted onto the connection record —
+// the field iterionBotLogins builds the App's "<slug>[bot]" identity from —
+// so a connection created before the slug was recorded (or under a platform
+// App with no slug configured) stops presenting an inert loop guard after
+// its first refresh. The account login the connect flow derives from the
+// slug is repaired along with it when it was left as the bare "[bot]".
+func TestRefreshWorker_PersistsTheAppSlugTheRefresherResolved(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	connStore := NewMemoryConnectionStore()
+	secStore := secrets.NewMemoryGenericSecretStore()
+	now := time.Unix(1700000000, 0).UTC()
+	c, _ := seedOAuthConn(t, sealer, connStore, secStore, now.Add(2*time.Minute))
+	ctx := context.Background()
+	c.Kind, c.Provider, c.AccountLogin, c.AppSlug = KindGitHubApp, ProviderGitHub, "[bot]", ""
+	if err := connStore.Update(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &RefreshWorker{
+		Connections: connStore, Secrets: secStore, Sealer: sealer,
+		Now: func() time.Time { return now },
+		RefresherFor: func(Connection) TokenRefresher {
+			return slugRefresher{fakeRefresher{newAccess: "new-access", expiresAt: now.Add(time.Hour)}, "iterion-forge-x"}
+		},
+	}
+	if n, err := w.RunOnce(ctx); err != nil || n != 1 {
+		t.Fatalf("RunOnce: n=%d err=%v", n, err)
+	}
+	got, err := connStore.Get(ctx, c.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AppSlug != "iterion-forge-x" {
+		t.Fatalf("AppSlug = %q, want the slug the refresher resolved persisted on the record", got.AppSlug)
+	}
+	if got.AccountLogin != "iterion-forge-x[bot]" {
+		t.Errorf("AccountLogin = %q, want the bare [bot] repaired from the slug", got.AccountLogin)
+	}
+	if got.SealedPayload == nil || got.AccessTokenExpiresAt == nil || !got.AccessTokenExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Errorf("the token refresh itself must still land: %+v", got)
+	}
+}

--- a/pkg/server/forge_app_client_cache_test.go
+++ b/pkg/server/forge_app_client_cache_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// forgeAdminFor is called once per lane per delivery, and a GitHub-App
+// client keeps its minted tokens on the instance — so a fresh client per call
+// meant a fresh mint per lane. One client per connection, validated against
+// the connection state it was built from, is what makes the second call free
+// and what lets a denial noted by one lane (PreflightFor's denied set) reach
+// the next.
+func TestForgeAdminForReusesOneAppClientPerConnection(t *testing.T) {
+	s, conn := appConnectionFixture(t)
+	ctx := context.Background()
+	build := func(c forge.Connection) forge.Admin {
+		t.Helper()
+		admin, err := s.forgeAdminFor(ctx, c)
+		if err != nil {
+			t.Fatalf("forgeAdminFor: %v", err)
+		}
+		return admin
+	}
+	first := build(conn)
+	if build(conn) != first {
+		t.Fatal("two calls on the same connection built two clients: every lane mints its own tokens")
+	}
+	other := conn
+	other.ID = "c-other"
+	if build(other) == first {
+		t.Error("two connections must never share a client")
+	}
+	if build(conn) != first {
+		t.Error("another connection's build must not evict this connection's entry")
+	}
+
+	// The invalidation rule: ONE entry per connection, held only while the
+	// state the client is built from is unchanged — a moved grant (the
+	// health probe synced it) or a status change builds a fresh client, which
+	// is then the one served.
+	synced := conn
+	synced.GrantedPermissions = map[string]string{"contents": "write", "metadata": "read"}
+	second := build(synced)
+	if second == first {
+		t.Error("a connection whose granted permissions moved must get a fresh client")
+	}
+	if build(synced) != second {
+		t.Error("the fresh client must be the one served from then on")
+	}
+	revoked := synced
+	revoked.Status = forge.StatusNeedsReauth
+	third := build(revoked)
+	if third == second {
+		t.Error("a connection whose status changed must get a fresh client")
+	}
+
+	// Explicit eviction — the delete route and the refresh route (which
+	// re-mints on purpose) use it.
+	s.forgetForgeAppClient(conn.ID)
+	if build(revoked) == third {
+		t.Error("forgetForgeAppClient must drop the entry so the next call builds a fresh client")
+	}
+}
+
+// The cache is for App clients only: a bearer-token client holds no state
+// worth keeping, and caching it would pin a token the connection may rotate.
+func TestForgeAdminForBuildsBearerClientsPerCall(t *testing.T) {
+	s := newWebhookTestServer(t)
+	sealed, err := forge.SealPAT(s.sealer, "c-pat", "ghp_fixture")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := forge.Connection{ID: "c-pat", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindPAT, Status: forge.StatusActive, SealedPayload: sealed}
+	a, err := s.forgeAdminFor(context.Background(), conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.forgeAdminFor(context.Background(), conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Error("a PAT connection's client must be built per call")
+	}
+}

--- a/pkg/server/forge_app_denied_lane_test.go
+++ b/pkg/server/forge_app_denied_lane_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// A connection whose token was minted WITH statuses, and whose status write
+// then gets GitHub's 403 (the grant revoked after the mint, a repo the
+// installation lost): the first approve fails at the write — nothing can know
+// beforehand — but the refusal is recorded on the connection's client, so the
+// NEXT approve's preflight reports statuses withheld and the lane writes
+// through the webhook's forge_token binding instead. Before the denial was
+// recorded, every approve on that connection failed the same way for up to
+// an hour while a working binding sat unused.
+func TestReviewApproveTakesTheBindingAfterAStatusWriteRefusal(t *testing.T) {
+	s, f, cfg, pt := appConnWorld(t, false, true)
+	f.statusForbidden = true
+	f.perms["maintainer-jane"] = "maintain"
+	approve := func(id int) map[string]string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), approveBodyFromID("maintainer-jane", id), prforge.EventHeaderIssueComment, pt))
+		if w.Code != http.StatusOK {
+			t.Fatalf("approve #%d: code=%d body=%s", id, w.Code, w.Body.String())
+		}
+		var resp map[string]string
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		return resp
+	}
+
+	first := approve(556)
+	if first["status"] == "revi-approved" {
+		t.Fatalf("the first write on a token the forge refuses cannot land: %v", first)
+	}
+	second := approve(557)
+	if second["status"] != "revi-approved" {
+		t.Fatalf("the second approve must take the binding the recorded denial arms: %v (status bearers=%v)", second, f.bearersFor("status"))
+	}
+	bearers := f.bearersFor("status")
+	if len(bearers) < 2 || bearers[len(bearers)-1] != "Bearer ghp_hand_owned" {
+		t.Fatalf("the second status write must ride the forge_token binding, got %v", bearers)
+	}
+	statuses, _ := f.snapshot()
+	if len(statuses) != 1 || statuses[0]["state"] != "success" {
+		t.Fatalf("want exactly one landed status (through the binding), got %v", statuses)
+	}
+}

--- a/pkg/server/forge_app_grant_lane_test.go
+++ b/pkg/server/forge_app_grant_lane_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// The publish and gate write paths reach GitHub through forgeAdminFor, whose
+// App client minted its management token from the constant baseline plus
+// statuses. An installation whose owner granted LESS than the baseline 422'd
+// on every mint — the retry without statuses 422'd again — so the connection
+// could never serve, and a connection-only integration lost every write lane
+// at once. The mint narrows to the grant the connection recorded, so the
+// approve lands through the connection with the token the grant allows.
+func TestReviewApproveServesAConnectionGrantedLessThanTheBaseline(t *testing.T) {
+	subset := map[string]string{"contents": "write", "pull_requests": "write", "metadata": "read", "statuses": "write"} // no issues, no repository_hooks
+	s := newWebhookTestServer(t)
+	f := newFakeGitHubForge(t)
+	f.granted = subset
+	f.perms["maintainer-jane"] = "maintain"
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	conns := forge.NewMemoryConnectionStore()
+	if err := conns.Create(context.Background(), forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: f.srv.URL, Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AccountLogin: "iterion-forge-x[bot]", AppSlug: "iterion-forge-x",
+		GrantedPermissions: subset, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.forgeConnections = conns
+	cfg, pt := ghConfig(t, s)
+	cfg.ForgeBaseURL = f.srv.URL
+	cfg.LaunchVars = map[string]string{gateContextVar: "revi/review"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), approveBodyFrom("maintainer-jane"), prforge.EventHeaderIssueComment, pt))
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if w.Code != http.StatusOK || resp["status"] != "revi-approved" {
+		t.Fatalf("an installation granted a strict subset of the baseline must still serve the approve through its connection: code=%d body=%s mints=%d", w.Code, w.Body.String(), f.mintCount())
+	}
+	statuses, _ := f.snapshot()
+	if len(statuses) != 1 || statuses[0]["state"] != "success" {
+		t.Fatalf("want one success status, got %v", statuses)
+	}
+	for _, b := range f.bearersFor("status") {
+		if !strings.HasPrefix(b, "Bearer ghs_") {
+			t.Fatalf("the status must be written with the connection's minted token, got %v", f.bearersFor("status"))
+		}
+	}
+}

--- a/pkg/server/forge_app_identity_lane_test.go
+++ b/pkg/server/forge_app_identity_lane_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// appConnWorldNoSlug is appConnWorld with NEITHER the platform App config
+// nor the connection record carrying the App slug — the shape of a
+// connection created before the slug was recorded, or of a platform App run
+// without ITERION_FORGE_GITHUB_APP_SLUG. No forge_token binding: the
+// connection is the only credential.
+func appConnWorldNoSlug(t *testing.T) (*Server, *fakeGitHubForge, webhooks.Config, string) {
+	t.Helper()
+	s := newWebhookTestServer(t)
+	f := newFakeGitHubForge(t)
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t)}
+	conns := forge.NewMemoryConnectionStore()
+	if err := conns.Create(context.Background(), forge.Connection{
+		ID: "c-app", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, ForgeBaseURL: f.srv.URL, Purpose: forge.PurposeRuntime,
+		InstallationID: 42, AccountLogin: "[bot]", CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.forgeConnections = conns
+	cfg, pt := ghConfig(t, s)
+	cfg.ForgeBaseURL = f.srv.URL
+	cfg.LaunchVars = map[string]string{gateContextVar: "revi/review"}
+	return s, f, cfg, pt
+}
+
+// The bot's own /command echoes back as an issue_comment by "<slug>[bot]".
+// The command gate's loop guard compares the commenter against WhoAmI; with
+// no slug configured anywhere that answered "github-app[bot]", so the App's
+// own comment cleared the guard and — the installation having write on its
+// own repositories — launched a run: the bot answering itself. The slug is
+// one GET /app away, and once learnt it is recorded on the connection so the
+// identity set every other guard reads (iterionBotLogins) names the App too.
+func TestPRForgeCommandGateLoopGuardSeesTheAppSlugItResolves(t *testing.T) {
+	s, f, cfg, pt := appConnWorldNoSlug(t)
+	f.perms["iterion-forge-x[bot]"] = "write"
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+	cfg.CommandMap = map[string][]webhooks.CommandRoute{"billy": {{BotID: "branch-improve-loop"}}}
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-loop", nil
+	}
+	body := `{"action":"created","repository":{"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"issue":{"number":7,"title":"t","body":"","state":"open","user":{"login":"alice"},"pull_request":{"html_url":"https://github.com/acme/widgets/pull/7"}},"comment":{"id":558,"body":"/billy","html_url":"https://github.com/acme/widgets/pull/7#issuecomment-558"},"sender":{"login":"iterion-forge-x[bot]"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+	if launched != 0 {
+		t.Fatalf("the App's own comment launched a run (code=%d body=%s): the loop guard compared against a login that never posts", w.Code, w.Body.String())
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("a self comment is a benign refusal (200/filtered), got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != webhooks.StatusFiltered {
+		t.Fatalf("status = %v, want filtered (loop-guard)", resp)
+	}
+	conn, err := s.forgeConnections.Get(context.Background(), "c-app")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn.AppSlug != "iterion-forge-x" {
+		t.Errorf("connection AppSlug = %q, want the slug the client resolved persisted on the record", conn.AppSlug)
+	}
+	if conn.AccountLogin != "iterion-forge-x[bot]" {
+		t.Errorf("connection AccountLogin = %q, want the bare [bot] repaired from the slug", conn.AccountLogin)
+	}
+	if got := f.appLookupCount(); got != 1 {
+		t.Fatalf("GET /app probes after the first delivery = %d, want 1", got)
+	}
+	// The slug is learnt once per connection: the cached client memoises it
+	// and the record now carries it, so a second self comment on the same
+	// connection is refused without another probe.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), strings.Replace(body, `"id":558`, `"id":559`, 1), prforge.EventHeaderIssueComment, pt))
+	if launched != 0 {
+		t.Fatalf("the App's second self comment launched a run (code=%d body=%s)", w.Code, w.Body.String())
+	}
+	if got := f.appLookupCount(); got != 1 {
+		t.Fatalf("GET /app probes after the second delivery = %d, want still 1 — the identity was resolved again instead of read from the cached client", got)
+	}
+}
+
+// One connection, one client: a second delivery on the same connection
+// mints nothing — the management token and the get profile minted for the
+// first delivery are reused until they near expiry. Before the per-connection
+// client, every lane built its own AppClient and every delivery paid the
+// full set of mints again.
+func TestAppConnectionMintsOncePerProfileAcrossDeliveries(t *testing.T) {
+	s, f, cfg, pt := appConnWorld(t, false, false)
+	f.perms["maintainer-jane"] = "maintain"
+	approve := func(id int) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), approveBodyFromID("maintainer-jane", id), prforge.EventHeaderIssueComment, pt))
+		var resp map[string]string
+		_ = json.Unmarshal(w.Body.Bytes(), &resp)
+		if w.Code != http.StatusOK || resp["status"] != "revi-approved" {
+			t.Fatalf("approve #%d: code=%d body=%s mints=%d", id, w.Code, w.Body.String(), f.mintCount())
+		}
+	}
+	approve(556)
+	afterFirst := f.mintCount()
+	if afterFirst == 0 {
+		t.Fatal("the connection must have minted for the first delivery")
+	}
+	approve(557)
+	if got := f.mintCount(); got != afterFirst {
+		t.Fatalf("mints after the second delivery = %d, want %d — every lane rebuilt the client and minted its tokens again", got, afterFirst)
+	}
+}

--- a/pkg/server/forge_app_reply_lane_test.go
+++ b/pkg/server/forge_app_reply_lane_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// The review-thread REPLY gate resolved its client from the webhook's
+// forge_token binding alone, so a connection-only integration — a GitHub
+// App, no binding, the ordinary shape — answered "no forge token resolved"
+// on every reply, while the same integration authorized /revi and the
+// re-request lane through its connection. The gate resolves the client the
+// way those lanes do: the covering connection first (its App client fetches
+// the thread under pull_requests:read), the binding as the fallback.
+func TestReviewThreadReplyServesThroughAConnectionWithoutABinding(t *testing.T) {
+	s, f, cfg, pt := appConnWorld(t, false, false)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	f.perms["alice"] = "write"
+	f.reviewComments = []map[string]any{
+		{"id": 9002, "in_reply_to_id": 9001, "body": "why?", "path": "pkg/x/y.go", "created_at": "2026-09-02T10:05:00Z", "user": map[string]any{"login": "alice"}},
+		{"id": 9001, "body": "the SSRF is reachable", "path": "pkg/x/y.go", "created_at": "2026-09-02T10:00:00Z", "user": map[string]any{"login": "iterion-forge-x[bot]"}},
+	}
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.EventAllowlist = []string{"issue_comment", "pull_request", "pull_request_review_comment"}
+	launched := 0
+	var gotBot string
+	var gotVars map[string]string
+	s.webhookLaunchBot = func(_ context.Context, botID string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		launched++
+		gotBot, gotVars = botID, vars
+		return "run-reply", nil
+	}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("alice", "why is this SSRF reachable?"), prforge.EventHeaderReviewComment, pt))
+	if launched != 1 || gotBot != "revi-converse" {
+		t.Fatalf("a connection-only integration must serve the reply gate through its connection: code=%d body=%s launched=%d bot=%q", w.Code, w.Body.String(), launched, gotBot)
+	}
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(gotVars["thread_context"], "iterion-forge-x[bot] (you, the bot)") {
+		t.Errorf("the thread fetched through the connection must ground the bot, got thread_context=%q", gotVars["thread_context"])
+	}
+	bearers := f.bearersFor("review_comments")
+	if len(bearers) == 0 {
+		t.Fatal("the thread must have been fetched")
+	}
+	for _, b := range bearers {
+		if !strings.HasPrefix(b, "Bearer ghs_") {
+			t.Fatalf("the thread fetch must ride the connection's minted token, got %v", bearers)
+		}
+	}
+}

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -116,24 +118,133 @@ func (s *Server) forgeAdminForToken(provider forge.Provider, baseURL, token stri
 }
 
 // forgeAdminFor builds a connection's admin client (the orchestrator's
-// AdminFor). A GitHub-App connection mints a fresh installation token from
-// the App private key on demand; every other kind opens its sealed token.
+// AdminFor). A GitHub-App connection is served by ONE client per connection
+// (githubAppClientFor), whose minted tokens outlive the call; every other
+// kind opens its sealed token into a stateless bearer client.
 func (s *Server) forgeAdminFor(ctx context.Context, conn forge.Connection) (forge.Admin, error) {
 	if conn.Kind == forge.KindGitHubApp {
-		cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-		if !ok {
-			return nil, fmt.Errorf("forge: no github app available for this connection")
-		}
-		return &forgegithub.AppClient{
-			HTTP: s.forgeHTTPClient(), WebBaseURL: conn.BaseURL(),
-			Cfg: cfg, InstallationID: conn.InstallationID,
-		}, nil
+		return s.githubAppClientFor(ctx, conn)
 	}
 	token, err := forge.AdminTokenFor(s.sealer, conn)
 	if err != nil {
 		return nil, err
 	}
 	return s.forgeAdminForToken(conn.Provider, conn.BaseURL(), token)
+}
+
+// cachedForgeAppClient is one connection's GitHub-App client with the
+// fingerprint of the state it was built from.
+type cachedForgeAppClient struct {
+	fp     string
+	cfg    forgegithub.AppConfig
+	client *forgegithub.AppClient
+}
+
+// githubAppClientFor returns the connection's App client — ONE per
+// connection per replica, so the tokens it mints (the management token, each
+// scoped profile) and the denials it learns (PreflightFor's set) are shared
+// by every lane and every delivery instead of rebuilt by each forgeAdminFor
+// call, which minted the same tokens again per lane.
+//
+// The entry is keyed by the connection id and held only while the state the
+// client is built from is unchanged: tenant, host, installation, the App's id
+// and private key, status, granted permissions, slug
+// (forgeAppClientFingerprint). Any connection update that moves one of them —
+// a re-provisioned App, a grant the health probe synced, a revocation, a key
+// rotation — builds a fresh client on the next call, so a stale entry can
+// never serve a token for state that no longer holds. Deletion and the
+// refresh route evict explicitly (forgetForgeAppClient). The client stays
+// network-free at construction; a slug it learns lazily is recorded on the
+// connection through OnSlugResolved.
+func (s *Server) githubAppClientFor(ctx context.Context, conn forge.Connection) (forge.Admin, error) {
+	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
+	if !ok {
+		return nil, fmt.Errorf("forge: no github app available for this connection")
+	}
+	if cfg.AppSlug == "" {
+		cfg.AppSlug = conn.AppSlug
+	}
+	fp := forgeAppClientFingerprint(conn, cfg)
+	s.forgeAppClientsMu.Lock()
+	defer s.forgeAppClientsMu.Unlock()
+	if e, ok := s.forgeAppClients[conn.ID]; ok && e.fp == fp {
+		return e.client, nil
+	}
+	client := &forgegithub.AppClient{
+		HTTP: s.forgeHTTPClient(), WebBaseURL: conn.BaseURL(),
+		Cfg: cfg, InstallationID: conn.InstallationID,
+	}
+	if cfg.AppSlug == "" {
+		client.OnSlugResolved = func(slug string) { s.recordForgeAppSlug(conn, slug) }
+	}
+	if s.forgeAppClients == nil {
+		s.forgeAppClients = map[string]*cachedForgeAppClient{}
+	}
+	s.forgeAppClients[conn.ID] = &cachedForgeAppClient{fp: fp, cfg: cfg, client: client}
+	return client, nil
+}
+
+// forgeAppClientFingerprint renders everything a connection's App client is
+// built from. A change in any of it means a cached client would serve state
+// that no longer holds, so the entry is rebuilt.
+func forgeAppClientFingerprint(conn forge.Connection, cfg forgegithub.AppConfig) string {
+	key := sha256.Sum256([]byte(cfg.PrivateKeyPEM))
+	return strings.Join([]string{
+		conn.TenantID, conn.BaseURL(), strconv.FormatInt(conn.InstallationID, 10), conn.OAuthAppID,
+		string(conn.Status), cfg.AppSlug, strconv.FormatInt(cfg.AppID, 10), hex.EncodeToString(key[:8]),
+		forgegithub.PermissionSetKey(conn.GrantedPermissions),
+	}, "|")
+}
+
+// forgetForgeAppClient drops a connection's cached client: the next
+// forgeAdminFor builds, and mints, afresh. The delete route calls it so a
+// removed connection holds no live token in memory; the refresh route calls
+// it because it re-mints on purpose, to show an owner the grant they just
+// approved.
+func (s *Server) forgetForgeAppClient(connID string) {
+	s.forgeAppClientsMu.Lock()
+	defer s.forgeAppClientsMu.Unlock()
+	delete(s.forgeAppClients, connID)
+}
+
+// recordForgeAppSlug persists the slug a connection's client resolved from
+// GET /app onto the connection record — the field iterionBotLogins builds the
+// App's "<slug>[bot]" identity from — and repairs the account login the
+// connect flow derived from an empty slug. Best-effort: the client already
+// answers with the slug; the record is what the OTHER guards read. The cache
+// entry's fingerprint follows the record, so the record as it now reads
+// still maps to the same client.
+func (s *Server) recordForgeAppSlug(conn forge.Connection, slug string) {
+	if s.forgeConnections == nil || slug == "" {
+		return
+	}
+	ctx := store.WithTenant(context.Background(), conn.TenantID)
+	fresh, err := s.forgeConnections.Get(ctx, conn.ID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("forge: record app slug %q for connection %s: %v", slug, conn.ID, err)
+		}
+		return
+	}
+	if fresh.AppSlug != slug {
+		fresh.AppSlug = slug
+		if fresh.AccountLogin == "" || fresh.AccountLogin == "[bot]" {
+			fresh.AccountLogin = slug + "[bot]"
+		}
+		fresh.UpdatedAt = time.Now().UTC()
+		if err := s.forgeConnections.Update(ctx, fresh); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("forge: persist app slug %q for connection %s: %v", slug, conn.ID, err)
+			}
+			return
+		}
+	}
+	s.forgeAppClientsMu.Lock()
+	defer s.forgeAppClientsMu.Unlock()
+	if e, ok := s.forgeAppClients[conn.ID]; ok {
+		e.cfg.AppSlug = slug
+		e.fp = forgeAppClientFingerprint(fresh, e.cfg)
+	}
 }
 
 // forgeCapabilityErr explains a failed capability assertion on a client

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -173,6 +173,10 @@ func (s *Server) githubAppClientFor(ctx context.Context, conn forge.Connection) 
 	client := &forgegithub.AppClient{
 		HTTP: s.forgeHTTPClient(), WebBaseURL: conn.BaseURL(),
 		Cfg: cfg, InstallationID: conn.InstallationID,
+		// The recorded grant narrows the management mint to what the
+		// installation approved; the fingerprint above rebuilds the client
+		// when the health probe syncs a new one.
+		Granted: conn.GrantedPermissions,
 	}
 	if cfg.AppSlug == "" {
 		client.OnSlugResolved = func(slug string) { s.recordForgeAppSlug(conn, slug) }

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -398,6 +398,7 @@ func (s *Server) handleDeleteForgeConnection(w http.ResponseWriter, r *http.Requ
 		httpError(w, http.StatusInternalServerError, "disconnect failed: %v", err)
 		return
 	}
+	s.forgetForgeAppClient(connID)
 	s.auditTenant(r, teamID, "forge.connection.deleted", "forge_connection", connID, nil)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/pkg/server/forge_refresh_route.go
+++ b/pkg/server/forge_refresh_route.go
@@ -66,8 +66,10 @@ func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Req
 		MissingPermissions:   missingDeliveryFor(conn, inst.Permissions),
 		MissingCIPermissions: missingCIFor(conn, inst.Permissions),
 	}
-	// Force a fresh token mint so the observability reflects the new grants
-	// (forgeAdminFor builds a fresh client → rest() mints on first use).
+	// Force a fresh token mint so the observability reflects the new grants:
+	// the connection's cached client is dropped first, so forgeAdminFor
+	// builds a new one and rest() mints on first use.
+	s.forgetForgeAppClient(conn.ID)
 	if admin, err := s.forgeAdminFor(r.Context(), conn); err == nil {
 		if _, err := admin.ListRepos(r.Context(), forge.RepoQuery{}); err != nil {
 			out.LiveError = err.Error()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -217,6 +217,12 @@ type Server struct {
 	configShareFC     func(context.Context, *configshare.Share) (forge.FileClient, error)
 	forgeConnections  forge.ConnectionStore
 	forgeIntegrations forge.RepoIntegrationStore
+	// forgeAppClients is the per-connection GitHub-App client cache
+	// (githubAppClientFor): one client — hence one set of minted tokens — per
+	// connection per replica, validated against the connection state it was
+	// built from and evicted by forgetForgeAppClient.
+	forgeAppClients   map[string]*cachedForgeAppClient
+	forgeAppClientsMu sync.Mutex
 	// boardBindings ties a team to one forge PROJECT board (ADR-097). Nil in
 	// local mode, which is what self-disables the endpoints and the sync
 	// worker.

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -136,6 +136,24 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 		return
 	}
 
+	// Fork guard, unconditional on the auto path — parity with the
+	// GitHub/Forgejo lanes: a fork MR is untrusted (anyone can open one to
+	// run code in the runner with the forge token and to spend the tenant's
+	// budget), and the launch pair (this project's clone URL + the fork's
+	// branch name) names no repository — the checkout misses, or hits a
+	// same-named branch here and the bot reviews the wrong code under the
+	// bot's identity. The payload names both projects (ids + source path),
+	// so a PROVEN fork is filtered here, naming the fork. A payload naming
+	// neither stays on its way: this lane refuses what the payload proves,
+	// while the lanes that resolve the MR through the API fail closed on an
+	// unproven head. A collaborator runs a bot on fork code deliberately,
+	// from a branch in this project.
+	if p.IsFork() {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, gitlabForkRefusal(p.HeadRepoFullName))
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
 	// Same per-bot fan-out as the GitHub PR lane — resolved BEFORE the
 	// hold-label/bot guards so the replier gate below can name the bot whose
 	// forge token authenticates the authz lookup.
@@ -501,8 +519,10 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 		// hit a same-named branch here and the bot answers grounded in the
 		// wrong code, under the bot's identity). The note payload carries
 		// neither source_project_id nor target_project_id, so proving
-		// same-project needs the API (pkg/forge/gitlab/ci.go toRef names
-		// HeadRepoFullName only when they agree).
+		// same-project needs the API (pkg/forge/gitlab/ci.go headProjectFor:
+		// a same-project MR is the project queried, a fork's source project
+		// is resolved by id so the refusal can name it, an invisible one
+		// stays unproven).
 		resolve := s.webhookGitLabPRResolver
 		if resolve == nil {
 			resolve = s.realWebhookGitLabPRResolver
@@ -514,7 +534,7 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 			return
 		}
 		if !resolved.SameRepoAs(p.ProjectPath) {
-			filtered("fork MR or unverifiable head project — /" + cmd + " runs are same-project only")
+			filtered(gitlabCommandForkRefusal(cmd, resolved.HeadRepoFullName))
 			return
 		}
 		vars = applyWebhookVarLayers(buildCommandVars(p, route, cmdArgs, nil), cfg)
@@ -833,6 +853,29 @@ func (s *Server) realWebhookReviewRequestGate(ctx context.Context, cfg webhooks.
 // to answer a boolean on the note hot path.
 func (s *Server) canRouteToConverseBot(cfg webhooks.Config, converseBot string) bool {
 	return cfg.AllowsBot(converseBot) && s.botExists(converseBot)
+}
+
+// gitlabForkRefusal words the MR lane's fork refusal for the delivery row,
+// naming the fork's own project when the payload named it. The /command
+// lanes refuse the same MR (same-project only), so the refusal never
+// advertises them as an escape hatch: fork work needs a branch in this
+// project before any bot runs on it.
+func gitlabForkRefusal(head string) string {
+	where := "the head lives in another project"
+	if head != "" {
+		where = "the head lives in " + head
+	}
+	return "fork MR — " + where + " — auto-launch blocked (untrusted; the /command lanes are same-project only too, so the fork's work needs a branch in this project before any bot runs on it)"
+}
+
+// gitlabCommandForkRefusal words the command lane's same-project refusal:
+// the fork's own project when the adapter resolved it, "unverifiable" when
+// the head could not be proven either way.
+func gitlabCommandForkRefusal(cmd, head string) string {
+	if head == "" {
+		return "fork MR or unverifiable head project — /" + cmd + " runs are same-project only"
+	}
+	return "fork MR — the head lives in " + head + " — /" + cmd + " runs are same-project only"
 }
 
 // recordNoteDelivery inserts a terminal note-event audit row with a

--- a/pkg/server/webhooks_gitlab_fork_test.go
+++ b/pkg/server/webhooks_gitlab_fork_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/gitlab"
+)
+
+// glForkMR is an MR opened from a fork: the payload names the source project
+// (mallory/widgets) and the target project (acme/widgets) by id and path.
+const glForkMR = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {"iid": 11, "action": "open", "source_branch": "feature/fork", "target_branch": "main",
+    "title": "From a fork", "description": "d", "url": "https://gitlab.com/acme/widgets/-/merge_requests/11",
+    "last_commit": {"id": "forksha"},
+    "source_project_id": 9, "target_project_id": 42,
+    "source": {"id": 9, "path_with_namespace": "mallory/widgets", "git_http_url": "https://gitlab.com/mallory/widgets.git"},
+    "target": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"}}
+}`
+
+// glSameProjectMR is the same event shape for an MR whose head lives in the
+// project itself (ids agree, source = the project).
+const glSameProjectMR = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {"iid": 12, "action": "open", "source_branch": "feature/own", "target_branch": "main",
+    "title": "Own branch", "description": "d", "url": "https://gitlab.com/acme/widgets/-/merge_requests/12",
+    "last_commit": {"id": "ownsha"},
+    "source_project_id": 42, "target_project_id": 42,
+    "source": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+    "target": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"}}
+}`
+
+func lastDeliveryReason(t *testing.T, s *Server) string {
+	t.Helper()
+	list, err := s.webhookDeliveries.ListByWebhook(context.Background(), "t1", "w1", 10)
+	if err != nil || len(list) == 0 {
+		t.Fatalf("deliveries: %v (%d)", err, len(list))
+	}
+	return list[0].Error
+}
+
+// The GitLab MR lane launched a fork MR on the launch pair (this project's
+// clone URL + the fork's branch name), which names no repository: the
+// checkout misses, or hits a same-named branch here and the bot reviews the
+// wrong code under the bot's identity. The payload names the source project,
+// so a PROVEN fork is refused here the way the GitHub/Forgejo lanes refuse
+// one — and the refusal names the fork.
+func TestGitLabWebhook_ForkMRNeverAutoLaunches(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-fork", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(glConfig()), glForkMR, gitlab.EventHeaderMergeRequest))
+	if launched != 0 {
+		t.Fatalf("a fork MR launched on the auto lane (code=%d body=%s): the launch pair names no repository", w.Code, w.Body.String())
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("a fork MR is a benign refusal (200/filtered), got %d body=%s", w.Code, w.Body.String())
+	}
+	if reason := lastDeliveryReason(t, s); !strings.Contains(reason, "mallory/widgets") || !strings.Contains(reason, "fork") {
+		t.Fatalf("the refusal must name the fork's own project, got %q", reason)
+	}
+}
+
+// The guard reads the payload's project ids: a same-project MR that carries
+// them launches exactly as one without them.
+func TestGitLabWebhook_SameProjectMRWithProjectIDsStillLaunches(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	var gotURL, gotRef string
+	s.webhookLaunchBot = func(_ context.Context, _ string, _ map[string]string, repoURL, repoRef, _ string, _, _ map[string]string) (string, error) {
+		launched++
+		gotURL, gotRef = repoURL, repoRef
+		return "run-own", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(glConfig()), glSameProjectMR, gitlab.EventHeaderMergeRequest))
+	if w.Code != http.StatusAccepted || launched != 1 {
+		t.Fatalf("same-project MR must launch: code=%d launched=%d body=%s", w.Code, launched, w.Body.String())
+	}
+	if gotURL != "https://gitlab.com/acme/widgets.git" || gotRef != "feature/own" {
+		t.Fatalf("launch pair = %q@%q, want the project's own clone URL and the MR branch", gotURL, gotRef)
+	}
+}
+
+// The /command note lane already refused a fork MR (fail-closed on an
+// unproven head). With the source project resolved by id, the refusal names
+// the fork instead of "unverifiable".
+func TestGitLabNoteHook_ForkRefusalNamesTheHead(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.webhookGitLabPRResolver = func(context.Context, webhooks.Config, gitlab.ParsedNote, string) (forge.PullRef, error) {
+		return forge.PullRef{State: "open", SourceBranch: "feature/x", TargetBranch: "main", HeadRepoFullName: "mallory/widgets"}, nil
+	}
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-forbidden", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glNoteReq(gitlabCtx(featurlyConfig()), glNoteFeaturly))
+	if launched != 0 || w.Code != http.StatusOK {
+		t.Fatalf("a fork MR command must filter: launched=%d code=%d body=%s", launched, w.Code, w.Body.String())
+	}
+	if reason := lastDeliveryReason(t, s); !strings.Contains(reason, "mallory/widgets") {
+		t.Fatalf("the refusal must name the fork's own project, got %q", reason)
+	}
+}

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -559,23 +559,29 @@ func buildPRForgeReviewReplyVars(p prforge.ParsedReviewComment, threadContext st
 }
 
 // realWebhookPRForgeReviewReplyGate is the production reply gate: resolve
-// the bot's forge token and hand the thread work to reviewReplyGateWithAPI.
-// ok=false + reason for benign refusals; err only for infra failure.
+// the forge client the way every other GitHub/Forgejo lane does — the team
+// connection covering the PR first, the webhook's forge_token binding as the
+// fallback (prforgeReplierAPIFor) — and hand the thread work to
+// reviewReplyGateWithAPI. ok=false + reason for benign refusals; err only
+// for infra failure.
 func (s *Server) realWebhookPRForgeReviewReplyGate(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedReviewComment, botID string) (bool, string, string, error) {
-	token, terr := s.resolveForgeToken(ctx, cfg, botID)
-	if terr != nil || token == "" {
-		return false, "", "no forge token resolved (configure a forge_token binding)", nil
-	}
 	baseURL := strings.TrimSpace(cfg.ForgeBaseURL)
 	if baseURL == "" {
-		return false, "", "no forge base url on this webhook", nil
+		var refusal string
+		baseURL, refusal = prforgeBaseURLFromRef(p.PRURL)
+		if refusal != "" {
+			return false, "", refusal, nil
+		}
 	}
-	client := prforgeReplierClient(provider, s.forgeHTTPClient(), baseURL, token)
-	api, ok := client.(prforgeReviewThreadAPI)
+	api, apiRefusal := s.prforgeReplierAPIFor(ctx, cfg, provider, baseURL, p.ProjectPath, botID)
+	if apiRefusal != "" {
+		return false, "", "reply refused: " + apiRefusal, nil
+	}
+	thread, ok := api.(prforgeReviewThreadAPI)
 	if !ok {
 		return false, "", "review-thread conversations are not supported on this provider yet", nil
 	}
-	return s.reviewReplyGateWithAPI(ctx, cfg, p, api)
+	return s.reviewReplyGateWithAPI(ctx, cfg, p, thread)
 }
 
 // reviewReplyGateWithAPI is the token-free core of the reply gate — split

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -682,9 +682,13 @@ type fakeGitHubForge struct {
 	// granted, when set, is the installation's approved permission set: a
 	// mint asking for anything outside it (or above its level) is refused
 	// with GitHub's permissions-not-granted 422.
-	granted       map[string]string
-	mints         int
-	mintsBaseline int // mints that did NOT ask for statuses
+	granted map[string]string
+	// statusForbidden refuses the commit-status write for every MINTED token
+	// with GitHub's 403 "Resource not accessible by integration" — a grant
+	// revoked after the mint — while a hand-owned binding still writes.
+	statusForbidden bool
+	mints           int
+	mintsBaseline   int // mints that did NOT ask for statuses
 	// bearers records, per endpoint, the Authorization values the forge
 	// saw — the proof of WHICH credential served a call: the minted
 	// installation token (ghs_…) or the webhook's hand-owned binding.
@@ -814,7 +818,11 @@ func newFakeGitHubForge(t *testing.T) *fakeGitHubForge {
 		if f.revoked(w, r) {
 			return
 		}
-		if r.Header.Get("Authorization") == bearerNoStatuses {
+		f.mu.Lock()
+		statusForbidden := f.statusForbidden
+		f.mu.Unlock()
+		bearer := r.Header.Get("Authorization")
+		if bearer == bearerNoStatuses || (statusForbidden && strings.HasPrefix(bearer, "Bearer ghs_")) {
 			reply(w, http.StatusForbidden, map[string]any{"message": "Resource not accessible by integration"})
 			return
 		}

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -701,6 +701,9 @@ type fakeGitHubForge struct {
 	// counts those probes.
 	slug       string
 	appLookups int
+	// reviewComments is what the PR's review-comments listing answers
+	// (newest first, as GitHub serves direction=desc).
+	reviewComments []map[string]any
 }
 
 // appLookupCount returns how many times the App identity was probed.
@@ -833,6 +836,19 @@ func newFakeGitHubForge(t *testing.T) *fakeGitHubForge {
 		f.statuses = append(f.statuses, body)
 		f.mu.Unlock()
 		reply(w, http.StatusCreated, map[string]any{"id": 1})
+	})
+	mux.HandleFunc("GET /api/v3/repos/acme/widgets/pulls/7/comments", func(w http.ResponseWriter, r *http.Request) {
+		seen("review_comments", r)
+		if f.revoked(w, r) {
+			return
+		}
+		f.mu.Lock()
+		comments := f.reviewComments
+		f.mu.Unlock()
+		if comments == nil {
+			comments = []map[string]any{}
+		}
+		reply(w, http.StatusOK, comments)
 	})
 	mux.HandleFunc("POST /api/v3/repos/acme/widgets/issues/7/comments", func(w http.ResponseWriter, r *http.Request) {
 		seen("comment", r)

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -689,6 +689,17 @@ type fakeGitHubForge struct {
 	// answers 401 to — a binding whose token was revoked or rotated away
 	// while the webhook still pins it.
 	revokedBearer string
+	// slug is what GET /app (the App-JWT identity probe) answers; appLookups
+	// counts those probes.
+	slug       string
+	appLookups int
+}
+
+// appLookupCount returns how many times the App identity was probed.
+func (f *fakeGitHubForge) appLookupCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.appLookups
 }
 
 // revoked answers 401 when the request carries the revoked bearer.
@@ -708,7 +719,7 @@ const bearerNoStatuses = "Bearer ghs_nostatus"
 
 func newFakeGitHubForge(t *testing.T) *fakeGitHubForge {
 	t.Helper()
-	f := &fakeGitHubForge{perms: map[string]string{}, prAuthor: "alice", headSHA: "deadbeef1234", bearers: map[string][]string{}}
+	f := &fakeGitHubForge{perms: map[string]string{}, prAuthor: "alice", headSHA: "deadbeef1234", bearers: map[string][]string{}, slug: "iterion-forge-x"}
 	reply := func(w http.ResponseWriter, code int, v any) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(code)
@@ -742,6 +753,13 @@ func newFakeGitHubForge(t *testing.T) *fakeGitHubForge {
 			token = "ghs_nostatus"
 		}
 		reply(w, http.StatusCreated, map[string]any{"token": token, "expires_at": "2099-01-01T00:00:00Z"})
+	})
+	mux.HandleFunc("GET /api/v3/app", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.appLookups++
+		slug := f.slug
+		f.mu.Unlock()
+		reply(w, http.StatusOK, map[string]any{"id": 42, "slug": slug, "name": "iterion forge"})
 	})
 	mux.HandleFunc("GET /api/v3/user", func(w http.ResponseWriter, r *http.Request) {
 		seen("user", r)

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -679,8 +679,12 @@ type fakeGitHubForge struct {
 	// installation created before the merge gate, or one that declined
 	// statuses:write.
 	mintDenyStatuses bool
-	mints            int
-	mintsBaseline    int // mints that did NOT ask for statuses
+	// granted, when set, is the installation's approved permission set: a
+	// mint asking for anything outside it (or above its level) is refused
+	// with GitHub's permissions-not-granted 422.
+	granted       map[string]string
+	mints         int
+	mintsBaseline int // mints that did NOT ask for statuses
 	// bearers records, per endpoint, the Authorization values the forge
 	// saw — the proof of WHICH credential served a call: the minted
 	// installation token (ghs_…) or the webhook's hand-owned binding.
@@ -742,11 +746,20 @@ func newFakeGitHubForge(t *testing.T) *fakeGitHubForge {
 		if !asksStatuses {
 			f.mintsBaseline++
 		}
-		fail, denyStatuses := f.mintFail, f.mintDenyStatuses
+		fail, denyStatuses, granted := f.mintFail, f.mintDenyStatuses, f.granted
 		f.mu.Unlock()
 		if fail || (denyStatuses && asksStatuses) {
 			reply(w, http.StatusUnprocessableEntity, map[string]any{"message": "The permissions requested are not granted to this installation."})
 			return
+		}
+		if granted != nil {
+			for name, level := range req.Permissions {
+				got, ok := granted[name]
+				if !ok || (level == "write" && got != "write" && got != "admin") {
+					reply(w, http.StatusUnprocessableEntity, map[string]any{"message": "The permissions requested are not granted to this installation."})
+					return
+				}
+			}
 		}
 		token := "ghs_inst"
 		if denyStatuses {

--- a/pkg/webhooks/gitlab/events.go
+++ b/pkg/webhooks/gitlab/events.go
@@ -81,6 +81,13 @@ type ObjectAttributes struct {
 	// auto-launch a bot; the trigger is the update that clears it.
 	Draft          bool `json:"draft"`
 	WorkInProgress bool `json:"work_in_progress"`
+	// SourceProjectID / TargetProjectID name the projects the head and base
+	// branches live in; Source / Target carry those projects' own path and
+	// clone URL. On a fork MR the source is not the event's project.
+	SourceProjectID int64    `json:"source_project_id"`
+	TargetProjectID int64    `json:"target_project_id"`
+	Source          *Project `json:"source"`
+	Target          *Project `json:"target"`
 }
 
 type Commit struct {

--- a/pkg/webhooks/gitlab/fork_test.go
+++ b/pkg/webhooks/gitlab/fork_test.go
@@ -1,0 +1,63 @@
+package gitlab
+
+import (
+	"strings"
+	"testing"
+)
+
+// mrForkPayload is a merge_request event whose head branch lives in a FORK:
+// GitLab names both projects by id and carries the source project's own
+// path and clone URL under object_attributes.source.
+const mrForkPayload = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {
+    "iid": 11, "action": "open", "source_branch": "feature/fork", "target_branch": "main",
+    "title": "From a fork", "url": "https://gitlab.com/acme/widgets/-/merge_requests/11",
+    "last_commit": {"id": "forksha"},
+    "source_project_id": 9, "target_project_id": 42,
+    "source": {"id": 9, "path_with_namespace": "mallory/widgets", "git_http_url": "https://gitlab.com/mallory/widgets.git"},
+    "target": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"}
+  }
+}`
+
+// The MR event payload names the head project (source), so the fork guard
+// on the MR lane decides from the payload alone — as the GitHub/Forgejo
+// twin does from head.repo — and a refusal names the fork.
+func TestParseMergeRequest_ForkSourceProject(t *testing.T) {
+	p, err := ParseMergeRequest([]byte(mrForkPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.HeadRepoFullName != "mallory/widgets" || p.HeadCloneURL != "https://gitlab.com/mallory/widgets.git" {
+		t.Fatalf("head = %q clone=%q, want the source project the payload names", p.HeadRepoFullName, p.HeadCloneURL)
+	}
+	if p.SourceProjectID != 9 || p.TargetProjectID != 42 {
+		t.Fatalf("project ids = %d/%d, want 9/42", p.SourceProjectID, p.TargetProjectID)
+	}
+	if p.SameRepoAsBase() || !p.IsFork() {
+		t.Fatalf("a payload naming two projects is a PROVEN fork: same=%v fork=%v", p.SameRepoAsBase(), p.IsFork())
+	}
+
+	same := strings.Replace(mrForkPayload, `"source_project_id": 9`, `"source_project_id": 42`, 1)
+	same = strings.Replace(same, `"source": {"id": 9, "path_with_namespace": "mallory/widgets", "git_http_url": "https://gitlab.com/mallory/widgets.git"}`,
+		`"source": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"}`, 1)
+	q, err := ParseMergeRequest([]byte(same))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !q.SameRepoAsBase() || q.IsFork() || q.HeadRepoFullName != "acme/widgets" {
+		t.Fatalf("a same-project payload must prove same-repo: %+v", q)
+	}
+
+	// A payload without the source (a legacy sender) proves nothing: not
+	// same-repo, but not a fork either — unknown is unproven, not refused
+	// as a fork.
+	legacy, err := ParseMergeRequest([]byte(mrOpenPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.HeadRepoFullName != "" || legacy.SameRepoAsBase() || legacy.IsFork() {
+		t.Fatalf("a payload without source/target must stay unproven: %+v", legacy)
+	}
+}

--- a/pkg/webhooks/gitlab/parser.go
+++ b/pkg/webhooks/gitlab/parser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
 )
 
 // Parsed is the normalized merge-request view the handler consumes.
@@ -44,6 +46,33 @@ type Parsed struct {
 	// gesture on GitLab versions that predate the re_requested attribute —
 	// and the fallback trigger when it is absent.
 	AddedReviewers []string
+	// HeadRepoFullName is the project the MR's head branch lives in, as the
+	// payload names it (object_attributes.source) — a fork's own on a fork
+	// MR. Empty when the payload carries no source project; SameRepoAsBase
+	// reads empty as NOT proven.
+	HeadRepoFullName string
+	// HeadCloneURL is the head project's clone URL when the payload names it.
+	HeadCloneURL string
+	// SourceProjectID / TargetProjectID are the project ids the payload
+	// carries (0 = absent). Two different ids are a fork whatever the paths
+	// say.
+	SourceProjectID int64
+	TargetProjectID int64
+}
+
+// SameRepoAsBase reports whether the head branch is PROVEN to live in the
+// event's own project — the contract of forge.PullRef.SameRepoAs: an empty
+// head is never proven.
+func (p Parsed) SameRepoAsBase() bool { return forge.SameRepo(p.HeadRepoFullName, p.ProjectPath) }
+
+// IsFork reports a PROVEN fork: the payload names two different projects
+// for the head and the base (by id, else by path). A payload naming neither
+// is unproven — not same-repo, but not a fork either.
+func (p Parsed) IsFork() bool {
+	if p.SourceProjectID > 0 && p.TargetProjectID > 0 {
+		return p.SourceProjectID != p.TargetProjectID
+	}
+	return p.HeadRepoFullName != "" && !p.SameRepoAsBase()
 }
 
 // ParseMergeRequest decodes a GitLab merge_request webhook body.
@@ -89,6 +118,15 @@ func ParseMergeRequest(body []byte) (Parsed, error) {
 			}
 		}
 	}
+	// The head project: the payload's source when it names one; otherwise
+	// the event's own project when the ids prove the MR is same-project.
+	head, headClone := "", ""
+	if oa.Source != nil {
+		head, headClone = oa.Source.PathWithNamespace, oa.Source.GitHTTPURL
+	}
+	if head == "" && oa.SourceProjectID > 0 && oa.SourceProjectID == oa.TargetProjectID {
+		head, headClone = e.Project.PathWithNamespace, e.Project.GitHTTPURL
+	}
 	return Parsed{
 		ProjectID:      e.Project.ID,
 		ProjectPath:    e.Project.PathWithNamespace,
@@ -113,6 +151,11 @@ func ParseMergeRequest(body []byte) (Parsed, error) {
 
 		ReRequestedReviewers: reRequested,
 		AddedReviewers:       added,
+
+		HeadRepoFullName: head,
+		HeadCloneURL:     headClone,
+		SourceProjectID:  oa.SourceProjectID,
+		TargetProjectID:  oa.TargetProjectID,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #711. Closes #710. Closes #717. Closes #708. Closes #728.

Follow-ups of #809 on the GitHub-App client and the webhook lanes, each red first.

## #711 — the App's real slug, one client per connection
`WhoAmI` returned `github-app[bot]` when `AppSlug` was empty, so the anti-loop actor guard compared against a login that never posts, and `forgeAdminFor` built a fresh `AppClient` per call (every lane minted again). Now the slug is resolved once from `GET /app` (App JWT), memoised, persisted on the connection (`AppSlug`, `AccountLogin` repaired from `[bot]`) and refreshed by the worker; `WhoAmI` errors instead of inventing a login. One client per connection id, cached with a fingerprint of everything it is built from (tenant, base URL, installation, OAuth app, status, slug, App id, `sha256(PEM)[:8]`, granted-permission set) — recomputed on every `forgeAdminFor`, so a re-synced grant, rotated key, status flip or moved installation replaces the entry; explicit eviction on delete and on the forced refresh route. Red: `the App's own comment launched a run (code=202)`; `mints after the second delivery = 6, want 3`. Green, plus `GET /app probes across two deliveries = 1`.

## #710 — the management token is minted from the recorded grant
`rest()` minted the constant baseline (+ `statuses:write`): a connection whose installation granted a strict subset 422'd on every mint (the approve lane fell to "filtered"). Now `ManagementPermissionsFor(a.Granted)` = baseline ∩ recorded grant, the names the narrowing dropped pre-recorded in `denied`, the statuses retry only when the grant covers it. Deviation, stated: a dedicated `ManagementPermissionsFor` rather than `RuntimePermissionsFor` — a management token must not carry `workflows:write`/`packages` just because the run token may. Mint-callers table in the commit body: the manifest ceiling stays constant by design; the per-op profiles stay minimum sets (a grant lacking one must 422 into the typed `PermissionError`, never be narrowed into a token that cannot do the op); the run-token mints were already narrowed.

## #717 — a 403 on the status write arms the preflight
`denied` was written only at mint time; a token minted WITH statuses that later got a 403 never armed the binding fallback. `SetCommitStatus` / `ListCommitStatuses` return the typed refusal and the App wrappers record the denial for the token's remaining life. Red: `PreflightFor(statuses) after the 403 = <nil>`, `bearers=[ghs_inst ghs_inst]` (fallback never taken). Green.

## #708 — the review-thread reply gate reads through the covering connection
Was token-only. Now resolved via `prforgeReplierAPIFor` (connection first, binding fallback, refusal named in the delivery row); `AppClient.ListPRReviewComments` mints `pull_requests:read` + `metadata:read`. Red: `code=200 body={"status":"filtered"} launched=0` on a connection-only team. Green.

## #728 — a GitLab fork MR names its source project
The adapter resolves `source_project_id` through the connection's client (`GET /projects/:id` → `path_with_namespace` + `http_url_to_repo`, cached per instance for 1 h) on every MR read path; 404/403 = unproven (refused as before), other errors surface. The webhook parser decodes the project ids (`Parsed.IsFork`, `SameRepoAsBase`); the MR-open lane filters a PROVEN fork with a reason naming it; the command-lane refusal names the fork's project; `PullRef.HeadCloneURL` plumbed on all three providers. Deviation, stated: no lane SERVES a fork — none did before either; this makes the head resolvable and named and brings the GitLab MR lane to parity, running a fork's code stays a trust decision.

## Verification
`go build ./...` · `go test ./pkg/forge/... ./pkg/server/... ./pkg/webhooks/... -count=1` ok · `go test -race ./pkg/forge/... ./pkg/webhooks/... ./pkg/server/ -count=1` ok · `task lint` 0 issues · `task openapi:check` exit 0 (connection record regenerated). Untouched: `boarddispatch.go`, `board_project.go`, `bots/**`, `forge_gate_reconcile.go`, `forge_gate_pause_notice.go`, `forge_publish.go`, `launchScheduledBot`.

## Left as separate findings (filed)
A `WhoAmI` error silently skips the loop guard (`webhooks_prforge.go`); `BlockForkPRs` is persisted and read by no lane; the converse lane launches on the base project's clone URL with the fork's branch name (safe only because unproven heads are refused); a `TempDir` cleanup flake in `TestProcessBoardCardCarriesPRLaunchContext` (an orphan-run reconcile writes after the test returns); the #812 items unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
