### PR TITLE
fix(golden-master): a stat-recorded path is stat-compared whatever today's size bound

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3201,6 +3201,7 @@ tool oracle_run:
         qui tournent, jamais une reimplementation — qui finirait par diverger d'eux.
         """
         failures, checked = [], [0]
+        skipped_under_root = []
 
         def check(name, got, want):
             checked[0] += 1
@@ -4661,6 +4662,24 @@ tool oracle_run:
                 os.remove(os.path.join(tmp, "mid.bin"))
                 check("une entree st: sans chiffres n'est pas migree",
                       split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
+                # Les deux formes stat sont UNE fonction ; un enregistrement par hachage est
+                # repondu par un hachage meme au-dessus du seuil actuel (miroir du bug).
+                saved_big = g["BIG_FILE_BYTES"]
+                g["BIG_FILE_BYTES"] = 16
+                try:
+                    with open(os.path.join(tmp, "big2.bin"), "wb") as f:
+                        f.write(b"y" * 64)
+                    fp_stat = dirty_fingerprint(tmp, "big2.bin")
+                    check("au-dessus du seuil, dirty_fingerprint et fingerprint_like(st-) donnent la meme forme stat",
+                          [fp_stat.startswith("st-"), fingerprint_like(tmp, "big2.bin", fp_stat) == fp_stat], [True, True])
+                    h = hashlib.sha1(b"y" * 64).hexdigest()
+                    check("un enregistrement par hachage est repondu par un hachage, seuil ou pas",
+                          fingerprint_like(tmp, "big2.bin", h) == h, True)
+                finally:
+                    g["BIG_FILE_BYTES"] = saved_big
+                    os.remove(os.path.join(tmp, "big2.bin"))
+                check("un enregistrement legacy avec mtime negatif migre",
+                      split_dirty_record(["st:10:-5:old.bin"]), {"old.bin": "st-10--5"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4686,7 +4705,8 @@ tool oracle_run:
             for f in failures:
                 log("  " + f)
             return 1
-        log("harnais : %d verifications passent" % checked[0])
+        log("harnais : %d verifications passent%s" % (
+            checked[0], (" (sautees sous root : %s)" % "; ".join(skipped_under_root)) if skipped_under_root else ""))
         return 0
 
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2435,6 +2435,26 @@ tool oracle_run:
             return "?"
 
 
+    def fingerprint_like(ws, path, recorded):
+        """The path's fingerprint in the SCHEME the record used: a stat record
+        ("st-…") is answered by the stat form whatever today's size bound is —
+        a record written under an 8 MiB bound compared to a content hash under
+        a 256 MiB bound could never match, and an untouched file was permanent
+        residue. Any other record is answered by dirty_fingerprint."""
+        if isinstance(recorded, str) and recorded.startswith("st-"):
+            full = os.path.join(repo_root_of(ws), path)
+            try:
+                if not os.path.lexists(full):
+                    return "absent"
+                st = os.lstat(full)
+                if not stat.S_ISREG(st.st_mode):
+                    return "?"
+                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+            except OSError:
+                return "?"
+        return dirty_fingerprint(ws, path)
+
+
     def status_porcelain_z(ws):
         """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
         merges the two streams, and a warning git prints on stderr (a directory
@@ -2500,7 +2520,7 @@ tool oracle_run:
                 # ("st:<size>:<mtime>:<path>"): read as the current form, so a
                 # marker across the upgrade still clears an untouched file.
                 parts = e.split(":", 3)
-                if len(parts) == 4 and parts[3]:
+                if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
                     rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
                     continue
             if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
@@ -2753,7 +2773,7 @@ tool oracle_run:
                     for q in after:
                         if q not in rec:
                             residue.append(q)
-                        elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                        elif rec[q] == "?" or fingerprint_like(ws, q, rec[q]) != rec[q]:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
@@ -2801,8 +2821,8 @@ tool oracle_run:
         than silence."""
         kind, text = _leftover_disposition(left)
         if left.get("vanished"):
-            text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+            text += (" Uncommitted work that was there before the mutant is clean now — undone by "
+                     "the revert, or by you since: %s." % ", ".join(left["vanished"][:20]))
         return kind, text
 
 
@@ -4509,6 +4529,8 @@ tool oracle_run:
                     os.chmod(secret, 0o755)
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
+                if os.geteuid() == 0:
+                    sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
                 if os.geteuid() != 0:
                     check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                           [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
@@ -4573,7 +4595,7 @@ tool oracle_run:
                 apply_mutant(lmeta, tmp)
                 left = revert_leftover_mutant(tmp)
                 check("le travail de l'operateur efface par le revert est nomme",
-                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "clean now" in leftover_disposition(left or {})[1]],
                       [["f.txt"], "reverted", True])
                 # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
                 os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
@@ -4598,13 +4620,30 @@ tool oracle_run:
                 left = revert_leftover_mutant(tmp)
                 kind, text = leftover_disposition(left or {})
                 check("residu ET travail efface : la porte s'arrete et nomme les deux",
-                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "clean now" in text, "keep yours" in text],
                       ["still_mutated", ["created.txt"], ["f.txt"], True, False])
                 os.remove(applied_marker_for(tmp))
                 os.remove(os.path.join(tmp, "created.txt"))
                 # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
                 check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
                       split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
+                # Un enregistrement par stat (ecrit sous un seuil plus bas) est compare par
+                # stat, meme si le fichier est aujourd'hui sous le seuil de hachage.
+                with open(os.path.join(tmp, "mid.bin"), "wb") as f:
+                    f.write(b"m" * 64)
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                mst = os.lstat(os.path.join(tmp, "mid.bin"))
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir,
+                               "dirty_before": ["st:%d:%d:mid.bin" % (mst.st_size, mst.st_mtime_ns)]}, f)
+                left = revert_leftover_mutant(tmp)
+                check("un enregistrement stat d'avant, fichier sous le seuil actuel : compare par stat, pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                os.remove(os.path.join(tmp, "mid.bin"))
+                check("une entree st: sans chiffres n'est pas migree",
+                      split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2425,31 +2425,44 @@ tool oracle_run:
             if not stat.S_ISREG(st.st_mode):
                 return "?"
             if st.st_size > BIG_FILE_BYTES:
-                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
-            h = hashlib.sha1()
-            with open(full, "rb") as f:
-                for chunk in iter(lambda: f.read(1 << 20), b""):
-                    h.update(chunk)
-            return h.hexdigest()
+                return stat_form(st)
+            return content_hash(full)
         except OSError:
             return "?"
 
 
+    def stat_form(st):
+        """The one stat fingerprint, "st-<size>-<mtime>": written by
+        dirty_fingerprint past the size bound and answered by fingerprint_like
+        for a stat record — one function, so the two cannot drift apart."""
+        return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+
+
+    def content_hash(full):
+        h = hashlib.sha1()
+        with open(full, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+
     def fingerprint_like(ws, path, recorded):
-        """The path's fingerprint in the SCHEME the record used: a stat record
-        ("st-…") is answered by the stat form whatever today's size bound is —
-        a record written under an 8 MiB bound compared to a content hash under
-        a 256 MiB bound could never match, and an untouched file was permanent
-        residue. Any other record is answered by dirty_fingerprint."""
-        if isinstance(recorded, str) and recorded.startswith("st-"):
+        """The path's fingerprint in the SCHEME the record used, whatever today's
+        size bound: a stat record ("st-…") is answered by the stat form, a
+        content-hash record by the content hash — a record written under one
+        bound compared under another could never match, and an untouched file
+        was permanent residue (measured with the bound raised; the mirror
+        holds when it is lowered). Any other record is answered by
+        dirty_fingerprint."""
+        if isinstance(recorded, str) and (recorded.startswith("st-") or len(recorded) == 40):
             full = os.path.join(repo_root_of(ws), path)
             try:
                 if not os.path.lexists(full):
                     return "absent"
                 st = os.lstat(full)
                 if not stat.S_ISREG(st.st_mode):
-                    return "?"
-                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+                    return dirty_fingerprint(ws, path)
+                return stat_form(st) if recorded.startswith("st-") else content_hash(full)
             except OSError:
                 return "?"
         return dirty_fingerprint(ws, path)
@@ -2520,8 +2533,12 @@ tool oracle_run:
                 # ("st:<size>:<mtime>:<path>"): read as the current form, so a
                 # marker across the upgrade still clears an untouched file.
                 parts = e.split(":", 3)
-                if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
-                    rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+                try:
+                    size, mtime = int(parts[1]), int(parts[2])
+                except (ValueError, IndexError):
+                    size = mtime = None
+                if len(parts) == 4 and parts[3] and size is not None:
+                    rec[parts[3]] = "st-%d-%d" % (size, mtime)
                     continue
             if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
@@ -4530,7 +4547,7 @@ tool oracle_run:
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
                 if os.geteuid() == 0:
-                    sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
+                    skipped_under_root.append("2 permission checks (chmod 0 denies nothing)")
                 if os.geteuid() != 0:
                     check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                           [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2216,6 +2216,26 @@ def dirty_fingerprint(ws, path):
         return "?"
 
 
+def fingerprint_like(ws, path, recorded):
+    """The path's fingerprint in the SCHEME the record used: a stat record
+    ("st-…") is answered by the stat form whatever today's size bound is —
+    a record written under an 8 MiB bound compared to a content hash under
+    a 256 MiB bound could never match, and an untouched file was permanent
+    residue. Any other record is answered by dirty_fingerprint."""
+    if isinstance(recorded, str) and recorded.startswith("st-"):
+        full = os.path.join(repo_root_of(ws), path)
+        try:
+            if not os.path.lexists(full):
+                return "absent"
+            st = os.lstat(full)
+            if not stat.S_ISREG(st.st_mode):
+                return "?"
+            return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+        except OSError:
+            return "?"
+    return dirty_fingerprint(ws, path)
+
+
 def status_porcelain_z(ws):
     """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
     merges the two streams, and a warning git prints on stderr (a directory
@@ -2281,7 +2301,7 @@ def split_dirty_record(entries):
             # ("st:<size>:<mtime>:<path>"): read as the current form, so a
             # marker across the upgrade still clears an untouched file.
             parts = e.split(":", 3)
-            if len(parts) == 4 and parts[3]:
+            if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
                 rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
                 continue
         if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
@@ -2534,7 +2554,7 @@ def revert_leftover_mutant(ws, gm_dir=None):
                 for q in after:
                     if q not in rec:
                         residue.append(q)
-                    elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                    elif rec[q] == "?" or fingerprint_like(ws, q, rec[q]) != rec[q]:
                         residue.append(q)
                         if rec[q] == "?":
                             residue_undecided = True
@@ -2582,8 +2602,8 @@ def leftover_disposition(left):
     than silence."""
     kind, text = _leftover_disposition(left)
     if left.get("vanished"):
-        text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                 "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+        text += (" Uncommitted work that was there before the mutant is clean now — undone by "
+                 "the revert, or by you since: %s." % ", ".join(left["vanished"][:20]))
     return kind, text
 
 
@@ -4290,6 +4310,8 @@ def _selftest():
                 os.chmod(secret, 0o755)
                 shutil.rmtree(secret, ignore_errors=True)
             os.remove(os.path.join(tmp, "other.txt"))
+            if os.geteuid() == 0:
+                sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
             if os.geteuid() != 0:
                 check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                       [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
@@ -4354,7 +4376,7 @@ def _selftest():
             apply_mutant(lmeta, tmp)
             left = revert_leftover_mutant(tmp)
             check("le travail de l'operateur efface par le revert est nomme",
-                  [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                  [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "clean now" in leftover_disposition(left or {})[1]],
                   [["f.txt"], "reverted", True])
             # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
             os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
@@ -4379,13 +4401,30 @@ def _selftest():
             left = revert_leftover_mutant(tmp)
             kind, text = leftover_disposition(left or {})
             check("residu ET travail efface : la porte s'arrete et nomme les deux",
-                  [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                  [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "clean now" in text, "keep yours" in text],
                   ["still_mutated", ["created.txt"], ["f.txt"], True, False])
             os.remove(applied_marker_for(tmp))
             os.remove(os.path.join(tmp, "created.txt"))
             # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
             check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
                   split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
+            # Un enregistrement par stat (ecrit sous un seuil plus bas) est compare par
+            # stat, meme si le fichier est aujourd'hui sous le seuil de hachage.
+            with open(os.path.join(tmp, "mid.bin"), "wb") as f:
+                f.write(b"m" * 64)
+            scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+            apply_mutant(lmeta, tmp)
+            mpath = applied_marker_for(tmp)
+            mst = os.lstat(os.path.join(tmp, "mid.bin"))
+            with open(mpath, "w", encoding="utf-8") as f:
+                json.dump({"id": "leftover-1", "dir": mdir,
+                           "dirty_before": ["st:%d:%d:mid.bin" % (mst.st_size, mst.st_mtime_ns)]}, f)
+            left = revert_leftover_mutant(tmp)
+            check("un enregistrement stat d'avant, fichier sous le seuil actuel : compare par stat, pas un residu",
+                  [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+            os.remove(os.path.join(tmp, "mid.bin"))
+            check("une entree st: sans chiffres n'est pas migree",
+                  split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2206,31 +2206,44 @@ def dirty_fingerprint(ws, path):
         if not stat.S_ISREG(st.st_mode):
             return "?"
         if st.st_size > BIG_FILE_BYTES:
-            return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
-        h = hashlib.sha1()
-        with open(full, "rb") as f:
-            for chunk in iter(lambda: f.read(1 << 20), b""):
-                h.update(chunk)
-        return h.hexdigest()
+            return stat_form(st)
+        return content_hash(full)
     except OSError:
         return "?"
 
 
+def stat_form(st):
+    """The one stat fingerprint, "st-<size>-<mtime>": written by
+    dirty_fingerprint past the size bound and answered by fingerprint_like
+    for a stat record — one function, so the two cannot drift apart."""
+    return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+
+
+def content_hash(full):
+    h = hashlib.sha1()
+    with open(full, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def fingerprint_like(ws, path, recorded):
-    """The path's fingerprint in the SCHEME the record used: a stat record
-    ("st-…") is answered by the stat form whatever today's size bound is —
-    a record written under an 8 MiB bound compared to a content hash under
-    a 256 MiB bound could never match, and an untouched file was permanent
-    residue. Any other record is answered by dirty_fingerprint."""
-    if isinstance(recorded, str) and recorded.startswith("st-"):
+    """The path's fingerprint in the SCHEME the record used, whatever today's
+    size bound: a stat record ("st-…") is answered by the stat form, a
+    content-hash record by the content hash — a record written under one
+    bound compared under another could never match, and an untouched file
+    was permanent residue (measured with the bound raised; the mirror
+    holds when it is lowered). Any other record is answered by
+    dirty_fingerprint."""
+    if isinstance(recorded, str) and (recorded.startswith("st-") or len(recorded) == 40):
         full = os.path.join(repo_root_of(ws), path)
         try:
             if not os.path.lexists(full):
                 return "absent"
             st = os.lstat(full)
             if not stat.S_ISREG(st.st_mode):
-                return "?"
-            return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+                return dirty_fingerprint(ws, path)
+            return stat_form(st) if recorded.startswith("st-") else content_hash(full)
         except OSError:
             return "?"
     return dirty_fingerprint(ws, path)
@@ -2301,8 +2314,12 @@ def split_dirty_record(entries):
             # ("st:<size>:<mtime>:<path>"): read as the current form, so a
             # marker across the upgrade still clears an untouched file.
             parts = e.split(":", 3)
-            if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
-                rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+            try:
+                size, mtime = int(parts[1]), int(parts[2])
+            except (ValueError, IndexError):
+                size = mtime = None
+            if len(parts) == 4 and parts[3] and size is not None:
+                rec[parts[3]] = "st-%d-%d" % (size, mtime)
                 continue
         if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
             rec[q] = fp
@@ -4311,7 +4328,7 @@ def _selftest():
                 shutil.rmtree(secret, ignore_errors=True)
             os.remove(os.path.join(tmp, "other.txt"))
             if os.geteuid() == 0:
-                sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
+                skipped_under_root.append("2 permission checks (chmod 0 denies nothing)")
             if os.geteuid() != 0:
                 check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                       [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2982,6 +2982,7 @@ def _selftest():
     qui tournent, jamais une reimplementation — qui finirait par diverger d'eux.
     """
     failures, checked = [], [0]
+    skipped_under_root = []
 
     def check(name, got, want):
         checked[0] += 1
@@ -4442,6 +4443,24 @@ def _selftest():
             os.remove(os.path.join(tmp, "mid.bin"))
             check("une entree st: sans chiffres n'est pas migree",
                   split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
+            # Les deux formes stat sont UNE fonction ; un enregistrement par hachage est
+            # repondu par un hachage meme au-dessus du seuil actuel (miroir du bug).
+            saved_big = g["BIG_FILE_BYTES"]
+            g["BIG_FILE_BYTES"] = 16
+            try:
+                with open(os.path.join(tmp, "big2.bin"), "wb") as f:
+                    f.write(b"y" * 64)
+                fp_stat = dirty_fingerprint(tmp, "big2.bin")
+                check("au-dessus du seuil, dirty_fingerprint et fingerprint_like(st-) donnent la meme forme stat",
+                      [fp_stat.startswith("st-"), fingerprint_like(tmp, "big2.bin", fp_stat) == fp_stat], [True, True])
+                h = hashlib.sha1(b"y" * 64).hexdigest()
+                check("un enregistrement par hachage est repondu par un hachage, seuil ou pas",
+                      fingerprint_like(tmp, "big2.bin", h) == h, True)
+            finally:
+                g["BIG_FILE_BYTES"] = saved_big
+                os.remove(os.path.join(tmp, "big2.bin"))
+            check("un enregistrement legacy avec mtime negatif migre",
+                  split_dirty_record(["st:10:-5:old.bin"]), {"old.bin": "st-10--5"})
             # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
             mpath = applied_marker_for(tmp)
             os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4467,7 +4486,8 @@ def _selftest():
         for f in failures:
             log("  " + f)
         return 1
-    log("harnais : %d verifications passent" % checked[0])
+    log("harnais : %d verifications passent%s" % (
+        checked[0], (" (sautees sous root : %s)" % "; ".join(skipped_under_root)) if skipped_under_root else ""))
     return 0
 
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2373,31 +2373,44 @@ tool sync_harness:
             if not stat.S_ISREG(st.st_mode):
                 return "?"
             if st.st_size > BIG_FILE_BYTES:
-                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
-            h = hashlib.sha1()
-            with open(full, "rb") as f:
-                for chunk in iter(lambda: f.read(1 << 20), b""):
-                    h.update(chunk)
-            return h.hexdigest()
+                return stat_form(st)
+            return content_hash(full)
         except OSError:
             return "?"
 
 
+    def stat_form(st):
+        """The one stat fingerprint, "st-<size>-<mtime>": written by
+        dirty_fingerprint past the size bound and answered by fingerprint_like
+        for a stat record — one function, so the two cannot drift apart."""
+        return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+
+
+    def content_hash(full):
+        h = hashlib.sha1()
+        with open(full, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+
     def fingerprint_like(ws, path, recorded):
-        """The path's fingerprint in the SCHEME the record used: a stat record
-        ("st-…") is answered by the stat form whatever today's size bound is —
-        a record written under an 8 MiB bound compared to a content hash under
-        a 256 MiB bound could never match, and an untouched file was permanent
-        residue. Any other record is answered by dirty_fingerprint."""
-        if isinstance(recorded, str) and recorded.startswith("st-"):
+        """The path's fingerprint in the SCHEME the record used, whatever today's
+        size bound: a stat record ("st-…") is answered by the stat form, a
+        content-hash record by the content hash — a record written under one
+        bound compared under another could never match, and an untouched file
+        was permanent residue (measured with the bound raised; the mirror
+        holds when it is lowered). Any other record is answered by
+        dirty_fingerprint."""
+        if isinstance(recorded, str) and (recorded.startswith("st-") or len(recorded) == 40):
             full = os.path.join(repo_root_of(ws), path)
             try:
                 if not os.path.lexists(full):
                     return "absent"
                 st = os.lstat(full)
                 if not stat.S_ISREG(st.st_mode):
-                    return "?"
-                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+                    return dirty_fingerprint(ws, path)
+                return stat_form(st) if recorded.startswith("st-") else content_hash(full)
             except OSError:
                 return "?"
         return dirty_fingerprint(ws, path)
@@ -2468,8 +2481,12 @@ tool sync_harness:
                 # ("st:<size>:<mtime>:<path>"): read as the current form, so a
                 # marker across the upgrade still clears an untouched file.
                 parts = e.split(":", 3)
-                if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
-                    rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
+                try:
+                    size, mtime = int(parts[1]), int(parts[2])
+                except (ValueError, IndexError):
+                    size = mtime = None
+                if len(parts) == 4 and parts[3] and size is not None:
+                    rec[parts[3]] = "st-%d-%d" % (size, mtime)
                     continue
             if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
                 rec[q] = fp
@@ -4478,7 +4495,7 @@ tool sync_harness:
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
                 if os.geteuid() == 0:
-                    sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
+                    skipped_under_root.append("2 permission checks (chmod 0 denies nothing)")
                 if os.geteuid() != 0:
                     check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                           [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3149,6 +3149,7 @@ tool sync_harness:
         qui tournent, jamais une reimplementation — qui finirait par diverger d'eux.
         """
         failures, checked = [], [0]
+        skipped_under_root = []
 
         def check(name, got, want):
             checked[0] += 1
@@ -4609,6 +4610,24 @@ tool sync_harness:
                 os.remove(os.path.join(tmp, "mid.bin"))
                 check("une entree st: sans chiffres n'est pas migree",
                       split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
+                # Les deux formes stat sont UNE fonction ; un enregistrement par hachage est
+                # repondu par un hachage meme au-dessus du seuil actuel (miroir du bug).
+                saved_big = g["BIG_FILE_BYTES"]
+                g["BIG_FILE_BYTES"] = 16
+                try:
+                    with open(os.path.join(tmp, "big2.bin"), "wb") as f:
+                        f.write(b"y" * 64)
+                    fp_stat = dirty_fingerprint(tmp, "big2.bin")
+                    check("au-dessus du seuil, dirty_fingerprint et fingerprint_like(st-) donnent la meme forme stat",
+                          [fp_stat.startswith("st-"), fingerprint_like(tmp, "big2.bin", fp_stat) == fp_stat], [True, True])
+                    h = hashlib.sha1(b"y" * 64).hexdigest()
+                    check("un enregistrement par hachage est repondu par un hachage, seuil ou pas",
+                          fingerprint_like(tmp, "big2.bin", h) == h, True)
+                finally:
+                    g["BIG_FILE_BYTES"] = saved_big
+                    os.remove(os.path.join(tmp, "big2.bin"))
+                check("un enregistrement legacy avec mtime negatif migre",
+                      split_dirty_record(["st:10:-5:old.bin"]), {"old.bin": "st-10--5"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)
@@ -4634,7 +4653,8 @@ tool sync_harness:
             for f in failures:
                 log("  " + f)
             return 1
-        log("harnais : %d verifications passent" % checked[0])
+        log("harnais : %d verifications passent%s" % (
+            checked[0], (" (sautees sous root : %s)" % "; ".join(skipped_under_root)) if skipped_under_root else ""))
         return 0
 
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2383,6 +2383,26 @@ tool sync_harness:
             return "?"
 
 
+    def fingerprint_like(ws, path, recorded):
+        """The path's fingerprint in the SCHEME the record used: a stat record
+        ("st-…") is answered by the stat form whatever today's size bound is —
+        a record written under an 8 MiB bound compared to a content hash under
+        a 256 MiB bound could never match, and an untouched file was permanent
+        residue. Any other record is answered by dirty_fingerprint."""
+        if isinstance(recorded, str) and recorded.startswith("st-"):
+            full = os.path.join(repo_root_of(ws), path)
+            try:
+                if not os.path.lexists(full):
+                    return "absent"
+                st = os.lstat(full)
+                if not stat.S_ISREG(st.st_mode):
+                    return "?"
+                return "st-%d-%d" % (st.st_size, st.st_mtime_ns)
+            except OSError:
+                return "?"
+        return dirty_fingerprint(ws, path)
+
+
     def status_porcelain_z(ws):
         """(exit, stdout) of `git status --porcelain -z`, stderr KEPT APART: run()
         merges the two streams, and a warning git prints on stderr (a directory
@@ -2448,7 +2468,7 @@ tool sync_harness:
                 # ("st:<size>:<mtime>:<path>"): read as the current form, so a
                 # marker across the upgrade still clears an untouched file.
                 parts = e.split(":", 3)
-                if len(parts) == 4 and parts[3]:
+                if len(parts) == 4 and parts[3] and parts[1].isdigit() and parts[2].isdigit():
                     rec[parts[3]] = "st-%s-%s" % (parts[1], parts[2])
                     continue
             if sep and q and (fp in ("absent", "?") or fp.startswith(("st-", "u-")) or (len(fp) == 40 and all(c in "0123456789abcdef" for c in fp))):
@@ -2701,7 +2721,7 @@ tool sync_harness:
                     for q in after:
                         if q not in rec:
                             residue.append(q)
-                        elif rec[q] == "?" or dirty_fingerprint(ws, q) != rec[q]:
+                        elif rec[q] == "?" or fingerprint_like(ws, q, rec[q]) != rec[q]:
                             residue.append(q)
                             if rec[q] == "?":
                                 residue_undecided = True
@@ -2749,8 +2769,8 @@ tool sync_harness:
         than silence."""
         kind, text = _leftover_disposition(left)
         if left.get("vanished"):
-            text += (" Uncommitted work that was there before the mutant is gone after the revert "
-                     "— the script undid it: %s." % ", ".join(left["vanished"][:20]))
+            text += (" Uncommitted work that was there before the mutant is clean now — undone by "
+                     "the revert, or by you since: %s." % ", ".join(left["vanished"][:20]))
         return kind, text
 
 
@@ -4457,6 +4477,8 @@ tool sync_harness:
                     os.chmod(secret, 0o755)
                     shutil.rmtree(secret, ignore_errors=True)
                 os.remove(os.path.join(tmp, "other.txt"))
+                if os.geteuid() == 0:
+                    sys.stderr.write("selftest: 2 permission checks skipped under root (chmod 0 denies nothing)\n")
                 if os.geteuid() != 0:
                     check("un repertoire illisible (avertissement git sur stderr) ne masque pas un vrai chemin",
                           [any(e.endswith(":other.txt") for e in db), any("warning" in e for e in db)], [True, False])
@@ -4521,7 +4543,7 @@ tool sync_harness:
                 apply_mutant(lmeta, tmp)
                 left = revert_leftover_mutant(tmp)
                 check("le travail de l'operateur efface par le revert est nomme",
-                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "gone after the revert" in leftover_disposition(left or {})[1]],
+                      [(left or {}).get("vanished"), leftover_disposition(left or {})[0], "clean now" in leftover_disposition(left or {})[1]],
                       [["f.txt"], "reverted", True])
                 # Un sous-repertoire illisible rend l'empreinte d'un repertoire indecidable.
                 os.makedirs(os.path.join(tmp, "u", "locked"), exist_ok=True)
@@ -4546,13 +4568,30 @@ tool sync_harness:
                 left = revert_leftover_mutant(tmp)
                 kind, text = leftover_disposition(left or {})
                 check("residu ET travail efface : la porte s'arrete et nomme les deux",
-                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "gone after the revert" in text, "keep yours" in text],
+                      [kind, (left or {}).get("residue"), (left or {}).get("vanished"), "clean now" in text, "keep yours" in text],
                       ["still_mutated", ["created.txt"], ["f.txt"], True, False])
                 os.remove(applied_marker_for(tmp))
                 os.remove(os.path.join(tmp, "created.txt"))
                 # L'ancienne forme « st:taille:mtime:chemin » d'un marqueur d'avant est lue.
                 check("l'ancienne empreinte st: d'un gros fichier est lue comme la nouvelle",
                       split_dirty_record(["st:8388609:1234:big.bin"]), {"big.bin": "st-8388609-1234"})
+                # Un enregistrement par stat (ecrit sous un seuil plus bas) est compare par
+                # stat, meme si le fichier est aujourd'hui sous le seuil de hachage.
+                with open(os.path.join(tmp, "mid.bin"), "wb") as f:
+                    f.write(b"m" * 64)
+                scripts("printf 'mutant\\n' >> f.txt", "git checkout -- f.txt")
+                apply_mutant(lmeta, tmp)
+                mpath = applied_marker_for(tmp)
+                mst = os.lstat(os.path.join(tmp, "mid.bin"))
+                with open(mpath, "w", encoding="utf-8") as f:
+                    json.dump({"id": "leftover-1", "dir": mdir,
+                               "dirty_before": ["st:%d:%d:mid.bin" % (mst.st_size, mst.st_mtime_ns)]}, f)
+                left = revert_leftover_mutant(tmp)
+                check("un enregistrement stat d'avant, fichier sous le seuil actuel : compare par stat, pas un residu",
+                      [(left or {}).get("residue"), leftover_disposition(left or {})[0]], [[], "reverted"])
+                os.remove(os.path.join(tmp, "mid.bin"))
+                check("une entree st: sans chiffres n'est pas migree",
+                      split_dirty_record(["st:a:b:c.txt"]), {"st:a:b:c.txt": "?"})
                 # Un dirty_before qui n'est pas une liste de chemins est refuse a la lecture.
                 mpath = applied_marker_for(tmp)
                 os.makedirs(os.path.dirname(mpath), mode=0o700, exist_ok=True)


### PR DESCRIPTION
## Follow-up of #866 — its third review round, merged out from under it

#866 merged from the head of the queue while its third round was being answered; the finding and the questions land here, on the merged harness.

- **The legacy `st:` migration could never match a file between the old and the new size bound** (medium): a record written under the 8 MiB bound for a file that hashes under the 256 MiB bound today compared a stat form to a content hash — an untouched operator file in that band was permanent residue, the very stop the migration was written to prevent. The comparison is scheme-aware now (`fingerprint_like`): a stat record is answered by the stat form of the path whatever the current bound. Self-test: a stat record of an earlier harness for a file now under the hash bound clears. Mutant: a stat record compared to a content hash — red.
- Questions answered in code: the legacy branch migrates digits only (mutant: red); the note about work that is clean after the revert claims what is known — "undone by the revert, or by you since" — not causation; a permission check skipped under root says so on stderr. Destroyed work without residue stays a note, not a stop: the revert's contract is to restore HEAD, and stopping there would block record mode on every checkout-based revert.

Self-test 204 → 206. `go test ./bots/` green (the byte-identity test covers the two inlined copies).


## First round (no finding; five questions, three answered in code)

- *One-directional scheme.* Fixed: a content-hash record is answered by the content hash whatever today's bound, a stat record by the stat form — the mirror bug (a lowered bound) cannot recur. Mutant: a hash record answered by today's scheme — red.
- *`isdigit` and a pre-epoch mtime.* The legacy record migrates on integers (`int()`), a negative mtime included. Mutant: red.
- *The root-skip note only on stderr.* It is in the count line the gate records now (`… verifications passent (sautees sous root : …)`).
- *The two stat forms could drift.* One function, `stat_form`, written by `dirty_fingerprint` and answered by `fingerprint_like`; `content_hash` likewise; the self-test pins them equal above the bound. Mutant: the two forms drifting apart — red.
- *The hedged wording of the loss note.* Kept: the fact known is "uncommitted before the mutant, clean now"; a text that asserts causation the harness cannot see is the larger error, and the operator is pointed at `git diff` either way.

A slip, owned: the first push of this round (6712d268b) carried the code half only — its patch stopped on a wrong anchor after the code was written — with the skip list appended to before being defined (a NameError under root only) and two of three mutants surviving. The corrective commit landed the self-test half twelve minutes later. Self-test 206 → 209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
