### PR TITLE
fix(golden-master): a revert that says 0 without restoring leaves a residue the sweep names and stops on

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2196,7 +2196,7 @@ tool oracle_run:
         au moins aussi discriminante que `git status` pour ce qu'on lui demande —
         savoir si un fichier a bouge. Si les DEUX echouent, on s'arrete.
         """
-        code, out = run("git status --porcelain", ws, timeout=120)
+        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
         if code == 0:
             return "git:" + out
         h = hashlib.sha256()
@@ -2356,7 +2356,25 @@ tool oracle_run:
             v = meta.get(k)
             if v is not None and (not isinstance(v, str) or "\0" in v):
                 return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
+        db = meta.get("dirty_before")
+        if db is not None and (not isinstance(db, list) or any(not isinstance(q, str) for q in db)):
+            return {}, "the marker %s holds a dirty_before that is not a list of paths" % marker
         return meta, ""
+
+
+    def dirty_paths_before_apply(ws):
+        """The paths `git status --porcelain` lists right before a mutant goes
+        down, recorded in the marker so a later sweep can tell the mutant's
+        residue from work that was already uncommitted (an operator's, in record
+        mode). None when git did not answer — unknown, which is not "clean".
+        Bounded and guarded like every git call that runs before the report, and
+        without the optional index refresh: a status that rewrites the index is a
+        write into the tree it is only meant to read (under a full disk or a size
+        limit it left a corrupt index behind, and every later checkout failed)."""
+        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+        if code != 0:
+            return None
+        return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
 
 
     def write_applied_marker(ws, meta):
@@ -2395,7 +2413,8 @@ tool oracle_run:
             return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
+                           "dirty_before": dirty_paths_before_apply(ws)}, f)
         except OSError as e:
             # The empty shell a failed write leaves behind records NOTHING — apply.sh
             # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2566,9 +2585,8 @@ tool oracle_run:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown = "", ""
+        dirty, unknown, residue = "", "", []
         if code == 0:
-            drop_applied_marker(ws, meta)
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
             # verdict: a `git` that is absent must not replace the JSON report with
@@ -2576,14 +2594,26 @@ tool oracle_run:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git status --porcelain", ws, timeout=120)
+            st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
             if st == 0:
                 dirty = st_out.strip()
+                before = meta.get("dirty_before")
+                if before is not None:
+                    # What is still modified now and was NOT when the mutant went
+                    # down is the mutant's residue: revert.sh's exit 0 is the
+                    # script's word, this is the tree's. An operator's own
+                    # uncommitted work was there before and is not residue —
+                    # record mode is where the difference matters, since nothing
+                    # else stops references from being sealed over a leftover.
+                    after = {l[3:] for l in st_out.splitlines() if l.strip()}
+                    residue = sorted(after - set(before))
             else:
                 unknown = "`git status` did not answer (exit %s)" % st
+            if not residue:
+                drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0,
-                "dirty": dirty[:400], "dirty_unknown": unknown}
+                "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2624,6 +2654,13 @@ tool oracle_run:
                 "marker %s."
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
+        if left.get("code") == 0 and left.get("residue"):
+            return "still_mutated", (
+                "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
+                "— revert.sh exited 0, but these paths are still modified and were clean when the "
+                "mutant went down: %s. The tree is still mutated and will be neither judged nor "
+                "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+                % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                     "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -4080,6 +4117,50 @@ tool oracle_run:
                 check("une application tuee par un signal est revertie, pas lue comme refusee",
                       [state, tree(), os.path.isfile(applied_marker_for(tmp))],
                       ["failed", "original\n", False])
+                # ── Le residu d'un revert qui dit « 0 » sans tout restaurer : ce qui
+                # est encore modifie ET etait propre quand le mutant est descendu.
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
+                sub("git", "checkout", "--", "f.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
+                check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
+                      [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+                left = revert_leftover_mutant(tmp)
+                check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
+                      [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
+                       os.path.isfile(applied_marker_for(tmp))],
+                      [0, ["f.txt"], True, True])
+                check("disposition d'un residu : la porte s'arrete",
+                      [leftover_disposition(left or {})[0], leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS],
+                      ["still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Le travail non committe d'AVANT le mutant n'est pas un residu.
+                with open(os.path.join(tmp, "g.txt"), "w", encoding="utf-8") as f:
+                    f.write("operator work\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                check("le travail deja non committe est enregistre comme tel",
+                      "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+                left = revert_leftover_mutant(tmp)
+                check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
+                      [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
+                       leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], True, "reverted", False])
+                os.remove(os.path.join(tmp, "g.txt"))
+                # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
+                mpath = applied_marker_for(tmp)
+                os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "x", "dir": mdir, "dirty_before": 5}, f)
+                os.chmod(mpath, 0o600)
+                check("un dirty_before qui n'est pas une liste est refuse",
+                      bool(read_applied_marker(tmp)[1]), True)
+                os.remove(mpath)
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2616,11 +2616,15 @@ tool oracle_run:
                     residue = after
                     residue_undecided = True
             else:
+                # A git that answered nothing is more undecidable still than one
+                # that answered with no record to compare against: the marker
+                # stays, the gate stops, an operator looks.
                 unknown = "`git status` did not answer (exit %s)" % st
-            if not residue:
+                residue_undecided = True
+            if not residue and not residue_undecided:
                 drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+                "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
                 "residue_undecided": residue_undecided}
 
@@ -2663,6 +2667,13 @@ tool oracle_run:
                 "marker %s."
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
+        if left.get("code") == 0 and left.get("residue_undecided") and not left.get("residue"):
+            return "still_mutated", (
+                "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                "exit 0), but whether the tree came back could not be checked: %s. Unknown is not "
+                "clean — the tree will be neither judged nor recorded. Check it by hand (git status, "
+                "git diff), revert the mutant's paths if any remain, then delete the marker %s."
+                % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
             if left.get("residue_undecided"):
                 return "still_mutated", (
@@ -4043,8 +4054,10 @@ tool oracle_run:
                 check("l'etat de l'arbre est INCONNU, pas propre",
                       [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
                       ["", True])
-                check("et la note le dit au lieu de laisser croire a un arbre propre",
-                      "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+                check("et la porte s'arrete au lieu de laisser croire a un arbre propre",
+                      [leftover_disposition(nogit or {})[0], "Unknown is not clean" in leftover_disposition(nogit or {})[1],
+                       (nogit or {}).get("kept")],
+                      ["still_mutated", True, True])
                 clear_marker()
                 # Un revert en ECHEC garde son enregistrement face au mutant suivant :
                 # la seconde application est refusee, rien ne tourne, et le revert du
@@ -4198,6 +4211,29 @@ tool oracle_run:
                 check("sans dirty_before, un arbre propre apres le revert est reverti",
                       [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                       [[], "reverted", False])
+                # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
+                # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
+                os.remove(os.path.join(tmp, ".gitignore"))
+                sub("git", "checkout", "--", ".gitignore")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                real_run = g["run"]
+
+                def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
+                    if "status --porcelain" in cmd:
+                        return 124, "timeout after 120s"
+                    return real_run(cmd, cwd, timeout)
+                g["run"] = mute_status
+                try:
+                    left = revert_leftover_mutant(tmp)
+                finally:
+                    g["run"] = real_run
+                check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
+                      [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
+                       (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
+                       leftover_disposition(left or {})[0]],
+                      [True, True, True, True, "still_mutated"])
+                os.remove(applied_marker_for(tmp))
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4172,6 +4172,12 @@ tool oracle_run:
                 # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
                 # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
                 # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+                # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
+                # test sont des fichiers non suivis, donc « modifies » pour git.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", ".gitignore")
+                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "true")
                 apply_mutant(lmeta, tmp)
                 mpath = applied_marker_for(tmp)
@@ -4184,12 +4190,6 @@ tool oracle_run:
                       [True, ["f.txt"], "still_mutated", True])
                 os.remove(applied_marker_for(tmp))
                 sub("git", "checkout", "--", "f.txt")
-                # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
-                # des fichiers non suivis, donc « modifies » pour git — ignores ici.
-                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                    f.write("m1/\nm2/\n")
-                sub("git", "add", ".gitignore")
-                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
                 with open(mpath, "w", encoding="utf-8") as f:

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2362,19 +2362,65 @@ tool oracle_run:
         return meta, ""
 
 
+    def dirty_fingerprint(ws, path):
+        """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
+        edit on an already-dirty path from the operator's untouched work: the
+        sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
+        to one line) the sha1 of its recursive listing of (path, size, mtime) —
+        a file a mutant creates inside moves it, an untouched build tree does
+        not; "?" when the path cannot be read or the listing is unreasonably
+        large: undecidable, which is not "unchanged"."""
+        full = os.path.join(ws, path)
+        try:
+            if os.path.isdir(full) and not os.path.islink(full):
+                h, n = hashlib.sha1(), 0
+                for root, dirs, files in os.walk(full):
+                    dirs.sort()
+                    for name in sorted(files):
+                        n += 1
+                        if n > 20000:
+                            return "?"
+                        fp = os.path.join(root, name)
+                        st = os.lstat(fp)
+                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+                return h.hexdigest()
+            with open(full, "rb") as f:
+                return hashlib.sha1(f.read()).hexdigest()
+        except OSError:
+            return "?"
+
+
     def dirty_paths_before_apply(ws):
         """The paths `git status --porcelain` lists right before a mutant goes
-        down, recorded in the marker so a later sweep can tell the mutant's
-        residue from work that was already uncommitted (an operator's, in record
-        mode). None when git did not answer — unknown, which is not "clean".
-        Bounded and guarded like every git call that runs before the report, and
-        without the optional index refresh: a status that rewrites the index is a
-        write into the tree it is only meant to read (under a full disk or a size
-        limit it left a corrupt index behind, and every later checkout failed)."""
+        down, each with its content fingerprint ("<sha1>:<path>"), recorded in
+        the marker so a later sweep can tell the mutant's residue from work that
+        was already uncommitted (an operator's, in record mode) — by content,
+        not by name: a mutant editing a file the operator had already edited is
+        residue too. None when git did not answer — unknown, which is not
+        "clean". Bounded and guarded like every git call that runs before the
+        report, and without the optional index refresh: a status that rewrites
+        the index is a write into the tree it is only meant to read (under a
+        full disk or a size limit it left a corrupt index behind, and every
+        later checkout failed)."""
         code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
         if code != 0:
             return None
-        return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+        paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+
+
+    def split_dirty_record(entries):
+        """{path: fingerprint} from a marker's dirty_before; an entry without a
+        fingerprint (a marker written before fingerprints were recorded) maps
+        to "?": its content then is unknown, so a change cannot be ruled out."""
+        rec = {}
+        for e in entries or []:
+            fp, sep, q = e.partition(":")
+            if sep and q:
+                rec[q] = fp
+            else:
+                rec[e] = "?"
+        return rec
 
 
     def write_applied_marker(ws, meta):
@@ -2601,12 +2647,22 @@ tool oracle_run:
                 after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
-                    # down is the mutant's residue: revert.sh's exit 0 is the
-                    # script's word, this is the tree's. An operator's own
-                    # uncommitted work was there before and is not residue —
-                    # record mode is where the difference matters, since nothing
-                    # else stops references from being sealed over a leftover.
-                    residue = sorted(set(after) - set(before))
+                    # down is the mutant's residue — and so is a path that was
+                    # already dirty but whose CONTENT moved since: revert.sh's
+                    # exit 0 is the script's word, this is the tree's. An
+                    # operator's own uncommitted work, untouched, is not residue
+                    # — record mode is where the difference matters, since
+                    # nothing else stops references from being sealed over a
+                    # leftover. A path whose earlier content is unknown ("?")
+                    # cannot be cleared: undecidable.
+                    rec = split_dirty_record(before)
+                    for q in after:
+                        if q not in rec:
+                            residue.append(q)
+                        elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                            residue.append(q)
+                            if rec[q] == "?":
+                                residue_undecided = True
                 elif after:
                     # No record of what was dirty before the mutant went down
                     # (git did not answer then, or the marker predates the
@@ -3772,7 +3828,12 @@ tool oracle_run:
                 sub("git", "config", "user.name", "t")
                 with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
                     f.write("original\n")
-                sub("git", "add", "f.txt")
+                # Les repertoires de mutants de ce test vivent DANS l'arbre, non suivis :
+                # ignores des le depart, sinon leur listing (que le test reecrit) lit
+                # comme un chemin modifie.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", "f.txt", ".gitignore")
                 sub("git", "commit", "-qm", "seed")
                 mdir = os.path.join(tmp, "m1")
                 os.makedirs(mdir)
@@ -4158,7 +4219,7 @@ tool oracle_run:
                 apply_mutant(lmeta, tmp)
                 db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
                 check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
-                      [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+                      [isinstance(db, list), any(e.endswith(":f.txt") for e in (db or []))], [True, False])
                 left = revert_leftover_mutant(tmp)
                 check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
                       [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
@@ -4174,8 +4235,9 @@ tool oracle_run:
                     f.write("operator work\n")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
-                check("le travail deja non committe est enregistre comme tel",
-                      "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+                check("le travail deja non committe est enregistre comme tel, avec son empreinte",
+                      any(e.endswith(":g.txt") and len(e.split(":")[0]) == 40
+                          for e in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or [])), True)
                 left = revert_leftover_mutant(tmp)
                 check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
                       [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
@@ -4185,12 +4247,6 @@ tool oracle_run:
                 # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
                 # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
                 # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
-                # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
-                # test sont des fichiers non suivis, donc « modifies » pour git.
-                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                    f.write("m1/\nm2/\n")
-                sub("git", "add", ".gitignore")
-                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "true")
                 apply_mutant(lmeta, tmp)
                 mpath = applied_marker_for(tmp)
@@ -4213,8 +4269,6 @@ tool oracle_run:
                       [[], "reverted", False])
                 # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
                 # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
-                os.remove(os.path.join(tmp, ".gitignore"))
-                sub("git", "checkout", "--", ".gitignore")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
                 real_run = g["run"]
@@ -4234,6 +4288,59 @@ tool oracle_run:
                        leftover_disposition(left or {})[0]],
                       [True, True, True, True, "still_mutated"])
                 os.remove(applied_marker_for(tmp))
