### PR TITLE
docs(platform-bots): a baked-catalog change ships in two halves — the runner that executes and the server that resolves

### DIFF
--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -78,6 +78,35 @@ is CLI-first.
   record for "what exactly is deployed". `admin bots` list shows the same
   digest.
 
+## Shipping a baked-catalog change — two halves, or it did not ship
+
+A change to `bots/<slug>/` that is MERGED reaches a deployment in two halves,
+and a run only sees it when both have moved:
+
+- the **runner image** — the pod that EXECUTES the bot (its engine evaluates
+  the bot's expressions, its baked `bots/` is what the by-ref rebuild reads);
+  it is pinned by digest in the deployment values, so a merge changes
+  nothing until the digest is bumped;
+- the **server** — the process that RESOLVES the bot at launch (team →
+  platform → baked, `pkg/server/bot_resolver.go`) from ITS OWN baked catalog
+  and stamps the ref on the queue message; it follows `:edge`, so a
+  `kubectl rollout restart deploy/iterion` is the bump.
+
+Bump the runner and forget the server, and every launch still resolves the
+OLD bot (2026-09-06: Billy 1.6.0 on the runner, 1.5.x served — no
+`delivery_reserve` node in the run). Push a platform override to skip the
+image rollout, and the override runs on the runner's CURRENT engine: a bot
+that needs a builtin the engine does not have (1.6.0's variadic `min`/`max`,
+#830, on a v3.112.7 engine) compiles, then fails at its first evaluation —
+and the failure auto-resumes in a loop (#857, #858). The order that works:
+
+1. bump the runner digest to an image built from the main that carries the
+   bot AND the engine it needs (`docs/cloud-deployment.md` § pinning);
+2. `kubectl rollout restart deploy/iterion` so the server resolves the new
+   baked catalog;
+3. only then dogfood; a platform override is for iterating on a bot the
+   deployed engine already supports.
+
 ## Trust model
 
 A platform override executes across **all tenants**, with each tenant's


### PR DESCRIPTION
Operational-knowledge reflex (CLAUDE.md), measured on the Billy 1.6.0 dogfood of 2026-09-06 (refs #857, #858):

- runner digest bumped to an image carrying Billy 1.6.0, server not restarted → every launch still resolved 1.5.x (no `delivery_reserve` node in the run): the SERVER resolves team → platform → baked from its own baked catalog;
- a platform override pushed to skip the image rollout ran 1.6.0 on the v3.112.7 engine → `expr: max() takes …` at the first evaluation, auto-resumed seven times.

New section in `docs/platform-bots.md` with the two halves, the failure modes, and the order that works (runner digest → server restart → dogfood; overrides only for a bot the deployed engine supports). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)