### PR TITLE
fix(server): a publish grant must belong to the run that carries it

### DIFF
--- a/pkg/server/forge_gate_autofix.go
+++ b/pkg/server/forge_gate_autofix.go
@@ -140,6 +140,13 @@ func (s *Server) autofixForRun(ctx context.Context, ev trigger.Event) error {
 	if !ok {
 		return nil
 	}
+	// The grant must be the RUN's own. This lane's blast radius is the widest
+	// of the three readers: it launches a code-pushing bot INTO grant.TeamID,
+	// on that team's budget and against that team's repo — so a run carrying
+	// another tenant's grant would spend and push as that tenant.
+	if !s.runOwnsGrant(run, grant, "gate auto-fix") {
+		return nil
+	}
 	host, repo, number, err := forge.ParsePullURL(prURL)
 	if err != nil {
 		return nil

--- a/pkg/server/forge_gate_dlq_notice.go
+++ b/pkg/server/forge_gate_dlq_notice.go
@@ -84,6 +84,12 @@ func (s *Server) gateNoticeTarget(ctx context.Context, run *store.Run, what stri
 		s.gateNoticeDebug(run, what, "its publish grant is expired or revoked")
 		return gateNoticeTarget{}, false
 	}
+	// The grant must be the RUN's own: every scope check below proves the
+	// grant self-consistent, and one minted for another tenant passes them
+	// all. runOwnsGrant speaks for itself (Warn + audit).
+	if !s.runOwnsGrant(run, grant, what) {
+		return gateNoticeTarget{}, false
+	}
 	host, repo, number, err := forge.ParsePullURL(prURL)
 	if err != nil {
 		s.gateNoticeDebug(run, what, "its pr_url does not parse: %v", err)

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -279,6 +279,15 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 		// longer than that, or the token store lost it.
 		return abstain("its publish grant is expired or revoked")
 	}
+	// The grant must be the RUN's own before any of its scope is trusted: the
+	// checks below prove it self-consistent, and one minted for another tenant
+	// passes every one of them while aiming this repair — a REQUIRED commit
+	// status — at that tenant's pull request under that tenant's identity.
+	// Not routed through abstain(): a tenant crossing is a security refusal,
+	// always loud, never quieted to Debug on a sweep pass.
+	if !s.runOwnsGrant(run, grant, "gate reconcile") {
+		return nil
+	}
 
 	// Holding a grant is NOT owing a verdict. The server mints one for any bot
 	// launched with a pr_url — the brancher, the docs amender, the implementer

--- a/pkg/server/forge_grant_tenant_test.go
+++ b/pkg/server/forge_grant_tenant_test.go
@@ -1,0 +1,335 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/audit"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// waitForTenantAudit polls a tenant's audit trail for an action — the inserts
+// are detached (goSafe), so they land shortly after the refusal.
+func waitForTenantAudit(t *testing.T, st audit.Store, tenantID, action string) []audit.Event {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		evs, err := st.ListByTenant(context.Background(), tenantID, audit.Page{})
+		if err != nil {
+			t.Fatalf("list %s audit: %v", tenantID, err)
+		}
+		var hits []audit.Event
+		for _, e := range evs {
+			if e.Action == action {
+				hits = append(hits, e)
+			}
+		}
+		if len(hits) > 0 {
+			return hits
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no %s audit row on tenant %q (got %d rows)", action, tenantID, len(evs))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A publish grant is minted for ONE tenant, at that tenant's own launch. The
+// token is a launch VAR, and injectForgePublishVars honours a caller-pinned
+// one — so a run of tenant B can end up carrying a grant minted for tenant A,
+// and every reader that acts on a grant would then speak through tenant A's
+// connection, under tenant A's forge identity: a comment on tenant A's pull
+// request, a REQUIRED commit status on it, and — on the auto-fix lane — a
+// code-pushing bot launched into tenant A on tenant A's money.
+//
+// The rule is one comparison at every reader that holds a run: the grant must
+// belong to the run's own tenant.
+func TestForgeGrant_ForeignTenantRefusedByTheGateReaders(t *testing.T) {
+	// gateReconcileFixture mints the grant for team1 on conn1/team1; the run
+	// below claims to belong to someone else.
+	const foreign = "team-b"
+
+	build := func(t *testing.T, runTenant string) (*Server, string, *listingGateClient, *stubCommenter) {
+		t.Helper()
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		s.auditStore = audit.NewMemoryStore()
+		c := &stubCommenter{}
+		s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) { return c, nil }
+		run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.TenantID = runTenant
+		run.Status = store.RunStatusFailedResumable
+		run.FailureCode = store.FailureDLQParked
+		at := time.Now().UTC().Add(time.Hour)
+		run.RetryState = &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"}
+		run.Error = "rate_limited: You've hit your weekly limit"
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		return s, runID, gc, c
+	}
+	loadRun := func(t *testing.T, s *Server, runID string) *store.Run {
+		t.Helper()
+		run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return run
+	}
+
+	t.Run("the DLQ notice posts nothing", func(t *testing.T) {
+		s, runID, _, c := build(t, foreign)
+		s.noticeGateDLQParked(context.Background(), loadRun(t, s, runID))
+		if len(c.bodies) != 0 {
+			t.Fatalf("commented on another tenant's pull request under its own identity: %v", c.bodies)
+		}
+		if rows := waitForTenantAudit(t, s.auditStore, foreign, auditActionGrantTenantMismatch); len(rows) != 1 {
+			t.Fatalf("want exactly one audit row, got %d", len(rows))
+		}
+	})
+
+	t.Run("the pause notice posts nothing", func(t *testing.T) {
+		s, runID, _, c := build(t, foreign)
+		s.noticeGatePausedForRetry(context.Background(), loadRun(t, s, runID))
+		if len(c.bodies) != 0 {
+			t.Fatalf("commented on another tenant's pull request under its own identity: %v", c.bodies)
+		}
+		waitForTenantAudit(t, s.auditStore, foreign, auditActionGrantTenantMismatch)
+	})
+
+	t.Run("the reconciler writes no commit status", func(t *testing.T) {
+		s, runID, gc, _ := build(t, foreign)
+		run := loadRun(t, s, runID)
+		run.FailureCode, run.RetryState = "", nil
+		run.Status = store.RunStatusFailed
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 0 {
+			t.Fatalf("wrote %d commit statuses on another tenant's required check (last: %q %q)",
+				gc.setCalls, gc.last.State, gc.last.Description)
+		}
+		waitForTenantAudit(t, s.auditStore, foreign, auditActionGrantTenantMismatch)
+	})
+
+	// The audit row names the two tenants and the surface, and NEVER the
+	// token — an audit trail that leaks the credential is a second incident.
+	t.Run("the audit row names the tenants, never the token", func(t *testing.T) {
+		s, runID, _, _ := build(t, foreign)
+		s.noticeGateDLQParked(context.Background(), loadRun(t, s, runID))
+		ev := waitForTenantAudit(t, s.auditStore, foreign, auditActionGrantTenantMismatch)[0]
+		if ev.TenantID != foreign || ev.TargetID != runID {
+			t.Fatalf("row = tenant %q target %q, want the RUN's tenant and id", ev.TenantID, ev.TargetID)
+		}
+		if ev.Meta["grant_tenant"] != "team1" {
+			t.Fatalf("meta = %v, want the grant's tenant named", ev.Meta)
+		}
+		for k, v := range ev.Meta {
+			if s, ok := v.(string); ok && s == "tok-gate" {
+				t.Fatalf("the audit row carries the token in %q", k)
+			}
+		}
+	})
+
+	// The run's OWN grant still works — the rule refuses a foreign grant, not
+	// every grant.
+	t.Run("a grant of the run's own tenant still posts", func(t *testing.T) {
+		s, runID, _, c := build(t, "team1")
+		s.noticeGateDLQParked(context.Background(), loadRun(t, s, runID))
+		if len(c.bodies) != 1 {
+			t.Fatalf("the run's own grant must still post, got %d comments", len(c.bodies))
+		}
+	})
+
+	// A filesystem store never stamps a tenant on a run (only the Mongo twin
+	// does), so a self-hosted single-tenant deployment states none — and a
+	// deployment with one tenant has no second tenant to protect. Refusing
+	// there would silence the gate on every such install.
+	t.Run("a run that states no tenant is not refused", func(t *testing.T) {
+		s, runID, _, c := build(t, "")
+		s.noticeGateDLQParked(context.Background(), loadRun(t, s, runID))
+		if len(c.bodies) != 1 {
+			t.Fatalf("a tenant-less run must keep working, got %d comments", len(c.bodies))
+		}
+	})
+}
+
+// The auto-fix lane has the widest blast radius of the three readers: it
+// launches a code-pushing bot INTO the grant's team, on that team's budget and
+// against that team's repository. A run of another tenant carrying the grant
+// must not reach it.
+func TestForgeGrant_ForeignTenantRefusedByTheAutofixLane(t *testing.T) {
+	const (
+		team   = "t1"
+		repo   = "acme/widgets"
+		prURL  = "https://github.com/acme/widgets/pull/7"
+		head   = "cafe1234cafe1234cafe1234cafe1234cafe1234"
+		gateNm = "iterion/review"
+	)
+	build := func(t *testing.T, runTenant string) (*Server, string, *int) {
+		t.Helper()
+		s := newWebhookTestServer(t)
+		s.cfg.WorkDir = writeConsumerBotFixture(t, "fixer-bot", "prior_review")
+		s.auditStore = audit.NewMemoryStore()
+		rs, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.Store = rs
+
+		conns := forge.NewMemoryConnectionStore()
+		if err := conns.Create(context.Background(), forge.Connection{
+			ID: "c1", TenantID: team, Provider: forge.ProviderGitHub,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeConnections = conns
+		s.forgePublishTokens = NewForgePublishTokenRegistry()
+		registerPublishToken(t, s, "run-token", ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo})
+
+		ints := forge.NewMemoryRepoIntegrationStore()
+		if err := ints.Create(context.Background(), forge.RepoIntegration{
+			ID: "i1", TenantID: team, ConnectionID: "c1", RepoFullName: repo,
+			BotIDs: []string{"fixer-bot"}, WebhookID: "w1", AutoFixOnGateFailure: true,
+			LaunchVars: map[string]string{gateContextVar: gateNm},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeIntegrations = ints
+		if err := s.webhookConfigs.Create(context.Background(), webhooks.Config{
+			ID: "w1", TenantID: team, BotIDs: []string{"fixer-bot"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+			return stubGateClient{head: head, state: forge.CommitStateFailure, ctxName: gateNm}, nil
+		}
+		launched := 0
+		s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+			launched++
+			return "run-fixer", nil
+		}
+
+		id, err := store.GenerateRunID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := rs.CreateRun(context.Background(), id, "reviewer-bot", map[string]any{
+			"pr_url": prURL, "gate_context": gateNm, "head_sha": head,
+			forgePublishVarToken: "run-token",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.BotID = "reviewer-bot"
+		run.Status = store.RunStatusFinished
+		run.TenantID = runTenant
+		if err := rs.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		return s, run.ID, &launched
+	}
+
+	t.Run("a foreign grant launches nothing", func(t *testing.T) {
+		s, runID, launched := build(t, "team-b")
+		s.autofixOffer(context.Background(), runID)
+		if *launched != 0 {
+			t.Fatalf("launched %d code-pushing runs into another tenant", *launched)
+		}
+		rows := waitForTenantAudit(t, s.auditStore, "team-b", auditActionGrantTenantMismatch)
+		if len(rows) != 1 {
+			t.Fatalf("want exactly one audit row, got %d", len(rows))
+		}
+		if got := rows[0].Meta["surface"]; got != "gate auto-fix" {
+			t.Fatalf("meta surface = %v, want the lane named", got)
+		}
+	})
+
+	t.Run("the run's own tenant still launches", func(t *testing.T) {
+		s, runID, launched := build(t, team)
+		s.autofixOffer(context.Background(), runID)
+		if *launched != 1 {
+			t.Fatalf("the lane must still fire for the run's own tenant, launched %d", *launched)
+		}
+	})
+}
+
+// The earliest door: a launch may pin its own forge_publish_token, and
+// injectForgePublishVars honours the pin rather than overwriting it. A pin
+// that resolves to ANOTHER tenant's grant is refused there, before the run
+// exists — the run would otherwise carry a credential the publish endpoint
+// authenticates on its own (that endpoint holds no run, so the token IS the
+// authority there and it cannot tell).
+func TestInjectForgePublishVars_RefusesAForeignPinnedGrant(t *testing.T) {
+	newServer := func(t *testing.T) *Server {
+		t.Helper()
+		s, _ := newForgePublishTestServer(t)
+		s.cfg.PublicURL = "https://iterion.test"
+		registerPublishToken(t, s, "tok-team1", ForgePublishGrant{
+			TeamID: "team1", ConnectionID: "conn1", Repo: "o/r", Bot: "review-pr",
+		})
+		return s
+	}
+	prVars := func(token string) map[string]string {
+		return map[string]string{"pr_url": "https://github.com/o/r/pull/42", forgePublishVarToken: token}
+	}
+
+	t.Run("another tenant's grant is refused, nothing launches", func(t *testing.T) {
+		s := newServer(t)
+		_, err := s.injectForgePublishVars(context.Background(), "team-b", "", "review-pr", prVars("tok-team1"), nil)
+		if err == nil {
+			t.Fatal("a pinned grant of another tenant was accepted — the run would publish as that tenant")
+		}
+		if !errors.Is(err, errForgePublishGrantTenant) {
+			t.Fatalf("err = %v, want the typed refusal so the HTTP lane answers 422", err)
+		}
+		if strings.Contains(err.Error(), "tok-team1") {
+			t.Fatalf("the refusal leaks the token: %v", err)
+		}
+	})
+
+	t.Run("the launch door propagates it", func(t *testing.T) {
+		s := newServer(t)
+		_, err := s.applyPRLaunchContext(context.Background(), "team-b", "", "review-pr", prVars("tok-team1"), nil)
+		if !errors.Is(err, errForgePublishGrantTenant) {
+			t.Fatalf("applyPRLaunchContext err = %v, want the typed refusal", err)
+		}
+	})
+
+	t.Run("a run pinning its OWN tenant's grant keeps it", func(t *testing.T) {
+		s := newServer(t)
+		out, err := s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", prVars("tok-team1"), nil)
+		if err != nil {
+			t.Fatalf("a team's own grant must be honoured: %v", err)
+		}
+		if out[forgePublishVarToken] != "tok-team1" {
+			t.Fatalf("the pin was overwritten: %q", out[forgePublishVarToken])
+		}
+	})
+
+	// An UNRESOLVABLE pin is not a tenant crossing: the in-memory registry is
+	// emptied by a restart, so refusing it would turn a stale token into a
+	// failed launch instead of a run that merely cannot publish. It stays
+	// honoured, and the publish endpoint answers 401.
+	t.Run("an unknown token is not refused", func(t *testing.T) {
+		s := newServer(t)
+		out, err := s.injectForgePublishVars(context.Background(), "team-b", "", "review-pr", prVars("tok-gone"), nil)
+		if err != nil {
+			t.Fatalf("an unresolvable pin must not fail the launch: %v", err)
+		}
+		if out[forgePublishVarToken] != "tok-gone" {
+			t.Fatalf("the pin was overwritten: %q", out[forgePublishVarToken])
+		}
+	})
+}

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -69,12 +69,75 @@ type ForgePublishGrant struct {
 	TeamID       string `json:"team_id"`
 	ConnectionID string `json:"connection_id"`
 	Repo         string `json:"repo"`
-	// Bot identifies WHICH workflow this grant was minted for. The server
-	// mints a grant for any bot launched with a pr_url, so the bot id is what
-	// separates "this run owed a merge-gate verdict" from "this run merely
-	// carried a token it never used" — see forge_gate_reconcile.go.
+	// Bot names the bot this grant was minted for. It is the FALLBACK record
+	// of which bot to relaunch when a gating run dies: the recovery reads the
+	// run's own BotID first and falls back here (gateRelaunchBotID), because
+	// an inline .bot launch persists none — and the answer is part of the
+	// relaunch claim key, so it decides whether a second death on a head is
+	// the same bot's or a peer's.
+	//
+	// It is NOT what decides that a run owed a verdict: the reconciler anchors
+	// on the repo's pinned gate_context, because a repo shares one context
+	// across several gating bots on purpose (see forge_gate_reconcile.go).
 	Bot       string    `json:"bot,omitempty"`
 	ExpiresAt time.Time `json:"-"`
+}
+
+// grantTenantMismatchReason is the typed refusal a publish grant earns when
+// it does not belong to the run carrying it. Named so a log line, an audit
+// row and a test all say the same word.
+const grantTenantMismatchReason = "grant_tenant_mismatch"
+
+// auditActionGrantTenantMismatch is the audit action the refusal records on
+// the RUN's tenant — the tenant whose run tried to speak as another.
+const auditActionGrantTenantMismatch = "forge.grant.tenant_mismatch"
+
+// runOwnsGrant proves a publish grant belongs to the run that carries it, and
+// is the ONE place that decides it: every reader holding a run funnels through
+// here, so the rule cannot hold at one surface and not the next.
+//
+// It exists because the grant token is a launch VAR. The scope checks each
+// reader already performs prove the grant is SELF-consistent — its connection
+// belongs to its team, its repo matches the pull request, its host matches the
+// connection — and a grant minted for another tenant passes every one of them.
+// What none of them asks is whether that tenant is the run's. Unasked, a run
+// carrying another tenant's token has iterion comment on that tenant's pull
+// request, post its REQUIRED commit status, and — on the auto-fix lane —
+// launch a code-pushing bot into that tenant, all under that tenant's forge
+// identity and against its budget.
+//
+// A run that states NO tenant is not refused: only the Mongo store stamps one
+// (store/mongo.stampTenant), so a filesystem-backed single-tenant deployment
+// states none — and a deployment with one tenant has no second tenant to
+// protect. A run that DOES state one must match exactly; a grant that names no
+// tenant fails that comparison, which is correct, since a cloud connection
+// always has one.
+//
+// Loud on every refusal, on purpose: a Warn (never the token — an audit trail
+// that leaks the credential is a second incident) plus an audit row on the
+// run's own tenant, so the team whose run attempted the crossing sees it. The
+// sweep re-offers a dead run for its whole lookback, so an unresolved refusal
+// repeats; that is the intended shape — a crossing that persists must stay
+// visible — and the rows collapse in one query on the run id.
+func (s *Server) runOwnsGrant(run *store.Run, grant ForgePublishGrant, what string) bool {
+	if run == nil {
+		return false
+	}
+	runTenant := strings.TrimSpace(run.TenantID)
+	if runTenant == "" || strings.EqualFold(runTenant, strings.TrimSpace(grant.TeamID)) {
+		return true
+	}
+	if s.logger != nil {
+		s.logger.Warn("forge gate: %s for run %s refused (%s): the run belongs to tenant %q but its publish grant was minted for tenant %q — nothing posted",
+			what, run.ID, grantTenantMismatchReason, runTenant, grant.TeamID)
+	}
+	s.auditSystem(runTenant, "forge-gate", auditActionGrantTenantMismatch, "run", run.ID, map[string]any{
+		"reason":       grantTenantMismatchReason,
+		"grant_tenant": grant.TeamID,
+		"grant_repo":   grant.Repo,
+		"surface":      what,
+	})
+	return false
 }
 
 // ForgePublishTokenStore is the per-run forge-publish token registry. The
@@ -236,6 +299,11 @@ func (s *Server) handleForgePublishReview(w http.ResponseWriter, r *http.Request
 		httpError(w, http.StatusUnauthorized, "unknown or expired run token")
 		return
 	}
+	// No runOwnsGrant here, and that is the contract rather than an omission:
+	// the request names no run — the token IS the authority on this endpoint —
+	// so there is no run tenant to compare the grant against. The crossing is
+	// refused where both facts exist instead, at injectForgePublishVars, which
+	// is why a run can never be handed a grant of another team to present here.
 
 	var req publishReviewRequest
 	r.Body = http.MaxBytesReader(w, r.Body, 2<<20)
@@ -601,55 +669,72 @@ const (
 //
 // preferredConnID pins the connection (repo-targeted launches); empty falls
 // back to the team's repo integrations, then to a connection host match.
-func (s *Server) injectForgePublishVars(ctx context.Context, teamID, preferredConnID, botID string, vars map[string]string, r *http.Request) map[string]string {
+//
+// A caller-pinned token is honoured rather than overwritten — but only for the
+// launching team. The publish endpoint holds no run, so there the token IS the
+// authority and it cannot tell whose run presents it; this is the only place
+// the two facts (which team launches, which team the grant names) are both in
+// hand, which makes it the door. A pin resolving to ANOTHER team's grant is
+// refused and nothing launches.
+//
+// An UNRESOLVABLE pin is not a crossing and stays honoured: the default token
+// registry is in-memory, so a restart empties it, and refusing there would
+// turn a stale token into a failed launch instead of a run that merely cannot
+// publish (the endpoint answers 401).
+func (s *Server) injectForgePublishVars(ctx context.Context, teamID, preferredConnID, botID string, vars map[string]string, r *http.Request) (map[string]string, error) {
 	if s == nil || s.forgePublishTokens == nil || s.forgeConnections == nil {
-		return vars
+		return vars, nil
 	}
 	prURL := strings.TrimSpace(vars["pr_url"])
 	if prURL == "" {
-		return vars
+		return vars, nil
 	}
-	if strings.TrimSpace(vars[forgePublishVarToken]) != "" {
+	if pinned := strings.TrimSpace(vars[forgePublishVarToken]); pinned != "" {
+		if grant, ok := s.forgePublishTokens.lookup(pinned); ok &&
+			!strings.EqualFold(strings.TrimSpace(grant.TeamID), strings.TrimSpace(teamID)) {
+			return vars, fmt.Errorf("%w: the launch pins a forge publish grant minted for team %q, but this launch belongs to team %q",
+				errForgePublishGrantTenant, grant.TeamID, teamID)
+		}
 		// The caller pinned its own grant — don't overwrite.
-		return vars
+		return vars, nil
 	}
 	base := s.publicBaseURL(r)
 	if base == "" {
 		if s.logger != nil {
 			s.logger.Warn("forge publish: no public base URL (set PublicURL); deterministic review publishing disabled for this launch")
 		}
-		return vars
+		return vars, nil
 	}
 	host, repo, _, err := forge.ParsePullURL(prURL)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("forge publish: %v; deterministic review publishing disabled for this launch", err)
 		}
-		return vars
+		return vars, nil
 	}
 	conn, ok := s.forgeConnectionForPR(ctx, teamID, preferredConnID, host, repo)
 	if !ok {
 		if s.logger != nil {
 			s.logger.Warn("forge publish: no team %s connection covers %s/%s; deterministic review publishing disabled for this launch", teamID, host, repo)
 		}
-		return vars
+		return vars, nil
 	}
 	token := newBoardMCPToken()
 	if token == "" {
-		return vars
+		return vars, nil
 	}
 	if err := s.forgePublishTokens.Register(token, ForgePublishGrant{TeamID: teamID, Bot: strings.TrimSpace(botID), ConnectionID: conn.ID, Repo: repo}); err != nil {
 		if s.logger != nil {
 			s.logger.Error("forge publish: %v; deterministic review publishing disabled for this launch", err)
 		}
-		return vars
+		return vars, nil
 	}
 	if vars == nil {
 		vars = map[string]string{}
 	}
 	vars[forgePublishVarURL] = base + "/api/v1/forge/publish-review"
 	vars[forgePublishVarToken] = token
-	return vars
+	return vars, nil
 }
 
 // applyPRLaunchContext gives a launch that targets a pull request the two
@@ -704,8 +789,13 @@ func (s *Server) applyPRLaunchContext(ctx context.Context, teamID, preferredConn
 			preferredConnID = conn.ID
 		}
 	}
-	return s.injectForgePublishVars(ctx, teamID, preferredConnID, botID, vars, r), nil
+	return s.injectForgePublishVars(ctx, teamID, preferredConnID, botID, vars, r)
 }
+
+// errForgePublishGrantTenant marks a launch that pinned a forge publish grant
+// belonging to another team — the operator's request is inadmissible, not a
+// forge that could not be asked, so the HTTP lane answers 422.
+var errForgePublishGrantTenant = errors.New("forge publish grant tenant mismatch")
 
 // errPRLaunchForkGuard marks a launch the fork guard refused — the operator's
 // pull request is not admissible, as opposed to a forge that could not be

--- a/pkg/server/forge_publish_test.go
+++ b/pkg/server/forge_publish_test.go
@@ -240,14 +240,20 @@ func TestInjectForgePublishVars(t *testing.T) {
 
 	// No pr_url → untouched.
 	vars := map[string]string{"base_ref": "main"}
-	out := s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", vars, nil)
+	out, err := s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", vars, nil)
+	if err != nil {
+		t.Fatalf("no pr_url: %v", err)
+	}
 	if _, ok := out[forgePublishVarToken]; ok {
 		t.Fatal("no pr_url: nothing must be injected")
 	}
 
 	// pr_url on the connection's host → grant minted + vars injected.
 	vars = map[string]string{"pr_url": "https://github.com/o/r/pull/42"}
-	out = s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", vars, nil)
+	out, err = s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", vars, nil)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
 	if out[forgePublishVarURL] != "https://iterion.example/api/v1/forge/publish-review" {
 		t.Fatalf("url var = %q", out[forgePublishVarURL])
 	}
@@ -261,13 +267,19 @@ func TestInjectForgePublishVars(t *testing.T) {
 	}
 
 	// Another team without a matching connection → untouched.
-	out = s.injectForgePublishVars(context.Background(), "team2", "", "review-pr", map[string]string{"pr_url": "https://github.com/o/r/pull/42"}, nil)
+	out, err = s.injectForgePublishVars(context.Background(), "team2", "", "review-pr", map[string]string{"pr_url": "https://github.com/o/r/pull/42"}, nil)
+	if err != nil {
+		t.Fatalf("no matching team connection: %v", err)
+	}
 	if _, ok := out[forgePublishVarToken]; ok {
 		t.Fatal("no matching team connection: nothing must be injected")
 	}
 
 	// A PR on a host no connection covers → untouched.
-	out = s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", map[string]string{"pr_url": "https://gitlab.example/g/p/-/merge_requests/1"}, nil)
+	out, err = s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", map[string]string{"pr_url": "https://gitlab.example/g/p/-/merge_requests/1"}, nil)
+	if err != nil {
+		t.Fatalf("host mismatch: %v", err)
+	}
 	if _, ok := out[forgePublishVarToken]; ok {
 		t.Fatal("host mismatch: nothing must be injected")
 	}

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -1184,7 +1184,28 @@ func (s *Server) launchWebhookTarget(
 	// carries a pr_url var — mint a per-run publish grant scoped to the
 	// webhook's tenant so the bot's deterministic publish node posts
 	// through the server's live forge client (never a workspace token).
-	vars = s.injectForgePublishVars(ctx, cfg.TenantID, "", botID, vars, r)
+	vars, verr := s.injectForgePublishVars(ctx, cfg.TenantID, "", botID, vars, r)
+	if verr != nil {
+		// The only refusal here is a launch pinning another team's publish
+		// grant (errForgePublishGrantTenant): the run would carry a
+		// credential that speaks as that team. The delivery row is already
+		// claimed, so it is marked failed like a launch that could not
+		// start — a redelivery re-enters, and the operator's pin still
+		// refuses until it is corrected.
+		failedAt := s.gateNow()
+		delivery.Status = webhooks.StatusLaunchError
+		delivery.Error = verr.Error()
+		delivery.FailedAt = &failedAt
+		s.updateWebhookDelivery(ctx, delivery)
+		s.markWebhookOutcome(cfg.Provider, webhooks.StatusLaunchError)
+		adm.rollback(s.logger)
+		out.Status = webhooks.StatusLaunchError
+		out.Error = verr.Error()
+		out.DeliveryID = delivery.ID
+		out.attempts = delivery.Attempts
+		out.httpStatus = http.StatusUnprocessableEntity
+		return out
+	}
 	// meta.ProjectPath is the forge slug already parsed by the provider
 	// handler — thread it onto the launch so the run is filterable by
 	// repository in the studio.


### PR DESCRIPTION
Closes #825. Follow-up to #824.

`gateNoticeTarget` (both gate notices) and the reconciler's grant walk validated that a `ForgePublishGrant` is self-consistent — repo, tenant, host, expiry — but never that it belongs to the RUN's tenant, and `injectForgePublishVars` honours a caller-pinned `forge_publish_token`. An operator of team B holding a team-A token string could have iterion comment on a PR and post a **required commit status** through team A's connection, under team A's identity; the auto-fix lane could launch a code-pushing bot into team A on team A's budget.

## One rule, one helper
`runOwnsGrant(run, grant, what)` (`pkg/server/forge_publish.go`): a grant whose `TeamID` differs from the run's `TenantID` is refused with the typed reason `grant_tenant_mismatch`, a Warn naming run id / run tenant / grant tenant (never the token), and an `auditSystem` row `forge.grant.tenant_mismatch` on the RUN's tenant (`{reason, grant_tenant, grant_repo, surface}`). Wired at every reader that holds a run:

| reader | blast radius | now |
|---|---|---|
| `gateNoticeTarget` (DLQ + quota-pause notices) | comment on another tenant's PR under its identity | guarded |
| reconciler grant walk (`forge_gate_reconcile.go`) | writes the required commit status | guarded, not routed through `abstain()` — a crossing is always loud |
| auto-fix lane (`forge_gate_autofix.go`) | launches a code-pushing bot into `grant.TeamID` on that team's budget | guarded |
| gate relaunch (`d.grant`) | relaunch into `d.grant.TeamID` | covered: every `deadGateRun` is built downstream of the check |
| HTTP publish endpoint | the token IS the authority, no run in hand | out of class by contract (written down); closed at launch instead |

**Empty-tenant decision, with evidence**: a run that states no tenant is not refused — only the Mongo twin stamps `Run.TenantID`; the filesystem store never does, so a self-hosted install states none and has no second tenant to protect. A run that DOES state one must match exactly, which also rejects a grant naming no tenant.

## The door closes at launch too
`injectForgePublishVars` refuses a pinned `forge_publish_token` that resolves to another team's grant (typed `errForgePublishGrantTenant` → the HTTP lane answers **422**, the webhook tail marks the delivery `launch_error` and rolls back the metered admission). Evidence: the grant record carries `TeamID`; the launching team is in hand at both call sites; nothing machine-generated pins the var (grep) and `handleResumeRun` does not re-inject; the board lane cannot carry it. Deliberately not tightened: an unresolvable pin (unknown/expired token — the registry is in-memory, a restart empties it) stays honoured; the run merely cannot publish (401), not a tenant crossing.

`ForgePublishGrant.Bot`: comment fixed to what the code does (which bot to relaunch; NOT what decides a run owed a verdict — the reconciler anchors on the shared `gate_context` by design).

## Tests (red first — failing line, then green)
`TestForgeGrant_ForeignTenantRefusedByTheGateReaders` (6 subtests; red: `commented on another tenant's PR under its own identity`, `wrote 1 commit statuses on another tenant's required check`, `no forge.grant.tenant_mismatch audit row`; positive controls: own tenant still posts, no-tenant run still posts), `TestForgeGrant_ForeignTenantRefusedByTheAutofixLane` (red: `launched 1 code-pushing runs into another tenant`), `TestInjectForgePublishVars_RefusesAForeignPinnedGrant` (4 subtests; red: `a pinned grant of another tenant was accepted`, `applyPRLaunchContext err = <nil>, want the typed refusal`; asserts the message never contains the token). `go build ./...` · `go test ./pkg/server/... ./pkg/audit/...` ok · `task lint` 0 issues · `task openapi:check` exit 0.

## Left as separate findings
#826 (the publish-token registry can saturate and orphan a claimed gate; a grant lives ~10 days past its run because `Revoke` is never called).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