+                # Le CONTENU, pas le nom : un chemin deja modifie par l'operateur ET
+                # edite par le mutant est un residu si son contenu a bouge ; le meme
+                # chemin intact ne l'est pas ; un fichier cree par le mutant dans un
+                # repertoire deja non suivi bouge la liste du repertoire.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                check("dirty_before porte une empreinte par chemin",
+                      all(":" in e and len(e.split(":")[0]) == 40 for e in db) and any(e.endswith(":f.txt") for e in db), True)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant sur un chemin deja modifie laisse un residu par CONTENU : still_mutated, marqueur garde",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [["f.txt"], "still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                scripts("printf 'mutant\\n' >> g.txt", "rm -f g.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("le travail intact de l'operateur sur f.txt n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], "reverted", False])
+                sub("git", "checkout", "--", "f.txt")
+                os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact\n")
+                scripts("printf 'mutant\\n' > build/injected.txt", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un fichier cree par le mutant dans un repertoire deja non suivi est un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["build/"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "build", "injected.txt"))
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un repertoire non suivi intact n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+                # Une entree sans empreinte (marqueur d'avant) sur un chemin encore modifie : indecidable.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir, "dirty_before": ["f.txt"]}, f)
+                left = revert_leftover_mutant(tmp)
+                check("une entree sans empreinte sur un chemin encore modifie est indecidable",
+                      [(left or {}).get("residue"), (left or {}).get("residue_undecided"), leftover_disposition(left or {})[0]],
+                      [["f.txt"], True, "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2585,7 +2585,7 @@ tool oracle_run:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue = "", "", []
+        dirty, unknown, residue, residue_undecided = "", "", [], False
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2598,6 +2598,7 @@ tool oracle_run:
             if st == 0:
                 dirty = st_out.strip()
                 before = meta.get("dirty_before")
+                after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
                     # down is the mutant's residue: revert.sh's exit 0 is the
@@ -2605,15 +2606,23 @@ tool oracle_run:
                     # uncommitted work was there before and is not residue —
                     # record mode is where the difference matters, since nothing
                     # else stops references from being sealed over a leftover.
-                    after = {l[3:] for l in st_out.splitlines() if l.strip()}
-                    residue = sorted(after - set(before))
+                    residue = sorted(set(after) - set(before))
+                elif after:
+                    # No record of what was dirty before the mutant went down
+                    # (git did not answer then, or the marker predates the
+                    # field): a tree that still shows changes is UNDECIDABLE,
+                    # and undecidable is not clean — every change is treated as
+                    # residue, the marker stays, an operator decides.
+                    residue = after
+                    residue_undecided = True
             else:
                 unknown = "`git status` did not answer (exit %s)" % st
             if not residue:
                 drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
-                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
+                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
+                "residue_undecided": residue_undecided}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2655,6 +2664,14 @@ tool oracle_run:
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
+            if left.get("residue_undecided"):
+                return "still_mutated", (
+                    "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                    "exit 0), but the tree still shows changes and nothing recorded what was already "
+                    "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
+                    "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                    "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
+                    % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
                 "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
                 "— revert.sh exited 0, but these paths are still modified and were clean when the "
@@ -4152,6 +4169,35 @@ tool oracle_run:
                        leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                       [[], True, "reverted", False])
                 os.remove(os.path.join(tmp, "g.txt"))
+                # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
+                # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
+                # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir}, f)
+                left = revert_leftover_mutant(tmp)
+                check("sans dirty_before, un arbre encore modifie est indecidable : still_mutated, marqueur garde",
+                      [(left or {}).get("residue_undecided"), (left or {}).get("residue"),
+                       leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [True, ["f.txt"], "still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
+                # des fichiers non suivis, donc « modifies » pour git — ignores ici.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", ".gitignore")
+                sub("git", "commit", "-qm", "ignore the mutant dirs")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir}, f)
+                left = revert_leftover_mutant(tmp)
+                check("sans dirty_before, un arbre propre apres le revert est reverti",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], "reverted", False])
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4334,7 +4380,7 @@ tool oracle_run:
             note(report, text)
 
         if mode != "record":
-            dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+            dirty = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain"],
                                    capture_output=True, text=True)
             if dirty.returncode == 0 and dirty.stdout.strip():
                 # Decoupe AVANT tout strip global. `git status --porcelain` ecrit

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2362,20 +2362,43 @@ tool oracle_run:
         return meta, ""
 
 
+    _repo_root_cache = {}
+
+
+    def repo_root_of(ws):
+        """The working tree's root, which porcelain paths are relative to — ws
+        itself when git does not answer (a gate runs at the root; the fallback
+        keeps a name comparison rather than none)."""
+        key = os.path.realpath(ws)
+        if key not in _repo_root_cache:
+            try:
+                p = subprocess.run(["git", "-C", ws, "rev-parse", "--show-toplevel"],
+                                   capture_output=True, text=True, timeout=60)
+                top = (p.stdout or "").strip() if p.returncode == 0 else ""
+            except (OSError, subprocess.SubprocessError):
+                top = ""
+            _repo_root_cache[key] = top or ws
+        return _repo_root_cache[key]
+
+
+    BIG_FILE_BYTES = 8 << 20
+
+
     def dirty_fingerprint(ws, path):
-        """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
-        edit on an already-dirty path from the operator's untouched work: the
-        sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
-        to one line) the sha1 of its recursive listing of (path, size, mtime) —
-        a file a mutant creates inside moves it, an untouched build tree does
-        not; "?" when the path cannot be read or the listing is unreasonably
-        large: undecidable, which is not "unchanged"."""
-        full = os.path.join(ws, path)
+        """What a dirty path IS, so a later sweep can tell a mutant's edit on an
+        already-dirty path from the operator's untouched work. A file: the sha1
+        of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
+        a leash: hashing is local and linear); a symlink: its target; a directory
+        (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
+        recursive NAME listing — a file a mutant creates or removes inside moves
+        it, a build tree merely rebuilt between two runs does not, and a change
+        inside an existing untracked file is the accepted blind spot; "absent"
+        for an uncommitted deletion (a state of its own, equal to itself); "?"
+        for a FIFO or a device (opening could block, on no leash), an unreadable
+        path or a listing past 20000 entries: undecidable, not "unchanged"."""
+        full = os.path.join(repo_root_of(ws), path)
         try:
             if not os.path.lexists(full):
-                # An uncommitted deletion (` D path`): a state of its own, so
-                # absent-before equals absent-after and an operator's deletion
-                # is not residue.
                 return "absent"
             st = os.lstat(full)
             if stat.S_ISDIR(st.st_mode):
@@ -2386,15 +2409,14 @@ tool oracle_run:
                         n += 1
                         if n > 20000:
                             return "?"
-                        fp = os.path.join(root, name)
-                        fst = os.lstat(fp)
-                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
+                        h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
             if not stat.S_ISREG(st.st_mode):
-                # A FIFO or a device: opening it could block, on no leash.
                 return "?"
+            if st.st_size > BIG_FILE_BYTES:
+                return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
             h = hashlib.sha1()
             with open(full, "rb") as f:
                 for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2404,19 +2426,37 @@ tool oracle_run:
             return "?"
 
 
+    def status_porcelain_z(ws):
+        """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
+        merges the two streams, and a warning git prints on stderr (a directory
+        it cannot read) would land inside the NUL entry stream and swallow a real
+        path. Bounded, guarded, without the optional index refresh."""
+        try:
+            p = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain", "-z"],
+                               capture_output=True, text=True, timeout=120)
+            return p.returncode, p.stdout or ""
+        except (OSError, subprocess.SubprocessError) as e:
+            return 124, "%s" % e
+
+
+    PORCELAIN_STATUS = " MADRCU?!"
+
+
     def porcelain_paths(out):
         """The paths of a `git status --porcelain -z` output: NUL-separated, no
-        quoting, a rename or copy followed by its source entry (skipped — the
-        destination is the path that exists)."""
+        quoting, a rename or copy (in the index or in the work tree) followed by
+        its source entry, skipped — the destination is the path that exists. An
+        entry that is not `XY<space>path` is not an entry (a stray line that is
+        not the porcelain) and is dropped rather than decided on."""
         entries = (out or "").split("\0")
         paths, i = [], 0
         while i < len(entries):
             e = entries[i]
             i += 1
-            if len(e) < 4:
+            if len(e) < 4 or e[2] != " " or e[0] not in PORCELAIN_STATUS or e[1] not in PORCELAIN_STATUS:
                 continue
             paths.append(e[3:])
-            if e[0] in "RC":
+            if e[0] in "RC" or e[1] in "RC":
                 i += 1
         return sorted(set(paths))
 
@@ -2433,7 +2473,7 @@ tool oracle_run:
         the index is a write into the tree it is only meant to read (under a
         full disk or a size limit it left a corrupt index behind, and every
         later checkout failed)."""
-        code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+        code, out = status_porcelain_z(ws)
         if code != 0:
             return None
         return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
@@ -2677,7 +2717,7 @@ tool oracle_run:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+            st, st_out = status_porcelain_z(ws)
             if st == 0:
                 after = porcelain_paths(st_out)
                 dirty = "\n".join(after)
@@ -2777,10 +2817,11 @@ tool oracle_run:
                     "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
                     % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
-                "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
-                "— revert.sh exited 0, but these paths are still modified and were clean when the "
-                "mutant went down: %s. The tree is still mutated and will be neither judged nor "
-                "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+                "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                "exit 0), but these paths changed since the mutant went down and the harness cannot "
+                "attribute the change — the mutant's residue, or work done in between: %s. The tree "
+                "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
+                "hand, keep yours, then delete the marker %s."
                 % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -4308,17 +4349,12 @@ tool oracle_run:
                 # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
-                real_run = g["run"]
-
-                def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
-                    if "status --porcelain" in cmd:
-                        return 124, "timeout after 120s"
-                    return real_run(cmd, cwd, timeout)
-                g["run"] = mute_status
+                real_status = g["status_porcelain_z"]
+                g["status_porcelain_z"] = lambda ws: (124, "timeout after 120s")
                 try:
                     left = revert_leftover_mutant(tmp)
                 finally:
-                    g["run"] = real_run
+                    g["status_porcelain_z"] = real_status
                 check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
                       [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
                        (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
@@ -4408,6 +4444,54 @@ tool oracle_run:
                 # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
                 check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
                       split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
+                # Le porcelain -z lu avec stderr A PART : un avertissement de git dans le
+                # flux fondrait un vrai chemin dans une entree fantome. Le parseur jette
+                # ce qui n'a pas la forme `XY<espace>chemin`, et suit les renommages
+                # d'index comme d'arbre de travail.
+                check("un avertissement dans le flux ne fabrique ni ne masque un chemin",
+                      porcelain_paths("warning: could not open directory 'secret/': Permission denied\n M a.txt\0?? b.txt\0"),
+                      ["b.txt"])
+                # L'origine d'un renommage est sautee meme quand son nom a la forme
+                # d'une entree (deux lettres de statut et une espace).
+                check("un renommage d'arbre de travail est suivi par sa destination",
+                      porcelain_paths(" R new.txt\0MM old.txt\0R  new2.txt\0AD old2.txt\0"), ["new.txt", "new2.txt"])
+                # Un avertissement REEL de git (repertoire illisible) sur stderr ne
+                # touche pas le flux des chemins : le vrai chemin modifie est enregistre.
+                secret = os.path.join(tmp, "secret")
+                os.makedirs(secret, exist_ok=True)
+                with open(os.path.join(secret, "s.txt"), "w", encoding="utf-8") as f:
+                    f.write("s\n")
+                with open(os.path.join(tmp, "other.txt"), "w", encoding="utf-8") as f:
+                    f.write("o\n")
+                os.chmod(secret, 0)
+                try:
+                    db = dirty_paths_before_apply(tmp) or []
+                finally:
+                    os.chmod(secret, 0o755)
+                    shutil.rmtree(secret, ignore_errors=True)
+                os.remove(os.path.join(tmp, "other.txt"))
+                check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                      [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+                # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
+                # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
+                os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact v1\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                time.sleep(0.01)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact v2, rebuilt\n")
+                left = revert_leftover_mutant(tmp)
+                check("un repertoire non suivi reconstruit n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+                # Un gros fichier modifie s'empreinte par (taille, mtime), sans le lire.
+                big = os.path.join(tmp, "big.bin")
+                with open(big, "wb") as f:
+                    f.truncate(BIG_FILE_BYTES + 1)
+                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+                os.remove(big)
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2372,7 +2372,13 @@ tool oracle_run:
         large: undecidable, which is not "unchanged"."""
         full = os.path.join(ws, path)
         try:
-            if os.path.isdir(full) and not os.path.islink(full):
+            if not os.path.lexists(full):
+                # An uncommitted deletion (` D path`): a state of its own, so
+                # absent-before equals absent-after and an operator's deletion
+                # is not residue.
+                return "absent"
+            st = os.lstat(full)
+            if stat.S_ISDIR(st.st_mode):
                 h, n = hashlib.sha1(), 0
                 for root, dirs, files in os.walk(full):
                     dirs.sort()
@@ -2381,13 +2387,38 @@ tool oracle_run:
                         if n > 20000:
                             return "?"
                         fp = os.path.join(root, name)
-                        st = os.lstat(fp)
-                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+                        fst = os.lstat(fp)
+                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
                 return h.hexdigest()
+            if stat.S_ISLNK(st.st_mode):
+                return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
+            if not stat.S_ISREG(st.st_mode):
+                # A FIFO or a device: opening it could block, on no leash.
+                return "?"
+            h = hashlib.sha1()
             with open(full, "rb") as f:
-                return hashlib.sha1(f.read()).hexdigest()
+                for chunk in iter(lambda: f.read(1 << 20), b""):
+                    h.update(chunk)
+            return h.hexdigest()
         except OSError:
             return "?"
+
+
+    def porcelain_paths(out):
+        """The paths of a `git status --porcelain -z` output: NUL-separated, no
+        quoting, a rename or copy followed by its source entry (skipped — the
+        destination is the path that exists)."""
+        entries = (out or "").split("\0")
+        paths, i = [], 0
+        while i < len(entries):
+            e = entries[i]
+            i += 1
+            if len(e) < 4:
+                continue
+            paths.append(e[3:])
+            if e[0] in "RC":
+                i += 1
+        return sorted(set(paths))
 
 
     def dirty_paths_before_apply(ws):
@@ -2402,11 +2433,10 @@ tool oracle_run:
         the index is a write into the tree it is only meant to read (under a
         full disk or a size limit it left a corrupt index behind, and every
         later checkout failed)."""
-        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+        code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
         if code != 0:
             return None
-        paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
-        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
 
 
     def split_dirty_record(entries):
@@ -2416,9 +2446,11 @@ tool oracle_run:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q:
+            if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
+                # No fingerprint (a marker written before they were recorded): the
+                # whole entry is the path, a colon in it included.
                 rec[e] = "?"
         return rec
 
@@ -2453,6 +2485,11 @@ tool oracle_run:
                            "in this run, or another harness is gating this tree; the tree is not "
                            "HEAD and nothing is applied on top of it"
                            % (prior.get("id") or "?", prior.get("dir") or marker))
+        # Read the tree BEFORE the exclusive create: the status and the hashing
+        # take real time, and a marker that exists but is empty is read as
+        # corrupt by the next gate — the create→write window must stay as short
+        # as a single write.
+        dirty_before = dirty_paths_before_apply(ws)
         try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
         except OSError as e:
@@ -2460,7 +2497,7 @@ tool oracle_run:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
-                           "dirty_before": dirty_paths_before_apply(ws)}, f)
+                           "dirty_before": dirty_before}, f)
         except OSError as e:
             # The empty shell a failed write leaves behind records NOTHING — apply.sh
             # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2640,11 +2677,11 @@ tool oracle_run:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+            st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
             if st == 0:
