### PR TITLE
fix(platform-bots): a stored override that shadows a newer baked bundle is no longer silent

### DIFF
--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -80,6 +80,16 @@ stable quantity in the whole dataset: **$0.61–$0.71** across all 33 runs.
   one commit (#758 gained `3f27d71c5`, #745 four commits, #761
   `2c9c06385`). Nothing here measures run-to-run variance on identical
   input. Measuring it needs two reviews launched on the same head.
+- *"Cost saturates at $3.5–$6.0"* — true of the reviews that **finished**,
+  and only of those. Every one of the 33 was sampled from `runs list` as a
+  `finished` row, so the population is conditioned on completion and the
+  expensive tail is invisible by construction. The #780/#785 entry above
+  measures that tail on the SAME day: `(36/12)`, `(30/12)`, `(14/12)` —
+  three reviews that died at the cap, none of which could appear here.
+  So the shape is **bimodal**, not saturating: most reviews land at $2–6,
+  a few explode past the cap and take the run with them.
+  **Do not size a budget from the table above** — it describes survivors.
+  The cap that the tail actually required is 48 (that entry's change).
 
 ### Open question — do NOT close it with cost
 

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -25,6 +25,78 @@ commit-status gate. Never edits or commits. See
   120m (same wall on the duration axis), pacer 12 evals / 6m with `cost_gt=32`
   (manifest 0.8.1). Re-run on both PRs after the catalogue is deployed.
 
+## 2026-09-05 — what a Revi review COSTS: 33 production reviews, and the model that fits them
+- Status: validated (measurement, not a dogfood run — 33 organic
+  webhook-launched reviews on this repo, 11:57Z → 16:42Z, no run launched
+  for the purpose)
+- Versions: bot **0.7.0 throughout** · iterion `d57851fb` then `2defa1a0`
+  (v3.103.0 → v3.104.0). The dataset is homogeneous *because* of the
+  override described in the entry below: 0.8.0's tiers never served during
+  the window, so no bot-version change straddles these numbers.
+- Method: default guard-shaped run — `reviewer_claude` (opus-5, effort
+  high), `converge` on sonnet, `severity_threshold: medium`,
+  `max_cost_usd: 12`. Cost read from each run's checkpoint (the run's
+  `budget_cost_usd` field reads 0); diff sizes from `gh pr view --json
+  additions`.
+
+### The model
+
+Not linear. **It saturates.**
+
+| added lines | rule | evidence |
+|---|---|---|
+| < ~500 | `$2.24 + $0.00072 × added`, ±15% on a SHORT pass (1–2 findings, <8 min) | #754 −8.6%, #756 −13.8%, #757 +4.1% |
+| ~500–1500 | same rule, +6% to +29% | #758 +7.6% / +5.9%, #760 +29% |
+| > ~1500 | **predict $3.5–$6.0 and ignore size** | see below |
+
+Above ~1500 lines the line count stops carrying information — it does not
+even order the plateaus:
+
+| PR | added | hand-written | observed |
+|---|---|---|---|
+| #764 | +1598 | — | $4.81, $4.81, $4.28, $5.36 |
+| #761 | +2738 | — | $4.47, $5.82 |
+| #745 | +10078 | 4804 | $3.96, $3.99, $4.01 |
+
+**The largest PR is the cheapest.** The cause is the 0.7.0 frugality
+contract working as designed: `review_system` tells the reviewer to read
+`git diff --stat` first, prioritise the risky hunks and stop sweeping, so a
+10k-line diff becomes a triage rather than a linear read. The findings
+support that reading — all four on #745 were `medium` and all four sat in
+the files carrying the new logic (`board_project.go` ×2,
+`board_binding_store.go`, `projects_app.go`).
+
+The floor is ~**$1.95–2.00** (#766 at 4.4 min), and `converge` is the most
+stable quantity in the whole dataset: **$0.61–$0.71** across all 33 runs.
+
+### Two claims of mine that did NOT survive more data
+
+- *"Cost is a stable property of a given PR"* — I measured #764 twice at
+  0.12% apart and said so publicly. Two further passes landed at $4.28 and
+  $5.36: the real spread is **25%**, and the 0.12% was a two-point
+  coincidence. Keep **±30%** as the per-PR predictor's band.
+- *"Excellent reproducibility"* — withdrawn outright. **There is no
+  same-sha pair anywhere in this dataset**; every repeat straddles at least
+  one commit (#758 gained `3f27d71c5`, #745 four commits, #761
+  `2c9c06385`). Nothing here measures run-to-run variance on identical
+  input. Measuring it needs two reviews launched on the same head.
+
+### Open question — do NOT close it with cost
+
+Does frugality cost *coverage* on very large PRs? Cost alone cannot answer
+it: absence of findings is not evidence of absence of defects. The
+experiment that would answer it: re-review #745 with the frugality clause
+disabled and diff the two finding sets.
+
+### Lessons for next run
+- Read cost from the checkpoint, not `budget_cost_usd` (which reads 0).
+- Predict from a prior review of the SAME PR when one exists — it beats any
+  function of the diff, but only to ±30%.
+- Before attributing a cost shift to a bot change, verify which bundle
+  actually served (`GET /api/admin/bots`, and look for the version-specific
+  nodes in the run's checkpoint outputs). That check is what turned this
+  window's apparent version straddle into a homogeneous dataset.
+
 ## 2026-09-05 — review tiers shipped (0.8.0, SocialGouv/iterion#685) — design note, live measurement pending
 - Status: implemented + covered by DSL-level tests (stub executor + expr-level
   unit tests); **not yet dogfooded live** — no LLM credentials in this
@@ -34,8 +106,22 @@ commit-status gate. Never edits or commits. See
   baseline documented in the 2026-09-03/04 entry below.
 - Versions: bot 0.7.0 → 0.8.0 · iterion `c6f8bac0f` (v3.102.1) at write time
 - Landed: SocialGouv/iterion#742 (merged 2026-09-05 11:54Z, in v3.102.6);
-  prod runners carry it since 12:25Z (`edd5b9dcf`). The next real PR review
-  on this repo is the first tier measurement — record it here.
+  prod runners carry the ENGINE since 12:25Z (`edd5b9dcf`).
+- **Correction (2026-09-06 16:50Z): the tiers did not serve a single
+  production review for the first 29 hours.** Carrying the engine is not
+  carrying the bot. A platform bot override for `review-pr`, pushed
+  2026-09-04 06:52Z for the 0.7.0 cost pass, still held the 0.7.0 bundle —
+  and a platform override outranks the baked catalog at every launch
+  surface, by design. Measured: prod review graphs on both 09-05 and 09-06
+  ran `diff_precheck → topology → reviewer_claude → merge_reviews →
+  converge → pr_gate` with **no `tier_expand` node**, and
+  `GET /api/admin/bots/review-pr` returned manifest version `0.7.0` whose
+  `main.bot` contained `TOKEN FRUGALITY` and `supervisor pacer` but none of
+  `tier_expand` / `review_tier` / `reviewer_claude_glance`. The override was
+  deleted at 17:00Z after verifying the repo's 0.8.0 is a strict superset
+  (it carries all three 0.7.0 markers plus #758 and #816); the effective
+  bundle then read `version 0.8.0` from `/opt/iterion/bots/review-pr`. The
+  first real tier measurement is still owed — record it here.
 - What shipped: `review_tier` (glance/guard/audit), a deterministic
   `tier_expand` compute node resolving severity_threshold/max_findings/
   post_to_board/effective_review_mode from sentinel-defaulted vars (any

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -115,6 +115,41 @@ of the baked image it replaces. That is why the surface is super-admin
 only, safe-origin-gated, and digest-audited. Treat a push like a deploy:
 review the diff first (`admin bots pull` + `git diff` against the repo).
 
+## An override outlives the release that made it necessary
+
+The tier's whole point is that a stored bundle **outranks the baked
+catalog** at every launch surface. The consequence is easy to miss: an
+override pushed once keeps serving after a later release bakes a *newer*
+bundle for the same slug. The image moves; the bot does not.
+
+Measured on 2026-09-06: `review-pr`'s override, pushed 2026-09-04 for the
+0.7.0 cost pass, was still serving every production review 29 hours after
+#742 baked the 0.8.0 review tiers into the image. Nothing said so — the
+release notes, the runner digest and the bilan all reported the tiers as
+deployed, while the graph that actually ran had no `tier_expand` node.
+
+**iterion now reports it, and still does not refuse it** (pinning an older
+bundle is a legitimate choice — a rollback is exactly this):
+
+- `GET /api/admin/bots` returns `bundle_version`, `baked_version` and
+  `shadows_newer_bake` on every row. The last one is omitted unless true,
+  so a healthy inventory stays quiet. This is the check to run after any
+  release that touched a bot you have overridden.
+- The resolver logs one `Warn` per drift state naming both versions and the
+  two ways out. Once per `(slug, stored, baked)` triple, not per launch.
+
+Versions are compared as dotted numeric components, so `0.10.0` correctly
+beats `0.9.0`. `Manifest.version` is free-form, so a pair that does not
+parse numerically is treated as **unordered** and never flagged — a false
+staleness alarm on an operator's own naming scheme would be worse than the
+silence it replaces.
+
+To clear a shadow, either re-push the current bundle
+(`iterion remote admin bots push bots/<slug>`) or drop the override and let
+the image serve (`DELETE /api/admin/bots/<slug>`). Prefer dropping it once
+the reason for the override has shipped: it restores the normal flow where
+releases carry bots, and removes the trap for the next release.
+
 ## Known gaps (v1)
 
 - **Binary files** cannot ride an override (the store carries JSON text);

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -135,8 +135,11 @@ bundle is a legitimate choice — a rollback is exactly this):
   `shadows_newer_bake` on every row. The last one is omitted unless true,
   so a healthy inventory stays quiet. This is the check to run after any
   release that touched a bot you have overridden.
-- The resolver logs one `Warn` per drift state naming both versions and the
-  two ways out. Once per `(slug, stored, baked)` triple, not per launch.
+- The resolver logs one `Warn` naming the tenant, both versions and the two
+  ways out — once per `(tenant, origin, slug, stored version)`, not per
+  launch. The tenant is in the key on purpose: many teams can hold a row for
+  the same slug, and a slug-only key would let the first one to launch
+  silence all the others.
 
 Versions are compared as dotted numeric components, so `0.10.0` correctly
 beats `0.9.0`. `Manifest.version` is free-form, so a pair that does not

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -131,10 +131,14 @@ deployed, while the graph that actually ran had no `tier_expand` node.
 **iterion now reports it, and still does not refuse it** (pinning an older
 bundle is a legitimate choice — a rollback is exactly this):
 
-- `GET /api/admin/bots` returns `bundle_version`, `baked_version` and
-  `shadows_newer_bake` on every row. The last one is omitted unless true,
-  so a healthy inventory stays quiet. This is the check to run after any
+- `GET /api/admin/bots` returns `bundle_version`, `shadowed_version` and
+  `shadows_newer_version` on every row. The last is omitted unless true, so
+  a healthy inventory stays quiet. This is the check to run after any
   release that touched a bot you have overridden.
+  `shadowed_version` is **what would serve without that row**, which is not
+  always the bake: resolution is team → platform → baked, so a team row is
+  measured against the platform override when one exists. The same fields
+  appear on the team listing (`GET /api/teams/{id}/bot-sources`).
 - The resolver logs one `Warn` naming the tenant, both versions and the two
   ways out — once per `(tenant, origin, slug, stored version)`, not per
   launch. The tenant is in the key on purpose: many teams can hold a row for

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -139,6 +139,10 @@ bundle is a legitimate choice — a rollback is exactly this):
   always the bake: resolution is team → platform → baked, so a team row is
   measured against the platform override when one exists. The same fields
   appear on the team listing (`GET /api/teams/{id}/bot-sources`).
+  If the catalog itself cannot be read, the response carries
+  `shadow_check_unavailable: true` and the per-row shadow fields are absent —
+  an inventory that looks clean because the check could not run would be
+  worse than one that admits it did not run.
 - The resolver logs one `Warn` naming the tenant, both versions and the two
   ways out — once per `(tenant, origin, slug, stored version)`, not per
   launch. The tenant is in the key on purpose: many teams can hold a row for

--- a/openapi.json
+++ b/openapi.json
@@ -2550,6 +2550,23 @@
         ],
         "type": "object"
       },
