### PR TITLE
fix(webhooks,gate,branch-improve-loop): a fixer stops when its PR closes, never pushes onto a merged one, and a gate that cannot decide fails closed

### DIFF
--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -210,6 +210,13 @@ vars:
   ## The run itself never holds a posting credential.
   forge_publish_url: string = ""
   forge_publish_token: string = ""
+  ## The READ half of the same grant: "is this pull request still open?".
+  ## The delivery tail asks it before pushing — a squash merge leaves the
+  ## source branch present and its head no ancestor of the base, so git in the
+  ## workspace reads a merged pull request as an open one. Empty (a local run,
+  ## or no connection covering the repo) means the question cannot be asked,
+  ## which is never read as a closure.
+  forge_pr_state_url: string = ""
 
   ## ─── Plan phase ───────────────────────────────────────────────
   ## The plan phase itself — the AUTHORED triage plan the campaign fixes
@@ -961,7 +968,18 @@ schema mr_gate_output:
 ## push_back_tool output — deterministic result of the PR-branch push.
 schema push_state:
   pushed: bool
+  ## superseded: the pull request had already merged or closed, so its branch
+  ## took no more commits. The run's answer is the banked branch below, not a
+  ## verdict on a head that left the merge decision.
+  superseded: bool
   reason: string
+  ## banked_branch / how_to_take: where the fixes ARE when they could not land
+  ## on the pull request's branch, and the command that takes them. Empty when
+  ## the push landed (or when there was nothing to push). Without them, work
+  ## that cost a full run is reachable only by someone who already knows to
+  ## look for it.
+  banked_branch: string
+  how_to_take: string
 
 ## publish_verdict I/O — the deterministic verdict + merge-gate status.
 schema post_feedback_input:
@@ -970,6 +988,16 @@ schema post_feedback_input:
   branch_clean: bool
   commits_pushed: bool
   push_reason: string
+  ## Where the commits ARE when they could not land on the pull request's own
+  ## branch, and the command that takes them — rendered verbatim into the
+  ## comment. A run whose work is only reachable by someone who already knows
+  ## the convention has not delivered it.
+  banked_branch: string
+  how_to_take: string
+  ## The pull request merged or closed while the campaign ran: this comment is
+  ## the run's whole answer, and the graph routes to the typed terminal after
+  ## it instead of claiming a verdict on a head that left the merge decision.
+  superseded: bool
   ## Did the DETERMINISTIC build/test gate end green, and did it actually RUN?
   ## Part of the merge-gate count: a tree that does not build is not mergeable
   ## whatever the findings, and a build that was skipped proves nothing at all.
@@ -983,6 +1011,9 @@ schema post_feedback_input:
 schema post_feedback_output:
   posted: bool
   note: string
+  ## Echoed from the input so the graph can route on it (a `when` reads a
+  ## boolean off the SOURCE node's own output).
+  superseded: bool
 
 ## forge_auth_probe output — deterministic "can we push?" so finalize_mr (an
 ## LLM agent) is only ever entered when a push credential actually exists.
@@ -1659,6 +1690,19 @@ fail campaign_declined:
   message: "{{outputs.decline_probe.reason}}"
   resumable: false
 
+## pr_superseded — the pull request ended under the run. NOT resumable, and
+## not a failure to repair: the work exists, on the branch the comment names,
+## and nothing about a merged pull request changes by running the fixer again.
+## It wears the same typed DECLINED code as the no-op terminal above because
+## the platform reads that code as "this is the answer": the gate relaunch
+## stands down on it, the reconciler leaves no dead-review wording, and the
+## notice quotes the message below — which is what carries the difference.
+fail pr_superseded:
+  description: "the pull request merged or closed while the fixer was working"
+  code: DECLINED
+  message: "{{outputs.push_back_tool.reason}}"
+  resumable: false
+
 ## verify_probe — DETERMINISTIC pre-check: is a usable verify.sh already in the
 ## scratch dir from an earlier pass of THIS run? verify_build is an LLM agent
 ## (~$0.69/13k tok EVERY pass); once pass 1 has authored verify.sh, re-authoring