-                dirty = st_out.strip()
+                after = porcelain_paths(st_out)
+                dirty = "\n".join(after)
                 before = meta.get("dirty_before")
-                after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
                     # down is the mutant's residue — and so is a path that was
@@ -4341,6 +4378,36 @@ tool oracle_run:
                       [["f.txt"], True, "still_mutated"])
                 os.remove(applied_marker_for(tmp))
                 sub("git", "checkout", "--", "f.txt")
+                # Une suppression non committee de l'operateur n'est pas un residu ; un
+                # renommage indexe non plus ; un chemin avec une espace edite par le
+                # mutant EST un residu (le porcelain -z ne le cite pas entre guillemets).
+                with open(os.path.join(tmp, "d.txt"), "w", encoding="utf-8") as f:
+                    f.write("doomed\n")
+                with open(os.path.join(tmp, "a b.txt"), "w", encoding="utf-8") as f:
+                    f.write("spaced\n")
+                sub("git", "add", "d.txt", "a b.txt")
+                sub("git", "commit", "-qm", "more files")
+                os.remove(os.path.join(tmp, "d.txt"))
+                sub("git", "mv", "a b.txt", "a c.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                check("une suppression est enregistree 'absent', un renommage par sa destination",
+                      ["absent:d.txt" in db, any(e.endswith(":a c.txt") for e in db), any(e.endswith(":a b.txt") for e in db)],
+                      [True, True, False])
+                left = revert_leftover_mutant(tmp)
+                check("suppression et renommage de l'operateur : pas un residu, reverti",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                scripts("printf 'mutant\\n' >> 'a c.txt'", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un chemin avec une espace edite par le mutant est un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["a c.txt"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "reset", "-q", "--hard", "HEAD")
+                # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
+                check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
+                      split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2143,19 +2143,65 @@ def read_applied_marker(ws):
     return meta, ""
 
 
+def dirty_fingerprint(ws, path):
+    """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
+    edit on an already-dirty path from the operator's untouched work: the
+    sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
+    to one line) the sha1 of its recursive listing of (path, size, mtime) —
+    a file a mutant creates inside moves it, an untouched build tree does
+    not; "?" when the path cannot be read or the listing is unreasonably
+    large: undecidable, which is not "unchanged"."""
+    full = os.path.join(ws, path)
+    try:
+        if os.path.isdir(full) and not os.path.islink(full):
+            h, n = hashlib.sha1(), 0
+            for root, dirs, files in os.walk(full):
+                dirs.sort()
+                for name in sorted(files):
+                    n += 1
+                    if n > 20000:
+                        return "?"
+                    fp = os.path.join(root, name)
+                    st = os.lstat(fp)
+                    h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+            return h.hexdigest()
+        with open(full, "rb") as f:
+            return hashlib.sha1(f.read()).hexdigest()
+    except OSError:
+        return "?"
+
+
 def dirty_paths_before_apply(ws):
     """The paths `git status --porcelain` lists right before a mutant goes
-    down, recorded in the marker so a later sweep can tell the mutant's
-    residue from work that was already uncommitted (an operator's, in record
-    mode). None when git did not answer — unknown, which is not "clean".
-    Bounded and guarded like every git call that runs before the report, and
-    without the optional index refresh: a status that rewrites the index is a
-    write into the tree it is only meant to read (under a full disk or a size
-    limit it left a corrupt index behind, and every later checkout failed)."""
+    down, each with its content fingerprint ("<sha1>:<path>"), recorded in
+    the marker so a later sweep can tell the mutant's residue from work that
+    was already uncommitted (an operator's, in record mode) — by content,
+    not by name: a mutant editing a file the operator had already edited is
+    residue too. None when git did not answer — unknown, which is not
+    "clean". Bounded and guarded like every git call that runs before the
+    report, and without the optional index refresh: a status that rewrites
+    the index is a write into the tree it is only meant to read (under a
+    full disk or a size limit it left a corrupt index behind, and every
+    later checkout failed)."""
     code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
     if code != 0:
         return None
-    return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+    paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+    return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+
+
+def split_dirty_record(entries):
+    """{path: fingerprint} from a marker's dirty_before; an entry without a
+    fingerprint (a marker written before fingerprints were recorded) maps
+    to "?": its content then is unknown, so a change cannot be ruled out."""
+    rec = {}
+    for e in entries or []:
+        fp, sep, q = e.partition(":")
+        if sep and q:
+            rec[q] = fp
+        else:
+            rec[e] = "?"
+    return rec
 
 
 def write_applied_marker(ws, meta):
@@ -2382,12 +2428,22 @@ def revert_leftover_mutant(ws, gm_dir=None):
             after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
             if before is not None:
                 # What is still modified now and was NOT when the mutant went
-                # down is the mutant's residue: revert.sh's exit 0 is the
-                # script's word, this is the tree's. An operator's own
-                # uncommitted work was there before and is not residue —
-                # record mode is where the difference matters, since nothing
-                # else stops references from being sealed over a leftover.
-                residue = sorted(set(after) - set(before))
+                # down is the mutant's residue — and so is a path that was
+                # already dirty but whose CONTENT moved since: revert.sh's
+                # exit 0 is the script's word, this is the tree's. An
+                # operator's own uncommitted work, untouched, is not residue
+                # — record mode is where the difference matters, since
+                # nothing else stops references from being sealed over a
+                # leftover. A path whose earlier content is unknown ("?")
+                # cannot be cleared: undecidable.
+                rec = split_dirty_record(before)
+                for q in after:
+                    if q not in rec:
+                        residue.append(q)
+                    elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                        residue.append(q)
+                        if rec[q] == "?":
+                            residue_undecided = True
             elif after:
                 # No record of what was dirty before the mutant went down
                 # (git did not answer then, or the marker predates the
@@ -3553,7 +3609,12 @@ def _selftest():
             sub("git", "config", "user.name", "t")
             with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
                 f.write("original\n")
-            sub("git", "add", "f.txt")
+            # Les repertoires de mutants de ce test vivent DANS l'arbre, non suivis :
+            # ignores des le depart, sinon leur listing (que le test reecrit) lit
+            # comme un chemin modifie.
+            with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                f.write("m1/\nm2/\n")
+            sub("git", "add", "f.txt", ".gitignore")
             sub("git", "commit", "-qm", "seed")
             mdir = os.path.join(tmp, "m1")
             os.makedirs(mdir)
@@ -3939,7 +4000,7 @@ def _selftest():
             apply_mutant(lmeta, tmp)
             db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
             check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
-                  [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+                  [isinstance(db, list), any(e.endswith(":f.txt") for e in (db or []))], [True, False])
             left = revert_leftover_mutant(tmp)
             check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
                   [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
@@ -3955,8 +4016,9 @@ def _selftest():
                 f.write("operator work\n")
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             apply_mutant(lmeta, tmp)
-            check("le travail deja non committe est enregistre comme tel",
-                  "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+            check("le travail deja non committe est enregistre comme tel, avec son empreinte",
+                  any(e.endswith(":g.txt") and len(e.split(":")[0]) == 40
+                      for e in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or [])), True)
             left = revert_leftover_mutant(tmp)
             check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
                   [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
@@ -3966,12 +4028,6 @@ def _selftest():
             # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
             # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
             # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
-            # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
-            # test sont des fichiers non suivis, donc « modifies » pour git.
-            with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                f.write("m1/\nm2/\n")
-            sub("git", "add", ".gitignore")
-            sub("git", "commit", "-qm", "ignore the mutant dirs")
             scripts("printf 'mutant\\n' >> f.txt", "true")
             apply_mutant(lmeta, tmp)
             mpath = applied_marker_for(tmp)
@@ -3994,8 +4050,6 @@ def _selftest():
                   [[], "reverted", False])
             # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
             # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
-            os.remove(os.path.join(tmp, ".gitignore"))
-            sub("git", "checkout", "--", ".gitignore")
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             apply_mutant(lmeta, tmp)
             real_run = g["run"]
@@ -4015,6 +4069,59 @@ def _selftest():
                    leftover_disposition(left or {})[0]],
                   [True, True, True, True, "still_mutated"])
             os.remove(applied_marker_for(tmp))
+            # Le CONTENU, pas le nom : un chemin deja modifie par l'operateur ET
+            # edite par le mutant est un residu si son contenu a bouge ; le meme
+            # chemin intact ne l'est pas ; un fichier cree par le mutant dans un
+            # repertoire deja non suivi bouge la liste du repertoire.
+            with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                f.write("operator edit\n")
+            scripts("printf 'mutant\\n' >> f.txt", "true")
+            apply_mutant(lmeta, tmp)
+            db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+            check("dirty_before porte une empreinte par chemin",
+                  all(":" in e and len(e.split(":")[0]) == 40 for e in db) and any(e.endswith(":f.txt") for e in db), True)
+            left = revert_leftover_mutant(tmp)
+            check("un mutant sur un chemin deja modifie laisse un residu par CONTENU : still_mutated, marqueur garde",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                  [["f.txt"], "still_mutated", True])
+            os.remove(applied_marker_for(tmp))
+            scripts("printf 'mutant\\n' >> g.txt", "rm -f g.txt")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("le travail intact de l'operateur sur f.txt n'est pas un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                  [[], "reverted", False])
+            sub("git", "checkout", "--", "f.txt")
+            os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+            with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                f.write("artefact\n")
+            scripts("printf 'mutant\\n' > build/injected.txt", "true")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("un fichier cree par le mutant dans un repertoire deja non suivi est un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["build/"], "still_mutated"])
+            os.remove(applied_marker_for(tmp))
+            os.remove(os.path.join(tmp, "build", "injected.txt"))
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("un repertoire non suivi intact n'est pas un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+            shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+            # Une entree sans empreinte (marqueur d'avant) sur un chemin encore modifie : indecidable.
+            with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                f.write("operator edit\n")
+            scripts("printf 'mutant\\n' >> f.txt", "true")
+            apply_mutant(lmeta, tmp)
+            mpath = applied_marker_for(tmp)
+            with open(mpath, "w", encoding="utf-8") as f:
+                json.dump({"id": "leftover-1", "dir": mdir, "dirty_before": ["f.txt"]}, f)
+            left = revert_leftover_mutant(tmp)
+            check("une entree sans empreinte sur un chemin encore modifie est indecidable",
+                  [(left or {}).get("residue"), (left or {}).get("residue_undecided"), leftover_disposition(left or {})[0]],
+                  [["f.txt"], True, "still_mutated"])
+            os.remove(applied_marker_for(tmp))
+            sub("git", "checkout", "--", "f.txt")
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3953,6 +3953,12 @@ def _selftest():
             # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
             # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
             # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+            # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
+            # test sont des fichiers non suivis, donc « modifies » pour git.
+            with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                f.write("m1/\nm2/\n")
+            sub("git", "add", ".gitignore")
+            sub("git", "commit", "-qm", "ignore the mutant dirs")
             scripts("printf 'mutant\\n' >> f.txt", "true")
             apply_mutant(lmeta, tmp)
             mpath = applied_marker_for(tmp)
@@ -3965,12 +3971,6 @@ def _selftest():
                   [True, ["f.txt"], "still_mutated", True])
             os.remove(applied_marker_for(tmp))
             sub("git", "checkout", "--", "f.txt")
-            # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
-            # des fichiers non suivis, donc « modifies » pour git — ignores ici.
-            with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                f.write("m1/\nm2/\n")
-            sub("git", "add", ".gitignore")
-            sub("git", "commit", "-qm", "ignore the mutant dirs")
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             apply_mutant(lmeta, tmp)
             with open(mpath, "w", encoding="utf-8") as f:

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2366,7 +2366,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-    dirty, unknown, residue = "", "", []
+    dirty, unknown, residue, residue_undecided = "", "", [], False
     if code == 0:
         # Through run(), and on a short leash. This sweep runs in EVERY mode,
         # record included, and the harness's contract is to answer with a
@@ -2379,6 +2379,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
         if st == 0:
             dirty = st_out.strip()
             before = meta.get("dirty_before")
+            after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
             if before is not None:
                 # What is still modified now and was NOT when the mutant went
                 # down is the mutant's residue: revert.sh's exit 0 is the
@@ -2386,15 +2387,23 @@ def revert_leftover_mutant(ws, gm_dir=None):
                 # uncommitted work was there before and is not residue —
                 # record mode is where the difference matters, since nothing
                 # else stops references from being sealed over a leftover.
-                after = {l[3:] for l in st_out.splitlines() if l.strip()}
-                residue = sorted(after - set(before))
+                residue = sorted(set(after) - set(before))
+            elif after:
+                # No record of what was dirty before the mutant went down
+                # (git did not answer then, or the marker predates the
+                # field): a tree that still shows changes is UNDECIDABLE,
+                # and undecidable is not clean — every change is treated as
+                # residue, the marker stays, an operator decides.
+                residue = after
+                residue_undecided = True
         else:
             unknown = "`git status` did not answer (exit %s)" % st
         if not residue:
             drop_applied_marker(ws, meta)
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
             "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
-            "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
+            "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
+            "residue_undecided": residue_undecided}
 
 
 # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2436,6 +2445,14 @@ def leftover_disposition(left):
             % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                left.get("marker")))
     if left.get("code") == 0 and left.get("residue"):
+        if left.get("residue_undecided"):
+            return "still_mutated", (
+                "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                "exit 0), but the tree still shows changes and nothing recorded what was already "
+                "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
+                "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
+                % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         return "still_mutated", (
             "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
             "— revert.sh exited 0, but these paths are still modified and were clean when the "
@@ -3933,6 +3950,35 @@ def _selftest():
                    leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                   [[], True, "reverted", False])
             os.remove(os.path.join(tmp, "g.txt"))
+            # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
+            # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
+            # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+            scripts("printf 'mutant\\n' >> f.txt", "true")
+            apply_mutant(lmeta, tmp)
+            mpath = applied_marker_for(tmp)
+            with open(mpath, "w", encoding="utf-8") as f:
+                json.dump({"id": "leftover-1", "dir": mdir}, f)
+            left = revert_leftover_mutant(tmp)
+            check("sans dirty_before, un arbre encore modifie est indecidable : still_mutated, marqueur garde",
+                  [(left or {}).get("residue_undecided"), (left or {}).get("residue"),
+                   leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                  [True, ["f.txt"], "still_mutated", True])
+            os.remove(applied_marker_for(tmp))
+            sub("git", "checkout", "--", "f.txt")
+            # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
+            # des fichiers non suivis, donc « modifies » pour git — ignores ici.
+            with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                f.write("m1/\nm2/\n")
+            sub("git", "add", ".gitignore")
+            sub("git", "commit", "-qm", "ignore the mutant dirs")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            with open(mpath, "w", encoding="utf-8") as f:
+                json.dump({"id": "leftover-1", "dir": mdir}, f)
+            left = revert_leftover_mutant(tmp)
+            check("sans dirty_before, un arbre propre apres le revert est reverti",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                  [[], "reverted", False])
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4115,7 +4161,7 @@ def main():
         note(report, text)
 
     if mode != "record":
-        dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+        dirty = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain"],
                                capture_output=True, text=True)
         if dirty.returncode == 0 and dirty.stdout.strip():
             # Decoupe AVANT tout strip global. `git status --porcelain` ecrit

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1977,7 +1977,7 @@ def tree_fingerprint(ws):
     au moins aussi discriminante que `git status` pour ce qu'on lui demande —
     savoir si un fichier a bouge. Si les DEUX echouent, on s'arrete.
     """
-    code, out = run("git status --porcelain", ws, timeout=120)
+    code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
     if code == 0:
         return "git:" + out
     h = hashlib.sha256()
@@ -2137,7 +2137,25 @@ def read_applied_marker(ws):
         v = meta.get(k)
         if v is not None and (not isinstance(v, str) or "\0" in v):
             return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
+    db = meta.get("dirty_before")
+    if db is not None and (not isinstance(db, list) or any(not isinstance(q, str) for q in db)):
+        return {}, "the marker %s holds a dirty_before that is not a list of paths" % marker
     return meta, ""
+
+
+def dirty_paths_before_apply(ws):
+    """The paths `git status --porcelain` lists right before a mutant goes
+    down, recorded in the marker so a later sweep can tell the mutant's
+    residue from work that was already uncommitted (an operator's, in record
+    mode). None when git did not answer — unknown, which is not "clean".
+    Bounded and guarded like every git call that runs before the report, and
+    without the optional index refresh: a status that rewrites the index is a
+    write into the tree it is only meant to read (under a full disk or a size
+    limit it left a corrupt index behind, and every later checkout failed)."""
+    code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+    if code != 0:
+        return None
+    return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
 
 
 def write_applied_marker(ws, meta):
@@ -2176,7 +2194,8 @@ def write_applied_marker(ws, meta):
         return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+            json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
+                       "dirty_before": dirty_paths_before_apply(ws)}, f)
     except OSError as e:
         # The empty shell a failed write leaves behind records NOTHING — apply.sh
         # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2347,9 +2366,8 @@ def revert_leftover_mutant(ws, gm_dir=None):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-    dirty, unknown = "", ""
+    dirty, unknown, residue = "", "", []
     if code == 0:
-        drop_applied_marker(ws, meta)
         # Through run(), and on a short leash. This sweep runs in EVERY mode,
         # record included, and the harness's contract is to answer with a
         # verdict: a `git` that is absent must not replace the JSON report with
@@ -2357,14 +2375,26 @@ def revert_leftover_mutant(ws, gm_dir=None):
         # wedged one must not hang the gate the way the incident behind this
         # whole guard hung it. Unanswered is reported as UNKNOWN, never as
         # clean — an empty porcelain and an absent git are not the same fact.
-        st, st_out = run("git status --porcelain", ws, timeout=120)
+        st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
         if st == 0:
             dirty = st_out.strip()
+            before = meta.get("dirty_before")
+            if before is not None:
+                # What is still modified now and was NOT when the mutant went
+                # down is the mutant's residue: revert.sh's exit 0 is the
+                # script's word, this is the tree's. An operator's own
+                # uncommitted work was there before and is not residue —
+                # record mode is where the difference matters, since nothing
+                # else stops references from being sealed over a leftover.
+                after = {l[3:] for l in st_out.splitlines() if l.strip()}
+                residue = sorted(after - set(before))
         else:
             unknown = "`git status` did not answer (exit %s)" % st
+        if not residue:
+            drop_applied_marker(ws, meta)
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-            "marker": marker, "refused": False, "kept": code != 0,
-            "dirty": dirty[:400], "dirty_unknown": unknown}
+            "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+            "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
 
 
 # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2405,6 +2435,13 @@ def leftover_disposition(left):
             "marker %s."
             % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                left.get("marker")))
