### PR TITLE
fix(pluginsource): the rename is the test-and-set, so an immutable tree is never retired on a stale read

### DIFF
--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -113,8 +113,8 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 		f.beforePublish(staging, dest)
 	}
 	// Only a MOVING ref publishes over an existing tree: its content changed,
-	// so the old one must go. A pinned ref's content cannot differ from what
-	// is already at its content-addressed path.
+	// so the old one must go. A pinned ref resolves to the same content every
+	// time, so a tree already under its key is what this fetch would put there.
 	if err := f.publish(staging, dest, !s.PinnedRef()); err != nil {
 		return "", fmt.Errorf("pluginsource: publish checkout for %q: %w", s.Name, err)
 	}
@@ -140,12 +140,17 @@ func isPublished(dest string) bool {
 // rename leaves it serving.
 //
 // For an immutable (pinned) ref a tree already there IS the tree being
-// published, so it is kept and the staging copy dropped. That is not only
-// cheaper: renaming it aside makes `dest` briefly ABSENT to every other
-// publisher, and that absence is the window a peer's "was it already
-// published?" read fell into — its own rename had lost, dest was then retired
-// by a third publisher, and it reported ENOTEMPTY for a tree that was there
-// (#854).
+// published, so it is kept and the staging copy dropped. The key is (git_url,
+// ref) — not a hash of the tree — so "immutable" is PinnedRef()'s reading of
+// the ref and nothing stronger; a re-pointed tag is served stale, exactly as
+// Fetch's cache hit above already serves it. Keeping a peer's tree therefore
+// adds no staleness this fetch did not already have.
+//
+// And keeping it is not only cheaper: renaming it aside makes `dest` briefly
+// ABSENT to every other publisher, and that absence is the window a peer's
+// "was it already published?" read fell into — its own rename had lost, dest
+// was then retired by a third publisher, and it reported ENOTEMPTY for a tree
+// that was there (#854).
 //
 // Closing that window takes the RENAME as the test-and-set, never a read: a
 // read is stale the syscall after it is taken, so deciding "nothing is there,

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -43,11 +43,11 @@ type Fetcher struct {
 	// production.
 	beforePublish func(staging, dest string)
 
-	// beforeRetire runs inside publish, after this publisher has lost the
-	// rename onto `dest` and before it moves what is there aside. The seam a
-	// test uses to fill that gap the way a peer would — the interleaving that
-	// decides whether a complete tree can still be renamed aside. Nil in
-	// production.
+	// beforeRetire runs inside publish, immediately before it moves whatever is
+	// at `dest` aside — which for an immutable ref is only ever after its own
+	// rename has already lost. The seam a test uses to fill that gap the way a
+	// peer would: the interleaving that decides whether a complete tree can
+	// still be renamed aside. Nil in production.
 	beforeRetire func(dest string)
 
 	mu       sync.Mutex

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -43,6 +43,13 @@ type Fetcher struct {
 	// production.
 	beforePublish func(staging, dest string)
 
+	// beforeRetire runs inside publish, after this publisher has lost the
+	// rename onto `dest` and before it moves what is there aside. The seam a
+	// test uses to fill that gap the way a peer would — the interleaving that
+	// decides whether a complete tree can still be renamed aside. Nil in
+	// production.
+	beforeRetire func(dest string)
+
 	mu       sync.Mutex
 	keyGates map[string]chan struct{}
 }
@@ -108,7 +115,7 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 	// Only a MOVING ref publishes over an existing tree: its content changed,
 	// so the old one must go. A pinned ref's content cannot differ from what
 	// is already at its content-addressed path.
-	if err := publish(staging, dest, !s.PinnedRef()); err != nil {
+	if err := f.publish(staging, dest, !s.PinnedRef()); err != nil {
 		return "", fmt.Errorf("pluginsource: publish checkout for %q: %w", s.Name, err)
 	}
 	return dest, nil
@@ -138,11 +145,34 @@ func isPublished(dest string) bool {
 // publisher, and that absence is the window a peer's "was it already
 // published?" read fell into — its own rename had lost, dest was then retired
 // by a third publisher, and it reported ENOTEMPTY for a tree that was there
-// (#854). Never retiring an immutable tree removes the window rather than
-// racing it.
-func publish(staging, dest string, replaceExisting bool) error {
-	if !replaceExisting && isPublished(dest) {
-		return nil // a peer published it while we were staging
+// (#854).
+//
+// Closing that window takes the RENAME as the test-and-set, never a read: a
+// read is stale the syscall after it is taken, so deciding "nothing is there,
+// I may retire" on one is exactly the bug. `rename(2)` onto a non-empty
+// directory cannot land, so on a cold cache dest goes absent -> published and
+// never back, and no publisher of an immutable ref reaches the retire at all.
+// The retire stays reachable for the MOVING ref, and for a dest holding
+// something no reader can use — which this package never produces, but an
+// operator or a half-deleted cache can; the belt below re-judges what it moved
+// aside rather than assume that state away.
+func (f *Fetcher) publish(staging, dest string, replaceExisting bool) error {
+	if !replaceExisting {
+		// The rename IS the test-and-set: it lands only while dest is absent,
+		// so an immutable tree is never renamed aside on the strength of a
+		// read a peer invalidated one syscall later. What is there is judged
+		// only AFTER this publisher has lost.
+		if err := os.Rename(staging, dest); err == nil {
+			return nil
+		}
+		if isPublished(dest) {
+			return nil // a peer published it while we were staging
+		}
+		// dest holds something that is NOT a checkout: fall through, so a
+		// half-written tree is repaired rather than served forever.
+	}
+	if f.beforeRetire != nil {
+		f.beforeRetire(dest)
 	}
 	retired := ""
 	if _, err := os.Stat(dest); err == nil {
@@ -152,6 +182,16 @@ func publish(staging, dest string, replaceExisting bool) error {
 				return err
 			}
 			retired = "" // someone else retired it first
+		} else if !replaceExisting && isPublished(retired) {
+			// What we moved aside is a COMPLETE tree of immutable content: a
+			// peer repaired dest between our lost rename and this one. It IS
+			// what we were about to publish, so put it back instead of leaving
+			// the path absent for the next publisher's read (#854).
+			if err := os.Rename(retired, dest); err == nil {
+				return nil
+			}
+			// The put-back lost in turn; `retired` stays set so the read below
+			// still reaps our copy.
 		}
 	}
 	if err := os.Rename(staging, dest); err != nil {

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -190,6 +190,8 @@ func TestPublish_NeverRetiresACompleteImmutableTree(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dest, "the-peers")); err != nil {
 			t.Fatalf("a complete immutable tree was renamed aside anyway: %v", err)
 		}
+		// `staging` is expected: publish leaves the copy it did not use to the
+		// caller's defer. What must NOT be here is a `dest.retired-…`.
 		assertNoLeftovers(t, root, "staging", "dest")
 	})
 }

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -62,15 +62,7 @@ func TestFetcher_PeerPublishedTheSamePinnedCheckoutFirst(t *testing.T) {
 
 	// Nothing parked beside it either: a retired or staging copy of a full
 	// checkout that nobody deletes is the cache growing one clone per race.
-	entries, err := os.ReadDir(cache)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), ".") {
-			t.Errorf("left behind in the cache dir: %s", e.Name())
-		}
-	}
+	assertNoLeftovers(t, cache, filepath.Base(got))
 }
 
 // The loser's own read of the final path is the second half of the rule: a

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -65,18 +65,24 @@ func TestFetcher_PeerPublishedTheSamePinnedCheckoutFirst(t *testing.T) {
 	assertNoLeftovers(t, cache, filepath.Base(got))
 }
 