@@ -2038,21 +2082,47 @@ print(json.dumps({'available': False, 'reason': 'no forge_token secret, no *_TOK
   output: forge_auth_state
 
 ## push_back_tool — DETERMINISTIC push of the run's HEAD onto the declared
-## forge branch (the PR's source branch). The in-repo truth decides: when
-## rev-list shows nothing new over origin/<push_branch> it no-ops cleanly, so
-## a converged-with-no-commits pass never errors. The token comes from the
-## mounted forge_token secret or a *_TOKEN env and is redacted from any
-## failure output; it is tried under the common forge basic-auth usernames
-## (x-access-token = GitHub, oauth2 = GitLab-style). No LLM — the push is a
-## mechanical act once the campaign banked the commits.
+## forge branch (the PR's source branch). Three questions decide, in order:
+##
+##   1. Is the pull request still OPEN? git alone cannot answer it — a squash
+##      merge leaves the source branch present and its head no ancestor of the
+##      base — so the run asks the iterion server through the READ half of its
+##      publish grant. A merged or closed pull request is never pushed onto:
+##      the head would leave the merge decision, and the branch is scheduled
+##      for deletion.
+##   2. Is there anything new? The in-repo truth decides: when rev-list shows
+##      nothing over origin/<push_branch> it no-ops cleanly, naming the two
+##      revisions it compared so the claim carries its own evidence.
+##   3. Did the push land? When it did not — a merged PR, a conflicting
+##      advance, a protected branch, a dead token — the commits are BANKED on
+##      a named branch and the output carries the command that takes them.
+##      Work nobody can reach is work nobody has.
+##
+## The token comes from the mounted forge_token secret or a *_TOKEN env and is
+## redacted from any failure output; it is tried under the common forge
+## basic-auth usernames (x-access-token = GitHub, oauth2 = GitLab-style), then
+## through `origin` itself for a remote no token can be injected into (ssh, a
+## local path) where git resolves the credential on its own. No LLM — the push
+## is a mechanical act once the campaign banked the commits.
+##
+## Keep this python body free of the double-quote character: the whole body is
+## wrapped by the shell in a double-quoted argument.
 tool push_back_tool:
-  command: `PUSH_BRANCH={{vars.push_branch}} python3 -c "
-import os, subprocess, json, re
+  command: `PUSH_BRANCH={{vars.push_branch}} PR_URL={{vars.pr_url}} PR_STATE_URL={{vars.forge_pr_state_url}} PR_STATE_TOKEN={{vars.forge_publish_token}} python3 -c "
+import os, subprocess, json, re, urllib.request, urllib.error, urllib.parse
 branch = os.environ.get('PUSH_BRANCH', '').strip()
+out = {'pushed': False, 'superseded': False, 'reason': '', 'banked_branch': '', 'how_to_take': ''}
+def emit(**kw):
+    out.update(kw)
+    print(json.dumps(out))
+    raise SystemExit(0)
 if not branch:
-    print(json.dumps({'pushed': False, 'reason': 'no push_branch declared'})); raise SystemExit(0)
+    emit(reason='no push_branch declared')
 def run(*a, **kw):
     return subprocess.run(list(a), capture_output=True, text=True, timeout=kw.get('timeout', 120))
+def sha(rev):
+    r = run('git', 'rev-parse', rev)
+    return (r.stdout or '').strip() if r.returncode == 0 else ''
 tok = ''
 p = '/run/iterion/secrets/forge_token'
 try:
@@ -2065,51 +2135,88 @@ if not tok:
         if os.environ.get(v):
             tok = os.environ[v].strip(); break
 if not tok:
-    print(json.dumps({'pushed': False, 'reason': 'no forge token available'})); raise SystemExit(0)
-r = run('git', 'remote', 'get-url', 'origin')
-m = re.match(r'https://(?:[^@/]+@)?([^/]+)/(.+?)(?:\\.git)?$', (r.stdout or '').strip())
-if not m:
-    print(json.dumps({'pushed': False, 'reason': 'origin is not an https remote'})); raise SystemExit(0)
-host, path = m.group(1), m.group(2)
-urls = [(u, 'https://' + u + ':' + tok + '@' + host + '/' + path + '.git') for u in ('x-access-token', 'oauth2')]
+    emit(reason='no forge token available')
 def redact(s):
     return (s or '').strip().replace(tok, '***')[-200:]
-last, rebased = '', False
-# Bounded fetch -> (rebase if remote advanced) -> push loop. A non-fast-forward
-# rejection is the EXPECTED case when the PR author (or another bot) pushed to
-# the branch while this review ran: re-fetch, replay OUR commits onto the fresh
-# remote head, and retry. Only a genuine rebase CONFLICT (the advance touched
-# the same lines we fixed) falls back to a flag — that needs a human.
-for attempt in range(3):
-    r = run('git', 'fetch', 'origin', branch)
-    if r.returncode != 0:
-        print(json.dumps({'pushed': False, 'reason': 'fetch origin/' + branch + ' failed (branch may be merged or deleted -> the fixes need a NEW PR onto the base): ' + redact(r.stderr or r.stdout)})); raise SystemExit(0)
-    ahead = run('git', 'rev-list', '--count', 'FETCH_HEAD..HEAD')
-    n = int((ahead.stdout or '0').strip() or '0') if ahead.returncode == 0 else -1
-    if n == 0:
-        print(json.dumps({'pushed': False, 'reason': 'nothing to push: HEAD not ahead of origin/' + branch})); raise SystemExit(0)
-    behind = run('git', 'rev-list', '--count', 'HEAD..FETCH_HEAD')
-    b = int((behind.stdout or '0').strip() or '0') if behind.returncode == 0 else 0
-    if b > 0:
-        mb = run('git', 'merge-base', 'FETCH_HEAD', 'HEAD')
-        base = (mb.stdout or '').strip()
-        rb = run('git', '-c', 'rebase.autoStash=true', 'rebase', '--onto', 'FETCH_HEAD', base, 'HEAD')
-        if rb.returncode != 0:
-            run('git', 'rebase', '--abort')
-            print(json.dumps({'pushed': False, 'reason': 'remote branch advanced by ' + str(b) + ' commit(s) that CONFLICT with these fixes (auto-rebase failed) -> needs a manual reconcile: ' + redact(rb.stderr or rb.stdout)})); raise SystemExit(0)
-        rebased = True
-        n = int((run('git', 'rev-list', '--count', 'FETCH_HEAD..HEAD').stdout or '0').strip() or '0')
-    nonff = False
+# Push targets: the token-injected https forms first (the cloud shape), then
+# plain origin for a remote no token can be injected into.
+urls = [('origin', 'origin')]
+r = run('git', 'remote', 'get-url', 'origin')
+m = re.match(r'https://(?:[^@/]+@)?([^/]+)/(.+?)(?:\\.git)?$', (r.stdout or '').strip())
+if m:
+    host, path = m.group(1), m.group(2)
+    urls = [(u, 'https://' + u + ':' + tok + '@' + host + '/' + path + '.git') for u in ('x-access-token', 'oauth2')] + urls
+def push_to(ref):
+    last = ''
     for user, url in urls:
-        r = run('git', 'push', url, 'HEAD:refs/heads/' + branch, timeout=180)
-        if r.returncode == 0:
-            print(json.dumps({'pushed': True, 'reason': 'pushed ' + str(n) + ' commit(s) HEAD->' + branch + ' as ' + user + (' (rebased onto advanced remote)' if rebased else '')})); raise SystemExit(0)
-        last = redact(r.stderr or r.stdout)
+        pr = run('git', 'push', url, 'HEAD:refs/heads/' + ref, timeout=180)
+        if pr.returncode == 0:
+            return True, user, ''
+        last = redact(pr.stderr or pr.stdout)
         if 'non-fast-forward' in last or 'fetch first' in last or 'rejected' in last or 'stale info' in last:
-            nonff = True; break
-    if not nonff:
-        print(json.dumps({'pushed': False, 'reason': 'push failed: ' + last})); raise SystemExit(0)
-print(json.dumps({'pushed': False, 'reason': 'push failed after 3 rebase-retries (remote kept advancing): ' + last}))
+            return False, user, last
+    return False, '', last
+# The bank: a NAMED branch on the forge carrying exactly what could not land
+# on the pull request, plus the command that takes it. Derived from the target
+# branch and this HEAD, so two runs of the same work reuse one name and a
+# reader can recognise it without knowing a run id.
+def bank(why, base):
+    head = sha('HEAD')
+    ref = 'iterion/banked/' + re.sub(r'[^A-Za-z0-9._/-]', '-', branch) + '-' + head[:12]
+    ok, _, err = push_to(ref)
+    if not ok:
+        emit(reason=why + ' -- and the fixes could NOT be banked either (' + (err or 'push refused') + '): they exist only in this run workspace')
+    take = 'git fetch origin ' + ref + ' && git cherry-pick ' + (base[:12] if base else 'origin/' + branch) + '..FETCH_HEAD'
+    emit(reason=why + ' -- the fixes are banked on ' + ref, banked_branch=ref, how_to_take=take, superseded=out['superseded'])
+# 1. The pull request's own state, read through the publish grant. No grant
+# (a local run) means no state to read, and the absence of an endpoint is
+# never a closure; an endpoint that answers badly says so in the report.
+state_note = ''
+pr_open = True
+su, st, pu = os.environ.get('PR_STATE_URL', '').strip(), os.environ.get('PR_STATE_TOKEN', '').strip(), os.environ.get('PR_URL', '').strip()
+if su and st and pu:
+    try:
+        req = urllib.request.Request(su + '?pr_url=' + urllib.parse.quote(pu, safe=''), headers={'X-Iterion-Run': st})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            js = json.loads(resp.read().decode())
+        pr_open = bool(js.get('open'))
+        if not pr_open:
+            state_note = str(js.get('state') or 'closed')
+    except urllib.error.HTTPError as e:
+        state_note = 'unreadable-http-' + str(e.code)
+    except Exception as e:
+        state_note = 'unreadable: ' + str(e)[:120]
+r = run('git', 'fetch', 'origin', branch)
+if r.returncode != 0:
+    emit(reason='fetch origin/' + branch + ' failed (branch may be merged or deleted -> the fixes need a NEW PR onto the base): ' + redact(r.stderr or r.stdout))
+mb = run('git', 'merge-base', 'FETCH_HEAD', 'HEAD')
+base = (mb.stdout or '').strip()
+ahead = run('git', 'rev-list', '--count', 'FETCH_HEAD..HEAD')
+n = int((ahead.stdout or '0').strip() or '0') if ahead.returncode == 0 else -1
+if n == 0:
+    # Name both revisions: a bare -nothing to push- is a git fact stated with
+    # no evidence, and a run whose campaign reported commits reads it as a lie
+    # (iterion#773).
+    emit(reason='nothing to push: HEAD ' + sha('HEAD')[:12] + ' is not ahead of origin/' + branch + ' at ' + sha('FETCH_HEAD')[:12])
+if not pr_open:
+    out['superseded'] = True
+    bank('the pull request is ' + state_note + ', so its branch takes no more commits', base)
+if state_note:
+    out['reason'] = 'the pull request state was ' + state_note + '; pushed anyway rather than strand the work. '
+behind = run('git', 'rev-list', '--count', 'HEAD..FETCH_HEAD')
+b = int((behind.stdout or '0').strip() or '0') if behind.returncode == 0 else 0
+rebased = False
+if b > 0:
+    rb = run('git', '-c', 'rebase.autoStash=true', 'rebase', '--onto', 'FETCH_HEAD', base, 'HEAD')
+    if rb.returncode != 0:
+        run('git', 'rebase', '--abort')
+        bank('remote branch advanced by ' + str(b) + ' commit(s) that CONFLICT with these fixes (auto-rebase failed) -> needs a manual reconcile: ' + redact(rb.stderr or rb.stdout), base)
+    rebased = True
+    n = int((run('git', 'rev-list', '--count', 'FETCH_HEAD..HEAD').stdout or '0').strip() or '0')
+ok, user, err = push_to(branch)
+if ok:
+    emit(pushed=True, reason=out['reason'] + 'pushed ' + str(n) + ' commit(s) HEAD->' + branch + ' as ' + user + (' (rebased onto advanced remote)' if rebased else ''))
+bank('push to ' + branch + ' refused (' + (err or 'unknown error') + ')', base)
 "`
   output: push_state
 
@@ -2169,15 +2276,18 @@ if u:
 ## Keep this python body free of the double-quote character: the whole body is
 ## wrapped by the shell in a double-quoted argument.
 tool publish_verdict:
-  command: `PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} PR_URL={{input.pr_url}} LEDGER={{input.finding_ledger}} SUMMARY={{input.review_summary}} CLEAN={{input.branch_clean}} PUSHED={{input.commits_pushed}} PUSH_REASON={{input.push_reason}} VERIFY_OK={{input.verify_ok}} VERIFY_SKIPPED={{input.verify_skipped}} GATE_ENABLED={{vars.gate_enabled}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
+  command: `PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} PR_URL={{input.pr_url}} LEDGER={{input.finding_ledger}} SUMMARY={{input.review_summary}} CLEAN={{input.branch_clean}} PUSHED={{input.commits_pushed}} PUSH_REASON={{input.push_reason}} BANKED_BRANCH={{input.banked_branch}} HOW_TO_TAKE={{input.how_to_take}} SUPERSEDED={{input.superseded}} VERIFY_OK={{input.verify_ok}} VERIFY_SKIPPED={{input.verify_skipped}} GATE_ENABLED={{vars.gate_enabled}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
 import os, json, urllib.request, urllib.error
-
-def emit(posted, note):
-    print(json.dumps({'posted': posted, 'note': note}))
-    raise SystemExit(0)
 
 def flag(name):
     return str(os.environ.get(name, '')).strip().lower() in ('1', 'true', 'yes', 'on')
+
+def emit(posted, note):
+    # superseded is echoed from the input so the graph can route the run to its
+    # typed terminal: a pull request that merged mid-campaign takes a comment,
+    # never a verdict on the head it left behind.
+    print(json.dumps({'posted': posted, 'note': note, 'superseded': flag('SUPERSEDED')}))
+    raise SystemExit(0)
 
 nl = chr(10)
 pr = os.environ.get('PR_URL', '').strip()
@@ -2207,10 +2317,16 @@ verify_ok = flag('VERIFY_OK')
 # never ran is a false statement, so a skip blocks like a red one.
 verify_skipped = flag('VERIFY_SKIPPED')
 
+banked = str(os.environ.get('BANKED_BRANCH') or '').strip()
+take = str(os.environ.get('HOW_TO_TAKE') or '').strip()
 # Nothing was pushed and no review was answered: this run has nothing to say
 # about this head, and whatever verdict already sits on it is still the truth.
 # Overwriting it would be speaking for a revision this run did not change.
-if not pushed and not ledger:
+# A BANKED branch is the exception - it is a fact about work that exists and
+# is otherwise reachable only by someone who already knows to look for it
+# (iterion#773: two runs banked 16.81 and 23.70 dollars of reviewed,
+# test-backed commits and neither verdict named the branch).
+if not pushed and not ledger and not banked:
     emit(False, 'nothing pushed and no prior review answered - left the existing verdict alone')
 
 unresolved = [e for e in ledger if str(e.get('status') or '').strip().lower() != 'fixed']
@@ -2225,6 +2341,13 @@ if pushed:
     body.append('Pushed fixes onto this branch. ' + str(os.environ.get('PUSH_REASON') or '').strip())
 else:
     body.append('No commits pushed. ' + str(os.environ.get('PUSH_REASON') or '').strip())
+if banked:
+    body.append('')
+    body.append('The commits are on ' + chr(96) + banked + chr(96) + ' on this remote. To take them:')
+    body.append('')
+    body.append(chr(96) * 3)
+    body.append(take)
+    body.append(chr(96) * 3)
 summary = str(os.environ.get('SUMMARY') or '').strip()
 if summary:
     body.append('')
@@ -2547,10 +2670,19 @@ workflow branch_improve_loop:
     branch_clean:   "{{outputs.campaign.branch_clean}}",
     commits_pushed: "{{outputs.push_back_tool.pushed}}",
     push_reason:    "{{outputs.push_back_tool.reason}}",
+    banked_branch:  "{{outputs.push_back_tool.banked_branch}}",
+    how_to_take:    "{{outputs.push_back_tool.how_to_take}}",
+    superseded:     "{{outputs.push_back_tool.superseded}}",
     finding_ledger: "{{outputs.campaign.finding_ledger}}",
     verify_ok:      "{{outputs.gate.converged}}",
     verify_skipped: "{{outputs.verify_run.skipped}}"
   }
+  ## The pull request merged (or closed) while the campaign ran. The comment
+  ## above is the whole answer — it names the branch the commits are on — and
+  ## the run ends on the typed refusal family the platform already reads:
+  ## no relaunch, no dead-review repair, no verdict on the head that left the
+  ## merge decision.
+  publish_verdict -> pr_superseded when superseded
   publish_verdict -> done
 
   ## Push credential present → finalize_mr pushes the run's HEAD (the series of

--- a/bots/branch-improve-loop/manifest.yaml
+++ b/bots/branch-improve-loop/manifest.yaml
@@ -1,7 +1,24 @@
 name: branch-improve-loop
 display_name: Billy
 icon: 🌿
-version: 1.6.0
+version: 1.7.0
+## 1.7.0 — the delivery tail asks whether the pull request is still there,
+## and never loses what it cannot land. A fixer kept working half an hour
+## past the squash-merge of its pull request, pushed six commits onto the
+## merged branch and posted its verdict on the pre-merge head (#863): git
+## in the workspace cannot see a squash merge — the source branch is still
+## present and its head is no ancestor of the base — so `push_back_tool`
+## now asks the server through `forge_pr_state_url`, the READ half of the
+## run's publish grant. A pull request that merged or closed routes to
+## `fail pr_superseded: code: DECLINED`: one comment, no push onto a dead
+## branch, no verdict on a head that left the merge decision. Second: every
+## refusal to push — a merged pull request, a conflicting advance, a
+## protected branch, a dead token — BANKS the run's HEAD on
+## `iterion/banked/<branch>-<head12>` and the verdict names it plus the
+## cherry-pick that takes it (#773: two runs banked $16.81 and $23.70 of
+## reviewed, test-backed commits and neither verdict said where they
+## were). The no-op reason now names both revisions it compared, so
+## "nothing to push" is falsifiable instead of merely surprising.
 ## 1.6.0 — the run reaches its own DELIVERY, and may refuse the task.
 ## Three production runs died within 2s of the 2h30m cap having pushed
 ## NOTHING: the campaign spent the whole window and the delivery tail

--- a/bots/branch_improve_gate_test.go
+++ b/bots/branch_improve_gate_test.go
@@ -31,7 +31,7 @@ func TestBranchImproveGateNeverGreenOnAnUnresolvedFinding(t *testing.T) {
 		Summary string         `json:"summary"`
 		Gate    map[string]any `json:"gate"`
 	}
-	runWith := func(t *testing.T, ledger, clean, pushed, verifyOK, verifySkipped string) (published, bool) {
+	runBanked := func(t *testing.T, ledger, clean, pushed, verifyOK, verifySkipped, banked, take string) (published, bool) {
 		t.Helper()
 		var got published
 		var posted bool
@@ -55,6 +55,9 @@ func TestBranchImproveGateNeverGreenOnAnUnresolvedFinding(t *testing.T) {
 			"{{input.branch_clean}}":       clean,
 			"{{input.commits_pushed}}":     pushed,
 			"{{input.push_reason}}":        "pushed 2 commits",
+			"{{input.banked_branch}}":      banked,
+			"{{input.how_to_take}}":        take,
+			"{{input.superseded}}":         "false",
 			"{{input.verify_ok}}":          verifyOK,
 			"{{input.verify_skipped}}":     verifySkipped,
 			"{{vars.gate_enabled}}":        "true",
@@ -76,6 +79,10 @@ func TestBranchImproveGateNeverGreenOnAnUnresolvedFinding(t *testing.T) {
 		return got, posted
 	}
 
+	runWith := func(t *testing.T, ledger, clean, pushed, verifyOK, verifySkipped string) (published, bool) {
+		t.Helper()
+		return runBanked(t, ledger, clean, pushed, verifyOK, verifySkipped, "", "")
+	}
 	run := func(t *testing.T, ledger, clean, pushed, verifyOK string) (published, bool) {
 		return runWith(t, ledger, clean, pushed, verifyOK, "false")
 	}
@@ -187,6 +194,26 @@ func TestBranchImproveGateNeverGreenOnAnUnresolvedFinding(t *testing.T) {
 		_, posted := run(t, `[]`, "true", "false", "true")
 		if posted {
 			t.Error("posted a verdict for a head this run neither changed nor reviewed")
+		}
+	})
+
+	// The one exception, and the reason it is one: a BANKED branch is not a
+	// verdict about the head, it is a fact about work that exists. Silence
+	// there strands it — iterion#773 measured two runs, $16.81 and $23.70 of
+	// reviewed, test-backed commits, whose verdicts named no branch and whose
+	// readers had no way to reach them.
+	t.Run("a banked branch is always named, even with nothing pushed", func(t *testing.T) {
+		const branch = "iterion/banked/feature-x-1234567890ab"
+		got, posted := runBanked(t, `[]`, "true", "false", "true", "false",
+			branch, "git fetch origin "+branch+" && git cherry-pick abcdef123456..FETCH_HEAD")
+		if !posted {
+			t.Fatal("work banked on a branch nobody is told about is work nobody has")
+		}
+		if !strings.Contains(got.Summary, branch) {
+			t.Errorf("the comment must name the branch:\n%s", got.Summary)
+		}
+		if !strings.Contains(got.Summary, "cherry-pick") {
+			t.Errorf("the comment must carry the command that takes the work:\n%s", got.Summary)
 		}
 	})
 }

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -287,7 +287,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `delivery_reserve_floor_minutes` (int), `delivery_reserve_ratio` (float), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `delivery_reserve_floor_minutes` (int), `delivery_reserve_ratio` (float), `forge_pr_state_url` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `campaign` — Campy

--- a/bots/push_back_banked_branch_test.go
+++ b/bots/push_back_banked_branch_test.go
@@ -1,0 +1,231 @@
+package bots
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// push_back_tool is the ONE node that pushes a fixer's commits onto a pull
+// request's branch, so it is where two production defects meet.
+//
+//   - #863: a fixer kept working half an hour past the squash-merge of its
+//     pull request and pushed six commits onto a branch nobody merges any
+//     more. git alone cannot see this — a squash leaves the source branch
+//     present and its head no ancestor of the base — so the tool has to ask.
+//   - #773: two runs banked $16.81 and $23.70 of reviewed, test-backed work
+//     and neither verdict named the branch it was on. "No commits pushed"
+//     with no pointer is work nobody can reach.
+//
+// Both answers are the same shape: when the fixes cannot land on the pull
+// request's own branch, push them somewhere NAMED and say where.
+type pushState struct {
+	Pushed       bool   `json:"pushed"`
+	Superseded   bool   `json:"superseded"`
+	Reason       string `json:"reason"`
+	BankedBranch string `json:"banked_branch"`
+	HowToTake    string `json:"how_to_take"`
+}
+
+// prStateServer stands in for the iterion server's read half of the publish
+// grant (GET /api/v1/forge/pull-request).
+func prStateServer(t *testing.T, state string, status int) (*httptest.Server, *int) {
+	t.Helper()
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"open": state == "" || state == "open", "state": state, "head_sha": "cafe",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestPushBackToolBanksAndNamesTheBranchItCannotLandOn(t *testing.T) {
+	for _, bin := range []string{"python3", "git", "sh"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH", bin)
+		}
+	}
+	command := toolCommand(t, "branch-improve-loop/main.bot", "push_back_tool")
+	env := hermeticGitEnv(t)
+
+	// upstream = the forge; ws = the run's worktree, cloned from it, with the
+	// fixer's commits on top of the PR branch.
+	world := func(t *testing.T) (upstream, ws string) {
+		t.Helper()
+		upstream = initRepo(t, env)
+		gitHermetic(t, env, upstream, "checkout", "-q", "-b", "feature/x")
+		commitFile(t, env, upstream, "base.txt", "feat: the PR's own work")
+		gitHermetic(t, env, upstream, "checkout", "-q", "main")
+		ws = t.TempDir()
+		gitHermetic(t, env, ".", "clone", "-q", "--no-tags", upstream, ws)
+		gitHermetic(t, env, ws, "fetch", "-q", "origin", "feature/x")
+		gitHermetic(t, env, ws, "checkout", "-q", "-B", "feature/x", "FETCH_HEAD")
+		commitFile(t, env, ws, "fix1.txt", "fix: the first defect")
+		commitFile(t, env, ws, "fix2.txt", "fix: the second defect")
+		return upstream, ws
+	}
+
+	run := func(t *testing.T, ws, branch, prURL, stateURL, token string) pushState {
+		t.Helper()
+		rendered := strings.NewReplacer(
+			"{{vars.push_branch}}", shellQuote(branch),
+			"{{vars.pr_url}}", shellQuote(prURL),
+			"{{vars.forge_pr_state_url}}", shellQuote(stateURL),
+			"{{vars.forge_publish_token}}", shellQuote(token),
+			"{{vars.base_ref}}", shellQuote("main"),
+		).Replace(command)
+		cmd := exec.Command("sh", "-c", rendered)
+		cmd.Dir = ws
+		cmd.Env = append(env, "GH_TOKEN=t0k", "HOME="+t.TempDir())
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("push_back_tool exited non-zero (%v): its result is the node OUTPUT, so a non-zero exit turns a delivery report into a crash.\nstdout=%q\nstderr=%s", err, out, stderr.String())
+		}
+		var st pushState
+		if uerr := json.Unmarshal(out, &st); uerr != nil {
+			t.Fatalf("push_back_tool output is not push_state JSON: %v (out %q)", uerr, out)
+		}
+		return st
+	}
+
+	t.Run("a merged pull request is never pushed onto", func(t *testing.T) {
+		upstream, ws := world(t)
+		srv, hits := prStateServer(t, "merged", http.StatusOK)
+		before := gitHermetic(t, env, upstream, "rev-parse", "feature/x")
+
+		st := run(t, ws, "feature/x", "https://github.com/o/r/pull/7", srv.URL, "tok")
+		if *hits == 0 {
+			t.Fatal("the tool never asked whether the pull request was still open")
+		}
+		if st.Pushed {
+			t.Fatalf("pushed onto a merged pull request's branch: %+v", st)
+		}
+		if after := gitHermetic(t, env, upstream, "rev-parse", "feature/x"); after != before {
+			t.Fatalf("the merged branch moved (%s -> %s) — that is exactly the production incident", before, after)
+		}
+		if !st.Superseded {
+			t.Fatalf("the tail has to be able to route on this: %+v", st)
+		}
+		if !strings.Contains(st.Reason, "merged") {
+			t.Fatalf("the reason must name the state: %q", st.Reason)
+		}
+		if st.BankedBranch == "" {
+			t.Fatalf("the fixes must be banked somewhere named, not dropped: %+v", st)
+		}
+		// The banked branch is REAL: the commits are on the forge under it.
+		got := gitHermetic(t, env, upstream, "rev-parse", st.BankedBranch)
+		want := gitHermetic(t, env, ws, "rev-parse", "HEAD")
+		if got != want {
+			t.Fatalf("banked branch %s is at %s, want the run's HEAD %s", st.BankedBranch, got, want)
+		}
+		if !strings.Contains(st.HowToTake, st.BankedBranch) || !strings.Contains(st.HowToTake, "cherry-pick") {
+			t.Fatalf("a reader needs the command that takes the work, got %q", st.HowToTake)
+		}
+	})
+
+	t.Run("an open pull request still gets its push", func(t *testing.T) {
+		upstream, ws := world(t)
+		srv, _ := prStateServer(t, "open", http.StatusOK)
+		st := run(t, ws, "feature/x", "https://github.com/o/r/pull/7", srv.URL, "tok")
+		if !st.Pushed || st.Superseded {
+			t.Fatalf("an open pull request must still be pushed onto: %+v", st)
+		}
+		got := gitHermetic(t, env, upstream, "rev-parse", "feature/x")
+		want := gitHermetic(t, env, ws, "rev-parse", "HEAD")
+		if got != want {
+			t.Fatalf("the PR branch is at %s, want the run's HEAD %s", got, want)
+		}
+	})
+
+	t.Run("no grant means no state to read, and the push proceeds", func(t *testing.T) {
+		upstream, ws := world(t)
+		// A local run holds no publish grant. The tool must not invent a
+		// closure from the absence of an endpoint.
+		st := run(t, ws, "feature/x", "https://github.com/o/r/pull/7", "", "")
+		if !st.Pushed {
+			t.Fatalf("a run with no publish grant must still deliver: %+v", st)
+		}
+		if got, want := gitHermetic(t, env, upstream, "rev-parse", "feature/x"), gitHermetic(t, env, ws, "rev-parse", "HEAD"); got != want {
+			t.Fatalf("branch %s != HEAD %s", got, want)
+		}
+	})
+
+	t.Run("an unreachable endpoint says so and does not decide for itself", func(t *testing.T) {
+		_, ws := world(t)
+		srv, _ := prStateServer(t, "", http.StatusBadGateway)
+		st := run(t, ws, "feature/x", "https://github.com/o/r/pull/7", srv.URL, "tok")
+		if st.Superseded {
+			t.Fatalf("an unreadable state is not a closure: %+v", st)
+		}
+		if !strings.Contains(st.Reason, "state") && !strings.Contains(st.Reason, "unreadable") {
+			t.Fatalf("the run report must carry that the check could not be made: %q", st.Reason)
+		}
+	})
+
+	t.Run("a push the forge refuses banks the work and names it", func(t *testing.T) {
+		upstream, ws := world(t)
+		// The remote branch advances with a CONFLICTING change, so the
+		// auto-rebase fails — the shape of run 01a0716a in #773.
+		gitHermetic(t, env, upstream, "checkout", "-q", "feature/x")
+		writeConflicting(t, env, upstream)
+		gitHermetic(t, env, upstream, "checkout", "-q", "main")
+		writeConflicting(t, env, ws)
+
+		srv, _ := prStateServer(t, "open", http.StatusOK)
+		st := run(t, ws, "feature/x", "https://github.com/o/r/pull/7", srv.URL, "tok")
+		if st.Pushed {
+			t.Fatalf("a conflicting advance cannot be pushed: %+v", st)
+		}
+		if st.BankedBranch == "" || st.HowToTake == "" {
+			t.Fatalf("#773: work that could not land must still be reachable — %+v", st)
+		}
+		if got := gitHermetic(t, env, upstream, "rev-parse", st.BankedBranch); got == "" {
+			t.Fatalf("banked branch %s is not on the forge", st.BankedBranch)
+		}
+	})
+
+	t.Run("nothing new to push names what it compared", func(t *testing.T) {
+		upstream, _ := world(t)
+		// A fresh clone with no commits of its own: HEAD is origin/feature/x.
+		ws2 := t.TempDir()
+		gitHermetic(t, env, ".", "clone", "-q", "--no-tags", upstream, ws2)
+		gitHermetic(t, env, ws2, "fetch", "-q", "origin", "feature/x")
+		gitHermetic(t, env, ws2, "checkout", "-q", "-B", "feature/x", "FETCH_HEAD")
+
+		srv, _ := prStateServer(t, "open", http.StatusOK)
+		st := run(t, ws2, "feature/x", "https://github.com/o/r/pull/7", srv.URL, "tok")
+		if st.Pushed || st.BankedBranch != "" {
+			t.Fatalf("a tree with nothing new must bank nothing: %+v", st)
+		}
+		head := gitHermetic(t, env, ws2, "rev-parse", "HEAD")
+		if !strings.Contains(st.Reason, head[:12]) {
+			t.Fatalf("#773: %q asserts a git fact with no evidence — it must name the two revisions it compared (HEAD %s)", st.Reason, head[:12])
+		}
+	})
+}
+
+func writeConflicting(t *testing.T, env []string, dir string) {
+	t.Helper()
+	const name = "conflict.txt"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(dir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitHermetic(t, env, dir, "add", "--", name)
+	gitHermetic(t, env, dir, "commit", "-q", "-m", "chore: touch the same line")
+}

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -530,7 +530,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `delivery_reserve_floor_minutes` (int), `delivery_reserve_ratio` (float), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `delivery_reserve_floor_minutes` (int), `delivery_reserve_ratio` (float), `forge_pr_state_url` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pilot` (string), `plan_budget_ratio` (float), `plan_large_diff_lines` (int), `plan_phase` (string), `plan_review` (string), `plan_review_policy` (string), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `campaign` — Campy

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,33 @@
 # Billy — branch-improvement validation
 
+## The delivery tail's contract (bot 1.7.0)
+
+Three properties `push_back_tool` and `publish_verdict` now hold, in the order
+they are decided. They exist because of two measured production defects
+(#863, #773); the tests that pin them execute the real command bodies against
+real git repositories (`bots/push_back_banked_branch_test.go`).
+
+- **A pull request that ended takes no more commits.** Before pushing, the
+  tool asks the iterion server whether the pull request is still open —
+  `forge_pr_state_url`, the read half of the run's publish grant. git in the
+  workspace cannot answer it: a squash merge leaves the source branch present
+  and its head no ancestor of the base, so a merged pull request reads locally
+  as an open one. A merged or closed pull request routes the run to
+  `pr_superseded` (typed `DECLINED`): one comment naming where the commits
+  are, no push onto the dead branch, no verdict on the head it left. No grant
+  (a local run) means the question cannot be asked, which is never read as a
+  closure; an endpoint that errors says so in the report and the push
+  proceeds.
+- **Work that cannot land is banked and NAMED.** Every refusal — a merged
+  pull request, a conflicting advance, a protected branch, a dead token —
+  pushes the run's HEAD to `iterion/banked/<branch>-<head12>` and the verdict
+  carries the branch plus the `git fetch … && git cherry-pick …` that takes
+  it. A run whose work is reachable only by someone who already knows the
+  convention has not delivered it.
+- **"Nothing to push" names what it compared.** The no-op reason carries both
+  revisions (HEAD and `origin/<branch>`), so a claim that contradicts the
+  campaign's own commit count is falsifiable instead of merely surprising.
+
 ## 2026-09-06 — 1.6.0 dogfooded live: three runs, the third validates the reserve and finds a real bug in the code it reviewed (runs 01a07804, 01a0782f, 01a07840)
 
 - Status: **validated** (run 3) — after two runs that validated nothing about

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -95,7 +95,6 @@ Webhook config ([`pkg/webhooks/types.go`](../pkg/webhooks/types.go)):
 | Field | Default | Meaning |
 |-------|---------|---------|
 | `review_on_sync` | `false` | Re-review on each push so the required status re-evaluates on the fixed head. **Required for a blocking gate.** |
-| `block_fork_prs` | `false` | Persisted and returned by the webhook CRUD API, but **no launch path reads it** — the only references are the struct field and the two CRUD assignments. Setting it changes nothing on any provider: the fork guard is unconditional everywhere (see the caution). |
 
 > **Caution — budget with `review_on_sync`.** The sync lane re-runs Revi's
 > selected topology on **every push** (each new head SHA): one LLM reviewer in
@@ -815,9 +814,48 @@ that from doing harm of its own:
   reaches is precisely the blast radius the grant exists to bound.
 - **`failure`, not `success`.** A review that did not happen has approved
   nothing.
+- **The remedy has to be one that can work.** The generic wording — *"review
+  died (…) — push again or comment the bot's command to re-run"* — is right for
+  an interruption and wrong for two typed outcomes, each of which gets its own:
+  - a run that ended **`DECLINED`** did not die. It read its task, concluded
+    the premise was wrong and deliberately changed nothing, so a push changes
+    nothing either: the next dispatch reads the same premise and refuses again.
+    The status says a bot was dispatched and declined, and routes to a human.
+    (The relaunch lane already stood down on the code; the reconciler was the
+    last reader still painting *review died* over a deliberate refusal.)
+  - a run that ended **`BUDGET_EXCEEDED`** dies at the same place on the next
+    attempt: the diff and the cap are unchanged. The status carries the spend
+    and the cap and asks for a human reviewer or a higher budget, and the
+    automatic relaunch **stands down after the second budget death in a row**
+    (a first overrun can be a spike and still gets its one retry; a repeat is
+    the cap being structurally short for that diff). Measured on
+    iterion#780: three deaths at 30–36 $ against a 12 $ cap on a seven-file
+    pull request, each one telling the developer to reproduce it.
 
 A paused run is not reconciled: it is expected to resume and post its own
 verdict.
+
+### No verdict on a pull request that already ended
+
+`postGateStatus` resolves the pull request before it writes, and refuses to
+write at all when its state is `merged` or `closed`. That head has left the
+merge decision: nothing consults the check any more, and the branch it
+describes is scheduled for deletion. This is the single point every bot's gate
+status crosses, which is what keeps the rule out of each bot's tail. An EMPTY
+state is a provider that does not report one, never a closure — the same
+predicate the relaunch, auto-fix and reconcile lanes use.
+
+The publish response says so (`gate_error`), so a bot's tail can route on it
+rather than claim a verdict it did not get. A bot that needs the answer
+*before* it acts — a fixer deciding whether to push onto the branch — reads
+the grant's own read half, `GET /api/v1/forge/pull-request?pr_url=…` with the
+same `X-Iterion-Run` token, injected as the `forge_pr_state_url` launch var.
+git in the workspace cannot answer the question: a squash merge leaves the
+source branch present and its head no ancestor of the base, so a merged pull
+request reads locally as an open one. Observed in production (run `01a07840`):
+a fixer kept working for half an hour past the squash of its pull request,
+pushed six commits onto the merged branch and posted `revi/review=success` on
+the pre-merge head.
 
 ### Two triggers, because one event is not a guarantee
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -134,7 +134,10 @@ Single URL, two event kinds dispatched on `X-Gitlab-Event`
      works. This is the ONLY bespoke lane left: a reply carries no
      command for the registry to resolve, so classifying "is this a
      Revi thread" stays a dedicated gate
-     (`realWebhookNoteGate`/`gitlabNoteGateWithAPI`).
+     (`realWebhookNoteGate`/`gitlabNoteGateWithAPI`). It proves the head
+     project through the same resolver the command lane uses and launches
+     on `forge.PullRef.HeadCloneURL`/`SourceBranch`, so the pair it hands
+     the runner names ONE repository.
 - **`Issue Hook`** — adding a trigger label (e.g. `implement`) launches the
   webhook's bot, same as GitHub `issues` (below). GitLab has no `labeled`
   action, so the parser diffs `changes.labels` (previous→current) and fires
@@ -219,6 +222,19 @@ failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
   ([pkg/webhooks/prforge/parser.go:IsReviewable](../pkg/webhooks/prforge/parser.go) +
   `SameRepoAsBase` behind `forkGuardRefusal`). A PR opened by iterion's **own forge bot** (another iterion
   bot's PR — see below) is also skipped.
+
+  **Fork pull requests are refused on every lane, and no configuration lifts
+  it.** The auto-review lane, the `/command` lanes, the reply-in-thread lane,
+  the gate relaunch and the gate auto-fix lane each require a head repository
+  PROVEN equal to the base before anything launches; a head the payload does
+  not name counts as unproven, which is the shape a deleted or blocked fork
+  takes. The reason is not only trust: the launch pair a fork produces — the
+  base repo's clone URL plus a head branch that lives elsewhere — does not
+  name one repository, so the checkout misses or hits a same-named branch on
+  the base and the bot reviews, comments and pushes against the wrong code
+  under iterion's own identity. Serving forks needs a lane of its own
+  (read-only, no publish grant, no fixer launch, no repo secrets, project
+  settings not honoured), not a switch on the existing ones.
 - **`issue_comment`** → the universal `/command` slash path (e.g.
   `/featurly <prompt>`, `/billy`), routed through the command registry —
   including the `/revi <question>` ⇄ bare `/revi` split, resolved by the
@@ -770,7 +786,6 @@ are accepted by `POST` / `PATCH`:
 | `secret_overrides` | — | Pins a stored secret per workflow-secret name, so several webhooks for the same bot can post under different forge tokens / bot identities. The secret twin of `key_overrides`. |
 | `retry_usage_window`, `retry_max_attempts`, `retry_max_wait`, `retry_jitter` | *(bot manifest, then machine default)* | The launch-surface layer of the [retry policy](scheduling.md#retry--a-provider-quota-window-is-waited-out-not-re-attempted) for a run that dies on an exhausted provider usage window. Only what is set here overrides the layers below. A webhook-launched run is often one an author is waiting on, so a shorter `max_wait` than a nightly's is usually right. |
 | `forge_base_url` | *(derived)* | Explicit forge base URL for a self-hosted instance. |
-| `block_fork_prs` | `false` | Persisted but **never read** by any launch path — the fork guard is unconditional on every provider (see [merge-gate.md](merge-gate.md)), so the flag has nothing left to add. |
 
 `authorized_repliers` / `min_replier_role` gate who may talk back to a
 bot in a note thread — see

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -1101,7 +1101,6 @@ func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
 	cfg.MonthlyCallLimit = prev.MonthlyCallLimit
 	cfg.AutoImplementOnOpen = prev.AutoImplementOnOpen
 	cfg.BranchImproveAsPR = prev.BranchImproveAsPR
-	cfg.BlockForkPRs = prev.BlockForkPRs
 	cfg.RetryUsageWindow = prev.RetryUsageWindow
 	cfg.RetryMaxAttempts = prev.RetryMaxAttempts
 	cfg.RetryMaxWait = prev.RetryMaxWait

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -66,6 +66,22 @@ var gateReasonWrappers = []*regexp.Regexp{
 // so the 140 characters a forge allows go to the remedy.
 const gateDLQDescription = "review parked on the DLQ — operator replay needed (iterion remote admin dlq)"
 
+// gateDeclineDescription is what a run that DECLINED its task leaves on the
+// head when nothing else answered the check. The generic trailer would be
+// false twice over here: the review did not die, and a push does not change
+// the refusal — the next dispatch reads the same premise and refuses again.
+// It is a `failure` like every other synthetic status, because a bot that
+// deliberately changed nothing has approved nothing either.
+const gateDeclineDescription = "a bot was dispatched here and declined the task — nothing was pushed, a human decides from here"
+
+// gateBudgetRemedy replaces the generic remedy when the run died on its own
+// budget. "Push again or comment the bot's command" is the one instruction
+// that cannot work: the next run reviews the same diff against the same cap
+// and dies at the same place. Measured on iterion#780 (#788) — three deaths
+// at 30–36 $ against a 12 $ cap, the lane's recovery exhausted, and a
+// developer told each time to reproduce it.
+const gateBudgetRemedy = ") — needs a human reviewer, or a higher budget"
+
 // gateInterruptedDescriptionFor prefixes the remedy with WHY the run died when
 // the run doc can say (budget exceeded, provider error, …). GitHub truncates
 // commit-status descriptions at 140 characters, so the reason is bounded and
@@ -76,6 +92,9 @@ const gateDLQDescription = "review parked on the DLQ — operator replay needed 
 func gateInterruptedDescriptionFor(run *store.Run) string {
 	if run != nil && run.FailureCode == store.FailureDLQParked {
 		return gateDLQDescription
+	}
+	if run != nil && run.FailureCode == declinedFailureCode {
+		return gateDeclineDescription
 	}
 	reason := ""
 	if run != nil {
@@ -107,6 +126,9 @@ func gateInterruptedDescriptionFor(run *store.Run) string {
 		}
 		reason = reason[:cut] + "…"
 	}
+	if run != nil && run.FailureCode == store.FailureBudgetExceeded {
+		return gateDiedDescriptionPrefix + reason + gateBudgetRemedy
+	}
 	return gateDiedDescriptionPrefix + reason + ") — push again or comment the bot's command to re-run"
 }
 
@@ -120,6 +142,7 @@ const gateDiedDescriptionPrefix = "review died ("
 func isSyntheticGateInterruption(description string) bool {
 	d := strings.TrimSpace(description)
 	return d == gateInterruptedDescription || d == gateDLQDescription ||
+		d == gateDeclineDescription ||
 		strings.HasPrefix(d, gateDiedDescriptionPrefix)
 }
 

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -423,3 +423,137 @@ func TestGateReconcile_ClosedPullRequestGetsNoSyntheticFailure(t *testing.T) {
 		})
 	}
 }
+
+// declining is an ANSWER, not a death. The relaunch lane already stands down
+// on the typed code; this reader was left behind and painted "review died …
+// push again or comment the bot's command to re-run" on a head where a bot
+// deliberately changed nothing — advice that re-derives the same refusal, and
+// a lie about what happened.
+func TestGateReconcile_DeclinedRunLeavesNoDeadReviewWording(t *testing.T) {
+	t.Run("no verdict on the head means say the decline, not a death", func(t *testing.T) {
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailed
+		run.FailureCode = declinedFailureCode
+		run.Error = "the queue ejected this PR on an unrelated flaky test; the diff has no defect"
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 1 {
+			t.Fatalf("the check still has to be answered — a pull request left on a claim nobody resolves is the bug this repair exists for (writes=%d)", gc.setCalls)
+		}
+		if strings.Contains(gc.last.Description, "review died") || strings.Contains(gc.last.Description, "push again") {
+			t.Fatalf("a decline is not a dead review and a push does not change it: %q", gc.last.Description)
+		}
+		if !strings.Contains(strings.ToLower(gc.last.Description), "declined") {
+			t.Fatalf("the description must name what actually happened: %q", gc.last.Description)
+		}
+		if !isSyntheticGateInterruption(gc.last.Description) {
+			t.Fatalf("the decline status is one of ours: a later pass that cannot recognise it treats it as a real verdict and goes silent — %q", gc.last.Description)
+		}
+	})
+
+	t.Run("a verdict already on the head is left alone", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses:       []forge.CommitStatus{{Context: "iterion/review", State: forge.CommitStateFailure, Description: "2 blocking finding(s) ≥high"}},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailed
+		run.FailureCode = declinedFailureCode
+		run.Error = "nothing to fix in this diff"
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 0 {
+			t.Fatalf("the reviewer's verdict from before the fixer ran is still the truth (%d writes: %q)", gc.setCalls, gc.last.Description)
+		}
+	})
+}
+
+// A review that died at its OWN cost cap does not come back by pushing: the
+// next run reaches the same cap on the same diff. The status has to say so as
+// a verdict and route to a human, instead of offering a remedy that
+// reproduces the death (#788).
+func TestGateReconcile_BudgetExceededVerdictRoutesToAHuman(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+	run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.RunStatusFailedResumable
+	run.FailureCode = store.FailureBudgetExceeded
+	run.Error = "budget exceeded: cost_usd (36/12)"
+	if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if gc.setCalls != 1 {
+		t.Fatalf("the check must be answered, writes=%d", gc.setCalls)
+	}
+	d := gc.last.Description
+	if strings.Contains(d, "push again") {
+		t.Fatalf("pushing again reproduces the death — the remedy must not be the disease: %q", d)
+	}
+	if !strings.Contains(d, "36") || !strings.Contains(d, "12") {
+		t.Fatalf("the spend and the cap are the two numbers a human decides on: %q", d)
+	}
+	if !strings.Contains(strings.ToLower(d), "human") {
+		t.Fatalf("a gate that cannot afford its review has no exit but a human — say it: %q", d)
+	}
+	if !isSyntheticGateInterruption(d) {
+		t.Fatalf("the budget verdict is one of ours and must stay recognisable: %q", d)
+	}
+}
+
+// Two deaths on the same cap are the automation's whole budget: the relaunch
+// replays the same review of the same diff against the same cap, so a third
+// launch is a third $30 for the same answer.
+func TestGateRelaunch_StandsDownOnASecondBudgetDeath(t *testing.T) {
+	inputs := gatingInputs()
+	inputs[gateRelaunchOfVar] = "run-that-also-died-on-budget"
+	run := &store.Run{
+		ID: "run-relaunched", Status: store.RunStatusFailedResumable,
+		FailureCode: store.FailureBudgetExceeded,
+		Error:       "budget exceeded: cost_usd (30/12)",
+		Inputs:      inputs,
+	}
+	if !gateRelaunchIsSpentOnBudget(run) {
+		t.Fatal("a relaunch that died on the same cap as the run it replaced must stop the automation")
+	}
+	first := &store.Run{
+		ID: "run-first", Status: store.RunStatusFailedResumable,
+		FailureCode: store.FailureBudgetExceeded,
+		Error:       "budget exceeded: cost_usd (36/12)",
+		Inputs:      gatingInputs(),
+	}
+	if gateRelaunchIsSpentOnBudget(first) {
+		t.Fatal("the FIRST budget death still gets its one relaunch — a transient overrun is real")
+	}
+	other := &store.Run{
+		ID: "run-other", Status: store.RunStatusFailedResumable,
+		FailureCode: store.FailureExecutionFailed,
+		Error:       "provider unreachable",
+		Inputs:      inputs,
+	}
+	if gateRelaunchIsSpentOnBudget(other) {
+		t.Fatal("a relaunch that died of something else keeps the ordinary recovery")
+	}
+}

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -48,6 +48,26 @@ const gateRelaunchLabel = "source:gate-reconcile"
 // while the first death stayed unfindable.
 const gateRelaunchOfVar = "gate_relaunch_of"
 
+// gateRelaunchIsSpentOnBudget reports whether this dead run is a RELAUNCH that
+// died on the same wall its predecessor did — the automation's stop condition
+// for a gate that cannot afford its own review.
+//
+// The stamp above is what makes the question answerable: a run carrying
+// gate_relaunch_of IS the one attempt the head gets, so a budget death there
+// is the second in a row. One overrun is a spike worth retrying; two are the
+// cap being structurally short for this diff, and a third launch buys the
+// same answer at the same price (#788: 36 $, then 30 $, then 33 $, all
+// against a 12 $ cap on a seven-file pull request).
+//
+// Keyed on the typed FailureCode alone — never on parsing run.Error — so a
+// duration or token overrun is judged by the same rule as a cost one.
+func gateRelaunchIsSpentOnBudget(run *store.Run) bool {
+	if run == nil || run.FailureCode != store.FailureBudgetExceeded {
+		return false
+	}
+	return runInputString(run, gateRelaunchOfVar) != ""
+}
+
 // deadGateRun carries what reconcileGateForRun already resolved about the dead
 // run, so the relaunch re-validates nothing it does not have to.
 type deadGateRun struct {
@@ -123,6 +143,19 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 		if s.logger != nil {
 			s.logger.Info("gate relaunch: run %s declined its task on %s#%d — not relaunching (a refusal is an answer, not a failure to repair): %s",
 				d.run.ID, d.repo, d.number, strings.TrimSpace(d.run.Error))
+		}
+		return
+	}
+	// A SECOND death on the same budget spends the automation's whole
+	// argument. The relaunch replays the same review of the same diff under
+	// the same cap, so where a transient overrun deserved one more attempt, a
+	// repeat says the cap is structurally short for this diff — and the third
+	// launch buys the same answer at the same price. The status carries the
+	// budget verdict (gateBudgetRemedy) and routes to a human instead.
+	if gateRelaunchIsSpentOnBudget(d.run) {
+		if s.logger != nil {
+			s.logger.Warn("gate relaunch: %s on %s#%d died on its budget and so did the run it replaced (%s) — not relaunching; the check now asks for a human reviewer or a higher budget",
+				d.gateCtx, d.repo, d.number, strings.TrimSpace(d.run.Error))
 		}
 		return
 	}
@@ -205,7 +238,7 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 	// mints a fresh one (and would overwrite a stale copy anyway).
 	vars := make(map[string]string, len(d.run.Inputs)+1)
 	for k, v := range d.run.Inputs {
-		if k == forgePublishVarToken || k == forgePublishVarURL {
+		if k == forgePublishVarToken || k == forgePublishVarURL || k == forgePublishVarPRState {
 			continue
 		}
 		if sv, ok := v.(string); ok {

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -546,6 +546,67 @@ func TestGateRelaunch(t *testing.T) {
 		}
 	})
 
+	// #788: a review that dies at its own cost cap, is relaunched, and dies at
+	// the same cap has proven the cap short for THIS diff. A third launch
+	// reviews the same diff under the same cap for the same answer, at the
+	// same price. Same shape as the case above that DOES relaunch — only the
+	// gate_relaunch_of stamp and the typed code differ.
+	t.Run("a second budget death stops the automation", func(t *testing.T) {
+		w := build(t, nil)
+		runID := seedDeadRun(t, w.s)
+		run, err := w.s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.FailureCode = store.FailureBudgetExceeded
+		run.Error = "budget exceeded: cost_usd (30/12)"
+		run.Inputs[gateRelaunchOfVar] = "run-that-also-died-on-budget"
+		if err := w.s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		w.s.relaunchDeadGateRun(context.Background(), deadGateRun{
+			run:   run,
+			grant: ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo, Bot: botID},
+			conn:  forge.Connection{ID: "c1", TenantID: team, Provider: forge.ProviderGitHub},
+			repo:  repo, number: 7,
+			pr:      forge.PullRef{HeadSHA: head, SourceBranch: "feat/x", TargetBranch: "main", HeadRepoFullName: repo},
+			gateCtx: gateNm, prURL: prURL,
+		})
+		if *w.launched != 0 {
+			t.Fatalf("relaunched a review that died twice on the same cap (%d launches) — the third death costs what the first two did", *w.launched)
+		}
+	})
+
+	// The FIRST budget death keeps its one relaunch: a spike (a long tool
+	// loop, one expensive turn) is real and a retry often lands inside the
+	// cap. Without this the guard would turn every overrun into a human ask.
+	t.Run("a first budget death still gets its one relaunch", func(t *testing.T) {
+		w := build(t, nil)
+		runID := seedDeadRun(t, w.s)
+		run, err := w.s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.FailureCode = store.FailureBudgetExceeded
+		run.Error = "budget exceeded: cost_usd (36/12)"
+		if err := w.s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		w.s.relaunchDeadGateRun(context.Background(), deadGateRun{
+			run:   run,
+			grant: ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo, Bot: botID},
+			conn:  forge.Connection{ID: "c1", TenantID: team, Provider: forge.ProviderGitHub},
+			repo:  repo, number: 7,
+			pr:      forge.PullRef{HeadSHA: head, SourceBranch: "feat/x", TargetBranch: "main", HeadRepoFullName: repo},
+			gateCtx: gateNm, prURL: prURL,
+		})
+		if *w.launched != 1 {
+			t.Fatalf("the first budget death must still be retried once (%d launches)", *w.launched)
+		}
+	})
+
 	// The relaunch pair — CloneURLFor(base) + d.pr.SourceBranch — is the
 	// same fork-unsafe pair the auto-launch and autofix lanes guard against.
 	// #642: SameRepoAs is false on a different owner AND on

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -583,6 +583,21 @@ func (s *Server) postGateStatus(ctx context.Context, conn forge.Connection, repo
 		out.errText = "forge returned no head sha for the PR"
 		return out
 	}
+	// A pull request that already merged or closed takes no verdict. The head
+	// resolved above is the PRE-merge revision — nobody merges it any more,
+	// nothing consults the check, and the branch it describes is scheduled for
+	// deletion — so a status there is a statement about a revision that left
+	// the merge decision. This is the ONE place every bot's gate status
+	// crosses, which is what keeps the rule out of each bot's tail.
+	//
+	// An EMPTY state is a provider that does not report one, never a closure:
+	// the same predicate the relaunch, auto-fix and reconcile lanes use, for
+	// the same reason — suppressing a required check on a guess deadlocks the
+	// pull request.
+	if pr.State != "" && pr.State != "open" {
+		out.errText = "pull request is " + pr.State + " — no gate status on a head that left the merge decision"
+		return out
+	}
 	out.sha = pr.HeadSHA
 
 	threshold := strings.TrimSpace(gate.Threshold)
@@ -655,9 +670,13 @@ func hostOfURL(raw string) string {
 // forgePublishVarURL / forgePublishVarToken are the launch vars the server
 // injects; a bot opts in by declaring them in its vars: block (undeclared
 // launch vars are dropped by the IR, so blind injection is safe).
+// forgePublishVarPRState is the read half's endpoint, injected alongside them
+// and authenticated by the SAME token: a delivery tail asks it whether the
+// pull request is still open before it pushes onto its branch.
 const (
-	forgePublishVarURL   = "forge_publish_url"
-	forgePublishVarToken = "forge_publish_token"
+	forgePublishVarURL     = "forge_publish_url"
+	forgePublishVarToken   = "forge_publish_token"
+	forgePublishVarPRState = "forge_pr_state_url"
 )
 
 // injectForgePublishVars mints a per-run forge-publish grant and injects the
@@ -733,6 +752,7 @@ func (s *Server) injectForgePublishVars(ctx context.Context, teamID, preferredCo
 		vars = map[string]string{}
 	}
 	vars[forgePublishVarURL] = base + "/api/v1/forge/publish-review"
+	vars[forgePublishVarPRState] = base + "/api/v1/forge/pull-request"
 	vars[forgePublishVarToken] = token
 	return vars, nil
 }

--- a/pkg/server/forge_publish_gate_test.go
+++ b/pkg/server/forge_publish_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -213,6 +214,59 @@ func TestForgePublishReview_GateMissingHeadSHA(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp.GatePosted || gc.setCalls != 0 || resp.GateError == "" {
 		t.Fatalf("missing head sha must skip status with an error: %+v (calls=%d)", resp, gc.setCalls)
+	}
+}
+
+// A verdict on a pull request that already merged names a revision nobody
+// merges any more: the check is gone from the merge decision, the head the
+// status lands on is pre-merge, and the branch it describes is scheduled for
+// deletion. Observed in production (run 01a07840): a fixer kept working for
+// half an hour past the squash and posted `revi/review=success` on the
+// pre-merge head. The chokepoint is here — every campaign bot's gate status
+// crosses postGateStatus, which already resolves the pull request.
+func TestForgePublishReview_GateRefusedOnAClosedPullRequest(t *testing.T) {
+	for _, state := range []string{"merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			s, _ := newForgePublishTestServer(t)
+			registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+			gc := &fakeGateClient{headSHA: "deadbeefcafe", state: state}
+			s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+			w := httptest.NewRecorder()
+			s.handleForgePublishReview(w, publishReq("tok1", publishBodyWithGate(`{"enabled":true,"context":"revi/review","blocking_count":0}`)))
+			if w.Code != http.StatusOK {
+				t.Fatalf("the review itself still lands: code=%d body=%s", w.Code, w.Body.String())
+			}
+			var resp publishReviewResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatal(err)
+			}
+			if gc.setCalls != 0 {
+				t.Fatalf("no status may be written on a %s pull request's head, got %d write(s): %+v", state, gc.setCalls, gc.last)
+			}
+			if resp.GatePosted {
+				t.Fatalf("gate_posted must be false on a %s pull request: %+v", state, resp)
+			}
+			if !strings.Contains(resp.GateError, state) {
+				t.Fatalf("gate_error must name the state the bot's tail has to route on, got %q", resp.GateError)
+			}
+			if !resp.Published {
+				t.Fatalf("the review comment is the one thing still worth posting: %+v", resp)
+			}
+		})
+	}
+}
+
+// An empty state is a provider that does not report one, never a closure:
+// suppressing a required check on a guess is how a pull request deadlocks.
+func TestForgePublishReview_GatePostedWhenTheStateIsUnknown(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+	gc := &fakeGateClient{headSHA: "deadbeefcafe"} // state "" — unreported
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+	w := httptest.NewRecorder()
+	s.handleForgePublishReview(w, publishReq("tok1", publishBodyWithGate(`{"enabled":true,"blocking_count":0}`)))
+	if gc.setCalls != 1 {
+		t.Fatalf("an unreported state must not suppress the verdict, writes=%d", gc.setCalls)
 	}
 }
 

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The READ half of the per-run forge-publish grant.
+//
+// A run's delivery tail has a decision to take before it acts: is the pull
+// request it is about to push onto, or post a verdict on, still open? Nothing
+// in a workspace can answer it — a squash merge leaves the source branch
+// present and its head no ancestor of the base, so git alone reads a merged
+// pull request as an open one — and the run deliberately holds no forge
+// credential (see forge_publish.go). So the server answers, under the same
+// token, the same repo scope and the same connection as the write half.
+//
+// Bot-agnostic by construction: the endpoint knows a grant and a pull-request
+// URL, never which bot is asking or what it will do with the answer.
+
+// forgePullRequestResponse is the pull request as the grant's connection sees
+// it, reduced to what a delivery tail decides on.
+type forgePullRequestResponse struct {
+	// Open is the DECISION, precomputed so every caller resolves an
+	// unreported state the same way: a provider that names no state has said
+	// nothing, and reading silence as a closure would strand a run's work on
+	// a guess. Open is therefore true for both "open" and "".
+	Open bool `json:"open"`
+	// State is the provider's own word ("open" | "closed" | "merged", or ""
+	// when it reports none) — what a message to a human quotes.
+	State string `json:"state"`
+	// HeadSHA is the revision the pull request currently points at, so a tail
+	// can tell "my work is on this head" from "the head moved under me".
+	HeadSHA string `json:"head_sha,omitempty"`
+	// SourceBranch / TargetBranch name the branches a tail pushes onto and
+	// diffs against.
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+	// Number is the pull request's own number, echoed for the caller's logs.
+	Number int `json:"number,omitempty"`
+}
+
+// handleForgePullRequest answers the state of the pull request a run's grant
+// covers. GET, read-only, and scoped exactly as the publish endpoint is: the
+// token IS the authority (a run carries no JWT), the grant's repo bounds what
+// it may read, and the connection must belong to the grant's team and serve
+// the URL's host.
+func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("X-Iterion-Run")
+	if token == "" {
+		httpError(w, http.StatusUnauthorized, "missing X-Iterion-Run header")
+		return
+	}
+	if s.forgePublishTokens == nil || s.forgeConnections == nil {
+		httpError(w, http.StatusNotFound, "forge publishing is not enabled on this server (no forge connections wired)")
+		return
+	}
+	grant, ok := s.forgePublishTokens.lookup(token)
+	if !ok {
+		httpError(w, http.StatusUnauthorized, "unknown or expired run token")
+		return
+	}
+	prURL := strings.TrimSpace(r.URL.Query().Get("pr_url"))
+	if prURL == "" {
+		httpError(w, http.StatusBadRequest, "pr_url is required")
+		return
+	}
+	host, repo, number, err := forge.ParsePullURL(prURL)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%v", err)
+		return
+	}
+	if !strings.EqualFold(repo, grant.Repo) {
+		httpError(w, http.StatusForbidden, "run token is scoped to repo %q, not %q", grant.Repo, repo)
+		return
+	}
+	conn, err := s.forgeConnections.Get(r.Context(), grant.ConnectionID)
+	if err != nil || conn.TenantID != grant.TeamID {
+		httpError(w, http.StatusNotFound, "connection not found")
+		return
+	}
+	if connHost := hostOfURL(conn.BaseURL()); connHost == "" || !strings.EqualFold(connHost, host) {
+		httpError(w, http.StatusBadRequest, "pr_url host %q is not on the connection's forge host", host)
+		return
+	}
+	gc, err := s.gateClientFor(r.Context(), conn)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "forge client: %v", err)
+		return
+	}
+	if gc == nil {
+		httpError(w, http.StatusNotImplemented, "provider %s cannot read pull requests", conn.Provider)
+		return
+	}
+	pr, err := gc.GetPullRequest(r.Context(), repo, number)
+	if err != nil {
+		// Explicit, never a default answer: a tail told "open" because the
+		// forge was unreachable would push onto a branch nobody checked.
+		httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
+		return
+	}
+	writeJSON(w, forgePullRequestResponse{
+		Open:         pr.State == "" || pr.State == "open",
+		State:        pr.State,
+		HeadSHA:      pr.HeadSHA,
+		SourceBranch: pr.SourceBranch,
+		TargetBranch: pr.TargetBranch,
+		Number:       number,
+	})
+}

--- a/pkg/server/forge_pullstate_test.go
+++ b/pkg/server/forge_pullstate_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+func prStateReq(token, prURL string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/forge/pull-request?pr_url="+prURL, nil)
+	if token != "" {
+		r.Header.Set("X-Iterion-Run", token)
+	}
+	return r
+}
+
+// A run's delivery tail has to know whether the pull request it is about to
+// push onto is still open, and it must learn it WITHOUT holding a forge
+// credential — the whole point of the publish grant. This is the read half of
+// that grant: same token, same repo scope, no write.
+func TestForgePullRequestState(t *testing.T) {
+	cases := []struct {
+		name      string
+		state     string
+		wantOpen  bool
+		wantState string
+	}{
+		{"open", "open", true, "open"},
+		{"merged", "merged", false, "merged"},
+		{"closed", "closed", false, "closed"},
+		// A provider that reports no state says nothing: the tail must not
+		// read silence as a closure and strand its work.
+		{"unreported", "", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newForgePublishTestServer(t)
+			registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+			gc := &fakeGateClient{headSHA: "deadbeefcafe", state: tc.state}
+			s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+
+			w := httptest.NewRecorder()
+			s.handleForgePullRequest(w, prStateReq("tok1", "https://github.com/o/r/pull/42"))
+			if w.Code != http.StatusOK {
+				t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+			}
+			var resp forgePullRequestResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatal(err)
+			}
+			if resp.Open != tc.wantOpen || resp.State != tc.wantState {
+				t.Fatalf("open=%v state=%q, want open=%v state=%q", resp.Open, resp.State, tc.wantOpen, tc.wantState)
+			}
+			if resp.HeadSHA != "deadbeefcafe" {
+				t.Fatalf("the tail compares its own work against this head: %+v", resp)
+			}
+		})
+	}
+}
+
+// The grant's repo is the whole authority here, exactly as on the write half:
+// a token must not be able to read a pull request outside it.
+func TestForgePullRequestState_ScopedToTheGrantsRepo(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+	gc := &fakeGateClient{headSHA: "abc"}
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+
+	w := httptest.NewRecorder()
+	s.handleForgePullRequest(w, prStateReq("tok1", "https://github.com/other/repo/pull/1"))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("a grant scoped to o/r must not read other/repo: code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestForgePullRequestState_RejectsAnUnknownToken(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	w := httptest.NewRecorder()
+	s.handleForgePullRequest(w, prStateReq("nope", "https://github.com/o/r/pull/42"))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unknown run token must 401, got %d", w.Code)
+	}
+}

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -291,7 +291,8 @@ func isPublicPath(path string) bool {
 	// the run token itself and 401s on a missing/unknown one, so the
 	// operator-JWT gate must not front them — a sandboxed or
 	// runner-launched run carries no JWT.
-	if strings.HasPrefix(path, "/api/v1/mcp/") || path == "/api/v1/forge/publish-review" {
+	if strings.HasPrefix(path, "/api/v1/mcp/") ||
+		path == "/api/v1/forge/publish-review" || path == "/api/v1/forge/pull-request" {
 		return true
 	}
 	if strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/static/") {

--- a/pkg/server/server_routes.go
+++ b/pkg/server/server_routes.go
@@ -334,6 +334,9 @@ func (s *Server) routes() {
 	// by injectForgePublishVars), so it intentionally bypasses requireAuth.
 	if s.forgeConnections != nil && s.forgePublishTokens != nil {
 		s.mux.ServeMux.HandleFunc("POST /api/v1/forge/publish-review", s.handleForgePublishReview)
+		// The read half of the same grant: a delivery tail asks whether the
+		// pull request is still open before it pushes or posts.
+		s.mux.ServeMux.HandleFunc("GET /api/v1/forge/pull-request", s.handleForgePullRequest)
 	}
 	// Event-driven trigger subscription CRUD backing the Triggers /
 	// Automations view. No-op without a TriggerStore.

--- a/pkg/server/webhooks_fanout_test.go
+++ b/pkg/server/webhooks_fanout_test.go
@@ -316,7 +316,6 @@ func TestFanOut_ForkPRStillBlocked(t *testing.T) {
 		return "", nil
 	}
 	cfg, pt := fanoutConfig(t, s)
-	cfg.BlockForkPRs = true
 	forkPR := strings.Replace(ghOpenPR,
 		`"head": {"ref": "feature/x", "sha": "abc123", "repo": {"full_name": "acme/widgets"}}`,
 		`"head": {"ref": "feature/x", "sha": "abc123", "repo": {"full_name": "mallory/widgets"}}`, 1)

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -115,7 +115,7 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// Fork guard (UNCONDITIONAL on the auto path): a fork PR (head repo != base
 	// repo) is untrusted — an adversary can open one to run code in our runner
 	// with the forge token and to exhaust the tenant's budget. So an inbound PR
-	// event NEVER auto-launches a bot on a fork, regardless of block_fork_prs.
+	// event NEVER auto-launches a bot on a fork — there is no config that lifts it.
 	// A repo-authorized collaborator can still run one DELIBERATELY by issuing a
 	// `/command` on the PR: that path (handlePRForgeComment) gates on the
 	// commenter's CollaboratorPermission, so only a trusted user, manually,

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -429,12 +429,13 @@ func TestGitHubWebhook_IterionBotPRSkipsReview(t *testing.T) {
 	}
 }
 
-// TestGitHubWebhook_ForkTicketPRStaysOnReviewer: the fork guard — a fork PR that
-// closes an issue must NOT route to the mutating bot; it stays on the reviewer.
-// A fork PR NEVER auto-launches a bot — not even the reviewer — regardless of
-// block_fork_prs. The auto path is untrusted (adversary-controlled code + budget
-// exhaustion); a repo collaborator triggers a bot manually via a command
-// instead (gated on CollaboratorPermission in handlePRForgeComment).
+// The fork guard: a fork PR NEVER auto-launches a bot — not even the reviewer,
+// and not even when it closes an issue the mutating bot would otherwise take.
+// UNCONDITIONAL, with no config to turn it off: the auto path is untrusted
+// (adversary-controlled code + budget exhaustion), and the launch pair a fork
+// produces names two repositories. A repo collaborator triggers a bot manually
+// via a command instead (gated on CollaboratorPermission in
+// handlePRForgeComment — which refuses forks too).
 func TestGitHubWebhook_ForkPRBlockedFromAutoLaunch(t *testing.T) {
 	s := newWebhookTestServer(t)
 	launched := 0
@@ -444,7 +445,6 @@ func TestGitHubWebhook_ForkPRBlockedFromAutoLaunch(t *testing.T) {
 	}
 	cfg, pt := ghConfig(t, s)
 	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
-	// block_fork_prs deliberately NOT set — the guard is unconditional now.
 
 	w := httptest.NewRecorder()
 	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghForkTicketPR, prforge.EventHeaderPullRequest, pt))
@@ -458,34 +458,6 @@ func TestGitHubWebhook_ForkPRBlockedFromAutoLaunch(t *testing.T) {
 	}
 	if launched != 0 {
 		t.Fatalf("fork PR must NOT auto-launch any bot, launched=%d", launched)
-	}
-}
-
-// TestGitHubWebhook_BlockForkPRs: with block_fork_prs on, a fork PR is filtered
-// (NO bot launches) — the opt-in anti budget-exhaustion boundary.
-func TestGitHubWebhook_BlockForkPRs(t *testing.T) {
-	s := newWebhookTestServer(t)
-	launched := 0
-	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
-		launched++
-		return "run-x", nil
-	}
-	cfg, pt := ghConfig(t, s)
-	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
-	cfg.BlockForkPRs = true
-
-	w := httptest.NewRecorder()
-	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghForkTicketPR, prforge.EventHeaderPullRequest, pt))
-	if w.Code != http.StatusOK {
-		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
-	}
-	var resp map[string]string
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["status"] != webhooks.StatusFiltered {
-		t.Fatalf("fork PR must be filtered with block_fork_prs, got %v", resp)
-	}
-	if launched != 0 {
-		t.Fatalf("no bot may launch on a blocked fork PR, launched=%d", launched)
 	}
 }
 

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -445,6 +445,23 @@ func (s *Server) handleGitLabNote(ctx context.Context, w http.ResponseWriter, r 
 	if s.logger != nil {
 		s.logger.Debug("webhooks: gitlab note %s!%d (reply) by %s authorized (%s)", p.ProjectPath, p.MRIID, p.AuthorUsername, reason)
 	}
+	// Prove the head project before launching, exactly as the command lane
+	// does. The note payload names neither source_project_id nor
+	// target_project_id, so `p.CloneURL + p.SourceBranch` is the base project
+	// paired with a branch name that, on a fork MR, lives somewhere else.
+	// HeadCloneURL (plumbed on all three providers) is what a lane serving
+	// forks would clone; reading it now means the day forks are served is not
+	// the day this pair is discovered to name two repositories.
+	head, herr := s.resolveGitLabNoteHead(ctx, cfg, p, converseBot)
+	if herr != nil {
+		s.recordNoteDelivery(ctx, cfg, webhooks.StatusLaunchError, payloadHash, srcIP, p, "MR resolution: "+herr.Error())
+		httpError(w, http.StatusBadGateway, "could not resolve the MR head project")
+		return
+	}
+	if !head.SameRepoAs(p.ProjectPath) {
+		filtered(gitlabCommandForkRefusal("reply", head.HeadRepoFullName))
+		return
+	}
 	question := strings.TrimSpace(p.NoteBody)
 	vars := applyWebhookVarLayers(reviewPRVars(p.MRURL, p.TargetBranch, strings.TrimSpace(p.MRTitle+"\n\n"+p.MRDesc), nil, map[string]string{
 		"conversation_mode": "reply",
@@ -463,7 +480,40 @@ func (s *Server) handleGitLabNote(ctx context.Context, w http.ResponseWriter, r 
 	// Idempotency: one launch per note.
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("%s|%s|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.SubjectID())))
 
-	s.insertAndLaunchWebhook(ctx, w, r, cfg, gitlabNoteMeta(p), idemKey, converseBot, vars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+	s.insertAndLaunchWebhook(ctx, w, r, cfg, gitlabNoteMeta(p), idemKey, converseBot,
+		vars, gitlabHeadCloneURL(head, p), gitlabHeadBranch(head, p), payloadHash, srcIP)
+}
+
+// resolveGitLabNoteHead resolves the merge request a note sits on through the
+// test-seamed resolver the command lane already uses, so both lanes prove the
+// head project the same way and a fake covers both.
+func (s *Server) resolveGitLabNoteHead(ctx context.Context, cfg webhooks.Config, p gitlab.ParsedNote, botID string) (forge.PullRef, error) {
+	resolve := s.webhookGitLabPRResolver
+	if resolve == nil {
+		resolve = s.realWebhookGitLabPRResolver
+	}
+	return resolve(ctx, cfg, p, botID)
+}
+
+// gitlabHeadCloneURL / gitlabHeadBranch are the launch pair, taken from the
+// RESOLVED head when the forge named it and from the note payload otherwise.
+// On a same-project merge request GitLab reports no separate head clone URL
+// (pkg/forge/gitlab/ci.go headProjectFor returns the queried project with no
+// URL of its own), so the payload's is the right answer; the fields exist for
+// the fork case, which every lane refuses today. Reading them here is what
+// keeps "serve forks" a policy decision instead of a plumbing change.
+func gitlabHeadCloneURL(head forge.PullRef, p gitlab.ParsedNote) string {
+	if u := strings.TrimSpace(head.HeadCloneURL); u != "" {
+		return u
+	}
+	return p.CloneURL
+}
+
+func gitlabHeadBranch(head forge.PullRef, p gitlab.ParsedNote) string {
+	if b := strings.TrimSpace(head.SourceBranch); b != "" {
+		return b
+	}
+	return p.SourceBranch
 }
 
 // handleGitLabCommandNote routes a generic slash-command note (any command
@@ -692,7 +742,15 @@ func (s *Server) realWebhookCommandGate(ctx context.Context, cfg webhooks.Config
 // loop-guard, then allowlist/role authorization honouring the route's
 // MinReplierRole (falling back to the webhook default).
 func (s *Server) gitlabCommandGateWithAPI(ctx context.Context, cfg webhooks.Config, p gitlab.ParsedNote, route webhooks.CommandRoute, api gitlabNoteAPI) (prforgeGateOutcome, string, error) {
-	if bot, berr := api.CurrentUser(ctx); berr == nil && bot.ID == p.AuthorID {
+	// FAILS CLOSED, like its GitHub/Forgejo twin: this is the only thing
+	// standing between the bot's own note and a run that answers it, so an
+	// unreadable identity refuses the delivery with a reason that reaches the
+	// delivery row — never falls through in silence.
+	bot, berr := api.CurrentUser(ctx)
+	switch {
+	case berr != nil:
+		return gateUnevaluable, loopGuardUnevaluable + ": " + berr.Error(), nil
+	case bot.ID == p.AuthorID:
 		return gateRefused, "self note (loop-guard)", nil
 	}
 	minRole := route.MinReplierRole
@@ -1079,13 +1137,18 @@ func gitlabNoteMeta(p gitlab.ParsedNote) webhookEventMeta {
 		subjectURL = p.IssueURL
 	}
 	return webhookEventMeta{
-		Kind:         "note",
-		Action:       "comment",
-		ProjectPath:  p.ProjectPath,
-		SubjectID:    p.SubjectID(),
-		SubjectSHA:   p.HeadSHA,
-		SenderHandle: p.AuthorUsername,
-		SubjectURL:   subjectURL,
+		Kind:        "note",
+		Action:      "comment",
+		ProjectPath: p.ProjectPath,
+		SubjectID:   p.SubjectID(),
+		// The merge request the note hangs off, when it has one. It is what
+		// the closed-MR stop queries: a command run (`/billy`) or a converse
+		// reply records the NOTE as its own subject, so without this link a
+		// fixer keeps working — and pushing — on an MR that already merged.
+		ParentSubjectID: p.ParentSubjectID(),
+		SubjectSHA:      p.HeadSHA,
+		SenderHandle:    p.AuthorUsername,
+		SubjectURL:      subjectURL,
 	}
 }
 

--- a/pkg/server/webhooks_gitlab_converse_head_test.go
+++ b/pkg/server/webhooks_gitlab_converse_head_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/gitlab"
+)
+
+// The reply-in-thread (converse) lane used to launch on the NOTE payload's
+// own pair — the event project's clone URL plus the MR's source branch name.
+// On a fork merge request that pair names two different projects: the base
+// project, and a branch that lives in the fork. The checkout then misses, or
+// hits a same-named branch on the base and the bot answers grounded in the
+// wrong code under its own identity.
+//
+// Every other GitLab lane already proves the head project before launching
+// (the command lane, the auto lane, the relaunch); this one did not, and it is
+// the field the #728 plumbing added — PullRef.HeadCloneURL — that it has to
+// read the day forks are served.
+func TestGitLabConverseLane_ProvesTheHeadProjectBeforeLaunching(t *testing.T) {
+	converseCfg := func() webhooks.Config {
+		cfg := glConfig()
+		cfg.BotIDs = []string{"review-pr", "revi-converse"}
+		return cfg
+	}
+	replyBody := strings.Replace(glNoteRevi, `"note": "/revi"`, `"note": "Can you expand on the SSRF fix?"`, 1)
+
+	newServer := func(t *testing.T) *Server {
+		t.Helper()
+		s := newWebhookTestServer(t)
+		s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+		s.webhookNoteGate = func(context.Context, webhooks.Config, gitlab.ParsedNote, string) (bool, bool, string, string, error) {
+			return true, true, "@revi (you, the bot):\nthe fix pins the host.", "reply", nil
+		}
+		return s
+	}
+
+	t.Run("a fork merge request never launches", func(t *testing.T) {
+		s := newServer(t)
+		s.webhookGitLabPRResolver = func(_ context.Context, _ webhooks.Config, p gitlab.ParsedNote, _ string) (forge.PullRef, error) {
+			return forge.PullRef{
+				State: "open", SourceBranch: p.SourceBranch, TargetBranch: p.TargetBranch,
+				HeadRepoFullName: "mallory/widgets",
+				HeadCloneURL:     "https://gitlab.com/mallory/widgets.git",
+			}, nil
+		}
+		launched := 0
+		s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+			launched++
+			return "run-x", nil
+		}
+		w := httptest.NewRecorder()
+		s.handleGitLabWebhook(w, glNoteReq(gitlabCtx(converseCfg()), replyBody))
+		if w.Code != http.StatusOK {
+			t.Fatalf("a refused fork reply is a clean 200/filtered (a 4xx gets the hook disabled): code=%d body=%s", w.Code, w.Body.String())
+		}
+		if launched != 0 {
+			t.Fatalf("launched %d run(s) on a fork merge request — the pair would be the BASE clone URL and a fork-chosen branch name", launched)
+		}
+	})
+
+	t.Run("a same-project merge request launches on the proven head", func(t *testing.T) {
+		s := newServer(t)
+		s.webhookGitLabPRResolver = func(_ context.Context, _ webhooks.Config, p gitlab.ParsedNote, _ string) (forge.PullRef, error) {
+			return forge.PullRef{
+				State: "open", SourceBranch: p.SourceBranch, TargetBranch: p.TargetBranch,
+				HeadRepoFullName: p.ProjectPath,
+				HeadCloneURL:     "https://gitlab.com/acme/widgets.git",
+			}, nil
+		}
+		var gotURL, gotRef, gotBot string
+		launched := 0
+		s.webhookLaunchBot = func(_ context.Context, botID string, _ map[string]string, repoURL, repoRef, _ string, _, _ map[string]string) (string, error) {
+			launched++
+			gotBot, gotURL, gotRef = botID, repoURL, repoRef
+			return "run-reply", nil
+		}
+		w := httptest.NewRecorder()
+		s.handleGitLabWebhook(w, glNoteReq(gitlabCtx(converseCfg()), replyBody))
+		if w.Code != http.StatusAccepted || launched != 1 {
+			t.Fatalf("a same-project reply must still launch: code=%d launched=%d body=%s", w.Code, launched, w.Body.String())
+		}
+		if gotBot != "revi-converse" {
+			t.Fatalf("bot = %q", gotBot)
+		}
+		if gotURL != "https://gitlab.com/acme/widgets.git" || gotRef != "feature/x" {
+			t.Fatalf("the launch must ride the RESOLVED head, not the note payload's project: url=%q ref=%q", gotURL, gotRef)
+		}
+	})
+
+	t.Run("an unresolvable merge request is a visible launch error", func(t *testing.T) {
+		s := newServer(t)
+		s.webhookGitLabPRResolver = func(context.Context, webhooks.Config, gitlab.ParsedNote, string) (forge.PullRef, error) {
+			return forge.PullRef{}, context.DeadlineExceeded
+		}
+		launched := 0
+		s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+			launched++
+			return "run-x", nil
+		}
+		w := httptest.NewRecorder()
+		s.handleGitLabWebhook(w, glNoteReq(gitlabCtx(converseCfg()), replyBody))
+		if w.Code != http.StatusBadGateway {
+			t.Fatalf("a head that could not be proven is an explicit failure, never a launch on a guess: code=%d body=%s", w.Code, w.Body.String())
+		}
+		if launched != 0 {
+			t.Fatalf("launched %d run(s) on an unresolved head", launched)
+		}
+	})
+}

--- a/pkg/server/webhooks_loopguard_test.go
+++ b/pkg/server/webhooks_loopguard_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/gitlab"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// A self-comment loop guard that cannot read the bot's own identity has
+// decided nothing. Since the App client stopped inventing a login (#711), an
+// unreachable `GET /app` is an ERROR — and the old `err == nil &&` shape read
+// that as "not the bot", walked the rest of the gate, and let the bot's own
+// comment authorize itself with nothing written anywhere.
+type loopGuardAPI struct {
+	login    string
+	whoErr   error
+	perm     string
+	permErr  error
+	permHits int
+}
+
+func (f *loopGuardAPI) WhoAmI(context.Context) (forge.Identity, error) {
+	if f.whoErr != nil {
+		return forge.Identity{}, f.whoErr // what a real client returns on a failed read
+	}
+	return forge.Identity{Login: f.login}, nil
+}
+
+func (f *loopGuardAPI) CollaboratorPermission(context.Context, string, string) (string, error) {
+	f.permHits++
+	return f.perm, f.permErr
+}
+
+func (f *loopGuardAPI) GetPullRequest(context.Context, string, int) (forge.PullRef, error) {
+	return forge.PullRef{}, nil
+}
+
+func TestPRForgeCommandGate_FailsClosedWhenTheBotIdentityIsUnreadable(t *testing.T) {
+	cfg := webhooks.Config{ID: "w1", TenantID: "t1", MinReplierRole: "write"}
+	// The dangerous shape: the commenter IS the bot, and it would clear the
+	// role gate on its own repo permission.
+	p := prforge.ParsedNote{ProjectPath: "acme/widgets", IssueNumber: 7, AuthorLogin: "iterion-bot[bot]"}
+	route := webhooks.CommandRoute{BotID: "branch-improve-loop"}
+
+	t.Run("an unreachable identity refuses the delivery", func(t *testing.T) {
+		api := &loopGuardAPI{whoErr: errors.New("GET /app: 503"), perm: "admin"}
+		outcome, reason, err := prforgeCommandGateWithAPI(context.Background(), cfg, p, route, api)
+		if err != nil {
+			t.Fatalf("a guard that cannot decide is a refusal, not an infra error: %v", err)
+		}
+		if outcome == gateAuthorized {
+			t.Fatal("the bot's own comment authorized itself while the loop guard was blind")
+		}
+		if outcome != gateUnevaluable {
+			t.Fatalf("outcome = %v, want gateUnevaluable (a maintainer has to fix the identity resolution)", outcome)
+		}
+		if !strings.Contains(reason, loopGuardUnevaluable) || !strings.Contains(reason, "503") {
+			t.Fatalf("the delivery row must carry WHY the guard could not decide: %q", reason)
+		}
+		if api.permHits != 0 {
+			t.Fatalf("the gate must stop at the blind guard, not walk on to the role read (%d permission calls)", api.permHits)
+		}
+	})
+
+	t.Run("an identity the forge does not name refuses too", func(t *testing.T) {
+		api := &loopGuardAPI{login: "", perm: "admin"}
+		outcome, reason, _ := prforgeCommandGateWithAPI(context.Background(), cfg, p, route, api)
+		if outcome != gateUnevaluable || !strings.Contains(reason, loopGuardUnevaluable) {
+			t.Fatalf("an empty login decides nothing either: outcome=%v reason=%q", outcome, reason)
+		}
+	})
+
+	t.Run("a readable identity still gates normally", func(t *testing.T) {
+		api := &loopGuardAPI{login: "iterion-bot[bot]"}
+		if outcome, reason, _ := prforgeCommandGateWithAPI(context.Background(), cfg, p, route, api); outcome != gateRefused || reason != "self comment (loop-guard)" {
+			t.Fatalf("the bot's own comment is refused in silence: outcome=%v reason=%q", outcome, reason)
+		}
+		human := prforge.ParsedNote{ProjectPath: "acme/widgets", IssueNumber: 7, AuthorLogin: "dev-dan"}
+		api2 := &loopGuardAPI{login: "iterion-bot[bot]", perm: "write"}
+		if outcome, reason, _ := prforgeCommandGateWithAPI(context.Background(), cfg, human, route, api2); outcome != gateAuthorized {
+			t.Fatalf("a write-permission human must still be authorized: outcome=%v reason=%q", outcome, reason)
+		}
+	})
+}
+
+// gitlabLoopGuardAPI is the GitLab half of the same class: CurrentUser is the
+// only self-note guard, so an error there must refuse, not fall through.
+type gitlabLoopGuardAPI struct {
+	id      int64
+	curErr  error
+	perm    int
+	permErr error
+	members int
+}
+
+func (f *gitlabLoopGuardAPI) CurrentUser(context.Context) (gitlab.User, error) {
+	if f.curErr != nil {
+		return gitlab.User{}, f.curErr // what a real client returns on a failed read
+	}
+	return gitlab.User{ID: f.id}, nil
+}
+
+func (f *gitlabLoopGuardAPI) Discussion(context.Context, int64, int64, string) ([]gitlab.DiscussionNote, error) {
+	return nil, nil
+}
+
+func (f *gitlabLoopGuardAPI) MemberAccessLevel(context.Context, int64, int64) (int, bool, error) {
+	f.members++
+	return f.perm, true, f.permErr
+}
+
+func TestGitLabCommandGate_FailsClosedWhenTheBotIdentityIsUnreadable(t *testing.T) {
+	s := New(Config{}, iterlog.New(iterlog.LevelError, nil))
+	cfg := webhooks.Config{ID: "w1", TenantID: "t1", MinReplierRole: "developer"}
+	p := gitlab.ParsedNote{ProjectPath: "acme/widgets", ProjectID: 42, MRIID: 7, AuthorID: 9, AuthorUsername: "iterion-bot"}
+	route := webhooks.CommandRoute{BotID: "branch-improve-loop"}
+
+	api := &gitlabLoopGuardAPI{id: 9, curErr: errors.New("GET /user: 503"), perm: 50}
+	outcome, reason, err := s.gitlabCommandGateWithAPI(context.Background(), cfg, p, route, api)
+	if err != nil {
+		t.Fatalf("a guard that cannot decide is a refusal, not an infra error: %v", err)
+	}
+	if outcome == gateAuthorized {
+		t.Fatal("the bot's own note authorized itself while the loop guard was blind")
+	}
+	if outcome != gateUnevaluable || !strings.Contains(reason, loopGuardUnevaluable) {
+		t.Fatalf("outcome=%v reason=%q, want an unevaluable gate naming the loop guard", outcome, reason)
+	}
+	if api.members != 0 {
+		t.Fatalf("the gate must stop at the blind guard (%d role reads)", api.members)
+	}
+
+	// The working path is unchanged: the bot's own note is refused in silence,
+	// a human clears the role gate.
+	ok := &gitlabLoopGuardAPI{id: 9, perm: 50}
+	if outcome, _, _ := s.gitlabCommandGateWithAPI(context.Background(), cfg, p, route, ok); outcome != gateRefused {
+		t.Fatalf("the bot's own note must stay refused, got %v", outcome)
+	}
+	human := p
+	human.AuthorID, human.AuthorUsername = 11, "dev-dan"
+	if outcome, reason, _ := s.gitlabCommandGateWithAPI(context.Background(), cfg, human, route, &gitlabLoopGuardAPI{id: 9, perm: 50}); outcome != gateAuthorized {
+		t.Fatalf("a developer must still be authorized: outcome=%v reason=%q", outcome, reason)
+	}
+}
+
+// The review-thread gate has a SECOND identity source (the connection's [bot]
+// slug), so an unreadable token identity does not blind it — it narrows it.
+// That degradation used to happen with nothing said anywhere, which is exactly
+// the shape a self-answering conversation hides in.
+func TestReviewReplyGate_SaysSoWhenTheTokenIdentityIsUnreadable(t *testing.T) {
+	var logbuf bytes.Buffer
+	s := New(Config{}, iterlog.New(iterlog.LevelWarn, &logbuf))
+	// The connection-derived half of the guard is present (an App's [bot]
+	// slug), so the lane keeps deciding — it just decides on less.
+	s.webhookIterionBotAuthor = func(_ context.Context, _ webhooks.Config, login string) bool {
+		return login == "iterion-bot[bot]"
+	}
+	cfg := webhooks.Config{ID: "w1", TenantID: "t1", MinReplierRole: "write"}
+	p := prforge.ParsedReviewComment{ProjectPath: "acme/widgets", PRNumber: 7, AuthorLogin: "dev-dan", CommentID: 5, ThreadRootID: 4}
+	api := &fakeThreadAPI{whoErr: errors.New("GET /app: 503")}
+
+	if _, _, _, err := s.reviewReplyGateWithAPI(context.Background(), cfg, p, api); err != nil {
+		t.Fatalf("the connection identity still decides — the lane must stay live: %v", err)
+	}
+	if !strings.Contains(logbuf.String(), "token identity is unreadable") {
+		t.Fatalf("a narrowed loop guard must say so, log was: %q", logbuf.String())
+	}
+}

--- a/pkg/server/webhooks_pr_closed_test.go
+++ b/pkg/server/webhooks_pr_closed_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/gitlab"
 	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
 )
 
@@ -111,5 +113,78 @@ func TestParsedIsClosed(t *testing.T) {
 	}
 	if open.IsClosed() {
 		t.Fatal("an opened PR must not read as closed")
+	}
+}
+
+const glMergedMR = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {"iid": 7, "action": "merge", "state": "merged", "source_branch": "feature/x", "target_branch": "main",
+    "title": "Add X", "description": "desc", "url": "https://gitlab.com/acme/widgets/-/merge_requests/7",
+    "last_commit": {"id": "sha1"}}
+}`
+
+const glNoteBilly = `{
+  "object_kind": "note",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "user": {"username": "alice"},
+  "object_attributes": {"id": 99, "note": "/billy fix the findings", "noteable_type": "MergeRequest", "discussion_id": "d-1", "author_id": 1},
+  "merge_request": {"iid": 7, "state": "opened", "source_branch": "feature/x", "target_branch": "main",
+    "title": "Add X", "description": "desc", "url": "https://gitlab.com/acme/widgets/-/merge_requests/7",
+    "last_commit": {"id": "headsha"}}
+}`
+
+// A GitLab command run (`/billy`, a converse reply) records the NOTE as its
+// own subject, so the closed-MR stop reaches it only through the parent link.
+// Without it a fixer keeps working — and pushing — on a merge request that
+// already merged. The delivery row is written by the real note lane here:
+// asserting on a hand-inserted row would only exercise the store's reader.
+func TestGitLabWebhook_ClosedMRStopsItsNoteLaunchedRuns(t *testing.T) {
+	s := newWebhookTestServer(t)
+	cfg := glConfig()
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+	cfg.CommandMap = map[string][]webhooks.CommandRoute{
+		"billy": {{BotID: "branch-improve-loop", Scope: "pr", ArgsVar: "scope_notes"}},
+	}
+	s.webhookCommandGate = func(context.Context, webhooks.Config, gitlab.ParsedNote, webhooks.CommandRoute) (prforgeGateOutcome, string, error) {
+		return gateAuthorized, "authorized", nil
+	}
+	s.webhookGitLabPRResolver = func(_ context.Context, _ webhooks.Config, p gitlab.ParsedNote, _ string) (forge.PullRef, error) {
+		return forge.PullRef{State: "open", SourceBranch: p.SourceBranch, TargetBranch: p.TargetBranch, HeadRepoFullName: p.ProjectPath}, nil
+	}
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		return "run-billy", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glNoteReq(gitlabCtx(cfg), glNoteBilly))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("the /billy note must launch: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var cancelled []string
+	s.webhookCancelRun = func(runID string) error {
+		cancelled = append(cancelled, runID)
+		return nil
+	}
+	w = httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(cfg), glMergedMR, gitlab.EventHeaderMergeRequest))
+	if w.Code != http.StatusOK {
+		t.Fatalf("a merged MR must answer 200/filtered: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(cancelled) != 1 || cancelled[0] != "run-billy" {
+		t.Fatalf("the note-launched fixer must stop when its merge request merges, cancelled=%v", cancelled)
+	}
+}
+
+// The parent link is what makes a note-launched run findable from its merge
+// request. An issue note hangs off no MR and must name none.
+func TestGitLabNoteMetaCarriesTheParentSubject(t *testing.T) {
+	mrNote := gitlab.ParsedNote{ProjectPath: "acme/widgets", NoteID: 99, MRIID: 7, MRURL: "https://gitlab.com/acme/widgets/-/merge_requests/7"}
+	if got := gitlabNoteMeta(mrNote).ParentSubjectID; got != "mr:7" {
+		t.Fatalf("an MR note must name mr:7 as its parent, got %q", got)
+	}
+	issueNote := gitlab.ParsedNote{ProjectPath: "acme/widgets", NoteID: 99, IssueIID: 4, IssueURL: "https://gitlab.com/acme/widgets/-/issues/4"}
+	if got := gitlabNoteMeta(issueNote).ParentSubjectID; got != "" {
+		t.Fatalf("an issue note hangs off no merge request, got parent %q", got)
 	}
 }

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -284,7 +284,34 @@ func (s *Server) realWebhookPRForgeCommandGate(ctx context.Context, cfg webhooks
 	if apiRefusal != "" {
 		return gateUnevaluable, apiRefusal, nil
 	}
-	if id, err := api.WhoAmI(ctx); err == nil && id.Login != "" && strings.EqualFold(id.Login, p.AuthorLogin) {
+	return prforgeCommandGateWithAPI(ctx, cfg, p, route, api)
+}
+
+// loopGuardUnevaluable is the refusal a self-comment guard earns when it
+// cannot read the bot's own identity. Named so a log line, a delivery row and
+// a test all say the same word.
+const loopGuardUnevaluable = "loop guard unevaluable: the bot's own identity is unreadable"
+
+// prforgeCommandGateWithAPI is the token-free core of the command gate — split
+// from the wrapper so tests drive it with a fake client, like its GitLab and
+// review-thread twins. Self-comment loop-guard, then allowlist/role
+// authorization honouring the route's MinReplierRole.
+//
+// The loop guard FAILS CLOSED. It is the only thing standing between the bot's
+// own comment and a run that answers it — and since the App client stopped
+// inventing a `github-app[bot]` login (#711), an unreachable `GET /app` is an
+// ERROR, not an empty identity. Falling through on it left the guard skipped
+// with nothing said anywhere; a guard that cannot decide must refuse, and the
+// refusal reaches the delivery row so the miss is greppable rather than
+// invisible.
+func prforgeCommandGateWithAPI(ctx context.Context, cfg webhooks.Config, p prforge.ParsedNote, route webhooks.CommandRoute, api prforgeReplierAPI) (prforgeGateOutcome, string, error) {
+	id, err := api.WhoAmI(ctx)
+	switch {
+	case err != nil:
+		return gateUnevaluable, loopGuardUnevaluable + ": " + err.Error(), nil
+	case id.Login == "":
+		return gateUnevaluable, loopGuardUnevaluable + ": the forge named no login", nil
+	case strings.EqualFold(id.Login, p.AuthorLogin):
 		return gateRefused, "self comment (loop-guard)", nil
 	}
 	// Allowlist short-circuit (no API call).
@@ -603,6 +630,14 @@ func (s *Server) reviewReplyGateWithAPI(ctx context.Context, cfg webhooks.Config
 		tokenLogin, base := id.Login, isBot
 		isBot = func(login string) bool { return base(login) || strings.EqualFold(login, tokenLogin) }
 		haveIdentity = true
+	} else if werr != nil && haveIdentity && s.logger != nil {
+		// The connection's [bot] slug still decides, so the lane stays live —
+		// but the guard is now NARROWER than it was designed to be: it no
+		// longer knows the account the reply would actually be posted as. That
+		// degradation used to happen in silence, which is the shape a
+		// self-answering conversation hides in.
+		s.logger.Warn("webhooks: %s !%d reply gate: the token identity is unreadable (%v) — the loop guard runs on the connection's bot identity alone",
+			p.ProjectPath, p.PRNumber, werr)
 	}
 	if !haveIdentity {
 		// Fail closed with an honest reason — "not a bot review thread"

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -51,7 +51,6 @@ type webhookConfigReq struct {
 	AuthorAllowlist     []string `json:"author_allowlist,omitempty"`
 	LabelAllowlist      []string `json:"label_allowlist,omitempty"`
 	HoldLabels          []string `json:"hold_labels,omitempty"`
-	BlockForkPRs        *bool    `json:"block_fork_prs,omitempty"`
 	ReviewOnSync        *bool    `json:"review_on_sync,omitempty"`
 	ReviewRequestLogins []string `json:"review_request_logins,omitempty"`
 	// ReviewOnSyncPinned clears (false) or restates (true) the provenance
@@ -266,7 +265,6 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		AuthorAllowlist:     req.AuthorAllowlist,
 		LabelAllowlist:      req.LabelAllowlist,
 		HoldLabels:          req.HoldLabels,
-		BlockForkPRs:        req.BlockForkPRs != nil && *req.BlockForkPRs,
 		ReviewOnSync:        req.ReviewOnSync != nil && *req.ReviewOnSync,
 		ReviewRequestLogins: req.ReviewRequestLogins,
 		ReviewOnSyncPinned:  req.ReviewOnSync != nil, // an explicit set at create is a decision too
@@ -477,9 +475,6 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 			httpError(w, http.StatusBadRequest, "%v", err)
 			return
 		}
-	}
-	if req.BlockForkPRs != nil {
-		cfg.BlockForkPRs = *req.BlockForkPRs
 	}
 	if req.AutoImplementOnOpen != nil {
 		cfg.AutoImplementOnOpen = *req.AutoImplementOnOpen

--- a/pkg/webhooks/gitlab/note.go
+++ b/pkg/webhooks/gitlab/note.go
@@ -191,3 +191,20 @@ func (p ParsedNote) Command() (cmd, args string) {
 func (p ParsedNote) SubjectID() string {
 	return "note:" + strconv.FormatInt(p.NoteID, 10)
 }
+
+// ParentSubjectID names the MERGE REQUEST a note hangs off ("mr:7"), or ""
+// when the note sits on an issue. Distinct from SubjectID, which identifies
+// the note itself and is what per-note idempotency keys on: a consumer
+// asking "what did this merge request launch" — the closed-MR stop — cannot
+// find a `/billy` run, or a converse reply, through "note:99". The
+// GitHub/Forgejo twin is prforge.ParsedNote.ParentSubjectID.
+// Anchored on the MR id ALONE, not IsMergeRequestNote: that predicate also
+// demands a discussion id, which is what makes a note answerable in-thread —
+// a routing question. Provenance is a different one, and a launch recorded
+// against an MR must stay findable from it either way.
+func (p ParsedNote) ParentSubjectID() string {
+	if p.MRIID == 0 {
+		return ""
+	}
+	return "mr:" + strconv.FormatInt(p.MRIID, 10)
+}

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -202,15 +202,18 @@ type Config struct {
 	// (review_on_sync_pinned: false) to hand the field back.
 	ReviewOnSyncPinned bool `bson:"review_on_sync_pinned,omitempty" json:"review_on_sync_pinned,omitempty"`
 
-	// BlockForkPRs, when true, filters (never auto-launches ANY bot on) a PR
-	// whose head branch lives in a DIFFERENT repo than its base — a fork PR.
-	// The anti budget-exhaustion boundary: a fork PR is untrusted (an adversary
-	// can open many to trigger costly bot runs), so an operator must validate it
-	// before a bot runs. Off by default (fork PRs still auto-review via Revi;
-	// the mutating branch-improve bot never runs on a PR-open regardless — the
-	// PR-open lane is review-only, see handlePRForgeReview). Recommended ON for
-	// a public repo.
-	BlockForkPRs bool `bson:"block_fork_prs,omitempty" json:"block_fork_prs,omitempty"`
+	// There is no fork switch here on purpose. A pull request whose head lives
+	// in another repository is refused on EVERY lane, unconditionally: the
+	// auto-review lane, the /command lanes, the reply-in-thread lane, the
+	// gate relaunch and the auto-fix lane all require a PROVEN same-repo head
+	// before anything launches. The launch pair a fork produces (the base
+	// repo's clone URL + a head branch that lives elsewhere) does not name one
+	// repository, so the checkout misses or — worse — hits a same-named branch
+	// on the base and the bot answers, comments and pushes grounded in the
+	// wrong code under iterion's own identity.
+	//
+	// Serving forks needs a lane of its own (read-only, no publish grant, no
+	// fixer, no repo secrets), not a boolean: see docs/webhooks.md.
 
 	// ForgeBaseURL, when set, pins the forge instance this webhook's bot
 	// token may call back to (e.g. "https://gitlab.example.com"). The


### PR DESCRIPTION
Four commits, one per ticket family — cluster webhooks / fixer lifecycle / gate residue (#863, #773, #847, #831, #788 pt 2).

## #863 — a fixer kept working after its PR merged (Billy pushed 6 commits onto a merged branch, verdict on a stale head)
**Layer 1, the PR-closed lane.** GitHub/Forgejo already reached comment-launched runs through `Delivery.ParentSubjectID` (#683); **GitLab did not** — `gitlabNoteMeta` never set the field and `gitlab.ParsedNote` had no `ParentSubjectID()`, so a `/billy` or converse run was recorded as `note:99` with no link to `mr:7` and `stopRunsForDeadPR` could not see it. Red first through the real note lane (`TestGitLabWebhook_ClosedMRStopsItsNoteLaunchedRuns`: `the note-launched fixer must stop when its merge request merges, cancelled=[]`). The lookup stays the shared `ListLaunchedBySubject` (subject OR parent, both twins) — only the writer was missing. Class table of every `webhookEventMeta` site in the commit body.
**Layer 2, the delivery-tail belt.** Chokepoint = `postGateStatus` (`pkg/server/forge_publish.go`), which every campaign bot's gate status crosses: a merged/closed pull request gets NO status on its head (`gate_error: pull request is merged — no gate status on a head that left the merge decision`), the review comment still lands, an unknown state stays "unreported". The push half needs a pre-action answer git cannot give (a squash merge leaves the branch present and its head no ancestor of the base), so the publish grant gains a **read half**: `GET /api/v1/forge/pull-request?pr_url=…` under the same `X-Iterion-Run` token/scope/connection, injected as `forge_pr_state_url` (knows a grant and a URL, never which bot asks). Bot side (`branch-improve-loop` 1.6.0 → 1.7.0): `push_back_tool` asks first; merged/closed ⇒ no push, commits banked on `iterion/banked/<branch>-<head12>`, one comment naming it, run ends `fail pr_superseded: code: DECLINED` — the family `forge_gate_decline_notice.go` keys on, so relaunch and reconciler stand down with no new vocabulary. Red: `pushed onto a merged pull request's branch: {Pushed:true …}` with only the new check neutered. Bots with a push tail (grep `refs/heads/`, `push_back_tool`): only branch-improve-loop; verdict-only bots are covered by the engine chokepoint.

## #773 — banked commits, unnamed branch, a false "nothing to push"
From the code: the graph reaches `mr_gate` on `ship_now` AND on loop exhaustion, then `push_auth_probe → push_back_tool` — there is no "don't push unless converged" rule, so explanation (2) is refuted; explanation (1) (a tree that never saw the commits) could not be proven without the run artifacts. Fixed the part that is a defect either way and made the next occurrence falsifiable: the no-op reason names **both revisions it compared** (`HEAD <sha12> is not ahead of origin/<branch> at <sha12>`), and **every** non-push outcome banks and names (`banked_branch` + `how_to_take`: `git fetch origin <ref> && git cherry-pick <base12>..FETCH_HEAD`), rendered verbatim in the verdict. Scope widening, stated: `push_to` now tries plain `origin` after the token-injected https forms (an ssh/local remote could not be pushed back to at all, and it is what makes the node testable against a real remote). Bilan: a present-tense contract section at the head of `docs/bot-runs/branch-improve-loop.md` + the 1.7.0 changelog.

## #847 — three webhook-gate defects
1. **WhoAmI/CurrentUser fall-through**: the loop guard ran only when the identity call succeeded — the bot's own comment could authorize itself while the guard was blind (`TestPRForgeCommandGate_FailsClosedWhenTheBotIdentityIsUnreadable`). `realWebhookPRForgeCommandGate` and its GitLab sibling `gitlabCommandGateWithAPI` (a class member the ticket did not name) now **fail closed** with a typed reason written onto the delivery row; `reviewReplyGateWithAPI` (a second identity source exists) Warns naming the degradation.
2. **`BlockForkPRs` deleted** (field, tags, create+PATCH routes, orchestrator carry, docs): persisted, read by no lane, its comment promised a behaviour that did not exist. `openapi.json` byte-identical (the field never reached the spec). `docs/webhooks.md` states the policy positively. The opt-in read-only fork lane it hinted at is designed in #874 (five constraints) for a maintainer decision.
3. **Converse lane** resolves the MR through the same seam as the command lane (`resolveGitLabNoteHead`), refuses unproven heads, launches on `PullRef.HeadCloneURL` (`a fork merge request never launches` was red: `code=202 … "status":"launched"`).

## #831 — a DECLINED run reached the dead-review repair
`gateInterruptedDescriptionFor` gains a `declinedFailureCode` branch beside the DLQ one (a neutral failure naming the decline — the claimed check must still be answered), `isSyntheticGateInterruption` learns the shape; a real verdict already on the head is left alone. Red: the synthetic `review died … push again` text on a DECLINED run.

## #788 point 2 — a gate that cannot afford its review
Status reads `review died (budget exceeded: cost_usd (36/12)) — needs a human reviewer, or a higher budget`; `gateRelaunchIsSpentOnBudget` stands the relaunch down when the dead run is itself a relaunch (`gate_relaunch_of`) that died `BUDGET_EXCEEDED` — a first overrun keeps its one retry (`TestGateRelaunch/a_second_budget_death_stops_the_automation` was red: `relaunched a review that died twice on the same cap`). The loop budget guard (#783) cannot be what stops this — it prices a back-edge, and a reviewer overrunning inside one pass never reaches one — said so in `docs/merge-gate.md`. Point 1 (why those diffs cost 3× the cap) is measured and fixed elsewhere: #867 → #869 (the reviewed content armed Claude Code's `Workflow` tool).

## Proof
Every change pinned by a test that was red first (excerpts above and in the commit bodies), incl. the bot's real command bodies against real git repositories (`bots/push_back_banked_branch_test.go`). `go build`, `go vet`, `task lint` (0 issues), `go test ./...`, `-race` on `pkg/server pkg/webhooks pkg/forge pkg/store ./bots`, `go test ./bots/...` (catalog regenerated for the new `forge_pr_state_url` var), `iterion validate` on the bot (31 nodes / 41 edges), Mongo harness on `pkg/webhooks pkg/forge pkg/server/cloudpublisher`. `openapi.json` byte-identical.

## Left out, stated
- No live dogfood yet: a `/billy` on a real merged PR is what confirms `forge_pr_state_url` reaches the node in the cloud sandbox — the session runs it after deploy (bot 1.7.0 ships in two halves: runner digest + server restart, `docs/platform-bots.md`).
- `push_back_tool` has no `e2e/` coverage (tree owned by another PR); the real body is executed by the bots test, not through the engine graph.
- A dedicated `SUPERSEDED` code was considered and rejected for reusing `DECLINED` (no new vocabulary; the decline notice's prose is slightly off for a superseded run — the bot's own `run.Error` carries the truth). Small follow-up if precision is wanted.
- Known, already carded (`native:54412d84`): `push_auth_probe` reports a token's presence, not its validity; this PR makes that failure recoverable (commits banked and named), not absent.

Closes #863, #773, #847, #831, #788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
