### PR TITLE
fix(bots): lot_verify's report search is bounded — a chatty stdout with no report is typed in seconds, not minutes

### DIFF
--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -882,27 +882,50 @@ tool lot_verify:
         harness prints it, or a pretty-printed block: the wrapper prints
         exactly one, after the harness has logged to stderr. A format is not
         a verdict, so both shapes read the same."""
-        # Bounded: a block starts at a column-0 "{" and at most 32 parses are
-        # attempted, so a chatty stdout with no report stays linear — the
-        # no-report path is the one this reader exists to type, and it must
-        # not burn minutes saying so.
+        # Bounded by the window, never at the expense of a verdict that was
+        # there: a one-line report costs one parse wherever it sits; a
+        # pretty-printed block ends at a "}"-terminated line and starts at a
+        # column-0 "{" above it — the two nearest are tried, then the
+        # window's outermost (`indent=0` puts a list's objects at column 0,
+        # and the nearest open would hand back an inner fragment). At most
+        # three joins per closing line, never every "{" above (that scan was
+        # quadratic on a chatty stdout with no report), and never a global
+        # budget (one that noise printed AFTER the report could spend typed
+        # a green oracle ORACLE_NOT_RUN).
+        # And only a REPORT is handed back — an object carrying at least one
+        # of the harness's verdict fields (an older harness writes no
+        # `mode`, it always writes `invalid`/`stable`/`ok`). A `{}` or a
+        # fragment `{"name": …}` printed after the report is skipped, not
+        # read as a mode-less gate verdict with an empty `invalid` list.
+        import bisect
+
+        def is_report(obj):
+            return isinstance(obj, dict) and any(
+                k in obj for k in ("mode", "stable", "ok", "invalid", "blind_lanes", "holdout_total"))
+
         lines = (text or "").splitlines()[-2000:]
-        attempts = 0
+        opens = [i for i, l in enumerate(lines) if l.startswith("{")]
         for j in range(len(lines) - 1, -1, -1):
-            tail = lines[j].rstrip()
+            tail = lines[j].strip()
             if not tail.endswith("}"):
                 continue
-            candidates = [j] if tail.startswith("{") else []
-            candidates += [i for i in range(j - 1, -1, -1) if lines[i].startswith("{")]
-            for i in candidates:
-                attempts += 1
-                if attempts > 32:
-                    return None
+            if tail.startswith("{"):
+                try:
+                    obj = json.loads(tail)
+                except ValueError:
+                    obj = None
+                if is_report(obj):
+                    return obj
+            k = bisect.bisect_left(opens, j)
+            starts = list(reversed(opens[max(0, k - 2):k]))
+            if k > 0 and opens[0] not in starts:
+                starts.append(opens[0])
+            for i in starts:
                 try:
                     obj = json.loads("\n".join(lines[i:j + 1]))
                 except ValueError:
                     continue
-                if isinstance(obj, dict):
+                if is_report(obj):
                     return obj
         return None
 
@@ -968,6 +991,10 @@ tool lot_verify:
                 else:
                     report["oracle_report"] = {"mode": oracle_report.get("mode"),
                                                "truncated": True, "bytes": len(as_text)}
+            # An older harness's report carries no `mode` and is a gate; the
+            # default is safe only because the reader above hands back
+            # nothing but reports (an object carrying a verdict field) — a
+            # `{}` or a fragment never reaches this line.
             mode = (oracle_report or {}).get("mode") or "gate"
             if code is None:
                 timed_out("the behavioural oracle", verify, log)

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -882,14 +882,22 @@ tool lot_verify:
         harness prints it, or a pretty-printed block: the wrapper prints
         exactly one, after the harness has logged to stderr. A format is not
         a verdict, so both shapes read the same."""
+        # Bounded: a block starts at a column-0 "{" and at most 32 parses are
+        # attempted, so a chatty stdout with no report stays linear — the
+        # no-report path is the one this reader exists to type, and it must
+        # not burn minutes saying so.
         lines = (text or "").splitlines()[-2000:]
+        attempts = 0
         for j in range(len(lines) - 1, -1, -1):
-            tail = lines[j].strip()
+            tail = lines[j].rstrip()
             if not tail.endswith("}"):
                 continue
             candidates = [j] if tail.startswith("{") else []
-            candidates += [i for i in range(j - 1, -1, -1) if lines[i].lstrip().startswith("{")]
+            candidates += [i for i in range(j - 1, -1, -1) if lines[i].startswith("{")]
             for i in candidates:
