### PR TITLE
fix(sandbox): every setup phase is bounded on both drivers, a tool_result crossing the IPC is clamped, and a promise on a dropped bind is withdrawn

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -816,9 +816,13 @@ declares `crane` needs `crane` whatever repo it is pointed at.
 
 A declined source is **reported, not dropped** — the
 `sandbox_devbox_provisioned` event carries `skipped_sources: ["repo"]`
-with the config it declined, and the run logs it. Without that, the only
-trace of the decision would be a binary missing later, which reads as an
-agent bug.
+with the config and the reason it declined
+(`skipped_configs` / `skipped_reasons`), and the run logs it. Without
+that, the only trace of the decision would be a binary missing later,
+which reads as an agent bug. The same channel reports the other decline:
+a **bot's** `devbox.json` on a driver with no host bind mounts, where its
+bundle cannot reach the container at all
+([sandbox.md](sandbox.md#best-effort-never-silent)).
 
 The override does **not** travel onto the cloud queue: what a cloud runner
 needs is the *workflow's* declaration, which rides the `.bot` itself. So a

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -52,6 +52,14 @@ Backend selection and provider routing use `ITERION_DEFAULT_BACKEND`,
 | Variable | Effect | Default |
 |---|---|---|
 | `ITERION_SANDBOX_PULL_TIMEOUT` | Caps `<runtime> pull` for the docker driver (Go duration, e.g. `20m`) so a stalled registry or blocked DNS cannot pend a run indefinitely. | `10m` |
+| `ITERION_SANDBOX_POST_CREATE_TIMEOUT` | Budget of the `post_create` snippet, on **both** drivers — the budget belongs to the phase, so raising it for a slow toolchain install raises it wherever the phase runs. Fails closed: a value that is not a positive Go duration is refused, the default applies, and one stderr line names the variable, the value and the default. | `30m` |
+| `ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT` | Budget of the kubernetes driver's workspace copy AND of the git fixup that follows, each end-to-end. Same fail-closed parsing. | `15m` |
+| `ITERION_SANDBOX_K8S_APPLY_TIMEOUT` | Budget of ONE `kubectl` control call on the kubernetes driver — the per-run Secret, the CA Secret, the pod, the NetworkPolicy, the mid-run secret refresh, and every `delete` (stale-pod eviction, rollbacks, cleanup). Also passed to `kubectl` as `--request-timeout`, so a wedged apiserver is bounded at both ends of the pipe. Same fail-closed parsing. | `2m` |
+
+Every setup phase and how its expiry is classified: [sandbox.md § setup
+phases](sandbox.md#setup-phases-and-their-timeouts). The pod-Ready wait
+has its own knob, `ITERION_SANDBOX_K8S_POD_READY_TIMEOUT`, documented
+there with the rest of the kubernetes scheduling family.
 
 The sandbox on/off default, cloud override, host-state mounts, and the
 default image are `ITERION_SANDBOX_DEFAULT`, `ITERION_SANDBOX_OVERRIDE`,

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -736,6 +736,21 @@ across the channel.
     nothing left to cut) is refused and reported on the runner's stderr,
     which the launcher folds into the node's error: one lost
     observation, never a dead channel, and never a silent one.
+  - **The reply direction is bounded the same way.** A host-side tool
+    result travelling BACK to the container (an MCP call's result, a
+    large file read, a `go test ./...` transcript) is cut to
+    `delegate.MaxToolResultBytes` (1 MiB) with a marker naming the bytes
+    produced on the host — the same ceiling the executor's own hooks
+    apply to an unsandboxed node's tool payload, so a sandboxed run and
+    an in-process one show the model the same amount of the same output.
+    A `ask_user` payload is the exception: its conversation is the
+    pre-pause LLM state the runner rebuilds from, so it crosses whole or
+    becomes an explicit tool error naming its size — a cut one would
+    resume onto a corrupted conversation. And whatever the producer,
+    `EnvelopeWriter` **refuses** an over-cap line at the source with a
+    typed error naming the envelope type: a writer that forgot to clamp
+    fails where it is, instead of killing the peer's reader with a
+    payload it can only report the size of.
   - **A turn's conversation crosses whole or not at all.** The snapshot a
     fork replays is relayed up to 2 MiB (a full 200k-token context, with
     room under the line cap); a larger one is left out and the turn

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -87,20 +87,31 @@ below as one that does not.
 
 | Phase | Driver | Bound | Env override (Go duration) |
 |---|---|---|---|
+| `kubectl apply` (per-run Secret, CA Secret, pod, NetworkPolicy, mid-run secret refresh) | kubernetes | 2 min each | `ITERION_SANDBOX_K8S_APPLY_TIMEOUT` |
 | Pod Ready wait | kubernetes | 10 min | `ITERION_SANDBOX_K8S_POD_READY_TIMEOUT` |
 | Workspace copy (host tar → `kubectl exec` tar) | kubernetes | 15 min | `ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT` |
 | Workspace git fixup | kubernetes | 15 min (shares the copy budget) | `ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT` |
 | `post_create` snippet | kubernetes | 30 min | `ITERION_SANDBOX_POST_CREATE_TIMEOUT` |
 | Image pull | docker | 10 min | `ITERION_SANDBOX_PULL_TIMEOUT` |
-| `post_create` snippet | docker | **unbounded** — a hung snippet blocks the run until `max_duration` fires | — |
+| `post_create` snippet | docker | 30 min (the same knob as kubernetes) | `ITERION_SANDBOX_POST_CREATE_TIMEOUT` |
 
-`post_create` gets its own, larger budget because installing a toolchain
-legitimately outlasts a copy; raising one knob does not move the other.
-Both take a Go duration (`5m`, `45m`, `2h`), and both fail **closed**: a
-value that is not a positive duration — including `5`, which Go reads as
-five *nanoseconds*, not five minutes — is refused rather than honoured,
-the default applies, and one stderr line per process names the variable,
-the value and the default that replaced it.
+A budget belongs to the **phase**, not to the driver: `post_create` reads
+one knob wherever it runs, so an operator raising it for a slow toolchain
+install raises it everywhere. `post_create` gets its own, larger budget
+because installing a toolchain legitimately outlasts a copy; raising one
+knob does not move another. Every knob takes a Go duration (`5m`, `45m`,
+`2h`) and fails **closed**: a value that is not a positive duration —
+including `5`, which Go reads as five *nanoseconds*, not five minutes —
+is refused rather than honoured, the default applies, and one stderr line
+per process names the variable, the value and the default that replaced
+it.
+
+The apply bound is enforced at both ends of the pipe: the phase deadline
+kills the local `kubectl`, and `--request-timeout` makes `kubectl` itself
+give up rather than wait on a wedged apiserver. `kubectl delete` (the
+stale-pod eviction before the pod apply, every rollback, the run's own
+cleanup) shares the apply budget but reports a plain deadline — a cleanup
+is not a setup phase and is never classified as one.
 
 A phase that burns its budget fails with `sandbox.ErrPhaseTimeout`, which
 the engine classifies as `SANDBOX_SETUP_TIMEOUT`: the run parks
@@ -414,9 +425,12 @@ iterion sandbox doctor                 # report driver + capabilities
   driver's workspace copy AND of the git fixup that follows, each
   end-to-end. Unset → 15 min. See [setup phases and their
   timeouts](#setup-phases-and-their-timeouts).
-- `ITERION_SANDBOX_POST_CREATE_TIMEOUT` — budget of the kubernetes
-  driver's `post_create` snippet. Unset → 30 min. Raise it for a
-  devcontainer that installs a large toolchain.
+- `ITERION_SANDBOX_POST_CREATE_TIMEOUT` — budget of the `post_create`
+  snippet on BOTH drivers. Unset → 30 min. Raise it for a devcontainer
+  that installs a large toolchain.
+- `ITERION_SANDBOX_K8S_APPLY_TIMEOUT` — budget of one `kubectl` control
+  call on the kubernetes driver (every `apply`, every `delete`), also
+  passed as `--request-timeout`. Unset → 2 min.
 - `ITERION_SANDBOX_OVERRIDE` — CLI-strength mode override (`""`,
   `none`, or `auto`), same precedence tier as `iterion run --sandbox`:
   `none` beats even a workflow's inline `sandbox:` block. Honoured by

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -180,6 +180,38 @@ system prompt and codex credential). A unit test whose fake
 `sandbox.Run` omits this interface tests the shared-filesystem half of
 the world only.
 
+#### A promise the driver drops takes its variable with it
+
+The mirror rule for anything the runtime hands the container as a PATH:
+every optional host bind (the run's attachments, its run-files
+directory, the bot's bundle) is dropped on a copy-based driver, and the
+promise made on it must go with it. On the pod backend:
+
+| Promise | On docker | On kubernetes |
+|---|---|---|
+| `ITERION_ARTIFACT_FILES_DIR` (where an in-sandbox tool drops files for the artifact-files panel) | set, bind-mounted | **absent** — a tool falls back to a temp dir |
+| Attachments path handed to nodes | the container path | the host path, which fails loudly rather than resolving to an empty mount point |
+| The bot's bundle `devbox.json` | provisioned | declined and reported (see [devbox provisioning](#best-effort-never-silent)) |
+
+The measured cost of getting this wrong: the run-files variable once
+named a directory the pod never had, a gate wrapper redirecting its
+report into it died on "Directory nonexistent", and four lots read an
+oracle verdict out of an environment failure.
+
+**Known gap — run-files on pods.** Nothing collects a pod's run files:
+the collector reads the host directory the bind would have served, and
+the pod writes to a temp dir that dies with it. Closing it needs a
+read-back seam the driver does not have — an emptyDir at the container
+path plus a drain at teardown, i.e. `WorkspaceExporter`'s shape widened
+past the workspace. Until then the artifact-files panel is empty for a
+pod run, and the variable stays honestly unset rather than naming a
+directory nobody reads.
+`TestSandboxSpec_NoPromiseSurvivesTheBindThatServedIt`
+([pkg/runtime](../pkg/runtime/sandbox_bind_promise_canary_test.go)) walks
+every `spec.Env` value and every path in `spec.PostCreate` against the
+mounts the driver keeps, so the next promise made on a dropped bind
+fails in CI rather than in a campaign.
+
 ### Host state mounts (`~/.iterion`, `~/.claude`)
 
 When `host_state: auto` (the default), iterion also bind-mounts:
@@ -570,7 +602,25 @@ Provisioning emits `sandbox_devbox_provisioned` (`target`
 `"sandbox"|"host"`, `sources`, `configs`, `bin_dirs`, `path`, plus
 `errors` on the host target when something failed) so you can audit
 what was picked up — and see when a declared toolchain could **not**
-be provisioned.
+be provisioned. A source that EXISTS and was deliberately declined is
+named on the same event, with its own reason:
+`skipped_sources` / `skipped_configs` / `skipped_reasons` (parallel
+arrays; `reason` joins the distinct ones).
+
+Two declines ship today:
+
+- `repo_devbox off` — the target repo pins a toolchain this run does not
+  need (see [dsl.md](dsl.md#the-target-repos-toolchain--repo_devbox)).
+- `no host bind mount on this driver` — the **bot's** `devbox.json` lives
+  in its bundle, which reaches the container as a host bind mount, and
+  the kubernetes driver has no host filesystem. The bundle is then not
+  declared at all, so no snippet is baked and no `PATH` entry promises a
+  directory nothing will populate. A bot that needs a tool on the pod
+  backend must get it from its `sandbox.image:` instead. The alternative
+  — a pod-side delivery channel for the bundle — would need a copy-in
+  seam that runs BEFORE `post_create`; the driver's only copy-in today is
+  the workspace tar, and the only writes it accepts afterwards
+  (`RefreshWorkspaceFile`) land after setup is over.
 
 ### Cost
 

--- a/pkg/backend/delegate/envelope.go
+++ b/pkg/backend/delegate/envelope.go
@@ -176,10 +176,25 @@ type EventData struct {
 
 // MaxEnvelopeLineBytes caps each NDJSON line. 4 MiB covers typical
 // `git log` outputs of large repos and big LLM tool_use payloads
-// without unbounded memory exposure. Lines exceeding this trigger an
-// error rather than truncation: a side-channel (shared volume) for
-// gigantic tool results is V3.
+// without unbounded memory exposure. A line over it fails the WHOLE
+// channel on the reading side, so nothing may write one: the producers
+// clamp their payloads first (see [MaxToolResultBytes] and the relay's
+// event clamp), and [EnvelopeWriter.Write] refuses what is still too
+// long rather than emitting a line that kills the peer.
 const MaxEnvelopeLineBytes = 4 * 1024 * 1024
+
+// MaxToolResultBytes caps the text a single tool_result carries to the
+// runner (its output, or its error message). A host-side tool can return
+// far more than the line cap — an MCP call's result, a large file read, a
+// `go test ./...` transcript — and an unclamped one would kill the run's
+// IPC instead of reaching the model.
+//
+// It equals the ceiling the executor's own hooks already apply to a
+// claude_code / claw tool payload in-process, so the sandboxed and
+// in-process paths bound the model's view identically (a conformance test
+// in pkg/backend/model keeps the two from drifting). Several such fields
+// still fit under one line.
+const MaxToolResultBytes = 1 << 20
 
 // ErrEnvelopeLineTooLong is returned when an incoming NDJSON line
 // exceeds [MaxEnvelopeLineBytes]. Callers should surface a clear error
@@ -243,10 +258,23 @@ func NewEnvelopeWriter(w io.Writer) *EnvelopeWriter {
 // Write marshals env and emits it as a single NDJSON line. Holds the
 // internal mutex for the duration of the write to keep lines
 // uninterleaved across concurrent goroutines.
+//
+// A line over [MaxEnvelopeLineBytes] is REFUSED here, at the source, and
+// nothing is written: the peer's reader fails the whole channel on such a
+// line and can only report the size it rejected, naming nothing that
+// produced it. Every writer on the channel — both directions — therefore
+// gets a typed error naming its own envelope type instead of a dead
+// channel elsewhere. Producers that can legitimately exceed the cap clamp
+// first ([ClampToolResult], the relay's event clamp); reaching this
+// refusal means one did not.
 func (ew *EnvelopeWriter) Write(env Envelope) error {
 	buf, err := json.Marshal(env)
 	if err != nil {
 		return fmt.Errorf("delegate: encode envelope: %w", err)
+	}
+	if len(buf)+1 > MaxEnvelopeLineBytes {
+		return fmt.Errorf("delegate: refusing to write a %q envelope of %d bytes (line cap %d): %w",
+			env.Type, len(buf)+1, MaxEnvelopeLineBytes, ErrEnvelopeLineTooLong)
 	}
 	buf = append(buf, '\n')
 	ew.mu.Lock()
@@ -280,13 +308,10 @@ func NewToolCallEnvelope(id, name string, input json.RawMessage) (Envelope, erro
 }
 
 // NewToolResultEnvelope builds a tool_result envelope. ID MUST match
-// the corresponding [EnvelopeToolCall].
+// the corresponding [EnvelopeToolCall]. The payload is clamped to
+// [MaxToolResultBytes] — see [ClampToolResult].
 func NewToolResultEnvelope(id, output, errMsg string) (Envelope, error) {
-	data, err := json.Marshal(ToolResultData{Output: output, Error: errMsg})
-	if err != nil {
-		return Envelope{}, fmt.Errorf("delegate: marshal tool_result: %w", err)
-	}
-	return Envelope{Type: EnvelopeToolResult, ID: id, Data: data}, nil
+	return newToolResultData(id, ToolResultData{Output: output, Error: errMsg})
 }
 
 // NewResultEnvelope builds the terminal result envelope. The runner

--- a/pkg/backend/delegate/envelope_clamp.go
+++ b/pkg/backend/delegate/envelope_clamp.go
@@ -1,0 +1,82 @@
+package delegate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// The IPC channel is NDJSON, and its reader fails the WHOLE channel on a
+// line over [MaxEnvelopeLineBytes] — so an oversize payload is not one
+// lost message, it is a dead run. The runner→launcher direction (relayed
+// events) clamps in pkg/backend/model; this is the launcher→runner half,
+// where the payload the host cannot bound is a TOOL RESULT: an MCP call's
+// result, a large file read, a `go test ./...` transcript.
+//
+// Same discipline as the relay: cut text and MARK the cut with the size
+// that was produced, never emit a fragment of a document the peer parses.
+
+// envelopeWrapperBytes covers `{"type":"tool_result","id":"…","data":}`
+// plus the newline when sizing a payload against the line cap. Generous
+// on purpose: the check exists to keep the channel alive, and a few
+// hundred spare bytes cost nothing.
+const envelopeWrapperBytes = 256
+
+// ClampToolResult bounds a tool_result payload so it crosses one NDJSON
+// line. Output and Error are cut to [MaxToolResultBytes] with a marker
+// naming what was produced on the host — the model must be able to tell a
+// short answer from one that was cut.
+//
+// The ask_user payload is NOT cut: its Conversation is the pre-pause LLM
+// state the runner rebuilds a typed *ErrAskUser from, and a truncated one
+// would resume onto a corrupted conversation. When that alone still
+// overflows the line, the result becomes an explicit tool ERROR naming
+// the size — the runner turns it into a Go error inside the LLM loop, so
+// the node fails with a reason instead of the channel dying with none.
+func ClampToolResult(data ToolResultData) ToolResultData {
+	data.Output = clampToolText(data.Output)
+	data.Error = clampToolText(data.Error)
+	if toolResultFitsOneLine(data) {
+		return data
+	}
+	convBytes := 0
+	if data.AskUser != nil {
+		convBytes = len(data.AskUser.Conversation)
+	}
+	return ToolResultData{
+		Error: fmt.Sprintf(
+			"iterion sandbox IPC: the ask_user payload is %d bytes of conversation, over the %d-byte channel line cap; it cannot be truncated without corrupting the resumed state, so the question could not be forwarded",
+			convBytes, MaxEnvelopeLineBytes),
+	}
+}
+
+// clampToolText cuts one text field and marks the cut.
+func clampToolText(s string) string {
+	if len(s) <= MaxToolResultBytes {
+		return s
+	}
+	return fmt.Sprintf("%s\n[iterion sandbox IPC: cut to %d bytes, %d bytes were produced on the host]",
+		truncate(s, MaxToolResultBytes), MaxToolResultBytes, len(s))
+}
+
+// toolResultFitsOneLine reports whether data, wrapped in its envelope,
+// stays under the channel's line cap.
+func toolResultFitsOneLine(data ToolResultData) bool {
+	buf, err := json.Marshal(data)
+	if err != nil {
+		// An unmarshalable payload is refused by the caller's own
+		// marshal; nothing to size here.
+		return true
+	}
+	return len(buf)+envelopeWrapperBytes <= MaxEnvelopeLineBytes
+}
+
+// newToolResultData builds a tool_result envelope from an already-shaped
+// payload, clamping it first. The single construction site for the type,
+// so no producer can bypass the bound.
+func newToolResultData(id string, data ToolResultData) (Envelope, error) {
+	buf, err := json.Marshal(ClampToolResult(data))
+	if err != nil {
+		return Envelope{}, fmt.Errorf("delegate: marshal tool_result: %w", err)
+	}
+	return Envelope{Type: EnvelopeToolResult, ID: id, Data: buf}, nil
+}

--- a/pkg/backend/delegate/envelope_clamp_test.go
+++ b/pkg/backend/delegate/envelope_clamp_test.go
@@ -1,0 +1,245 @@
+package delegate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #837: the launcher→runner direction had no clamp. A host-side tool
+// whose result exceeds MaxEnvelopeLineBytes (an MCP call, a large file
+// read, a big `git diff`) produced a line the runner's reader refuses —
+// killing the WHOLE IPC channel, so the node died on a channel error
+// instead of the model receiving a bounded result.
+//
+// The runner→launcher half (relayed events) was clamped by #811; this is
+// its mirror, with the same marker discipline: truncate text with a
+// marker naming the omitted bytes, never emit a broken JSON.
+
+// oversizeToolResultFixture drives a REAL Multiplexer over pipes: the
+// test plays the runner (emitting a tool_call, then reading the reply
+// with the real EnvelopeReader), the multiplexer plays the launcher.
+type oversizeToolResultFixture struct {
+	t          *testing.T
+	toRunner   *EnvelopeReader
+	runnerSend *EnvelopeWriter
+	done       chan error
+}
+
+func newToolCallFixture(t *testing.T, onToolCall func(context.Context, string, json.RawMessage) (string, error)) *oversizeToolResultFixture {
+	t.Helper()
+	runnerOutR, runnerOutW := io.Pipe() // runner → launcher
+	launcherOutR, launcherOutW := io.Pipe()
+
+	m := NewMultiplexer(runnerOutR, launcherOutW, MultiplexerHandler{OnToolCall: onToolCall})
+	f := &oversizeToolResultFixture{
+		t:          t,
+		toRunner:   NewEnvelopeReader(launcherOutR),
+		runnerSend: NewEnvelopeWriter(runnerOutW),
+		done:       make(chan error, 1),
+	}
+	go func() {
+		_, err := m.Run(context.Background())
+		f.done <- err
+	}()
+	t.Cleanup(func() {
+		_ = runnerOutW.Close()
+		_ = launcherOutW.Close()
+	})
+	return f
+}
+
+// call emits a tool_call and returns the launcher's reply.
+func (f *oversizeToolResultFixture) call(id, name string) (Envelope, error) {
+	f.t.Helper()
+	env, err := NewToolCallEnvelope(id, name, json.RawMessage(`{}`))
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if err := f.runnerSend.Write(env); err != nil {
+		f.t.Fatalf("write tool_call: %v", err)
+	}
+	type read struct {
+		env Envelope
+		err error
+	}
+	ch := make(chan read, 1)
+	go func() {
+		e, rerr := f.toRunner.Read()
+		ch <- read{e, rerr}
+	}()
+	select {
+	case r := <-ch:
+		return r.env, r.err
+	case <-time.After(10 * time.Second):
+		f.t.Fatal("launcher never answered the tool_call")
+		return Envelope{}, nil
+	}
+}
+
+// A 5 MiB host-side tool result must reach the model BOUNDED and MARKED,
+// and the channel must survive: today the line is written whole, the
+// runner's reader refuses it (ErrEnvelopeLineTooLong) and the node dies.
+func TestToolResult_OversizeIsClampedAndTheChannelSurvives(t *testing.T) {
+	huge := strings.Repeat("x", 5*1024*1024)
+	f := newToolCallFixture(t, func(context.Context, string, json.RawMessage) (string, error) {
+		return huge, nil
+	})
+
+	env, err := f.call("call-1", "read_file")
+	if err != nil {
+		if errors.Is(err, ErrEnvelopeLineTooLong) {
+			t.Fatalf("a 5 MiB tool result killed the IPC channel (%v) — the node dies on a wire error instead of the model getting a bounded result", err)
+		}
+		t.Fatalf("reading the tool_result failed: %v", err)
+	}
+	if env.Type != EnvelopeToolResult || env.ID != "call-1" {
+		t.Fatalf("got envelope %+v, want a tool_result correlated to call-1", env)
+	}
+	var data ToolResultData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("tool_result payload is not decodable JSON: %v — a cut mid-document is never acceptable", err)
+	}
+	if len(data.Output) > MaxToolResultBytes+512 {
+		t.Fatalf("clamped output is %d bytes, want ≤ MaxToolResultBytes (%d) plus the marker", len(data.Output), MaxToolResultBytes)
+	}
+	if !strings.Contains(data.Output, "5242880") {
+		t.Fatalf("clamped output does not name the original size — the model cannot tell a short answer from one that was cut: %q", lastBytes(data.Output, 200))
+	}
+	if data.Error != "" {
+		t.Fatalf("clamping turned a successful tool call into an error: %q", data.Error)
+	}
+
+	// The channel must still carry the NEXT call — one clamped result is
+	// not a dead session.
+	f2, err := f.call("call-2", "read_file")
+	if err != nil {
+		t.Fatalf("the channel died after the oversize result: %v", err)
+	}
+	if f2.ID != "call-2" {
+		t.Fatalf("second reply correlated to %q, want call-2", f2.ID)
+	}
+}
+
+// The error channel carries tool output too (a failing command's stderr),
+// so it is clamped by the same rule — an oversize error message would
+// kill the IPC exactly as an oversize output does.
+func TestToolResult_OversizeErrorIsClamped(t *testing.T) {
+	huge := strings.Repeat("e", 5*1024*1024)
+	f := newToolCallFixture(t, func(context.Context, string, json.RawMessage) (string, error) {
+		return "", errors.New(huge)
+	})
+
+	env, err := f.call("call-err", "bash")
+	if err != nil {
+		t.Fatalf("a 5 MiB tool ERROR killed the IPC channel: %v", err)
+	}
+	var data ToolResultData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatalf("tool_result payload is not decodable JSON: %v", err)
+	}
+	if len(data.Error) > MaxToolResultBytes+512 {
+		t.Fatalf("clamped error is %d bytes, want ≤ MaxToolResultBytes (%d) plus the marker", len(data.Error), MaxToolResultBytes)
+	}
+	if !strings.Contains(data.Error, "5242880") {
+		t.Fatalf("clamped error does not name the original size: %q", lastBytes(data.Error, 200))
+	}
+}
+
+// A result that fits must cross untouched — no marker, no truncation on
+// the ordinary path.
+func TestToolResult_InBudgetIsUntouched(t *testing.T) {
+	f := newToolCallFixture(t, func(context.Context, string, json.RawMessage) (string, error) {
+		return "ok\n", nil
+	})
+	env, err := f.call("call-small", "bash")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var data ToolResultData
+	if err := json.Unmarshal(env.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if data.Output != "ok\n" {
+		t.Fatalf("in-budget output was altered: %q", data.Output)
+	}
+}
+
+// The ask_user payload carries the pre-pause LLM state the runner
+// rebuilds a typed *ErrAskUser from: cutting it would resume onto a
+// corrupted conversation. When it alone overflows the line, the result
+// must become an explicit tool ERROR naming the size — the node then
+// fails with a reason, and the channel lives.
+func TestClampToolResult_OversizeAskUserBecomesAnExplicitError(t *testing.T) {
+	conv := json.RawMessage(`{"messages":"` + strings.Repeat("m", 5*1024*1024) + `"}`)
+	got := ClampToolResult(ToolResultData{AskUser: &AskUserToolFail{
+		Question:     "continue?",
+		Conversation: conv,
+	}})
+	if got.AskUser != nil {
+		t.Fatal("an over-cap ask_user payload was forwarded — the line kills the channel")
+	}
+	if got.Error == "" {
+		t.Fatal("an over-cap ask_user payload was dropped with no error — the runner would wait on a reply that says nothing")
+	}
+	if !strings.Contains(got.Error, "5242") {
+		t.Fatalf("the refusal does not name the payload size: %q", got.Error)
+	}
+	if !toolResultFitsOneLine(got) {
+		t.Fatal("the refusal itself does not fit one line")
+	}
+}
+
+// An ask_user payload that fits crosses whole — the refusal above is for
+// the overflow case only, never the ordinary pause.
+func TestClampToolResult_InBudgetAskUserCrossesWhole(t *testing.T) {
+	conv := json.RawMessage(`{"messages":["hi"]}`)
+	got := ClampToolResult(ToolResultData{AskUser: &AskUserToolFail{
+		Question:     "continue?",
+		Conversation: conv,
+	}})
+	if got.AskUser == nil {
+		t.Fatal("an in-budget ask_user payload was refused — every sandboxed pause would break")
+	}
+	if string(got.AskUser.Conversation) != string(conv) {
+		t.Fatalf("conversation altered: %s", got.AskUser.Conversation)
+	}
+}
+
+// The writer is the chokepoint EVERY envelope crosses, in both
+// directions. A line over the cap must fail AT THE SOURCE, naming the
+// envelope type and its size — not silently, and not as an opaque
+// ErrEnvelopeLineTooLong on the peer, which reports the reader's view of
+// a payload it never saw and names nothing that produced it.
+func TestEnvelopeWriter_RefusesAnOversizeLineAtTheSource(t *testing.T) {
+	var sink strings.Builder
+	w := NewEnvelopeWriter(&sink)
+	env := Envelope{
+		Type: EnvelopeSessionReplay,
+		Data: json.RawMessage(`"` + strings.Repeat("z", 5*1024*1024) + `"`),
+	}
+	err := w.Write(env)
+	if err == nil {
+		t.Fatal("an over-cap line was written — the peer's reader fails the WHOLE channel on it, with no idea what produced it")
+	}
+	if !errors.Is(err, ErrEnvelopeLineTooLong) {
+		t.Fatalf("write refusal must carry ErrEnvelopeLineTooLong, got %v", err)
+	}
+	if !strings.Contains(err.Error(), string(EnvelopeSessionReplay)) {
+		t.Fatalf("write refusal must name the envelope type that produced it, got %v", err)
+	}
+	if sink.Len() != 0 {
+		t.Fatalf("a refused envelope still wrote %d bytes — a partial line desynchronises the channel", sink.Len())
+	}
+}
+
+func lastBytes(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/pkg/backend/delegate/multiplexer.go
+++ b/pkg/backend/delegate/multiplexer.go
@@ -163,11 +163,13 @@ func (m *Multiplexer) handleToolCall(ctx context.Context, env Envelope) error {
 			data.Error = callErr.Error()
 		}
 	}
-	buf, err := json.Marshal(data)
+	// Clamped before it goes on the wire: a host-side tool can return more
+	// than the channel's line cap, and an unclamped line kills the whole
+	// IPC instead of handing the model a bounded result.
+	reply, err := newToolResultData(env.ID, data)
 	if err != nil {
-		return fmt.Errorf("delegate: marshal tool_result: %w", err)
+		return err
 	}
-	reply := Envelope{Type: EnvelopeToolResult, ID: env.ID, Data: buf}
 	return m.writer.Write(reply)
 }
 

--- a/pkg/backend/model/sandbox_relay_test.go
+++ b/pkg/backend/model/sandbox_relay_test.go
@@ -233,6 +233,22 @@ func TestSandboxRelay_HostWarnsOnAnUndecodableRelayedEvent(t *testing.T) {
 	}
 }
 
+// The sandboxed and in-process paths must bound the model's view of a
+// tool payload identically: the launcher clamps a tool_result crossing
+// the IPC to delegate.MaxToolResultBytes, the executor's own hooks clamp
+// an in-process one to maxFieldSize. Two constants for one promise drift
+// the moment either moves.
+func TestToolPayloadCeiling_IsTheSameSandboxedAndInProcess(t *testing.T) {
+	if maxFieldSize != delegate.MaxToolResultBytes {
+		t.Fatalf("in-process ceiling maxFieldSize = %d, IPC ceiling delegate.MaxToolResultBytes = %d — a sandboxed node and an unsandboxed one would show the model different amounts of the same tool output",
+			maxFieldSize, delegate.MaxToolResultBytes)
+	}
+	if relayFieldBudget != delegate.MaxToolResultBytes {
+		t.Fatalf("relayFieldBudget = %d, delegate.MaxToolResultBytes = %d — the two IPC directions would clamp differently",
+			relayFieldBudget, delegate.MaxToolResultBytes)
+	}
+}
+
 // A write that fails is reported, not swallowed: the runner cannot return
 // an error from a hook, and a dead channel must leave a trace.
 func TestSandboxRelayHooks_ReportsAFailedWrite(t *testing.T) {

--- a/pkg/runtime/repo_devbox_test.go
+++ b/pkg/runtime/repo_devbox_test.go
@@ -171,8 +171,8 @@ func TestResolveDevboxProjects_CLIOverrideBeatsTheWorkflow(t *testing.T) {
 	if len(got) != 1 || got[0].label != "repo" {
 		t.Fatalf("--repo-devbox on must re-enable the repo source, got %+v", got)
 	}
-	if skipped != "" {
-		t.Errorf("nothing was declined, got skipped=%q", skipped)
+	if len(skipped) != 0 {
+		t.Errorf("nothing was declined, got skipped=%+v", skipped)
 	}
 }
 

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -391,7 +391,17 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 		spec.Env[runFilesEnvVar] = runFilesContainerPath
 	}
 	seedDefaultLocale(spec)
-	bundleContainerPath := addOptionalBindMount(spec, p.BundleHostDir, p.BundleContainerPath, "/run/iterion/bundle", "bundle", true, logger)
+	// The bundle is a host bind and nothing else: a driver with no host
+	// filesystem would have it dropped below, leaving every promise made
+	// on it — the devbox prologue's staged copy first — naming a path the
+	// container never had. Not declaring it is what makes the promises
+	// downstream honest: applyDevboxProvisioning sees no container path
+	// and REPORTS the bot source as declined instead of baking a snippet
+	// that fails soft.
+	bundleContainerPath := ""
+	if caps.SupportsHostBindMounts {
+		bundleContainerPath = addOptionalBindMount(spec, p.BundleHostDir, p.BundleContainerPath, "/run/iterion/bundle", "bundle", true, logger)
+	}
 	sharedStateDir := applyHostStateMounts(spec, p.Workflow, p, emitEvent, logger)
 	// Back ${PROJECT_SCRATCH_DIR} with a host dir so a parent and its
 	// sub-bot children — separate runs in separate containers — can hand

--- a/pkg/runtime/sandbox_bind_promise_canary_test.go
+++ b/pkg/runtime/sandbox_bind_promise_canary_test.go
@@ -1,0 +1,187 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #834, the canary. On a driver with no host filesystem the runtime
+// DECLARES host bind mounts, makes promises on their behalf, and then
+// drops the binds — leaving the promises. Measured twice: the run-files
+// variable naming a directory the pod never had (#815, four lots read
+// "oracle RED" out of "Directory nonexistent"), and the bundle bind whose
+// devbox provisioning bakes `cp /run/iterion/bundle/devbox.json …` into
+// post_create and fails soft, so a bot's declared toolchain silently
+// provisions nothing on cloud.
+//
+// The rule this pins: every path the runtime NAMES to the container — in
+// `spec.Env` and in `spec.PostCreate` — must be served by a mount the
+// driver actually keeps. It walks the REAL wiring twice, once on a driver
+// that honours host binds and once on one that does not, so the dropped
+// targets are measured rather than listed.
+
+// specCapturingDriver records the spec handed to Prepare and then refuses
+// to Start: the canary reads what the runtime BUILT, and nothing must run.
+type specCapturingDriver struct {
+	hostBinds bool
+	captured  sandbox.Spec
+}
+
+var errCanaryStop = errors.New("canary: not starting")
+
+func (d *specCapturingDriver) Name() string { return "docker" }
+
+func (d *specCapturingDriver) Capabilities() sandbox.Capabilities {
+	return sandbox.Capabilities{
+		SupportsImage:          true,
+		SupportsMounts:         true,
+		SupportsHostBindMounts: d.hostBinds,
+		SupportsPostCreate:     true,
+		SupportsRemoteUser:     true,
+	}
+}
+
+func (d *specCapturingDriver) Prepare(_ context.Context, spec sandbox.Spec) (sandbox.PreparedSpec, error) {
+	d.captured = spec
+	return nil, errCanaryStop
+}
+
+func (d *specCapturingDriver) Start(context.Context, sandbox.PreparedSpec, sandbox.RunInfo) (sandbox.Run, error) {
+	return nil, errCanaryStop
+}
+
+// buildSandboxSpecFor runs the production mount wiring against a driver
+// with the given host-bind capability and returns the spec it produced.
+func buildSandboxSpecFor(t *testing.T, hostBinds bool, p SandboxParams) sandbox.Spec {
+	t.Helper()
+	t.Setenv("ITERION_MODE", "local") // pin the factory preference to docker,podman,noop
+	d := &specCapturingDriver{hostBinds: hostBinds}
+	p.Drivers = map[string]sandbox.DriverConstructor{
+		"docker": func() (sandbox.Driver, error) { return d, nil },
+	}
+	p.Logger = iterlog.Nop()
+	p.EmitEvent = func(store.EventType, map[string]any) error { return nil }
+	if _, err := resolveAndStartSandbox(context.Background(), p); !errors.Is(err, errCanaryStop) {
+		t.Fatalf("resolveAndStartSandbox = %v, want the canary driver's refusal — the wiring did not reach Prepare, so this test proves nothing", err)
+	}
+	return d.captured
+}
+
+// canaryParams is a run carrying every optional host bind the runtime
+// declares: a bundle (with a devbox.json, so the provisioning fires),
+// attachments, and a run-files directory.
+func canaryParams(t *testing.T) SandboxParams {
+	t.Helper()
+	bundleDir := t.TempDir()
+	writeDevboxConfig(t, bundleDir, "go-containerregistry@latest")
+	return SandboxParams{
+		Workflow: &ir.Workflow{
+			Name:    "wf",
+			Sandbox: &ir.SandboxSpec{Mode: "inline", Image: "example.invalid/sbx:test", HostState: "none"},
+		},
+		RunID:                    "run-canary",
+		WorkspacePath:            t.TempDir(),
+		AttachmentsHostDir:       t.TempDir(),
+		AttachmentsContainerPath: attachmentsContainerPath,
+		RunFilesHostDir:          t.TempDir(),
+		RunFilesContainerPath:    "/iterion/artifact-files",
+		BundleHostDir:            bundleDir,
+		BundleContainerPath:      "/run/iterion/bundle",
+	}
+}
+
+func TestSandboxSpec_NoPromiseSurvivesTheBindThatServedIt(t *testing.T) {
+	p := canaryParams(t)
+	withBinds := buildSandboxSpecFor(t, true, p)
+	poddish := buildSandboxSpecFor(t, false, p)
+
+	dropped := droppedMountTargets(withBinds.Mounts, poddish.Mounts)
+	if len(dropped) == 0 {
+		t.Fatal("no host bind was dropped — the fixture declares none, so the canary would pass vacuously")
+	}
+	// The two halves of the walk must each have something to find, or a
+	// green run proves nothing: a variable the runtime sets on a bind
+	// (#815's own), and a snippet it bakes on one (the devbox prologue).
+	if withBinds.Env[runFilesEnvVar] == "" {
+		t.Fatal("the bind-capable spec sets no run-files variable — the Env half of the walk is vacuous")
+	}
+	if !strings.Contains(withBinds.PostCreate, "devbox install") {
+		t.Fatalf("the bind-capable spec bakes no devbox prologue — the post_create half of the walk is vacuous:\n%s", withBinds.PostCreate)
+	}
+
+	for key, value := range poddish.Env {
+		if target := underAny(value, dropped); target != "" {
+			t.Errorf("spec.Env[%s] = %s, under the dropped bind %s — the runtime promises a directory the container never had", key, value, target)
+		}
+	}
+	// A promise is not only a variable. The devbox provisioning bakes
+	// `cp <bundle>/devbox.json …` into post_create, and that path is
+	// exactly a dropped bind's target.
+	for _, ref := range absolutePathsIn(poddish.PostCreate) {
+		if target := underAny(ref, dropped); target != "" {
+			t.Errorf("post_create names %s, under the dropped bind %s — the snippet runs against a path the container never had (it fails soft, so a bot's devbox.json silently provisions nothing)", ref, target)
+		}
+	}
+}
+
+// droppedMountTargets returns the mount targets present in `all` and gone
+// from `kept`, cleaned.
+func droppedMountTargets(all, kept []string) []string {
+	keptTargets := map[string]bool{}
+	for _, m := range kept {
+		if tgt := mountTarget(m); tgt != "" {
+			keptTargets[path.Clean(tgt)] = true
+		}
+	}
+	var out []string
+	for _, m := range all {
+		tgt := mountTarget(m)
+		if tgt == "" {
+			continue
+		}
+		if c := path.Clean(tgt); !keptTargets[c] {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// underAny returns the dropped target `value` sits under, or "".
+func underAny(value string, dropped []string) string {
+	v := path.Clean(strings.TrimSpace(value))
+	if v == "" || v == "." || !path.IsAbs(v) {
+		return ""
+	}
+	for _, d := range dropped {
+		if v == d || strings.HasPrefix(v, d+"/") {
+			return d
+		}
+	}
+	return ""
+}
+
+// absolutePathsIn pulls every absolute-looking path out of a shell
+// snippet. Deliberately coarse: a promise the runtime bakes into
+// post_create is a literal path, and a false positive here is a mount the
+// driver kept, which the caller filters on.
+func absolutePathsIn(snippet string) []string {
+	var out []string
+	for _, field := range strings.FieldsFunc(snippet, func(r rune) bool {
+		return r == ' ' || r == '\n' || r == '\t' || r == '"' || r == '\'' || r == ';' || r == '{' || r == '}' || r == '&' || r == '|'
+	}) {
+		if strings.HasPrefix(field, "/") {
+			out = append(out, field)
+		}
+	}
+	return out
+}

--- a/pkg/runtime/sandbox_devbox.go
+++ b/pkg/runtime/sandbox_devbox.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
@@ -83,6 +84,32 @@ const (
 	fallbackContainerPATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
+// devboxSkip is a devbox source that EXISTS on the host and was
+// deliberately not installed. Reported so a decision is never
+// indistinguishable from a source nobody declared — the failure mode
+// this type exists to close is a bot whose `devbox.json` provisions
+// nothing and says nothing, leaving the operator to read a missing
+// binary as an agent bug.
+type devboxSkip struct {
+	// label names the source ("repo" | "bot").
+	label string
+	// config is the host path of the declined devbox.json.
+	config string
+	// reason says why, in terms an operator can act on.
+	reason string
+}
+
+// Reasons a devbox source is declined. Named so the event payload and
+// the log line cannot drift apart.
+const (
+	devboxSkipRepoOff = "repo_devbox off"
+	// devboxSkipNoBundleMount: the bot's bundle is a host bind mount and
+	// this driver has no host filesystem to honour it (the pod backend).
+	// The staged copy the install prologue would run reads from a path
+	// the container never had, so the source cannot be installed at all.
+	devboxSkipNoBundleMount = "no host bind mount on this driver"
+)
+
 // devboxProject is one resolved devbox source: where its config lives
 // inside the container and how it got there.
 type devboxProject struct {
@@ -137,18 +164,15 @@ func applyDevboxProvisioning(
 	if spec == nil {
 		return
 	}
-	projects, skippedRepo := resolveDevboxProjects(spec, p, bundleContainerPath, logger)
+	projects, skipped := resolveDevboxProjects(spec, p, bundleContainerPath, logger)
 	if len(projects) == 0 {
-		if skippedRepo != "" {
+		if len(skipped) > 0 {
 			// Nothing to install, but something WAS declared and
 			// deliberately not installed. Saying so is the difference
 			// between a decision and a missing binary nobody explains.
-			_ = emitEvent(store.EventSandboxDevboxProvisioned, map[string]any{
-				"target":          "sandbox",
-				"skipped_sources": []string{"repo"},
-				"skipped_configs": []string{skippedRepo},
-				"reason":          "repo_devbox off",
-			})
+			payload := map[string]any{"target": "sandbox"}
+			addDevboxSkips(payload, skipped)
+			_ = emitEvent(store.EventSandboxDevboxProvisioned, payload)
 		}
 		return
 	}
@@ -184,12 +208,33 @@ func applyDevboxProvisioning(
 		"bin_dirs": binDirs,
 		"path":     spec.Env["PATH"],
 	}
-	if skippedRepo != "" {
-		payload["skipped_sources"] = []string{"repo"}
-		payload["skipped_configs"] = []string{skippedRepo}
-		payload["reason"] = "repo_devbox off"
-	}
+	addDevboxSkips(payload, skipped)
 	_ = emitEvent(store.EventSandboxDevboxProvisioned, payload)
+}
+
+// addDevboxSkips records the declined sources on the provisioning event:
+// three parallel arrays plus the joined `reason` its single-skip form
+// always carried, so a reader can tell WHICH source was declined and WHY.
+func addDevboxSkips(payload map[string]any, skipped []devboxSkip) {
+	if len(skipped) == 0 {
+		return
+	}
+	labels := make([]string, 0, len(skipped))
+	configs := make([]string, 0, len(skipped))
+	reasons := make([]string, 0, len(skipped))
+	distinct := make([]string, 0, len(skipped))
+	for _, s := range skipped {
+		labels = append(labels, s.label)
+		configs = append(configs, s.config)
+		reasons = append(reasons, s.reason)
+		if !slices.Contains(distinct, s.reason) {
+			distinct = append(distinct, s.reason)
+		}
+	}
+	payload["skipped_sources"] = labels
+	payload["skipped_configs"] = configs
+	payload["skipped_reasons"] = reasons
+	payload["reason"] = strings.Join(distinct, "; ")
 }
 
 // resolveDevboxProjects lists the devbox sources this run carries, in
@@ -197,25 +242,26 @@ func applyDevboxProvisioning(
 // pins its own toolchain stays authoritative for building itself; the
 // bot's packages fill in what the repo does not provide.
 //
-// The second return is the host path of a repo devbox.json that EXISTS but
-// was declined by `repo_devbox: off` — "" when there was none to decline.
-// The caller reports it: a source dropped in silence is indistinguishable
-// from a source nobody declared.
+// The second return lists the sources that EXIST and were deliberately
+// not installed — `repo_devbox: off` for the repo's, an unmounted bundle
+// for the bot's. The caller reports them: a source dropped in silence is
+// indistinguishable from a source nobody declared.
 func resolveDevboxProjects(
 	spec *sandbox.Spec,
 	p SandboxParams,
 	bundleContainerPath string,
 	logger *iterlog.Logger,
-) ([]devboxProject, string) {
+) ([]devboxProject, []devboxSkip) {
 	var out []devboxProject
-	skippedRepo := ""
+	var skipped []devboxSkip
 
 	repoCfg := devboxConfigIn(p.WorkspacePath, "workspace", logger)
 	if repoCfg != "" && !resolveRepoDevbox(p.RepoDevboxOverride, p.Workflow) {
 		if logger != nil {
 			logger.Info("runtime: sandbox devbox: repo_devbox is off — %s is NOT installed for this run; the packages the target repo pins are unavailable (the bot's own devbox.json still is)", repoCfg)
 		}
-		skippedRepo, repoCfg = repoCfg, ""
+		skipped = append(skipped, devboxSkip{label: "repo", config: repoCfg, reason: devboxSkipRepoOff})
+		repoCfg = ""
 	}
 	if cfg := repoCfg; cfg != "" {
 		// Installs in place: the workspace bind is read-write, and a
@@ -229,8 +275,20 @@ func resolveDevboxProjects(
 			dir:        containerWorkspaceFolder(spec, p.WorkspacePath),
 		})
 	}
-	if bundleContainerPath != "" {
-		if cfg := devboxConfigIn(p.BundleHostDir, "bundle", logger); cfg != "" {
+	if cfg := devboxConfigIn(p.BundleHostDir, "bundle", logger); cfg != "" {
+		if bundleContainerPath == "" {
+			// The bundle reaches the container as a host bind mount and
+			// this driver has none, so the staged copy the install
+			// prologue runs would read a path the container never had.
+			// The snippet fails soft, so the run would proceed on
+			// whatever the image happens to bake — a bot's declared
+			// toolchain silently absent. Decline it and say so.
+			if logger != nil {
+				logger.Warn("runtime: sandbox devbox: the bot's %s (%s) is NOT installed for this run — %s, so the bundle it lives in cannot be read from inside the sandbox; the packages it declares are unavailable and the run proceeds on what the image ships",
+					devboxConfigName, cfg, devboxSkipNoBundleMount)
+			}
+			skipped = append(skipped, devboxSkip{label: "bot", config: cfg, reason: devboxSkipNoBundleMount})
+		} else {
 			out = append(out, devboxProject{
 				label:      "bot",
 				hostConfig: cfg,
@@ -253,7 +311,7 @@ func resolveDevboxProjects(
 		}
 		kept = append(kept, pr)
 	}
-	return kept, skippedRepo
+	return kept, skipped
 }
 
 // devboxConfigIn returns the host path of dir's devbox.json, or "" when

--- a/pkg/runtime/sandbox_devbox_test.go
+++ b/pkg/runtime/sandbox_devbox_test.go
@@ -92,6 +92,76 @@ func TestApplyDevboxProvisioning_BotOnly(t *testing.T) {
 	}
 }
 
+// #834: on a driver with no host filesystem the bundle bind is never
+// declared, so the staged copy the install prologue would run has nothing
+// to read. The old shape baked the snippet anyway and let it fail soft
+// (`|| echo … >&2`), so a bot shipping a devbox.json provisioned NOTHING
+// on cloud and the run proceeded on whatever the image happened to bake —
+// a missing binary the operator reads as an agent bug. The decision must
+// be visible instead: no snippet, no PATH entry, and the event names the
+// declined source and why.
+func TestApplyDevboxProvisioning_BotSourceDeclinedWhenTheBundleIsNotMounted(t *testing.T) {
+	f := newDevboxFixture(t, false, true)
+	emit := func(ev store.EventType, data map[string]any) error {
+		f.events = append(f.events, ev)
+		f.eventData = append(f.eventData, data)
+		return nil
+	}
+	applyDevboxProvisioning(f.spec, f.params, "", emit, iterlog.Nop())
+
+	if strings.Contains(f.spec.PostCreate, botDevboxDir) || strings.Contains(f.spec.PostCreate, "devbox install") {
+		t.Errorf("a snippet was baked for a bundle the container never had:\n%s", f.spec.PostCreate)
+	}
+	if p := f.spec.Env["PATH"]; strings.Contains(p, botDevboxDir) {
+		t.Errorf("PATH promises %s, a directory nothing will ever populate: %q", botDevboxDir, p)
+	}
+	if len(f.events) != 1 || f.events[0] != store.EventSandboxDevboxProvisioned {
+		t.Fatalf("want a single %s event naming the decline, got %v", store.EventSandboxDevboxProvisioned, f.events)
+	}
+	data := f.eventData[0]
+	sources, _ := data["skipped_sources"].([]string)
+	if len(sources) != 1 || sources[0] != "bot" {
+		t.Fatalf("skipped_sources = %v, want [bot]", data["skipped_sources"])
+	}
+	configs, _ := data["skipped_configs"].([]string)
+	if len(configs) != 1 || !strings.HasPrefix(configs[0], f.params.BundleHostDir) {
+		t.Errorf("skipped_configs = %v, want the bot's own devbox.json path", data["skipped_configs"])
+	}
+	reasons, _ := data["skipped_reasons"].([]string)
+	if len(reasons) != 1 || reasons[0] != devboxSkipNoBundleMount {
+		t.Errorf("skipped_reasons = %v, want [%s]", data["skipped_reasons"], devboxSkipNoBundleMount)
+	}
+	if got, _ := data["reason"].(string); got != devboxSkipNoBundleMount {
+		t.Errorf("reason = %q, want %q", got, devboxSkipNoBundleMount)
+	}
+}
+
+// Both sources declined, for DIFFERENT reasons: the event must say which
+// is which, or an operator reads one decision and chases the other.
+func TestApplyDevboxProvisioning_TwoDeclinesKeepTheirOwnReasons(t *testing.T) {
+	f := newDevboxFixture(t, true, true)
+	f.params.RepoDevboxOverride = "off"
+	emit := func(ev store.EventType, data map[string]any) error {
+		f.events = append(f.events, ev)
+		f.eventData = append(f.eventData, data)
+		return nil
+	}
+	applyDevboxProvisioning(f.spec, f.params, "", emit, iterlog.Nop())
+
+	if len(f.events) != 1 {
+		t.Fatalf("want one event, got %v", f.events)
+	}
+	data := f.eventData[0]
+	sources, _ := data["skipped_sources"].([]string)
+	reasons, _ := data["skipped_reasons"].([]string)
+	if len(sources) != 2 || sources[0] != "repo" || sources[1] != "bot" {
+		t.Fatalf("skipped_sources = %v, want [repo bot]", data["skipped_sources"])
+	}
+	if len(reasons) != 2 || reasons[0] != devboxSkipRepoOff || reasons[1] != devboxSkipNoBundleMount {
+		t.Fatalf("skipped_reasons = %v, want [%s %s]", data["skipped_reasons"], devboxSkipRepoOff, devboxSkipNoBundleMount)
+	}
+}
+
 // TestApplyDevboxProvisioning_RepoOnly covers a target repo declaring a
 // devbox.json at its workspace root with no bot devbox. It installs in
 // place (relative package refs only resolve next to the config).
@@ -346,8 +416,8 @@ func TestResolveDevboxProjects_RejectsPathPoisoningDir(t *testing.T) {
 	}
 	// Dropped for being unusable, NOT declined by repo_devbox — the two
 	// reasons must not be conflated in what the operator is told.
-	if skipped != "" {
-		t.Errorf("a poisoned dir is not a repo_devbox refusal, got skipped=%q", skipped)
+	if len(skipped) != 0 {
+		t.Errorf("a poisoned dir is not a repo_devbox refusal, got skipped=%+v", skipped)
 	}
 }
 

--- a/pkg/sandbox/docker/driver.go
+++ b/pkg/sandbox/docker/driver.go
@@ -919,9 +919,21 @@ func cleanupTempDirs(dirs []string) {
 // runPostCreate runs the spec's post-create command inside the
 // freshly started container. Stdout/stderr are streamed to the
 // driver's logger so users see install progress.
+//
+// BOUNDED like every other setup phase: a snippet that never returns (a
+// package install waiting on a dead mirror, a command reading stdin)
+// would otherwise hold the run in setup until the outer max_duration
+// fires — no `sandbox_started`, no typed failure. Budget:
+// sandbox.ResolvePostCreateTimeout (ITERION_SANDBOX_POST_CREATE_TIMEOUT),
+// the same knob the kubernetes driver reads — the phase owns the budget,
+// not the driver. The expiry carries sandbox.ErrPhaseTimeout, so the
+// engine parks the run failed_resumable with SANDBOX_SETUP_TIMEOUT.
 func (r *Run) runPostCreate(ctx context.Context, snippet string) error {
 	r.driver.logger.Info("sandbox: running postCreateCommand")
-	return sandbox.RunPostCreate(ctx, r, snippet, r.driver.logger)
+	return sandbox.RunWithPhaseTimeout(ctx, r.driver.logger, "post_create", sandbox.PostCreateTimeoutEnv, sandbox.ResolvePostCreateTimeout(),
+		func(ctx context.Context) error {
+			return sandbox.RunPostCreate(ctx, r, snippet, r.driver.logger)
+		})
 }
 
 // containerNameFor maps a run ID to a deterministic container name.

--- a/pkg/sandbox/docker/post_create_timeout_test.go
+++ b/pkg/sandbox/docker/post_create_timeout_test.go
@@ -1,0 +1,78 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// The post_create snippet is a SETUP phase, and every setup phase carries
+// its own bound: an unbounded one does not fail, it waits, and a run
+// waiting in setup emits no `sandbox_started`, holds whatever lease it
+// took, and only dies when the run's own max_duration fires. The
+// kubernetes driver bounds it; the docker driver must land on the same
+// contract and the same typed park, through the same helper.
+//
+// Driven through the REAL runPostCreate with a container-runtime shim
+// that never exits — the "package install waiting on a dead mirror"
+// shape, seen from the host side.
+func TestRunPostCreate_DockerStallIsBoundedAndTyped(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	rt := Runtime("iterion-test-wedged-runtime")
+	shimDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shimDir, string(rt)), []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(sandbox.PostCreateTimeoutEnv, "300ms")
+
+	r := &Run{
+		driver:      &Driver{rt: rt, logger: iterlog.Nop()},
+		containerID: "deadbeef",
+		prepared:    &Prepared{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- r.runPostCreate(context.Background(), "apt-get install -y the-world") }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a wedged post_create returned no error")
+		}
+		if !errors.Is(err, sandbox.ErrPhaseTimeout) {
+			t.Fatalf("post_create stall does not carry sandbox.ErrPhaseTimeout: %v — the setup classifier cannot park it resumable", err)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("post_create stall does not carry context.DeadlineExceeded: %v", err)
+		}
+		if !strings.Contains(err.Error(), "post_create phase timed out") {
+			t.Fatalf("timeout error must name the phase, got %q", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runPostCreate never returned — the snippet runs on the bare ctx, so the run sits in sandbox setup until the outer max_duration fires")
+	}
+}
+
+// The docker post_create reads the SAME knob as the kubernetes one: the
+// budget belongs to the phase, not to the driver, so an operator raising
+// it for a slow toolchain install raises it everywhere the phase runs.
+func TestRunPostCreate_DockerReadsTheSharedPhaseKnob(t *testing.T) {
+	t.Setenv(sandbox.PostCreateTimeoutEnv, "45m")
+	if got, want := sandbox.ResolvePostCreateTimeout(), 45*time.Minute; got != want {
+		t.Fatalf("ResolvePostCreateTimeout() = %s, want %s", got, want)
+	}
+	if sandbox.PostCreateTimeoutEnv != "ITERION_SANDBOX_POST_CREATE_TIMEOUT" {
+		t.Fatalf("post_create knob = %q, want the documented ITERION_SANDBOX_POST_CREATE_TIMEOUT", sandbox.PostCreateTimeoutEnv)
+	}
+}

--- a/pkg/sandbox/kubernetes/apply_timeout_test.go
+++ b/pkg/sandbox/kubernetes/apply_timeout_test.go
@@ -1,0 +1,144 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// #823 part 2: every per-run resource the driver creates — the credential
+// Secret, the CA Secret, the sandbox pod, the NetworkPolicy, and the
+// mid-run secret refresh — goes through `kubectl apply` on the BARE run
+// context. A wedged apiserver (a control-plane rollout, a throttled
+// webhook, a TCP connect that never completes) therefore hangs sandbox
+// creation BEFORE the first bounded phase is reached: no
+// `sandbox_started`, no typed failure, no redelivery. kubectlCmdContext's
+// WaitDelay only bounds orphaned pipes after a cancellation that never
+// comes.
+//
+// Driven through the REAL applyManifest with a kubectl shim that never
+// exits — the wedged-apiserver shape as the driver sees it.
+func TestApplyManifest_StallIsBoundedAndTyped(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	shimDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shimDir, kubeBinaryName), []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(applyTimeoutEnv, "300ms")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- applyManifest(context.Background(), iterlog.Nop(), "ns", "apply pod", []byte("kind: Pod\n"))
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a wedged apply returned no error")
+		}
+		if !errors.Is(err, sandbox.ErrPhaseTimeout) {
+			t.Fatalf("apply stall does not carry sandbox.ErrPhaseTimeout: %v — the setup classifier cannot park it resumable and the runner cannot nak it", err)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("apply stall does not carry context.DeadlineExceeded: %v", err)
+		}
+		if !strings.Contains(err.Error(), "apply pod phase timed out") {
+			t.Fatalf("timeout error must name WHICH apply stalled, got %q", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("applyManifest never returned — sandbox creation hangs before the first bounded phase, holding the run's lease until max_duration fires")
+	}
+}
+
+// The bound must also reach kubectl itself: without --request-timeout the
+// client waits on the apiserver indefinitely, so a phase deadline that
+// fires can only kill the process, never let it report why. The two
+// together mean a timeout is a timeout at both ends of the pipe.
+func TestApplyManifest_PassesRequestTimeoutToKubectl(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	shimDir := t.TempDir()
+	argvFile := filepath.Join(shimDir, "argv")
+	shim := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvFile + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(shimDir, kubeBinaryName), []byte(shim), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(applyTimeoutEnv, "90s")
+
+	if err := applyManifest(context.Background(), iterlog.Nop(), "ns", "apply pod", []byte("kind: Pod\n")); err != nil {
+		t.Fatalf("apply against a healthy shim failed: %v", err)
+	}
+	argv, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(argv), "--request-timeout=1m30s") {
+		t.Fatalf("kubectl argv = %q, want --request-timeout carrying the phase budget", string(argv))
+	}
+}
+
+// The same class, one helper further: `kubectl delete` is one apiserver
+// call too, it runs in the middle of the setup sequence (the stale-pod
+// eviction before the pod apply) and on every rollback path, and most
+// callers DISCARD its result — so an unbounded one hangs the run with
+// nothing to show for it. Bounded by the same budget, but on a plain
+// deadline: a cleanup is not a setup phase.
+func TestDeleteResource_StallIsBounded(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	shimDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shimDir, kubeBinaryName), []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(applyTimeoutEnv, "300ms")
+
+	done := make(chan error, 1)
+	go func() { done <- deleteResource(context.Background(), "ns", "pod", "sandbox-x") }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a wedged delete returned no error")
+		}
+		if errors.Is(err, sandbox.ErrPhaseTimeout) {
+			t.Fatalf("a cleanup delete carries the SETUP-phase sentinel: %v — the classifier would park a cleanup stall as a setup timeout", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("deleteResource never returned — a rollback or the stale-pod eviction hangs the run on a wedged apiserver")
+	}
+}
+
+// The apply family reads its own knob, fail-closed like its siblings: a
+// garbage value falls back to the default rather than disabling the bound.
+func TestResolveApplyTimeout_HonoursItsOwnEnvFailClosed(t *testing.T) {
+	if got := resolveApplyTimeout(); got != DefaultApplyTimeout {
+		t.Fatalf("resolveApplyTimeout() = %s with no env, want the default %s", got, DefaultApplyTimeout)
+	}
+	t.Setenv(applyTimeoutEnv, "5m")
+	if got, want := resolveApplyTimeout(), 5*time.Minute; got != want {
+		t.Fatalf("resolveApplyTimeout() = %s, want %s (operator override lost)", got, want)
+	}
+	t.Setenv(applyTimeoutEnv, "5 minutes")
+	if got := resolveApplyTimeout(); got != DefaultApplyTimeout {
+		t.Fatalf("garbage override = %s, want the default %s (an unbounded apply is the bug this closes)", got, DefaultApplyTimeout)
+	}
+	// The post_create knob must not move with it.
+	if got := sandbox.ResolvePostCreateTimeout(); got != sandbox.DefaultPostCreateTimeout {
+		t.Fatalf("the apply override moved the post_create bound to %s — the phases have separate budgets", got)
+	}
+}

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -68,7 +67,7 @@ const DefaultPodReadyTimeout = 10 * time.Minute
 // Fifteen minutes because no measured copy duration exists to size it
 // from: iterion's own checkout is 355 MB streamed through the apiserver,
 // and a cold copy on a slow apiserver must not be killed for being slow
-// but healthy. The halfway warning in runWithPhaseTimeout makes such a
+// but healthy. The halfway warning in sandbox.RunWithPhaseTimeout makes such a
 // copy visible at 7m30s, before the bound strikes. Overridable per host
 // via ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT (a Go duration).
 const DefaultWorkspaceCopyTimeout = 15 * time.Minute
@@ -83,131 +82,36 @@ const workspaceCopyTimeoutEnv = "ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT"
 // override that never took, with nothing saying so.
 var workspaceCopyTimeoutWarnOnce sync.Once
 
-// DefaultPostCreateTimeout bounds the post_create snippet — the setup
-// phase that follows the copy and the git fixup. A hung snippet (a
-// package install waiting on a dead mirror, a command that reads stdin)
-// held the run in setup with no typed failure and no redelivery: the
-// same shape the copy bound closed, one phase later.
-//
-// Thirty minutes because a post_create legitimately outlasts a copy —
-// it is where a devcontainer installs its toolchain — so it carries its
-// own budget rather than sharing the copy's. Overridable per host via
-// ITERION_SANDBOX_POST_CREATE_TIMEOUT (a Go duration).
-const DefaultPostCreateTimeout = 30 * time.Minute
+// DefaultApplyTimeout bounds one `kubectl apply` — the per-run Secret,
+// the CA Secret, the sandbox pod, the NetworkPolicy, and the mid-run
+// secret refresh. An apply against a healthy apiserver takes
+// milliseconds; a wedged one (a control-plane rollout, a throttled
+// admission webhook, a TCP connect that never completes) otherwise hangs
+// sandbox creation BEFORE the first bounded phase is reached, with no
+// `sandbox_started` event and no typed failure. Two minutes leaves a
+// contended apiserver plenty of room while keeping the stall inside the
+// window a redelivery can clear. Overridable per host via
+// ITERION_SANDBOX_K8S_APPLY_TIMEOUT (a Go duration).
+const DefaultApplyTimeout = 2 * time.Minute
 
-// postCreateTimeoutEnv is the post_create override key.
-const postCreateTimeoutEnv = "ITERION_SANDBOX_POST_CREATE_TIMEOUT"
+// applyTimeoutEnv is the override key for the apply family — one knob for
+// every resource the driver applies, since they share an apiserver and
+// stall together.
+const applyTimeoutEnv = "ITERION_SANDBOX_K8S_APPLY_TIMEOUT"
 
-// postCreateTimeoutWarnOnce is the post_create half of the
-// once-per-process unparseable-override warning: each knob warns for
-// itself, or a bad value on one is silenced by a bad value on the other.
-var postCreateTimeoutWarnOnce sync.Once
+// applyTimeoutWarnOnce is the apply family's half of the once-per-process
+// unparseable-override warning: each knob warns for itself, or a bad
+// value on one is silenced by a bad value on the other.
+var applyTimeoutWarnOnce sync.Once
 
 // resolveWorkspaceCopyTimeout returns the effective copy/fixup budget.
 func resolveWorkspaceCopyTimeout() time.Duration {
-	return resolvePhaseTimeout(workspaceCopyTimeoutEnv, DefaultWorkspaceCopyTimeout, &workspaceCopyTimeoutWarnOnce)
+	return sandbox.ResolvePhaseTimeout(workspaceCopyTimeoutEnv, DefaultWorkspaceCopyTimeout, &workspaceCopyTimeoutWarnOnce)
 }
 
-// resolvePostCreateTimeout returns the effective post_create budget.
-func resolvePostCreateTimeout() time.Duration {
-	return resolvePhaseTimeout(postCreateTimeoutEnv, DefaultPostCreateTimeout, &postCreateTimeoutWarnOnce)
-}
-
-// resolvePhaseTimeout returns a setup phase's effective timeout,
-// honouring its env override with a fail-safe fallback: a garbage or
-// non-positive value ("banana", "0", "-5m", or "5" — which Go parses as
-// five NANOseconds, not the five minutes the operator meant) falls back
-// to the default (a setup phase left unbounded is exactly the bug this
-// exists to close) and warns once, naming the key, the value and the
-// default. One resolver for every phase, so a knob added later cannot
-// come with different failure semantics.
-func resolvePhaseTimeout(envKey string, def time.Duration, warnOnce *sync.Once) time.Duration {
-	raw := strings.TrimSpace(os.Getenv(envKey))
-	if raw == "" {
-		return def
-	}
-	d, err := time.ParseDuration(raw)
-	if err != nil || d <= 0 {
-		warnOnce.Do(func() {
-			// Stderr, not the driver logger: a leaf helper with no
-			// logger in reach.
-			fmt.Fprintf(os.Stderr,
-				"iterion: %s=%q is not a positive Go duration (use e.g. 5m, 15m, 2h) — using the default %s\n",
-				envKey, raw, def)
-		})
-		return def
-	}
-	return d
-}
-
-// phaseTimeoutWarnRatio is where the halfway-mark warning fires, as a
-// fraction of the phase budget: a slow-but-healthy copy shows up on the
-// runner log BEFORE the bound strikes, with enough runway left to tell
-// "clogged and finishing" from "wedged". A var so tests can lower it.
-var phaseTimeoutWarnRatio = 0.5
-
-// runWithPhaseTimeout runs fn under a bounded child context. When THIS
-// phase's deadline strikes it returns an error naming the phase and the
-// wall-clock elapsed time, wrapping sandbox.ErrPhaseTimeout,
-// context.DeadlineExceeded AND fn's own error through errors.Join, so
-// every consumer can classify the shape with errors.Is (the setup
-// classifier routes it to failed_resumable, the runner NAKs it) and the
-// operator still reads the actual cause. An outer ctx cancellation (run
-// cancel, pod SIGTERM) keeps its own shape: a cooperative stop is not a
-// stall.
-//
-// The bound is only as strong as fn's ctx discipline. fn is called
-// synchronously and nothing races the deadline: the child ctx expires,
-// and whatever fn does with that is the whole enforcement. For the
-// workspace copy that is exec.CommandContext killing the LOCAL tar and
-// kubectl processes; the in-pod tar behind `kubectl exec` is not reached
-// by that signal (Setpgid signals only the leader), it dies with the
-// pipe. A callee that ignores its ctx and returns nil after the deadline
-// therefore completes — and is warned about, so a phase that burned its
-// whole budget and won by a hair is visible before the next occurrence
-// trips the bound.
-//
-// The halfway warning (phaseTimeoutWarnRatio × timeout) runs on a side
-// goroutine that fn's return cancels; on an early return it emits
-// nothing. Both warnings name envKey — the knob of THIS phase — so an
-// operator reading them raises the bound that actually applies.
-func runWithPhaseTimeout(ctx context.Context, logger *iterlog.Logger, phase, envKey string, timeout time.Duration, fn func(context.Context) error) error {
-	if logger == nil {
-		logger = iterlog.Nop()
-	}
-	phaseCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	start := time.Now()
-
-	// The warn delay is computed here, not in the goroutine, so the
-	// ratio is read before the goroutine exists (tests lower it).
-	warnAfter := time.Duration(float64(timeout) * phaseTimeoutWarnRatio)
-	done := make(chan struct{})
-	go func() {
-		select {
-		case <-done:
-		case <-time.After(warnAfter):
-			logger.Warn("sandbox: %s phase still running after %s of its %s budget — a stall from here on fails the phase (%s raises the bound)",
-				phase, time.Since(start).Round(time.Second), timeout, envKey)
-		}
-	}()
-
-	err := fn(phaseCtx)
-	close(done)
-
-	if err == nil {
-		if phaseCtx.Err() != nil {
-			logger.Warn("sandbox: %s phase completed at or past its %s budget (elapsed %s) — raise %s or investigate the delay",
-				phase, timeout, time.Since(start).Round(time.Millisecond), envKey)
-		}
-		return nil
-	}
-	if phaseCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
-		return fmt.Errorf("kubernetes: %s phase timed out after %s (deadline %s exceeded): %w",
-			phase, time.Since(start).Round(time.Millisecond), timeout,
-			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, err))
-	}
-	return err
+// resolveApplyTimeout returns the effective per-apply budget.
+func resolveApplyTimeout() time.Duration {
+	return sandbox.ResolvePhaseTimeout(applyTimeoutEnv, DefaultApplyTimeout, &applyTimeoutWarnOnce)
 }
 
 // Downward-API env vars the runner pod's Helm chart should inject so the
@@ -718,7 +622,7 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 		if err != nil {
 			return nil, fmt.Errorf("kubernetes: build file secrets secret: %w", err)
 		}
-		if err := applyManifest(ctx, d.namespace, secretManifest); err != nil {
+		if err := applyManifest(ctx, d.logger, d.namespace, "apply file-secrets secret", secretManifest); err != nil {
 			return nil, fmt.Errorf("kubernetes: apply file secrets secret: %w", err)
 		}
 	}
@@ -736,7 +640,7 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 			}
 			return nil, fmt.Errorf("kubernetes: build CA secret: %w", err)
 		}
-		if err := applyManifest(ctx, d.namespace, caSecret); err != nil {
+		if err := applyManifest(ctx, d.logger, d.namespace, "apply CA secret", caSecret); err != nil {
 			if secretFilesSecretName != "" {
 				_ = deleteResource(ctx, d.namespace, "secret", secretFilesSecretName)
 			}
@@ -774,11 +678,12 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	// immutable and the runner SA intentionally lacks pods/patch → Forbidden,
 	// parking the run on the DLQ. Force-delete any stale pod so apply always
 	// CREATEs fresh; the resume re-populates the workspace from the checkpoint.
-	delStale := kubectlCmdContext(ctx, "--namespace", d.namespace, "delete", "pod", podName,
-		"--ignore-not-found=true", "--grace-period=0", "--force")
-	_, _ = delStale.CombinedOutput()
+	// Goes through deleteResource so it inherits that helper's bound: it is
+	// one apiserver call in the middle of the setup sequence, and an
+	// unbounded one hangs the run before the first bounded phase.
+	_ = deleteResource(ctx, d.namespace, "pod", podName, "--grace-period=0", "--force")
 
-	if err := applyManifest(ctx, d.namespace, manifest); err != nil {
+	if err := applyManifest(ctx, d.logger, d.namespace, "apply pod", manifest); err != nil {
 		if caSecretName != "" {
 			_ = deleteResource(ctx, d.namespace, "secret", caSecretName)
 		}
@@ -832,7 +737,7 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: build netpolicy: %w", err)
 		}
-		if err := applyManifest(ctx, d.namespace, netpolicy); err != nil {
+		if err := applyManifest(ctx, d.logger, d.namespace, "apply networkpolicy", netpolicy); err != nil {
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: apply netpolicy: %w", err)
 		}
@@ -866,13 +771,13 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	// overrides).
 	if info.WorkspacePath != "" {
 		copyTimeout := resolveWorkspaceCopyTimeout()
-		if err := runWithPhaseTimeout(ctx, d.logger, "workspace copy", workspaceCopyTimeoutEnv, copyTimeout, func(ctx context.Context) error {
+		if err := sandbox.RunWithPhaseTimeout(ctx, d.logger, "workspace copy", workspaceCopyTimeoutEnv, copyTimeout, func(ctx context.Context) error {
 			return r.populateWorkspace(ctx, info.WorkspacePath, p.workspace)
 		}); err != nil {
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: populate workspace: %w", err)
 		}
-		if err := runWithPhaseTimeout(ctx, d.logger, "workspace git fixup", workspaceCopyTimeoutEnv, copyTimeout, func(ctx context.Context) error {
+		if err := sandbox.RunWithPhaseTimeout(ctx, d.logger, "workspace git fixup", workspaceCopyTimeoutEnv, copyTimeout, func(ctx context.Context) error {
 			return r.fixupWorkspaceGit(ctx, p.workspace)
 		}); err != nil {
 			_ = r.Cleanup(ctx)
@@ -958,7 +863,7 @@ func (r *Run) RefreshSecretFile(ctx context.Context, name string, value []byte) 
 	if err != nil {
 		return err
 	}
-	if err := applyManifest(ctx, r.namespace, manifest); err != nil {
+	if err := applyManifest(ctx, r.driver.logger, r.namespace, "refresh file-secret", manifest); err != nil {
 		return fmt.Errorf("kubernetes: refresh file secret %s: apply: %w", name, err)
 	}
 	return nil
@@ -1116,13 +1021,14 @@ func (r *Run) Cleanup(_ context.Context) error {
 // until the outer max_duration fires — no typed failure, no redelivery,
 // the pod sitting on the run lease. The bound lives here rather than at
 // the Start call site so every caller inherits it. Budget:
-// resolvePostCreateTimeout (ITERION_SANDBOX_POST_CREATE_TIMEOUT); the
-// expiry carries sandbox.ErrPhaseTimeout, so the engine parks the run
-// failed_resumable with SANDBOX_SETUP_TIMEOUT exactly as a copy stall
-// does.
+// sandbox.ResolvePostCreateTimeout (ITERION_SANDBOX_POST_CREATE_TIMEOUT)
+// — the same one the docker driver reads, the phase owning the knob
+// rather than the driver; the expiry carries sandbox.ErrPhaseTimeout, so
+// the engine parks the run failed_resumable with SANDBOX_SETUP_TIMEOUT
+// exactly as a copy stall does.
 func (r *Run) runPostCreate(ctx context.Context, snippet string) error {
 	r.driver.logger.Info("sandbox: running postCreateCommand in pod %s", r.podName)
-	return runWithPhaseTimeout(ctx, r.driver.logger, "post_create", postCreateTimeoutEnv, resolvePostCreateTimeout(),
+	return sandbox.RunWithPhaseTimeout(ctx, r.driver.logger, "post_create", sandbox.PostCreateTimeoutEnv, sandbox.ResolvePostCreateTimeout(),
 		func(ctx context.Context) error {
 			return sandbox.RunPostCreate(ctx, r, snippet, r.driver.logger)
 		})

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -41,6 +41,8 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/internal/proc"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 )
 
 // kubeBinaryName is the kubectl CLI iterion shells out to. Hardcoded
@@ -110,23 +112,51 @@ func kubectlCmdContext(ctx context.Context, args ...string) *exec.Cmd {
 // diagnostic surfacing — kubectl writes the failure reason to
 // stderr in a structured way ("Error from server (NotFound)") that
 // callers can parse without re-issuing the request.
-func applyManifest(ctx context.Context, namespace string, manifest []byte) error {
-	cmd := kubectlCmdContext(ctx, "--namespace", namespace, "apply", "-f", "-")
-	cmd.Stdin = bytes.NewReader(manifest)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("kubectl apply: %w\noutput: %s", err, string(out))
-	}
-	return nil
+//
+// BOUNDED, and bounded at both ends of the pipe: the phase helper caps
+// the call (resolveApplyTimeout, ITERION_SANDBOX_K8S_APPLY_TIMEOUT) and
+// kills the process on expiry, and `--request-timeout` makes kubectl
+// itself give up rather than wait on a wedged apiserver forever. Without
+// the pair, an apply on the bare run context hangs sandbox creation
+// BEFORE the first bounded phase is reached. The expiry carries
+// sandbox.ErrPhaseTimeout, so the engine parks the run failed_resumable
+// with SANDBOX_SETUP_TIMEOUT like every other setup stall.
+//
+// phase names WHICH apply stalled ("apply pod", "apply networkpolicy",
+// …) — every per-run resource shares one budget but not one diagnosis.
+func applyManifest(ctx context.Context, logger *iterlog.Logger, namespace, phase string, manifest []byte) error {
+	timeout := resolveApplyTimeout()
+	return sandbox.RunWithPhaseTimeout(ctx, logger, phase, applyTimeoutEnv, timeout, func(ctx context.Context) error {
+		cmd := kubectlCmdContext(ctx, "--namespace", namespace,
+			"--request-timeout="+timeout.String(), "apply", "-f", "-")
+		cmd.Stdin = bytes.NewReader(manifest)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("kubectl apply: %w\noutput: %s", err, string(out))
+		}
+		return nil
+	})
 }
 
 // deleteResource runs `kubectl delete <kind> <name> --namespace ...`.
 // Treats NotFound as success — callers invoke it from defer paths
 // where the resource may already be gone (a panicking iterion run
-// can leak partial state).
-func deleteResource(ctx context.Context, namespace, kind, name string) error {
-	cmd := kubectlCmdContext(ctx, "--namespace", namespace, "delete", kind, name,
-		"--ignore-not-found=true", "--wait=false")
+// can leak partial state). extraArgs appends per-call flags (e.g. a
+// force-delete's `--grace-period=0 --force`).
+//
+// Bounded by the apply family's budget, and by `--request-timeout` on
+// kubectl itself: a delete is one apiserver call like an apply, and most
+// callers discard its result — a wedged apiserver would otherwise hang a
+// rollback or a stale-pod eviction with nothing to show for it. Plain
+// context deadline, NOT sandbox.ErrPhaseTimeout: a cleanup is not a setup
+// phase and must not be classified as one.
+func deleteResource(ctx context.Context, namespace, kind, name string, extraArgs ...string) error {
+	timeout := resolveApplyTimeout()
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	args := []string{"--namespace", namespace, "--request-timeout=" + timeout.String(),
+		"delete", kind, name, "--ignore-not-found=true", "--wait=false"}
+	cmd := kubectlCmdContext(ctx, append(args, extraArgs...)...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		// Even with --ignore-not-found, delete returns non-zero on

--- a/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
+++ b/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -24,113 +23,9 @@ import (
 // wiped the pod and re-delivered the message onto a stale `running`
 // status). The phase must fail with a typed, visible error naming both
 // the phase and the elapsed wall-clock time.
-
-// lockedBuffer is a goroutine-safe io.Writer for capturing the driver
-// logger: the halfway warning is written from a side goroutine.
-type lockedBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-}
-
-func (b *lockedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
-}
-
-func (b *lockedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
-}
-
-func captureLogger() (*iterlog.Logger, *lockedBuffer) {
-	buf := &lockedBuffer{}
-	return iterlog.New(iterlog.LevelWarn, buf), buf
-}
-
-// A stall past the phase budget must surface as a typed timeout error
-// naming the phase and the elapsed time.
-func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
-	ctx := context.Background()
-	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, 30*time.Millisecond, func(pctx context.Context) error {
-		select {
-		case <-pctx.Done():
-			return pctx.Err()
-		case <-time.After(2 * time.Second):
-			t.Fatal("phase context did not fire the deadline")
-			return nil
-		}
-	})
-	if err == nil {
-		t.Fatal("phase stall did not surface as an error — the run would block on the outer ctx (the exact bug #669 part 1 measured live)")
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("phase timeout must wrap context.DeadlineExceeded (errors.Is), got %v", err)
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "workspace copy phase timed out") {
-		t.Fatalf("timeout error must name the PHASE, got %q", msg)
-	}
-	if !strings.Contains(msg, "deadline 30ms exceeded") {
-		t.Fatalf("timeout error must name the deadline the operator set (needed to distinguish the fleet default from a raised cap), got %q", msg)
-	}
-}
-
-// A phase completing under budget must pass through untouched (no
-// double-wrapping of a nil error, no bogus timeout report).
-func TestRunWithPhaseTimeout_NominalCompletionIsPassthrough(t *testing.T) {
-	ctx := context.Background()
-	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, time.Second, func(context.Context) error {
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("nominal phase must not error, got %v", err)
-	}
-}
-
-// A phase erroring for its own reason (not a timeout) keeps its native
-// error shape — the operator needs to see the real cause (e.g. a git
-// fixup failure), not "the phase timed out".
-func TestRunWithPhaseTimeout_InnerErrorIsNotMisreportedAsTimeout(t *testing.T) {
-	ctx := context.Background()
-	sentinel := errors.New("tar: broken pipe")
-	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, time.Second, func(context.Context) error {
-		return sentinel
-	})
-	if err == nil {
-		t.Fatal("inner error was swallowed")
-	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("inner tar-broken-pipe misreported as a phase timeout: %v — the ops would chase the wrong bug", err)
-	}
-	if errors.Is(err, sandbox.ErrPhaseTimeout) {
-		t.Fatalf("inner error carries the phase-timeout sentinel: %v — the setup classifier would park a hard failure as resumable", err)
-	}
-	if !errors.Is(err, sentinel) {
-		t.Fatalf("inner error identity lost; got %v", err)
-	}
-}
-
-// An OUTER context cancellation (run cancel, pod SIGTERM) must keep
-// its own shape — the phase-timeout wrapper is only for the phase's
-// OWN deadline, otherwise a cooperative stop would look like an
-// unbounded stall in every log parser.
-func TestRunWithPhaseTimeout_OuterCancelIsNotMisreportedAsPhaseTimeout(t *testing.T) {
-	parent, cancel := context.WithCancel(context.Background())
-	// Cancel BEFORE fn runs so phaseCtx.Err() will read Canceled, not
-	// DeadlineExceeded, when we check it.
-	cancel()
-	err := runWithPhaseTimeout(parent, iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, time.Hour, func(pctx context.Context) error {
-		return pctx.Err()
-	})
-	if err == nil {
-		t.Fatal("cancelled outer ctx must surface")
-	}
-	if strings.Contains(err.Error(), "phase timed out") || errors.Is(err, sandbox.ErrPhaseTimeout) {
-		t.Fatalf("outer cancel misreported as phase timeout: %v (would flood the ops channel on every pod SIGTERM)", err)
-	}
-}
+//
+// The bound's own contract is owned by pkg/sandbox (phase_test.go); what
+// follows drives THIS driver's phases through it.
 
 // The env override is honoured (operator can raise the cap for a slow
 // cluster or a huge workspace without editing the binary).
@@ -184,32 +79,6 @@ func TestResolveWorkspaceCopyTimeout_GarbageEnvIsWarnedOnce(t *testing.T) {
 	}
 }
 
-// The wrapped error must expose BOTH sandbox.ErrPhaseTimeout AND
-// context.DeadlineExceeded via errors.Is even when the callee's own
-// error is neither — a `%w` on the inner cause alone hides the deadline
-// shape from the setup classifier. Stub callee: the shape, in isolation.
-func TestRunWithPhaseTimeout_WrapsPhaseTimeoutSentinelViaErrorsIs(t *testing.T) {
-	ctx := context.Background()
-	sentinel := errors.New("kubectl-exec pipe stalled")
-	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, 30*time.Millisecond, func(pctx context.Context) error {
-		// Ignores pctx: a callee whose helpers do not respect ctx.
-		time.Sleep(80 * time.Millisecond)
-		return sentinel
-	})
-	if err == nil {
-		t.Fatal("stall returned no error")
-	}
-	if !errors.Is(err, sandbox.ErrPhaseTimeout) {
-		t.Fatalf("errors.Is(err, sandbox.ErrPhaseTimeout) = false — the setup classifier cannot route this to failed_resumable")
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("errors.Is(err, context.DeadlineExceeded) = false — the deadline shape is invisible to every consumer")
-	}
-	if !errors.Is(err, sentinel) {
-		t.Fatalf("errors.Is(err, inner) = false — the operator loses the actual cause; got %v", err)
-	}
-}
-
 // The same shape driven through the REAL populateWorkspace: a kubectl
 // shim on PATH that never reads its stdin and never exits is the in-pod
 // tar side of the copy pipe, wedged. The phase must strike its own
@@ -236,7 +105,7 @@ func TestRunWithPhaseTimeout_RealWorkspaceCopyStallIsClassified(t *testing.T) {
 	r := &Run{driver: &Driver{logger: iterlog.Nop()}, podName: "sandbox-x", namespace: "ns"}
 
 	start := time.Now()
-	err := runWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, 300*time.Millisecond, func(ctx context.Context) error {
+	err := sandbox.RunWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", workspaceCopyTimeoutEnv, 300*time.Millisecond, func(ctx context.Context) error {
 		return r.populateWorkspace(ctx, src, "/workspace")
 	})
 	elapsed := time.Since(start)
@@ -257,43 +126,6 @@ func TestRunWithPhaseTimeout_RealWorkspaceCopyStallIsClassified(t *testing.T) {
 	}
 }
 
-// A callee that ignores its ctx and returns nil past the deadline is
-// warned about: a phase that burned its whole budget and won by a hair
-// must be visible before the next occurrence trips the bound.
-func TestRunWithPhaseTimeout_OverrunButNilCalleeWarns(t *testing.T) {
-	logger, out := captureLogger()
-	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", workspaceCopyTimeoutEnv, 10*time.Millisecond, func(pctx context.Context) error {
-		time.Sleep(30 * time.Millisecond) // past the deadline, ignoring pctx
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("nil-return-past-deadline unexpectedly errored: %v", err)
-	}
-	if got := out.String(); !strings.Contains(got, "workspace copy phase completed at or past its") {
-		t.Fatalf("overrun warning missing: %q (silent success past budget hides the next occurrence's failure)", got)
-	}
-}
-
-// The halfway-mark warning fires while the phase is still running, so a
-// slow-but-healthy copy is visible BEFORE the bound strikes.
-func TestRunWithPhaseTimeout_HalfwayMarkWarns(t *testing.T) {
-	prev := phaseTimeoutWarnRatio
-	phaseTimeoutWarnRatio = 0.25
-	defer func() { phaseTimeoutWarnRatio = prev }()
-
-	logger, out := captureLogger()
-	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", workspaceCopyTimeoutEnv, 400*time.Millisecond, func(pctx context.Context) error {
-		time.Sleep(200 * time.Millisecond) // past the 25% mark, under the deadline
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := out.String(); !strings.Contains(got, "workspace copy phase still running") {
-		t.Fatalf("halfway warning did not fire: %q (a slow copy needs a signal BEFORE the deadline)", got)
-	}
-}
-
 // #719: the post_create snippet is the setup phase right after the copy
 // and the git fixup, and it ran on the bare context. A hung snippet (a
 // package install waiting on a dead mirror, a command that reads stdin)
@@ -310,7 +142,7 @@ func TestRunPostCreate_StallIsBoundedAndTyped(t *testing.T) {
 	if err := os.WriteFile(shim, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv(postCreateTimeoutEnv, "300ms")
+	t.Setenv(sandbox.PostCreateTimeoutEnv, "300ms")
 
 	r := &Run{
 		driver:    &Driver{logger: iterlog.Nop(), kubectl: shim},
@@ -340,87 +172,16 @@ func TestRunPostCreate_StallIsBoundedAndTyped(t *testing.T) {
 	}
 }
 
-// The post_create bound has its OWN env override: a package install
-// legitimately outlasts a workspace copy, and an operator raising one
-// must not have to raise the other.
-func TestResolvePostCreateTimeout_HonoursItsOwnEnv(t *testing.T) {
-	if got := resolvePostCreateTimeout(); got != DefaultPostCreateTimeout {
-		t.Fatalf("resolvePostCreateTimeout() = %s with no env, want the default %s", got, DefaultPostCreateTimeout)
+// The post_create bound reads the SHARED phase knob and the copy knob
+// must not move with it: a package install legitimately outlasts a
+// workspace copy, and an operator raising one must not have to raise the
+// other.
+func TestResolvePostCreateTimeout_DoesNotMoveTheCopyBound(t *testing.T) {
+	t.Setenv(sandbox.PostCreateTimeoutEnv, "45m")
+	if got, want := sandbox.ResolvePostCreateTimeout(), 45*time.Minute; got != want {
+		t.Fatalf("ResolvePostCreateTimeout() = %s, want %s (operator override lost)", got, want)
 	}
-	t.Setenv(postCreateTimeoutEnv, "45m")
-	if got, want := resolvePostCreateTimeout(), 45*time.Minute; got != want {
-		t.Fatalf("resolvePostCreateTimeout() = %s, want %s (operator override lost)", got, want)
-	}
-	// The copy knob must not move with it.
 	if got := resolveWorkspaceCopyTimeout(); got != DefaultWorkspaceCopyTimeout {
 		t.Fatalf("the post_create override moved the copy bound to %s — the two phases have separate budgets", got)
-	}
-	// Garbage falls back to the default, fail-closed like the copy's.
-	t.Setenv(postCreateTimeoutEnv, "45 minutes")
-	if got := resolvePostCreateTimeout(); got != DefaultPostCreateTimeout {
-		t.Fatalf("garbage override = %s, want the default %s (an unbounded post_create is the bug this closes)", got, DefaultPostCreateTimeout)
-	}
-}
-
-// A garbage post_create override must be VISIBLE on stderr, naming its
-// OWN key — the copy's convention, and the reason the phase carries the
-// key rather than the helper hardcoding one.
-func TestResolvePostCreateTimeout_GarbageEnvIsWarnedOnce(t *testing.T) {
-	stderr, restore := captureStderr(t)
-	defer restore()
-	postCreateTimeoutWarnOnce = sync.Once{}
-
-	t.Setenv(postCreateTimeoutEnv, "5")
-	_ = resolvePostCreateTimeout()
-	got := stderr()
-	if !strings.Contains(got, postCreateTimeoutEnv) {
-		t.Fatalf("stderr = %q, want it to name %s", got, postCreateTimeoutEnv)
-	}
-	if !strings.Contains(got, `"5"`) || !strings.Contains(got, DefaultPostCreateTimeout.String()) {
-		t.Fatalf("stderr = %q, want the operator's value and the default that replaced it", got)
-	}
-	_ = resolvePostCreateTimeout()
-	if got := stderr(); got != "" {
-		t.Fatalf("second call re-warned: %q", got)
-	}
-}
-
-// The halfway warning names the knob of the phase that is running: an
-// operator told to raise the copy timeout for a slow post_create raises
-// the wrong one.
-func TestRunWithPhaseTimeout_WarningNamesThePhasesOwnKnob(t *testing.T) {
-	prev := phaseTimeoutWarnRatio
-	phaseTimeoutWarnRatio = 0.25
-	defer func() { phaseTimeoutWarnRatio = prev }()
-
-	logger, out := captureLogger()
-	err := runWithPhaseTimeout(context.Background(), logger, "post_create", postCreateTimeoutEnv, 400*time.Millisecond, func(context.Context) error {
-		time.Sleep(200 * time.Millisecond)
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	got := out.String()
-	if !strings.Contains(got, postCreateTimeoutEnv) {
-		t.Fatalf("halfway warning = %q, want it to name %s", got, postCreateTimeoutEnv)
-	}
-	if strings.Contains(got, workspaceCopyTimeoutEnv) {
-		t.Fatalf("halfway warning = %q, want it NOT to name the copy's knob", got)
-	}
-}
-
-// A phase that finishes before the halfway mark says nothing: the
-// warning is for slow copies, not a heartbeat.
-func TestRunWithPhaseTimeout_FastPhaseIsSilent(t *testing.T) {
-	logger, out := captureLogger()
-	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", workspaceCopyTimeoutEnv, time.Second, func(context.Context) error {
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got := out.String(); got != "" {
-		t.Fatalf("a fast phase warned: %q", got)
 	}
 }

--- a/pkg/sandbox/phase.go
+++ b/pkg/sandbox/phase.go
@@ -1,0 +1,143 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// Everything between "the container/pod exists" and "the first node runs"
+// is SETUP, and each phase carries its own bound. An unbounded phase does
+// not fail — it waits, and a run waiting in setup has no `sandbox_started`
+// event, holds its queue lease, and only dies when the run's own
+// max_duration fires hours later. The helpers below are the ONE
+// implementation of that bound: a phase added later cannot come with
+// different failure semantics, and a phase shared by two drivers cannot
+// be bounded on one and not the other.
+
+// DefaultPostCreateTimeout bounds the post_create snippet on every driver
+// that honours [Spec.PostCreate]. A hung snippet (a package install
+// waiting on a dead mirror, a command that reads stdin) holds the run in
+// setup with no typed failure and no redelivery.
+//
+// Thirty minutes because a post_create legitimately outlasts the phases
+// around it — it is where a devcontainer installs its toolchain — so it
+// carries its own budget rather than sharing another's. Overridable per
+// host via [PostCreateTimeoutEnv].
+const DefaultPostCreateTimeout = 30 * time.Minute
+
+// PostCreateTimeoutEnv is the post_create override key. The budget belongs
+// to the PHASE, not to a driver: an operator raising it for a slow
+// toolchain install raises it everywhere the phase runs.
+const PostCreateTimeoutEnv = "ITERION_SANDBOX_POST_CREATE_TIMEOUT"
+
+// postCreateTimeoutWarnOnce bounds the "unparseable override" warning to
+// one stderr line per process (the ITERION_BUDGET_EXIT_GRACE convention).
+var postCreateTimeoutWarnOnce sync.Once
+
+// ResolvePostCreateTimeout returns the effective post_create budget.
+func ResolvePostCreateTimeout() time.Duration {
+	return ResolvePhaseTimeout(PostCreateTimeoutEnv, DefaultPostCreateTimeout, &postCreateTimeoutWarnOnce)
+}
+
+// ResolvePhaseTimeout returns a setup phase's effective timeout,
+// honouring its env override with a fail-safe fallback: a garbage or
+// non-positive value ("banana", "0", "-5m", or "5" — which Go parses as
+// five NANOseconds, not the five minutes the operator meant) falls back
+// to the default (a setup phase left unbounded is exactly the bug this
+// exists to close) and warns once, naming the key, the value and the
+// default. One resolver for every phase, so a knob added later cannot
+// come with different failure semantics.
+func ResolvePhaseTimeout(envKey string, def time.Duration, warnOnce *sync.Once) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(envKey))
+	if raw == "" {
+		return def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		warnOnce.Do(func() {
+			// Stderr, not a logger: a leaf helper with none in reach.
+			fmt.Fprintf(os.Stderr,
+				"iterion: %s=%q is not a positive Go duration (use e.g. 5m, 15m, 2h) — using the default %s\n",
+				envKey, raw, def)
+		})
+		return def
+	}
+	return d
+}
+
+// phaseTimeoutWarnRatio is where the halfway-mark warning fires, as a
+// fraction of the phase budget: a slow-but-healthy phase shows up on the
+// runner log BEFORE the bound strikes, with enough runway left to tell
+// "clogged and finishing" from "wedged". A var so tests can lower it.
+var phaseTimeoutWarnRatio = 0.5
+
+// RunWithPhaseTimeout runs fn under a bounded child context. When THIS
+// phase's deadline strikes it returns an error naming the phase and the
+// wall-clock elapsed time, wrapping [ErrPhaseTimeout],
+// context.DeadlineExceeded AND fn's own error through errors.Join, so
+// every consumer can classify the shape with errors.Is (the setup
+// classifier routes it to failed_resumable, the runner NAKs it) and the
+// operator still reads the actual cause. An outer ctx cancellation (run
+// cancel, pod SIGTERM) keeps its own shape: a cooperative stop is not a
+// stall.
+//
+// The bound is only as strong as fn's ctx discipline. fn is called
+// synchronously and nothing races the deadline: the child ctx expires,
+// and whatever fn does with that is the whole enforcement. For a
+// subprocess phase that is exec.CommandContext killing the LOCAL process;
+// a process the local one merely pipes into (the in-pod tar behind
+// `kubectl exec`) is not reached by that signal (Setpgid signals only the
+// leader), it dies with the pipe. A callee that ignores its ctx and
+// returns nil after the deadline therefore completes — and is warned
+// about, so a phase that burned its whole budget and won by a hair is
+// visible before the next occurrence trips the bound.
+//
+// The halfway warning (phaseTimeoutWarnRatio × timeout) runs on a side
+// goroutine that fn's return cancels; on an early return it emits
+// nothing. Both warnings name envKey — the knob of THIS phase — so an
+// operator reading them raises the bound that actually applies.
+func RunWithPhaseTimeout(ctx context.Context, logger *iterlog.Logger, phase, envKey string, timeout time.Duration, fn func(context.Context) error) error {
+	if logger == nil {
+		logger = iterlog.Nop()
+	}
+	phaseCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	start := time.Now()
+
+	// The warn delay is computed here, not in the goroutine, so the
+	// ratio is read before the goroutine exists (tests lower it).
+	warnAfter := time.Duration(float64(timeout) * phaseTimeoutWarnRatio)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+		case <-time.After(warnAfter):
+			logger.Warn("sandbox: %s phase still running after %s of its %s budget — a stall from here on fails the phase (%s raises the bound)",
+				phase, time.Since(start).Round(time.Second), timeout, envKey)
+		}
+	}()
+
+	err := fn(phaseCtx)
+	close(done)
+
+	if err == nil {
+		if phaseCtx.Err() != nil {
+			logger.Warn("sandbox: %s phase completed at or past its %s budget (elapsed %s) — raise %s or investigate the delay",
+				phase, timeout, time.Since(start).Round(time.Millisecond), envKey)
+		}
+		return nil
+	}
+	if phaseCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+		return fmt.Errorf("sandbox: %s phase timed out after %s (deadline %s exceeded): %w",
+			phase, time.Since(start).Round(time.Millisecond), timeout,
+			errors.Join(ErrPhaseTimeout, context.DeadlineExceeded, err))
+	}
+	return err
+}

--- a/pkg/sandbox/phase_test.go
+++ b/pkg/sandbox/phase_test.go
@@ -1,0 +1,354 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// The setup-phase bound is ONE implementation shared by every driver: a
+// phase that only one driver bounds is a phase the fleet does not bound.
+// These tests own the helper's contract; each driver keeps an integration
+// test driving its own phase through it.
+
+const testPhaseEnv = "ITERION_SANDBOX_TEST_PHASE_TIMEOUT"
+
+// lockedBuffer is a goroutine-safe io.Writer for capturing the logger:
+// the halfway warning is written from a side goroutine.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func captureLogger() (*iterlog.Logger, *lockedBuffer) {
+	buf := &lockedBuffer{}
+	return iterlog.New(iterlog.LevelWarn, buf), buf
+}
+
+// captureStderr redirects os.Stderr to a pipe for the caller's scope,
+// returns a `read` callback draining everything so far, and a `restore`
+// undoing the redirect.
+func captureStderr(t *testing.T) (read func() string, restore func()) {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	restored := false
+	restore = func() {
+		if restored {
+			return
+		}
+		restored = true
+		os.Stderr = orig
+		_ = w.Close()
+		_ = r.Close()
+	}
+	read = func() string {
+		// Close the write side so ReadAll sees EOF, then re-open a fresh
+		// pipe so the caller can drain multiple times without blocking.
+		// Order matters — close BEFORE reopening.
+		os.Stderr = orig
+		_ = w.Close()
+		buf, _ := io.ReadAll(r)
+		_ = r.Close()
+		nr, nw, perr := os.Pipe()
+		if perr == nil {
+			r, w = nr, nw
+			os.Stderr = w
+		}
+		return string(buf)
+	}
+	return read, restore
+}
+
+// A stall past the phase budget must surface as a typed timeout error
+// naming the phase and the elapsed time.
+func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
+	ctx := context.Background()
+	err := RunWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", testPhaseEnv, 30*time.Millisecond, func(pctx context.Context) error {
+		select {
+		case <-pctx.Done():
+			return pctx.Err()
+		case <-time.After(2 * time.Second):
+			t.Error("phase context did not fire the deadline")
+			return nil
+		}
+	})
+	if err == nil {
+		t.Fatal("phase stall did not surface as an error — the run would block on the outer ctx")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("phase timeout must wrap context.DeadlineExceeded (errors.Is), got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "workspace copy phase timed out") {
+		t.Fatalf("timeout error must name the PHASE, got %q", msg)
+	}
+	if !strings.Contains(msg, "deadline 30ms exceeded") {
+		t.Fatalf("timeout error must name the deadline the operator set (needed to distinguish the fleet default from a raised cap), got %q", msg)
+	}
+}
+
+// A phase completing under budget must pass through untouched (no
+// double-wrapping of a nil error, no bogus timeout report).
+func TestRunWithPhaseTimeout_NominalCompletionIsPassthrough(t *testing.T) {
+	err := RunWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", testPhaseEnv, time.Second, func(context.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nominal phase must not error, got %v", err)
+	}
+}
+
+// A phase erroring for its own reason (not a timeout) keeps its native
+// error shape — the operator needs to see the real cause, not "the phase
+// timed out".
+func TestRunWithPhaseTimeout_InnerErrorIsNotMisreportedAsTimeout(t *testing.T) {
+	sentinel := errors.New("tar: broken pipe")
+	err := RunWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", testPhaseEnv, time.Second, func(context.Context) error {
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("inner error was swallowed")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("inner tar-broken-pipe misreported as a phase timeout: %v — the ops would chase the wrong bug", err)
+	}
+	if errors.Is(err, ErrPhaseTimeout) {
+		t.Fatalf("inner error carries the phase-timeout sentinel: %v — the setup classifier would park a hard failure as resumable", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("inner error identity lost; got %v", err)
+	}
+}
+
+// An OUTER context cancellation (run cancel, pod SIGTERM) must keep its
+// own shape — the phase-timeout wrapper is only for the phase's OWN
+// deadline, otherwise a cooperative stop would look like an unbounded
+// stall in every log parser.
+func TestRunWithPhaseTimeout_OuterCancelIsNotMisreportedAsPhaseTimeout(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	// Cancel BEFORE fn runs so phaseCtx.Err() reads Canceled, not
+	// DeadlineExceeded, when we check it.
+	cancel()
+	err := RunWithPhaseTimeout(parent, iterlog.Nop(), "workspace copy", testPhaseEnv, time.Hour, func(pctx context.Context) error {
+		return pctx.Err()
+	})
+	if err == nil {
+		t.Fatal("cancelled outer ctx must surface")
+	}
+	if strings.Contains(err.Error(), "phase timed out") || errors.Is(err, ErrPhaseTimeout) {
+		t.Fatalf("outer cancel misreported as phase timeout: %v (would flood the ops channel on every pod SIGTERM)", err)
+	}
+}
+
+// The wrapped error must expose BOTH ErrPhaseTimeout AND
+// context.DeadlineExceeded via errors.Is even when the callee's own error
+// is neither — a `%w` on the inner cause alone hides the deadline shape
+// from the setup classifier.
+func TestRunWithPhaseTimeout_WrapsPhaseTimeoutSentinelViaErrorsIs(t *testing.T) {
+	sentinel := errors.New("kubectl-exec pipe stalled")
+	err := RunWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", testPhaseEnv, 30*time.Millisecond, func(context.Context) error {
+		// Ignores pctx: a callee whose helpers do not respect ctx.
+		time.Sleep(80 * time.Millisecond)
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("stall returned no error")
+	}
+	if !errors.Is(err, ErrPhaseTimeout) {
+		t.Fatalf("errors.Is(err, ErrPhaseTimeout) = false — the setup classifier cannot route this to failed_resumable")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("errors.Is(err, context.DeadlineExceeded) = false — the deadline shape is invisible to every consumer")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("errors.Is(err, inner) = false — the operator loses the actual cause; got %v", err)
+	}
+}
+
+// A callee that ignores its ctx and returns nil past the deadline is
+// warned about: a phase that burned its whole budget and won by a hair
+// must be visible before the next occurrence trips the bound.
+func TestRunWithPhaseTimeout_OverrunButNilCalleeWarns(t *testing.T) {
+	logger, out := captureLogger()
+	err := RunWithPhaseTimeout(context.Background(), logger, "workspace copy", testPhaseEnv, 10*time.Millisecond, func(context.Context) error {
+		time.Sleep(30 * time.Millisecond) // past the deadline, ignoring pctx
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nil-return-past-deadline unexpectedly errored: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "workspace copy phase completed at or past its") {
+		t.Fatalf("overrun warning missing: %q (silent success past budget hides the next occurrence's failure)", got)
+	}
+}
+
+// The halfway-mark warning fires while the phase is still running, so a
+// slow-but-healthy copy is visible BEFORE the bound strikes.
+func TestRunWithPhaseTimeout_HalfwayMarkWarns(t *testing.T) {
+	prev := phaseTimeoutWarnRatio
+	phaseTimeoutWarnRatio = 0.25
+	defer func() { phaseTimeoutWarnRatio = prev }()
+
+	logger, out := captureLogger()
+	err := RunWithPhaseTimeout(context.Background(), logger, "workspace copy", testPhaseEnv, 400*time.Millisecond, func(context.Context) error {
+		time.Sleep(200 * time.Millisecond) // past the 25% mark, under the deadline
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "workspace copy phase still running") {
+		t.Fatalf("halfway warning did not fire: %q (a slow copy needs a signal BEFORE the deadline)", got)
+	}
+}
+
+// The halfway warning names the knob of the phase that is running: an
+// operator told to raise the copy timeout for a slow post_create raises
+// the wrong one.
+func TestRunWithPhaseTimeout_WarningNamesThePhasesOwnKnob(t *testing.T) {
+	prev := phaseTimeoutWarnRatio
+	phaseTimeoutWarnRatio = 0.25
+	defer func() { phaseTimeoutWarnRatio = prev }()
+
+	logger, out := captureLogger()
+	err := RunWithPhaseTimeout(context.Background(), logger, "post_create", PostCreateTimeoutEnv, 400*time.Millisecond, func(context.Context) error {
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, PostCreateTimeoutEnv) {
+		t.Fatalf("halfway warning = %q, want it to name %s", got, PostCreateTimeoutEnv)
+	}
+	if strings.Contains(got, testPhaseEnv) {
+		t.Fatalf("halfway warning = %q, want it NOT to name another phase's knob", got)
+	}
+}
+
+// A phase that finishes before the halfway mark says nothing: the warning
+// is for slow phases, not a heartbeat.
+func TestRunWithPhaseTimeout_FastPhaseIsSilent(t *testing.T) {
+	logger, out := captureLogger()
+	err := RunWithPhaseTimeout(context.Background(), logger, "workspace copy", testPhaseEnv, time.Second, func(context.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("a fast phase warned: %q", got)
+	}
+}
+
+// The env override is honoured (an operator can raise the cap for a slow
+// cluster or a huge workspace without editing the binary), and garbage
+// falls back to the default rather than disabling the bound.
+func TestResolvePhaseTimeout_HonoursEnvAndFailsClosed(t *testing.T) {
+	var once sync.Once
+	if got := ResolvePhaseTimeout(testPhaseEnv, 15*time.Minute, &once); got != 15*time.Minute {
+		t.Fatalf("unset override = %s, want the default", got)
+	}
+	t.Setenv(testPhaseEnv, "12m")
+	if got, want := ResolvePhaseTimeout(testPhaseEnv, 15*time.Minute, &once), 12*time.Minute; got != want {
+		t.Fatalf("ResolvePhaseTimeout = %s, want %s (operator override lost)", got, want)
+	}
+	for _, bad := range []string{"not-a-duration", "0", "-5m"} {
+		t.Setenv(testPhaseEnv, bad)
+		if got := ResolvePhaseTimeout(testPhaseEnv, 15*time.Minute, &once); got != 15*time.Minute {
+			t.Fatalf("override %q = %s, want the default (an unbounded phase is the bug this closes)", bad, got)
+		}
+	}
+}
+
+// Garbage in a phase knob must be VISIBLE: silently returning the default
+// lets the operator believe the override took ("5" reads as five
+// nanoseconds to Go, five minutes to a human). One stderr line per
+// process, naming the key, the value and the default.
+func TestResolvePhaseTimeout_GarbageEnvIsWarnedOnce(t *testing.T) {
+	stderr, restore := captureStderr(t)
+	defer restore()
+
+	var once sync.Once
+	t.Setenv(testPhaseEnv, "5")
+	_ = ResolvePhaseTimeout(testPhaseEnv, 15*time.Minute, &once)
+	got := stderr()
+	if !strings.Contains(got, testPhaseEnv) {
+		t.Fatalf("stderr = %q, want it to name %s (garbage was silently swallowed before)", got, testPhaseEnv)
+	}
+	if !strings.Contains(got, `"5"`) || !strings.Contains(got, (15*time.Minute).String()) {
+		t.Fatalf("stderr = %q, want it to echo the operator's value and the default that replaced it", got)
+	}
+
+	// Second call in the same process must NOT re-warn (sync.Once).
+	_ = ResolvePhaseTimeout(testPhaseEnv, 15*time.Minute, &once)
+	if got := stderr(); got != "" {
+		t.Fatalf("second call re-warned: %q — expected sync.Once suppression", got)
+	}
+}
+
+// The post_create budget is a PHASE knob, not a driver knob: both drivers
+// resolve it here, so an operator raising it for a slow toolchain install
+// raises it wherever the phase runs.
+func TestResolvePostCreateTimeout_HonoursItsOwnEnv(t *testing.T) {
+	if got := ResolvePostCreateTimeout(); got != DefaultPostCreateTimeout {
+		t.Fatalf("ResolvePostCreateTimeout() = %s with no env, want the default %s", got, DefaultPostCreateTimeout)
+	}
+	t.Setenv(PostCreateTimeoutEnv, "45m")
+	if got, want := ResolvePostCreateTimeout(), 45*time.Minute; got != want {
+		t.Fatalf("ResolvePostCreateTimeout() = %s, want %s (operator override lost)", got, want)
+	}
+	t.Setenv(PostCreateTimeoutEnv, "45 minutes")
+	if got := ResolvePostCreateTimeout(); got != DefaultPostCreateTimeout {
+		t.Fatalf("garbage override = %s, want the default %s (an unbounded post_create is the bug this closes)", got, DefaultPostCreateTimeout)
+	}
+}
+
+// A garbage post_create override must be VISIBLE on stderr, naming its
+// OWN key — the reason the phase carries the key rather than the helper
+// hardcoding one.
+func TestResolvePostCreateTimeout_GarbageEnvIsWarnedOnce(t *testing.T) {
+	stderr, restore := captureStderr(t)
+	defer restore()
+	postCreateTimeoutWarnOnce = sync.Once{}
+
+	t.Setenv(PostCreateTimeoutEnv, "5")
+	_ = ResolvePostCreateTimeout()
+	got := stderr()
+	if !strings.Contains(got, PostCreateTimeoutEnv) {
+		t.Fatalf("stderr = %q, want it to name %s", got, PostCreateTimeoutEnv)
+	}
+	if !strings.Contains(got, `"5"`) || !strings.Contains(got, DefaultPostCreateTimeout.String()) {
+		t.Fatalf("stderr = %q, want the operator's value and the default that replaced it", got)
+	}
+	_ = ResolvePostCreateTimeout()
+	if got := stderr(); got != "" {
+		t.Fatalf("second call re-warned: %q", got)
+	}
+}


### PR DESCRIPTION
Three commits, one per ticket — cluster sandbox / IPC (#823, #837, #834).

## #823 — two setup phases ran on the bare context
The docker driver's `runPostCreate` and every `kubectl apply` of the kubernetes driver (per-run Secret, CA Secret, pod, NetworkPolicy, mid-run secret refresh) had no bound: a wedged daemon or apiserver held the run's lease until `max_duration`. The phase helpers (`RunWithPhaseTimeout`, `ResolvePhaseTimeout`, the warn ratio) move out of the kubernetes driver into `pkg/sandbox/phase.go` — the budget belongs to the phase, not the driver — so both drivers read the ONE `post_create` knob. `applyManifest` is bounded per call (`apply pod`, `apply networkpolicy`, …) under a new `ITERION_SANDBOX_K8S_APPLY_TIMEOUT` (2 min, fail-closed parsing) AND passes `--request-timeout=<budget>` so kubectl gives up at its own end. `deleteResource` gets the same budget as a PLAIN deadline (a cleanup is not a setup phase, never `ErrPhaseTimeout`), and the stale-pod eviction that inlined its own `kubectl delete --force` is routed through it instead of being a fourth copy.
Red first: `TestRunPostCreate_DockerStallIsBoundedAndTyped` (`runPostCreate never returned — the snippet runs on the bare ctx…`), `TestApplyManifest_StallIsBoundedAndTyped`, `TestApplyManifest_PassesRequestTimeoutToKubectl` (`kubectl argv = "--namespace ns apply -f -", want --request-timeout carrying the phase budget`), `TestDeleteResource_StallIsBounded`. Class table (every `kubectlCmdContext` / `runtimeCmdContext` site) in the commit body; three in-class sites are deliberately left to their owners: the pod-start probe (`pod_start.go`, the #697 path), docker container create (a different bound), the teardown export (a different class). Docs: `docs/sandbox.md` § "Setup phases and their timeouts" + `docs/environment-variables.md`.

## #837 — a `tool_result` over 4 MiB killed the IPC (launcher→runner had no clamp)
`Multiplexer.handleToolCall` marshalled a host-side tool result straight onto the wire; a 5 MiB result (an MCP call, a big diff) tripped the reader's `MaxEnvelopeLineBytes` and the WHOLE channel died — the node ended on a wire error instead of the model getting a bounded result. Proven over real pipes: `a 5 MiB tool result killed the IPC channel (delegate: envelope line exceeds MaxEnvelopeLineBytes)`.
Fix (option a of the ticket): `pkg/backend/delegate/envelope_clamp.go` — `MaxToolResultBytes = 1 MiB`, equal to the executor's in-process `maxFieldSize` (a conformance test in `sandbox_relay_test.go` binds the three constants), `ClampToolResult` cuts `Output`/`Error` with a marker naming the omitted bytes; the `ask_user` payload is never cut (it is pre-pause LLM state the runner rebuilds from) — when it alone overflows, the result becomes an explicit tool error naming the size. One construction site (`newToolResultData`) serves both `NewToolResultEnvelope` and `handleToolCall`. **Chokepoint added:** `EnvelopeWriter.Write` refuses an over-cap line at the source with a typed error naming the envelope type and writes nothing — every producer in both directions crosses it; the `session_capture` sink now degrades to its documented "one snapshot behind" instead of killing the run. Producer/direction/before/after table in the commit body; readers: one constructor, one limit.

## #834 — promises made on host binds the pod driver drops
1. **Bundle bind → devbox provisioning**: no pod-side pre-`post_create` copy-in seam exists (the only copy-in is the workspace tar at pod start; `RefreshWorkspaceFile` lands after `post_create`), so inventing one would mean a new driver interface. The bundle bind is now declared only when `caps.SupportsHostBindMounts`; downstream `resolveDevboxProjects` sees no container path, **declines** the bot source and says so on `sandbox_devbox_provisioned` (`skipped_sources` / `skipped_configs` / `skipped_reasons`: `no host bind mount on this driver`, one reason per source). No soft-failing snippet, no `PATH` entry for a directory nothing populates.
2. **Run-files on pods**: there is no read-back seam (an emptyDir + a teardown drain would widen `WorkspaceExporter`); documented in `docs/sandbox.md` (new subsection "A promise the driver drops takes its variable with it", with the per-promise docker/kubernetes table) — nothing faked, and the canary verifies nothing promises `ITERION_ARTIFACT_FILES_DIR` on pods.
3. **The canary**, red first on the old tree: `TestSandboxSpec_NoPromiseSurvivesTheBindThatServedIt` (`pkg/runtime/sandbox_bind_promise_canary_test.go`) runs the real wiring twice — bind-capable and not — derives the dropped targets from the difference, and walks every `spec.Env` value AND every absolute path in `spec.PostCreate` against them (`post_create names /run/iterion/bundle/devbox.json, under the dropped bind /run/iterion/bundle …`). An `Env`-only walk would have passed vacuously — the bundle promise lives in `PostCreate`; both halves are asserted non-vacuous.

## Proof
`go build`, `go vet`, `task lint` (0 issues), `go test` + `-race` on `pkg/sandbox/... pkg/backend/delegate pkg/backend/model pkg/runtime`, full `go test ./...`.

## Found on the way (not this PR)
`TestAwaitAnswersDoorbellNeverMissed` (`e2e/async_interaction_test.go:175`, a 15 s window) is red on `origin/main` itself at times (1/1 at iteration 0 on a clean main checkout, 2/10 on this branch) — a merge-queue ejector of the #860 class, handed to the CI sweep in flight.

Closes #823, #837, #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
