### PR TITLE
fix(review-pr): the run budget follows the measured workload — $48, sized on two deaths at $36 and $30 and the engine's 90% wall

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -1508,12 +1508,16 @@ workflow review_pr:
     ## catch a hung run. 45m killed real reviews mid-publish (a forfait
     ## retry or a big diff walks past it while spending nothing).
     max_duration: "90m"
-    ## Sized from production: median ~$3.6/run, p95 ~$10.5 (2026-09-03
-    ## sample). The exit grace (cap × 1.1) still walks an over-cap run
-    ## forward to publish, so a big-diff review delivers at ~$13 instead
-    ## of dying. Re-budget a deliberate deep review per run with
-    ## --max-cost-usd.
-    max_cost_usd: 12
+    ## Sized from production, twice. The 2026-09-03 sample said median
+    ## ~$3.6/run, p95 ~$10.5, and the cap was 12 with the exit grace
+    ## (cap × 1.1) walking an over-cap run forward to publish. Three days
+    ## later the guard tier died at $36 and $30 on a 7-file PR — twice on
+    ## one revision, the relaunch included — and the merge gate posted no
+    ## verdict at all: a required check that dies is worse than one that
+    ## costs. A review that reproduces its findings and answers the fixer's
+    ## rounds is the workload now; the cap follows it. Re-budget a
+    ## deliberate deep review per run with --max-cost-usd.
+    max_cost_usd: 40
 
   ## EFFICIENCY: an empty review diff skips tier resolution, both LLM
   ## reviewers, and emit.

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -393,7 +393,10 @@ vars:
 ## exploration, re-reads, long silence without finalisation) it posts a
 ## single "wrap up now" steering message the reviewer picks up at its
 ## next turn. It never judges code and never adds findings. Cost is
-## bounded by design: ≤4 haiku evals on a 5m cooldown (~cents/run).
+## bounded by design: ≤12 haiku evals on a 6m cooldown (~cents/run) — a
+## window that still exists when spend nears the wall: with 4 evals on 5m
+## the coordinator refused every wake ("eval budget exhausted") long
+## before a $32 trigger could match on a review that runs 40-60 minutes.
 ## The cost_gt monitor rides the debounced mid-node usage_progress
 ## samples (plus budget_warning), so it fires WHILE the review runs —
 ## the cooldown wakes cover pacing between samples.
@@ -401,8 +404,8 @@ supervisor pacer:
   watches: [reviewer_claude, reviewer_gpt]
   model: "${ITERION_VIBE_MODEL_SUPERVISOR:-anthropic/claude-haiku-4-5}"
   system: pacer_policy
-  cooldown: "5m"
-  max_evals: 4
+  cooldown: "6m"
+  max_evals: 12
   ## An ABSOLUTE dollar trigger, kept at ~2/3 of the cap (it was 8 of 12):
   ## calibrated lower it fires in the cheap early phase, spends its four
   ## evals telling a review to wrap up before it has reproduced anything,
@@ -1510,8 +1513,13 @@ workflow review_pr:
     max_parallel_branches: 2
     ## The money guard is max_cost_usd; the duration cap only needs to
     ## catch a hung run. 45m killed real reviews mid-publish (a forfait
-    ## retry or a big diff walks past it while spending nothing).
-    max_duration: "90m"
+    ## retry or a big diff walks past it while spending nothing). The same
+    ## 90% wall applies here, no grace: 90m refused new nodes at 81 min.
+    ## The two deaths sized above ran ~40 min each (push → death: 84 min
+    ## for two runs of one PR, 53 min for the other); a review funded to
+    ## ~$43 may run 45-60 min, so 120m keeps its 108-minute wall clear of
+    ## the workload the cost cap now admits.
+    max_duration: "120m"
     ## Sized from production, twice. The 2026-09-03 sample said median
     ## ~$3.6/run, p95 ~$10.5, and the cap was 12 with the exit grace
     ## (cap × 1.1) walking an over-cap run forward to publish. Three days

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -403,7 +403,11 @@ supervisor pacer:
   system: pacer_policy
   cooldown: "5m"
   max_evals: 4
-  monitors: ["cost_gt=8"]
+  ## An ABSOLUTE dollar trigger, kept at ~2/3 of the cap (it was 8 of 12):
+  ## calibrated lower it fires in the cheap early phase, spends its four
+  ## evals telling a review to wrap up before it has reproduced anything,
+  ## and is silent by the time spend nears the real wall.
+  monitors: ["cost_gt=32"]
 
 prompt pacer_policy:
   You pace a READ-ONLY code reviewer that has a hard cost budget. Its
@@ -1515,9 +1519,16 @@ workflow review_pr:
     ## one revision, the relaunch included — and the merge gate posted no
     ## verdict at all: a required check that dies is worse than one that
     ## costs. A review that reproduces its findings and answers the fixer's
