### PR TITLE
fix(server,trigger,cloudsched): the trigger spine and cron schedules launch through the org gate, and an emit meters what it fans out to

### DIFF
--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -56,10 +56,10 @@ exists, so nothing was consumed):
 | Inbound webhooks, **board mode** (the command creates a card; the dispatcher launches it) | the token's | pre-check only, at card creation | **no** — a card is not a run; the pre-check's slot is handed back at once and the dispatcher meters the launch when it claims the card |
 | **Board dispatcher** (`processBoardCard`) | `board-dispatcher` on the card's team | yes | yes, rolled back on a refused launch |
 | Retry sweeper (automatic resume of a `failed_resumable` run) | the run's owner | yes | yes, rolled back on a failed resume |
-| `POST /api/v1/triggers/emit` (custom event) | the caller's | once per request | once per request — the launches it fans out to go through the spine launcher below |
-| Trigger spine direct launches (`serviceLauncher`: `mode: direct` board triggers, run-completion chains, the emit fan-out) | store tenant only, no auth identity | **no** | no |
-| `cloudsched` scheduled launches (`launchScheduledBot`) | store tenant only, no auth identity | **no** | no |
-| Local mode (`iterion studio` / `iterion dispatch` with no identity store) | — | no gate exists | — |
+| `POST /api/v1/triggers/emit` (custom event) | the caller's | pre-check only, per request | **no** — an emit is one EVENT and fans out to 0..N launches; the pre-check's slot is handed back at once and the spine meters each launch it performs |
+| Trigger spine direct launches (`serviceLauncher`: `mode: direct` board triggers, run-completion chains, the emit fan-out, the local schedule source) | `trigger-spine` on the subscription's team | yes | yes, rolled back on a refused launch |
+| `cloudsched` scheduled launches (`launchScheduledBot`) | `cloud-scheduler` on the schedule's team | yes | yes, rolled back on a refused launch |
+| Local mode (`iterion studio` / `iterion dispatch` with no identity store, the pipelines admission) | — | no gate exists | — |
 
 On the board dispatcher a denial is a **launch refusal** of the
 dispatcher's transient class, not a verdict on the card
@@ -72,6 +72,19 @@ ready cards on the backoff schedule, not on every 5s tick. A cap that
 does not free within the attempt cap files the card `blocked` under
 `launch_given_up` with the rule on it, and the pipeline board shows it
 in its *Needs attention* lane.
+
+On the two surfaces that have no request to answer, a denial is recorded
+where an operator reads it, never skipped in silence:
+
+- a **trigger subscription** carries `last_error` + `last_error_at`
+  (`GET /api/v1/triggers`, `iterion remote triggers list`), raised by the
+  refusal and cleared by the next launch that goes through;
+- a **schedule** carries the same two fields
+  (`GET /api/teams/{id}/schedules`, `iterion remote schedules list`), plus
+  the tick-audit row the ticker already wrote.
+
+Both are targeted field writes on both store twins, so an operator editing
+the row between the match and the record does not lose the edit.
 
 ## Limits, fields and platform defaults
 

--- a/pkg/cloudsched/cloudsched_test.go
+++ b/pkg/cloudsched/cloudsched_test.go
@@ -305,6 +305,30 @@ func TestMongoStore_CAS(t *testing.T) {
 		t.Errorf("post-claim state: %+v", got)
 	}
 
+	// Launch health, the twin of MemoryStore.MarkLaunchError: a targeted
+	// $set/$unset on the two fields, round-tripped, and ErrNotFound for a
+	// row that is gone.
+	if err := store.MarkLaunchError(ctx, "sb-1", "launch gate: concurrency_cap_exceeded", now); err != nil {
+		t.Fatalf("MarkLaunchError: %v", err)
+	}
+	got, _ = store.Get(ctx, "sb-1")
+	if got.LastError != "launch gate: concurrency_cap_exceeded" || got.LastErrorAt == nil {
+		t.Errorf("launch health after a refusal = (%q, %v), want the message and its instant", got.LastError, got.LastErrorAt)
+	}
+	if !got.NextFireAt.Equal(newNext) {
+		t.Errorf("next_fire_at = %v after the health write, want %v — a $set must not disturb the CAS field", got.NextFireAt, newNext)
+	}
+	if err := store.MarkLaunchError(ctx, "sb-1", "", now); err != nil {
+		t.Fatalf("MarkLaunchError(clear): %v", err)
+	}
+	got, _ = store.Get(ctx, "sb-1")
+	if got.LastError != "" || got.LastErrorAt != nil {
+		t.Errorf("launch health after a clear = (%q, %v), want empty", got.LastError, got.LastErrorAt)
+	}
+	if err := store.MarkLaunchError(ctx, "ghost", "boom", now); !errors.Is(err, ErrNotFound) {
+		t.Errorf("MarkLaunchError on an unknown id = %v, want ErrNotFound", err)
+	}
+
 	if err := store.Delete(ctx, "sb-1"); err != nil {
 		t.Errorf("Delete: %v", err)
 	}

--- a/pkg/cloudsched/memory.go
+++ b/pkg/cloudsched/memory.go
@@ -68,6 +68,19 @@ func (s *MemoryStore) ClaimTick(_ context.Context, id string, expectedNext, newN
 	return won, nil
 }
 