+                attempts += 1
+                if attempts > 32:
+                    return None
                 try:
                     obj = json.loads("\n".join(lines[i:j + 1]))
                 except ValueError:

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -882,52 +882,56 @@ tool lot_verify:
         harness prints it, or a pretty-printed block: the wrapper prints
         exactly one, after the harness has logged to stderr. A format is not
         a verdict, so both shapes read the same."""
-        # Bounded by the window, never at the expense of a verdict that was
-        # there: a one-line report costs one parse wherever it sits; a
-        # pretty-printed block ends at a "}"-terminated line and starts at a
-        # column-0 "{" above it — the two nearest are tried, then the
-        # window's outermost (`indent=0` puts a list's objects at column 0,
-        # and the nearest open would hand back an inner fragment). At most
-        # three joins per closing line, never every "{" above (that scan was
-        # quadratic on a chatty stdout with no report), and never a global
-        # budget (one that noise printed AFTER the report could spend typed
-        # a green oracle ORACLE_NOT_RUN).
+        # Bounded AND lossless. Every line that opens with a "{" is a
+        # candidate start, tried ONCE, in place, with `raw_decode` — which
+        # parses one object and stops. So a one-line report costs one parse
+        # wherever it sits, and a pretty-printed block, an `indent=0` dump
+        # (whose list objects sit at column 0) and a block a wrapper
+        # indented all read the same: no candidate start is ever dropped.
+        # At most one parse per line of the window — never a re-join of the
+        # slice above every closing line, which was quadratic on the very
+        # path this reader exists to type (a chatty stdout with no report),
+        # and never a global budget, which noise printed AFTER the report
+        # could spend to type a green oracle ORACLE_NOT_RUN.
+        # A candidate whose first token is neither a key string nor "}" is
+        # not a JSON object: refused in O(1), so the dict reprs a chatty
+        # harness logs (`{'line': 0, …}`) never reach the parser. That
+        # refusal is what keeps the bound — a FAILED parse is the expensive
+        # one, `json` re-deriving line:column over the whole blob for the
+        # error it raises.
+        # The report is the object whose parse ENDS last, so an inner
+        # fragment never shadows the report that contains it.
         # And only a REPORT is handed back — an object carrying at least one
         # of the harness's verdict fields (an older harness writes no
         # `mode`, it always writes `invalid`/`stable`/`ok`). A `{}` or a
         # fragment `{"name": …}` printed after the report is skipped, not
         # read as a mode-less gate verdict with an empty `invalid` list.
-        import bisect
-
         def is_report(obj):
             return isinstance(obj, dict) and any(
                 k in obj for k in ("mode", "stable", "ok", "invalid", "blind_lanes", "holdout_total"))
 
         lines = (text or "").splitlines()[-2000:]
-        opens = [i for i, l in enumerate(lines) if l.startswith("{")]
-        for j in range(len(lines) - 1, -1, -1):
-            tail = lines[j].strip()
-            if not tail.endswith("}"):
+        blob = "\n".join(lines)
+        decode = json.JSONDecoder().raw_decode
+        found, found_end = None, -1
+        at = 0
+        for line in lines:
+            head = line.lstrip()
+            start, at = at + len(line) - len(head), at + len(line) + 1
+            if not head.startswith("{"):
                 continue
-            if tail.startswith("{"):
-                try:
-                    obj = json.loads(tail)
-                except ValueError:
-                    obj = None
-                if is_report(obj):
-                    return obj
-            k = bisect.bisect_left(opens, j)
-            starts = list(reversed(opens[max(0, k - 2):k]))
-            if k > 0 and opens[0] not in starts:
-                starts.append(opens[0])
-            for i in starts:
-                try:
-                    obj = json.loads("\n".join(lines[i:j + 1]))
-                except ValueError:
-                    continue
-                if is_report(obj):
-                    return obj
-        return None
+            probe = start + 1
+            while probe < len(blob) and blob[probe] in " \t\r\n":
+                probe += 1
+            if probe >= len(blob) or blob[probe] not in ('"', '}'):
+                continue
+            try:
+                obj, end = decode(blob, start)
+            except ValueError:
+                continue
+            if end > found_end and is_report(obj):
+                found, found_end = obj, end
+        return found
 
     # 1. The lot's own gate, every command, in order.
     report["gate_passed"] = True

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -917,7 +917,8 @@ tool lot_verify:
         at = 0
         for line in lines:
             head = line.lstrip()
-            start, at = at + len(line) - len(head), at + len(line) + 1
+            start = at + len(line) - len(head)  # the "{" itself, its indent skipped
+            at += len(line) + 1                 # the next line, past the "\n" the join put back
             if not head.startswith("{"):
                 continue
             probe = start + 1

--- a/bots/modernize_lot_verify_report_scratch_test.go
+++ b/bots/modernize_lot_verify_report_scratch_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The wrapper the net materialises, reduced to what these tests pin: it
@@ -154,6 +155,21 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		}
 		if !strings.Contains(res.BlockReason, "Directory nonexistent") {
 			t.Fatalf("the typed message kept the oldest output instead of the cause: %q", res.BlockReason)
+		}
+	})
+
+	t.Run("a chatty stdout with no report is typed in seconds, not minutes", func(t *testing.T) {
+		noisy := scratchWrapperHead +
+			"i=0; while [ $i -lt 6000 ]; do echo \"{'line': $i, 'note': 'a python dict repr the harness logged, brace first, no JSON anywhere'}\"; i=$((i+1)); done\n" +
+			"exit 2\n"
+		ws, base := scratchWorkspace(t, noisy)
+		started := time.Now()
+		res := scratchVerify(t, script, ws, base)
+		if d := time.Since(started); d > 8*time.Second {
+			t.Fatalf("typing a no-report stdout of 6000 brace-first lines took %s — the report search is not bounded", d)
+		}
+		if !res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a chatty wrapper death read as something else: %+v", res)
 		}
 	})
 

--- a/bots/modernize_lot_verify_report_scratch_test.go
+++ b/bots/modernize_lot_verify_report_scratch_test.go
@@ -173,6 +173,92 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		}
 	})
 
+	t.Run("a report buried under chatter and followed by one noise line is still read", func(t *testing.T) {
+		// The budget bounds the SEARCH; it must never discard a verdict that
+		// was there. A bounded scan that gave up on the first brace-terminated
+		// noise line after the report typed a green oracle ORACLE_NOT_RUN.
+		buried := scratchWrapperHead +
+			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
+			"echo '{\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
+			"echo \"{'teardown': 'one more brace-first line after the report'}\"\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, buried)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("a report followed by one noise line was discarded: %+v", res)
+		}
+		if res.OracleReport == nil || res.OracleReport["mode"] != "gate" {
+			t.Fatalf("the buried report is not in the verdict: %+v", res)
+		}
+	})
+
+	t.Run("a pretty-printed report buried under chatter and followed by noise is still read", func(t *testing.T) {
+		// The block starts at the nearest column-0 "{" above its closing
+		// line: forty brace-first lines above and two below must not push it
+		// out of reach, whatever the search spends on the noise.
+		buried := scratchWrapperHead +
+			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
+			"printf '{\\n  \"mode\": \"gate\",\\n  \"ok\": true,\\n  \"invalid\": []\\n}\\n'\n" +
+			"echo \"{'teardown': 'one more brace-first line after the report'}\"\n" +
+			"echo \"{'teardown': 'and another'}\"\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, buried)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("a pretty-printed report followed by noise was discarded: %+v", res)
+		}
+		if res.OracleReport == nil || res.OracleReport["mode"] != "gate" {
+			t.Fatalf("the buried pretty-printed report is not in the verdict: %+v", res)
+		}
+	})
+
+	t.Run("an indent=0 report whose list objects sit at column 0 is read whole, not as a fragment", func(t *testing.T) {
+		// json.dumps(indent=0) puts every object of a list at column 0; the
+		// nearest opening line above the closing brace then starts an inner
+		// object, and a fragment without a mode was read as a green gate.
+		zero := scratchWrapperHead +
+			"printf '{\\n\"mode\": \"gate\",\\n\"invalid\": [\\n{\\n\"name\": \"m1\"\\n},\\n{\\n\"name\": \"m2\"\\n}\\n],\\n\"stable\": true\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, zero)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("an indent=0 report was not read as a gate verdict: %+v", res)
+		}
+		if len(res.OracleInvalid) != 2 {
+			t.Fatalf("the report's invalid list was lost — a fragment was read instead of the report: %+v", res)
+		}
+	})
+
+	t.Run("an indented one-line report is read wherever it sits", func(t *testing.T) {
+		indented := scratchWrapperHead +
+			"echo '   {\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, indented)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed || res.OracleReport["mode"] != "gate" {
+			t.Fatalf("an indented one-line report was lost: %+v", res)
+		}
+	})
+
+	t.Run("a JSON object carrying no verdict field is not a report — the report above it is read", func(t *testing.T) {
+		// A wrapper that prints `{}` (or a fragment) after its report: the
+		// object is skipped, the report is the verdict. Read as a mode-less
+		// gate report, `{}` was a green verdict with an empty `invalid` list.
+		bare := scratchWrapperHead +
+			"echo '{\"mode\":\"gate\",\"ok\":false,\"invalid\":[\"m1\"]}'\n" +
+			"echo '{}'\n" +
+			"echo '{\"name\": \"m2\"}'\n" +
+			"exit 1\n"
+		ws, base := scratchWorkspace(t, bare)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a red report followed by non-report objects was not read as the RED it is: %+v", res)
+		}
+		if len(res.OracleInvalid) != 1 {
+			t.Fatalf("the report's invalid list was lost — a later object was read instead: %+v", res)
+		}
+	})
+
 	t.Run("a wrapper that exits 0 without printing a report is not a pass", func(t *testing.T) {
 		silent := scratchWrapperHead + "exit 0\n"
 		ws, base := scratchWorkspace(t, silent)

--- a/bots/modernize_lot_verify_report_scratch_test.go
+++ b/bots/modernize_lot_verify_report_scratch_test.go
@@ -193,9 +193,9 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 	})
 
 	t.Run("a pretty-printed report buried under chatter and followed by noise is still read", func(t *testing.T) {
-		// The block starts at the nearest column-0 "{" above its closing
-		// line: forty brace-first lines above and two below must not push it
-		// out of reach, whatever the search spends on the noise.
+		// Every line that opens with a "{" is a candidate start: forty
+		// brace-first lines above and two below must not push the block out
+		// of reach, whatever the search spends on the noise.
 		buried := scratchWrapperHead +
 			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
 			"printf '{\\n  \"mode\": \"gate\",\\n  \"ok\": true,\\n  \"invalid\": []\\n}\\n'\n" +
@@ -212,12 +212,18 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		}
 	})
 
-	t.Run("an indent=0 report whose list objects sit at column 0 is read whole, not as a fragment", func(t *testing.T) {
-		// json.dumps(indent=0) puts every object of a list at column 0; the
-		// nearest opening line above the closing brace then starts an inner
-		// object, and a fragment without a mode was read as a green gate.
+	t.Run("an indent=0 report buried under chatter is read whole, not as a fragment", func(t *testing.T) {
+		// json.dumps(indent=0) puts every object of a list at column 0, so the
+		// openings nearest the closing brace start INNER objects and the
+		// report's own is only reachable as a candidate in its own right. The
+		// chatter above is what makes this non-vacuous: a scan that fell back
+		// to the window's first column-0 "{" read the report only when
+		// nothing had been logged before it, and lost it behind one noise
+		// line — a whole RED/GREEN verdict typed ORACLE_NOT_RUN.
 		zero := scratchWrapperHead +
+			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
 			"printf '{\\n\"mode\": \"gate\",\\n\"invalid\": [\\n{\\n\"name\": \"m1\"\\n},\\n{\\n\"name\": \"m2\"\\n}\\n],\\n\"stable\": true\\n}\\n'\n" +
+			"echo \"{'teardown': 'one more brace-first line after the report'}\"\n" +
 			"exit 0\n"
 		ws, base := scratchWorkspace(t, zero)
 		res := scratchVerify(t, script, ws, base)
@@ -237,6 +243,23 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		res := scratchVerify(t, script, ws, base)
 		if res.OracleNotRun || !res.OraclePassed || res.OracleReport["mode"] != "gate" {
 			t.Fatalf("an indented one-line report was lost: %+v", res)
+		}
+	})
+
+	t.Run("a pretty-printed report a wrapper indented is read too", func(t *testing.T) {
+		// Nothing promises the block reaches stdout at column 0 — a tee, a
+		// textwrap.indent or a logger prefix shifts it. The indentation is a
+		// format, and a format is not a verdict: the block reads the same.
+		shifted := scratchWrapperHead +
+			"printf '  {\\n    \"mode\": \"gate\",\\n    \"ok\": true,\\n    \"invalid\": []\\n  }\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, shifted)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("an indented pretty-printed report was discarded: %+v", res)
+		}
+		if res.OracleReport == nil || res.OracleReport["mode"] != "gate" {
+			t.Fatalf("the indented pretty-printed report is not in the verdict: %+v", res)
 		}
 	})
 


### PR DESCRIPTION
Follow-up to #815 (Revi finding R552485, medium): `lot_verify`'s report search
was quadratic on the very path it exists to type — a chatty stdout with no
report.

## What was measured

On the shipped `last_json_object`: for every stdout line ending in `}` the
search retried a parse against every earlier line whose `lstrip()` started
with `{`, re-joining the slice each time. 30 s of CPU for 2000 lines of 33
characters, 86 s at 500 characters — linear in line length, on the no-report
path (a wrapper that died before the harness printed anything).

## What changes

- A block starts at a **column-0** `{` (the harness prints its report as one
  `json.dumps` line; a pretty-printed report still starts at column 0).
- At most **32** parse attempts, then `None` — the caller types the run
  `ORACLE_NOT_RUN` with the wrapper's tail, as before.

## Proof

- `TestModernizeLotVerifyReportScratch/…chatty stdout with no report…`: a
  6000-line brace-first stdout with no report is typed in well under the 8 s
  bound (0.1 s measured; the unbounded scan takes ~18 s on the same input).
- Mutant (the unbounded scan restored) red on that bound.
- The one-line and pretty-printed report cases of the same test still read.

No behaviour change on a run that prints a report.