+    if left.get("code") == 0 and left.get("residue"):
+        return "still_mutated", (
+            "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
+            "— revert.sh exited 0, but these paths are still modified and were clean when the "
+            "mutant went down: %s. The tree is still mutated and will be neither judged nor "
+            "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+            % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
     if left.get("code") == 0:
         text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                 "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -3861,6 +3898,50 @@ def _selftest():
             check("une application tuee par un signal est revertie, pas lue comme refusee",
                   [state, tree(), os.path.isfile(applied_marker_for(tmp))],
                   ["failed", "original\n", False])
+            # ── Le residu d'un revert qui dit « 0 » sans tout restaurer : ce qui
+            # est encore modifie ET etait propre quand le mutant est descendu.
+            try:
+                os.remove(applied_marker_for(tmp))
+            except OSError:
+                pass
+            sub("git", "checkout", "--", "f.txt")
+            scripts("printf 'mutant\\n' >> f.txt", "true")
+            apply_mutant(lmeta, tmp)
+            db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
+            check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
+                  [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+            left = revert_leftover_mutant(tmp)
+            check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
+                  [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
+                   os.path.isfile(applied_marker_for(tmp))],
+                  [0, ["f.txt"], True, True])
+            check("disposition d'un residu : la porte s'arrete",
+                  [leftover_disposition(left or {})[0], leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS],
+                  ["still_mutated", True])
+            os.remove(applied_marker_for(tmp))
+            sub("git", "checkout", "--", "f.txt")
+            # Le travail non committe d'AVANT le mutant n'est pas un residu.
+            with open(os.path.join(tmp, "g.txt"), "w", encoding="utf-8") as f:
+                f.write("operator work\n")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            check("le travail deja non committe est enregistre comme tel",
+                  "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+            left = revert_leftover_mutant(tmp)
+            check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
+                  [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
+                   leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                  [[], True, "reverted", False])
+            os.remove(os.path.join(tmp, "g.txt"))
+            # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
+            mpath = applied_marker_for(tmp)
+            os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
+            with open(mpath, "w", encoding="utf-8") as f:
+                json.dump({"id": "x", "dir": mdir, "dirty_before": 5}, f)
+            os.chmod(mpath, 0o600)
+            check("un dirty_before qui n'est pas une liste est refuse",
+                  bool(read_applied_marker(tmp)[1]), True)
+            os.remove(mpath)
         finally:
             shutil.rmtree(tmp, ignore_errors=True)
             shutil.rmtree(outside, ignore_errors=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2397,11 +2397,15 @@ def revert_leftover_mutant(ws, gm_dir=None):
                 residue = after
                 residue_undecided = True
         else:
+            # A git that answered nothing is more undecidable still than one
+            # that answered with no record to compare against: the marker
+            # stays, the gate stops, an operator looks.
             unknown = "`git status` did not answer (exit %s)" % st
-        if not residue:
+            residue_undecided = True
+        if not residue and not residue_undecided:
             drop_applied_marker(ws, meta)
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-            "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+            "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
             "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
             "residue_undecided": residue_undecided}
 
@@ -2444,6 +2448,13 @@ def leftover_disposition(left):
             "marker %s."
             % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                left.get("marker")))
+    if left.get("code") == 0 and left.get("residue_undecided") and not left.get("residue"):
+        return "still_mutated", (
+            "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+            "exit 0), but whether the tree came back could not be checked: %s. Unknown is not "
+            "clean — the tree will be neither judged nor recorded. Check it by hand (git status, "
+            "git diff), revert the mutant's paths if any remain, then delete the marker %s."
+            % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
     if left.get("code") == 0 and left.get("residue"):
         if left.get("residue_undecided"):
             return "still_mutated", (
@@ -3824,8 +3835,10 @@ def _selftest():
             check("l'etat de l'arbre est INCONNU, pas propre",
                   [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
                   ["", True])
-            check("et la note le dit au lieu de laisser croire a un arbre propre",
-                  "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+            check("et la porte s'arrete au lieu de laisser croire a un arbre propre",
+                  [leftover_disposition(nogit or {})[0], "Unknown is not clean" in leftover_disposition(nogit or {})[1],
+                   (nogit or {}).get("kept")],
+                  ["still_mutated", True, True])
             clear_marker()
             # Un revert en ECHEC garde son enregistrement face au mutant suivant :
             # la seconde application est refusee, rien ne tourne, et le revert du
@@ -3979,6 +3992,29 @@ def _selftest():
             check("sans dirty_before, un arbre propre apres le revert est reverti",
                   [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                   [[], "reverted", False])
+            # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
+            # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
+            os.remove(os.path.join(tmp, ".gitignore"))
+            sub("git", "checkout", "--", ".gitignore")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            real_run = g["run"]
+
+            def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
+                if "status --porcelain" in cmd:
+                    return 124, "timeout after 120s"
+                return real_run(cmd, cwd, timeout)
+            g["run"] = mute_status
+            try:
+                left = revert_leftover_mutant(tmp)
+            finally:
+                g["run"] = real_run
+            check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
+                  [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
+                   (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
+                   leftover_disposition(left or {})[0]],
+                  [True, True, True, True, "still_mutated"])
+            os.remove(applied_marker_for(tmp))
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2153,7 +2153,13 @@ def dirty_fingerprint(ws, path):
     large: undecidable, which is not "unchanged"."""
     full = os.path.join(ws, path)
     try:
-        if os.path.isdir(full) and not os.path.islink(full):
+        if not os.path.lexists(full):
+            # An uncommitted deletion (` D path`): a state of its own, so
+            # absent-before equals absent-after and an operator's deletion
+            # is not residue.
+            return "absent"
+        st = os.lstat(full)
+        if stat.S_ISDIR(st.st_mode):
             h, n = hashlib.sha1(), 0
             for root, dirs, files in os.walk(full):
                 dirs.sort()
@@ -2162,13 +2168,38 @@ def dirty_fingerprint(ws, path):
                     if n > 20000:
                         return "?"
                     fp = os.path.join(root, name)
-                    st = os.lstat(fp)
-                    h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+                    fst = os.lstat(fp)
+                    h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
             return h.hexdigest()
+        if stat.S_ISLNK(st.st_mode):
+            return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
+        if not stat.S_ISREG(st.st_mode):
+            # A FIFO or a device: opening it could block, on no leash.
+            return "?"
+        h = hashlib.sha1()
         with open(full, "rb") as f:
-            return hashlib.sha1(f.read()).hexdigest()
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
     except OSError:
         return "?"
+
+
+def porcelain_paths(out):
+    """The paths of a `git status --porcelain -z` output: NUL-separated, no
+    quoting, a rename or copy followed by its source entry (skipped — the
+    destination is the path that exists)."""
+    entries = (out or "").split("\0")
+    paths, i = [], 0
+    while i < len(entries):
+        e = entries[i]
+        i += 1
+        if len(e) < 4:
+            continue
+        paths.append(e[3:])
+        if e[0] in "RC":
+            i += 1
+    return sorted(set(paths))
 
 
 def dirty_paths_before_apply(ws):
@@ -2183,11 +2214,10 @@ def dirty_paths_before_apply(ws):
     the index is a write into the tree it is only meant to read (under a
     full disk or a size limit it left a corrupt index behind, and every
     later checkout failed)."""
-    code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+    code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
     if code != 0:
         return None
-    paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
-    return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+    return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
 
 
 def split_dirty_record(entries):
@@ -2197,9 +2227,11 @@ def split_dirty_record(entries):
     rec = {}
     for e in entries or []:
         fp, sep, q = e.partition(":")
-        if sep and q:
+        if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
             rec[q] = fp
         else:
+            # No fingerprint (a marker written before they were recorded): the
+            # whole entry is the path, a colon in it included.
             rec[e] = "?"
     return rec
 
@@ -2234,6 +2266,11 @@ def write_applied_marker(ws, meta):
                        "in this run, or another harness is gating this tree; the tree is not "
                        "HEAD and nothing is applied on top of it"
                        % (prior.get("id") or "?", prior.get("dir") or marker))
+    # Read the tree BEFORE the exclusive create: the status and the hashing
+    # take real time, and a marker that exists but is empty is read as
+    # corrupt by the next gate — the create→write window must stay as short
+    # as a single write.
+    dirty_before = dirty_paths_before_apply(ws)
     try:
         fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
     except OSError as e:
@@ -2241,7 +2278,7 @@ def write_applied_marker(ws, meta):
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
-                       "dirty_before": dirty_paths_before_apply(ws)}, f)
+                       "dirty_before": dirty_before}, f)
     except OSError as e:
         # The empty shell a failed write leaves behind records NOTHING — apply.sh
         # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2421,11 +2458,11 @@ def revert_leftover_mutant(ws, gm_dir=None):
         # wedged one must not hang the gate the way the incident behind this
         # whole guard hung it. Unanswered is reported as UNKNOWN, never as
         # clean — an empty porcelain and an absent git are not the same fact.