-    ## rounds is the workload now; the cap follows it. Re-budget a
-    ## deliberate deep review per run with --max-cost-usd.
-    max_cost_usd: 40
+    ## rounds is the workload now; the cap follows it.
+    ##
+    ## The EFFECTIVE ceiling is 0.9 × cap, not the cap: the engine refuses
+    ## any new node — the publish tail included — once an axis sits at 90%
+    ## of its cap, with no grace on that band (pkg/runtime/budget.go). And
+    ## $36 was the spend at the kill, a lower bound on the workload, since
+    ## the run never paid for converge + publish. 48 puts $36 at 75% and
+    ## leaves ~$43 before the wall. Re-budget a deliberate deep review per
+    ## run with --max-cost-usd.
+    max_cost_usd: 48
 
   ## EFFICIENCY: an empty review diff skips tier resolution, both LLM
   ## reviewers, and emit.

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -2,12 +2,15 @@ name: review-pr
 display_name: Revi
 icon: 🔎
 version: 0.8.1
-## 0.8.1 — budget max_cost_usd 12 → 40: the guard tier died at $36 and $30
+## 0.8.1 — budget max_cost_usd 12 → 48: the guard tier died at $36 and $30
 ## on a 7-file PR, twice on one revision (the automatic relaunch included),
 ## and the merge gate posted no verdict. A review that reproduces its
 ## findings and answers the fixer's rounds is the workload now; a required
-## check that dies is worse than one that costs. --max-cost-usd still
-## re-budgets one run.
+## check that dies is worse than one that costs. The effective ceiling is
+## 0.9 × cap (the engine refuses new nodes at 90%, no grace on that band),
+## so 48 leaves ~$43 usable with the measured $36 — a lower bound, the run
+## died there — at 75%. The pacer monitor follows (cost_gt 8 → 32, ~2/3 of
+## the cap). --max-cost-usd still re-budgets one run.
 ## 0.8.0 — REVIEW TIERS (SocialGouv/iterion#685): a repo's criticality or
 ## budget policy picks ONE preset (`review_tier`: glance | guard | audit)
 ## instead of five separate vars. guard is the DEFAULT and is

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,13 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.8.0
+version: 0.8.1
+## 0.8.1 — budget max_cost_usd 12 → 40: the guard tier died at $36 and $30
+## on a 7-file PR, twice on one revision (the automatic relaunch included),
+## and the merge gate posted no verdict. A review that reproduces its
+## findings and answers the fixer's rounds is the workload now; a required
+## check that dies is worse than one that costs. --max-cost-usd still
+## re-budgets one run.
 ## 0.8.0 — REVIEW TIERS (SocialGouv/iterion#685): a repo's criticality or
 ## budget policy picks ONE preset (`review_tier`: glance | guard | audit)
 ## instead of five separate vars. guard is the DEFAULT and is

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -10,7 +10,10 @@ version: 0.8.1
 ## 0.9 × cap (the engine refuses new nodes at 90%, no grace on that band),
 ## so 48 leaves ~$43 usable with the measured $36 — a lower bound, the run
 ## died there — at 75%. The pacer monitor follows (cost_gt 8 → 32, ~2/3 of