-// The loser's own read of the final path is the second half of the rule: a
-// rename that lost to a peer is success when the path holds a complete
-// checkout, and an error — carrying the rename's own cause — when it does not.
-func TestPublish_LostRenameReadsTheFinalPath(t *testing.T) {
-	t.Run("complete final is kept, not swapped", func(t *testing.T) {
+// Once the rename has lost, WHAT IS AT the final path decides — and the two
+// answers differ by whether a reader could be handed it, never by who got
+// there first. A complete checkout of the same key is the tree this publish
+// wanted, so it is accepted and the staged copy dropped; anything else is
+// replaced, so a half-written tree is repaired rather than served forever.
+//
+// `replaceExisting` is what splits those from the moving-ref rule, and each arm
+// is taken below — the true one has no other test in the package.
+func TestPublish_WhatIsAtTheFinalPathDecides(t *testing.T) {
+	t.Run("a lost rename onto a complete final keeps that tree", func(t *testing.T) {
 		root := t.TempDir()
 		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
 		mkCheckout(t, staging, "ours")
 		mkCheckout(t, dest, "the-peers")
-		// replaceExisting=false is the immutable case: the peer's tree stands,
-		// untouched — asserted by WHOSE tree is there, since "still a checkout"
-		// would also hold after a swap.
+		// replaceExisting=false is the immutable case: the rename cannot land
+		// on a non-empty dest, and the peer's tree then stands untouched —
+		// asserted by WHOSE tree is there, since "still a checkout" would also
+		// hold after a swap.
 		if err := (&Fetcher{}).publish(staging, dest, false); err != nil {
 			t.Fatalf("a complete final path is the tree this publish wanted: %v", err)
 		}
@@ -85,22 +91,45 @@ func TestPublish_LostRenameReadsTheFinalPath(t *testing.T) {
 		}
 	})
 
-	t.Run("incomplete final keeps the rename's cause", func(t *testing.T) {
+	t.Run("an incomplete final is replaced, never accepted", func(t *testing.T) {
 		root := t.TempDir()
 		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
 		mkCheckout(t, staging, "ours")
 		// A directory that exists and holds something, but is NOT a checkout:
-		// the retire moves it aside, the rename then wins, and the tree that
-		// gets published is ours — never a silent accept of a partial tree.
+		// the rename loses, the read finds nothing a reader could use, so the
+		// retire moves it aside and ours lands. Never a silent accept of a
+		// partial tree — the loader would then report "no plugin.yaml" and name
+		// the wrong cause.
 		if err := os.MkdirAll(filepath.Join(dest, "half-written"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		if err := (&Fetcher{}).publish(staging, dest, false); err != nil {
 			t.Fatalf("publish over an incomplete final: %v", err)
 		}
-		if !isPublished(dest) {
-			t.Fatal("an incomplete final path must be replaced by the staged checkout, not kept")
+		if _, err := os.Stat(filepath.Join(dest, "ours")); err != nil {
+			t.Fatalf("an incomplete final path must be replaced by the staged checkout, not kept: %v", err)
 		}
+		assertNoLeftovers(t, root, "dest")
+	})
+
+	t.Run("a moving ref replaces the tree that is there, and parks no copy", func(t *testing.T) {
+		root := t.TempDir()
+		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
+		mkCheckout(t, staging, "ours")
+		mkCheckout(t, dest, "the-old")
+		// replaceExisting=true is the MOVING ref: the content under this key
+		// changed, so a complete tree already there is exactly what must NOT be
+		// kept — the opposite of the immutable rule, and the arm every other
+		// test in this file leaves untaken.
+		if err := (&Fetcher{}).publish(staging, dest, true); err != nil {
+			t.Fatalf("publish a moving ref over its older tree: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dest, "ours")); err != nil {
+			t.Fatalf("a moving ref must publish the new tree, not keep the old one: %v", err)
+		}
+		// The old tree is renamed aside first — so a failed rename leaves it
+		// serving — and deleted after the swap, never parked.
+		assertNoLeftovers(t, root, "dest")
 	})
 }
 

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -85,7 +85,7 @@ func TestPublish_LostRenameReadsTheFinalPath(t *testing.T) {
 		// replaceExisting=false is the immutable case: the peer's tree stands,
 		// untouched — asserted by WHOSE tree is there, since "still a checkout"
 		// would also hold after a swap.
-		if err := publish(staging, dest, false); err != nil {
+		if err := (&Fetcher{}).publish(staging, dest, false); err != nil {
 			t.Fatalf("a complete final path is the tree this publish wanted: %v", err)
 		}
 		if _, err := os.Stat(filepath.Join(dest, "the-peers")); err != nil {
@@ -103,13 +103,99 @@ func TestPublish_LostRenameReadsTheFinalPath(t *testing.T) {
 		if err := os.MkdirAll(filepath.Join(dest, "half-written"), 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := publish(staging, dest, false); err != nil {
+		if err := (&Fetcher{}).publish(staging, dest, false); err != nil {
 			t.Fatalf("publish over an incomplete final: %v", err)
 		}
 		if !isPublished(dest) {
 			t.Fatal("an incomplete final path must be replaced by the staged checkout, not kept")
 		}
 	})
+}
+
+// Retiring a tree makes `dest` ABSENT for an instant, and that absence is what
+// #854's loser read. So a publish of an IMMUTABLE ref must never rename a
+// complete tree aside — not even one that appeared after it looked. Deciding on
+// a read cannot promise that (the read is stale one syscall later); only making
+// the rename itself the test-and-set can.
+//
+// Both subtests drive the interleaving through the beforeRetire seam, so the
+// window is scripted rather than wagered on a `-count` stress run.
+func TestPublish_NeverRetiresACompleteImmutableTree(t *testing.T) {
+	t.Run("an absent final is taken by the rename, not by a read then a retire", func(t *testing.T) {
+		root := t.TempDir()
+		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
+		mkCheckout(t, staging, "ours")
+
+		// dest is absent — the one state a read-then-retire design re-decides
+		// on: it reads "nothing there", a peer publishes, and the retire that
+		// follows moves that complete tree aside. Reaching the retire AT ALL
+		// from here is the defect, so that is what is asserted; a rename that
+		// lands cannot have raced anyone.
+		f := &Fetcher{}
+		retired := false
+		f.beforeRetire = func(string) { retired = true }
+		if err := f.publish(staging, dest, false); err != nil {
+			t.Fatalf("publish onto an absent final: %v", err)
+		}
+		if retired {
+			t.Fatal("publish took a read and then retired: a peer publishing in that gap has its immutable tree renamed aside, and the next publisher's read finds the path ABSENT (#854)")
+		}
+		if _, err := os.Stat(filepath.Join(dest, "ours")); err != nil {
+			t.Fatalf("the staged tree did not land: %v", err)
+		}
+	})
+
+	t.Run("a peer that repairs an incomplete final is accepted, not retired", func(t *testing.T) {
+		root := t.TempDir()
+		staging, dest := filepath.Join(root, "staging"), filepath.Join(root, "dest")
+		mkCheckout(t, staging, "ours")
+		// The one state that still reaches the retire: dest exists and is NOT a
+		// checkout. A peer repairs it in that gap — what it published is
+		// byte-for-byte what we would have, so it must be kept.
+		if err := os.MkdirAll(filepath.Join(dest, "half-written"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		f := &Fetcher{}
+		f.beforeRetire = func(dest string) {
+			if err := os.RemoveAll(dest); err != nil {
+				t.Errorf("stand in for the peer's publish: %v", err)
+				return
+			}
+			mkCheckout(t, dest, "the-peers")
+		}
+		if err := f.publish(staging, dest, false); err != nil {
+			t.Fatalf("publish onto a final a peer repaired: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dest, "the-peers")); err != nil {
+			t.Fatalf("a complete immutable tree was renamed aside anyway: %v", err)
+		}
+		assertNoLeftovers(t, root, "staging", "dest")
+	})
+}
+
+// assertNoLeftovers fails when dir holds anything but the named entries: a
+// retired or staging copy of a full checkout that nobody deletes is the cache
+// growing one clone per race. Names are matched WHOLE — a retired copy is
+// `<key>.retired-…`, which no prefix filter over "." can catch.
+func assertNoLeftovers(t *testing.T, dir string, want ...string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keep := map[string]bool{}
+	for _, w := range want {
+		keep[w] = true
+	}
+	var extra []string
+	for _, e := range entries {
+		if !keep[e.Name()] {
+			extra = append(extra, e.Name())
+		}
+	}
+	if len(extra) > 0 {
+		t.Errorf("left behind in %s: %s", dir, strings.Join(extra, ", "))
+	}
 }
 
 // mkCheckout builds a directory isPublished accepts, marked so a later

--- a/pkg/pluginsource/publish_race_test.go
+++ b/pkg/pluginsource/publish_race_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // A peer that publishes the same PINNED checkout while this fetch is staging has
-// published exactly the tree this fetch wanted: the cache path is
-// content-addressed and the ref immutable. The loser must take it — and must
+// published exactly the tree this fetch wanted: same key, and a pinned ref
+// resolves to the same content every time. The loser must take it — and must
 // NOT swap its own copy in, because renaming the peer's tree aside leaves
 // `dest` ABSENT for an instant, and that instant is the window a THIRD
 // publisher's "was it already published?" read falls into: its own rename has


### PR DESCRIPTION
Refs #854, #855. Authored by Billy 1.6.0 (`branch-improve-loop`, run `01a07840`) during its live dogfood on #855 — the campaign pushed these six commits onto the PR branch thirty minutes after #855 had merged, so they are re-based here onto main as their own PR (the fixer-after-merge gap is filed separately).

## The residual race in #855
#855's early-accept at `fetch.go` was a READ, while the retire it exists to prevent is decided two syscalls later — nothing serialises them across publishers, so #854 stayed reachable: C reads `dest` absent; A renames its tree in; B's rename loses `ENOTEMPTY` and enters the fallback; C's `os.Stat` now sees A's tree and retires it, leaving `dest` ABSENT; B's read finds nothing and returns the `ENOTEMPTY` cause — the exact message that ejected #822 from the merge queue. Not argued from syscall ordering alone: the three-party interleaving was scripted through throwaway probes at the two TOCTOU boundaries and REPRODUCED on the pre-fix code (`rename <staging> <dest>: file exists`), then run against the fix → nil.

## The fix
The RENAME is the test-and-set for an immutable ref: it lands only while `dest` is absent, so on a cold cache `dest` goes absent → published and never back, and no publisher of a pinned ref reaches the retire at all — the window is removed, not narrowed. A belt re-judges what the retire does move aside on the paths that remain (moving ref, or a `dest` holding something no reader can use). Red/green is deterministic via an unexported `beforeRetire` seam: reverted to the read-first shape, both new subtests fail (`publish took a read and then retired…`, `a complete immutable tree was renamed aside anyway`).

## Tests and docs
The leftover sweep filtered on a dot prefix and could not match a retired copy (`<key>.retired-…`) — the very leak the branch claims to fix; replaced with whole-name matching (`assertNoLeftovers`) and verified by injecting a retired dir. The subtest "incomplete final keeps the rename's cause" never produced a cause; renamed to what it asserts. First test of the `replaceExisting=true` arm (verified as a real guard by making the flag inert). Three comments corrected: the cache path is REF-addressed (`sha256(git_url\0ref)[:16]`), so the immutability premise is `PinnedRef()`'s heuristic; `beforeRetire`'s contract now holds for both arms.

## Gate (the campaign's, then re-run here after the rebase)
`task test` exit 0 (136 packages), `task lint` 0 issues, `go build ./...`, `pkg/pluginsource` green under `-race` (`-count=30` on the concurrency tests), a 9,600-publisher stress of the fixed publish path clean; after the rebase onto main: `go build ./...`, `go test -race -count=1 ./pkg/pluginsource/...` ok, `go vet` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