-        st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+        st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
         if st == 0:
-            dirty = st_out.strip()
+            after = porcelain_paths(st_out)
+            dirty = "\n".join(after)
             before = meta.get("dirty_before")
-            after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
             if before is not None:
                 # What is still modified now and was NOT when the mutant went
                 # down is the mutant's residue — and so is a path that was
@@ -4122,6 +4159,36 @@ def _selftest():
                   [["f.txt"], True, "still_mutated"])
             os.remove(applied_marker_for(tmp))
             sub("git", "checkout", "--", "f.txt")
+            # Une suppression non committee de l'operateur n'est pas un residu ; un
+            # renommage indexe non plus ; un chemin avec une espace edite par le
+            # mutant EST un residu (le porcelain -z ne le cite pas entre guillemets).
+            with open(os.path.join(tmp, "d.txt"), "w", encoding="utf-8") as f:
+                f.write("doomed\n")
+            with open(os.path.join(tmp, "a b.txt"), "w", encoding="utf-8") as f:
+                f.write("spaced\n")
+            sub("git", "add", "d.txt", "a b.txt")
+            sub("git", "commit", "-qm", "more files")
+            os.remove(os.path.join(tmp, "d.txt"))
+            sub("git", "mv", "a b.txt", "a c.txt")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+            check("une suppression est enregistree 'absent', un renommage par sa destination",
+                  ["absent:d.txt" in db, any(e.endswith(":a c.txt") for e in db), any(e.endswith(":a b.txt") for e in db)],
+                  [True, True, False])
+            left = revert_leftover_mutant(tmp)
+            check("suppression et renommage de l'operateur : pas un residu, reverti",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+            scripts("printf 'mutant\\n' >> 'a c.txt'", "true")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("un chemin avec une espace edite par le mutant est un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["a c.txt"], "still_mutated"])
+            os.remove(applied_marker_for(tmp))
+            sub("git", "reset", "-q", "--hard", "HEAD")
+            # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
+            check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
+                  split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2143,20 +2143,43 @@ def read_applied_marker(ws):
     return meta, ""
 
 
+_repo_root_cache = {}
+
+
+def repo_root_of(ws):
+    """The working tree's root, which porcelain paths are relative to — ws
+    itself when git does not answer (a gate runs at the root; the fallback
+    keeps a name comparison rather than none)."""
+    key = os.path.realpath(ws)
+    if key not in _repo_root_cache:
+        try:
+            p = subprocess.run(["git", "-C", ws, "rev-parse", "--show-toplevel"],
+                               capture_output=True, text=True, timeout=60)
+            top = (p.stdout or "").strip() if p.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            top = ""
+        _repo_root_cache[key] = top or ws
+    return _repo_root_cache[key]
+
+
+BIG_FILE_BYTES = 8 << 20
+
+
 def dirty_fingerprint(ws, path):
-    """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
-    edit on an already-dirty path from the operator's untouched work: the
-    sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
-    to one line) the sha1 of its recursive listing of (path, size, mtime) —
-    a file a mutant creates inside moves it, an untouched build tree does
-    not; "?" when the path cannot be read or the listing is unreasonably
-    large: undecidable, which is not "unchanged"."""
-    full = os.path.join(ws, path)
+    """What a dirty path IS, so a later sweep can tell a mutant's edit on an
+    already-dirty path from the operator's untouched work. A file: the sha1
+    of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
+    a leash: hashing is local and linear); a symlink: its target; a directory
+    (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
+    recursive NAME listing — a file a mutant creates or removes inside moves
+    it, a build tree merely rebuilt between two runs does not, and a change
+    inside an existing untracked file is the accepted blind spot; "absent"
+    for an uncommitted deletion (a state of its own, equal to itself); "?"
+    for a FIFO or a device (opening could block, on no leash), an unreadable
+    path or a listing past 20000 entries: undecidable, not "unchanged"."""
+    full = os.path.join(repo_root_of(ws), path)
     try:
         if not os.path.lexists(full):
-            # An uncommitted deletion (` D path`): a state of its own, so
-            # absent-before equals absent-after and an operator's deletion
-            # is not residue.
             return "absent"
         st = os.lstat(full)
         if stat.S_ISDIR(st.st_mode):
@@ -2167,15 +2190,14 @@ def dirty_fingerprint(ws, path):
                     n += 1
                     if n > 20000:
                         return "?"
-                    fp = os.path.join(root, name)
-                    fst = os.lstat(fp)
-                    h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
+                    h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
             return h.hexdigest()
         if stat.S_ISLNK(st.st_mode):
             return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
         if not stat.S_ISREG(st.st_mode):
-            # A FIFO or a device: opening it could block, on no leash.
             return "?"
+        if st.st_size > BIG_FILE_BYTES:
+            return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
         h = hashlib.sha1()
         with open(full, "rb") as f:
             for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2185,19 +2207,37 @@ def dirty_fingerprint(ws, path):
         return "?"
 
 
+def status_porcelain_z(ws):
+    """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
+    merges the two streams, and a warning git prints on stderr (a directory
+    it cannot read) would land inside the NUL entry stream and swallow a real
+    path. Bounded, guarded, without the optional index refresh."""
+    try:
+        p = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain", "-z"],
+                           capture_output=True, text=True, timeout=120)
+        return p.returncode, p.stdout or ""
+    except (OSError, subprocess.SubprocessError) as e:
+        return 124, "%s" % e
+
+
+PORCELAIN_STATUS = " MADRCU?!"
+
+
 def porcelain_paths(out):
     """The paths of a `git status --porcelain -z` output: NUL-separated, no
-    quoting, a rename or copy followed by its source entry (skipped — the
-    destination is the path that exists)."""
+    quoting, a rename or copy (in the index or in the work tree) followed by
+    its source entry, skipped — the destination is the path that exists. An
+    entry that is not `XY<space>path` is not an entry (a stray line that is
+    not the porcelain) and is dropped rather than decided on."""
     entries = (out or "").split("\0")
     paths, i = [], 0
     while i < len(entries):
         e = entries[i]
         i += 1
-        if len(e) < 4:
+        if len(e) < 4 or e[2] != " " or e[0] not in PORCELAIN_STATUS or e[1] not in PORCELAIN_STATUS:
             continue
         paths.append(e[3:])
-        if e[0] in "RC":
+        if e[0] in "RC" or e[1] in "RC":
             i += 1
     return sorted(set(paths))
 
@@ -2214,7 +2254,7 @@ def dirty_paths_before_apply(ws):
     the index is a write into the tree it is only meant to read (under a
     full disk or a size limit it left a corrupt index behind, and every
     later checkout failed)."""
-    code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+    code, out = status_porcelain_z(ws)
     if code != 0:
         return None
     return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
@@ -2458,7 +2498,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
         # wedged one must not hang the gate the way the incident behind this
         # whole guard hung it. Unanswered is reported as UNKNOWN, never as
         # clean — an empty porcelain and an absent git are not the same fact.
-        st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+        st, st_out = status_porcelain_z(ws)
         if st == 0:
             after = porcelain_paths(st_out)
             dirty = "\n".join(after)
@@ -2558,10 +2598,11 @@ def leftover_disposition(left):
                 "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
                 % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         return "still_mutated", (
-            "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
-            "— revert.sh exited 0, but these paths are still modified and were clean when the "
-            "mutant went down: %s. The tree is still mutated and will be neither judged nor "
-            "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+            "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+            "exit 0), but these paths changed since the mutant went down and the harness cannot "
+            "attribute the change — the mutant's residue, or work done in between: %s. The tree "
+            "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
+            "hand, keep yours, then delete the marker %s."
             % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
     if left.get("code") == 0:
         text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -4089,17 +4130,12 @@ def _selftest():
             # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
             scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
             apply_mutant(lmeta, tmp)
-            real_run = g["run"]
-
-            def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
-                if "status --porcelain" in cmd:
-                    return 124, "timeout after 120s"
-                return real_run(cmd, cwd, timeout)
-            g["run"] = mute_status
+            real_status = g["status_porcelain_z"]
+            g["status_porcelain_z"] = lambda ws: (124, "timeout after 120s")
             try:
                 left = revert_leftover_mutant(tmp)
             finally:
-                g["run"] = real_run
+                g["status_porcelain_z"] = real_status
             check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
                   [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
                    (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
@@ -4189,6 +4225,54 @@ def _selftest():
             # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
             check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
                   split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
+            # Le porcelain -z lu avec stderr A PART : un avertissement de git dans le
+            # flux fondrait un vrai chemin dans une entree fantome. Le parseur jette
+            # ce qui n'a pas la forme `XY<espace>chemin`, et suit les renommages
+            # d'index comme d'arbre de travail.
+            check("un avertissement dans le flux ne fabrique ni ne masque un chemin",
+                  porcelain_paths("warning: could not open directory 'secret/': Permission denied\n M a.txt\0?? b.txt\0"),
+                  ["b.txt"])
+            # L'origine d'un renommage est sautee meme quand son nom a la forme
+            # d'une entree (deux lettres de statut et une espace).
+            check("un renommage d'arbre de travail est suivi par sa destination",
+                  porcelain_paths(" R new.txt\0MM old.txt\0R  new2.txt\0AD old2.txt\0"), ["new.txt", "new2.txt"])
+            # Un avertissement REEL de git (repertoire illisible) sur stderr ne
+            # touche pas le flux des chemins : le vrai chemin modifie est enregistre.
+            secret = os.path.join(tmp, "secret")
+            os.makedirs(secret, exist_ok=True)
+            with open(os.path.join(secret, "s.txt"), "w", encoding="utf-8") as f:
+                f.write("s\n")
+            with open(os.path.join(tmp, "other.txt"), "w", encoding="utf-8") as f:
+                f.write("o\n")
+            os.chmod(secret, 0)
+            try:
+                db = dirty_paths_before_apply(tmp) or []
+            finally:
+                os.chmod(secret, 0o755)
+                shutil.rmtree(secret, ignore_errors=True)
+            os.remove(os.path.join(tmp, "other.txt"))
+            check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                  [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+            # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
+            # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
+            os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+            with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                f.write("artefact v1\n")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            time.sleep(0.01)
+            with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                f.write("artefact v2, rebuilt\n")
+            left = revert_leftover_mutant(tmp)
+            check("un repertoire non suivi reconstruit n'est pas un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+            shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+            # Un gros fichier modifie s'empreinte par (taille, mtime), sans le lire.
+            big = os.path.join(tmp, "big.bin")
+            with open(big, "wb") as f:
+                f.truncate(BIG_FILE_BYTES + 1)
+            check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+            os.remove(big)
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2144,7 +2144,7 @@ tool sync_harness:
         au moins aussi discriminante que `git status` pour ce qu'on lui demande —
         savoir si un fichier a bouge. Si les DEUX echouent, on s'arrete.
         """
-        code, out = run("git status --porcelain", ws, timeout=120)
+        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
         if code == 0:
             return "git:" + out
         h = hashlib.sha256()
@@ -2304,7 +2304,25 @@ tool sync_harness:
             v = meta.get(k)
             if v is not None and (not isinstance(v, str) or "\0" in v):
                 return {}, "the marker %s holds a %s that is not a usable string" % (marker, k)
+        db = meta.get("dirty_before")
+        if db is not None and (not isinstance(db, list) or any(not isinstance(q, str) for q in db)):
+            return {}, "the marker %s holds a dirty_before that is not a list of paths" % marker
         return meta, ""
+
+
+    def dirty_paths_before_apply(ws):
+        """The paths `git status --porcelain` lists right before a mutant goes
+        down, recorded in the marker so a later sweep can tell the mutant's
+        residue from work that was already uncommitted (an operator's, in record
+        mode). None when git did not answer — unknown, which is not "clean".
+        Bounded and guarded like every git call that runs before the report, and
+        without the optional index refresh: a status that rewrites the index is a
+        write into the tree it is only meant to read (under a full disk or a size
+        limit it left a corrupt index behind, and every later checkout failed)."""
+        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+        if code != 0:
+            return None
+        return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
 
 
     def write_applied_marker(ws, meta):
@@ -2343,7 +2361,8 @@ tool sync_harness:
             return False, "cannot create the marker %s: %s" % (marker, e.strerror or e)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump({"id": meta.get("id"), "dir": meta.get("dir")}, f)
+                json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
+                           "dirty_before": dirty_paths_before_apply(ws)}, f)
         except OSError as e:
             # The empty shell a failed write leaves behind records NOTHING — apply.sh
             # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2514,9 +2533,8 @@ tool sync_harness:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown = "", ""
+        dirty, unknown, residue = "", "", []
         if code == 0:
-            drop_applied_marker(ws, meta)
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
             # verdict: a `git` that is absent must not replace the JSON report with
@@ -2524,14 +2542,26 @@ tool sync_harness:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git status --porcelain", ws, timeout=120)
+            st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
             if st == 0:
                 dirty = st_out.strip()
+                before = meta.get("dirty_before")
+                if before is not None:
+                    # What is still modified now and was NOT when the mutant went
+                    # down is the mutant's residue: revert.sh's exit 0 is the
+                    # script's word, this is the tree's. An operator's own
+                    # uncommitted work was there before and is not residue —
+                    # record mode is where the difference matters, since nothing
+                    # else stops references from being sealed over a leftover.
+                    after = {l[3:] for l in st_out.splitlines() if l.strip()}
+                    residue = sorted(after - set(before))
             else:
                 unknown = "`git status` did not answer (exit %s)" % st
+            if not residue:
+                drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0,
-                "dirty": dirty[:400], "dirty_unknown": unknown}
+                "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2572,6 +2602,13 @@ tool sync_harness:
                 "marker %s."
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
+        if left.get("code") == 0 and left.get("residue"):
+            return "still_mutated", (
+                "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
+                "— revert.sh exited 0, but these paths are still modified and were clean when the "
+                "mutant went down: %s. The tree is still mutated and will be neither judged nor "
+                "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+                % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
                     "(revert.sh exit 0). The interrupted attempt's verdict, if any, judged a "
@@ -4028,6 +4065,50 @@ tool sync_harness:
                 check("une application tuee par un signal est revertie, pas lue comme refusee",
                       [state, tree(), os.path.isfile(applied_marker_for(tmp))],
                       ["failed", "original\n", False])
+                # ── Le residu d'un revert qui dit « 0 » sans tout restaurer : ce qui
+                # est encore modifie ET etait propre quand le mutant est descendu.
+                try:
+                    os.remove(applied_marker_for(tmp))
+                except OSError:
+                    pass
+                sub("git", "checkout", "--", "f.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
+                check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
+                      [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+                left = revert_leftover_mutant(tmp)
+                check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
+                      [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
+                       os.path.isfile(applied_marker_for(tmp))],
+                      [0, ["f.txt"], True, True])
+                check("disposition d'un residu : la porte s'arrete",
+                      [leftover_disposition(left or {})[0], leftover_disposition(left or {})[0] in LEFTOVER_BAIL_KINDS],
+                      ["still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Le travail non committe d'AVANT le mutant n'est pas un residu.
+                with open(os.path.join(tmp, "g.txt"), "w", encoding="utf-8") as f:
+                    f.write("operator work\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                check("le travail deja non committe est enregistre comme tel",
+                      "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+                left = revert_leftover_mutant(tmp)
+                check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
+                      [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
+                       leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], True, "reverted", False])
+                os.remove(os.path.join(tmp, "g.txt"))
+                # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
+                mpath = applied_marker_for(tmp)
+                os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "x", "dir": mdir, "dirty_before": 5}, f)
+                os.chmod(mpath, 0o600)
+                check("un dirty_before qui n'est pas une liste est refuse",
+                      bool(read_applied_marker(tmp)[1]), True)
+                os.remove(mpath)
             finally:
                 shutil.rmtree(tmp, ignore_errors=True)
                 shutil.rmtree(outside, ignore_errors=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2310,19 +2310,65 @@ tool sync_harness:
         return meta, ""
 
 
+    def dirty_fingerprint(ws, path):
+        """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
+        edit on an already-dirty path from the operator's untouched work: the
+        sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
+        to one line) the sha1 of its recursive listing of (path, size, mtime) —
+        a file a mutant creates inside moves it, an untouched build tree does
+        not; "?" when the path cannot be read or the listing is unreasonably
+        large: undecidable, which is not "unchanged"."""
+        full = os.path.join(ws, path)
+        try:
+            if os.path.isdir(full) and not os.path.islink(full):
+                h, n = hashlib.sha1(), 0
+                for root, dirs, files in os.walk(full):
+                    dirs.sort()
+                    for name in sorted(files):
+                        n += 1
+                        if n > 20000:
+                            return "?"
+                        fp = os.path.join(root, name)
+                        st = os.lstat(fp)
+                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+                return h.hexdigest()
+            with open(full, "rb") as f:
+                return hashlib.sha1(f.read()).hexdigest()
+        except OSError:
+            return "?"
+
+
     def dirty_paths_before_apply(ws):
         """The paths `git status --porcelain` lists right before a mutant goes
-        down, recorded in the marker so a later sweep can tell the mutant's
-        residue from work that was already uncommitted (an operator's, in record
-        mode). None when git did not answer — unknown, which is not "clean".
-        Bounded and guarded like every git call that runs before the report, and
-        without the optional index refresh: a status that rewrites the index is a
-        write into the tree it is only meant to read (under a full disk or a size
-        limit it left a corrupt index behind, and every later checkout failed)."""
+        down, each with its content fingerprint ("<sha1>:<path>"), recorded in
+        the marker so a later sweep can tell the mutant's residue from work that
+        was already uncommitted (an operator's, in record mode) — by content,
+        not by name: a mutant editing a file the operator had already edited is
+        residue too. None when git did not answer — unknown, which is not
+        "clean". Bounded and guarded like every git call that runs before the
+        report, and without the optional index refresh: a status that rewrites
+        the index is a write into the tree it is only meant to read (under a
+        full disk or a size limit it left a corrupt index behind, and every
+        later checkout failed)."""
         code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
         if code != 0:
             return None
-        return sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+        paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
+        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+
+
+    def split_dirty_record(entries):
+        """{path: fingerprint} from a marker's dirty_before; an entry without a
+        fingerprint (a marker written before fingerprints were recorded) maps
+        to "?": its content then is unknown, so a change cannot be ruled out."""
+        rec = {}
+        for e in entries or []:
+            fp, sep, q = e.partition(":")
+            if sep and q:
+                rec[q] = fp
+            else:
+                rec[e] = "?"
+        return rec
 
 
     def write_applied_marker(ws, meta):
@@ -2549,12 +2595,22 @@ tool sync_harness:
                 after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
-                    # down is the mutant's residue: revert.sh's exit 0 is the
-                    # script's word, this is the tree's. An operator's own
-                    # uncommitted work was there before and is not residue —
-                    # record mode is where the difference matters, since nothing
-                    # else stops references from being sealed over a leftover.
-                    residue = sorted(set(after) - set(before))
+                    # down is the mutant's residue — and so is a path that was
+                    # already dirty but whose CONTENT moved since: revert.sh's
+                    # exit 0 is the script's word, this is the tree's. An
+                    # operator's own uncommitted work, untouched, is not residue
+                    # — record mode is where the difference matters, since
+                    # nothing else stops references from being sealed over a
+                    # leftover. A path whose earlier content is unknown ("?")
+                    # cannot be cleared: undecidable.
+                    rec = split_dirty_record(before)
+                    for q in after:
+                        if q not in rec:
+                            residue.append(q)
+                        elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                            residue.append(q)
+                            if rec[q] == "?":
+                                residue_undecided = True
                 elif after:
                     # No record of what was dirty before the mutant went down
                     # (git did not answer then, or the marker predates the
@@ -3720,7 +3776,12 @@ tool sync_harness:
                 sub("git", "config", "user.name", "t")
                 with open(os.path.join(tmp, "f.txt"), "w", encoding="utf-8") as f:
                     f.write("original\n")
-                sub("git", "add", "f.txt")
+                # Les repertoires de mutants de ce test vivent DANS l'arbre, non suivis :
+                # ignores des le depart, sinon leur listing (que le test reecrit) lit
+                # comme un chemin modifie.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", "f.txt", ".gitignore")
                 sub("git", "commit", "-qm", "seed")
                 mdir = os.path.join(tmp, "m1")
                 os.makedirs(mdir)
@@ -4106,7 +4167,7 @@ tool sync_harness:
                 apply_mutant(lmeta, tmp)
                 db = (read_applied_marker(tmp)[0] or {}).get("dirty_before")
                 check("le marqueur enregistre ce qui etait deja modifie avant l'application (pas f.txt)",
-                      [isinstance(db, list), "f.txt" in (db or [])], [True, False])
+                      [isinstance(db, list), any(e.endswith(":f.txt") for e in (db or []))], [True, False])
                 left = revert_leftover_mutant(tmp)
                 check("un revert.sh a 0 qui ne restaure pas laisse un residu nomme, marqueur garde",
                       [(left or {}).get("code"), (left or {}).get("residue"), (left or {}).get("kept"),
@@ -4122,8 +4183,9 @@ tool sync_harness:
                     f.write("operator work\n")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
-                check("le travail deja non committe est enregistre comme tel",
-                      "g.txt" in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or []), True)
+                check("le travail deja non committe est enregistre comme tel, avec son empreinte",
+                      any(e.endswith(":g.txt") and len(e.split(":")[0]) == 40
+                          for e in ((read_applied_marker(tmp)[0] or {}).get("dirty_before") or [])), True)
                 left = revert_leftover_mutant(tmp)
                 check("un revert propre au milieu du travail de l'operateur : pas de residu, note, marqueur efface",
                       [(left or {}).get("residue"), "g.txt" in ((left or {}).get("dirty") or ""),
@@ -4133,12 +4195,6 @@ tool sync_harness:
                 # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
                 # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
                 # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
-                # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
-                # test sont des fichiers non suivis, donc « modifies » pour git.
-                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                    f.write("m1/\nm2/\n")
-                sub("git", "add", ".gitignore")
-                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "true")
                 apply_mutant(lmeta, tmp)
                 mpath = applied_marker_for(tmp)
@@ -4161,8 +4217,6 @@ tool sync_harness:
                       [[], "reverted", False])
                 # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
                 # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
-                os.remove(os.path.join(tmp, ".gitignore"))
-                sub("git", "checkout", "--", ".gitignore")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
                 real_run = g["run"]
@@ -4182,6 +4236,59 @@ tool sync_harness:
                        leftover_disposition(left or {})[0]],
                       [True, True, True, True, "still_mutated"])
                 os.remove(applied_marker_for(tmp))
+                # Le CONTENU, pas le nom : un chemin deja modifie par l'operateur ET
+                # edite par le mutant est un residu si son contenu a bouge ; le meme
+                # chemin intact ne l'est pas ; un fichier cree par le mutant dans un
+                # repertoire deja non suivi bouge la liste du repertoire.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                check("dirty_before porte une empreinte par chemin",
+                      all(":" in e and len(e.split(":")[0]) == 40 for e in db) and any(e.endswith(":f.txt") for e in db), True)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant sur un chemin deja modifie laisse un residu par CONTENU : still_mutated, marqueur garde",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [["f.txt"], "still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                scripts("printf 'mutant\\n' >> g.txt", "rm -f g.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("le travail intact de l'operateur sur f.txt n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], "reverted", False])
+                sub("git", "checkout", "--", "f.txt")
+                os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact\n")
+                scripts("printf 'mutant\\n' > build/injected.txt", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un fichier cree par le mutant dans un repertoire deja non suivi est un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["build/"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "build", "injected.txt"))
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un repertoire non suivi intact n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+                # Une entree sans empreinte (marqueur d'avant) sur un chemin encore modifie : indecidable.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir, "dirty_before": ["f.txt"]}, f)
+                left = revert_leftover_mutant(tmp)
+                check("une entree sans empreinte sur un chemin encore modifie est indecidable",
+                      [(left or {}).get("residue"), (left or {}).get("residue_undecided"), leftover_disposition(left or {})[0]],
+                      [["f.txt"], True, "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4120,6 +4120,12 @@ tool sync_harness:
                 # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
                 # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
                 # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+                # Baseline VRAIMENT propre d'abord : les repertoires de mutants de ce
+                # test sont des fichiers non suivis, donc « modifies » pour git.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", ".gitignore")
+                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "true")
                 apply_mutant(lmeta, tmp)
                 mpath = applied_marker_for(tmp)
@@ -4132,12 +4138,6 @@ tool sync_harness:
                       [True, ["f.txt"], "still_mutated", True])
                 os.remove(applied_marker_for(tmp))
                 sub("git", "checkout", "--", "f.txt")
-                # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
-                # des fichiers non suivis, donc « modifies » pour git — ignores ici.
-                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
-                    f.write("m1/\nm2/\n")
-                sub("git", "add", ".gitignore")
-                sub("git", "commit", "-qm", "ignore the mutant dirs")
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
                 with open(mpath, "w", encoding="utf-8") as f:

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2533,7 +2533,7 @@ tool sync_harness:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue = "", "", []
+        dirty, unknown, residue, residue_undecided = "", "", [], False
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2546,6 +2546,7 @@ tool sync_harness:
             if st == 0:
                 dirty = st_out.strip()
                 before = meta.get("dirty_before")
+                after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
                     # down is the mutant's residue: revert.sh's exit 0 is the
@@ -2553,15 +2554,23 @@ tool sync_harness:
                     # uncommitted work was there before and is not residue —
                     # record mode is where the difference matters, since nothing
                     # else stops references from being sealed over a leftover.
-                    after = {l[3:] for l in st_out.splitlines() if l.strip()}
-                    residue = sorted(after - set(before))
+                    residue = sorted(set(after) - set(before))
+                elif after:
+                    # No record of what was dirty before the mutant went down
+                    # (git did not answer then, or the marker predates the
+                    # field): a tree that still shows changes is UNDECIDABLE,
+                    # and undecidable is not clean — every change is treated as
+                    # residue, the marker stays, an operator decides.
+                    residue = after
+                    residue_undecided = True
             else:
                 unknown = "`git status` did not answer (exit %s)" % st
             if not residue:
                 drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
-                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50]}
+                "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
+                "residue_undecided": residue_undecided}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2603,6 +2612,14 @@ tool sync_harness:
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
+            if left.get("residue_undecided"):
+                return "still_mutated", (
+                    "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                    "exit 0), but the tree still shows changes and nothing recorded what was already "
+                    "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
+                    "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                    "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
+                    % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
                 "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
                 "— revert.sh exited 0, but these paths are still modified and were clean when the "