-## the cap). --max-cost-usd still re-budgets one run.
+## the cap, on 12 evals / 6m instead of 4 / 5m so it is still awake near
+## the wall). max_duration 90m → 120m: the same 90% wall applies to the
+## duration axis, and a review funded to ~$43 runs 45-60 min.
+## --max-cost-usd / --max-duration still re-budget one run.
 ## 0.8.0 — REVIEW TIERS (SocialGouv/iterion#685): a repo's criticality or
 ## budget policy picks ONE preset (`review_tier`: glance | guard | audit)
 ## instead of five separate vars. guard is the DEFAULT and is

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -8,6 +8,23 @@ pr_url` it also posts an inline forge review and an optional deterministic
 commit-status gate. Never edits or commits. See
 [bots/review-pr/](../../bots/review-pr/).
 
+## 2026-09-05 — two guard-tier reviews die at the cost cap, no verdict (#780, #785)
+
+- Runs: `01a072d6-24ab` (#780, head `4aee1d641`) — `budget exceeded: cost_usd (36/12)`,
+  superseded by the automatic relaunch `01a072eb-067d`, itself dead at `(30/12)`;
+  #785 (head `ecca4b03c`) dead at `(14/12)`. Push → final failure status: 84 min
+  for the two runs of #780, 53 min for #785 (the runs are not in the campaign
+  store; the timestamps are the head commit and the `revi/review` status).
+- Outcome: the merge gate posted a synthetic `failure` twice with no review — a
+  7-file PR and a 12-file one (7 of them vendor), both open since.
+- Reading: the cap (12, sized 2026-09-03 on median $3.6 / p95 $10.5) is 3× short
+  of the guard tier that reproduces its findings and answers the fixer's rounds;
+  the engine refuses new nodes at 90% of the cap with no grace, so the usable
+  spend was $10.8 — and the $36 is a lower bound (the run died there).
+- Change: `max_cost_usd` 12 → 48 (0.9 × 48 = $43 usable), `max_duration` 90m →
+  120m (same wall on the duration axis), pacer 12 evals / 6m with `cost_gt=32`
+  (manifest 0.8.1). Re-run on both PRs after the catalogue is deployed.
+
 ## 2026-09-05 — review tiers shipped (0.8.0, SocialGouv/iterion#685) — design note, live measurement pending
 - Status: implemented + covered by DSL-level tests (stub executor + expr-level
   unit tests); **not yet dogfooded live** — no LLM credentials in this


### PR DESCRIPTION
## Measured

The merge gate `revi/review` died twice on one revision of a 7-file PR (#780) — `budget exceeded: cost_usd (36/12)`, then `(30/12)` on the automatic relaunch — and posted no verdict; #785 died the same way. Both PRs are dead on a required check that says, in its own words, that a run budget too short for the workload is a structural problem.

## Fix

`bots/review-pr/main.bot`: `max_cost_usd` 12 → 48. The cap was sized on a 2026-09-03 sample (median $3.6, p95 $10.5); the guard tier that reproduces its findings and answers the fixer's rounds costs three times that now. A required check that dies is worse than one that costs. The per-run `--max-cost-usd` override stays for a deliberate deep review; the comment carries both measurements.

Deploy: the server compiles the catalogue at launch, so the new cap applies after a server restart; the two dead PRs then need a push or the bot's re-run command.


## First round (two findings, both reproduced against the engine)

- **A cap of 40 left the measured worst case inside the engine's 90% wall** (high): the engine refuses any new node once an axis sits at 90% of its cap, with no grace on that band, so $36 was the usable spend — the very figure the change was sized on, and a lower bound, since that run died there before paying for converge and publish. The cap is 48: $36 sits at 75%, about $43 is usable, and the comment says the effective ceiling is 0.9 × cap.
- **The pacer's absolute trigger was still calibrated to the old cap** (medium): `cost_gt=8` was two thirds of 12 and 20% of the new cap — it would have spent its four evals in the cheap early phase and gone silent near the wall. It follows the cap at two thirds: `cost_gt=32`.

Open questions, answered:

- *Was $36 the completed cost or the spend at the kill?* At the kill: `budget exceeded: cost_usd (36/12)` is the check that stopped the run; the true workload is above it, which the 48 accounts for.
- *A platform ceiling below the cap?* To check on the deployment before the restart: a clamped cap (`CapImposed`) refuses the exit grace entirely, so a ceiling under 48 would make the raise worse than the 12 on the delivery path. Handed to the operator with the deploy.
- *The org monthly quota at 3.3× the cap?* Unmeasured here; the launch gate refusing is at least a verdict, unlike a run dying mid-graph.
- *Deploy path and the two dead PRs.* Either a platform bot override (`iterion remote admin bots push`, immediate) or the image rollout plus a server restart; the operator picks the window. #780 and #785 then need a push or the bot's re-run command — tracked in the campaign's handover.


## Second round (two findings, both reproduced against the engine)

- **The pacer's eval budget ran out before its trigger could match** (medium): four evals on a five-minute cooldown are spent in the cheap early phase — the coordinator refuses every wake once the budget is exhausted, monitor matches included — so `cost_gt=32` fired into silence. Twelve evals on six minutes keep the pacer awake near the wall.
- **The duration axis has the same 90% wall** (medium): 90m refused new nodes at 81 min, and the reviews this raise funds run longer. The two deaths ran ~40 min each (push → final status: 84 min for the two runs of #780, 53 min for #785; the runs themselves are on the forge team's store, not readable here); a review funded to ~$43 may run 45-60 min. `max_duration` 90m → 120m keeps its 108-minute wall clear.
- The two deaths are in `docs/bot-runs/review-pr.md` now — run ids, approximate wall-clock, outcomes, the sizing they led to — where the repo keeps a bot's evidence.

Open questions, answered:

- *Wall-clock of the deaths.* Above; approximate, from the head commit and the status timestamps.
- *A platform ceiling under 48.* Verified on the deployment by the operator: limits disabled, no cost ceiling variable — the cap will not be clamped.
- *A `glance` review carrying the same ceiling.* The budget block is a compile-time literal, not tier-varied by the DSL; a runaway glance is bounded by the same cap as before relative to its own spend (its reviewer is the cheaper model); a per-tier budget is a DSL change, out of scope.
- *The org monthly quota at a 4× cap.* Unmeasured; a launch-gate refusal is a verdict, a mid-graph death is not.
- *The bilan entry.* Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
