### PR TITLE
fix(pluginsource): a peer that published the same pinned checkout first has published this fetch's tree

### DIFF
--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -37,6 +37,12 @@ type Fetcher struct {
 	// Nil (or a nil return) means "public repository".
 	CredentialFor func(ctx context.Context, s PluginSource) (string, error)
 
+	// beforePublish runs after the checkout is staged and before it is moved
+	// onto the cache path. The seam a test uses to let a peer win the publish
+	// race on demand, instead of wagering on a `-count` stress run. Nil in
+	// production.
+	beforePublish func(staging, dest string)
+
 	mu       sync.Mutex
 	keyGates map[string]chan struct{}
 }
@@ -62,7 +68,7 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 
 	// A pinned ref makes the checkout immutable, so an existing tree is
 	// authoritative and we skip the network entirely.
-	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil && s.PinnedRef() {
+	if isPublished(dest) && s.PinnedRef() {
 		return dest, nil
 	}
 	if err := os.MkdirAll(f.CacheDir, 0o700); err != nil {
@@ -96,20 +102,48 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 	if err := f.git(ctx, staging, cred, "checkout", "--force", "FETCH_HEAD"); err != nil {
 		return "", err
 	}
-	if err := publish(staging, dest); err != nil {
+	if f.beforePublish != nil {
+		f.beforePublish(staging, dest)
+	}
+	// Only a MOVING ref publishes over an existing tree: its content changed,
+	// so the old one must go. A pinned ref's content cannot differ from what
+	// is already at its content-addressed path.
+	if err := publish(staging, dest, !s.PinnedRef()); err != nil {
 		return "", fmt.Errorf("pluginsource: publish checkout for %q: %w", s.Name, err)
 	}
 	return dest, nil
 }
 
-// publish moves a finished checkout onto its cache path. A moving ref replaces
-// an older tree, so the previous one is renamed aside first and deleted after
-// the swap — never before, so a failed rename leaves the old tree serving.
+// isPublished reports whether dest holds a checkout a reader can be handed.
+// `.git` is the marker the cache hit above reads, and publish reads the same
+// one: "complete enough to serve" must mean one thing in this package, or a
+// publisher and a reader can disagree about the very same directory.
+func isPublished(dest string) bool {
+	_, err := os.Stat(filepath.Join(dest, ".git"))
+	return err == nil
+}
+
+// publish moves a finished checkout onto its cache path. The in-process gate
+// does not cover a second process — nor a second Fetcher — sharing the cache
+// dir, so N publishers can arrive at the same path at once.
 //
-// The in-process gate does not cover a second process sharing the cache dir, so
-// a publisher that loses the race finds the path already holding an equivalent
-// checkout and keeps it rather than failing the launch.
-func publish(staging, dest string) error {
+// replaceExisting says whether a tree already there has to go. It is true only
+// for a MOVING ref, whose content changed under the same key; then the old tree
+// is renamed aside first and deleted after the swap — never before, so a failed
+// rename leaves it serving.
+//
+// For an immutable (pinned) ref a tree already there IS the tree being
+// published, so it is kept and the staging copy dropped. That is not only
+// cheaper: renaming it aside makes `dest` briefly ABSENT to every other
+// publisher, and that absence is the window a peer's "was it already
+// published?" read fell into — its own rename had lost, dest was then retired
+// by a third publisher, and it reported ENOTEMPTY for a tree that was there
+// (#854). Never retiring an immutable tree removes the window rather than
+// racing it.
+func publish(staging, dest string, replaceExisting bool) error {
+	if !replaceExisting && isPublished(dest) {
+		return nil // a peer published it while we were staging
+	}
 	retired := ""
 	if _, err := os.Stat(dest); err == nil {
 		retired = dest + ".retired-" + filepath.Base(staging)
@@ -124,7 +158,15 @@ func publish(staging, dest string) error {
 		if retired != "" {
 			_ = os.Rename(retired, dest)
 		}
-		if _, statErr := os.Stat(filepath.Join(dest, ".git")); statErr == nil {
+		// Lost the race: the path holds a complete checkout of this same key,
+		// which is what this fetch was going to put there. Keep it rather than
+		// failing the launch — the staging copy goes with the caller's defer.
+		// A dest that is ABSENT or INCOMPLETE is still an error, carrying the
+		// rename's own cause.
+		if isPublished(dest) {
+			if retired != "" {
+				_ = os.RemoveAll(retired)
+			}
 			return nil
 		}
 		return err

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -1,0 +1,127 @@
+package pluginsource
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A peer that publishes the same PINNED checkout while this fetch is staging has
+// published exactly the tree this fetch wanted: the cache path is
+// content-addressed and the ref immutable. The loser must take it — and must
+// NOT swap its own copy in, because renaming the peer's tree aside leaves
+// `dest` ABSENT for an instant, and that instant is the window a THIRD
+// publisher's "was it already published?" read falls into: its own rename has
+// already lost, so it finds nothing and reports ENOTEMPTY for a tree that is
+// there (#854, which ejected a PR from the merge queue).
+//
+// The interleaving is scripted through the fetcher's beforePublish seam, not
+// wagered on `-count`: the peer publishes at the one instant that matters.
+func TestFetcher_PeerPublishedTheSamePinnedCheckoutFirst(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	origin := gitOrigin(t, "v1.0.0")
+	cache := t.TempDir()
+	s := validSource()
+	s.GitURL, s.Ref = origin, "v1.0.0"
+
+	const peerMark = ".published-by-the-peer"
+	peer := &Fetcher{CacheDir: cache}
+	f := &Fetcher{CacheDir: cache}
+	published := false
+	f.beforePublish = func(_, dest string) {
+		if published {
+			return
+		}
+		published = true
+		if _, err := peer.Fetch(context.Background(), s); err != nil {
+			t.Errorf("the peer's own fetch failed, so this test proves nothing: %v", err)
+			return
+		}
+		// Marks the peer's inode, so "was it kept?" is answerable after the
+		// fact — both trees have identical content otherwise.
+		if err := os.WriteFile(filepath.Join(dest, peerMark), nil, 0o644); err != nil {
+			t.Errorf("mark the peer's tree: %v", err)
+		}
+	}
+
+	got, err := f.Fetch(context.Background(), s)
+	if err != nil {
+		t.Fatalf("a peer publishing the same pinned checkout first must not fail this fetch: %v", err)
+	}
+	if body, rerr := os.ReadFile(filepath.Join(got, "skills", "deploy-target.md")); rerr != nil || string(body) != "playbook\n" {
+		t.Fatalf("the returned path is not a complete checkout: %v %q", rerr, body)
+	}
+	if _, serr := os.Stat(filepath.Join(got, peerMark)); serr != nil {
+		t.Fatalf("the peer's published tree was replaced: renaming an immutable tree aside makes %q ABSENT to every other publisher, which is the window #854 fell into", got)
+	}
+
+	// Nothing parked beside it either: a retired or staging copy of a full
+	// checkout that nobody deletes is the cache growing one clone per race.
+	entries, err := os.ReadDir(cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			t.Errorf("left behind in the cache dir: %s", e.Name())
+		}
+	}
+}
+
+// The loser's own read of the final path is the second half of the rule: a
+// rename that lost to a peer is success when the path holds a complete
+// checkout, and an error — carrying the rename's own cause — when it does not.
+func TestPublish_LostRenameReadsTheFinalPath(t *testing.T) {
+	t.Run("complete final is kept, not swapped", func(t *testing.T) {
+		root := t.TempDir()
+		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
+		mkCheckout(t, staging, "ours")
+		mkCheckout(t, dest, "the-peers")
+		// replaceExisting=false is the immutable case: the peer's tree stands,
+		// untouched — asserted by WHOSE tree is there, since "still a checkout"
+		// would also hold after a swap.
+		if err := publish(staging, dest, false); err != nil {
+			t.Fatalf("a complete final path is the tree this publish wanted: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dest, "the-peers")); err != nil {
+			t.Fatalf("the peer's tree was swapped out instead of accepted: %v", err)
+		}
+	})
+
+	t.Run("incomplete final keeps the rename's cause", func(t *testing.T) {
+		root := t.TempDir()
+		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
+		mkCheckout(t, staging, "ours")
+		// A directory that exists and holds something, but is NOT a checkout:
+		// the retire moves it aside, the rename then wins, and the tree that
+		// gets published is ours — never a silent accept of a partial tree.
+		if err := os.MkdirAll(filepath.Join(dest, "half-written"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := publish(staging, dest, false); err != nil {
+			t.Fatalf("publish over an incomplete final: %v", err)
+		}
+		if !isPublished(dest) {
+			t.Fatal("an incomplete final path must be replaced by the staged checkout, not kept")
+		}
+	})
+}
+
+// mkCheckout builds a directory isPublished accepts, marked so a later
+// assertion can tell WHOSE tree ended up at a path.
+func mkCheckout(t *testing.T, dir string, marks ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range marks {
+		if err := os.WriteFile(filepath.Join(dir, m), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #854.

Merge-queue build of #822: `TestFetcher_SeparateFetchersSharingACacheDirNeverSeeAPartialTree` — `publish checkout: rename …staging-… …/deploy-k8s-msociaux-<hash>: directory not empty`. Not reproducible by stress (0/15 locally); it ejected the PR.

## The cause is narrower than "the loser errors although the tree is there"
`publish` already re-read the final path after a lost rename. That read could find NOTHING: `publish` renames an existing tree *aside* (`.retired-…`) before its own rename, so with three publishers A/B/C — A wins, B loses `ENOTEMPTY` and enters the fallback, C stats the final path, finds it and retires it to make room — B stats an ABSENT path and returns the `ENOTEMPTY` cause. The retire exists only to replace *changed* content (a moving ref); a **pinned** ref's content is immutable, so a tree already at its content-addressed path IS the tree being published. `publish` now takes `replaceExisting` (false for a pinned ref) and keeps what is there, dropping the staging copy — the window is removed, not raced. The loser's read stays as the belt for the moving-ref case, explicit: complete final → success (and the retired copy is cleaned up — it used to be left behind, one full checkout per lost race); absent or incomplete → the original cause. `Fetch`'s cache hit and `publish` read the same marker through one `isPublished` helper (`.git`), no second marker.

## Red then green — deterministic, no `-count`
An unexported seam `Fetcher.beforePublish(staging, dest)` fires between staging and rename; the test lets a peer publish at that instant, marks the peer's tree, and asserts WHOSE tree survives. Red with the early-accept removed: `publish_race_test.go:60: the peer's published tree was replaced: renaming an immutable tree aside makes "…" ABSENT to every other publisher`; `:92: the peer's tree was swapped out instead of accepted`. Green; whole package `-race -count=1` ok. Self-correction: a first subtest asserted only `isPublished(dest)` and passed unfixed — strengthened to an identity marker and re-verified red.

## Class (every `os.Rename` in `pkg/`, non-test)
Directory publish onto a content-addressed path: `pkg/pluginsource/fetch.go` (fixed); `pkg/bundle/loader.go` already compliant (a `.ready` sentinel checked before renaming and re-read after a lost rename). File-over-file renames (`store_atomic`, `attachments`, `claimjournal`, `dispatcher/workspace`, `runner/loop_gitws`, `loop_secrets`, `sandbox/docker`, `workspacetrack`, `marketplace_download`): atomic, last-writer-wins, no `ENOTEMPTY`. `pkg/memory`, `pkg/skilllib`, `pkg/worktreepool`: no directory publish by rename.

## Left as separate findings
`pkg/botinstall/install.go` publishes by `RemoveAll(target)` + `copyTree` — not atomic (a reader sees a partial tree, a failed copy destroys the previous install); `pkg/bundle/loader.go`'s lost-rename fallback polls for the peer's sentinel with a sleep it can never usefully wait on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
