### PR TITLE
fix(server,cloudpublisher): the board dispatcher launches through the org gate, a run no credential tier can fund is refused at publish, and a launch give-up reaches the needs-attention lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,10 @@ the hours this one spent.
   with one call instead of a k8s-secret edit + redeploy — and the
   one-credential activation of the campaign bots' **cross-model plan
   review** (provision the codex OAuth forfait → `plan_review` resolves
-  `on` at the next launch, nothing else to configure).
+  `on` at the next launch, nothing else to configure) — and
+  `ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL`, which refuses at publish (HTTP
+  `422`, a board give-back) a run no tier can fund instead of queueing one
+  that dies at its first call.
 - [docs/web-search.md](docs/web-search.md) — sovereign web search tiers
   (SearXNG → Firecrawl) + the `ITERION_WEB_SEARCH` resolver.
 - [docs/credential-pool.md](docs/credential-pool.md) — mutualising

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -378,22 +378,30 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("server: %w", err)
 	}
+	// Refuse at publish a run no credential tier can fund, instead of
+	// queueing one that fails at its first LLM call. Off by default: the
+	// runner may still fund a run from its pod's ambient env.
+	requireLLMCredential, err := envBoolStrict("ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL")
+	if err != nil {
+		return fmt.Errorf("server: %w", err)
+	}
 	pub, err := cloudpublisher.New(cloudpublisher.Config{
-		NATS:             natsConn,
-		Store:            st,
-		MongoColl:        st.RunsCollection(),
-		Logger:           logger,
-		Metrics:          mreg,
-		ApiKeys:          stores.apiKeys,
-		GenericSecrets:   stores.genericSecrets,
-		BotBindings:      stores.botBindings,
-		RunSecrets:       stores.runSecrets,
-		Sealer:           sealer,
-		OAuthForfait:     stores.oauth,
-		ForgeConnections: stores.forgeConn,
-		Identity:         authStack.identityStore,
-		PluginSources:    newPluginSourceResolver(stores, pluginFetcher, logger),
-		CredPool:         credBroker,
+		RequireLLMCredential: requireLLMCredential,
+		NATS:                 natsConn,
+		Store:                st,
+		MongoColl:            st.RunsCollection(),
+		Logger:               logger,
+		Metrics:              mreg,
+		ApiKeys:              stores.apiKeys,
+		GenericSecrets:       stores.genericSecrets,
+		BotBindings:          stores.botBindings,
+		RunSecrets:           stores.runSecrets,
+		Sealer:               sealer,
+		OAuthForfait:         stores.oauth,
+		ForgeConnections:     stores.forgeConn,
+		Identity:             authStack.identityStore,
+		PluginSources:        newPluginSourceResolver(stores, pluginFetcher, logger),
+		CredPool:             credBroker,
 		// The fleet's shared meter: a forfait the provider has refused is
 		// skipped at launch so the run falls through to the next
 		// credential tier instead of parking for a reset it could have
@@ -1204,4 +1212,18 @@ func buildOIDCRegistry(cfg iterconfig.Config) *oidc.Registry {
 		registry.Register(oidc.NewGenericConnector(cfg.Auth.OIDC.Generic.IssuerURL, cfg.Auth.OIDC.Generic.ClientID, cfg.Auth.OIDC.Generic.ClientSecret, cfg.Auth.OIDC.Generic.DisplayName, cfg.Auth.OIDC.Generic.Scopes))
 	}
 	return registry
+}
+
+// envBoolStrict reads a boolean env knob: unset or empty is false, and a
+// value strconv cannot parse refuses the boot rather than reading as off.
+func envBoolStrict(name string) (bool, error) {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return false, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("%s=%q: want a boolean (1/0, true/false)", name, v)
+	}
+	return b, nil
 }

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -115,6 +115,25 @@ OpenAI's ChatGPT-forfait has never had an equivalent restriction.
   `tokens.account_id`, and when it is false the forfait is silently skipped.
   Re-run `codex login` with "Sign in with ChatGPT" and upload the file
   unedited.
+- **A run with no credential at all is QUEUED, not refused, by default.**
+  The publisher logs one Warn (`no credential resolved for run=… tiers
+  consulted: byok, oauth-forfait, pool, platform`) and the runner falls
+  back to its pod's ambient env — or fails at the first LLM call, a pod
+  and some minutes after the launch was accepted.
+  `ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL=1` (server env) refuses such a
+  run at publish time instead: HTTP `422` with `error_code:
+  NO_LLM_CREDENTIAL` naming the providers to provision, and on the board
+  a launch refusal retried with the dispatcher's backoff
+  ([dispatcher.md](dispatcher.md)). The rule is **per route**, read
+  through the same walk the credential stamp uses: only a run whose
+  EVERY LLM route pins a provider the deployment knows (a `provider/`
+  model prefix or a `provider:` hint) and NONE of them is funded by any
+  tier is refused; one funded pinned provider is enough, and a route the
+  walk cannot attribute (a `claude_code` node with no `model:`, `auto`, a
+  hint outside the vocabulary such as `kimi-code/…`) is never refused,
+  because the runner may still fund it from its env. Turn it on when the
+  runner deployment carries no ambient LLM env — then a credential-less
+  run can never start, and refusing it early is free information.
 
 ## Ingestion gate — what a `400` on provisioning means
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -304,6 +304,19 @@ one attempt per backoff, not one per 5s tick, and queues behind the
 cards not tried yet (its `updated_at` moves). The server draining
 consumes no attempt: another replica claims the card on its next tick.
 
