### PR TITLE
fix(golden-master): a type change is a dirty path, a big file's fingerprint round-trips, an unreadable subtree is undecidable

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2413,9 +2413,12 @@ tool oracle_run:
                             return "?"
                         h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
                 if unreadable:
-                    # A subtree that could not be listed: the fingerprint would be
-                    # stable across a real change inside it — undecidable instead.
-                    return "?"
+                    # A subtree that could not be listed (a 0700 cache, a
+                    # docker-owned build dir): the readable part is fingerprinted
+                    # and marked partial — equal to itself across two reads, so
+                    # an untouched tree still clears; a change inside the
+                    # unreadable part is the blind spot, said by the prefix.
+                    return "u-" + h.hexdigest()
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
@@ -2492,7 +2495,15 @@ tool oracle_run:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+            if e.startswith("st:"):
+                # The colon form a previous harness wrote for a big file
+                # ("st:<size>:<mtime>:<path>"): read as the current form, so a
+                # marker across the upgrade still clears an untouched file.
+                parts = e.split(":", 3)
+                if len(parts) == 4 and parts[3]:
+                    rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+                    continue
+            if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
                 # No fingerprint (a marker written before they were recorded): the
@@ -2714,7 +2725,7 @@ tool oracle_run:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
+        dirty, unknown, residue, residue_undecided, vanished, undecided_cause = "", "", [], False, [], ""
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2746,6 +2757,7 @@ tool oracle_run:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
+                                undecided_cause = "unknown_content"
                     # Work that was uncommitted before the mutant and is clean now
                     # was undone by the revert (a `git checkout -- .`): not the
                     # residue this sweep stops on, but said — the operator lost it.
@@ -2758,6 +2770,7 @@ tool oracle_run:
                     # residue, the marker stays, an operator decides.
                     residue = after
                     residue_undecided = True
+                    undecided_cause = "no_record"
             else:
                 # A git that answered nothing is more undecidable still than one
                 # that answered with no record to compare against: the marker
@@ -2769,7 +2782,8 @@ tool oracle_run:
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-                "residue_undecided": residue_undecided, "vanished": vanished[:50]}
+                "residue_undecided": residue_undecided, "vanished": vanished[:50],
+                "undecided_cause": undecided_cause}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2780,6 +2794,19 @@ tool oracle_run:
 
 
     def leftover_disposition(left):
+        """The disposition text, with the operator's destroyed work named on EVERY
+        kind: a revert that erased uncommitted work and left residue stops the
+        gate, and the stop is where the operator is told what to do — a text
+        that says "keep yours" after the script already removed it is worse
+        than silence."""
+        kind, text = _leftover_disposition(left)
+        if left.get("vanished"):
+            text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+        return kind, text
+
+
+    def _leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
         Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
@@ -2819,19 +2846,21 @@ tool oracle_run:
                 % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
             if left.get("residue_undecided"):
+                why = ("nothing recorded what was already uncommitted when the mutant went down"
+                       if left.get("undecided_cause") != "unknown_content" else
+                       "their content when the mutant went down could not be read or listed")
                 return "still_mutated", (
                     "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
-                    "exit 0), but the tree still shows changes and nothing recorded what was already "
-                    "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
-                    "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                    "exit 0), but the tree still shows changes and %s, so their origin is UNDECIDABLE: "
+                    "%s. Undecidable is not clean — the tree will be neither judged nor recorded. Check "
                     "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