+func (s *MemoryStore) MarkLaunchError(_ context.Context, id, lastError string, at time.Time) error {
+	_, err := s.kit.Mutate(id, func(sb *ScheduledBot) bool {
+		sb.LastError = lastError
+		sb.LastErrorAt = nil
+		if lastError != "" {
+			t := at.UTC()
+			sb.LastErrorAt = &t
+		}
+		return true
+	})
+	return err
+}
+
 func (s *MemoryStore) Update(_ context.Context, id string, patch SchedulePatch) (ScheduledBot, error) {
 	var out ScheduledBot
 	if _, err := s.kit.Mutate(id, func(sb *ScheduledBot) bool {

--- a/pkg/cloudsched/mongo.go
+++ b/pkg/cloudsched/mongo.go
@@ -84,6 +84,25 @@ func (s *MongoStore) ClaimTick(ctx context.Context, id string, expectedNext, new
 	return res.MatchedCount > 0, nil
 }
 
+// MarkLaunchError sets (or clears) the schedule's launch health with a
+// targeted field write — never the full-replace Update below uses, because the
+// ticker's copy is the one ListDue returned and an operator may have retuned
+// the row since.
+func (s *MongoStore) MarkLaunchError(ctx context.Context, id, lastError string, at time.Time) error {
+	update := bson.M{"$set": bson.M{"last_error": lastError, "last_error_at": at.UTC()}}
+	if lastError == "" {
+		update = bson.M{"$unset": bson.M{"last_error": "", "last_error_at": ""}}
+	}
+	res, err := s.kit.Coll().UpdateOne(ctx, bson.M{"_id": id}, update)
+	if err != nil {
+		return fmt.Errorf("cloudsched: mark launch error: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // Update applies a partial mutation. Reads the current row, mutates it via
 // applySchedulePatch, and writes back via ReplaceOne — the atomicity that
 // matters here is exactly-once fire (ClaimTick's CAS), not multi-writer

--- a/pkg/cloudsched/schedule.go
+++ b/pkg/cloudsched/schedule.go
@@ -66,6 +66,16 @@ type ScheduledBot struct {
 	NextFireAt time.Time  `bson:"next_fire_at" json:"next_fire_at"`
 	LastFireAt *time.Time `bson:"last_fire_at,omitempty" json:"last_fire_at,omitempty"`
 
+	// LastError is the verdict of the last tick that consumed a slot: empty
+	// means the launch went through, a message says why it did not (an org
+	// launch-gate denial, a run service that refused the run). LastErrorAt is
+	// when that verdict was recorded. Both are rendered by
+	// GET /api/teams/{id}/schedules and `iterion remote schedules list`, so a
+	// schedule that stopped producing runs is visible to its operator instead
+	// of living only in a replica's log.
+	LastError   string     `bson:"last_error,omitempty" json:"last_error,omitempty"`
+	LastErrorAt *time.Time `bson:"last_error_at,omitempty" json:"last_error_at,omitempty"`
+
 	CreatedBy string    `bson:"created_by,omitempty" json:"created_by,omitempty"`
 	CreatedAt time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
@@ -89,6 +99,12 @@ type Store interface {
 	// THIS caller won the CAS. A losing replica gets (false, nil). This is the
 	// exactly-once primitive — no leader election.
 	ClaimTick(ctx context.Context, id string, expectedNext, newNext, firedAt time.Time) (bool, error)
+	// MarkLaunchError records the verdict of the tick that just consumed a
+	// slot: a non-empty message raises last_error with its instant, "" clears
+	// both. A TARGETED field write, never a read-modify-replace: the ticker
+	// holds the copy ListDue returned, and an operator retuning the schedule
+	// in between must not lose the edit to a health write.
+	MarkLaunchError(ctx context.Context, id, lastError string, at time.Time) error
 	// Update applies a partial mutation to an existing schedule. Only the
 	// non-nil fields of patch are written; NextFireAt is recomputed from the
 	// new Cron when Cron is set.

--- a/pkg/cloudsched/ticker.go
+++ b/pkg/cloudsched/ticker.go
@@ -102,6 +102,7 @@ func (t *Ticker) Tick(ctx context.Context) (int, error) {
 		if lerr != nil {
 			t.warn("launch %s (%s): %v", sb.ID, sb.BotID, lerr)
 		}
+		t.recordLaunchVerdict(ctx, sb, lerr, now)
 		if t.Audit != nil {
 			rec := schedgate.NewTickRecord(schedgate.SurfaceCloud, sb.ID, now, schedgate.LaunchDecision(lerr))
 			rec.ScheduleName = sb.BotID
@@ -115,6 +116,25 @@ func (t *Ticker) Tick(ctx context.Context) (int, error) {
 		}
 	}
 	return fired, nil
+}
+
+// recordLaunchVerdict persists on the schedule itself what became of the tick
+// that just consumed its slot: a refusal — an org launch-gate denial above all
+// — raises last_error, and the next tick that launches clears it. Written only
+// when the verdict CHANGES, so a schedule that has been refused for a week
+// costs one write, not one per minute. A failed write is logged, never fatal:
+// the slot is already consumed and the audit row still carries the error.
+func (t *Ticker) recordLaunchVerdict(ctx context.Context, sb ScheduledBot, launchErr error, now time.Time) {
+	msg := ""
+	if launchErr != nil {
+		msg = launchErr.Error()
+	}
+	if msg == sb.LastError {
+		return
+	}
+	if err := t.Store.MarkLaunchError(ctx, sb.ID, msg, now); err != nil {
+		t.warn("recording the launch verdict of %s: %v", sb.ID, err)
+	}
 }
 
 // Run loops Tick every Interval until ctx is cancelled. Start one per replica.

--- a/pkg/cloudsched/ticker_health_test.go
+++ b/pkg/cloudsched/ticker_health_test.go
@@ -1,0 +1,101 @@
+package cloudsched
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// A tick that could not launch — an org launch-gate denial above all — must be
+// readable on the schedule itself. Before this the only trace was one Warn in
+// whichever replica happened to win the CAS, so a schedule silently stopped
+// producing runs and `iterion remote schedules list` still showed it healthy.
+
+func dueSchedule(t *testing.T, s Store, now time.Time) ScheduledBot {
+	t.Helper()
+	sb := ScheduledBot{ID: "sb-1", TenantID: "t1", BotID: "probe", Cron: "* * * * *", NextFireAt: now.Add(-time.Minute)}
+	if err := s.Create(context.Background(), sb); err != nil {
+		t.Fatal(err)
+	}
+	return sb
+}
+
+func TestTicker_LaunchRefusalLandsOnTheSchedule(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStore()
+	now := time.Now().UTC()
+	dueSchedule(t, st, now)
+	refusal := errors.New("launch gate: concurrency_cap_exceeded: org has 3 active runs (cap 3)")
+	tk := &Ticker{
+		Store:  st,
+		Launch: func(context.Context, ScheduledBot) error { return refusal },
+		Now:    func() time.Time { return now },
+	}
+
+	if fired, err := tk.Tick(ctx); err != nil || fired != 1 {
+		t.Fatalf("Tick = (%d, %v), want (1, nil)", fired, err)
+	}
+	got, err := st.Get(ctx, "sb-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastError == "" {
+		t.Fatal("the refused tick left no last_error on the schedule — the operator has nothing to read but a pod log")
+	}
+	if got.LastError != refusal.Error() {
+		t.Errorf("last_error = %q, want the refusal verbatim %q", got.LastError, refusal.Error())
+	}
+	if got.LastErrorAt == nil {
+		t.Error("last_error carries no instant — an operator cannot tell today's refusal from last month's")
+	}
+}
+
+func TestTicker_ATickThatLaunchesClearsTheFlag(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStore()
+	now := time.Now().UTC()
+	dueSchedule(t, st, now)
+	if err := st.MarkLaunchError(ctx, "sb-1", "launch gate: monthly_run_quota_exceeded", now.Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	tk := &Ticker{
+		Store:  st,
+		Launch: func(context.Context, ScheduledBot) error { return nil },
+		Now:    func() time.Time { return now },
+	}
+
+	if _, err := tk.Tick(ctx); err != nil {
+		t.Fatalf("Tick = %v, want nil", err)
+	}
+	got, _ := st.Get(ctx, "sb-1")
+	if got.LastError != "" || got.LastErrorAt != nil {
+		t.Errorf("a tick that launched left last_error=%q at=%v — a stale refusal reads as a live one", got.LastError, got.LastErrorAt)
+	}
+}
+
+// The health write is targeted: an operator retuning the cron between the CAS
+// and the record must not lose the edit to it.
+func TestMemoryStore_MarkLaunchErrorDoesNotClobberAnEdit(t *testing.T) {
+	ctx := context.Background()
+	st := NewMemoryStore()
+	now := time.Now().UTC()
+	dueSchedule(t, st, now)
+	cron := "0 4 * * *"
+	if _, err := st.Update(ctx, "sb-1", SchedulePatch{Cron: &cron, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MarkLaunchError(ctx, "sb-1", "boom", now); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := st.Get(ctx, "sb-1")
+	if got.Cron != cron {
+		t.Errorf("cron = %q, want %q — the health write replaced the row instead of setting its two fields", got.Cron, cron)
+	}
+	if got.LastError != "boom" || got.LastErrorAt == nil {
+		t.Errorf("health = (%q, %v), want (\"boom\", set)", got.LastError, got.LastErrorAt)
+	}
+	if err := st.MarkLaunchError(ctx, "ghost", "boom", now); !errors.Is(err, ErrNotFound) {
+		t.Errorf("MarkLaunchError on an unknown id = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/server/schedules_launch_gate_test.go
+++ b/pkg/server/schedules_launch_gate_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/cloudsched"
+	"github.com/SocialGouv/iterion/pkg/identity"
+	"github.com/SocialGouv/iterion/pkg/orgusage"
+)
+
+// A cloud schedule is a launch like any other (#844): before this, a team
+// could schedule its way around every cap — the tick launched with neither
+// admission nor metering, so a suspended org, an org at its concurrency cap
+// and an org past its monthly quota all kept firing every cron slot for free.
+
+func scheduledBot(tenant string) cloudsched.ScheduledBot {
+	return cloudsched.ScheduledBot{
+		ID: "sb-1", TenantID: tenant, BotID: "probe", Cron: "* * * * *",
+		NextFireAt: time.Now().UTC(),
+	}
+}
+
+func TestLaunchScheduledBot_GateDenialRefusesTheTick(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", maxConcurrentRuns: 1}, pub)
+	s.cfg.Store = fakeActiveStore{RunStore: s.cfg.Store, active: 1}
+
+	err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1"))
+	var deny *launchDeniedError
+	if !errors.As(err, &deny) || deny.Reason != denyConcurrencyCap {
+		t.Fatalf("launchScheduledBot = %v, want the gate's typed %s denial", err, denyConcurrencyCap)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("the run service was asked %d time(s) at the org's concurrency cap, want 0", got)
+	}
+}
+
+func TestLaunchScheduledBot_SuspendedTeamCannotFire(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", teamStatus: identity.TeamStatusSuspended}, pub)
+
+	err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1"))
+	var deny *launchDeniedError
+	if !errors.As(err, &deny) || deny.Reason != denyOrgSuspended {
+		t.Fatalf("launchScheduledBot = %v, want the gate's typed %s denial", err, denyOrgSuspended)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("a suspended team fired %d scheduled run(s), want 0", got)
+	}
+}
+
+func TestLaunchScheduledBot_MetersTheTickAndRollsBackARefusal(t *testing.T) {
+	t.Run("fired tick meters one slot", func(t *testing.T) {
+		pub := &spinePublisher{}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+
+		if err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1")); err != nil {
+			t.Fatalf("launchScheduledBot = %v, want nil", err)
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 1 {
+			t.Errorf("monthly runs = %d after one scheduled launch, want 1", u.Runs)
+		}
+	})
+	t.Run("refused launch releases the slot", func(t *testing.T) {
+		pub := &spinePublisher{err: errors.New("cloudpublisher: queue unavailable")}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+
+		if err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1")); err == nil {
+			t.Fatal("launchScheduledBot = nil, want the run service's refusal")
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 0 {
+			t.Errorf("monthly runs = %d after a refused launch, want 0", u.Runs)
+		}
+	})
+	t.Run("the quota is enforced, not just counted", func(t *testing.T) {
+		pub := &spinePublisher{}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 1}, pub)
+		s.orgUsage = orgusage.NewMemoryCounter()
+
+		if err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1")); err != nil {
+			t.Fatalf("first tick = %v, want nil", err)
+		}
+		err := s.launchScheduledBot(spineCtx(t), scheduledBot("t1"))
+		var deny *launchDeniedError
+		if !errors.As(err, &deny) || deny.Reason != denyMonthlyRunQuota {
+			t.Fatalf("second tick = %v, want the gate's typed %s denial", err, denyMonthlyRunQuota)
+		}
+		if got := pub.count(); got != 1 {
+			t.Errorf("the run service was asked %d time(s) for a quota of 1, want 1", got)
+		}
+	})
+}

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -137,7 +137,7 @@ func (s *Server) ListenAndServe() error {
 		}
 		var launcher trigger.Launcher
 		if s.runs != nil {
-			launcher = newServiceLauncher(s.runs, s.logger, s.resolveRunRetryPolicy, s.resolveBotSource)
+			launcher = s.triggerLauncher()
 		}
 		s.triggerCoord = StartTriggerCoordinator(s.cfg.NativeTrackerStore, s.cfg.TriggerStore, nudger, launcher, s.scheduleGate(), s.cfg.EventsBus, s.logger)
 	}
@@ -149,7 +149,7 @@ func (s *Server) ListenAndServe() error {
 	if s.cfg.NativeTrackerStore == nil && s.cfg.CloudBoardCoordinator != nil && s.cfg.TriggerStore != nil && s.runs != nil {
 		s.cloudTriggerCoord = StartCloudTriggerCoordinator(
 			s.cfg.CloudBoardCoordinator, s.cfg.TriggerStore,
-			newServiceLauncher(s.runs, s.logger, s.resolveRunRetryPolicy, s.resolveBotSource),
+			s.triggerLauncher(),
 			s.boardProjection(), s.cfg.EventsBus, s.logger)
 	}
 	// Wire the run-completion source onto the process's single event spine

--- a/pkg/server/trigger_launcher.go
+++ b/pkg/server/trigger_launcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -32,10 +33,30 @@ type serviceLauncher struct {
 	// second, override-blind resolution path here is exactly what the
 	// resolver sweep forbids.
 	resolveBot func(ctx context.Context, botID string) (*launchBot, error)
+	// gate is the server's shared launch admission (suspend → concurrency →
+	// launch rate → monthly caps), injected for the same no-*Server reason.
+	// REQUIRED: a direct launch that skipped it would be the one cloud
+	// launch nobody metered.
+	gate func(ctx context.Context) (*launchAdmission, *launchDenial)
 }
 
-func newServiceLauncher(runs *runview.Service, logger *iterlog.Logger, resolveRetry func(string, ...retrypolicy.Layer) *store.RunRetryPolicy, resolveBot func(context.Context, string) (*launchBot, error)) *serviceLauncher {
-	return &serviceLauncher{runs: runs, logger: logger, resolveRetry: resolveRetry, resolveBot: resolveBot}
+// triggerSpineActor is the identity the trigger spine launches under: the
+// store owner on the ctx it stamps and the auth principal the launch gate
+// meters on the subscription's team.
+const triggerSpineActor = "trigger-spine"
+
+// triggerLauncher builds the spine's direct-mode launcher — the ONE
+// construction site, shared by the local and the cloud coordinator, so a
+// capability wired here (the launch gate) cannot be wired on one spine and
+// missing on the other.
+func (s *Server) triggerLauncher() *serviceLauncher {
+	return &serviceLauncher{
+		runs:         s.runs,
+		logger:       s.logger,
+		resolveRetry: s.resolveRunRetryPolicy,
+		resolveBot:   s.resolveBotSource,
+		gate:         s.gateLaunch,
+	}
 }
 
 func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (string, error) {
@@ -55,14 +76,32 @@ func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (
 	if l.resolveBot == nil {
 		return "", errors.New("trigger: no bot resolver wired for direct launch")
 	}
+	if l.gate == nil {
+		return "", errors.New("trigger: no launch gate wired for direct launch")
+	}
+	// The subscription owns the team, so the spine launches AS that team: the
+	// store identity scopes the run and seals its credentials, and the auth
+	// identity is what the gate reads to find the caps to apply.
+	ctx = store.WithIdentity(ctx, plan.TenantID, triggerSpineActor)
 	lb, err := l.resolveBot(ctx, plan.BotID)
 	if err != nil {
 		return "", fmt.Errorf("trigger: resolve bot %q: %w", plan.BotID, err)
 	}
 	defer lb.Cleanup()
 	lb.Stamp(&spec)
+	// The SAME admission every other launch surface passes — suspend →
+	// concurrency → launch rate → monthly caps. The denial travels up as the
+	// effect's error: the evaluator records it on the subscription (its
+	// last_error) and the outbox retries it on the backoff.
+	adm, deny := l.gate(auth.WithIdentity(ctx, auth.Identity{TeamID: plan.TenantID, UserID: triggerSpineActor}))
+	if deny != nil {
+		return "", deny.err()
+	}
 	res, err := l.runs.Launch(ctx, spec)
 	if err != nil {
+		// Every error out of Launch means no run started, so the metered slot
+		// goes back — as the HTTP handler does.
+		adm.rollback(l.logger)
 		return "", err
 	}
 	return res.RunID, nil

--- a/pkg/server/trigger_launcher_gate_test.go
+++ b/pkg/server/trigger_launcher_gate_test.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/identity"
+	"github.com/SocialGouv/iterion/pkg/orgusage"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// The trigger spine's direct launches (#844) — a `mode: direct` board
+// trigger, a run-completion chain, the emit fan-out — pass the SAME admission
+// every other cloud launch surface passes, under the subscription's own team,
+// and meter the same monthly slot. Before this the spine was a hole through
+// which an org launched past its suspend, its concurrency cap, its launch rate
+// and its monthly caps, unmetered and under no tenant at all.
+
+// spinePublisher records what each launch was published under and how many
+// launches were attempted — the oracle for "the run service was never asked".
+type spinePublisher struct {
+	mu       sync.Mutex
+	launches int
+	err      error
+	tenant   string
+	owner    string
+}
+
+func (p *spinePublisher) SubmitLaunch(ctx context.Context, _ string, _ runview.LaunchSpec, _ *ir.Workflow, _ string) (int, error) {
+	p.mu.Lock()
+	p.launches++
+	p.tenant, _ = store.TenantFromContext(ctx)
+	p.owner, _ = store.OwnerFromContext(ctx)
+	p.mu.Unlock()
+	return 0, p.err
+}
+
+func (p *spinePublisher) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.launches
+}
+
+func (*spinePublisher) CancelRun(context.Context, string) error { return nil }
+func (*spinePublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
+	return nil
+}
+func (*spinePublisher) SubmitResume(context.Context, runview.ResumeSpec, *ir.Workflow, string) error {
+	return nil
+}
+
+const spineProbeBot = "schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"yes\"}'`\n  output: probe_out\n\nworkflow spine_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n"
+
+// newGatedSpineServer is a cloud-shaped server carrying one org+team, the
+// probe bot in its catalog, and a run service whose publisher is the caller's.
+func newGatedSpineServer(t *testing.T, spec gateSpec, pub *spinePublisher) *Server {
+	t.Helper()
+	s := newOrgTestServer(t)
+	seedGate(t, s, spec)
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(spineProbeBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = rs
+	svc, err := runview.NewService("", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.runs = svc
+	return s
+}
+
+func spinePlan(tenant string) trigger.LaunchPlan {
+	return trigger.LaunchPlan{
+		BotID:    "probe",
+		TenantID: tenant,
+		Mode:     bundle.ExecutionDirect,
+		Event: trigger.Event{
+			ID: "custom:probe:1", Source: trigger.SourceCustom, Kind: "probe",
+			TenantID: tenant, OccurredAt: time.Now().UTC(),
+		},
+	}
+}
+
+func spineCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestServiceLauncher_GateDenialRefusesTheLaunch(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", maxConcurrentRuns: 1}, pub)
+	s.cfg.Store = fakeActiveStore{RunStore: s.cfg.Store, active: 1}
+
+	_, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1"))
+	var deny *launchDeniedError
+	if !errors.As(err, &deny) || deny.Reason != denyConcurrencyCap {
+		t.Fatalf("Launch = %v, want the gate's typed %s denial", err, denyConcurrencyCap)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("the run service was asked %d time(s) at the org's concurrency cap, want 0", got)
+	}
+}
+
+func TestServiceLauncher_SuspendedTeamCannotLaunch(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", teamStatus: identity.TeamStatusSuspended}, pub)
+
+	_, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1"))
+	var deny *launchDeniedError
+	if !errors.As(err, &deny) || deny.Reason != denyOrgSuspended {
+		t.Fatalf("Launch = %v, want the gate's typed %s denial", err, denyOrgSuspended)
+	}
+	if got := pub.count(); got != 0 {
+		t.Errorf("a suspended team launched %d run(s) through the spine, want 0", got)
+	}
+}
+
+func TestServiceLauncher_MetersOnePerLaunchAndRollsBackARefusal(t *testing.T) {
+	t.Run("admitted launch meters one slot", func(t *testing.T) {
+		pub := &spinePublisher{}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+
+		if _, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1")); err != nil {
+			t.Fatalf("Launch = %v, want nil", err)
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 1 {
+			t.Errorf("monthly runs = %d after one spine launch, want 1", u.Runs)
+		}
+	})
+	t.Run("refused launch releases the slot", func(t *testing.T) {
+		pub := &spinePublisher{err: errors.New("cloudpublisher: seal run bundle: kms unavailable")}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 3}, pub)
+		counter := orgusage.NewMemoryCounter()
+		s.orgUsage = counter
+
+		if _, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1")); err == nil {
+			t.Fatal("Launch = nil, want the run service's refusal")
+		}
+		u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+		if u.Runs != 0 {
+			t.Errorf("monthly runs = %d after a refused launch, want 0 — a run that never started consumes no slot", u.Runs)
+		}
+	})
+	t.Run("the quota is enforced, not just counted", func(t *testing.T) {
+		pub := &spinePublisher{}
+		s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 1}, pub)
+		s.orgUsage = orgusage.NewMemoryCounter()
+
+		if _, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1")); err != nil {
+			t.Fatalf("first Launch = %v, want nil", err)
+		}
+		_, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1"))
+		var deny *launchDeniedError
+		if !errors.As(err, &deny) || deny.Reason != denyMonthlyRunQuota {
+			t.Fatalf("second Launch = %v, want the gate's typed %s denial", err, denyMonthlyRunQuota)
+		}
+		if got := pub.count(); got != 1 {
+			t.Errorf("the run service was asked %d time(s) for a quota of 1, want 1", got)
+		}
+	})
+}
+
+// The plan's tenant is the run's tenant: the spine launches on behalf of a
+// subscription that names its team, and the publisher reads that team off the
+// ctx to scope the run and seal its credentials. Launching under the empty
+// tenant leaves a cloud run belonging to nobody.
+func TestServiceLauncher_StampsThePlansTenantOnTheRun(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1"}, pub)
+
+	if _, err := s.triggerLauncher().Launch(spineCtx(t), spinePlan("t1")); err != nil {
+		t.Fatalf("Launch = %v, want nil", err)
+	}
+	if pub.tenant != "t1" {
+		t.Errorf("the run was published under tenant %q, want %q", pub.tenant, "t1")
+	}
+	if pub.owner != triggerSpineActor {
+		t.Errorf("the run was published under owner %q, want %q", pub.owner, triggerSpineActor)
+	}
+}

--- a/pkg/server/triggers_emit_gate_test.go
+++ b/pkg/server/triggers_emit_gate_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/eventbus"
+	"github.com/SocialGouv/iterion/pkg/orgusage"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// POST /api/v1/triggers/emit publishes ONE event that fans out to however many
+// subscriptions match it — zero, one or ten. Charging the request a monthly run
+// slot therefore priced the wrong thing on both sides: an event nobody listens
+// to consumed a slot, and ten launches consumed one. The request keeps the
+// admission as a PRE-CHECK (a suspended org still gets its 403 synchronously)
+// but hands its slot back at once; the spine meters each launch it performs.
+
+func emitRequest(t *testing.T, s *Server, ctx context.Context, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/triggers/emit", strings.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.handleEmitTrigger(rec, req)
+	return rec
+}
+
+func TestEmitTrigger_FanOutToNothingMetersNothing(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 5}, pub)
+	counter := orgusage.NewMemoryCounter()
+	s.orgUsage = counter
+	s.cfg.TriggerStore = trigger.NewMemorySubscriptionStore()
+	s.cfg.EventsBus = eventbus.NewInProcBus(s.logger)
+	ctx := gatedTeamCtx("t1")
+
+	rec := emitRequest(t, s, ctx, `{"kind":"probe"}`)
+	if rec.Code != 202 {
+		t.Fatalf("emit = %d %s, want 202", rec.Code, rec.Body.String())
+	}
+	u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+	if u.Runs != 0 {
+		t.Errorf("monthly runs = %d after an emit that launched nothing, want 0", u.Runs)
+	}
+}
+
+// A suspended org still gets a synchronous refusal: the pre-check stays, only
+// its metered slot is released.
+func TestEmitTrigger_DeniedOrgIsRefusedSynchronously(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", maxConcurrentRuns: 1}, pub)
+	s.cfg.Store = fakeActiveStore{active: 1}
+	s.cfg.TriggerStore = trigger.NewMemorySubscriptionStore()
+	s.cfg.EventsBus = eventbus.NewInProcBus(s.logger)
+	ctx := gatedTeamCtx("t1")
+
+	rec := emitRequest(t, s, ctx, `{"kind":"probe"}`)
+	if rec.Code != 429 || !strings.Contains(rec.Body.String(), denyConcurrencyCap) {
+		t.Fatalf("emit = %d %s, want 429 %s", rec.Code, rec.Body.String(), denyConcurrencyCap)
+	}
+}
+
+// N matching subscriptions = N launches = N metered slots. Driven through the
+// evaluator directly (the bus worker is asynchronous; the metering claim is
+// about the fan-out, not about delivery timing).
+func TestEmitFanOut_MetersOneSlotPerLaunch(t *testing.T) {
+	pub := &spinePublisher{}
+	s := newGatedSpineServer(t, gateSpec{id: "t1", orgRunQuota: 5}, pub)
+	counter := orgusage.NewMemoryCounter()
+	s.orgUsage = counter
+	subs := trigger.NewMemorySubscriptionStore()
+	for _, id := range []string{"sub-a", "sub-b"} {
+		if err := subs.Create(context.Background(), trigger.Subscription{
+			ID: id, TenantID: "t1", BotID: "probe",
+			Invocation: bundle.InvocationKindBoard, Mode: bundle.ExecutionDirect,
+			Match:   trigger.Matcher{Sources: []trigger.Source{trigger.SourceCustom}},
+			Enabled: true, CreatedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	eval := trigger.NewEvaluator(subs, trigger.WithLauncher(s.triggerLauncher()))
+
+	ev := trigger.Event{ID: "custom:probe:1", TenantID: "t1", Source: trigger.SourceCustom, Kind: "probe", OccurredAt: time.Now().UTC()}
+	if err := eval.Handle(spineCtx(t), ev); err != nil {
+		t.Fatalf("Handle = %v, want nil", err)
+	}
+	if got := pub.count(); got != 2 {
+		t.Fatalf("the fan-out launched %d run(s), want 2", got)
+	}
+	u, _ := counter.Usage(context.Background(), "t1", time.Now().UTC())
+	if u.Runs != 2 {
+		t.Errorf("monthly runs = %d for a fan-out of 2 launches, want 2", u.Runs)
+	}
+}
+
+// gatedTeamCtx is the request context of a signed-in member of the seeded
+// team — what the gate reads to find the org and its caps.
+func gatedTeamCtx(id string) context.Context {
+	return auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: id, OrgID: id})
+}

--- a/pkg/server/triggers_routes.go
+++ b/pkg/server/triggers_routes.go
@@ -212,15 +212,19 @@ func (s *Server) handleEmitTrigger(w http.ResponseWriter, r *http.Request) {
 		dispatcher.WriteErr(w, http.StatusBadRequest, errors.New("kind is required"))
 		return
 	}
-	// Run-launch admission. A custom emit can fan out to N matching
-	// subscriptions, each a launch — gate it exactly like the inbound
-	// webhook path so an authenticated integration can't bypass the
-	// per-org quota / cost cap / rate limit. Fail-open (nil) in local
-	// single-host scope, so this is a no-op there.
-	if _, d := s.gateLaunch(r.Context()); d != nil {
+	// Run-launch admission as a PRE-CHECK: a suspended org, an org at its
+	// concurrency cap or over its monthly caps is refused here and now, with
+	// the same envelope the other surfaces send. The metered slot is handed
+	// back at once — an emit is one EVENT, and it fans out to however many
+	// subscriptions match it (zero, one, ten), each of which the spine
+	// launcher meters as its own launch. Fail-open (nil) in local single-host
+	// scope, so this is a no-op there.
+	adm, d := s.gateLaunch(r.Context())
+	if d != nil {
 		s.writeLaunchDenial(w, r, d)
 		return
 	}
+	adm.rollback(s.logger)
 	payload := map[string]any{}
 	if len(req.Vars) > 0 {
 		total := 0

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -1099,11 +1100,16 @@ func (s *Server) updateWebhookDelivery(ctx context.Context, d webhooks.Delivery)
 	_ = s.webhookDeliveries.Update(ctx, d)
 }
 
+// scheduledLaunchActor is the auth principal a cron tick launches under: the
+// gate meters it on the schedule's own team.
+const scheduledLaunchActor = "cloud-scheduler"
+
 // launchScheduledBot is the cloudsched.LaunchFunc: it launches a recurring bot
-// run for its tenant through the run service (cloud → publisher). The tenant
-// identity is stamped on the ctx so the publisher seals credentials + scopes
-// the run to the org. When the schedule pins a RepoURL, it is threaded onto
-// the LaunchSpec so the runner clones the repo before the bot starts —
+// run for its tenant through the run service (cloud → publisher), past the
+// shared org launch gate. The tenant identity is stamped on the ctx so the
+// publisher seals credentials + scopes the run to the org. When the schedule
+// pins a RepoURL, it is threaded onto the LaunchSpec so the runner clones
+// the repo before the bot starts —
 // mandatory for stateful bots that persist state to git (feed-watch
 // state_commit=true), which need a workspace with push credentials wired.
 // Generic secrets declared by the bot (e.g. `webhooks`) resolve via the
@@ -1130,8 +1136,20 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 	}
 	spec.SecretOverrides = overrides
 	lb.Stamp(&spec)
-	_, err = s.runs.Launch(ctx, spec)
-	return err
+	// The SAME admission every other launch surface passes — suspend →
+	// concurrency → launch rate → monthly caps — on the schedule's own team,
+	// so a cron cadence is not a way around any of them. The denial is
+	// returned so the ticker records it on the schedule and audits the tick;
+	// the metered slot goes back when the run service then refuses.
+	adm, deny := s.gateLaunch(auth.WithIdentity(ctx, auth.Identity{TeamID: sb.TenantID, UserID: scheduledLaunchActor}))
+	if deny != nil {
+		return deny.err()
+	}
+	if _, err = s.runs.Launch(ctx, spec); err != nil {
+		adm.rollback(s.logger)
+		return err
+	}
+	return nil
 }
 
 // scheduledForgeOverrides resolves a repo-bound schedule's forge connection

--- a/pkg/trigger/evaluator.go
+++ b/pkg/trigger/evaluator.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
@@ -212,6 +212,7 @@ func (e *Evaluator) applyEffect(ctx context.Context, sub Subscription, ev Event,
 			}
 		}
 		_, err := e.launcher.Launch(ctx, e.buildPlan(sub, ev))
+		recordLaunchVerdict(ctx, e.subs, e.logger, sub, err)
 		return err
 	}
 }

--- a/pkg/trigger/health.go
+++ b/pkg/trigger/health.go
@@ -1,0 +1,43 @@
+package trigger
+
+import (
+	"context"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// healthWriteTimeout bounds the detached last_error write.
+const healthWriteTimeout = 5 * time.Second
+
+// recordLaunchVerdict persists on the subscription itself what became of the
+// direct launch it just asked for: a refusal — an org launch-gate denial above
+// all — raises last_error, and the next launch that goes through clears it.
+// EVERY direct-launch site in this package calls it (the evaluator's launch
+// arm and the scheduler's tick), because a warn line in one replica's log is
+// not a surface: without this a subscription silently stops producing runs and
+// the triggers API still shows it healthy.
+//
+// Written only when the verdict CHANGES — an outbox retry re-reports the same
+// refusal on every backoff, and this row is read by an operator, not by a hot
+// loop. Failing to write it is logged, never fatal: the launch's own outcome
+// is what the caller is waiting on.
+func recordLaunchVerdict(ctx context.Context, subs SubscriptionStore, logger *iterlog.Logger, sub Subscription, launchErr error) {
+	if subs == nil || sub.ID == "" {
+		return
+	}
+	msg := ""
+	if launchErr != nil {
+		msg = launchErr.Error()
+	}
+	if msg == sub.LastError {
+		return
+	}
+	// Detached ctx: a cancelled parent (this replica draining mid-launch) must
+	// not be what decides whether the operator ever sees the refusal.
+	wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), healthWriteTimeout)
+	defer cancel()
+	if err := subs.MarkLaunchError(wctx, sub.ID, msg, time.Now().UTC()); err != nil && logger != nil {
+		logger.Warn("trigger: recording the launch verdict of subscription %s failed: %v", sub.ID, err)
+	}
+}

--- a/pkg/trigger/memstore.go
+++ b/pkg/trigger/memstore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 )
 
 // MemorySubscriptionStore is the in-memory SubscriptionStore for tests and
@@ -43,6 +44,23 @@ func (m *MemorySubscriptionStore) Update(_ context.Context, s Subscription) erro
 		return ErrSubscriptionNotFound
 	}
 	m.items[s.ID] = s
