### PR TITLE
fix(bots): lot_verify reads the oracle report with one decoder pass per opening line — the enclosing object wins, a named report never loses to an unnamed one; no guessed block start, no budget

### DIFF
--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -882,57 +882,70 @@ tool lot_verify:
         harness prints it, or a pretty-printed block: the wrapper prints
         exactly one, after the harness has logged to stderr. A format is not
         a verdict, so both shapes read the same."""
-        # Bounded AND lossless. Every line that opens with a "{" is a
-        # candidate start, tried ONCE, in place, with `raw_decode` — which
-        # parses one object and stops. So a one-line report costs one parse
-        # wherever it sits, and a pretty-printed block, an `indent=0` dump
-        # (whose list objects sit at column 0) and a block a wrapper
-        # indented all read the same: no candidate start is ever dropped.
-        # At most one parse per line of the window — never a re-join of the
-        # slice above every closing line, which was quadratic on the very
-        # path this reader exists to type (a chatty stdout with no report),
-        # and never a global budget, which noise printed AFTER the report
-        # could spend to type a green oracle ORACLE_NOT_RUN.
-        # A candidate whose first token is neither a key string nor "}" is
-        # not a JSON object: refused in O(1), so the dict reprs a chatty
-        # harness logs (`{'line': 0, …}`) never reach the parser. That
-        # refusal is what keeps the bound — a FAILED parse is the expensive
-        # one, `json` re-deriving line:column over the whole blob for the
-        # error it raises.
-        # The report is the object whose parse ENDS last, so an inner
-        # fragment never shadows the report that contains it.
-        # And only a REPORT is handed back — an object carrying at least one
-        # of the harness's verdict fields (an older harness writes no
-        # `mode`, it always writes `invalid`/`stable`/`ok`). A `{}` or a
-        # fragment `{"name": …}` printed after the report is skipped, not
-        # read as a mode-less gate verdict with an empty `invalid` list.
-        def is_report(obj):
-            return isinstance(obj, dict) and any(
-                k in obj for k in ("mode", "stable", "ok", "invalid", "blind_lanes", "holdout_total"))
+        # One in-place decoder pass per "{" line of the window, from the
+        # last upward (raw_decode(text, idx)): a noise line — a python repr
+        # the harness logged — fails on its first bad token, a report parses
+        # once whatever follows it. No join per pair of lines (30 s on 2000
+        # lines), no budget that noise printed after the report could spend
+        # (a green oracle was typed ORACLE_NOT_RUN by one), no guess at
+        # which "{" starts a block (`indent=0` puts a list's objects at
+        # column 0; a logger indents — the line is lstripped).
+        #
+        # Only a REPORT is handed back: an object naming itself (`mode`) or
+        # carrying two of the verdict's fields — what every mode-less
+        # harness generation writes, and what a progress line ({"ok": true})
+        # or a ledger entry an agent wrote never has both of.
+        REPORT_FIELDS = ("stable", "ok", "invalid", "blind_lanes", "holdout_total")
 
-        lines = (text or "").splitlines()[-2000:]
-        blob = "\n".join(lines)
-        decode = json.JSONDecoder().raw_decode
-        found, found_end = None, -1
-        at = 0
-        for line in lines:
-            head = line.lstrip()
-            start = at + len(line) - len(head)  # the "{" itself, its indent skipped
-            at += len(line) + 1                 # the next line, past the "\n" the join put back
-            if not head.startswith("{"):
-                continue
-            probe = start + 1
-            while probe < len(blob) and blob[probe] in " \t\r\n":
-                probe += 1
-            if probe >= len(blob) or blob[probe] not in ('"', '}'):
-                continue
+        def is_report(obj):
+            return isinstance(obj, dict) and ("mode" in obj or sum(k in obj for k in REPORT_FIELDS) >= 2)
+
+        # The window is capped in characters as well as lines: a failing
+        # parse counts lines up to its offset, quadratic on a 40 MB stdout
+        # (7.9 s measured, 0.02 s capped). split("\n"), not splitlines():
+        # the latter also cuts on U+2028/U+2029/U+0085, which a report
+        # printed with ensure_ascii=False may carry inside a string.
+        text = text or ""
+        cut = len(text) > 2000000 or text.count("\n") >= 2000
+        lines = text[-2000000:].split("\n")[-2000:]
+        window = "\n".join(lines)
+        starts, pos = [], 0
+        for l in lines:
+            body = l.lstrip()
+            if body.startswith("{"):
+                starts.append(pos + len(l) - len(body))
+            pos += len(l) + 1
+        decoder = json.JSONDecoder()
+        # Selection, scanning last → first. A candidate ENCLOSING the one
+        # held (its parse ends at or after it) always replaces it: the
+        # outermost object of a block is the report, its nested entries —
+        # a lane carrying `mode`, a ledger block carrying `ok` — are not.
+        # Among disjoint candidates a NAMED report never loses to an
+        # unnamed one (an object with two verdict fields printed after the
+        # report would be read as a gate by the mode default); otherwise
+        # the last one wins. No early stop — a stop on the first
+        # non-enclosing candidate fired between two siblings of one block.
+        best = None  # (named, end, report)
+        for at in reversed(starts):
             try:
-                obj, end = decode(blob, start)
-            except ValueError:
+                obj, end = decoder.raw_decode(window, at)
+            except (ValueError, RecursionError):
                 continue
-            if end > found_end and is_report(obj):
-                found, found_end = obj, end
-        return found
+            if not is_report(obj):
+                continue
+            named = "mode" in obj
+            if best is None or end >= best[1] or (named and not best[0]):
+                best = (named, end, obj)
+        if best is None:
+            return None
+        if cut and window[best[1]:].lstrip()[:1] in (",", "}", "]"):
+            # The window lost its head, and the object held is followed by
+            # a separator or a closer: by JSON's own grammar that makes it
+            # an entry of a report whose first line the cut took, named or
+            # not — an intact trailing report is followed by nothing, or by
+            # a log line. Without the report itself there is no verdict.
+            return None
+        return best[2]
 
     # 1. The lot's own gate, every command, in order.
     report["gate_passed"] = True

--- a/bots/modernize_lot_verify_report_scratch_test.go
+++ b/bots/modernize_lot_verify_report_scratch_test.go
@@ -193,9 +193,9 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 	})
 
 	t.Run("a pretty-printed report buried under chatter and followed by noise is still read", func(t *testing.T) {
-		// Every line that opens with a "{" is a candidate start: forty
-		// brace-first lines above and two below must not push the block out
-		// of reach, whatever the search spends on the noise.
+		// The block starts at the nearest column-0 "{" above its closing
+		// line: forty brace-first lines above and two below must not push it
+		// out of reach, whatever the search spends on the noise.
 		buried := scratchWrapperHead +
 			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
 			"printf '{\\n  \"mode\": \"gate\",\\n  \"ok\": true,\\n  \"invalid\": []\\n}\\n'\n" +
@@ -212,18 +212,12 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		}
 	})
 
-	t.Run("an indent=0 report buried under chatter is read whole, not as a fragment", func(t *testing.T) {
-		// json.dumps(indent=0) puts every object of a list at column 0, so the
-		// openings nearest the closing brace start INNER objects and the
-		// report's own is only reachable as a candidate in its own right. The
-		// chatter above is what makes this non-vacuous: a scan that fell back
-		// to the window's first column-0 "{" read the report only when
-		// nothing had been logged before it, and lost it behind one noise
-		// line — a whole RED/GREEN verdict typed ORACLE_NOT_RUN.
+	t.Run("an indent=0 report whose list objects sit at column 0 is read whole, not as a fragment", func(t *testing.T) {
+		// json.dumps(indent=0) puts every object of a list at column 0; the
+		// nearest opening line above the closing brace then starts an inner
+		// object, and a fragment without a mode was read as a green gate.
 		zero := scratchWrapperHead +
-			"i=0; while [ $i -lt 40 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
 			"printf '{\\n\"mode\": \"gate\",\\n\"invalid\": [\\n{\\n\"name\": \"m1\"\\n},\\n{\\n\"name\": \"m2\"\\n}\\n],\\n\"stable\": true\\n}\\n'\n" +
-			"echo \"{'teardown': 'one more brace-first line after the report'}\"\n" +
 			"exit 0\n"
 		ws, base := scratchWorkspace(t, zero)
 		res := scratchVerify(t, script, ws, base)
@@ -235,6 +229,275 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		}
 	})
 
+	t.Run("an indent=0 report preceded by chatter is read whole — the block starts at its own line, never at the window's first", func(t *testing.T) {
+		// R46d257: with the block's start guessed among the nearest opening
+		// lines and the window's FIRST one, an indent=0 report whose two
+		// list objects sit at column 0 was lost as soon as any brace-first
+		// line preceded it (fragments filtered, the first line of the window
+		// not the report's) — a green oracle typed ORACLE_NOT_RUN.
+		zero := scratchWrapperHead +
+			"i=0; while [ $i -lt 5 ]; do echo \"{'line': $i, 'note': 'a dict repr the harness logged before its report'}\"; i=$((i+1)); done\n" +
+			"printf '{\\n\"mode\": \"gate\",\\n\"invalid\": [\\n{\\n\"name\": \"m1\"\\n},\\n{\\n\"name\": \"m2\"\\n}\\n],\\n\"stable\": true\\n}\\n'\n" +
+			"echo \"{'teardown': 'one more brace-first line after the report'}\"\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, zero)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("an indent=0 report preceded by chatter was lost: %+v", res)
+		}
+		if len(res.OracleInvalid) != 2 {
+			t.Fatalf("the report's invalid list was lost — a fragment was read instead of the report: %+v", res)
+		}
+	})
+
+	t.Run("an indented pretty-printed block is read from its own first line", func(t *testing.T) {
+		// A logger prefix or a tee that indents the wrapper's stdout must not
+		// leave the block without a start: the block begins at the first
+		// "{" of a line, wherever that line's indentation puts it.
+		indentedBlock := scratchWrapperHead +
+			"printf '    {\\n      \"mode\": \"gate\",\\n      \"ok\": true,\\n      \"invalid\": []\\n    }\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, indentedBlock)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed || res.OracleReport["mode"] != "gate" {
+			t.Fatalf("an indented pretty-printed report was lost: %+v", res)
+		}
+	})
+
+	t.Run("a nested object carrying a verdict field never shadows the report that encloses it", func(t *testing.T) {
+		// An indented block's nested objects are candidates too and sit
+		// lower than the outer "{": a ledger block an agent wrote inside
+		// pending_extensions with an `ok` key was read as the report — no
+		// mode, so a gate PASS — while the report itself said selfcheck.
+		nested := scratchWrapperHead +
+			"printf '{\\n  \"mode\": \"selfcheck\",\\n  \"ok\": true,\\n  \"invalid\": [],\\n  \"pending_extensions\": [\\n    {\\n      \"id\": \"E1\",\\n      \"ok\": true,\\n      \"notice\": \"agent-authored\"\\n    }\\n  ]\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, nested)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a selfcheck report was read as a gate pass — its nested object shadowed it: %+v", res)
+		}
+		if !strings.Contains(res.BlockReason, "mode=selfcheck") {
+			t.Fatalf("the typed cause does not carry the report's own mode: %q", res.BlockReason)
+		}
+	})
+
+	t.Run("two nested entries of a selfcheck report: the second sibling never shadows the report", func(t *testing.T) {
+		// A stop on the first non-enclosing candidate fired between two
+		// siblings of one block and handed the lower sibling back — a
+		// selfcheck report with two pending_extensions entries read as a
+		// gate PASS; a gate-subset report with two invalid mutants likewise.
+		nested := scratchWrapperHead +
+			"printf '{\\n  \"mode\": \"selfcheck\",\\n  \"ok\": true,\\n  \"invalid\": [],\\n  \"pending_extensions\": [\\n    {\\n      \"id\": \"E1\",\\n      \"ok\": true,\\n      \"invalid\": []\\n    },\\n    {\\n      \"id\": \"E2\",\\n      \"ok\": true,\\n      \"invalid\": []\\n    }\\n  ]\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, nested)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed || !strings.Contains(res.BlockReason, "mode=selfcheck") {
+			t.Fatalf("a selfcheck report with two nested entries was not read as itself: %+v", res)
+		}
+		subset := scratchWrapperHead +
+			"printf '{\\n  \"mode\": \"gate-subset\",\\n  \"stable\": true,\\n  \"invalid\": [\\n    {\\n      \"name\": \"m1\"\\n    },\\n    {\\n      \"name\": \"m2\",\\n      \"ok\": false,\\n      \"stable\": false\\n    }\\n  ]\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base = scratchWorkspace(t, subset)
+		res = scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed || !strings.Contains(res.BlockReason, "mode=gate-subset") {
+			t.Fatalf("a gate-subset report with nested mutant objects was read as a pass: %+v", res)
+		}
+	})
+
+	t.Run("a single verdict key does not make a report: an ok line after a selfcheck report is not the verdict", func(t *testing.T) {
+		single := scratchWrapperHead +
+			"echo '{\"mode\":\"selfcheck\",\"ok\":true,\"invalid\":[]}'\n" +
+			"echo '{\"ok\": true}'\n" +
+			"echo '{\"invalid\": []}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, single)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed || !strings.Contains(res.BlockReason, "mode=selfcheck") {
+			t.Fatalf("a one-key object after a selfcheck report became the verdict: %+v", res)
+		}
+	})
+
+	t.Run("a report whose head the window cut is not replaced by one of its nested objects", func(t *testing.T) {
+		// 700 pretty-printed entries push the report's own first line out
+		// of the 2000-line window; the surviving nested objects carry two
+		// verdict fields each. Without the report's own mode: no verdict.
+		huge := scratchWrapperHead +
+			"printf '{\\n\"mode\": \"gate\",\\n\"invalid\": [\\n'; i=0; while [ $i -lt 700 ]; do printf '{\\n\"name\": \"m%d\",\\n\"ok\": true,\\n\"invalid\": []\\n},\\n' $i; i=$((i+1)); done; printf '{\\n\"name\": \"last\",\\n\"ok\": true,\\n\"invalid\": []\\n}\\n]\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, huge)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a head-cut report was replaced by a nested object and passed: %+v", res)
+		}
+	})
+
+	t.Run("a named report never loses to an unnamed object that ends after it", func(t *testing.T) {
+		// An object with two verdict fields printed after the report — or
+		// an envelope holding the report — ended last and won; the mode
+		// default then read it as a gate: a selfcheck became a PASS, a RED
+		// lost its invalid list.
+		trailing := scratchWrapperHead +
+			"echo '{\"mode\":\"selfcheck\",\"ok\":true,\"invalid\":[]}'\n" +
+			"echo '{\"stable\": true, \"invalid\": []}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, trailing)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed || !strings.Contains(res.BlockReason, "mode=selfcheck") {
+			t.Fatalf("an unnamed trailing object replaced the selfcheck report: %+v", res)
+		}
+		red := scratchWrapperHead +
+			"echo '{\"mode\":\"gate\",\"ok\":false,\"invalid\":[\"m1\",\"m2\"]}'\n" +
+			"echo '{\"ok\": true, \"stable\": true}'\n" +
+			"exit 1\n"
+		ws, base = scratchWorkspace(t, red)
+		res = scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed || len(res.OracleInvalid) != 2 {
+			t.Fatalf("an unnamed trailing object erased a RED report's invalid list: %+v", res)
+		}
+	})
+
+	t.Run("the enclosing report wins over a named entry nested in it", func(t *testing.T) {
+		// A mode-less RED report whose lanes list carries entries with a
+		// `mode` of their own: ranking named over unnamed handed back the
+		// entry — the RED lost its invalid list, a green one with a
+		// selfcheck entry would have been typed. The outermost object of a
+		// block is the report, whatever its entries carry.
+		envelope := scratchWrapperHead +
+			"printf '{\\n \"ok\": false,\\n \"stable\": false,\\n \"invalid\": [\"m1\"],\\n \"lanes\": [\\n  {\\n   \"mode\": \"gate\",\\n   \"ok\": true,\\n   \"stable\": true\\n  }\\n ]\\n}\\n'\n" +
+			"exit 1\n"
+		ws, base := scratchWorkspace(t, envelope)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed || len(res.OracleInvalid) != 1 {
+			t.Fatalf("a named nested entry replaced the RED report enclosing it: %+v", res)
+		}
+	})
+
+	t.Run("a head-cut report is no verdict even when its surviving entries are named", func(t *testing.T) {
+		// 800 lanes carrying {"mode": "gate"} push a selfcheck report's own
+		// first line out of the window; the last surviving entry is named
+		// and would read as a gate PASS. Something follows it — the
+		// parent's closers — so it is an entry, not a report.
+		shadow := scratchWrapperHead +
+			"printf '{\\n\"mode\": \"selfcheck\",\\n\"ok\": true,\\n\"stable\": true,\\n\"invalid\": [],\\n\"lanes\": [\\n'; i=0; while [ $i -lt 800 ]; do printf '{\\n\"mode\": \"gate\",\\n\"ok\": true,\\n\"stable\": true\\n},\\n'; i=$((i+1)); done; printf '{\\n\"mode\": \"gate\",\\n\"ok\": true,\\n\"stable\": true\\n}\\n]\\n}\\n'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, shadow)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a named entry of a head-cut selfcheck report was read as a gate pass: %+v", res)
+		}
+	})
+
+	t.Run("a one-key object is never a report: alone it is no verdict, after a mode-less RED it does not replace it", func(t *testing.T) {
+		// Pins the two-field threshold itself, which the named clause hid
+		// from every other test: with one key accepted, {"ok": true} alone
+		// was a green gate, and it erased a mode-less RED's invalid list.
+		alone := scratchWrapperHead +
+			"echo '{\"ok\": true}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, alone)
+		res := scratchVerify(t, script, ws, base)
+		if !res.OracleNotRun || res.OraclePassed {
+			t.Fatalf("a one-key object alone was read as a verdict: %+v", res)
+		}
+		after := scratchWrapperHead +
+			"echo '{\"ok\":false,\"invalid\":[\"m1\"],\"stable\":false}'\n" +
+			"echo '{\"ok\": true}'\n" +
+			"exit 1\n"
+		ws, base = scratchWorkspace(t, after)
+		res = scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed || len(res.OracleInvalid) != 1 {
+			t.Fatalf("a one-key object replaced the mode-less RED report before it: %+v", res)
+		}
+	})
+
+	t.Run("an intact report followed by a log line is read however long the stdout before it", func(t *testing.T) {
+		// The cut guard must recognise an ENTRY (a separator or a closer
+		// follows it, by JSON's grammar), not "anything follows": above
+		// 2000 lines a report followed by `done in 41s` was discarded.
+		long := scratchWrapperHead +
+			"i=0; while [ $i -lt 2100 ]; do echo \"noise line $i\"; i=$((i+1)); done\n" +
+			"echo '{\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
+			"echo 'done in 41s'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, long)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("an intact report followed by a log line was discarded above the line cap: %+v", res)
+		}
+	})
+
+	t.Run("an intact trailing mode-less report after thousands of log lines ending in a colon is read", func(t *testing.T) {
+		long := scratchWrapperHead +
+			"i=0; while [ $i -lt 2500 ]; do echo \"Caused by:\"; i=$((i+1)); done\n" +
+			"echo '{\"stable\":true,\"ok\":true,\"invalid\":[],\"blind_lanes\":[],\"holdout_total\":3}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, long)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("an intact trailing mode-less report after colon-ended lines was dropped: %+v", res)
+		}
+	})
+
+	t.Run("an intact mode-less report on the last line is read however long the stdout before it", func(t *testing.T) {
+		// The cut guard is about a report whose OWN head the window cut;
+		// a trailing report of an older harness after 2100 lines of noise
+		// is intact and stays the verdict.
+		long := scratchWrapperHead +
+			"i=0; while [ $i -lt 2100 ]; do echo \"noise line $i\"; i=$((i+1)); done\n" +
+			"echo '{\"ok\":false,\"invalid\":[\"m1\"],\"stable\":false}'\n" +
+			"exit 1\n"
+		ws, base := scratchWorkspace(t, long)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed || len(res.OracleInvalid) != 1 {
+			t.Fatalf("an intact trailing mode-less report was dropped by the cut guard: %+v", res)
+		}
+	})
+
+	t.Run("a progress line carrying a harmless key after a RED report does not become the verdict", func(t *testing.T) {
+		noisy := scratchWrapperHead +
+			"echo '{\"mode\":\"gate\",\"ok\":false,\"invalid\":[\"m1\"]}'\n" +
+			"echo '{\"notice\": \"step 3/7 done\"}'\n" +
+			"echo '{\"collateral\": 0}'\n" +
+			"exit 1\n"
+		ws, base := scratchWorkspace(t, noisy)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || res.OraclePassed || len(res.OracleInvalid) != 1 {
+			t.Fatalf("a RED report followed by progress lines was not read as the RED it is: %+v", res)
+		}
+	})
+
+	t.Run("a report after megabytes of long noise lines is read in seconds", func(t *testing.T) {
+		// A failing parse counts lines up to its offset: quadratic in bytes
+		// on a huge stdout (7.9 s measured on 40 MB). The window is capped
+		// in bytes as well as lines, and the report after the noise is read.
+		long := scratchWrapperHead +
+			"line=$(printf 'x%.0s' $(seq 1 20000)); i=0; while [ $i -lt 300 ]; do echo \"{'noise': $i, 'pad': '$line'}\"; i=$((i+1)); done\n" +
+			"echo '{\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, long)
+		started := time.Now()
+		res := scratchVerify(t, script, ws, base)
+		if d := time.Since(started); d > 8*time.Second {
+			t.Fatalf("reading a report after 6 MB of noise took %s", d)
+		}
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("the report after the long noise was lost: %+v", res)
+		}
+	})
+
+	t.Run("a line that nests deeper than the parser allows is skipped, never a crash of the node", func(t *testing.T) {
+		deep := scratchWrapperHead +
+			"echo '{\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
+			"printf '{\"a\":'; i=0; while [ $i -lt 30000 ]; do printf '['; i=$((i+1)); done; echo\n" +
+			"exit 0\n"
+		ws, base := scratchWorkspace(t, deep)
+		res := scratchVerify(t, script, ws, base)
+		if res.OracleNotRun || !res.OraclePassed {
+			t.Fatalf("a deeply nested noise line hid the report or crashed the reader: %+v", res)
+		}
+	})
+
 	t.Run("an indented one-line report is read wherever it sits", func(t *testing.T) {
 		indented := scratchWrapperHead +
 			"echo '   {\"mode\":\"gate\",\"ok\":true,\"invalid\":[]}'\n" +
@@ -243,23 +506,6 @@ func TestModernizeLotVerifyOracleReportNeverDependsOnAMount(t *testing.T) {
 		res := scratchVerify(t, script, ws, base)
 		if res.OracleNotRun || !res.OraclePassed || res.OracleReport["mode"] != "gate" {
 			t.Fatalf("an indented one-line report was lost: %+v", res)
-		}
-	})
-
-	t.Run("a pretty-printed report a wrapper indented is read too", func(t *testing.T) {
-		// Nothing promises the block reaches stdout at column 0 — a tee, a
-		// textwrap.indent or a logger prefix shifts it. The indentation is a
-		// format, and a format is not a verdict: the block reads the same.
-		shifted := scratchWrapperHead +
-			"printf '  {\\n    \"mode\": \"gate\",\\n    \"ok\": true,\\n    \"invalid\": []\\n  }\\n'\n" +
-			"exit 0\n"
-		ws, base := scratchWorkspace(t, shifted)
-		res := scratchVerify(t, script, ws, base)
-		if res.OracleNotRun || !res.OraclePassed {
-			t.Fatalf("an indented pretty-printed report was discarded: %+v", res)
-		}
-		if res.OracleReport == nil || res.OracleReport["mode"] != "gate" {
-			t.Fatalf("the indented pretty-printed report is not in the verdict: %+v", res)
 		}
 	})
 


### PR DESCRIPTION
Revi (R46d257, medium) on the bounded scan: the block's start was guessed
among the two nearest opening lines and the window's FIRST one, so an
indent=0 report (a list's objects at column 0) preceded by any brace-first
line was lost and a green oracle typed ORACLE_NOT_RUN. The guess is gone:
json.JSONDecoder().raw_decode(window, idx) parses in place from each
"{" line of the window (lstripped: a logger's indentation leaves a block
without a start otherwise), from the last upward; a noise line fails on
its first bad token, a report parses once whatever follows it.

What five local adversarial rounds found in that reader, closed here:
- an indented block's nested objects are candidates too and sit lower, so
  a ledger entry an agent wrote with an `ok` key shadowed a selfcheck
  report into a gate PASS; then a stop on the first non-enclosing candidate
  fired between two SIBLINGS of one block and handed the lower one back.
  Now a candidate ENCLOSING the one held always replaces it — the outermost
  object of a block is the report, its entries (a lane carrying `mode`, a
  ledger block carrying `ok`) are not — with no early stop;
- one verdict key made a report, so a progress line {"ok": true} after a
  selfcheck report became the verdict: a report names itself (`mode`) or
  carries at least two verdict fields, which every mode-less harness
  generation writes;
- among disjoint candidates a named report never loses to an unnamed one:
  an object with two verdict fields printed after the report ended last
  and won, and the mode default read it as a gate (a selfcheck as a PASS,
  a RED without its invalid list);
- a window cut at its head (2000 lines / 2 MB) lost the report's own first
  line and an entry of it parsed instead, named or not: after a cut, an
  object followed by anything (its parent's closers) is an entry and no
  verdict; an intact trailing report is followed by nothing or by a log
  line, and stays read ("anything follows" discarded a report followed by
  `done in 41s` above the line cap);
- a failing parse counts lines up to its offset — quadratic in bytes,
  7.9 s on a 40 MB stdout — the window is capped in characters too
  (0.02 s); a RecursionError from a pathological line is skipped, not a
  crash of the node; lines are split on "\n" only (splitlines() cuts on
  U+2028).

Reachability, proven on the emitted stack: the wrapper prints exactly one
object and its exit code decides green/red, RUNNER_VERDICT_PY exits 3 on a
non-gate mode — the mis-picked-object class is live only with pre-#815
wrappers on client mirrors (exit 0 on a non-gate mode), which exist.

Proof, each shape red on the reader it fixes, and a one-key object alone
or after a mode-less RED pins the two-field threshold (the named clause
hid it from every other test): an indent=0 report with two
invalid mutants preceded by five brace-first lines and followed by one
reads whole; an indented block reads; a selfcheck report with one, then
two, nested {"ok": true} entries stays a selfcheck; a gate-subset report
with nested mutant objects stays typed; {"ok": true} after a selfcheck
report is not the verdict; a mode-less RED report keeps its invalid list
over a named lane entry; a head-cut report (2800 lines, and 4000 lines of
named lanes) is no verdict; an intact mode-less report after 2100 noise
lines, and after 2500 lines ending in a colon, is read; a RED report
followed by {"notice"} and {"collateral"} lines stays RED; a report after
6 MB of 20 KB lines reads in 0.2 s (a guard); a 30000-deep line is skipped.

## Against the reader #852 merged (the improvement loop's balance-based scan)

The 36 subtests of this branch, run against `main` at e6a1f12d1: 6 fail — `a single verdict key does not make a report` (a one-key `{"ok": true}` after a selfcheck report becomes the verdict), `a report whose head the window cut is not replaced by one of its nested objects`, `a head-cut report is no verdict even when its surviving entries are named`, `a named report never loses to an unnamed object that ends after it`, `a one-key object is never a report`, `a line that nests deeper than the parser allows is skipped, never a crash of the node`. Three of those are false PASS shapes (a non-gate report read as a green gate through the mode default), one is a RecursionError escaping the tool node.

Five local adversarial rounds ran on this reader before the push; each round's hole is a red test on the reader it replaced; the enclosure, named, cut-guard, threshold and first-candidate clauses each have a named test that kills their mutant.