+      "botSourceListView": {
+        "properties": {
+          "bot_sources": {
+            "items": {
+              "$ref": "#/components/schemas/botSourceMetaView"
+            },
+            "type": "array"
+          },
+          "shadow_check_unavailable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "bot_sources"
+        ],
+        "type": "object"
+      },
       "botSourceMetaView": {
         "properties": {
           "bundle_version": {
@@ -3458,18 +3475,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "bot_sources": {
-                      "items": {
-                        "$ref": "#/components/schemas/botSourceMetaView"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "required": [
-                    "bot_sources"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/botSourceListView"
                 }
               }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -2552,6 +2552,12 @@
       },
       "botSourceMetaView": {
         "properties": {
+          "baked_version": {
+            "type": "string"
+          },
+          "bundle_version": {
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"
@@ -2573,6 +2579,9 @@
           },
           "origin": {
             "type": "string"
+          },
+          "shadows_newer_bake": {
+            "type": "boolean"
           },
           "slug": {
             "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -2552,9 +2552,6 @@
       },
       "botSourceMetaView": {
         "properties": {
-          "baked_version": {
-            "type": "string"
-          },
           "bundle_version": {
             "type": "string"
           },
@@ -2580,7 +2577,10 @@
           "origin": {
             "type": "string"
           },
-          "shadows_newer_bake": {
+          "shadowed_version": {
+            "type": "string"
+          },
+          "shadows_newer_version": {
             "type": "boolean"
           },
           "slug": {

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/SocialGouv/iterion/pkg/botregistry"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+)
+
+// A stored bundle (team or platform botsource row) OUTRANKS the baked catalog
+// at every launch surface — that is the tier's whole purpose. The cost is that
+// a bundle pushed once keeps serving after a later release bakes a NEWER one
+// into the image, and nothing said so.
+//
+// The override is never REFUSED: pinning an older bundle is a legitimate
+// operator choice, and this package warns rather than rejects wherever an
+// operator could want the thing. What changes is that a shadowed newer bake is
+// no longer silent — it is reported once per drift state in the log, and on
+// every row the operator's own inventory returns.
+
+// bundleVersionOrder compares two free-form bundle version strings by their
+// dotted numeric components: -1, 0 or +1, with ok=false when either side
+// cannot be ordered.
+//
+// Manifest.Version is documented free-form ("semver or any"), so an
+// unparsable pair is UNORDERED rather than guessed — claiming staleness
+// against an operator's own naming scheme would be a false alarm, and a false
+// alarm on a warning nobody can silence is worse than the silence it replaces.
+// Components are compared numerically (so 0.10.0 > 0.9.0, which a string
+// compare gets backwards), and a shorter version is padded with zeros
+// (1.2 == 1.2.0).
+func bundleVersionOrder(a, b string) (int, bool) {
+	pa, okA := numericVersionParts(a)
+	pb, okB := numericVersionParts(b)
+	if !okA || !okB {
+		return 0, false
+	}
+	for i := 0; i < len(pa) || i < len(pb); i++ {
+		var ca, cb int
+		if i < len(pa) {
+			ca = pa[i]
+		}
+		if i < len(pb) {
+			cb = pb[i]
+		}
+		if ca != cb {
+			if ca < cb {
+				return -1, true
+			}
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+// numericVersionParts splits a version into its dotted numeric components. A
+// leading "v" is tolerated; anything else non-numeric makes the whole version
+// unorderable.
+func numericVersionParts(v string) ([]int, bool) {
+	s := strings.TrimSpace(v)
+	s = strings.TrimPrefix(s, "v")
+	if s == "" {
+		return nil, false
+	}
+	fields := strings.Split(s, ".")
+	out := make([]int, 0, len(fields))
+	for _, f := range fields {
+		n, err := strconv.Atoi(strings.TrimSpace(f))
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
+}
+
+// bakedBundleVersion returns the version this image bakes for slug, or "" when
+// the slug has no baked bundle (a stored-only bot shadows nothing) or its
+// manifest carries no version.
+func (s *Server) bakedBundleVersion(slug string) string {
+	path, err := botregistry.ResolveBotPath(slug, s.effectivePaths())
+	if err != nil {
+		return ""
+	}
+	m, err := bundle.LoadManifest(filepath.Join(filepath.Dir(path), bundle.ManifestFile))
+	if err != nil || m == nil {
+		return ""
+	}
+	return strings.TrimSpace(m.Version)
+}
+
+// overrideShadowsNewerBake reports the baked version for slug and whether the
+// stored bundle at storedVersion is strictly OLDER than it — i.e. whether this
+// override is holding back what the deployment already ships.
+func (s *Server) overrideShadowsNewerBake(slug, storedVersion string) (baked string, shadowed bool) {
+	baked = s.bakedBundleVersion(slug)
+	if baked == "" || strings.TrimSpace(storedVersion) == "" {
+		return baked, false
+	}
+	cmp, ok := bundleVersionOrder(storedVersion, baked)
+	return baked, ok && cmp < 0
+}
+
+// staleOverrideWarned dedups the resolve-time warning per drift state, so a
+// shadowed override costs one line per (slug, stored, baked) triple instead of
+// one per launch — a bot serving every webhook would otherwise drown its own
+// signal.
+var staleOverrideWarned sync.Map
+
+// warnIfOverrideShadowsNewerBake logs, once per drift state, that a stored
+// bundle is serving while this image bakes a newer one for the same slug.
+// Deliberately observational: the launch proceeds on the override.
+func (s *Server) warnIfOverrideShadowsNewerBake(slug, origin, storedVersion string) {
+	if s.logger == nil {
+		return
+	}
+	baked, shadowed := s.overrideShadowsNewerBake(slug, storedVersion)
+	if !shadowed {
+		return
+	}
+	key := slug + "\x00" + storedVersion + "\x00" + baked
+	if _, seen := staleOverrideWarned.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	s.logger.Warn("bot %q serves the %s override at version %s while this image bakes %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",
+		slug, origin, storedVersion, baked, slug, slug)
+}

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
+	"github.com/SocialGouv/iterion/pkg/botsource"
 )
 
 // A stored bundle (team or platform botsource row) OUTRANKS the baked catalog
@@ -109,12 +110,41 @@ func (s *Server) bakedVersions() map[string]string {
 	return out
 }
 
-// shadowsNewerBake reports the baked version for slug and whether the stored
-// bundle at storedVersion is strictly OLDER than it — i.e. whether this
-// override is holding back what this deployment would otherwise serve. Takes
-// the catalog map so a caller comparing N rows pays for one walk.
-func shadowsNewerBake(baked map[string]string, slug, storedVersion string) (string, bool) {
-	b := baked[slug]
+// versionsBelow returns what would serve for each slug if tenantID's own row
+// were removed — the whole point of the comparison, and not the same map for
+// both tiers. Resolution is team → platform → baked, so a TEAM row is shadowed
+// by the platform override when one exists, not by the baked catalog behind
+// it: comparing a team row against the bake alone would call a 0.9.0 team
+// override "current" while it holds back a 1.0.0 platform one.
+func (s *Server) versionsBelow(tenantID string) map[string]string {
+	out := s.bakedVersions()
+	if tenantID == botsource.PlatformTenantID {
+		return out
+	}
+	set := s.platformBotSetCached()
+	if set == nil {
+		return out
+	}
+	if out == nil {
+		out = make(map[string]string, len(set.manifests))
+	}
+	for slug, m := range set.manifests {
+		if m == nil {
+			continue
+		}
+		if v := strings.TrimSpace(m.Version); v != "" {
+			out[slug] = v
+		}
+	}
+	return out
+}
+
+// shadowsNewerVersion reports what would serve for slug without this row, and
+// whether the stored bundle at storedVersion is strictly OLDER than it — i.e.
+// whether this override is holding back what this deployment would otherwise
+// serve. Takes the map so a caller comparing N rows pays for one walk.
+func shadowsNewerVersion(below map[string]string, slug, storedVersion string) (string, bool) {
+	b := below[slug]
 	if b == "" || strings.TrimSpace(storedVersion) == "" {
 		return b, false
 	}
@@ -152,10 +182,10 @@ func (s *Server) warnIfOverrideShadowsNewerBake(tenantID, slug, origin, storedVe
 	// Not a shadow: the key stays stored. The answer cannot change within a
 	// process, so re-walking the catalog on every later launch of the same row
 	// would buy nothing.
-	baked, shadowed := shadowsNewerBake(s.bakedVersions(), slug, storedVersion)
+	below, shadowed := shadowsNewerVersion(s.versionsBelow(tenantID), slug, storedVersion)
 	if !shadowed {
 		return
 	}
 	s.logger.Warn("bot %q serves the %s override of tenant %s at version %s while this deployment would otherwise serve %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",
-		slug, origin, tenantID, storedVersion, baked, slug, slug)
+		slug, origin, tenantID, storedVersion, below, slug, slug)
 }

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -1,13 +1,11 @@
 package server
 
 import (
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
-	"github.com/SocialGouv/iterion/pkg/bundle"
 )
 
 // A stored bundle (team or platform botsource row) OUTRANKS the baked catalog
@@ -18,8 +16,8 @@ import (
 // The override is never REFUSED: pinning an older bundle is a legitimate
 // operator choice, and this package warns rather than rejects wherever an
 // operator could want the thing. What changes is that a shadowed newer bake is
-// no longer silent — it is reported once per drift state in the log, and on
-// every row the operator's own inventory returns.
+// no longer silent — it is reported once per distinct shadow in the log, and
+// on every row the operator's own inventory returns.
 
 // bundleVersionOrder compares two free-form bundle version strings by their
 // dotted numeric components: -1, 0 or +1, with ok=false when either side
@@ -32,6 +30,11 @@ import (
 // Components are compared numerically (so 0.10.0 > 0.9.0, which a string
 // compare gets backwards), and a shorter version is padded with zeros
 // (1.2 == 1.2.0).
+//
+// KNOWN BLIND SPOT: a suffixed version (0.8.0-rc1) is unorderable, so an
+// override pinned at one is never flagged against a plain 0.8.0 bake. Widening
+// this to semver precedence would mean deciding that -rc1 sorts BEFORE 0.8.0
+// for every operator, which the free-form contract does not license.
 func bundleVersionOrder(a, b string) (int, bool) {
 	pa, okA := numericVersionParts(a)
 	pb, okB := numericVersionParts(b)
@@ -77,54 +80,82 @@ func numericVersionParts(v string) ([]int, bool) {
 	return out, true
 }
 
-// bakedBundleVersion returns the version this image bakes for slug, or "" when
-// the slug has no baked bundle (a stored-only bot shadows nothing) or its
-// manifest carries no version.
-func (s *Server) bakedBundleVersion(slug string) string {
-	path, err := botregistry.ResolveBotPath(slug, s.effectivePaths())
+// bakedVersions walks the catalog ONCE and returns slug → manifest version.
+//
+// Callers comparing several rows build it once and reuse it: resolving a
+// version per row would re-walk every configured bot root and re-parse every
+// manifest for each one, turning a listing into O(rows × catalog) filesystem
+// work. The version comes straight off botregistry.Entry, which already
+// mirrors the manifest field — loading the manifest again would re-read what
+// the walk just produced.
+//
+// "Baked" means whatever THIS server discovers on disk, deliberately the same
+// source every other bot lookup uses: the field answers "what would serve if
+// this override were removed", not "what some image ships". With no
+// --bots-path pinned that follows the live WorkDir, so on a local studio the
+// answer legitimately changes with the open project — which is the correct
+// answer to the question the field asks.
+func (s *Server) bakedVersions() map[string]string {
+	entries, err := botregistry.List(s.botListOptions())
 	if err != nil {
-		return ""
+		return nil
 	}
-	m, err := bundle.LoadManifest(filepath.Join(filepath.Dir(path), bundle.ManifestFile))
-	if err != nil || m == nil {
-		return ""
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if v := strings.TrimSpace(e.Version); v != "" {
+			out[e.Name] = v
+		}
 	}
-	return strings.TrimSpace(m.Version)
+	return out
 }
 
-// overrideShadowsNewerBake reports the baked version for slug and whether the
-// stored bundle at storedVersion is strictly OLDER than it — i.e. whether this
-// override is holding back what the deployment already ships.
-func (s *Server) overrideShadowsNewerBake(slug, storedVersion string) (baked string, shadowed bool) {
-	baked = s.bakedBundleVersion(slug)
-	if baked == "" || strings.TrimSpace(storedVersion) == "" {
-		return baked, false
+// shadowsNewerBake reports the baked version for slug and whether the stored
+// bundle at storedVersion is strictly OLDER than it — i.e. whether this
+// override is holding back what this deployment would otherwise serve. Takes
+// the catalog map so a caller comparing N rows pays for one walk.
+func shadowsNewerBake(baked map[string]string, slug, storedVersion string) (string, bool) {
+	b := baked[slug]
+	if b == "" || strings.TrimSpace(storedVersion) == "" {
+		return b, false
 	}
-	cmp, ok := bundleVersionOrder(storedVersion, baked)
-	return baked, ok && cmp < 0
+	cmp, ok := bundleVersionOrder(storedVersion, b)
+	return b, ok && cmp < 0
 }
 
-// staleOverrideWarned dedups the resolve-time warning per drift state, so a
-// shadowed override costs one line per (slug, stored, baked) triple instead of
-// one per launch — a bot serving every webhook would otherwise drown its own
-// signal.
+// staleOverrideWarned dedups the resolve-time warning, so a shadowed override
+// costs one line per distinct shadow instead of one per launch — a bot serving
+// every webhook would otherwise drown its own signal.
+//
+// The key carries the TENANT and the origin, not just the slug: on the team
+// tier many tenants hold a row for the same slug, and a slug-only key would
+// let the first team to launch consume it and silence every other team —
+// exactly the silence this file exists to end. The baked version is
+// deliberately NOT in the key: it cannot change without a new image, and a new
+// image is a new process with a fresh map.
 var staleOverrideWarned sync.Map
 
-// warnIfOverrideShadowsNewerBake logs, once per drift state, that a stored
-// bundle is serving while this image bakes a newer one for the same slug.
-// Deliberately observational: the launch proceeds on the override.
-func (s *Server) warnIfOverrideShadowsNewerBake(slug, origin, storedVersion string) {
-	if s.logger == nil {
+// warnIfOverrideShadowsNewerBake logs, once per (tenant, origin, slug, stored
+// version), that a stored bundle is serving while this deployment would
+// otherwise serve a newer one. Deliberately observational: the launch proceeds
+// on the override.
+//
+// The dedup check runs BEFORE the catalog walk, so a repeat launch of the same
+// row costs a map lookup rather than a full discovery pass.
+func (s *Server) warnIfOverrideShadowsNewerBake(tenantID, slug, origin, storedVersion string) {
+	if s.logger == nil || strings.TrimSpace(storedVersion) == "" {
 		return
 	}
-	baked, shadowed := s.overrideShadowsNewerBake(slug, storedVersion)
-	if !shadowed {
-		return
-	}
-	key := slug + "\x00" + storedVersion + "\x00" + baked
+	key := strings.Join([]string{tenantID, origin, slug, storedVersion}, "\x00")
 	if _, seen := staleOverrideWarned.LoadOrStore(key, struct{}{}); seen {
 		return
 	}
-	s.logger.Warn("bot %q serves the %s override at version %s while this image bakes %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",
-		slug, origin, storedVersion, baked, slug, slug)
+	// Not a shadow: the key stays stored. The answer cannot change within a
+	// process, so re-walking the catalog on every later launch of the same row
+	// would buy nothing.
+	baked, shadowed := shadowsNewerBake(s.bakedVersions(), slug, storedVersion)
+	if !shadowed {
+		return
+	}
+	s.logger.Warn("bot %q serves the %s override of tenant %s at version %s while this deployment would otherwise serve %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",
+		slug, origin, tenantID, storedVersion, baked, slug, slug)
 }

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/platformcfg"
 )
 
 // A stored bundle (team or platform botsource row) OUTRANKS the baked catalog
@@ -96,18 +99,42 @@ func numericVersionParts(v string) ([]int, bool) {
 // --bots-path pinned that follows the live WorkDir, so on a local studio the
 // answer legitimately changes with the open project — which is the correct
 // answer to the question the field asks.
-func (s *Server) bakedVersions() map[string]string {
-	entries, err := botregistry.List(s.botListOptions())
-	if err != nil {
-		return nil
-	}
-	out := make(map[string]string, len(entries))
-	for _, e := range entries {
-		if v := strings.TrimSpace(e.Version); v != "" {
-			out[e.Name] = v
+// bakedCatalog is the cached slug → version projection of the on-disk catalog.
+// A struct rather than a bare map so "never read successfully" (nil) stays
+// distinguishable from "read, and it holds nothing" (empty map): reporting a
+// broken catalog as a clean inventory would be a lie told by the very endpoint
+// the runbook calls the check to run after a release.
+type bakedCatalog struct {
+	versions map[string]string
+}
+
+// newBakedCatalogResolver builds the TTL cache. Walking the catalog is the
+// expensive half of the comparison, so it is the DATA that is cached, never
+// the verdict: a cached verdict would outlive the platform-override overlay it
+// was computed against. A walk failure propagates, so the resolver logs it and
+// serves the LAST-KNOWN map rather than an empty one.
+func (s *Server) newBakedCatalogResolver() *platformcfg.Resolver[bakedCatalog] {
+	return platformcfg.NewResolverFunc(func(context.Context) (*bakedCatalog, error) {
+		entries, err := botregistry.List(s.botListOptions())
+		if err != nil {
+			return nil, fmt.Errorf("bot catalog walk for the override-staleness check: %w", err)
 		}
+		out := bakedCatalog{versions: make(map[string]string, len(entries))}
+		for _, e := range entries {
+			if v := strings.TrimSpace(e.Version); v != "" {
+				out.versions[e.Name] = v
+			}
+		}
+		return &out, nil
+	}, s.logger.Warn)
+}
+
+func (s *Server) bakedVersions() (map[string]string, bool) {
+	c := s.bakedCatalog.Get(context.Background())
+	if c == nil {
+		return nil, false
 	}
-	return out
+	return c.versions, true
 }
 
 // versionsBelow returns what would serve for each slug if tenantID's own row
@@ -116,17 +143,25 @@ func (s *Server) bakedVersions() map[string]string {
 // by the platform override when one exists, not by the baked catalog behind
 // it: comparing a team row against the bake alone would call a 0.9.0 team
 // override "current" while it holds back a 1.0.0 platform one.
-func (s *Server) versionsBelow(tenantID string) map[string]string {
-	out := s.bakedVersions()
+// The bool is false when the catalog could not be read at all: the caller must
+// then report "unknown", never "nothing is shadowed".
+func (s *Server) versionsBelow(tenantID string) (map[string]string, bool) {
+	baked, ok := s.bakedVersions()
+	if !ok {
+		return nil, false
+	}
 	if tenantID == botsource.PlatformTenantID {
-		return out
+		return baked, true
 	}
 	set := s.platformBotSetCached()
 	if set == nil {
-		return out
+		return baked, true
 	}
-	if out == nil {
-		out = make(map[string]string, len(set.manifests))
+	// Copy: the cached catalog map is shared, and the platform overlay is
+	// per-tenant-tier.
+	out := make(map[string]string, len(baked)+len(set.manifests))
+	for k, v := range baked {
+		out[k] = v
 	}
 	for slug, m := range set.manifests {
 		if m == nil {
@@ -136,7 +171,7 @@ func (s *Server) versionsBelow(tenantID string) map[string]string {
 			out[slug] = v
 		}
 	}
-	return out
+	return out, true
 }
 
 // shadowsNewerVersion reports what would serve for slug without this row, and
@@ -159,9 +194,14 @@ func shadowsNewerVersion(below map[string]string, slug, storedVersion string) (s
 // The key carries the TENANT and the origin, not just the slug: on the team
 // tier many tenants hold a row for the same slug, and a slug-only key would
 // let the first team to launch consume it and silence every other team —
-// exactly the silence this file exists to end. The baked version is
-// deliberately NOT in the key: it cannot change without a new image, and a new
-// image is a new process with a fresh map.
+// exactly the silence this file exists to end.
+//
+// Only a POSITIVE verdict is ever stored. Caching "nothing to report" would
+// silence a shadow that appears later in the same process, and both inputs do
+// change at runtime: a team row is measured against the platform overlay,
+// which is a TTL cache that every `admin bots push` refills. Recomputing is
+// cheap because what is cached is the catalog walk (bakedCatalog), not the
+// verdict.
 var staleOverrideWarned sync.Map
 
 // warnIfOverrideShadowsNewerBake logs, once per (tenant, origin, slug, stored
@@ -175,15 +215,19 @@ func (s *Server) warnIfOverrideShadowsNewerBake(tenantID, slug, origin, storedVe
 	if s.logger == nil || strings.TrimSpace(storedVersion) == "" {
 		return
 	}
-	key := strings.Join([]string{tenantID, origin, slug, storedVersion}, "\x00")
-	if _, seen := staleOverrideWarned.LoadOrStore(key, struct{}{}); seen {
+	versions, ok := s.versionsBelow(tenantID)
+	if !ok {
+		// The catalog could not be read; the resolver already warned about
+		// that. Staying silent here is honest — claiming "nothing shadowed"
+		// would not be.
 		return
 	}
-	// Not a shadow: the key stays stored. The answer cannot change within a
-	// process, so re-walking the catalog on every later launch of the same row
-	// would buy nothing.
-	below, shadowed := shadowsNewerVersion(s.versionsBelow(tenantID), slug, storedVersion)
+	below, shadowed := shadowsNewerVersion(versions, slug, storedVersion)
 	if !shadowed {
+		return
+	}
+	key := strings.Join([]string{tenantID, origin, slug, storedVersion}, "\x00")
+	if _, seen := staleOverrideWarned.LoadOrStore(key, struct{}{}); seen {
 		return
 	}
 	s.logger.Warn("bot %q serves the %s override of tenant %s at version %s while this deployment would otherwise serve %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/botsource"
+)
+
+func TestBundleVersionOrder(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+		ok   bool
+	}{
+		{"0.7.0", "0.8.0", -1, true},
+		{"0.8.0", "0.7.0", 1, true},
+		{"0.8.0", "0.8.0", 0, true},
+		// A string compare gets this one backwards, and it is the shape a
+		// bot reaches on its tenth minor release.
+		{"0.9.0", "0.10.0", -1, true},
+		// A shorter version is the same release, not an older one.
+		{"1.2", "1.2.0", 0, true},
+		{"v1.3.0", "1.4.0", -1, true},
+		// Free-form versions are UNORDERED, never guessed.
+		{"2026-09-04", "0.8.0", 0, false},
+		{"0.8.0-rc1", "0.8.0", 0, false},
+		{"", "0.8.0", 0, false},
+		{"nightly", "stable", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := bundleVersionOrder(c.a, c.b)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("bundleVersionOrder(%q,%q) = %d,%v — want %d,%v", c.a, c.b, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// seedBakedBot writes a one-bot catalog and pins the server to it.
+func seedBakedBot(t *testing.T, s *Server, slug, version string) {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, botsource.MainBotFile), []byte(testBotMain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: " + slug + "\nversion: " + version + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{root}
+}
+
+// The regression this guards: a stored override outranks the baked catalog
+// forever, so a bundle pushed once keeps serving after a later release bakes a
+// newer one — measured in prod on 2026-09-06, where a review-pr override
+// pinned at 0.7.0 shadowed the 0.8.0 review tiers for 29 hours while the
+// operator's own inventory showed nothing wrong.
+func TestBotSourceListing_ReportsAnOverrideShadowingANewerBake(t *testing.T) {
+	s, editor, _ := newBotSourceTestServer(t)
+	edCtx := auth.WithIdentity(context.Background(), editor)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+
+	store := func(version string) {
+		t.Helper()
+		files := map[string]string{
+			botsource.MainBotFile: testBotMain,
+			"manifest.yaml":       "name: reviewer\nversion: " + version + "\n",
+		}
+		body, _ := json.Marshal(botSourcePutReq{Files: files})
+		r := httptest.NewRequest("PUT", "/api/teams/t1/bot-sources/reviewer", strings.NewReader(string(body))).WithContext(edCtx)
+		r.SetPathValue("id", "t1")
+		r.SetPathValue("slug", "reviewer")
+		w := httptest.NewRecorder()
+		s.handlePutBotSource(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("store %s = %d: %s", version, w.Code, w.Body.String())
+		}
+	}
+
+	row := func() botSourceMetaView {
+		t.Helper()
+		r := httptest.NewRequest("GET", "/api/teams/t1/bot-sources", nil).WithContext(edCtx)
+		r.SetPathValue("id", "t1")
+		w := httptest.NewRecorder()
+		s.handleListBotSources(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("list = %d: %s", w.Code, w.Body.String())
+		}
+		var got struct {
+			BotSources []botSourceMetaView `json:"bot_sources"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+			t.Fatal(err)
+		}
+		for _, v := range got.BotSources {
+			if v.Slug == "reviewer" {
+				return v
+			}
+		}
+		t.Fatal("reviewer absent from the listing")
+		return botSourceMetaView{}
+	}
+
+	// An override OLDER than the bake is the defect: it serves, and the
+	// inventory must say the newer bundle is being held back.
+	store("0.7.0")
+	got := row()
+	if !got.ShadowsNewerBake {
+		t.Errorf("an override at 0.7.0 against a 0.8.0 bake must report shadows_newer_bake; got %+v", got)
+	}
+	if got.BundleVersion != "0.7.0" || got.BakedVersion != "0.8.0" {
+		t.Errorf("versions = stored %q / baked %q — want 0.7.0 / 0.8.0", got.BundleVersion, got.BakedVersion)
+	}
+
+	// Control: caught up. The flag must clear, or it is decoration.
+	store("0.8.0")
+	if got := row(); got.ShadowsNewerBake {
+		t.Errorf("an override AT the baked version shadows nothing; got %+v", got)
+	}
+
+	// Control: ahead of the bake (an operator shipping before a release).
+	store("0.9.0")
+	if got := row(); got.ShadowsNewerBake {
+		t.Errorf("an override NEWER than the bake shadows nothing; got %+v", got)
+	}
+}
+
+// A slug the image does not bake shadows nothing — the common case for a
+// team's own bot, which must not be flagged.
+func TestOverrideShadowsNewerBake_StoredOnlySlugIsNotStale(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+	if baked, shadowed := s.overrideShadowsNewerBake("a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
+		t.Errorf("a stored-only slug must shadow nothing; got baked=%q shadowed=%v", baked, shadowed)
+	}
+}

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/botsource"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 func TestBundleVersionOrder(t *testing.T) {
@@ -118,33 +119,66 @@ func TestBotSourceListing_ReportsAnOverrideShadowingANewerBake(t *testing.T) {
 	// inventory must say the newer bundle is being held back.
 	store("0.7.0")
 	got := row()
-	if !got.ShadowsNewerBake {
-		t.Errorf("an override at 0.7.0 against a 0.8.0 bake must report shadows_newer_bake; got %+v", got)
+	if !got.ShadowsNewerVersion {
+		t.Errorf("an override at 0.7.0 against a 0.8.0 bake must report shadows_newer_version; got %+v", got)
 	}
-	if got.BundleVersion != "0.7.0" || got.BakedVersion != "0.8.0" {
-		t.Errorf("versions = stored %q / baked %q — want 0.7.0 / 0.8.0", got.BundleVersion, got.BakedVersion)
+	if got.BundleVersion != "0.7.0" || got.ShadowedVersion != "0.8.0" {
+		t.Errorf("versions = stored %q / baked %q — want 0.7.0 / 0.8.0", got.BundleVersion, got.ShadowedVersion)
 	}
 
 	// Control: caught up. The flag must clear, or it is decoration.
 	store("0.8.0")
-	if got := row(); got.ShadowsNewerBake {
+	if got := row(); got.ShadowsNewerVersion {
 		t.Errorf("an override AT the baked version shadows nothing; got %+v", got)
 	}
 
 	// Control: ahead of the bake (an operator shipping before a release).
 	store("0.9.0")
-	if got := row(); got.ShadowsNewerBake {
+	if got := row(); got.ShadowsNewerVersion {
 		t.Errorf("an override NEWER than the bake shadows nothing; got %+v", got)
 	}
 }
 
 // A slug the catalog does not carry shadows nothing — the common case for a
 // team's own bot, which must not be flagged.
-func TestShadowsNewerBake_StoredOnlySlugIsNotStale(t *testing.T) {
+func TestShadowsNewerVersion_StoredOnlySlugIsNotStale(t *testing.T) {
 	s, _, _ := newBotSourceTestServer(t)
 	seedBakedBot(t, s, "reviewer", "0.8.0")
-	if baked, shadowed := shadowsNewerBake(s.bakedVersions(), "a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
-		t.Errorf("a stored-only slug must shadow nothing; got baked=%q shadowed=%v", baked, shadowed)
+	if baked, shadowed := shadowsNewerVersion(s.versionsBelow("t1"), "a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
+		t.Errorf("a stored-only slug must shadow nothing; got below=%q shadowed=%v", baked, shadowed)
+	}
+}
+
+// Resolution is team → platform → baked, so what a TEAM row holds back is the
+// platform override when one exists — not the bake behind it. Comparing a team
+// row against the bake alone called a 0.9.0 team override "current" while it
+// shadowed a 1.0.0 platform one (Revi's open question on the parent commit).
+func TestVersionsBelow_ATeamRowIsShadowedByThePlatformTier(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+	pctx := store.WithTenant(context.Background(), botsource.PlatformTenantID)
+	if _, err := s.botSources.Create(pctx, botsource.BotSource{
+		TenantID: botsource.PlatformTenantID,
+		Slug:     "reviewer",
+		Files: map[string]string{
+			botsource.MainBotFile: testBotMain,
+			"manifest.yaml":       "name: reviewer\nversion: 1.0.0\n",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.invalidatePlatformBots()
+
+	// A team row NEWER than the bake but OLDER than the platform override.
+	below, shadowed := shadowsNewerVersion(s.versionsBelow("t1"), "reviewer", "0.9.0")
+	if !shadowed || below != "1.0.0" {
+		t.Errorf("a team row at 0.9.0 shadows the 1.0.0 platform override; got below=%q shadowed=%v", below, shadowed)
+	}
+
+	// The platform row itself is measured against the bake — never itself.
+	below, shadowed = shadowsNewerVersion(s.versionsBelow(botsource.PlatformTenantID), "reviewer", "1.0.0")
+	if shadowed || below != "0.8.0" {
+		t.Errorf("a platform row compares against the bake; got below=%q shadowed=%v", below, shadowed)
 	}
 }
 

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/botsource"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
 func TestBundleVersionOrder(t *testing.T) {
@@ -136,12 +138,51 @@ func TestBotSourceListing_ReportsAnOverrideShadowingANewerBake(t *testing.T) {
 	}
 }
 
-// A slug the image does not bake shadows nothing — the common case for a
+// A slug the catalog does not carry shadows nothing — the common case for a
 // team's own bot, which must not be flagged.
-func TestOverrideShadowsNewerBake_StoredOnlySlugIsNotStale(t *testing.T) {
+func TestShadowsNewerBake_StoredOnlySlugIsNotStale(t *testing.T) {
 	s, _, _ := newBotSourceTestServer(t)
 	seedBakedBot(t, s, "reviewer", "0.8.0")
-	if baked, shadowed := s.overrideShadowsNewerBake("a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
+	if baked, shadowed := shadowsNewerBake(s.bakedVersions(), "a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
 		t.Errorf("a stored-only slug must shadow nothing; got baked=%q shadowed=%v", baked, shadowed)
+	}
+}
+
+// The dedup key must carry the tenant. A slug-only key let the FIRST team to
+// launch a shadowed override consume it and silenced every other team holding
+// the same one — the very silence this file exists to end (Revi R7c09d4).
+func TestWarnOverrideShadow_DedupsPerTenantNotPerSlug(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+	var buf bytes.Buffer
+	s.logger = iterlog.New(iterlog.LevelWarn, &buf)
+	staleOverrideWarned.Range(func(k, _ any) bool { staleOverrideWarned.Delete(k); return true })
+
+	s.warnIfOverrideShadowsNewerBake("team-a", "reviewer", "team", "0.7.0")
+	s.warnIfOverrideShadowsNewerBake("team-b", "reviewer", "team", "0.7.0")
+	// Count LINES, not slug occurrences — the message names the slug three
+	// times (subject + both remedies).
+	if got := strings.Count(buf.String(), "serves the"); got != 2 {
+		t.Errorf("two tenants shadowing the same slug must BOTH warn; got %d line(s):\n%s", got, buf.String())
+	}
+	for _, want := range []string{"team-a", "team-b", "0.7.0", "0.8.0"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("the warning must name %q; got:\n%s", want, buf.String())
+		}
+	}
+
+	// Same tenant again: deduped, or a bot serving every webhook drowns its
+	// own signal.
+	before := buf.Len()
+	s.warnIfOverrideShadowsNewerBake("team-a", "reviewer", "team", "0.7.0")
+	if buf.Len() != before {
+		t.Errorf("a repeat of the same shadow must be deduped; got:\n%s", buf.String()[before:])
+	}
+
+	// An override that shadows nothing stays silent.
+	buf.Reset()
+	s.warnIfOverrideShadowsNewerBake("team-c", "reviewer", "team", "0.9.0")
+	if buf.Len() != 0 {
+		t.Errorf("an override newer than the bake must not warn; got:\n%s", buf.String())
 	}
 }

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -46,6 +46,17 @@ func TestBundleVersionOrder(t *testing.T) {
 	}
 }
 
+// shadowsNewerVersionFor resolves the tier below tenantID and compares one
+// row against it, failing the test when the catalog could not be read at all.
+func shadowsNewerVersionFor(t *testing.T, s *Server, tenantID, slug, stored string) (string, bool) {
+	t.Helper()
+	versions, ok := s.versionsBelow(tenantID)
+	if !ok {
+		t.Fatalf("the catalog must be readable in this test")
+	}
+	return shadowsNewerVersion(versions, slug, stored)
+}
+
 // seedBakedBot writes a one-bot catalog and pins the server to it.
 func seedBakedBot(t *testing.T, s *Server, slug, version string) {
 	t.Helper()
@@ -144,7 +155,7 @@ func TestBotSourceListing_ReportsAnOverrideShadowingANewerBake(t *testing.T) {
 func TestShadowsNewerVersion_StoredOnlySlugIsNotStale(t *testing.T) {
 	s, _, _ := newBotSourceTestServer(t)
 	seedBakedBot(t, s, "reviewer", "0.8.0")
-	if baked, shadowed := shadowsNewerVersion(s.versionsBelow("t1"), "a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
+	if baked, shadowed := shadowsNewerVersionFor(t, s, "t1", "a-bot-only-this-team-has", "0.1.0"); shadowed || baked != "" {
 		t.Errorf("a stored-only slug must shadow nothing; got below=%q shadowed=%v", baked, shadowed)
 	}
 }
@@ -170,15 +181,115 @@ func TestVersionsBelow_ATeamRowIsShadowedByThePlatformTier(t *testing.T) {
 	s.invalidatePlatformBots()
 
 	// A team row NEWER than the bake but OLDER than the platform override.
-	below, shadowed := shadowsNewerVersion(s.versionsBelow("t1"), "reviewer", "0.9.0")
+	below, shadowed := shadowsNewerVersionFor(t, s, "t1", "reviewer", "0.9.0")
 	if !shadowed || below != "1.0.0" {
 		t.Errorf("a team row at 0.9.0 shadows the 1.0.0 platform override; got below=%q shadowed=%v", below, shadowed)
 	}
 
 	// The platform row itself is measured against the bake — never itself.
-	below, shadowed = shadowsNewerVersion(s.versionsBelow(botsource.PlatformTenantID), "reviewer", "1.0.0")
+	below, shadowed = shadowsNewerVersionFor(t, s, botsource.PlatformTenantID, "reviewer", "1.0.0")
 	if shadowed || below != "0.8.0" {
 		t.Errorf("a platform row compares against the bake; got below=%q shadowed=%v", below, shadowed)
+	}
+}
+
+// A shadow that appears MID-PROCESS must still be reported. Caching the
+// negative verdict burned the key on the first quiet launch, so a platform
+// override pushed afterwards was silenced for the process's lifetime — and the
+// platform overlay is a TTL cache that every `admin bots push` refills, so
+// this is a routine sequence, not a corner (Revi Rac8574).
+func TestWarnOverrideShadow_ReportsAShadowThatAppearsMidProcess(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+	var buf bytes.Buffer
+	s.logger = iterlog.New(iterlog.LevelWarn, &buf)
+	staleOverrideWarned.Range(func(k, _ any) bool { staleOverrideWarned.Delete(k); return true })
+
+	// A team row at 0.9.0 is ahead of the 0.8.0 bake: nothing to report yet.
+	s.warnIfOverrideShadowsNewerBake("t1", "reviewer", "team", "0.9.0")
+	if buf.Len() != 0 {
+		t.Fatalf("nothing shadowed yet; got:\n%s", buf.String())
+	}
+
+	// A super-admin pushes a platform override at 1.0.0. The SAME team row now
+	// holds it back.
+	pctx := store.WithTenant(context.Background(), botsource.PlatformTenantID)
+	if _, err := s.botSources.Create(pctx, botsource.BotSource{
+		TenantID: botsource.PlatformTenantID,
+		Slug:     "reviewer",
+		Files: map[string]string{
+			botsource.MainBotFile: testBotMain,
+			"manifest.yaml":       "name: reviewer\nversion: 1.0.0\n",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.invalidatePlatformBots()
+
+	s.warnIfOverrideShadowsNewerBake("t1", "reviewer", "team", "0.9.0")
+	if !strings.Contains(buf.String(), "1.0.0") {
+		t.Errorf("a shadow appearing mid-process must warn; got:\n%s", buf.String())
+	}
+}
+
+// An unreadable catalog must read as UNKNOWN, never as a clean inventory — on
+// the very endpoint the runbook calls the check to run after a release
+// (Revi Re7858f).
+func TestBotSourceListing_AnUnreadableCatalogIsNotACleanInventory(t *testing.T) {
+	s, editor, _ := newBotSourceTestServer(t)
+	edCtx := auth.WithIdentity(context.Background(), editor)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+
+	files := map[string]string{
+		botsource.MainBotFile: testBotMain,
+		"manifest.yaml":       "name: reviewer\nversion: 0.7.0\n",
+	}
+	body, _ := json.Marshal(botSourcePutReq{Files: files})
+	r := httptest.NewRequest("PUT", "/api/teams/t1/bot-sources/reviewer", strings.NewReader(string(body))).WithContext(edCtx)
+	r.SetPathValue("id", "t1")
+	r.SetPathValue("slug", "reviewer")
+	w := httptest.NewRecorder()
+	s.handlePutBotSource(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("store = %d: %s", w.Code, w.Body.String())
+	}
+
+	// Break the catalog: a manifest the loader refuses.
+	broken := t.TempDir()
+	dir := filepath.Join(broken, "reviewer")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, botsource.MainBotFile), []byte(testBotMain), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: [unterminated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{broken}
+	s.bakedCatalog = s.newBakedCatalogResolver()
+
+	req := httptest.NewRequest("GET", "/api/teams/t1/bot-sources", nil).WithContext(edCtx)
+	req.SetPathValue("id", "t1")
+	rec := httptest.NewRecorder()
+	s.handleListBotSources(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list = %d: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		ShadowCheckUnavailable bool                `json:"shadow_check_unavailable"`
+		BotSources             []botSourceMetaView `json:"bot_sources"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.ShadowCheckUnavailable {
+		t.Errorf("an unreadable catalog must be reported, not read as clean; got %s", rec.Body.String())
+	}
+	for _, v := range got.BotSources {
+		if v.ShadowsNewerVersion {
+			t.Errorf("no row may claim a verdict when the check could not run; got %+v", v)
+		}
 	}
 }
 

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -168,6 +168,12 @@ func (s *Server) storedLaunchBot(bs botsource.BotSource, origin string) (*launch
 		_ = os.RemoveAll(dir)
 		return nil, err
 	}
+	// The override wins — that is the tier's purpose — but say so when this
+	// image bakes a NEWER bundle for the same slug, or a bot pinned by one
+	// push keeps serving across releases with nothing naming the shadow.
+	if m := bs.Manifest(); m != nil {
+		s.warnIfOverrideShadowsNewerBake(bs.Slug, origin, m.Version)
+	}
 	return &launchBot{
 		BotID:     bs.Slug,
 		Origin:    origin,

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -172,7 +172,7 @@ func (s *Server) storedLaunchBot(bs botsource.BotSource, origin string) (*launch
 	// image bakes a NEWER bundle for the same slug, or a bot pinned by one
 	// push keeps serving across releases with nothing naming the shadow.
 	if m := bs.Manifest(); m != nil {
-		s.warnIfOverrideShadowsNewerBake(bs.Slug, origin, m.Version)
+		s.warnIfOverrideShadowsNewerBake(bs.TenantID, bs.Slug, origin, m.Version)
 	}
 	return &launchBot{
 		BotID:     bs.Slug,

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -25,6 +25,11 @@ var resolverSweepAllowed = map[string]string{
 	"server_dsl.go":           "studio Home display walker over FS load names (cosmetic; /bots gallery is the covered surface)",
 	"catalog_regen.go":        "regenerates the FS catalog skill from the FS manifests by design",
 	"config_shares_routes.go": "botManifest's baked-FS FALLBACK, reached after platformBotManifest",
+	// The inversion the rest of this allowlist guards against IS this file's
+	// job: it reads the baked bundle PAST the override, on purpose, to report
+	// an override that shadows a newer bake. Routing it through the authority
+	// would return the override and always compare a version with itself.
+	"bot_override_staleness.go": "reads the baked catalog deliberately, to compare it AGAINST the override",
 }
 
 func TestBotResolutionSweep_NoRawRegistryReads(t *testing.T) {

--- a/pkg/server/bot_sources_routes.go
+++ b/pkg/server/bot_sources_routes.go
@@ -86,16 +86,42 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 	views := make([]botSourceMetaView, 0, len(list))
 	for _, b := range list {
 		digest := botsource.Digest(b.Files)
+		bundleVersion := ""
+		if m := b.Manifest(); m != nil {
+			bundleVersion = strings.TrimSpace(m.Version)
+		}
+		baked, shadowed := s.overrideShadowsNewerBake(b.Slug, bundleVersion)
 		b.Files = nil
-		views = append(views, botSourceMetaView{BotSource: b, Digest: digest})
+		views = append(views, botSourceMetaView{
+			BotSource:        b,
+			Digest:           digest,
+			BundleVersion:    bundleVersion,
+			BakedVersion:     baked,
+			ShadowsNewerBake: shadowed,
+		})
 	}
 	s.writeJSONFor(w, r, map[string]any{"bot_sources": views})
 }
 
 // botSourceMetaView is one list row: the metadata plus the content digest.
+//
+// It also answers the question this inventory exists to answer — "what is
+// actually serving?" — because an override outranks the baked catalog
+// forever, so a row that looks current can be holding back a newer bundle the
+// deployment already ships. BundleVersion/BakedVersion are the two sides;
+// ShadowsNewerBake is the comparison, omitted unless true so a healthy
+// inventory stays quiet.
 type botSourceMetaView struct {
 	botsource.BotSource
 	Digest string `json:"digest,omitempty"`
+	// BundleVersion is the stored manifest's version ("" when it carries none).
+	BundleVersion string `json:"bundle_version,omitempty"`
+	// BakedVersion is what THIS image ships for the same slug ("" when the
+	// slug is stored-only, which shadows nothing).
+	BakedVersion string `json:"baked_version,omitempty"`
+	// ShadowsNewerBake reports a stored bundle strictly older than the baked
+	// one. Never an error: pinning an older bundle is a legitimate choice.
+	ShadowsNewerBake bool `json:"shadows_newer_bake,omitempty"`
 }
 
 func (s *Server) handleGetBotSource(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/bot_sources_routes.go
+++ b/pkg/server/bot_sources_routes.go
@@ -83,6 +83,9 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 	}
 	// Strip Files from the list payload — it is metadata only. Digest gives
 	// "what exactly is deployed" a comparable answer without the content.
+	// One catalog walk for the whole listing: resolving the baked version per
+	// row would re-discover every configured bot root for each one.
+	baked := s.bakedVersions()
 	views := make([]botSourceMetaView, 0, len(list))
 	for _, b := range list {
 		digest := botsource.Digest(b.Files)
@@ -90,13 +93,13 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 		if m := b.Manifest(); m != nil {
 			bundleVersion = strings.TrimSpace(m.Version)
 		}
-		baked, shadowed := s.overrideShadowsNewerBake(b.Slug, bundleVersion)
+		bakedVersion, shadowed := shadowsNewerBake(baked, b.Slug, bundleVersion)
 		b.Files = nil
 		views = append(views, botSourceMetaView{
 			BotSource:        b,
 			Digest:           digest,
 			BundleVersion:    bundleVersion,
-			BakedVersion:     baked,
+			BakedVersion:     bakedVersion,
 			ShadowsNewerBake: shadowed,
 		})
 	}

--- a/pkg/server/bot_sources_routes.go
+++ b/pkg/server/bot_sources_routes.go
@@ -83,9 +83,9 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 	}
 	// Strip Files from the list payload — it is metadata only. Digest gives
 	// "what exactly is deployed" a comparable answer without the content.
-	// One catalog walk for the whole listing: resolving what sits below each
+	// One catalog read for the whole listing: resolving what sits below each
 	// row would re-discover every configured bot root for each one.
-	below := s.versionsBelow(tenantID)
+	below, shadowCheckOK := s.versionsBelow(tenantID)
 	views := make([]botSourceMetaView, 0, len(list))
 	for _, b := range list {
 		digest := botsource.Digest(b.Files)
@@ -103,7 +103,22 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 			ShadowsNewerVersion: shadowed,
 		})
 	}
-	s.writeJSONFor(w, r, map[string]any{"bot_sources": views})
+	s.writeJSONFor(w, r, botSourceListView{
+		BotSources:             views,
+		ShadowCheckUnavailable: !shadowCheckOK,
+	})
+}
+
+// botSourceListView is the listing payload. A named type, shared by the
+// handler and the OpenAPI declaration, so the shape the spec promises and the
+// shape the server writes cannot drift apart.
+type botSourceListView struct {
+	BotSources []botSourceMetaView `json:"bot_sources"`
+	// ShadowCheckUnavailable reports that the catalog could not be read, so
+	// every row's shadow fields are absent. An inventory that looks clean
+	// because the check could not run is worse than one that admits it did
+	// not run.
+	ShadowCheckUnavailable bool `json:"shadow_check_unavailable,omitempty"`
 }
 
 // botSourceMetaView is one list row: the metadata plus the content digest.

--- a/pkg/server/bot_sources_routes.go
+++ b/pkg/server/bot_sources_routes.go
@@ -83,9 +83,9 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 	}
 	// Strip Files from the list payload — it is metadata only. Digest gives
 	// "what exactly is deployed" a comparable answer without the content.
-	// One catalog walk for the whole listing: resolving the baked version per
+	// One catalog walk for the whole listing: resolving what sits below each
 	// row would re-discover every configured bot root for each one.
-	baked := s.bakedVersions()
+	below := s.versionsBelow(tenantID)
 	views := make([]botSourceMetaView, 0, len(list))
 	for _, b := range list {
 		digest := botsource.Digest(b.Files)
@@ -93,14 +93,14 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 		if m := b.Manifest(); m != nil {
 			bundleVersion = strings.TrimSpace(m.Version)
 		}
-		bakedVersion, shadowed := shadowsNewerBake(baked, b.Slug, bundleVersion)
+		shadowedVersion, shadowed := shadowsNewerVersion(below, b.Slug, bundleVersion)
 		b.Files = nil
 		views = append(views, botSourceMetaView{
-			BotSource:        b,
-			Digest:           digest,
-			BundleVersion:    bundleVersion,
-			BakedVersion:     bakedVersion,
-			ShadowsNewerBake: shadowed,
+			BotSource:           b,
+			Digest:              digest,
+			BundleVersion:       bundleVersion,
+			ShadowedVersion:     shadowedVersion,
+			ShadowsNewerVersion: shadowed,
 		})
 	}
 	s.writeJSONFor(w, r, map[string]any{"bot_sources": views})
@@ -109,22 +109,23 @@ func (s *Server) listBotSourcesFor(w http.ResponseWriter, r *http.Request, tenan
 // botSourceMetaView is one list row: the metadata plus the content digest.
 //
 // It also answers the question this inventory exists to answer — "what is
-// actually serving?" — because an override outranks the baked catalog
+// actually serving?" — because an override outranks the tier below it
 // forever, so a row that looks current can be holding back a newer bundle the
-// deployment already ships. BundleVersion/BakedVersion are the two sides;
-// ShadowsNewerBake is the comparison, omitted unless true so a healthy
-// inventory stays quiet.
+// deployment already has.
 type botSourceMetaView struct {
 	botsource.BotSource
 	Digest string `json:"digest,omitempty"`
 	// BundleVersion is the stored manifest's version ("" when it carries none).
 	BundleVersion string `json:"bundle_version,omitempty"`
-	// BakedVersion is what THIS image ships for the same slug ("" when the
-	// slug is stored-only, which shadows nothing).
-	BakedVersion string `json:"baked_version,omitempty"`
-	// ShadowsNewerBake reports a stored bundle strictly older than the baked
-	// one. Never an error: pinning an older bundle is a legitimate choice.
-	ShadowsNewerBake bool `json:"shadows_newer_bake,omitempty"`
+	// ShadowedVersion is what would serve for this slug WITHOUT this row —
+	// the baked catalog for a platform row, the platform override (else the
+	// bake) for a team one, since resolution is team → platform → baked. ""
+	// when nothing else offers the slug, which shadows nothing.
+	ShadowedVersion string `json:"shadowed_version,omitempty"`
+	// ShadowsNewerVersion reports a stored bundle strictly older than what it
+	// shadows. Omitted unless true, so a healthy inventory stays quiet. Never
+	// an error: pinning an older bundle is a legitimate choice.
+	ShadowsNewerVersion bool `json:"shadows_newer_version,omitempty"`
 }
 
 func (s *Server) handleGetBotSource(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -75,11 +75,7 @@ func routeSchemas() map[string]routeOp {
 		"DELETE /api/admin/usage-readings/{fingerprint}": {response: usageReadingsClearedView{}},
 
 		// Platform bot overrides (super-admin) — the DB-backed bot catalog.
-		"GET /api/admin/bots": {
-			response: struct {
-				BotSources []botSourceMetaView `json:"bot_sources"`
-			}{},
-		},
+		"GET /api/admin/bots":              {response: botSourceListView{}},
 		"GET /api/admin/bots/{slug}":       {response: botSourceView{}},
 		"PUT /api/admin/bots/{slug}":       {request: botSourcePutReq{}, response: botSourceView{}},
 		"DELETE /api/admin/bots/{slug}":    {},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -209,7 +209,11 @@ type Server struct {
 	botVarsStore    platformcfg.Store[platformcfg.BotVars]
 	// platformBots caches the platform-override entry set per replica
 	// (TTL-bounded read cache; Mongo stays the authority — bot_resolver.go).
-	platformBots   *platformcfg.Resolver[platformBotSet]
+	platformBots *platformcfg.Resolver[platformBotSet]
+	// bakedCatalog caches slug → version for the on-disk catalog, so the
+	// override-staleness comparison can be recomputed on every launch without
+	// re-walking every bot root each time (bot_override_staleness.go).
+	bakedCatalog   *platformcfg.Resolver[bakedCatalog]
 	configShares   configshare.Store
 	configShareSvc *configshare.Service
 	// configShareFC overrides forge-client resolution in tests (nil in prod →
@@ -637,6 +641,7 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 	// tests wire s.botSources after New, and the resolver must already
 	// exist for them — same reason the roles/sandbox resolvers are.
 	s.platformBots = s.newPlatformBotsResolver()
+	s.bakedCatalog = s.newBakedCatalogResolver()
 	// Runtime usage-cap resolver: env defaults + the DB record, TTL-cached.
 	// A malformed env policy leaves it nil — the health echo reports the
 	// invalid value (existing behaviour) instead of a resolver quietly

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6194,6 +6194,8 @@ export interface components {
             from: string;
         };
         botSourceMetaView: {
+            baked_version?: string;
+            bundle_version?: string;
             /** Format: date-time */
             created_at: string;
             created_by?: string;
@@ -6203,6 +6205,7 @@ export interface components {
             };
             id: string;
             origin?: string;
+            shadows_newer_bake?: boolean;
             slug: string;
             tenant_id: string;
             /** Format: date-time */

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6193,6 +6193,10 @@ export interface components {
         botSourceForkReq: {
             from: string;
         };
+        botSourceListView: {
+            bot_sources: components["schemas"]["botSourceMetaView"][];
+            shadow_check_unavailable?: boolean;
+        };
         botSourceMetaView: {
             bundle_version?: string;
             /** Format: date-time */
@@ -6510,9 +6514,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        bot_sources: components["schemas"]["botSourceMetaView"][];
-                    };
+                    "application/json": components["schemas"]["botSourceListView"];
                 };
             };
         };

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6194,7 +6194,6 @@ export interface components {
             from: string;
         };
         botSourceMetaView: {
-            baked_version?: string;
             bundle_version?: string;
             /** Format: date-time */
             created_at: string;
@@ -6205,7 +6204,8 @@ export interface components {
             };
             id: string;
             origin?: string;
-            shadows_newer_bake?: boolean;
+            shadowed_version?: string;
+            shadows_newer_version?: boolean;
             slug: string;
             tenant_id: string;
             /** Format: date-time */


### PR DESCRIPTION
## Why

A platform (or team) bot override **outranks the baked catalog at every launch surface** — that is the tier's purpose. The cost, unmeasured until now: a bundle pushed once keeps serving after a later release bakes a newer one for the same slug. The image moves, the bot does not, and nothing says so.

Measured in prod on 2026-09-06:

- `review-pr`'s platform override, pushed **2026-09-04 06:52Z** for the 0.7.0 cost pass, was still serving **every** production review **29 hours** after #742 baked the 0.8.0 review tiers into the image.
- Prod review graphs on both 09-05 and 09-06 ran `diff_precheck → topology → reviewer_claude → merge_reviews → converge → pr_gate` — **no `tier_expand` node**.
- `GET /api/admin/bots/review-pr` returned manifest version `0.7.0`, whose `main.bot` carried `TOKEN FRUGALITY` and `supervisor pacer` but none of `tier_expand` / `review_tier` / `reviewer_claude_glance`.
- Meanwhile the release, the runner digest bump and `docs/bot-runs/review-pr.md` all reported the tiers as deployed.

Documented as functional while inert — the failure mode CLAUDE.md calls worse than absence.

The prod instance is already cleared (the override was deleted after verifying the repo's 0.8.0 is a strict superset — all three 0.7.0 markers plus #758 and #816 — and the effective bundle then read `0.8.0` from `/opt/iterion/bots/review-pr`). **This PR closes the class**, so the next one is noticed in seconds rather than a day.

## What changes

The override is **still never refused** — pinning an older bundle is a legitimate operator choice, and a rollback is exactly this shape. What changes is that the shadow is reported:

- `GET /api/admin/bots` (and the team bot-sources listing, which shares the handler) return `bundle_version`, `baked_version` and `shadows_newer_bake` per row. The last is `omitempty`, so a healthy inventory stays quiet. This is the check to run after any release that touched an overridden bot.
- The resolver logs one `Warn` per `(slug, stored, baked)` triple — not per launch, or a bot serving every webhook would drown its own signal.

Two judgement calls worth reviewing:

- **Versions compare as dotted numeric components**, so `0.10.0` beats `0.9.0` (a string compare gets that backwards, and it is the shape a bot reaches on its tenth minor release). `Manifest.version` is documented free-form, so a pair that does not parse is treated as **unordered and never flagged** — a false staleness alarm on an operator's own naming scheme would be worse than the silence it replaces.
- **The baked read is deliberately raw.** Routing it through the resolution authority would return the override and compare a version with itself, so it earns an entry in `bot_resolver_sweep_test.go`'s allowlist with that reason rather than a bypass.

## Evidence

Canary proven red-first — with the comparison neutralised, the listing test fails on the exact prod shape:

```
bot_override_staleness_test.go:120: an override at 0.7.0 against a 0.8.0 bake
must report shadows_newer_bake; got {... BundleVersion:0.7.0 BakedVersion:0.8.0
ShadowsNewerBake:false}
```

Restored → green. `TestBundleVersionOrder` covers the ordering rules including the `0.9.0 < 0.10.0` trap, `1.2 == 1.2.0`, and four unorderable shapes. Controls assert the flag **clears** when the override catches up or runs ahead, and that a stored-only slug (a team's own bot) is never flagged. `go test ./pkg/server/` and `task lint` are green; `openapi.json` + `studio/src/api/schema.ts` regenerated for the three new response fields.

## Docs

- `docs/platform-bots.md` — a new section on the hazard, the two ways to clear a shadow, and why dropping the override is usually right once its reason has shipped.
- `docs/bot-runs/review-pr.md` — corrects the entry that asserted the tiers were deployed, and records the **33-production-review cost measurement** taken during that window. The override is what makes that dataset trustworthy: bot 0.7.0 served throughout, so no version change straddles the numbers. It also documents two claims of mine that did not survive more data (a "0.12% stable per-PR cost" that turned out to be a two-point coincidence — the real spread is 25% — and a reproducibility claim withdrawn outright, since no same-sha pair exists in the data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