+The **org launch gate** is one of these refusals. The board launch passes
+the same admission as an HTTP launch — `gateLaunch`: suspend →
+concurrency → launch rate → monthly caps
+([quotas-and-limits.md](quotas-and-limits.md#which-surfaces-are-gated)) —
+under the `board-dispatcher` identity on the card's team, and is metered
+the same way (the monthly slot is handed back when the run service then
+refuses). A denial reads on the ledger as `launch gate: <rule>:
+<detail>` — `concurrency_cap_exceeded` while the org is at its cap,
+`monthly_run_quota_exceeded` once the month's runs are spent — and costs
+one attempt like any other refusal. So does a run the publisher refuses
+for want of an LLM credential (`ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL`,
+[cloud-llm-credentials.md](cloud-llm-credentials.md#gotchas-that-cost-real-time)).
+
 After `ITERION_BOARD_LAUNCH_ATTEMPTS` consecutive refusals (default 8,
 about an hour and a half of retries; an unparsable value keeps the
 default and is logged once at startup) the card is filed `blocked` under
@@ -312,7 +325,10 @@ on its ledger and a give-up stamp naming it — reflected onto a bound
 external board on purpose: a human has to decide now. A successful
 launch (any run stamped on the card) clears the ledger, and so does an
 operator's *Reopen*, so a card reopened after the cap starts its retries
-afresh.
+afresh. The pipeline board shows a card filed this way in its **Needs
+attention** lane — the give-up stamp carries `launch: true`, so it needs
+no run to be current, and a card nobody could launch is not filed among
+the done ones.
 
 Each verdict is logged **once per card and reason**, and every watchdog
 pass logs one tally line — `N refused at admission, M returned to their

--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -8,8 +8,11 @@ here come from real fields on real records — not aspirational settings.
 Iterion enforces five distinct limits at run launch and one at the
 webhook intake. They live behind a single decision function
 ([pkg/server/launch_gate.go:gateLaunch](../pkg/server/launch_gate.go))
-called by every code path that creates a run: launch / resume /
-inbound webhook.
+called by every code path that creates a run on a cloud instance: the
+HTTP launch and resume, the inbound webhooks, the retry sweeper's
+automatic resumes and the board dispatcher's launches — the table in
+[Which surfaces are gated](#which-surfaces-are-gated) is the exhaustive
+list, with the two paths that still launch outside it.
 
 ## The launch-admission order
 
@@ -36,6 +39,39 @@ wedge every launch — quotas are an operator policy, not a hard security
 boundary. The one nuance: when `AllowRun` errors at step 5 the launch
 still proceeds **unmetered** (logged WARN) instead of being denied; the
 denial path is only the deliberate "this would exceed the cap" case.
+
+## Which surfaces are gated
+
+Every launch a cloud instance performs passes `gateLaunch` with the
+identity of whoever is launching, meters one monthly run at step 5, and
+hands the slot back when the run service then refuses the launch (a
+sealing failure, a queue outage, a bot that does not compile — no run
+exists, so nothing was consumed):
+
+| Surface | Identity on the ctx | Gated | Metered |
+|---|---|---|---|
+| `POST /api/runs`, the studio, `iterion remote runs launch`, the MCP `remote_runs_launch` | the caller's | yes | yes, rolled back on a refused launch |
+| `POST /api/runs/{id}/resume`, the WS answer that resumes a run | the caller's | yes | yes |
+| Inbound webhooks, direct launch (`insertAndLaunchWebhook`) — including the merge-gate auto-fix and relaunch lanes, which reuse that tail | the token's synthetic `webhook` identity | yes | yes, rolled back on a refused launch and for the idempotency loser |
+| Inbound webhooks, **board mode** (the command creates a card; the dispatcher launches it) | the token's | pre-check only, at card creation | **no** — a card is not a run; the pre-check's slot is handed back at once and the dispatcher meters the launch when it claims the card |
+| **Board dispatcher** (`processBoardCard`) | `board-dispatcher` on the card's team | yes | yes, rolled back on a refused launch |
+| Retry sweeper (automatic resume of a `failed_resumable` run) | the run's owner | yes | yes, rolled back on a failed resume |
+| `POST /api/v1/triggers/emit` (custom event) | the caller's | once per request | once per request — the launches it fans out to go through the spine launcher below |
+| Trigger spine direct launches (`serviceLauncher`: `mode: direct` board triggers, run-completion chains, the emit fan-out) | store tenant only, no auth identity | **no** | no |
+| `cloudsched` scheduled launches (`launchScheduledBot`) | store tenant only, no auth identity | **no** | no |
+| Local mode (`iterion studio` / `iterion dispatch` with no identity store) | — | no gate exists | — |
+
+On the board dispatcher a denial is a **launch refusal** of the
+dispatcher's transient class, not a verdict on the card
+([dispatcher.md](dispatcher.md#claim-selection-on-the-cloud-board--what-is-never-claimed)):
+the card returns to its column under the machine provenance
+`launch_refused`, its ledger reads the rule that refused it — `launch
+gate: concurrency_cap_exceeded: org has 3 active runs (cap 3) …` — and
+the next attempt waits out the backoff, so an org at its cap retries its
+ready cards on the backoff schedule, not on every 5s tick. A cap that
+does not free within the attempt cap files the card `blocked` under
+`launch_given_up` with the rule on it, and the pipeline board shows it
+in its *Needs attention* lane.
 
 ## Limits, fields and platform defaults
 

--- a/openapi.json
+++ b/openapi.json
@@ -979,6 +979,9 @@
           "attempts": {
             "type": "integer"
           },
+          "launch": {
+            "type": "boolean"
+          },
           "reason": {
             "type": "string"
           },

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -812,6 +812,17 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	} else if !got.GaveUp.Current(got.State, "run-1") {
 		t.Errorf("stamp does not describe the issue it was written on: state=%q stamp=%+v", got.State, got.GaveUp)
 	}
+	// A LAUNCH give-up (the launch attempt cap) names no run; the marker must
+	// round-trip too, or the stamp reads as run-bound and the needs-attention
+	// lane loses the card on the next read.
+	if err := store.SetGaveUp(created.ID, &native.GiveUp{State: current.State, Attempts: 8, Reason: "refused 8 times", Launch: true}); err != nil {
+		t.Errorf("SetGaveUp(launch): %v", err)
+	}
+	if got, err := store.Get(created.ID); err != nil {
+		t.Errorf("Get after SetGaveUp(launch): %v", err)
+	} else if got.GaveUp == nil || !got.GaveUp.Launch || !got.GaveUp.Current(got.State, "") {
+		t.Errorf("launch give-up not persisted as such: %+v", got.GaveUp)
+	}
 	// Moving the ticket expires the stamp for good — both stores enforce it
 	// on their write path, or a returning ticket would resurrect a give-up.
 	if _, err := store.SetState(created.ID, native.StateBlocked); err != nil {

--- a/pkg/dispatcher/native/giveup_launch_test.go
+++ b/pkg/dispatcher/native/giveup_launch_test.go
@@ -1,0 +1,54 @@
+package native
+
+import "testing"
+
+// A launch give-up (the launch attempt cap) names no run: it is current for
+// the card in the state it wrote, whatever run — if any — the card points
+// at. A run give-up stays bound to its run id.
+func TestGiveUpCurrent_LaunchGiveUpIsBoundToTheStateNotARun(t *testing.T) {
+	launch := &GiveUp{State: StateBlocked, Attempts: 8, Launch: true}
+	if !launch.Current(StateBlocked, "") {
+		t.Error("a launch give-up must be current with no run at all")
+	}
+	if !launch.Current(StateBlocked, "run-old") {
+		t.Error("a launch give-up must be current whatever run the card points at")
+	}
+	if launch.Current(StateReady, "") {
+		t.Error("a give-up never describes a card that left the state it wrote")
+	}
+	run := &GiveUp{State: StateBlocked, RunID: "run-1", Attempts: 3}
+	if !run.Current(StateBlocked, "run-1") || run.Current(StateBlocked, "run-2") || run.Current(StateBlocked, "") {
+		t.Error("a run give-up must stay bound to its run id")
+	}
+	if SameGiveUp(launch, &GiveUp{State: StateBlocked, Attempts: 8}) {
+		t.Error("Launch is part of a stamp's identity: a launch give-up and a run give-up are not the same stamp")
+	}
+}
+
+// The filesystem twin round-trips the marker (the Mongo twin is pinned by the
+// conformance suite): a stamp that lost it on disk would fall back to the
+// run-bound rule and vanish from the needs-attention lane on the next read.
+func TestStoreSetGaveUp_LaunchStampRoundTrips(t *testing.T) {
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	created, err := s.Create(Issue{Title: "never launched", State: StateReady})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.SetState(created.ID, StateBlocked); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetGaveUp(created.ID, &GiveUp{State: StateBlocked, Attempts: 8, Reason: "refused 8 times", Launch: true}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.GaveUp == nil || !got.GaveUp.Launch || !got.GaveUp.Current(got.State, "") {
+		t.Fatalf("launch give-up not persisted as such: %+v", got.GaveUp)
+	}
+}

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -207,6 +207,11 @@ type GiveUp struct {
 	// is gone. Operator-facing (rendered on the pipeline board); a
 	// retry-budget give-up leaves it empty and reads by Attempts.
 	Reason string `json:"reason,omitempty"`
+	// Launch marks a give-up written before any run existed: the launch
+	// attempt cap (see LaunchRefusal). Such a stamp names no run, so it is
+	// current for the card in its state whatever run — if any — the card
+	// points at; a run give-up stays bound to its RunID.
+	Launch bool `json:"launch,omitempty"`
 	// At is when the give-up was stamped (UTC).
 	At time.Time `json:"at"`
 }
@@ -241,10 +246,15 @@ func (r *LaunchRefusal) Clone() *LaunchRefusal {
 // A stamp with no run id never matches: it cannot be attributed to the card
 // being rendered, and guessing is how the lane got confusing in the first place.
 func (g *GiveUp) Current(issueState, runID string) bool {
-	if g == nil || g.RunID == "" {
+	if g == nil || g.State != issueState {
 		return false
 	}
-	return g.State == issueState && g.RunID == runID
+	// A launch give-up names no run: the card in its state is the whole
+	// subject, whatever run — if any — it points at.
+	if g.Launch {
+		return true
+	}
+	return g.RunID != "" && g.RunID == runID
 }
 
 // ExternalRef links a board card to an issue on an external forge. Set by

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -382,7 +382,7 @@ func SameGiveUp(a, b *GiveUp) bool {
 	if a == nil || b == nil {
 		return a == nil && b == nil
 	}
-	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts && a.Reason == b.Reason
+	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts && a.Reason == b.Reason && a.Launch == b.Launch
 }
 
 // AddComment appends a note to the issue's discussion thread and returns

--- a/pkg/runview/credential_error.go
+++ b/pkg/runview/credential_error.go
@@ -1,0 +1,15 @@
+package runview
+
+import "errors"
+
+// NoLLMCredentialErrorCode is the stable API code a launch or resume answers
+// with when the cloud publisher refused it for want of an LLM credential.
+const NoLLMCredentialErrorCode = "NO_LLM_CREDENTIAL"
+
+// ErrNoLLMCredential is the publish-time refusal of a run that cannot start:
+// every LLM route it may take pins a provider the deployment knows, and no
+// credential tier holds one for any of them. Wrapped by the cloud publisher
+// (with the providers and the tiers consulted) when the deployment opts in;
+// a run the runner could still fund from its pod's ambient env is never
+// refused with it. A launch refusal, not a run failure: no run exists.
+var ErrNoLLMCredential = errors.New("no LLM credential for this run")

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/dispatcher"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
@@ -98,9 +99,12 @@ var errCardContinuable = errors.New("board dispatcher: run continuable")
 //     bot the resolver cannot find, carries malformed reserved bot-args, or
 //     the run service is not wired. Card back to its column, claim freed,
 //     one Warn per (card, reason) edge.
-//   - errCardLaunchRefused — the run service refused the launch before any
-//     run existed (a sealing failure, a queue outage, the server draining,
-//     a bot that does not compile, an invalid spec): transient, retryable.
+//   - errCardLaunchRefused — the launch was refused before any run existed:
+//     by the org launch gate (`launch gate: <rule>: <detail>` — the same
+//     admission every other surface passes) or by the run service (a
+//     sealing failure, a queue outage, the server draining, a bot that does
+//     not compile, an invalid spec, a run no credential tier can fund):
+//     transient, retryable.
 //     Card back to its column under the machine ReasonLaunchRefused, the
 //     card's launch-refusal ledger advanced (the dispatch listing skips it
 //     for a backoff), one Warn per (card, reason) edge — and past the
@@ -114,9 +118,14 @@ var errCardContinuable = errors.New("board dispatcher: run continuable")
 //     card stays where it is; the retry machinery or the operator continues.
 //   - a cancelled parent context — this replica is draining → the card
 //     stays where it is, the claim is released.
-//   - anything else — the run was launched and ended in a terminal failure,
-//     or the publisher refused the launch (quota, sealing, …) → `blocked`.
+//   - anything else — the run was launched and ended in a terminal failure
+//     → `blocked`: the run's verdict.
 var errCardUnlaunchable = errors.New("board dispatcher: card cannot be launched")
+
+// boardDispatcherActor is the identity the cloud dispatcher launches under:
+// the store owner on every ctx it stamps and the auth principal the launch
+// gate meters on the card's team.
+const boardDispatcherActor = "board-dispatcher"
 
 // errCardLaunchRefused marks a launch the run service refused before any run
 // started — see the taxonomy above. Typed at the ONE boundary where it is
@@ -422,6 +431,7 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 					State:    d.blockedState,
 					Attempts: ledger.Attempts,
 					Reason:   fmt.Sprintf("the launch was refused %d times; last refusal: %s", ledger.Attempts, ledger.LastReason),
+					Launch:   true,
 				}
 				kind = heldLaunchGivenUp
 			}
@@ -1729,7 +1739,7 @@ func (s *Server) boardRunStatus(ctx context.Context, tenant, runID string) (stor
 	if s.runs == nil {
 		return "", errors.New("run service unavailable")
 	}
-	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
 	run, err := s.runs.LoadRunCtx(ctx, runID)
 	if err != nil {
 		return "", err
@@ -1744,7 +1754,7 @@ func (s *Server) boardRun(ctx context.Context, tenant, runID string) (*store.Run
 	if s.runs == nil {
 		return nil, errors.New("run service unavailable")
 	}
-	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
 	return s.runs.LoadRunCtx(ctx, runID)
 }
 
@@ -1759,7 +1769,7 @@ func (s *Server) boardIssueRuns(ctx context.Context, tenant, issueID string) ([]
 	if rs == nil {
 		return nil, errors.New("run store unavailable")
 	}
-	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
 	ids, err := rs.ListRunsBySourceIssue(ctx, issueID)
 	if err != nil {
 		return nil, err
@@ -1790,7 +1800,7 @@ func (s *Server) boardLaunchPreconditions(ctx context.Context, tenant string, is
 	if iss.Bot == "" {
 		return nil, boardLaunchContext{}, fmt.Errorf("card %s has no bot: %w", iss.ID, errCardUnlaunchable)
 	}
-	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
 	lb, err := s.resolveBotSource(ctx, iss.Bot)
 	if err != nil {
 		return nil, boardLaunchContext{}, fmt.Errorf("card %s names bot %q: %w: %w", iss.ID, iss.Bot, err, errCardUnlaunchable)
@@ -1828,7 +1838,7 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 		return err
 	}
 	defer lb.Cleanup()
-	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
 	// A card that targets a pull request also needs the repo's launch policy
 	// and a publish grant, neither of which can ride the card itself — and it
 	// passes the fork guard at CLAIM time: a head repo can vanish between
@@ -1858,8 +1868,21 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 		},
 	}
 	lb.Stamp(&spec)
+	// The SAME admission every other launch surface passes — suspend →
+	// concurrency → launch rate → monthly caps — under the dispatcher's own
+	// identity on the card's team (the gate reads the team from it). A
+	// denial is a launch refusal of the class below: no run exists, the
+	// card goes back under machine provenance with the rule on its ledger,
+	// and the retry waits out the backoff. The metered admission is handed
+	// back when the run service then refuses, as the HTTP handler does: a
+	// run that never started consumes no monthly slot.
+	adm, deny := s.gateLaunch(auth.WithIdentity(ctx, auth.Identity{TeamID: tenant, UserID: boardDispatcherActor}))
+	if deny != nil {
+		return &launchRefusal{cardID: iss.ID, cause: deny.err()}
+	}
 	res, err := s.runs.Launch(ctx, spec)
 	if err != nil {
+		adm.rollback(s.logger)
 		// Every error out of Launch means no run was started — the class is
 		// decidable here, at the boundary, without reading the error's text.
 		return &launchRefusal{cardID: iss.ID, cause: err}

--- a/pkg/server/boarddispatch_launchgate_test.go
+++ b/pkg/server/boarddispatch_launchgate_test.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/orgusage"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The board dispatcher launches through the SAME admission gate as every
+// other launch surface (#841): suspend → concurrency → launch rate → monthly
+// caps, metered like an HTTP launch and rolled back when the run service then
+// refuses. A denial is a launch refusal of the ordinary class (#814): the card
+// goes back to its column under machine provenance, the rule that refused it
+// on the ledger, and the retry waits out the backoff.
+
+// countingPublisher accepts or refuses every launch and counts the attempts —
+// the oracle for "the run service was never asked" on a gate denial. onLaunch
+// runs with the run id the service chose, so a test can materialise the run
+// the way a runner pod would.
+type countingPublisher struct {
+	mu       sync.Mutex
+	launches int
+	err      error
+	onLaunch func(runID string)
+}
+
+func (p *countingPublisher) SubmitLaunch(_ context.Context, runID string, _ runview.LaunchSpec, _ *ir.Workflow, _ string) (int, error) {
+	p.mu.Lock()
+	p.launches++
+	p.mu.Unlock()
+	if p.onLaunch != nil {
+		p.onLaunch(runID)
+	}
+	return 0, p.err
+}
+func (p *countingPublisher) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.launches
+}
+func (*countingPublisher) CancelRun(context.Context, string) error { return nil }
+func (*countingPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
+	return nil
+}
+func (*countingPublisher) SubmitResume(context.Context, runview.ResumeSpec, *ir.Workflow, string) error {
+	return nil
+}
+
+const boardGateProbeBot = "schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"yes\"}'`\n  output: probe_out\n\nworkflow board_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n"
+
+// newGatedBoardServer is a cloud-shaped server: an identity store with one
+// org+team seeded per spec (so the gate has a team to read), a bot catalog
+// holding the tool-only probe bot, and a run service whose publisher is the
+// caller's. The run store is returned so a test can play the runner pod.
+func newGatedBoardServer(t *testing.T, spec gateSpec, pub *countingPublisher) (*Server, *store.FilesystemRunStore) {
+	t.Helper()
+	s := newOrgTestServer(t)
+	seedGate(t, s, spec)
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(boardGateProbeBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+	return s, rs
+}
+
+// TestProcessBoardCard_GateDenialIsALaunchRefusal: an org at its concurrency
+// cap — the run service is never asked, the error is the launch-refusal class
+// carrying the gate's typed denial, and the reason that reaches the card's
+// ledger names the rule.
+func TestProcessBoardCard_GateDenialIsALaunchRefusal(t *testing.T) {
+	pub := &countingPublisher{}
+	s, rs := newGatedBoardServer(t, gateSpec{id: "t1", maxConcurrentRuns: 1}, pub)
+	s.cfg.Store = fakeActiveStore{RunStore: rs, active: 1}
+
+	err := s.processBoardCard(boundedCtx(t), "t1", native.Issue{ID: "native:1", Bot: "probe", State: native.StateReady})
+	if !errors.Is(err, errCardLaunchRefused) {
+		t.Fatalf("processBoardCard = %v, want errCardLaunchRefused — a gate denial launches nothing, so no verdict belongs on the card", err)
+	}
+	var deny *launchDeniedError
+	if !errors.As(err, &deny) || deny.Reason != denyConcurrencyCap {
+		t.Fatalf("the refusal does not carry the gate's typed denial: %v", err)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("the run service was asked %d time(s) after a gate denial, want 0", got)
+	}
+	if reason := launchRefusalReason(err); !strings.Contains(reason, denyConcurrencyCap) {
+		t.Errorf("ledger reason = %q, want it to name the gate rule %q", reason, denyConcurrencyCap)
+	}
+}
+
+// TestProcessBoardCard_AdmittedLaunchIsMetered: the board's launch consumes
+// a monthly run slot exactly like an HTTP launch — and only when the run
+// service accepted it; a refused launch hands the slot back (the HTTP
+// handler's rollback, on this surface too).
+func TestProcessBoardCard_AdmittedLaunchIsMetered(t *testing.T) {
+	t.Run("refused launch releases the slot", func(t *testing.T) {
+		pub := &countingPublisher{err: errors.New("cloudpublisher: seal run bundle: kms unavailable")}
+		s, _ := newGatedBoardServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+		err := s.processBoardCard(boundedCtx(t), "t1", native.Issue{ID: "native:1", Bot: "probe", State: native.StateReady})
+		if !errors.Is(err, errCardLaunchRefused) {
+			t.Fatalf("processBoardCard = %v, want errCardLaunchRefused", err)
+		}
+		if got := pub.count(); got != 1 {
+			t.Fatalf("the run service was asked %d time(s), want 1 — the gate admitted this launch", got)
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 0 {
+			t.Errorf("monthly runs = %d after a refused launch, want 0 — a run that never started must not consume a slot", u.Runs)
+		}
+	})
+	t.Run("accepted launch keeps the slot", func(t *testing.T) {
+		pub := &countingPublisher{}
+		s, rs := newGatedBoardServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+		pub.onLaunch = func(runID string) { finishRunAs(t, rs, runID, store.RunStatusFinished) }
+		if err := s.processBoardCard(boundedCtx(t), "t1", native.Issue{ID: "native:1", Bot: "probe", State: native.StateReady}); err != nil {
+			t.Fatalf("processBoardCard = %v, want nil for a finished run", err)
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 1 {
+			t.Errorf("monthly runs = %d after an accepted launch, want 1", u.Runs)
+		}
+	})
+}
+
+// boundedCtx keeps a launch that WAS admitted from polling a run nobody
+// finishes for the test's whole timeout: a pre-fix run fails on its
+// assertion instead of hanging.
+func boundedCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// finishRunAs plays the runner pod for a cloud launch: the publisher owns the
+// run record in production, so the test materialises it in the service's
+// store at the given terminal status and the dispatcher's poll sees it end.
+func finishRunAs(t *testing.T, rs *store.FilesystemRunStore, runID string, st store.RunStatus) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := rs.CreateRun(ctx, runID, "board_probe", nil); err != nil {
+		t.Fatalf("CreateRun(%s): %v", runID, err)
+	}
+	run, err := rs.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun(%s): %v", runID, err)
+	}
+	run.Status = st
+	if err := rs.SaveRun(ctx, run); err != nil {
+		t.Fatalf("SaveRun(%s): %v", runID, err)
+	}
+}
+
+// TestBoardDispatcher_GateDenialKeepsTheCardReadyUntilTheCapFrees, end to
+// end through the dispatcher: an org at its concurrency cap → the card stays
+// `ready`, no run, machine provenance, the rule on its ledger, one Warn; the
+// cap frees → the next eligible tick launches it.
+func TestBoardDispatcher_GateDenialKeepsTheCardReadyUntilTheCapFrees(t *testing.T) {
+	pub := &countingPublisher{}
+	s, rs := newGatedBoardServer(t, gateSpec{id: "t1", maxConcurrentRuns: 1}, pub)
+	s.cfg.Store = fakeActiveStore{RunStore: rs, active: 1}
+	f := newFakeBoardCoord(readyCard("native:1", "probe"))
+	var buf bytes.Buffer
+	d := newBoardDispatcher(f, s.processBoardCard, "replica-A", 4, iterlog.New(iterlog.LevelWarn, &buf))
+
+	before := time.Now()
+	d.tick(boundedCtx(t))
+	d.wg.Wait()
+	if got := f.states["native:1"]; got != native.StateReady {
+		t.Errorf("a gate denial ended the card in %q, want %q — the column it was taken from", got, native.StateReady)
+	}
+	if got := f.reasons["native:1"]; got != tracker.ReasonLaunchRefused {
+		t.Errorf("the give-back carried provenance %q, want %q", got, tracker.ReasonLaunchRefused)
+	}
+	rec := f.refusals["native:1"]
+	if rec == nil || rec.Attempts != 1 || !rec.NotBefore.After(before) || !strings.Contains(rec.LastReason, denyConcurrencyCap) {
+		t.Fatalf("launch-refusal ledger = %+v, want attempts=1, a NotBefore in the future and the gate rule as reason", rec)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("the run service was asked %d time(s) while the org was at its cap, want 0", got)
+	}
+	if len(f.claimed) != 0 {
+		t.Errorf("the claim must be freed after the give-back: %v", f.claimed)
+	}
+	if _, stamped := f.gaveUps["native:1"]; stamped {
+		t.Error("a single denial stamped a give-up — that is the attempt cap's job")
+	}
+	if got := linesMentioning(buf.String(), "native:1"); got != 1 {
+		t.Errorf("the denial was logged %d time(s), want exactly 1:\n%s", got, buf.String())
+	}
+
+	// The cap frees and the backoff elapses: the next tick claims the card
+	// again and this time the run service is asked.
+	s.cfg.Store = fakeActiveStore{RunStore: rs, active: 0}
+	pub.onLaunch = func(runID string) { finishRunAs(t, rs, runID, store.RunStatusFinished) }
+	f.mu.Lock()
+	f.refusals["native:1"].NotBefore = time.Now().Add(-time.Second)
+	f.mu.Unlock()
+	d.tick(boundedCtx(t))
+	d.wg.Wait()
+	if got := pub.count(); got != 1 {
+		t.Fatalf("the run service was asked %d time(s) once the cap freed, want 1", got)
+	}
+	if f.claimCalls != 2 {
+		t.Errorf("Claim was attempted %d time(s) over the two ticks, want 2", f.claimCalls)
+	}
+	if got := f.states["native:1"]; got != d.doneState {
+		t.Errorf("after the launch the card is %q, want %q", got, d.doneState)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -135,6 +135,16 @@ type Config struct {
 	// back to the team key and an org-level monthly cost cap can never
 	// accumulate against the org document.
 	Identity TeamResolver
+	// RequireLLMCredential refuses, at publish time, a run that cannot
+	// possibly start: one whose every LLM route pins a provider iterion
+	// knows and for which no tier (BYOK, OAuth forfait, pool, platform)
+	// holds a credential. Off by default: the runner legitimately proceeds
+	// on its pod's ambient env when the bundle carries nothing (see
+	// runner.Config.SecretsRef semantics), so refusing is a deployment
+	// decision — ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL. A route the walk
+	// cannot attribute (no model prefix, no provider hint, `auto`, a hint
+	// outside the vocabulary) is never refused, on or off.
+	RequireLLMCredential bool
 }
 
 // TeamResolver is the slice of the identity store the publisher needs
@@ -154,26 +164,27 @@ type Publisher struct {
 	// maxPayload reports the NATS server-negotiated max message size so
 	// the offload path can size a RunMessage against it. Nil (the default
 	// in unit tests) disables IR offload — the message is published as-is.
-	maxPayload     func() int64
-	store          store.RunStore
-	runs           *mongo.Collection
-	logger         *iterlog.Logger
-	metrics        *metrics.Registry
-	apiKeys        secrets.ApiKeyStore
-	genericSecrets secrets.GenericSecretStore
-	botBindings    secrets.BotSecretBindingStore
-	runSecrets     secrets.RunSecretsStore
-	sealer         secrets.Sealer
-	oauthForfait   secrets.OAuthStore
-	forgeConns     forge.ConnectionStore
-	pluginSources  *pluginsource.Resolver
-	sandboxImage   func(context.Context) string
-	credPool       *credpool.Broker
-	usageCaps      usagecap.Store
-	capPolicy      usagecap.PolicySource
-	trust          usagecap.Trust
-	usageProbe     UsageProbe
-	identity       TeamResolver
+	maxPayload           func() int64
+	store                store.RunStore
+	runs                 *mongo.Collection
+	logger               *iterlog.Logger
+	metrics              *metrics.Registry
+	apiKeys              secrets.ApiKeyStore
+	genericSecrets       secrets.GenericSecretStore
+	botBindings          secrets.BotSecretBindingStore
+	runSecrets           secrets.RunSecretsStore
+	sealer               secrets.Sealer
+	oauthForfait         secrets.OAuthStore
+	forgeConns           forge.ConnectionStore
+	pluginSources        *pluginsource.Resolver
+	sandboxImage         func(context.Context) string
+	credPool             *credpool.Broker
+	usageCaps            usagecap.Store
+	capPolicy            usagecap.PolicySource
+	trust                usagecap.Trust
+	usageProbe           UsageProbe
+	identity             TeamResolver
+	requireLLMCredential bool
 
 	// orgCache memoizes team → org id so the publish hot path doesn't
 	// add a Mongo read per launch (team/org membership changes are
@@ -249,27 +260,28 @@ func New(cfg Config) (*Publisher, error) {
 			_, err := cfg.NATS.PublishRun(ctx, msg)
 			return err
 		},
-		cancelRun:      cfg.NATS.CancelRun,
-		maxPayload:     cfg.NATS.MaxPayload,
-		store:          cfg.Store,
-		runs:           cfg.MongoColl,
-		logger:         cfg.Logger,
-		metrics:        cfg.Metrics,
-		apiKeys:        cfg.ApiKeys,
-		genericSecrets: cfg.GenericSecrets,
-		botBindings:    cfg.BotBindings,
-		runSecrets:     cfg.RunSecrets,
-		sealer:         cfg.Sealer,
-		oauthForfait:   cfg.OAuthForfait,
-		forgeConns:     cfg.ForgeConnections,
-		pluginSources:  cfg.PluginSources,
-		sandboxImage:   cfg.SandboxImage,
-		credPool:       cfg.CredPool,
-		usageCaps:      cfg.UsageCaps,
-		capPolicy:      cfg.CapPolicy,
-		trust:          cfg.UsageCapTrust.Normalized(),
-		usageProbe:     cfg.UsageProbe,
-		identity:       cfg.Identity,
+		cancelRun:            cfg.NATS.CancelRun,
+		maxPayload:           cfg.NATS.MaxPayload,
+		store:                cfg.Store,
+		runs:                 cfg.MongoColl,
+		logger:               cfg.Logger,
+		metrics:              cfg.Metrics,
+		apiKeys:              cfg.ApiKeys,
+		genericSecrets:       cfg.GenericSecrets,
+		botBindings:          cfg.BotBindings,
+		runSecrets:           cfg.RunSecrets,
+		sealer:               cfg.Sealer,
+		oauthForfait:         cfg.OAuthForfait,
+		forgeConns:           cfg.ForgeConnections,
+		pluginSources:        cfg.PluginSources,
+		sandboxImage:         cfg.SandboxImage,
+		credPool:             cfg.CredPool,
+		usageCaps:            cfg.UsageCaps,
+		capPolicy:            cfg.CapPolicy,
+		trust:                cfg.UsageCapTrust.Normalized(),
+		usageProbe:           cfg.UsageProbe,
+		identity:             cfg.Identity,
+		requireLLMCredential: cfg.RequireLLMCredential,
 	}, nil
 }
 
@@ -744,6 +756,20 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 		p.logger.Warn("cloudpublisher: no credential resolved for run=%s tenant=%s — tiers consulted: byok, oauth-forfait, pool, platform; the runner falls back to its env or fails at the first LLM call",
 			runID, tenantID)
 	}
+	// The deployment may REFUSE what the Warn only reports. Per route, on
+	// the walk the stamp above reads: refused only when every LLM route
+	// pins a provider the vocabulary knows and none of the pinned providers
+	// is funded by any tier. One funded provider is enough — the other
+	// route's failure is the run's to report — and a route the walk cannot
+	// attribute may still be funded by the pod's env, so it is never
+	// refused. Returned WITH res: a pool grant acquired above must reach
+	// the caller's release.
+	if p.requireLLMCredential && wf != nil && wf.UsesLLM() {
+		if unfunded := unfundedPinnedProviders(spend, bundle); len(unfunded) > 0 {
+			return res, fmt.Errorf("cloudpublisher: %w: every LLM route of run %s pins %s and no tier (byok, oauth-forfait, pool, platform) holds a credential for any of them — provision one for tenant %s, or unset ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL to let the runner fall back to its env",
+				runview.ErrNoLLMCredential, runID, strings.Join(unfunded, ", "), tenantID)
+		}
+	}
 	if noLLMCred && len(bundle.GenericSecrets) == 0 {
 		return res, nil
 	}
@@ -841,6 +867,35 @@ func spendableProviders(wf *ir.Workflow, overrides model.ModelOverrides, runFall
 		pinned[p] = true
 	}
 	return spendable{pinned: pinned}
+}
+
+// unfundedPinnedProviders returns the run's pinned providers, sorted, when
+// NONE of them is funded by the bundle — an API key of that provider, or an
+// OAuth credential whose kind authenticates against it. Nil when the run has
+// an unattributable route (a nil spendable set allows everything) or when at
+// least one pinned provider is funded: such a run can start.
+func unfundedPinnedProviders(spend spendable, bundle secrets.RunBundle) []string {
+	if spend.pinned == nil {
+		return nil
+	}
+	funded := make(map[string]bool, len(bundle.APIKeys)+len(bundle.OAuthCredentials))
+	for prov := range bundle.APIKeys {
+		funded[strings.ToLower(string(prov))] = true
+	}
+	for kind := range bundle.OAuthCredentials {
+		if prov := providerOfOAuthKind(kind); prov != "" {
+			funded[prov] = true
+		}
+	}
+	out := make([]string, 0, len(spend.pinned))
+	for prov := range spend.pinned {
+		if funded[prov] {
+			return nil
+		}
+		out = append(out, prov)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // providerOfOAuthKind maps an OAuth slot to the provider its credential

--- a/pkg/server/cloudpublisher/require_llm_credential_test.go
+++ b/pkg/server/cloudpublisher/require_llm_credential_test.go
@@ -1,0 +1,121 @@
+package cloudpublisher
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// A run whose every LLM route pins a provider the deployment knows, and for
+// which no tier holds a credential, cannot start: under
+// Config.RequireLLMCredential the publisher refuses it with the typed
+// runview.ErrNoLLMCredential instead of queueing a run that fails at its
+// first call (#841). The rule is per route, read through the same walk the
+// credential stamp uses: a route the walk cannot attribute is never refused,
+// and one funded pinned provider is enough — the other route's failure is
+// the run's to report.
+
+func compileTestSource(t *testing.T, src string) *ir.Workflow {
+	t.Helper()
+	pr := parser.Parse("test.bot", src)
+	if pr.File == nil {
+		t.Fatalf("parse failed: %+v", pr.Diagnostics)
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatalf("compile failed: %+v", cr.Diagnostics)
+	}
+	return cr.Workflow
+}
+
+const (
+	anthropicPinnedBot = "agent draft:\n  model: \"anthropic/claude-opus-5\"\n  backend: \"claw\"\n\nworkflow main:\n  draft -> done\n"
+	openaiPinnedBot    = "agent draft:\n  model: \"openai/gpt-5.4-mini\"\n  backend: \"claw\"\n\nworkflow main:\n  draft -> done\n"
+	twoRoutesBot       = "agent draft:\n  model: \"anthropic/claude-opus-5\"\n  backend: \"claw\"\n\njudge verify:\n  model: \"openai/gpt-5.4-mini\"\n  backend: \"claw\"\n\nworkflow main:\n  draft -> verify\n  verify -> done\n"
+	unattributableBot  = "agent draft:\n  backend: \"claude_code\"\n\nworkflow main:\n  draft -> done\n"
+	unknownVocabBot    = "agent draft:\n  model: \"kimi-code/kimi-for-coding\"\n  backend: \"kimi\"\n\nworkflow main:\n  draft -> done\n"
+	toolOnlyBot        = "schema out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"yes\"}'`\n  output: out\n\nworkflow main:\n  entry: noop\n  noop -> done\n"
+)
+
+func TestResolve_RequireLLMCredentialRefusesOnlyARunThatCannotStart(t *testing.T) {
+	cases := []struct {
+		name    string
+		require bool
+		bot     string
+		seed    []secrets.Provider
+		refused bool
+	}{
+		{"knob off: nothing funded, nothing refused", false, anthropicPinnedBot, nil, false},
+		{"pinned anthropic, nothing funded", true, anthropicPinnedBot, nil, true},
+		{"pinned anthropic, anthropic key", true, anthropicPinnedBot, []secrets.Provider{secrets.ProviderAnthropic}, false},
+		{"pinned anthropic, only an openai key", true, anthropicPinnedBot, []secrets.Provider{secrets.ProviderOpenAI}, true},
+		{"pinned openai, only an anthropic key", true, openaiPinnedBot, []secrets.Provider{secrets.ProviderAnthropic}, true},
+		{"two routes, one funded", true, twoRoutesBot, []secrets.Provider{secrets.ProviderAnthropic}, false},
+		{"two routes, neither funded", true, twoRoutesBot, nil, true},
+		{"unattributable route (no model prefix)", true, unattributableBot, nil, false},
+		{"hint outside the vocabulary", true, unknownVocabBot, nil, false},
+		{"tool-only workflow", true, toolOnlyBot, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+			if err != nil {
+				t.Fatalf("sealer: %v", err)
+			}
+			keys := secrets.NewMemoryApiKeyStore()
+			for i, prov := range tc.seed {
+				seedKeyFP(t, keys, sealer, "team1", prov, "sk-"+string(prov), "fp-"+string(prov)+string(rune('a'+i)))
+			}
+			var buf bytes.Buffer
+			p := &Publisher{apiKeys: keys, usageCaps: usagecap.NewMemStore(),
+				runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer,
+				logger: iterlog.New(iterlog.LevelInfo, &buf), requireLLMCredential: tc.require}
+			wf := compileTestSource(t, tc.bot)
+			ctx := store.WithTenant(context.Background(), "team1")
+			_, err = p.resolveAndSealCredentials(ctx, "run-req", "", "team1", "owner1", "",
+				wf, nil, nil, model.ModelOverrides{}, nil)
+			if tc.refused {
+				if !errors.Is(err, runview.ErrNoLLMCredential) {
+					t.Fatalf("resolveAndSealCredentials = %v, want runview.ErrNoLLMCredential", err)
+				}
+				msg := err.Error()
+				if !strings.Contains(msg, "byok") || !strings.Contains(msg, "platform") {
+					t.Errorf("the refusal does not name the tiers consulted: %q", msg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveAndSealCredentials = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// The refusal names what it could not fund, so the operator reads which
+// provider to provision — not just that "something" was missing.
+func TestResolve_RequireLLMCredentialNamesTheUnfundedProviders(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	p := &Publisher{apiKeys: secrets.NewMemoryApiKeyStore(), usageCaps: usagecap.NewMemStore(),
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer,
+		logger: iterlog.Nop(), requireLLMCredential: true}
+	ctx := store.WithTenant(context.Background(), "team1")
+	_, err = p.resolveAndSealCredentials(ctx, "run-req", "", "team1", "owner1", "",
+		compileTestSource(t, twoRoutesBot), nil, nil, model.ModelOverrides{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "anthropic") || !strings.Contains(err.Error(), "openai") {
+		t.Fatalf("refusal = %v, want it to name both pinned providers", err)
+	}
+}

--- a/pkg/server/invocation_dispatch.go
+++ b/pkg/server/invocation_dispatch.go
@@ -139,25 +139,30 @@ func (s *Server) dispatchInvocation(
 	}
 	if route.Mode == string(bundle.ExecutionBoard) && s.cfg.CloudBoardFor != nil {
 		if s.cfg.CloudBoardCoordinator != nil {
-			// Dispatcher active: gate (per-org quota), create the card in the
-			// eligible state, and let the dispatcher own execution + state
+			// Dispatcher active: pre-check the org gate, create the card in
+			// the eligible state, and let the dispatcher own execution + state
 			// transitions — no direct launch (else the card would run twice).
 			//
-			// Idempotency BEFORE metering: gateLaunch performs the per-org
+			// Idempotency BEFORE the gate: gateLaunch performs the per-org
 			// quota CAS increment, and ensureBoardCard is idempotent on the
-			// per-comment label only AFTER that. So a webhook redelivery would
-			// re-charge the quota while creating no new card. Short-circuit to
-			// a "carded" replay when the card already exists, before gating.
+			// per-comment label only AFTER that. Short-circuit to a "carded"
+			// replay when the card already exists, before gating.
 			if s.boardCardExists(cfg, meta) {
 				s.markWebhookOutcome(cfg.Provider, webhooks.StatusDuplicate)
 				writeJSONStatus(w, http.StatusOK, map[string]string{"status": "carded", "bot": route.BotID})
 				return
 			}
-			if _, d := s.gateLaunch(ctx); d != nil {
+			adm, d := s.gateLaunch(ctx)
+			if d != nil {
 				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, d.reason)
 				s.writeLaunchDenial(w, r, d)
 				return
 			}
+			// A pre-check, not the metering: a card is not a run. The
+			// dispatcher passes the same gate — and meters — when it claims
+			// the card (processBoardCard), so the slot taken here is handed
+			// back at once; keeping it would charge one command two runs.
+			adm.rollback(s.logger)
 			seed()
 			s.ensureBoardCard(ctx, cfg, route, vars, meta, native.StateReady, repoURL, repoRef)
 			s.markWebhookOutcome(cfg.Provider, webhooks.StatusAccepted)

--- a/pkg/server/launch_gate.go
+++ b/pkg/server/launch_gate.go
@@ -35,6 +35,34 @@ type launchDenial struct {
 	resetAt    time.Time
 }
 
+// launchDeniedError is a gate denial as an error, for the launch surfaces
+// that record a refusal on a ledger instead of answering an HTTP request
+// (the board dispatcher, whose card keeps the rule that refused it).
+// Reason is the stable denial token below; Detail the sentence the HTTP
+// envelope carries; RetryAfter / ResetAt the hints it would have sent.
+type launchDeniedError struct {
+	Reason     string
+	Detail     string
+	RetryAfter time.Duration
+	ResetAt    time.Time
+}
+
+func (e *launchDeniedError) Error() string {
+	if e.Detail == "" {
+		return "launch gate: " + e.Reason
+	}
+	return "launch gate: " + e.Reason + ": " + e.Detail
+}
+
+// err converts a denial for a caller that reports through an error chain.
+// Nil-safe: an allowed launch has no error.
+func (d *launchDenial) err() error {
+	if d == nil {
+		return nil
+	}
+	return &launchDeniedError{Reason: d.reason, Detail: d.detail, RetryAfter: d.retryAfter, ResetAt: d.resetAt}
+}
+
 // Stable denial reason tokens (API contract — documented in
 // docs/quotas-and-limits.md).
 const (
@@ -95,7 +123,9 @@ func (a *launchAdmission) rollback(logger interface{ Warn(string, ...any) }) {
 // gateLaunch is the shared run-launch admission gate: suspend →
 // concurrency → launch rate → monthly cost cap → monthly run quota
 // (the last one is also the metering increment). Called by
-// handleLaunchRun, handleResumeRun and the inbound webhook handlers.
+// handleLaunchRun, handleResumeRun, the inbound webhook handlers, the retry
+// sweeper and the board dispatcher (processBoardCard) — every cloud launch
+// surface (the table in docs/quotas-and-limits.md).
 // On allow it returns the admission handle for the metered increment
 // (nil when nothing was metered).
 //

--- a/pkg/server/pipeline_boards_launch_giveup_test.go
+++ b/pkg/server/pipeline_boards_launch_giveup_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A card the dispatcher gave up on BEFORE any run existed — the launch
+// attempt cap of #814 — has no run to carry the flag, and a give-up bound to
+// a run id would not describe it. The pipeline board's needs-attention lane
+// must show it anyway (#841): filed among the done tickets, a card nobody
+// could launch is the "invisible but not lost" failure again.
+
+func launchGiveUp() *native.GiveUp {
+	return &native.GiveUp{
+		State:    native.StateBlocked,
+		Attempts: 8,
+		Reason:   "the launch was refused 8 times; last refusal: launch gate: concurrency_cap_exceeded",
+		Launch:   true,
+	}
+}
+
+// TestPipelineBoard_LaunchGiveUpLandsInNeedsAttention: the never-launched
+// card (no run at all) is a ticket card in the needs-attention lane, carrying
+// the stamp; a card an operator filed blocked by hand stays Closed.
+func TestPipelineBoard_LaunchGiveUpLandsInNeedsAttention(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Never launched", State: native.StateReady, Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.board.SetState(issue.ID, native.StateBlocked); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.board.SetGaveUp(issue.ID, launchGiveUp()); err != nil {
+		t.Fatal(err)
+	}
+	byHand, err := env.board.Create(native.Issue{Title: "Filed by hand", State: native.StateReady, Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.board.SetState(byHand.ID, native.StateBlocked); err != nil {
+		t.Fatal(err)
+	}
+
+	cards := env.projection(t).Cards
+	card := findPipelineCard(t, cards, "task:"+issue.ID)
+	if card.ColumnID != pipelineColumnNeedsAttention {
+		t.Errorf("a launch give-up landed in %q, want %q", card.ColumnID, pipelineColumnNeedsAttention)
+	}
+	if card.GaveUp == nil || !card.GaveUp.Launch || card.GaveUp.Attempts != 8 {
+		t.Errorf("the card does not carry the launch give-up stamp: %+v", card.GaveUp)
+	}
+	if card.ReservesSlot {
+		t.Error("a terminal ticket never reserves a slot")
+	}
+	ctrl := findPipelineCard(t, cards, "task:"+byHand.ID)
+	if ctrl.ColumnID != pipelineColumnClosed || ctrl.GaveUp != nil {
+		t.Errorf("a card filed by hand projected as %q with stamp %+v, want %q and no stamp", ctrl.ColumnID, ctrl.GaveUp, pipelineColumnClosed)
+	}
+}
+
+// TestPipelineBoard_LaunchGiveUpOnACardWithAnOldRun: the card once ran (an
+// older failed attempt), was restaged, and then could not be launched again
+// — the launch give-up is current whatever run the card points at, so the
+// run card takes the lane and the stamp.
+func TestPipelineBoard_LaunchGiveUpOnACardWithAnOldRun(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	run := env.seedRun(t, "old-attempt", "review", store.RunStatusFailed, nil)
+	issue, err := env.board.Create(native.Issue{Title: "Relaunch refused", State: native.StateReady, Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.board.SetLastRun(issue.ID, run.ID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.board.SetState(issue.ID, native.StateBlocked); err != nil {
+		t.Fatal(err)
+	}
+	if err := env.board.SetGaveUp(issue.ID, launchGiveUp()); err != nil {
+		t.Fatal(err)
+	}
+
+	card := findPipelineCard(t, env.projection(t).Cards, "run:"+run.ID)
+	if card.ColumnID != pipelineColumnNeedsAttention {
+		t.Errorf("a launch give-up on a card with an old run landed in %q, want %q", card.ColumnID, pipelineColumnNeedsAttention)
+	}
+	if card.GaveUp == nil || !card.GaveUp.Launch {
+		t.Errorf("the run card does not carry the launch give-up stamp: %+v", card.GaveUp)
+	}
+}

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -329,11 +329,19 @@ func pipelineLaneForRoot(root *store.Run, issue *native.Issue, terminalStates ma
 // own — a newer run or any move of the ticket makes it stale (native.GiveUp.
 // Current) — so no writer has to remember to clear it, and a stale stamp can
 // never pin a card to the lane.
+//
+// root is nil for a ticket that never ran. Only a LAUNCH give-up (the launch
+// attempt cap, native.GiveUp.Launch) can be current there — it names no run;
+// a run give-up needs the run it was written on.
 func pipelineTicketGaveUp(issue *native.Issue, root *store.Run) bool {
-	if issue == nil || root == nil {
+	if issue == nil {
 		return false
 	}
-	return issue.GaveUp.Current(issue.State, root.ID)
+	rootID := ""
+	if root != nil {
+		rootID = root.ID
+	}
+	return issue.GaveUp.Current(issue.State, rootID)
 }
 
 // pipelineTicketHoldsSlot is the ONE definition of "this ticket is holding a

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -549,8 +549,19 @@ func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue, prior *stor
 	// no Ready badge (waiting_deps surfaces via open_blocker_count + reason).
 	ready := issue.State == native.StateReady
 	column := pipelineColumnOpened
+	var gaveUp *native.GiveUp
 	if terminal {
 		column = pipelineColumnClosed
+		// A ticket the dispatcher gave up on BEFORE any run existed (the
+		// launch attempt cap) has no run card to carry the flag, and an
+		// exhausted budget is an anomaly, not a filing: the ticket card
+		// takes the needs-attention lane and the stamp. It reserves
+		// nothing, like the run-card give-up (pipelineLaneForRoot) — a
+		// terminal ticket never relaunches on its own.
+		if pipelineTicketGaveUp(issue, prior) {
+			column = pipelineColumnNeedsAttention
+			gaveUp = issue.GaveUp
+		}
 	}
 	entry := stringMapToAny(issue.BotArgs)
 	if len(entry) == 0 && prior != nil {
@@ -579,6 +590,7 @@ func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue, prior *stor
 		CreatedAt:    issue.CreatedAt,
 		UpdatedAt:    issue.UpdatedAt,
 		Attempts:     b.attemptsForIssue(issue, prior),
+		GaveUp:       gaveUp,
 	}
 	b.attachDeps(&card, issue)
 	b.cards = append(b.cards, card)

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -534,6 +534,10 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 			span.SetStatus(codes.Error, "queue unavailable")
 			return
 		}
+		if s.writeNoLLMCredentialError(w, r, "launch", err) {
+			span.SetStatus(codes.Error, "no llm credential")
+			return
+		}
 		s.httpErrorFor(w, r, http.StatusBadRequest, "launch: %v", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "launch failed")
@@ -726,6 +730,9 @@ func (s *Server) writeResumeError(w http.ResponseWriter, r *http.Request, err er
 	if s.writeQueueOutageError(w, r, "resume", err) {
 		return
 	}
+	if s.writeNoLLMCredentialError(w, r, "resume", err) {
+		return
+	}
 	if runtime.IsWorkflowSourceChanged(err) {
 		s.writeJSONError(w, r, http.StatusBadRequest, map[string]any{
 			"error":      fmt.Sprintf("resume: %v", err),
@@ -734,6 +741,22 @@ func (s *Server) writeResumeError(w http.ResponseWriter, r *http.Request, err er
 		return
 	}
 	s.httpErrorFor(w, r, http.StatusBadRequest, "resume: %v", err)
+}
+
+// writeNoLLMCredentialError answers a launch or resume the cloud publisher
+// refused for want of an LLM credential (runview.ErrNoLLMCredential): 422 —
+// the request is well-formed and the instance healthy; the same request
+// succeeds once a credential is provisioned — with the stable code and the
+// publisher's own sentence, which names the providers to provision.
+func (s *Server) writeNoLLMCredentialError(w http.ResponseWriter, r *http.Request, operation string, err error) bool {
+	if !errors.Is(err, runview.ErrNoLLMCredential) {
+		return false
+	}
+	s.writeJSONError(w, r, http.StatusUnprocessableEntity, map[string]any{
+		"error":      fmt.Sprintf("%s: %v", operation, err),
+		"error_code": runview.NoLLMCredentialErrorCode,
+	})
+	return true
 }
 
 // writeQueueOutageError is shared by launch and both resume error sites

--- a/pkg/server/runs_launch_nocred_test.go
+++ b/pkg/server/runs_launch_nocred_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/runview"
+)
+
+// A launch or resume the cloud publisher refused for want of an LLM
+// credential (Config.RequireLLMCredential, #841) is not a malformed request
+// and not an outage: the same request succeeds once a credential is
+// provisioned. Both surfaces answer 422 with a stable code and the
+// publisher's own sentence, which names the providers to provision.
+
+func assertNoLLMCredentialResponse(t *testing.T, code int, body []byte) {
+	t.Helper()
+	if code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d; body=%s", code, http.StatusUnprocessableEntity, body)
+	}
+	var resp struct {
+		Error     string `json:"error"`
+		ErrorCode string `json:"error_code"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode response %q: %v", body, err)
+	}
+	if resp.ErrorCode != runview.NoLLMCredentialErrorCode {
+		t.Errorf("error_code = %q, want %q", resp.ErrorCode, runview.NoLLMCredentialErrorCode)
+	}
+	if !errors.Is(runview.ErrNoLLMCredential, runview.ErrNoLLMCredential) || resp.Error == "" || !bytes.Contains([]byte(resp.Error), []byte("anthropic")) {
+		t.Errorf("error = %q, want the publisher's sentence naming the provider", resp.Error)
+	}
+}
+
+func TestLaunchRefusedForWantOfCredentialIs422(t *testing.T) {
+	srv := newQueueOutageHTTPTestServer(t)
+	installQueueOutageTestPublisher(t, srv, fmt.Errorf("cloudpublisher: %w: every route pins anthropic and no tier holds a credential for it", runview.ErrNoLLMCredential))
+	body, err := json.Marshal(map[string]any{
+		"file_path": "nocred.bot",
+		"source":    "workflow nocred:\n  entry: done\n",
+		"run_id":    "run-nocred-launch",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.handleLaunchRun(rec, req)
+	assertNoLLMCredentialResponse(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestWriteResumeError_NoLLMCredentialIs422(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/r1/resume", nil)
+	(&Server{}).writeResumeError(rec, req, fmt.Errorf("cloudpublisher: republish: %w: every route pins anthropic", runview.ErrNoLLMCredential))
+	assertNoLLMCredentialResponse(t, rec.Code, rec.Body.Bytes())
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5711,6 +5711,7 @@ export interface components {
             /** Format: date-time */
             at: string;
             attempts?: number;
+            launch?: boolean;
             reason?: string;
             run_id?: string;
             state?: string;


### PR DESCRIPTION
Closes #841. **Stacked on #840** (base = `fix/board-dispatch-launch-refusal-is-transient`); retargeted to `main` once #840 merges — the diff here is this PR's three commits only.

## The gate covers the board path (one choke point)
`processBoardCard` now runs the HTTP handlers' exact sequence before `runs.Launch`: identity on the ctx (`auth.Identity{TeamID: tenant, UserID: "board-dispatcher"}`), `gateLaunch` (org run quota, monthly cost cap, concurrency, launch rate), metered admission, `rollback` when the run service refuses. A denial is a launch refusal of #814's class — typed `launchDeniedError{Reason, Detail, RetryAfter, ResetAt}` → the card is given back under `launch_refused`, the ledger's `LastReason` names the gate rule, the #814 backoff / attempt cap applies. Double-metering fixed on the way: the board-mode webhook branch keeps its pre-check but releases the slot at once — a card is not a run; the dispatcher meters when it claims it.

| surface | gated |
|---|---|
| `POST /api/runs`, resume, WS answer-resume | yes (unchanged) |
| webhooks direct launch, gate autofix/relaunch lanes | yes (unchanged) |
| webhooks board mode | pre-check only → slot released, dispatcher meters (**fixed**) |
| board dispatcher | **now yes** |
| retry sweeper | yes (unchanged) |
| trigger spine direct launches, `cloudsched` scheduled bots, `emit` per-request metering | **not gated — #844** |
| local mode (no identity store) | no-op by design |

Red: `TestProcessBoardCard_GateDenialIsALaunchRefusal` (`context deadline exceeded, want errCardLaunchRefused` — the old code launched past the cap), `TestProcessBoardCard_AdmittedLaunchIsMetered` (`monthly runs = 0 after an accepted launch, want 1`), `TestBoardDispatcher_GateDenialKeepsTheCardReadyUntilTheCapFrees` (card `in_progress`/provenance `""`/ledger nil → `ready`, `launch_refused`, one Warn, then the freed cap launches on the next tick).

## A run no credential tier can fund is refused at publish — opt-in, per route
The blanket rule would be wrong: the runner legitimately proceeds with an empty bundle on its pod's ambient env. Behind `ITERION_CLOUD_REQUIRE_LLM_CREDENTIAL` (unparsable value refuses boot), on the same `spendableProviders` walk the credential stamp uses: refuse `runview.ErrNoLLMCredential` iff the workflow uses an LLM, every LLM route pins a provider in the vocabulary, and NONE of the pinned providers is funded by any tier (API key or OAuth kind). One funded provider is enough; an unattributable route (a `claude_code` node with no `model:`, `auto`, a `kimi-code/…` hint) is never refused. HTTP launch and resume answer **422** + `error_code: NO_LLM_CREDENTIAL` naming the providers; on the board it is a launch refusal through the typed wrapper. Ten table cases red → green; HTTP `status = 400, want 422` → green.

## A launch give-up reaches the needs-attention lane
`native.GiveUp.Launch` (both twins; conformance extended and run against a real Mongo), `Current` treats a launch give-up as current whatever run it points at, `pipelineTicketGaveUp` accepts a nil root, `addTaskCard` routes it to `needs_attention`. Red (`landed in "closed"`, stamp nil) → green.

## Verification
`go build ./...` · `go test ./pkg/server/... ./pkg/dispatcher/... ./pkg/orgusage/... ./pkg/runview/...` ok · `task lint` 0 issues · Mongo conformance against a throwaway `mongo:7` replica set: PASS · `task openapi:gen` (`launch` boolean). Docs: `docs/quotas-and-limits.md` (the gate covers the board path + the surface table), `docs/dispatcher.md`, `docs/cloud-llm-credentials.md` (the knob), one clause in CLAUDE.md's runbook index. Rebased on main after #824 (the `CancelRunWithReason(…, store.RunEndReason)` fakes updated in the commits that introduced them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