@@ -4100,6 +4117,35 @@ tool sync_harness:
                        leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                       [[], True, "reverted", False])
                 os.remove(os.path.join(tmp, "g.txt"))
+                # Un marqueur SANS dirty_before (git muet a l'application, ou harnais
+                # d'avant) et un arbre encore modifie apres le revert : INDECIDABLE,
+                # donc pas propre — marqueur garde, porte arretee. Arbre propre : reverti.
+                scripts("printf 'mutant\\n' >> f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir}, f)
+                left = revert_leftover_mutant(tmp)
+                check("sans dirty_before, un arbre encore modifie est indecidable : still_mutated, marqueur garde",
+                      [(left or {}).get("residue_undecided"), (left or {}).get("residue"),
+                       leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [True, ["f.txt"], "still_mutated", True])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "checkout", "--", "f.txt")
+                # Un arbre VRAIMENT propre : les repertoires de mutants de ce test sont
+                # des fichiers non suivis, donc « modifies » pour git — ignores ici.
+                with open(os.path.join(tmp, ".gitignore"), "w", encoding="utf-8") as f:
+                    f.write("m1/\nm2/\n")
+                sub("git", "add", ".gitignore")
+                sub("git", "commit", "-qm", "ignore the mutant dirs")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir}, f)
+                left = revert_leftover_mutant(tmp)
+                check("sans dirty_before, un arbre propre apres le revert est reverti",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
+                      [[], "reverted", False])
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4282,7 +4328,7 @@ tool sync_harness:
             note(report, text)
 
         if mode != "record":