+	return nil
+}
+
+func (m *MemorySubscriptionStore) MarkLaunchError(_ context.Context, id, lastError string, at time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.items[id]
+	if !ok {
+		return ErrSubscriptionNotFound
+	}
+	s.LastError = lastError
+	s.LastErrorAt = nil
+	if lastError != "" {
+		t := at.UTC()
+		s.LastErrorAt = &t
+	}
+	m.items[id] = s
 	return nil
 }
 

--- a/pkg/trigger/mongostore.go
+++ b/pkg/trigger/mongostore.go
@@ -3,6 +3,7 @@ package trigger
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -51,6 +52,21 @@ func (s *MongoSubscriptionStore) Get(ctx context.Context, id string) (Subscripti
 
 func (s *MongoSubscriptionStore) Update(ctx context.Context, sub Subscription) error {
 	return mongoutil.ReplaceOneChecked(ctx, s.coll, bson.M{"_id": sub.ID}, sub, nil, ErrSubscriptionNotFound, "trigger: update subscription")
+}
+
+func (s *MongoSubscriptionStore) MarkLaunchError(ctx context.Context, id, lastError string, at time.Time) error {
+	update := bson.M{"$set": bson.M{"last_error": lastError, "last_error_at": at.UTC()}}
+	if lastError == "" {
+		update = bson.M{"$unset": bson.M{"last_error": "", "last_error_at": ""}}
+	}
+	res, err := s.coll.UpdateOne(ctx, bson.M{"_id": id}, update)
+	if err != nil {
+		return fmt.Errorf("trigger: mark subscription launch error: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrSubscriptionNotFound
+	}
+	return nil
 }
 
 func (s *MongoSubscriptionStore) Delete(ctx context.Context, id string) error {

--- a/pkg/trigger/scheduler.go
+++ b/pkg/trigger/scheduler.go
@@ -324,6 +324,7 @@ func (s *Scheduler) fire(ctx context.Context, sub Subscription) {
 		},
 	}
 	runID, err := s.launcher.Launch(ctx, plan)
+	recordLaunchVerdict(ctx, s.subs, s.logger, sub, err)
 	rec := s.tickRecord(sub, schedgate.LaunchDecision(err))
 	rec.RunID = runID
 	if err != nil {

--- a/pkg/trigger/store.go
+++ b/pkg/trigger/store.go
@@ -3,6 +3,7 @@ package trigger
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // ErrSubscriptionNotFound is returned by Get/Update/Delete for an unknown id.
@@ -18,6 +19,14 @@ type SubscriptionStore interface {
 	Get(ctx context.Context, id string) (Subscription, error)
 	Update(ctx context.Context, s Subscription) error
 	Delete(ctx context.Context, id string) error
+
+	// MarkLaunchError records the verdict of the subscription's last direct
+	// launch: a non-empty message raises last_error with its instant, "" clears
+	// both. A TARGETED field write rather than a read-modify-replace — the
+	// recorder holds a copy the evaluator matched, which on an outbox retry is
+	// minutes old, and an operator editing the row in between must not lose the
+	// edit to a health write.
+	MarkLaunchError(ctx context.Context, id, lastError string, at time.Time) error
 
 	// ListByTenant returns every subscription owned by a tenant
 	// ("" tenant = the local single-host scope).

--- a/pkg/trigger/subscription.go
+++ b/pkg/trigger/subscription.go
@@ -149,6 +149,16 @@ type Subscription struct {
 	CreatedBy string    `json:"created_by,omitempty" bson:"created_by,omitempty"`
 	CreatedAt time.Time `json:"created_at" bson:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" bson:"updated_at"`
+
+	// LastError is the verdict of the last direct launch this subscription
+	// asked for: empty means it went through, a message says why it did not
+	// (an org launch-gate denial, a run service that refused the run).
+	// LastErrorAt is when that verdict was recorded. Both are rendered by
+	// GET /api/v1/triggers and `iterion remote triggers list`, so a
+	// subscription that stopped firing is visible to its operator instead of
+	// living only in a replica's log.
+	LastError   string     `json:"last_error,omitempty" bson:"last_error,omitempty"`
+	LastErrorAt *time.Time `json:"last_error_at,omitempty" bson:"last_error_at,omitempty"`
 }
 
 // NextFire computes the subscription's next-fire instant after `after`,

--- a/pkg/trigger/subscription_health_test.go
+++ b/pkg/trigger/subscription_health_test.go
@@ -1,0 +1,150 @@
+package trigger
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+)
+
+// A direct launch the spine could not perform — an org launch-gate denial
+// above all — must land on the subscription that asked for it. Without it the
+// only trace is a warn line in one replica's log: the operator sees a trigger
+// that silently stopped firing.
+
+// refusingLauncher refuses every launch with err, and counts the attempts.
+type refusingLauncher struct {
+	err      error
+	launches int
+}
+
+func (l *refusingLauncher) Launch(context.Context, LaunchPlan) (string, error) {
+	l.launches++
+	return "run-1", l.err
+}
+
+func directSub(id string) Subscription {
+	return Subscription{
+		ID:         id,
+		BotID:      "probe",
+		Invocation: bundle.InvocationKindBoard,
+		Mode:       bundle.ExecutionDirect,
+		Match:      Matcher{Sources: []Source{SourceCustom}},
+		Enabled:    true,
+		CreatedAt:  time.Now().UTC(),
+	}
+}
+
+func customEvent() Event {
+	return Event{ID: "custom:probe:1", Source: SourceCustom, Kind: "probe", OccurredAt: time.Now().UTC()}
+}
+
+func TestEvaluator_LaunchRefusalLandsOnTheSubscription(t *testing.T) {
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore()
+	if err := subs.Create(ctx, directSub("sub-1")); err != nil {
+		t.Fatal(err)
+	}
+	l := &refusingLauncher{err: errors.New("launch gate: concurrency_cap_exceeded: org has 3 active runs (cap 3)")}
+	eval := NewEvaluator(subs, WithLauncher(l))
+
+	if err := eval.Handle(ctx, customEvent()); err != nil {
+		t.Fatalf("Handle = %v, want nil (one failing subscription must not fail the event)", err)
+	}
+	got, err := subs.Get(ctx, "sub-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastError == "" {
+		t.Fatal("the refused launch left no last_error on the subscription — the operator has nothing to read but a pod log")
+	}
+	if got.LastError != l.err.Error() {
+		t.Errorf("last_error = %q, want the refusal verbatim %q", got.LastError, l.err.Error())
+	}
+	if got.LastErrorAt == nil {
+		t.Error("last_error carries no instant — an operator cannot tell a refusal from last month from one a minute ago")
+	}
+}
+
+func TestEvaluator_ALaunchThatGoesThroughClearsTheFlag(t *testing.T) {
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore()
+	sub := directSub("sub-1")
+	sub.LastError = "launch gate: monthly_run_quota_exceeded: monthly run quota (10) exhausted"
+	when := time.Now().UTC().Add(-time.Hour)
+	sub.LastErrorAt = &when
+	if err := subs.Create(ctx, sub); err != nil {
+		t.Fatal(err)
+	}
+	eval := NewEvaluator(subs, WithLauncher(&refusingLauncher{}))
+
+	if err := eval.Handle(ctx, customEvent()); err != nil {
+		t.Fatalf("Handle = %v, want nil", err)
+	}
+	got, err := subs.Get(ctx, "sub-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastError != "" || got.LastErrorAt != nil {
+		t.Errorf("a launch that went through left last_error=%q at=%v — a stale refusal reads as a live one", got.LastError, got.LastErrorAt)
+	}
+}
+
+// A benign non-fire is not a refusal: a machine-caused event owes no effect,
+// so it must not stamp a failure on a healthy subscription.
+func TestEvaluator_MachineCausedEventLeavesTheHealthAlone(t *testing.T) {
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore()
+	if err := subs.Create(ctx, directSub("sub-1")); err != nil {
+		t.Fatal(err)
+	}
+	l := &refusingLauncher{err: errors.New("should never be called")}
+	eval := NewEvaluator(subs, WithLauncher(l))
+
+	ev := customEvent()
+	ev.Payload = map[string]any{"reason": "watchdog"}
+	if err := eval.Handle(ctx, ev); err != nil {
+		t.Fatalf("Handle = %v, want nil", err)
+	}
+	if l.launches != 0 {
+		t.Fatalf("a machine-caused event launched %d time(s), want 0", l.launches)
+	}
+	got, _ := subs.Get(ctx, "sub-1")
+	if got.LastError != "" {
+		t.Errorf("last_error = %q after a benign non-fire, want empty", got.LastError)
+	}
+}
+
+// The health write is targeted, so an operator edit made between the match and
+// the record survives it (both twins; the Mongo half is a $set on the two
+// fields).
+func TestMemorySubscriptionStore_MarkLaunchErrorDoesNotClobberAnEdit(t *testing.T) {
+	ctx := context.Background()
+	subs := NewMemorySubscriptionStore()
+	stale := directSub("sub-1")
+	if err := subs.Create(ctx, stale); err != nil {
+		t.Fatal(err)
+	}
+	// The operator re-points the subscription at another bot after the
+	// evaluator read its copy.
+	edited := stale
+	edited.BotID = "other"
+	if err := subs.Update(ctx, edited); err != nil {
+		t.Fatal(err)
+	}
+	if err := subs.MarkLaunchError(ctx, "sub-1", "boom", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := subs.Get(ctx, "sub-1")
+	if got.BotID != "other" {
+		t.Errorf("bot_id = %q, want %q — the health write replaced the row instead of setting its two fields", got.BotID, "other")
+	}
+	if got.LastError != "boom" {
+		t.Errorf("last_error = %q, want %q", got.LastError, "boom")
+	}
+	if err := subs.MarkLaunchError(ctx, "ghost", "boom", time.Now()); !errors.Is(err, ErrSubscriptionNotFound) {
+		t.Errorf("MarkLaunchError on an unknown id = %v, want ErrSubscriptionNotFound", err)
+	}
+}


### PR DESCRIPTION
## Why

PR #850 routed the board dispatcher through `gateLaunch` and tabulated every `runs.Launch` surface; three stayed outside the org gate (run quota, monthly cost cap, concurrency, launch rate — `pkg/orgusage`): the trigger spine's direct launches, `cloudsched`'s scheduled bots, and the `emit` endpoint that metered one slot per request whatever it fanned out to (#844).

A fourth defect the ticket did not name, found red-first: the spine's launches carried **no store identity at all** — the evaluator's ctx comes from `context.Background()` (`cloudBoardSource.run`, `EffectWorker.Tick`, the `InProcBus` worker), so `cloudpublisher.SubmitLaunch` read `TenantFromContext` → `("", false)` and every cloud `mode: direct` trigger launch, run-completion chain and emit fan-out published a run **scoped to no tenant and no owner** (`the run was published under tenant "", want "t1"`).

## What changes

- **Trigger spine** — `Server.triggerLauncher()` is the one construction site (both `StartTriggerCoordinator` and `StartCloudTriggerCoordinator` use it); `serviceLauncher.Launch` stamps `store.WithIdentity(ctx, plan.TenantID, "trigger-spine")`, gates under `auth.Identity{TeamID: plan.TenantID, UserID: "trigger-spine"}`, and rolls the metered admission back when the run service refuses.
- **Scheduled bots** — `launchScheduledBot` (the launch tail only; the converse lane of `webhooks_gitlab.go` is untouched) gates and meters under `cloud-scheduler` on the schedule's team, same rollback.
- **`POST /api/v1/triggers/emit`** — a synchronous pre-check whose slot is released at once; the spine meters each launch the event fans out to (0 ⇒ 0, N ⇒ N).
- **Recorded denials, never a silent skip** — `trigger.Subscription` and `cloudsched.ScheduledBot` gain `last_error` / `last_error_at`, written by a targeted `MarkLaunchError` on both twins (memory + Mongo `$set`/`$unset`, never the full-replace `Update`, so an operator edit between match and record survives), from one shared helper (`pkg/trigger/health.go:recordLaunchVerdict`) called by the evaluator's launch arm, the local scheduler's tick and `cloudsched.Ticker`. Written only when the verdict changes, cleared by the next launch that goes through. Surfaced by `GET /api/v1/triggers` / `GET /api/teams/{id}/schedules` → `iterion remote triggers list` / `remote schedules list`. `openapi.json` regenerated (byte-identical).

## Launch-surface table (after)

| Surface | Identity on the ctx | Gated | Metered |
|---|---|---|---|
| `POST /api/runs`, studio, `remote runs launch`, MCP | caller's | yes | yes, rolled back on refusal |
| Resume (API, sweeper, WS) | caller's / run owner | yes | yes |
| Inbound webhooks, direct launch (incl. merge-gate auto-fix/relaunch) | token's synthetic `webhook` | yes | yes, rolled back |
| Inbound webhooks, board mode | token's | pre-check only | no (dispatcher meters at claim) |
| Board dispatcher | `board-dispatcher` on the card's team | yes | yes, rolled back |
| `POST /api/v1/triggers/emit` | caller's | **pre-check only** | **no — slot released; the spine meters each fan-out launch** |
| **Trigger spine direct launches** (incl. local `trigger.Scheduler`) | **`trigger-spine` on the subscription's team** | **yes** | **yes, rolled back** |
| **`cloudsched` (`launchScheduledBot`)** | **`cloud-scheduler` on the schedule's team** | **yes** | **yes, rolled back** |
| Local `pipeline_admission.go`, `dispatcher/engine_runner.go` | — | no gate exists (no identity store) | — |

`runview.Service.Launch` is the sole path into `LaunchPublisher.SubmitLaunch`; its 8 non-test call sites are the rows above. No fourth ungated surface remains.

## Proof (red first)

- `pkg/server/trigger_launcher_gate_test.go`: `TestServiceLauncher_GateDenialRefusesTheLaunch` (`Launch = <nil>, want the gate's typed concurrency_cap_exceeded denial`), `_SuspendedTeamCannotLaunch`, `admitted_launch_meters_one_slot` (`monthly runs = 0 after one spine launch, want 1`), `the_quota_is_enforced,_not_just_counted`, `_StampsThePlansTenantOnTheRun` (`published under tenant "", want "t1"`).
- `pkg/server/schedules_launch_gate_test.go`: the same four shapes for `launchScheduledBot`.
- `pkg/server/triggers_emit_gate_test.go`: `TestEmitTrigger_FanOutToNothingMetersNothing` (`monthly runs = 1 after an emit that launched nothing, want 0`), `TestEmitFanOut_MetersOneSlotPerLaunch`, `TestEmitTrigger_DeniedOrgIsRefusedSynchronously`.
- `pkg/trigger/subscription_health_test.go` + `pkg/cloudsched/ticker_health_test.go`: a refusal lands on the record, a launch that goes through clears it; twin integrity (`MarkLaunchError` does not clobber an edit) on both memory stores; Mongo conformance row inside `TestMongoStore_CAS` for cloudsched (`$set` round-trip, `next_fire_at` undisturbed, `$unset` clear, `ErrNotFound`).
- `go build`, `go vet`, `task lint` (0 issues), `go test ./pkg/... ./e2e/... ./cmd/...`, `-race` on `pkg/trigger pkg/cloudsched pkg/server`, Mongo harness on `pkg/cloudsched pkg/store/mongo pkg/internal/storekit pkg/orgusage pkg/identity` (rs0 PRIMARY, ran not skipped).

## Left out, stated

- `pkg/trigger`'s Mongo twin `MarkLaunchError` was verified by hand against the live replica set (`$set` round-trip, `$unset` clear, `ErrSubscriptionNotFound` on a ghost id) but its conformance row is not committed: `TestMongoGatedPackagesAreInTheCIJob` refuses a Mongo-gated test in a package absent from the `mongo-conformance` job, and the workflow file is owned by the in-flight CI PR. That PR adds `./pkg/trigger/...` to the job; the row follows as a one-file PR.
- Side effect, deliberate: in local mode the spine's store owner goes from `""` to `trigger-spine` (the tenant stays `""`), so a locally-scheduled bot using a `visibility: user` memory space gets a new space — the precedent `board-dispatcher` / `scheduler:<bot>` already set; an ownerless "user" space was degenerate.
- Found on the way, filed as #871: team-authored bot sources are unreachable from every automated launch surface (`resolveBotSource` hardcodes an empty team id).

Closes #844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