-                    % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
+                    % (left.get("id"), why, ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
                 "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
                 "exit 0), but these paths changed since the mutant went down and the harness cannot "
                 "attribute the change — the mutant's residue, or work done in between: %s. The tree "
                 "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
-                "hand, keep yours, then delete the marker %s."
+                "hand, then delete the marker %s."
                 % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -2844,9 +2873,6 @@ tool oracle_run:
             elif left.get("dirty_unknown"):
                 text += (" Whether the tree actually came back could not be checked: %s. "
                          "Unknown, not clean." % left["dirty_unknown"])
-            if left.get("vanished"):
-                text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                         "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -4483,8 +4509,9 @@ tool oracle_run:
                     os.chmod(secret, 0o755)
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
-                check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
-                      [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+                if os.geteuid() != 0:
+                    check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                          [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
                 # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
                 # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
                 os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
@@ -4554,10 +4581,30 @@ tool oracle_run:
                     f.write("x")
                 os.chmod(os.path.join(tmp, "u", "locked"), 0)
                 try:
-                    check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+                    if os.geteuid() != 0:
+                        check("un sous-repertoire illisible donne une empreinte partielle, stable",
+                              [dirty_fingerprint(tmp, "u/").startswith("u-"), dirty_fingerprint(tmp, "u/") == dirty_fingerprint(tmp, "u/")],
+                              [True, True])
                 finally:
                     os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
                     shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
+                # Le travail efface est nomme AUSSI quand la porte s'arrete : un revert
+                # `git checkout -- .` efface l'edition de l'operateur ET laisse un fichier
+                # cree par le mutant.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' > created.txt", "git checkout -- .")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                kind, text = leftover_disposition(left or {})
+                check("residu ET travail efface : la porte s'arrete et nomme les deux",
+                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                      ["still_mutated", ["created.txt"], ["f.txt"], True, False])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "created.txt"))
+                # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
+                check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
+                      split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2381,14 +2381,16 @@ tool oracle_run:
         return _repo_root_cache[key]
 
 
-    BIG_FILE_BYTES = 8 << 20
+    BIG_FILE_BYTES = 256 << 20
 
 
     def dirty_fingerprint(ws, path):
         """What a dirty path IS, so a later sweep can tell a mutant's edit on an
         already-dirty path from the operator's untouched work. A file: the sha1
-        of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
-        a leash: hashing is local and linear); a symlink: its target; a directory
+        of its content, or "st-<size>-<mtime>" past BIG_FILE_BYTES (a bound, not
+        a leash: hashing is local and linear — and a stat fingerprint moves when
+        identical content is rewritten, so the bound is high); a symlink: its
+        target; a directory
         (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
         recursive NAME listing — a file a mutant creates or removes inside moves
         it, a build tree merely rebuilt between two runs does not, and a change
@@ -2402,21 +2404,25 @@ tool oracle_run:
                 return "absent"
             st = os.lstat(full)
             if stat.S_ISDIR(st.st_mode):
-                h, n = hashlib.sha1(), 0
-                for root, dirs, files in os.walk(full):
+                h, n, unreadable = hashlib.sha1(), 0, []
+                for root, dirs, files in os.walk(full, onerror=unreadable.append):
                     dirs.sort()
                     for name in sorted(files):
                         n += 1
                         if n > 20000:
                             return "?"
                         h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
+                if unreadable:
+                    # A subtree that could not be listed: the fingerprint would be
+                    # stable across a real change inside it — undecidable instead.
+                    return "?"
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
             if not stat.S_ISREG(st.st_mode):
                 return "?"
             if st.st_size > BIG_FILE_BYTES:
-                return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
+                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
             h = hashlib.sha1()
             with open(full, "rb") as f:
                 for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2439,7 +2445,7 @@ tool oracle_run:
             return 124, "%s" % e
 
 
-    PORCELAIN_STATUS = " MADRCU?!"
+    PORCELAIN_STATUS = " MTADRCU?!"
 
 
     def porcelain_paths(out):
@@ -2486,7 +2492,7 @@ tool oracle_run:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+            if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
                 # No fingerprint (a marker written before they were recorded): the
@@ -2708,7 +2714,7 @@ tool oracle_run:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue, residue_undecided = "", "", [], False
+        dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2740,6 +2746,10 @@ tool oracle_run:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
+                    # Work that was uncommitted before the mutant and is clean now
+                    # was undone by the revert (a `git checkout -- .`): not the
+                    # residue this sweep stops on, but said — the operator lost it.
+                    vanished = sorted(q for q in rec if q not in after and rec[q] != "absent")
                 elif after:
                     # No record of what was dirty before the mutant went down
                     # (git did not answer then, or the marker predates the
@@ -2759,7 +2769,7 @@ tool oracle_run:
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-                "residue_undecided": residue_undecided}
+                "residue_undecided": residue_undecided, "vanished": vanished[:50]}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2834,6 +2844,9 @@ tool oracle_run:
             elif left.get("dirty_unknown"):
                 text += (" Whether the tree actually came back could not be checked: %s. "
                          "Unknown, not clean." % left["dirty_unknown"])
+            if left.get("vanished"):
+                text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                         "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -4490,8 +4503,61 @@ tool oracle_run:
                 big = os.path.join(tmp, "big.bin")
                 with open(big, "wb") as f:
                     f.truncate(BIG_FILE_BYTES + 1)
-                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st-"), True)
                 os.remove(big)
+                # Un changement de TYPE (fichier -> lien) est un chemin modifie : enregistre,
+                # et residu si le revert ne le restaure pas.
+                os.remove(os.path.join(tmp, "f.txt"))
+                os.symlink("d.txt", os.path.join(tmp, "f.txt"))
+                check("un changement de type est un chemin modifie",
+                      any(e.endswith(":f.txt") for e in (dirty_paths_before_apply(tmp) or [])), True)
+                os.remove(os.path.join(tmp, "f.txt"))
+                sub("git", "checkout", "--", "f.txt")
+                scripts("rm f.txt && ln -s d.txt f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant qui remplace un fichier par un lien laisse un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["f.txt"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "f.txt"))
+                sub("git", "checkout", "--", "f.txt")
+                # Un gros fichier deja modifie fait l'aller-retour marqueur -> balayage sans residu.
+                saved_big = g["BIG_FILE_BYTES"]
+                g["BIG_FILE_BYTES"] = 16
+                try:
+                    with open(os.path.join(tmp, "big.bin"), "wb") as f:
+                        f.write(b"x" * 64)
+                    scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                    apply_mutant(lmeta, tmp)
+                    db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                    check("un gros fichier s'enregistre par stat, sans deux-points",
+                          [any(e.startswith("st-") and e.endswith(":big.bin") for e in db),
+                           "big.bin" in split_dirty_record(db)], [True, True])
+                    left = revert_leftover_mutant(tmp)
+                    check("un gros fichier intact de l'operateur n'est pas un residu",
+                          [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                finally:
+                    g["BIG_FILE_BYTES"] = saved_big
+                    os.remove(os.path.join(tmp, "big.bin"))
+                # Un revert qui EFFACE le travail de l'operateur (git checkout -- .) le dit.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- .")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("le travail de l'operateur efface par le revert est nomme",
+                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                      [["f.txt"], "reverted", True])
+                # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
+                os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
+                with open(os.path.join(tmp, "u", "locked", "x"), "w", encoding="utf-8") as f:
+                    f.write("x")
+                os.chmod(os.path.join(tmp, "u", "locked"), 0)
+                try:
+                    check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+                finally:
+                    os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
+                    shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2194,9 +2194,12 @@ def dirty_fingerprint(ws, path):
                         return "?"
                     h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
             if unreadable:
-                # A subtree that could not be listed: the fingerprint would be
-                # stable across a real change inside it — undecidable instead.
-                return "?"
+                # A subtree that could not be listed (a 0700 cache, a
+                # docker-owned build dir): the readable part is fingerprinted
+                # and marked partial — equal to itself across two reads, so
+                # an untouched tree still clears; a change inside the
+                # unreadable part is the blind spot, said by the prefix.
+                return "u-" + h.hexdigest()
             return h.hexdigest()
         if stat.S_ISLNK(st.st_mode):
             return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
@@ -2273,7 +2276,15 @@ def split_dirty_record(entries):
     rec = {}
     for e in entries or []:
         fp, sep, q = e.partition(":")
-        if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+        if e.startswith("st:"):
+            # The colon form a previous harness wrote for a big file
+            # ("st:<size>:<mtime>:<path>"): read as the current form, so a
+            # marker across the upgrade still clears an untouched file.
+            parts = e.split(":", 3)
+            if len(parts) == 4 and parts[3]:
+                rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+                continue
+        if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
             rec[q] = fp
         else:
             # No fingerprint (a marker written before they were recorded): the
@@ -2495,7 +2506,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-    dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
+    dirty, unknown, residue, residue_undecided, vanished, undecided_cause = "", "", [], False, [], ""
     if code == 0:
         # Through run(), and on a short leash. This sweep runs in EVERY mode,
         # record included, and the harness's contract is to answer with a
@@ -2527,6 +2538,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
                         residue.append(q)
                         if rec[q] == "?":
                             residue_undecided = True
+                            undecided_cause = "unknown_content"
                 # Work that was uncommitted before the mutant and is clean now
                 # was undone by the revert (a `git checkout -- .`): not the
                 # residue this sweep stops on, but said — the operator lost it.
@@ -2539,6 +2551,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
                 # residue, the marker stays, an operator decides.
                 residue = after
                 residue_undecided = True
+                undecided_cause = "no_record"
         else:
             # A git that answered nothing is more undecidable still than one
             # that answered with no record to compare against: the marker
@@ -2550,7 +2563,8 @@ def revert_leftover_mutant(ws, gm_dir=None):
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
             "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
             "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-            "residue_undecided": residue_undecided, "vanished": vanished[:50]}
+            "residue_undecided": residue_undecided, "vanished": vanished[:50],
+            "undecided_cause": undecided_cause}
 
 
 # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2561,6 +2575,19 @@ LEFTOVER_BAIL_KINDS = ("still_mutated", "unusable", "refused")
 
 
 def leftover_disposition(left):
+    """The disposition text, with the operator's destroyed work named on EVERY
+    kind: a revert that erased uncommitted work and left residue stops the
+    gate, and the stop is where the operator is told what to do — a text
+    that says "keep yours" after the script already removed it is worse
+    than silence."""
+    kind, text = _leftover_disposition(left)
+    if left.get("vanished"):
+        text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                 "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+    return kind, text
+
+
+def _leftover_disposition(left):
     """What the gate says about a leftover, and whether it may proceed.
 
     Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
@@ -2600,19 +2627,21 @@ def leftover_disposition(left):
             % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
     if left.get("code") == 0 and left.get("residue"):
         if left.get("residue_undecided"):
+            why = ("nothing recorded what was already uncommitted when the mutant went down"
+                   if left.get("undecided_cause") != "unknown_content" else
+                   "their content when the mutant went down could not be read or listed")
             return "still_mutated", (
                 "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
-                "exit 0), but the tree still shows changes and nothing recorded what was already "
-                "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
-                "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                "exit 0), but the tree still shows changes and %s, so their origin is UNDECIDABLE: "
+                "%s. Undecidable is not clean — the tree will be neither judged nor recorded. Check "
                 "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
-                % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
+                % (left.get("id"), why, ", ".join(left["residue"][:20]), left.get("marker")))
         return "still_mutated", (
             "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
             "exit 0), but these paths changed since the mutant went down and the harness cannot "
             "attribute the change — the mutant's residue, or work done in between: %s. The tree "
             "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
-            "hand, keep yours, then delete the marker %s."
+            "hand, then delete the marker %s."
             % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
     if left.get("code") == 0:
         text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -2625,9 +2654,6 @@ def leftover_disposition(left):
         elif left.get("dirty_unknown"):
             text += (" Whether the tree actually came back could not be checked: %s. "
                      "Unknown, not clean." % left["dirty_unknown"])
-        if left.get("vanished"):
-            text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
         return "reverted", text
     how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
     return "still_mutated", (
@@ -4264,8 +4290,9 @@ def _selftest():
                 os.chmod(secret, 0o755)
                 shutil.rmtree(secret, ignore_errors=True)
             os.remove(os.path.join(tmp, "other.txt"))
-            check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
-                  [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+            if os.geteuid() != 0:
+                check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                      [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
             # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
             # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
             os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
@@ -4335,10 +4362,30 @@ def _selftest():
                 f.write("x")
             os.chmod(os.path.join(tmp, "u", "locked"), 0)
             try:
-                check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+                if os.geteuid() != 0:
+                    check("un sous-repertoire illisible donne une empreinte partielle, stable",
+                          [dirty_fingerprint(tmp, "u/").startswith("u-"), dirty_fingerprint(tmp, "u/") == dirty_fingerprint(tmp, "u/")],
+                          [True, True])
             finally:
                 os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
                 shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
+            # Le travail efface est nomme AUSSI quand la porte s'arrete : un revert
+            # `git checkout -- .` efface l'edition de l'operateur ET laisse un fichier
+            # cree par le mutant.
+            with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                f.write("operator edit\n")
+            scripts("printf 'mutant\\n' > created.txt", "git checkout -- .")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            kind, text = leftover_disposition(left or {})
+            check("residu ET travail efface : la porte s'arrete et nomme les deux",
+                  [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                  ["still_mutated", ["created.txt"], ["f.txt"], True, False])
+            os.remove(applied_marker_for(tmp))
+            os.remove(os.path.join(tmp, "created.txt"))
+            # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
+            check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
+                  split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2162,14 +2162,16 @@ def repo_root_of(ws):
     return _repo_root_cache[key]
 
 
-BIG_FILE_BYTES = 8 << 20
+BIG_FILE_BYTES = 256 << 20
 
 
 def dirty_fingerprint(ws, path):
     """What a dirty path IS, so a later sweep can tell a mutant's edit on an
     already-dirty path from the operator's untouched work. A file: the sha1
-    of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
-    a leash: hashing is local and linear); a symlink: its target; a directory
+    of its content, or "st-<size>-<mtime>" past BIG_FILE_BYTES (a bound, not
+    a leash: hashing is local and linear — and a stat fingerprint moves when
+    identical content is rewritten, so the bound is high); a symlink: its
+    target; a directory
     (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
     recursive NAME listing — a file a mutant creates or removes inside moves
     it, a build tree merely rebuilt between two runs does not, and a change
@@ -2183,21 +2185,25 @@ def dirty_fingerprint(ws, path):
             return "absent"
         st = os.lstat(full)
         if stat.S_ISDIR(st.st_mode):
-            h, n = hashlib.sha1(), 0
-            for root, dirs, files in os.walk(full):
+            h, n, unreadable = hashlib.sha1(), 0, []
+            for root, dirs, files in os.walk(full, onerror=unreadable.append):
                 dirs.sort()
                 for name in sorted(files):
                     n += 1
                     if n > 20000:
                         return "?"
                     h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
+            if unreadable:
+                # A subtree that could not be listed: the fingerprint would be
+                # stable across a real change inside it — undecidable instead.
+                return "?"
             return h.hexdigest()
         if stat.S_ISLNK(st.st_mode):
             return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
         if not stat.S_ISREG(st.st_mode):
             return "?"
         if st.st_size > BIG_FILE_BYTES:
-            return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
+            return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
         h = hashlib.sha1()
         with open(full, "rb") as f:
             for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2220,7 +2226,7 @@ def status_porcelain_z(ws):
         return 124, "%s" % e
 
 
-PORCELAIN_STATUS = " MADRCU?!"
+PORCELAIN_STATUS = " MTADRCU?!"
 
 
 def porcelain_paths(out):
@@ -2267,7 +2273,7 @@ def split_dirty_record(entries):
     rec = {}
     for e in entries or []:
         fp, sep, q = e.partition(":")
-        if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+        if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
             rec[q] = fp
         else:
             # No fingerprint (a marker written before they were recorded): the
@@ -2489,7 +2495,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
         code, out = run_script(script, ws)
     else:
         code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-    dirty, unknown, residue, residue_undecided = "", "", [], False
+    dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
     if code == 0:
         # Through run(), and on a short leash. This sweep runs in EVERY mode,
         # record included, and the harness's contract is to answer with a
@@ -2521,6 +2527,10 @@ def revert_leftover_mutant(ws, gm_dir=None):
                         residue.append(q)
                         if rec[q] == "?":
                             residue_undecided = True
+                # Work that was uncommitted before the mutant and is clean now
+                # was undone by the revert (a `git checkout -- .`): not the
+                # residue this sweep stops on, but said — the operator lost it.
+                vanished = sorted(q for q in rec if q not in after and rec[q] != "absent")
             elif after:
                 # No record of what was dirty before the mutant went down
                 # (git did not answer then, or the marker predates the
@@ -2540,7 +2550,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
     return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
             "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
             "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-            "residue_undecided": residue_undecided}
+            "residue_undecided": residue_undecided, "vanished": vanished[:50]}
 
 
 # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2615,6 +2625,9 @@ def leftover_disposition(left):
         elif left.get("dirty_unknown"):
             text += (" Whether the tree actually came back could not be checked: %s. "
                      "Unknown, not clean." % left["dirty_unknown"])
+        if left.get("vanished"):
+            text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
         return "reverted", text
     how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
     return "still_mutated", (
@@ -4271,8 +4284,61 @@ def _selftest():
             big = os.path.join(tmp, "big.bin")
             with open(big, "wb") as f:
                 f.truncate(BIG_FILE_BYTES + 1)
-            check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+            check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st-"), True)
             os.remove(big)
+            # Un changement de TYPE (fichier -> lien) est un chemin modifie : enregistre,
+            # et residu si le revert ne le restaure pas.
+            os.remove(os.path.join(tmp, "f.txt"))
+            os.symlink("d.txt", os.path.join(tmp, "f.txt"))
+            check("un changement de type est un chemin modifie",
+                  any(e.endswith(":f.txt") for e in (dirty_paths_before_apply(tmp) or [])), True)
+            os.remove(os.path.join(tmp, "f.txt"))
+            sub("git", "checkout", "--", "f.txt")
+            scripts("rm f.txt && ln -s d.txt f.txt", "true")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("un mutant qui remplace un fichier par un lien laisse un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["f.txt"], "still_mutated"])
+            os.remove(applied_marker_for(tmp))
+            os.remove(os.path.join(tmp, "f.txt"))
+            sub("git", "checkout", "--", "f.txt")
+            # Un gros fichier deja modifie fait l'aller-retour marqueur -> balayage sans residu.
+            saved_big = g["BIG_FILE_BYTES"]
+            g["BIG_FILE_BYTES"] = 16
+            try:
+                with open(os.path.join(tmp, "big.bin"), "wb") as f:
+                    f.write(b"x" * 64)
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                check("un gros fichier s'enregistre par stat, sans deux-points",
+                      [any(e.startswith("st-") and e.endswith(":big.bin") for e in db),
+                       "big.bin" in split_dirty_record(db)], [True, True])
+                left = revert_leftover_mutant(tmp)
+                check("un gros fichier intact de l'operateur n'est pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+            finally:
+                g["BIG_FILE_BYTES"] = saved_big
+                os.remove(os.path.join(tmp, "big.bin"))
+            # Un revert qui EFFACE le travail de l'operateur (git checkout -- .) le dit.
+            with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                f.write("operator edit\n")
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- .")
+            apply_mutant(lmeta, tmp)
+            left = revert_leftover_mutant(tmp)
+            check("le travail de l'operateur efface par le revert est nomme",
+                  [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                  [["f.txt"], "reverted", True])
+            # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
+            os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
+            with open(os.path.join(tmp, "u", "locked", "x"), "w", encoding="utf-8") as f:
+                f.write("x")
+            os.chmod(os.path.join(tmp, "u", "locked"), 0)
+            try:
+                check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+            finally:
+                os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
+                shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2329,14 +2329,16 @@ tool sync_harness:
         return _repo_root_cache[key]
 
 
-    BIG_FILE_BYTES = 8 << 20
+    BIG_FILE_BYTES = 256 << 20
 
 
     def dirty_fingerprint(ws, path):
         """What a dirty path IS, so a later sweep can tell a mutant's edit on an
         already-dirty path from the operator's untouched work. A file: the sha1
-        of its content, or "st:<size>:<mtime>" past BIG_FILE_BYTES (a bound, not
-        a leash: hashing is local and linear); a symlink: its target; a directory
+        of its content, or "st-<size>-<mtime>" past BIG_FILE_BYTES (a bound, not
+        a leash: hashing is local and linear — and a stat fingerprint moves when
+        identical content is rewritten, so the bound is high); a symlink: its
+        target; a directory
         (`?? dir/`, an untracked tree collapsed to one line): the sha1 of its
         recursive NAME listing — a file a mutant creates or removes inside moves
         it, a build tree merely rebuilt between two runs does not, and a change
@@ -2350,21 +2352,25 @@ tool sync_harness:
                 return "absent"
             st = os.lstat(full)
             if stat.S_ISDIR(st.st_mode):
-                h, n = hashlib.sha1(), 0
-                for root, dirs, files in os.walk(full):
+                h, n, unreadable = hashlib.sha1(), 0, []
+                for root, dirs, files in os.walk(full, onerror=unreadable.append):
                     dirs.sort()
                     for name in sorted(files):
                         n += 1
                         if n > 20000:
                             return "?"
                         h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
+                if unreadable:
+                    # A subtree that could not be listed: the fingerprint would be
+                    # stable across a real change inside it — undecidable instead.
+                    return "?"
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
             if not stat.S_ISREG(st.st_mode):
                 return "?"
             if st.st_size > BIG_FILE_BYTES:
-                return "st:%d:%d" % (st.st_size, st.st_mtime_ns)
+                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
             h = hashlib.sha1()
             with open(full, "rb") as f:
                 for chunk in iter(lambda: f.read(1 << 20), b""):
@@ -2387,7 +2393,7 @@ tool sync_harness:
             return 124, "%s" % e
 
 
-    PORCELAIN_STATUS = " MADRCU?!"
+    PORCELAIN_STATUS = " MTADRCU?!"
 
 
     def porcelain_paths(out):
@@ -2434,7 +2440,7 @@ tool sync_harness:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q and (fp in ("absent", "?") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+            if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
                 # No fingerprint (a marker written before they were recorded): the
@@ -2656,7 +2662,7 @@ tool sync_harness:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue, residue_undecided = "", "", [], False
+        dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2688,6 +2694,10 @@ tool sync_harness:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
+                    # Work that was uncommitted before the mutant and is clean now
+                    # was undone by the revert (a `git checkout -- .`): not the
+                    # residue this sweep stops on, but said — the operator lost it.
+                    vanished = sorted(q for q in rec if q not in after and rec[q] != "absent")
                 elif after:
                     # No record of what was dirty before the mutant went down
                     # (git did not answer then, or the marker predates the
@@ -2707,7 +2717,7 @@ tool sync_harness:
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-                "residue_undecided": residue_undecided}
+                "residue_undecided": residue_undecided, "vanished": vanished[:50]}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2782,6 +2792,9 @@ tool sync_harness:
             elif left.get("dirty_unknown"):
                 text += (" Whether the tree actually came back could not be checked: %s. "
                          "Unknown, not clean." % left["dirty_unknown"])
+            if left.get("vanished"):
+                text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                         "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -4438,8 +4451,61 @@ tool sync_harness:
                 big = os.path.join(tmp, "big.bin")
                 with open(big, "wb") as f:
                     f.truncate(BIG_FILE_BYTES + 1)
-                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st:"), True)
+                check("un gros fichier s'empreinte par stat", dirty_fingerprint(tmp, "big.bin").startswith("st-"), True)
                 os.remove(big)
+                # Un changement de TYPE (fichier -> lien) est un chemin modifie : enregistre,
+                # et residu si le revert ne le restaure pas.
+                os.remove(os.path.join(tmp, "f.txt"))
+                os.symlink("d.txt", os.path.join(tmp, "f.txt"))
+                check("un changement de type est un chemin modifie",
+                      any(e.endswith(":f.txt") for e in (dirty_paths_before_apply(tmp) or [])), True)
+                os.remove(os.path.join(tmp, "f.txt"))
+                sub("git", "checkout", "--", "f.txt")
+                scripts("rm f.txt && ln -s d.txt f.txt", "true")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("un mutant qui remplace un fichier par un lien laisse un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [["f.txt"], "still_mutated"])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "f.txt"))
+                sub("git", "checkout", "--", "f.txt")
+                # Un gros fichier deja modifie fait l'aller-retour marqueur -> balayage sans residu.
+                saved_big = g["BIG_FILE_BYTES"]
+                g["BIG_FILE_BYTES"] = 16
+                try:
+                    with open(os.path.join(tmp, "big.bin"), "wb") as f:
+                        f.write(b"x" * 64)
+                    scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                    apply_mutant(lmeta, tmp)
+                    db = (read_applied_marker(tmp)[0] or {}).get("dirty_before") or []
+                    check("un gros fichier s'enregistre par stat, sans deux-points",
+                          [any(e.startswith("st-") and e.endswith(":big.bin") for e in db),
+                           "big.bin" in split_dirty_record(db)], [True, True])
+                    left = revert_leftover_mutant(tmp)
+                    check("un gros fichier intact de l'operateur n'est pas un residu",
+                          [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                finally:
+                    g["BIG_FILE_BYTES"] = saved_big
+                    os.remove(os.path.join(tmp, "big.bin"))
+                # Un revert qui EFFACE le travail de l'operateur (git checkout -- .) le dit.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- .")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                check("le travail de l'operateur efface par le revert est nomme",
+                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                      [["f.txt"], "reverted", True])
+                # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
+                os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
+                with open(os.path.join(tmp, "u", "locked", "x"), "w", encoding="utf-8") as f:
+                    f.write("x")
+                os.chmod(os.path.join(tmp, "u", "locked"), 0)
+                try:
+                    check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+                finally:
+                    os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
+                    shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2361,9 +2361,12 @@ tool sync_harness:
                             return "?"
                         h.update((os.path.relpath(os.path.join(root, name), full) + "\n").encode("utf-8", "replace"))
                 if unreadable:
-                    # A subtree that could not be listed: the fingerprint would be
-                    # stable across a real change inside it — undecidable instead.
-                    return "?"
+                    # A subtree that could not be listed (a 0700 cache, a
+                    # docker-owned build dir): the readable part is fingerprinted
+                    # and marked partial — equal to itself across two reads, so
+                    # an untouched tree still clears; a change inside the
+                    # unreadable part is the blind spot, said by the prefix.
+                    return "u-" + h.hexdigest()
                 return h.hexdigest()
             if stat.S_ISLNK(st.st_mode):
                 return hashlib.sha1(os.readlink(full).encode("utf-8", "replace")).hexdigest()
@@ -2440,7 +2443,15 @@ tool sync_harness:
         rec = {}
         for e in entries or []:
             fp, sep, q = e.partition(":")
-            if sep and q and (fp in ("absent", "?") or fp.startswith("st-") or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
+            if e.startswith("st:"):
+                # The colon form a previous harness wrote for a big file
+                # ("st:<size>:<mtime>:<path>"): read as the current form, so a
+                # marker across the upgrade still clears an untouched file.
+                parts = e.split(":", 3)
+                if len(parts) == 4 and parts[3]:
+                    rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+                    continue
+            if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
             else:
                 # No fingerprint (a marker written before they were recorded): the
@@ -2662,7 +2673,7 @@ tool sync_harness:
             code, out = run_script(script, ws)
         else:
             code, out = None, "the mutant's revert.sh is no longer there: %s" % script
-        dirty, unknown, residue, residue_undecided, vanished = "", "", [], False, []
+        dirty, unknown, residue, residue_undecided, vanished, undecided_cause = "", "", [], False, [], ""
         if code == 0:
             # Through run(), and on a short leash. This sweep runs in EVERY mode,
             # record included, and the harness's contract is to answer with a
@@ -2694,6 +2705,7 @@ tool sync_harness:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
+                                undecided_cause = "unknown_content"
                     # Work that was uncommitted before the mutant and is clean now
                     # was undone by the revert (a `git checkout -- .`): not the
                     # residue this sweep stops on, but said — the operator lost it.
@@ -2706,6 +2718,7 @@ tool sync_harness:
                     # residue, the marker stays, an operator decides.
                     residue = after
                     residue_undecided = True
+                    undecided_cause = "no_record"
             else:
                 # A git that answered nothing is more undecidable still than one
                 # that answered with no record to compare against: the marker
@@ -2717,7 +2730,8 @@ tool sync_harness:
         return {"id": meta.get("id"), "dir": mdir, "code": code, "out": (out or "")[-300:],
                 "marker": marker, "refused": False, "kept": code != 0 or bool(residue) or residue_undecided,
                 "dirty": dirty[:400], "dirty_unknown": unknown, "residue": residue[:50],
-                "residue_undecided": residue_undecided, "vanished": vanished[:50]}
+                "residue_undecided": residue_undecided, "vanished": vanished[:50],
+                "undecided_cause": undecided_cause}
 
 
     # The dispositions on which the gate STOPS rather than judges. Only "reverted"
@@ -2728,6 +2742,19 @@ tool sync_harness:
 
 
     def leftover_disposition(left):
+        """The disposition text, with the operator's destroyed work named on EVERY
+        kind: a revert that erased uncommitted work and left residue stops the
+        gate, and the stop is where the operator is told what to do — a text
+        that says "keep yours" after the script already removed it is worse
+        than silence."""
+        kind, text = _leftover_disposition(left)
+        if left.get("vanished"):
+            text += (" Uncommitted work that was there before the mutant is gone after the revert "
+                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+        return kind, text
+
+
+    def _leftover_disposition(left):
         """What the gate says about a leftover, and whether it may proceed.
 
         Returns (kind, text): "reverted" — revert.sh exit 0, a note (with what
@@ -2767,19 +2794,21 @@ tool sync_harness:
                 % (left.get("id"), left.get("dirty_unknown") or "no record", left.get("marker")))
         if left.get("code") == 0 and left.get("residue"):
             if left.get("residue_undecided"):
+                why = ("nothing recorded what was already uncommitted when the mutant went down"
+                       if left.get("undecided_cause") != "unknown_content" else
+                       "their content when the mutant went down could not be read or listed")
                 return "still_mutated", (
                     "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
-                    "exit 0), but the tree still shows changes and nothing recorded what was already "
-                    "uncommitted when the mutant went down, so their origin is UNDECIDABLE: %s. "
-                    "Undecidable is not clean — the tree will be neither judged nor recorded. Check "
+                    "exit 0), but the tree still shows changes and %s, so their origin is UNDECIDABLE: "
+                    "%s. Undecidable is not clean — the tree will be neither judged nor recorded. Check "
                     "those paths (git diff), revert the mutant's by hand, then delete the marker %s."
-                    % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
+                    % (left.get("id"), why, ", ".join(left["residue"][:20]), left.get("marker")))
             return "still_mutated", (
                 "a mutant left APPLIED by an interrupted gate was reverted at start (%s, revert.sh "
                 "exit 0), but these paths changed since the mutant went down and the harness cannot "
                 "attribute the change — the mutant's residue, or work done in between: %s. The tree "
                 "will be neither judged nor recorded. Inspect them (git diff), revert the mutant's by "
-                "hand, keep yours, then delete the marker %s."
+                "hand, then delete the marker %s."
                 % (left.get("id"), ", ".join(left["residue"][:20]), left.get("marker")))
         if left.get("code") == 0:
             text = ("a mutant left APPLIED by an interrupted gate was reverted at start: %s "
@@ -2792,9 +2821,6 @@ tool sync_harness:
             elif left.get("dirty_unknown"):
                 text += (" Whether the tree actually came back could not be checked: %s. "
                          "Unknown, not clean." % left["dirty_unknown"])
-            if left.get("vanished"):
-                text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                         "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
             return "reverted", text
         how = "revert.sh is missing" if left.get("code") is None else "revert.sh exited %s" % left.get("code")
         return "still_mutated", (
@@ -4431,8 +4457,9 @@ tool sync_harness:
                     os.chmod(secret, 0o755)
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
-                check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
-                      [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
+                if os.geteuid() != 0:
+                    check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
+                          [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
                 # Un repertoire non suivi RECONSTRUIT entre deux runs (memes noms, autres
                 # contenus/mtimes) n'est pas un residu ; un fichier cree dedans l'est.
                 os.makedirs(os.path.join(tmp, "build"), exist_ok=True)
@@ -4502,10 +4529,30 @@ tool sync_harness:
                     f.write("x")
                 os.chmod(os.path.join(tmp, "u", "locked"), 0)
                 try:
-                    check("un sous-repertoire illisible rend l'empreinte indecidable", dirty_fingerprint(tmp, "u/"), "?")
+                    if os.geteuid() != 0:
+                        check("un sous-repertoire illisible donne une empreinte partielle, stable",
+                              [dirty_fingerprint(tmp, "u/").startswith("u-"), dirty_fingerprint(tmp, "u/") == dirty_fingerprint(tmp, "u/")],
+                              [True, True])
                 finally:
                     os.chmod(os.path.join(tmp, "u", "locked"), 0o755)
                     shutil.rmtree(os.path.join(tmp, "u"), ignore_errors=True)
+                # Le travail efface est nomme AUSSI quand la porte s'arrete : un revert
+                # `git checkout -- .` efface l'edition de l'operateur ET laisse un fichier
+                # cree par le mutant.
+                with open(os.path.join(tmp, "f.txt"), "a", encoding="utf-8") as f:
+                    f.write("operator edit\n")
+                scripts("printf 'mutant\\n' > created.txt", "git checkout -- .")
+                apply_mutant(lmeta, tmp)
+                left = revert_leftover_mutant(tmp)
+                kind, text = leftover_disposition(left or {})
+                check("residu ET travail efface : la porte s'arrete et nomme les deux",
+                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                      ["still_mutated", ["created.txt"], ["f.txt"], True, False])
+                os.remove(applied_marker_for(tmp))
+                os.remove(os.path.join(tmp, "created.txt"))
+                # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
+                check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
+                      split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)


### PR DESCRIPTION
## Follow-up of #856 — its sixth review round, merged out from under it

#856 merged while its sixth round was being pushed; the two findings and the questions of that round land here, on the merged harness.

- **The porcelain status set lacked `T`** (medium): a type change (a tracked file swapped for a symlink) was neither recorded before the mutant nor seen after a revert that left it — the one disposition that lets the gate through, on the fail-open #856 closes. `T` is a status. Self-test: a file-to-symlink change is recorded, and is residue when a mutant's revert does not restore it. Mutant: `T` dropped — red.
- **The big-file fingerprint carried colons** (medium): `st:<size>:<mtime>` broke the marker's `<fingerprint>:<path>` entry format, the real path went missing from the record, and after a clean revert the operator's untouched large file was residue — permanent, every later gate stopped on it. The fingerprint is colon-free (`st-…`), accepted by the parser, and the bound is 256 MiB: a stat fingerprint moves when identical content is rewritten, so hashing goes much further before it is used. Self-test: a large untouched file round-trips through the marker with no residue. Mutant: the colon fingerprint back — red.
- Questions answered in code: an unreadable subtree of an untracked directory made the walk skip it silently, a stable fingerprint across a real change inside — it makes the fingerprint undecidable (mutant: the subtree skipped — red); work that was uncommitted before the mutant and clean after the revert was undone by the script (`git checkout -- .`) — not the residue the sweep stops on, but named in the note, the operator lost it (mutant: unnamed — red). The status read just before the exclusive create is fine: the create is the mutual exclusion, and a second harness racing it is refused by it. Real mutants target tracked paths; the untracked-directory blind spot stays as documented.

Self-test 196 → 202. `go test ./bots/` green (the byte-identity test covers the two inlined copies).


## Second round (one finding, reproduced; five questions answered)

- **The sentence naming the operator's destroyed work was appended only where the gate went on** (medium): where it stopped — a `git checkout -- .` that erased the operator's edit AND left a file the mutant created, the common shape — the text told the operator to "keep yours" after the script had removed it. One wrapper now names the loss on every disposition, and the residue stop no longer promises what is gone. Self-test: residue and destroyed work together stop the gate and name both. Mutant: the loss named on the pass path only — red.

Open questions, answered:

- *`vanished` excludes paths recorded `absent`.* Deliberate: a deletion the revert put back lost no bytes and is redone in one command; the note is about work that cannot be redone.
- *An unreadable subtree made a directory permanent residue.* It did (`?` never equals itself). The readable part is fingerprinted and marked partial (`u-…`), equal to itself across two reads, so an untouched cache directory clears; the unreadable part is the blind spot, said by the prefix. Mutant: `?` again — red.
- *The undecided message sent the operator after a missing record.* It names its cause now: no record, or a record whose content could not be read or listed.
- *A marker from the previous harness with the colon big-file form.* Read as the current form, so a marker across the upgrade still clears an untouched file. Mutant: the legacy form not read — red.
- *Permission-based self-test checks under root.* Both skipped when `os.geteuid() == 0`, where `chmod 0` denies nothing.

Self-test 202 → 204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