-            dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+            dirty = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain"],
                                    capture_output=True, text=True)
             if dirty.returncode == 0 and dirty.stdout.strip():
                 # Decoupe AVANT tout strip global. `git status --porcelain` ecrit

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2564,11 +2564,15 @@ tool sync_harness:
                     residue = after
                     residue_undecided = True
             else:
+                # A git that answered nothing is more undecidable still than one
+                # that answered with no record to compare against: the marker
+                # stays, the gate stops, an operator looks.
                 unknown = "`git status` did not answer (exit %s)" % st
-            if not residue:
+                residue_undecided = True
+            if not residue and not residue_undecided:
                 drop_applied_marker(ws, meta)
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
-                "marker": marker, "refused": False, "kept": code != 0 or bool(residue),
+                "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
                 "residue_undecided": residue_undecided}
 
@@ -2611,6 +2615,13 @@ tool sync_harness:
                 "marker %s."
                 % (left.get("id") or "?", left.get("dir") or "?", left.get("out") or "?",
                    left.get("marker")))
+        if left.get("code") == 0 and left.get("residue_undecided") and not left.get("residue"):
+            return "still_mutated", (
+                "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                "exit 0), but whether the tree came back could not be checked: %s. Unknown is not "
+                "clean — the tree will be neither judged nor recorded. Check it by hand (git status, "
+                "git diff), revert the mutant's paths if any remain, then delete the marker %s."
+                % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
             if left.get("residue_undecided"):
                 return "still_mutated", (
@@ -3991,8 +4002,10 @@ tool sync_harness:
                 check("l'etat de l'arbre est INCONNU, pas propre",
                       [(nogit or {}).get("dirty"), bool((nogit or {}).get("dirty_unknown"))],
                       ["", True])
-                check("et la note le dit au lieu de laisser croire a un arbre propre",
-                      "Unknown, not clean" in leftover_disposition(nogit or {})[1], True)
+                check("et la porte s'arrete au lieu de laisser croire a un arbre propre",
+                      [leftover_disposition(nogit or {})[0], "Unknown is not clean" in leftover_disposition(nogit or {})[1],
+                       (nogit or {}).get("kept")],
+                      ["still_mutated", True, True])
                 clear_marker()
                 # Un revert en ECHEC garde son enregistrement face au mutant suivant :
                 # la seconde application est refusee, rien ne tourne, et le revert du
@@ -4146,6 +4159,29 @@ tool sync_harness:
                 check("sans dirty_before, un arbre propre apres le revert est reverti",
                       [(left or {}).get("residue"), leftover_disposition(left or {})[0], os.path.isfile(applied_marker_for(tmp))],
                       [[], "reverted", False])
+                # Un `git status` qui ne repond pas apres le revert : inconnu, pas propre —
+                # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
+                os.remove(os.path.join(tmp, ".gitignore"))
+                sub("git", "checkout", "--", ".gitignore")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                real_run = g["run"]
+
+                def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
+                    if "status --porcelain" in cmd:
+                        return 124, "timeout after 120s"
+                    return real_run(cmd, cwd, timeout)
+                g["run"] = mute_status
+                try:
+                    left = revert_leftover_mutant(tmp)
+                finally:
+                    g["run"] = real_run
+                check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
+                      [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
+                       (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
+                       leftover_disposition(left or {})[0]],
+                      [True, True, True, True, "still_mutated"])
+                os.remove(applied_marker_for(tmp))
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2320,7 +2320,13 @@ tool sync_harness:
         large: undecidable, which is not "unchanged"."""
         full = os.path.join(ws, path)
         try:
-            if os.path.isdir(full) and not os.path.islink(full):
+            if not os.path.lexists(full):
+                # An uncommitted deletion (` D path`): a state of its own, so
+                # absent-before equals absent-after and an operator's deletion
+                # is not residue.
+                return "absent"
+            st = os.lstat(full)
+            if stat.S_ISDIR(st.st_mode):
                 h, n = hashlib.sha1(), 0
                 for root, dirs, files in os.walk(full):
                     dirs.sort()
@@ -2329,13 +2335,38 @@ tool sync_harness:
                         if n > 20000:
                             return "?"
                         fp = os.path.join(root, name)
-                        st = os.lstat(fp)
-                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), st.st_size, st.st_mtime_ns)).encode("utf-8", "replace"))
+                        fst = os.lstat(fp)
+                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
                 return h.hexdigest()
+            if stat.S_ISLNK(st.st_mode):
+                return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
+            if not stat.S_ISREG(st.st_mode):
+                # A FIFO or a device: opening it could block, on no leash.
+                return "?"
+            h = hashlib.sha1()
             with open(full, "rb") as f:
-                return hashlib.sha1(f.read()).hexdigest()
+                for chunk in iter(lambda: f.read(1 << 20), b""):
+                    h.update(chunk)
+            return h.hexdigest()
         except OSError:
             return "?"
+
+
+    def porcelain_paths(out):
+        """The paths of a `git status --porcelain -z` output: NUL-separated, no
+        quoting, a rename or copy followed by its source entry (skipped — the
+        destination is the path that exists)."""
+        entries = (out or "").split("\0")
+        paths, i = [], 0
+        while i < len(entries):
+            e = entries[i]
+            i += 1
+            if len(e) < 4:
+                continue
+            paths.append(e[3:])
+            if e[0] in "RC":
+                i += 1
+        return sorted(set(paths))
 
 
     def dirty_paths_before_apply(ws):
@@ -2350,11 +2381,10 @@ tool sync_harness:
         the index is a write into the tree it is only meant to read (under a
         full disk or a size limit it left a corrupt index behind, and every
         later checkout failed)."""
-        code, out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+        code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
         if code != 0:
             return None
-        paths = sorted({l[3:] for l in (out or "").splitlines() if l.strip()})
-        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in paths]
+        return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
 
 
     def split_dirty_record(entries):
@@ -2364,9 +2394,11 @@ tool sync_harness:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q:
+            if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
+                # No fingerprint (a marker written before they were recorded): the
+                # whole entry is the path, a colon in it included.
                 rec[e] = "?"
         return rec
 
@@ -2401,6 +2433,11 @@ tool sync_harness:
                            "in this run, or another harness is gating this tree; the tree is not "
                            "HEAD and nothing is applied on top of it"
                            % (prior.get("id") or "?", prior.get("dir") or marker))
+        # Read the tree BEFORE the exclusive create: the status and the hashing
+        # take real time, and a marker that exists but is empty is read as
+        # corrupt by the next gate — the create→write window must stay as short
+        # as a single write.
+        dirty_before = dirty_paths_before_apply(ws)
         try:
             fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
         except OSError as e:
@@ -2408,7 +2445,7 @@ tool sync_harness:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"id": meta.get("id"), "dir": meta.get("dir"),
-                           "dirty_before": dirty_paths_before_apply(ws)}, f)
+                           "dirty_before": dirty_before}, f)
         except OSError as e:
             # The empty shell a failed write leaves behind records NOTHING — apply.sh
             # will not run — but the NEXT gate reads it as a corrupt marker: kind
@@ -2588,11 +2625,11 @@ tool sync_harness:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git --no-optional-locks status --porcelain", ws, timeout=120)
+            st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
             if st == 0:
-                dirty = st_out.strip()
+                after = porcelain_paths(st_out)
+                dirty = "\n".join(after)
                 before = meta.get("dirty_before")
-                after = sorted({l[3:] for l in st_out.splitlines() if l.strip()})
                 if before is not None:
                     # What is still modified now and was NOT when the mutant went
                     # down is the mutant's residue — and so is a path that was
@@ -4289,6 +4326,36 @@ tool sync_harness:
                       [["f.txt"], True, "still_mutated"])
                 os.remove(applied_marker_for(tmp))
                 sub("git", "checkout", "--", "f.txt")
+                # Une suppression non committee de l'operateur n'est pas un residu ; un
+                # renommage indexe non plus ; un chemin avec une espace edite par le
+                # mutant EST un residu (le porcelain -z ne le cite pas entre guillemets).
+                with open(os.path.join(tmp, "d.txt"), "w", encoding="utf-8") as f:
+                    f.write("doomed\n")
+                with open(os.path.join(tmp, "a b.txt"), "w", encoding="utf-8") as f:
+                    f.write("spaced\n")
+                sub("git", "add", "d.txt", "a b.txt")
+                sub("git", "commit", "-qm", "more files")
+                os.remove(os.path.join(tmp, "d.txt"))
+                sub("git", "mv", "a b.txt", "a c.txt")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                check("une suppression est enregistree 'absent', un renommage par sa destination",
+                      ["absent:d.txt" in db, any(e.endswith(":a c.txt") for e in db), any(e.endswith(":a b.txt") for e in db)],
+                      [True, True, False])
+                left = revert_leftover_mutant(tmp)
+                check("suppression et renommage de l'operateur : pas un residu, reverti",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                scripts("printf 'mutant\\n' >> 'a c.txt'", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un chemin avec une espace edite par le mutant est un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["a c.txt"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                sub("git", "reset", "-q", "--hard", "HEAD")
+                # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
+                check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
+                      split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2310,20 +2310,43 @@ tool sync_harness:
         return meta, ""
 
 
+    _repo_root_cache = {}
+
+
+    def repo_root_of(ws):
+        """The working tree's root, which porcelain paths are relative to — ws
+        itself when git does not answer (a gate runs at the root; the fallback
+        keeps a name comparison rather than none)."""
+        key = os.path.realpath(ws)
+        if key not in _repo_root_cache:
+            try:
+                p = subprocess.run(["git", "-C", ws, "rev-parse", "--show-toplevel"],
+                                   capture_output=True, text=True, timeout=60)
+                top = (p.stdout or "").strip() if p.returncode == 0 else ""
+            except (OSError, subprocess.SubprocessError):
+                top = ""
+            _repo_root_cache[key] = top or ws
+        return _repo_root_cache[key]
+
+
+    BIG_FILE_BYTES = 8 << 20
+
+
     def dirty_fingerprint(ws, path):
-        """What a dirty path's CONTENT is, so a later sweep can tell a mutant's
-        edit on an already-dirty path from the operator's untouched work: the
-        sha1 of a file; for a directory (`?? dir/`, an untracked tree collapsed
-        to one line) the sha1 of its recursive listing of (path, size, mtime) —
-        a file a mutant creates inside moves it, an untouched build tree does
-        not; "?" when the path cannot be read or the listing is unreasonably
-        large: undecidable, which is not "unchanged"."""
-        full = os.path.join(ws, path)
+        """What a dirty path IS, so a later sweep can tell a mutant's edit on an
+        already-dirty path from the operator's untouched work. A file: the sha1
+        of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
+        a leash: hashing is local and linear); a symlink: its target; a directory
+        (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
+        recursive NAME listing — a file a mutant creates or removes inside moves
+        it, a build tree merely rebuilt between two runs does not, and a change
+        inside an existing untracked file is the accepted blind spot; "absent"
+        for an uncommitted deletion (a state of its own, equal to itself); "?"
+        for a FIFO or a device (opening could block, on no leash), an unreadable
+        path or a listing past 20000 entries: undecidable, not "unchanged"."""
+        full = os.path.join(repo_root_of(ws), path)
         try:
             if not os.path.lexists(full):
-                # An uncommitted deletion (` D path`): a state of its own, so
-                # absent-before equals absent-after and an operator's deletion
-                # is not residue.
                 return "absent"
             st = os.lstat(full)
             if stat.S_ISDIR(st.st_mode):
@@ -2334,15 +2357,14 @@ tool sync_harness:
                         n += 1
                         if n > 20000:
                             return "?"
-                        fp = os.path.join(root, name)
-                        fst = os.lstat(fp)
-                        h.update(("%s\0%d\0%d\n" % (os.path.relpath(fp, full), fst.st_size, fst.st_mtime_ns)).encode("utf-8", "replace"))
+                        h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
             if not stat.S_ISREG(st.st_mode):
-                # A FIFO or a device: opening it could block, on no leash.
                 return "?"
+            if st.st_size > BIG_FILE_BYTES:
+                return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
             h = hashlib.sha1()
             with open(full, "rb") as f:
                 for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2352,19 +2374,37 @@ tool sync_harness:
             return "?"
 
 
+    def status_porcelain_z(ws):
+        """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
+        merges the two streams, and a warning git prints on stderr (a directory
+        it cannot read) would land inside the NUL entry stream and swallow a real
+        path. Bounded, guarded, without the optional index refresh."""
+        try:
+            p = subprocess.run(["git", "-C", ws, "--no-optional-locks", "status", "--porcelain", "-z"],
+                               capture_output=True, text=True, timeout=120)
+            return p.returncode, p.stdout or ""
+        except (OSError, subprocess.SubprocessError) as e:
+            return 124, "%s" % e
+
+
+    PORCELAIN_STATUS = " MADRCU?!"
+
+
     def porcelain_paths(out):
         """The paths of a `git status --porcelain -z` output: NUL-separated, no
-        quoting, a rename or copy followed by its source entry (skipped — the
-        destination is the path that exists)."""
+        quoting, a rename or copy (in the index or in the work tree) followed by
+        its source entry, skipped — the destination is the path that exists. An
+        entry that is not `XY<space>path` is not an entry (a stray line that is
+        not the porcelain) and is dropped rather than decided on."""
         entries = (out or "").split("\0")
         paths, i = [], 0
         while i < len(entries):
             e = entries[i]
             i += 1
-            if len(e) < 4:
+            if len(e) < 4 or e[2] != " " or e[0] not in PORCELAIN_STATUS or e[1] not in PORCELAIN_STATUS:
                 continue
             paths.append(e[3:])
-            if e[0] in "RC":
+            if e[0] in "RC" or e[1] in "RC":
                 i += 1
         return sorted(set(paths))
 
@@ -2381,7 +2421,7 @@ tool sync_harness:
         the index is a write into the tree it is only meant to read (under a
         full disk or a size limit it left a corrupt index behind, and every
         later checkout failed)."""
-        code, out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+        code, out = status_porcelain_z(ws)
         if code != 0:
             return None
         return ["%s:%s" % (dirty_fingerprint(ws, q), q) for q in porcelain_paths(out)]
@@ -2625,7 +2665,7 @@ tool sync_harness:
             # wedged one must not hang the gate the way the incident behind this
             # whole guard hung it. Unanswered is reported as UNKNOWN, never as
             # clean — an empty porcelain and an absent git are not the same fact.
-            st, st_out = run("git --no-optional-locks status --porcelain -z", ws, timeout=120)
+            st, st_out = status_porcelain_z(ws)
             if st == 0:
                 after = porcelain_paths(st_out)
                 dirty = "\n".join(after)
@@ -2725,10 +2765,11 @@ tool sync_harness:
                     "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
                     % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
-                "a mutant left APPLIED by an interrupted gate was NOT fully reverted at start: %s "
-                "— revert.sh exited 0, but these paths are still modified and were clean when the "
-                "mutant went down: %s. The tree is still mutated and will be neither judged nor "
-                "recorded. Revert by hand (git checkout -- <those paths>), then delete the marker %s."
+                "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
+                "exit 0), but these paths changed since the mutant went down and the harness cannot "
+                "attribute the change — the mutant's residue, or work done in between: %s. The tree "
+                "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
+                "hand, keep yours, then delete the marker %s."
                 % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -4256,17 +4297,12 @@ tool sync_harness:
                 # marqueur garde, porte arretee (doublure de run() sur cette commande seule).
                 scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
                 apply_mutant(lmeta, tmp)
-                real_run = g["run"]
-
-                def mute_status(cmd, cwd, timeout=CMD_TIMEOUT_S):
-                    if "status --porcelain" in cmd:
-                        return 124, "timeout after 120s"
-                    return real_run(cmd, cwd, timeout)
-                g["run"] = mute_status
+                real_status = g["status_porcelain_z"]
+                g["status_porcelain_z"] = lambda ws: (124, "timeout after 120s")
                 try:
                     left = revert_leftover_mutant(tmp)
                 finally:
-                    g["run"] = real_run
+                    g["status_porcelain_z"] = real_status
                 check("un git status muet apres le revert : inconnu, marqueur garde, porte arretee",
                       [(left or {}).get("residue_undecided"), bool((left or {}).get("dirty_unknown")),
                        (left or {}).get("kept"), os.path.isfile(applied_marker_for(tmp)),
@@ -4356,6 +4392,54 @@ tool sync_harness:
                 # Une entree d'avant les empreintes dont le chemin contient ':' reste un chemin entier.
                 check("un chemin d'avant les empreintes avec ':' n'est pas coupe",
                       split_dirty_record(["src/a:b.txt", "absent:d.txt"]), {"src/a:b.txt": "?", "d.txt": "absent"})
+                # Le porcelain -z lu avec stderr A PART : un avertissement de git dans le
+                # flux fondrait un vrai chemin dans une entree fantome. Le parseur jette
+                # ce qui n'a pas la forme `XY<espace>chemin`, et suit les renommages
+                # d'index comme d'arbre de travail.
+                check("un avertissement dans le flux ne fabrique ni ne masque un chemin",
+                      porcelain_paths("warning: could not open directory 'secret/': Permission denied\n M a.txt\0?? b.txt\0"),
+                      ["b.txt"])
+                # L'origine d'un renommage est sautee meme quand son nom a la forme
+                # d'une entree (deux lettres de statut et une espace).
+                check("un renommage d'arbre de travail est suivi par sa destination",
+                      porcelain_paths(" R new.txt\0MM old.txt\0R  new2.txt\0AD old2.txt\0"), ["new.txt", "new2.txt"])
+                # Un avertissement REEL de git (repertoire illisible) sur stderr ne
+                # touche pas le flux des chemins : le vrai chemin modifie est enregistre.
+                secret = os.path.join(tmp, "secret")
+                os.makedirs(secret, exist_ok=True)
+                with open(os.path.join(secret, "s.txt"), "w", encoding="utf-8") as f:
+                    f.write("s\n")
+                with open(os.path.join(tmp, "other.txt"), "w", encoding="utf-8") as f:
+                    f.write("o\n")
+                os.chmod(secret, 0)
+                try:
+                    db = dirty_paths_before_apply(tmp) or []
+                finally:
+                    os.chmod(secret, 0o755)
+                    shutil.rmtree(secret, ignore_errors=True)
+                os.remove(os.path.join(tmp, "other.txt"))
+                check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                      [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+                # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
+                # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
+                os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact v1\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                time.sleep(0.01)
+                with open(os.path.join(tmp, "build", "a.o"), "w", encoding="utf-8") as f:
+                    f.write("artefact v2, rebuilt\n")
+                left = revert_leftover_mutant(tmp)
+                check("un repertoire non suivi reconstruit n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                shutil.rmtree(os.path.join(tmp, "build"), ignore_errors=True)
+                # Un gros fichier modifie s'empreinte par (taille, mtime), sans le lire.
+                big = os.path.join(tmp, "big.bin")
+                with open(big, "wb") as f:
+                    f.truncate(BIG_FILE_BYTES + 1)
+                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+                os.remove(big)
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)


### PR DESCRIPTION
## Follow-up of #807 — the last open question of its fourth review round

`leftover_disposition` returned "reverted" — the one kind that lets the gate through — whenever `revert.sh` exited 0, even when the `git status` it had just run still showed changes: the note said so, nothing stopped. In `gate` and `selfcheck` the dirty check follows and names the residue as the lot's uncommitted work; `record` mode has no dirty check at all, so an under-specified `revert.sh` that exits 0 without fully restoring would have the references sealed over the residue — the harm the sweep runs in record mode to prevent.

## Fix

- The marker records what was already uncommitted when the mutant went down (`dirty_before`, from `git status --porcelain`). After a clean-looking revert the sweep compares: what is still modified and was clean before is the mutant's **residue** — the script's exit is its word, this is the tree's. Residue keeps the marker and is `still_mutated`; an operator's own uncommitted work was there before and is not residue. The read side proves the new field's type like the others.
- Every gate-start `git status` runs with `--no-optional-locks`: a status that refreshes the index is a write into the tree it is only meant to read — under the self-test's file-size limit it left a corrupt index behind and every later checkout failed with exit 128.

## Proof

Self-test 172 → 178: a `revert.sh` at 0 that does not restore leaves a named residue, the marker kept, the disposition `still_mutated`; a clean revert in the middle of the operator's uncommitted work leaves no residue, a note, the marker gone; a `dirty_before` that is not a list of paths is refused at read. Mutants, each red on its own check: residue never computed; `dirty_before` not recorded; the marker dropped despite residue; the disposition ignoring residue; the read side no longer proving the field's type. `go test ./bots/` green (the byte-identity test covers the two inlined copies).


## Second round (two findings, reproduced; four questions answered)

- **The gate's own dirty check still refreshed the index** (medium): the sweep's three status calls had the flag, the gate's dirty check a few lines later on the same path did not, and could still leave a truncated index behind under a full disk or a size limit. Every list-form status call carries `--no-optional-locks` now.
- **A git status that did not answer after the revert cleared the record** (medium): the residue stayed at its empty initialiser, the marker was dropped and the disposition fell through to "reverted" with an "unknown, not clean" sentence in the note — the one path that cleared the record while the sibling branch (git answered, nothing recorded) already held it. Unknown is undecidable: the marker stays, the gate stops, an operator checks the tree. The git-absent self-test case now expects that stop. Mutant: the unanswered status dropping the marker again — red.
- Along the way: a marker without `dirty_before` (git did not answer at apply time, or the marker predates the field) on a tree that still shows changes is undecidable too, not clean — the pre-fix fail-open is closed in record mode as well. Mutant: the unknown record reading as clean again — red. Self-test 178 → 181.

Open questions, answered:

- *A path both already-dirty and mutated is subtracted out of the residue.* Yes: path-level granularity is the deliberate limit. Treating the intersection as undecidable would stop every record-mode run that has any uncommitted operator work on a file a mutant touches, which is where operator work is expected; the mutant's own contract (its `revert.sh` restores its paths) is what covers that path, and the gate's dirty check backstops it in every mode that scores mutants.
- *`revert_mutant`, the in-run revert, still drops the marker on exit 0 without a residue check.* Out of this PR's scope on purpose: mutants are applied and reverted in-run only in the modes that end with the dirty check (`gate`, `selfcheck`, `validate`); record mode never scores a mutant, and the sweep at its start is the guard this PR hardens.
- *Markers from a build predating `dirty_before` now stop the gate on any uncommitted work.* Fail-closed by design; the stop's message names the marker path and the `rm` an operator runs after checking the tree. Such a marker exists only where an interrupted gate left one, and the harness is synced into a tree at gate start, so the population is a leftover from an interruption that already needed a hand.
- *Wall-clock of the extra status calls without the index refresh.* Not measured; one more `git status --porcelain` per mutant application, each on its own 120-second leash. On the target tree a porcelain status is well under a second.


## Third round (one finding, reproduced; four questions answered)

- **Residue was a difference of path names** (medium): a path the operator had uncommitted before the mutant went down was exempt even when its content was now the mutant's, and a file a mutant created inside a directory git had already collapsed to `?? dir/` moved nothing — the exact harm, in the exact scenario `dirty_before` was introduced for. `dirty_before` now records a **fingerprint per dirty path** (`<sha1>:<path>`, still a list of strings for the read side's type proof): a file's content, a directory's recursive listing of paths, sizes and mtimes (bounded; `?` when unreadable or unreasonably large). After a clean-looking revert a path is residue when it is new or when its fingerprint moved; a path whose earlier content is unknown (`?`, or a marker written before fingerprints) cannot be cleared and is undecidable; the operator's untouched work is still not residue. Self-test 181 → 187: the mutant's edit on an already-dirty file, the untouched operator file, a file created inside an untracked directory, an untouched untracked directory, a fingerprint-less entry. Mutants, each red: content ignored (names only); directories fingerprinted as a constant; a fingerprint-less entry read as unchanged.

Open questions, answered:

- *The two early-return dicts lack the new keys.* Every reader goes through `.get()`; the report the bot consumes is `main`'s, not these dicts. Nothing indexes them directly.
- *A mutant writing to a gitignored path.* Out of this guard's reach by construction — `git status` cannot see it; the in-run check over the mutant's declared paths (`tree_fingerprint`, `data_fingerprint`) is where that lives, and it is unchanged.
- *A full status before every application, `dirty_before` unbounded.* Not measured on the largest target; the marker holds one line per dirty path, a directory collapses to one line, and a write that fails refuses the mutant through the existing arm rather than applying it untracked.
- *Re-statting the whole tree without a refreshed index.* Not measured either; on the target tree a porcelain status is well under a second, and the index corruption it trades against wedged every later checkout of a gate.


## Fourth round (two findings, reproduced; five questions answered)

- **An absent path fingerprinted as `?`, so an operator's uncommitted deletion was permanent residue** (medium): `?` never compares equal to itself, and the gate stopped after a clean revert demanding a manual marker removal. Absent is a state of its own now (absent before equals absent after); only regular files are hashed, in chunks; a symlink hashes its target; a FIFO or a device is `?`. Self-test: an uncommitted deletion and a staged rename are not residue. Mutant: absent read as `?` again — red.
- **The status and the hashing ran inside the marker's exclusive-create window** (medium): a marker that exists but is empty reads as corrupt at the next gate and wedges it, and the window had grown from one write to seconds. The tree is read before the create; the window is one write again. Reviewed, not mutation-tested: nothing in the self-test observes timing.
- Along the way: the porcelain was parsed by lines, which git quotes for a path with a space or a non-ASCII byte and lists a rename as `a -> b` — a mutant's edit on such a path was invisible. Both status calls use `-z` now. Self-test: a mutant's edit on a path with a space is residue. Mutant: the porcelain without `-z` — red. A legacy entry whose path holds a colon is no longer split at it (an entry is fingerprinted only when its prefix is one). Mutant: red. Self-test 187 → 191.

Open questions, answered:

- *The gate's own dirty check only notes.* Yes, and that is its strength today; a stop in the modes that score mutants would be a change of the rite's contract (the rite gates its own committed tree), named as a follow-up rather than folded in here.
- *Artifacts a mutant's own scoring produced before an interruption count as residue.* Intended, fail-closed: an interrupted gate already needs a hand, and the stop's message names the paths and the marker.
- *I/O per application, unbounded read.* Chunked now, regular files only; not measured on the largest target, one status per application on its own leash.
- *A legacy entry with a colon in its path.* Fixed by the prefix rule above; no version bump needed — a legacy marker is one an interrupted gate of the previous harness left, and it is read as a set of unknowns, which the sweep already treats as undecidable.
- *A non-regular dirty path.* `?` without opening it; out of scope for the target trees, but no longer a way to block the gate.


## Fifth round (two findings, reproduced; five questions answered)

- **The porcelain was read out of a stream that also carried git's stderr** (medium): `run()` merges the two, and git writes a warning on stderr while exiting 0 for a directory it cannot read — the docker-owned directories this repo documents — so the warning landed inside the NUL entry stream, swallowed the real dirty path into a phantom entry, and the residue guard compared the phantom to itself: fail-open. Both status reads keep stderr apart now (`status_porcelain_z`), and `porcelain_paths` drops any entry that is not `XY<space>path`; a rename in the index or in the work tree is followed by its destination. Self-test: a real unreadable directory hides no path; a rename origin shaped like an entry is skipped. Mutants: stderr merged back; the parser accepting any entry; work-tree renames not followed — each red.
- **The residue stop claimed the paths "were clean when the mutant went down" and told the operator to `git checkout` them** (medium): false for a path whose fingerprint moved, and destructive for work done since. It names the paths as unattributable — the mutant's residue or work done in between — and leads with `git diff`, like its undecided sibling.

Open questions, answered in code where they were code:

- *A rebuilt untracked build directory read as residue.* It did — the directory fingerprint carried per-file mtimes. It is the sha1 of the **name listing** now: a file a mutant creates or removes inside still moves it, a rebuild does not, and a change inside an existing untracked file is the accepted blind spot. Self-test and mutant.
- *Unbounded file hashing.* A file past 8 MiB is fingerprinted by size and mtime, not read; smaller ones are hashed in chunks. Self-test and mutant.
- *Porcelain paths are relative to the repository root, `ws` may not be it.* They are joined on `git rev-parse --show-toplevel` now (cached; `ws` when git does not answer, which keeps a name comparison rather than none).
- *Work-tree renames.* Followed, see above.
- *The in-run `revert_mutant` still drops the marker on exit 0.* Yes, deliberately for this PR: a residue of mutant N becomes `dirty_before` of N+1, and the gate's own end-of-run dirty check is the backstop in every mode that scores mutants. Applying the residue check in-run is a follow-up.

Self-test 191 → 196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
