### PR TITLE
fix(model): ChainHooks forwards every EventHooks field, and run.* resolves in the single template pass

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -380,9 +380,14 @@ Two conventions:
   figure a bot cannot reconstruct for itself. A guard that compares
   against a cap therefore needs the `budget:` block that declares it.
 
-An unknown member (`run.no_such_thing`) resolves to nothing — the same
-silence as `vars.<unknown>` — rather than raising. Comparing it in an
-expression is what fails, loudly, at the node.
+An unknown member (`run.no_such_thing`) is UNRESOLVED, never an empty
+value. In an expression it is nil — the same silence as
+`vars.<unknown>` — and comparing it is what fails, loudly, at the node.
+In a rendered body it takes the missing-ref rule every namespace
+follows: the `{{…}}` placeholder stays in a prompt and in a shell
+`command:` / `postcondition:`, so `sh -c` fails on visible braces
+instead of running one argument short, and it renders as `null` in a
+`script:` body so the interpreter still parses.
 
 The members are available in `compute` expressions and quoted `when`
 conditions, in prompt bodies, in tool `command:` / `script:` /

--- a/e2e/branch_template_context_test.go
+++ b/e2e/branch_template_context_test.go
@@ -104,14 +104,14 @@ func TestTemplateContextReachesFanOutBranches(t *testing.T) {
 		t.Fatalf("load events: %v", err)
 	}
 
-	// --- tool `command:` — the silent-constant half -----------------------
+	// --- tool `command:` --------------------------------------------------
 	//
-	// A `{{run.id}}` a tool node cannot resolve does not survive as visible
-	// braces: resolveRunRefs substitutes it with the empty string, so the
-	// command runs with an argument nobody notices is missing. An
-	// `{{outputs.*}}` ref the command resolver did not know (#797) survived
-	// the other way — as the literal braces, handed to sh -c as an argument.
-	// Both are asserted on every dispatch path.
+	// `{{run.*}}` and `{{outputs.*}}` resolve in the SAME single pass as
+	// `{{input.*}}`, from the same snapshot, under the same missing-ref
+	// rule (asserted by TestToolCommandKeepsUnresolvableRunRefVisible
+	// below). Here every ref is resolvable, so what this pins is that the
+	// snapshot reaches all three dispatch paths — a missing snapshot would
+	// show up as a kept placeholder, not as a silent empty argument.
 	toolItems := map[string]bool{}
 	for _, probe := range []struct {
 		node  string
@@ -190,6 +190,50 @@ func TestTemplateContextReachesFanOutBranches(t *testing.T) {
 	}
 	if len(items) != 2 {
 		t.Errorf("the two fan_out_each bodies rendered %v, want one prompt per item", items)
+	}
+}
+
+// TestToolCommandKeepsUnresolvableRunRefVisible pins the missing-ref rule
+// for the `run.*` namespace in a tool `command:`, end to end through the
+// engine: a member the namespace does not carry keeps its `{{…}}`
+// placeholder and reaches sh -c as visible braces — the same rule
+// `{{input.*}}` and `{{outputs.*}}` follow. Rendering it as the empty
+// string instead removes the argument from the command line, which is
+// worse than an error because nothing downstream can see it happened.
+func TestToolCommandKeepsUnresolvableRunRefVisible(t *testing.T) {
+	const command = "`printf '{\"seen\":\"%s\"}' {{run.no_such_member}}`"
+	wf := compileSource(t, "run_ref_missing_member.bot", `
+schema probe_out:
+  seen: string
+
+tool probe:
+  command: `+command+`
+  output: probe_out
+
+workflow run_ref_missing_member:
+  worktree: none
+  sandbox: none
+  entry: probe
+
+  probe -> done
+`)
+	s := tmpStore(t)
+	const runID = "e2e-run-ref-missing-member"
+	exec := model.NewClawExecutor(model.NewRegistry(), wf, model.WithWorkDir(t.TempDir()))
+
+	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	events, err := s.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	outs := nodeOutputsFor(events, "probe")
+	if len(outs) != 1 {
+		t.Fatalf("tool probe produced %d outputs, want 1", len(outs))
+	}
+	if got := outs[0]["seen"]; got != "{{run.no_such_member}}" {
+		t.Errorf("unresolvable {{run.no_such_member}} reached sh -c as %q, want the placeholder kept", got)
 	}
 }
 

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -285,25 +285,36 @@ func chainCb6[A, B, C, D, E, F any](a, b func(A, B, C, D, E, F)) func(A, B, C, D
 // side run in order (a then b) for every event. Either side may leave
 // any callback nil; the result keeps the non-nil one without an extra
 // closure.
+//
+// EVERY field of EventHooks must appear below, in declaration order: a
+// field left out here is not a degraded composition, it is a silent drop
+// — the caller registered a callback that then never fires, on a path
+// (runview's ExtraHooks merge) that has no other way to notice.
+// TestChainHooksForwardsEveryField walks the struct by reflection and
+// fails on the first field this list forgets.
 func ChainHooks(a, b EventHooks) EventHooks {
 	return EventHooks{
-		OnLLMRequest:        chainCb2(a.OnLLMRequest, b.OnLLMRequest),
-		OnLLMPrompt:         chainCb3(a.OnLLMPrompt, b.OnLLMPrompt),
-		OnLLMResponse:       chainCb2(a.OnLLMResponse, b.OnLLMResponse),
-		OnLLMRetry:          chainCb2(a.OnLLMRetry, b.OnLLMRetry),
-		OnLLMStepFinish:     chainCb2(a.OnLLMStepFinish, b.OnLLMStepFinish),
-		OnLLMTurnCapture:    chainCb2(a.OnLLMTurnCapture, b.OnLLMTurnCapture),
-		OnLLMCompacted:      chainCb2(a.OnLLMCompacted, b.OnLLMCompacted),
-		OnToolStarted:       chainCb2(a.OnToolStarted, b.OnToolStarted),
-		OnToolCall:          chainCb2(a.OnToolCall, b.OnToolCall),
-		OnToolNodeResult:    chainCb6(a.OnToolNodeResult, b.OnToolNodeResult),
-		OnDelegateStarted:   chainCb2(a.OnDelegateStarted, b.OnDelegateStarted),
-		OnDelegateFinished:  chainCb2(a.OnDelegateFinished, b.OnDelegateFinished),
-		OnDelegateError:     chainCb2(a.OnDelegateError, b.OnDelegateError),
-		OnDelegateRetry:     chainCb2(a.OnDelegateRetry, b.OnDelegateRetry),
-		OnProviderFallback:  chainCb2(a.OnProviderFallback, b.OnProviderFallback),
-		OnSessionDegraded:   chainCb2(a.OnSessionDegraded, b.OnSessionDegraded),
-		OnMCPServerDegraded: chainCb2(a.OnMCPServerDegraded, b.OnMCPServerDegraded),
-		OnNodeFinished:      chainCb2(a.OnNodeFinished, b.OnNodeFinished),
+		OnLLMRequest:         chainCb2(a.OnLLMRequest, b.OnLLMRequest),
+		OnLLMPrompt:          chainCb3(a.OnLLMPrompt, b.OnLLMPrompt),
+		OnLLMResponse:        chainCb2(a.OnLLMResponse, b.OnLLMResponse),
+		OnLLMRetry:           chainCb2(a.OnLLMRetry, b.OnLLMRetry),
+		OnLLMStepFinish:      chainCb2(a.OnLLMStepFinish, b.OnLLMStepFinish),
+		OnAssistantText:      chainCb2(a.OnAssistantText, b.OnAssistantText),
+		OnLLMTurnCapture:     chainCb2(a.OnLLMTurnCapture, b.OnLLMTurnCapture),
+		OnUsageCap:           chainCb2(a.OnUsageCap, b.OnUsageCap),
+		OnUsageProgress:      chainCb2(a.OnUsageProgress, b.OnUsageProgress),
+		OnOrchestrationStall: chainCb2(a.OnOrchestrationStall, b.OnOrchestrationStall),
+		OnLLMCompacted:       chainCb2(a.OnLLMCompacted, b.OnLLMCompacted),
+		OnToolStarted:        chainCb2(a.OnToolStarted, b.OnToolStarted),
+		OnToolCall:           chainCb2(a.OnToolCall, b.OnToolCall),
+		OnToolNodeResult:     chainCb6(a.OnToolNodeResult, b.OnToolNodeResult),
+		OnDelegateStarted:    chainCb2(a.OnDelegateStarted, b.OnDelegateStarted),
+		OnDelegateFinished:   chainCb2(a.OnDelegateFinished, b.OnDelegateFinished),
+		OnDelegateError:      chainCb2(a.OnDelegateError, b.OnDelegateError),
+		OnDelegateRetry:      chainCb2(a.OnDelegateRetry, b.OnDelegateRetry),
+		OnProviderFallback:   chainCb2(a.OnProviderFallback, b.OnProviderFallback),
+		OnSessionDegraded:    chainCb2(a.OnSessionDegraded, b.OnSessionDegraded),
+		OnMCPServerDegraded:  chainCb2(a.OnMCPServerDegraded, b.OnMCPServerDegraded),
+		OnNodeFinished:       chainCb2(a.OnNodeFinished, b.OnNodeFinished),
 	}
 }

--- a/pkg/backend/model/executor_hooks_chain_test.go
+++ b/pkg/backend/model/executor_hooks_chain_test.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestChainHooksForwardsEveryField is the structural guard behind
+// ChainHooks: it walks EventHooks by reflection, installs a recorder on
+// BOTH halves of one field at a time, fires the chained result, and
+// requires exactly two calls in order (a then b).
+//
+// Field-by-field composition is the kind of code that silently stops
+// covering the struct it composes the moment a field is added — a hook a
+// caller registered then never fires, with no build error and no test
+// failure anywhere. Enumerating the fields from the type itself is what
+// makes that omission impossible: a new EventHooks field fails here until
+// ChainHooks forwards it.
+func TestChainHooksForwardsEveryField(t *testing.T) {
+	typ := reflect.TypeOf(EventHooks{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		t.Run(field.Name, func(t *testing.T) {
+			if field.Type.Kind() != reflect.Func {
+				t.Fatalf("EventHooks.%s is a %s, not a func — extend this guard "+
+					"so the new field's composition is covered too",
+					field.Name, field.Type.Kind())
+			}
+			var order []string
+			recorder := func(side string) reflect.Value {
+				return reflect.MakeFunc(field.Type, func([]reflect.Value) []reflect.Value {
+					order = append(order, side)
+					return nil
+				})
+			}
+			a := reflect.New(typ).Elem()
+			a.Field(i).Set(recorder("a"))
+			b := reflect.New(typ).Elem()
+			b.Field(i).Set(recorder("b"))
+
+			chained := ChainHooks(a.Interface().(EventHooks), b.Interface().(EventHooks))
+			fn := reflect.ValueOf(chained).Field(i)
+			if fn.IsNil() {
+				t.Fatalf("ChainHooks dropped EventHooks.%s: both halves registered a "+
+					"callback and the composed hooks carry none", field.Name)
+			}
+			args := make([]reflect.Value, field.Type.NumIn())
+			for j := range args {
+				args[j] = reflect.Zero(field.Type.In(j))
+			}
+			fn.Call(args)
+
+			if len(order) != 2 || order[0] != "a" || order[1] != "b" {
+				t.Errorf("EventHooks.%s fired %v, want [a b]", field.Name, order)
+			}
+		})
+	}
+}
+
+// TestChainHooksKeepsTheLoneSideOfEveryField pins the other half of the
+// contract: when only one side registered a callback, the composed hooks
+// carry it. A field ChainHooks forgets is invisible to the both-sides
+// walk above whenever the omission is a whole-field drop, so this asserts
+// the single-side path per field as well.
+func TestChainHooksKeepsTheLoneSideOfEveryField(t *testing.T) {
+	typ := reflect.TypeOf(EventHooks{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Type.Kind() != reflect.Func {
+			t.Fatalf("EventHooks.%s is a %s, not a func — extend this guard",
+				field.Name, field.Type.Kind())
+		}
+		for _, side := range []string{"a", "b"} {
+			t.Run(field.Name+"/"+side, func(t *testing.T) {
+				calls := 0
+				hooks := reflect.New(typ).Elem()
+				hooks.Field(i).Set(reflect.MakeFunc(field.Type, func([]reflect.Value) []reflect.Value {
+					calls++
+					return nil
+				}))
+				var chained EventHooks
+				if side == "a" {
+					chained = ChainHooks(hooks.Interface().(EventHooks), EventHooks{})
+				} else {
+					chained = ChainHooks(EventHooks{}, hooks.Interface().(EventHooks))
+				}
+				fn := reflect.ValueOf(chained).Field(i)
+				if fn.IsNil() {
+					t.Fatalf("ChainHooks dropped EventHooks.%s registered on side %s",
+						field.Name, side)
+				}
+				args := make([]reflect.Value, field.Type.NumIn())
+				for j := range args {
+					args[j] = reflect.Zero(field.Type.In(j))
+				}
+				fn.Call(args)
+				if calls != 1 {
+					t.Errorf("EventHooks.%s (side %s) fired %d times, want 1", field.Name, side, calls)
+				}
+			})
+		}
+	}
+}

--- a/pkg/backend/model/executor_template.go
+++ b/pkg/backend/model/executor_template.go
@@ -439,10 +439,11 @@ func outputsTemplateValue(td *TemplateData, segs []string) (any, bool) {
 }
 
 // lookupRunTemplateRef resolves one `{{run.<key>}}` reference for a PROMPT
-// body, formatting the raw value runNamespaceValue returns. The tool-command
-// path (resolveRunRefs) reads the same lookup with its own renderer, so a
-// member added to the namespace reaches both instead of rendering as a
-// literal placeholder in whichever one was forgotten.
+// body, formatting the raw value runNamespaceValue returns. The tool
+// command / script / postcondition path (resolveTemplateWith) reads the
+// same lookup with its own renderer, so a member added to the namespace
+// reaches both instead of rendering as a literal placeholder in whichever
+// one was forgotten.
 //
 // `id` is served from RunID whether or not the snapshot's Run map is
 // populated: callers that predate the map (tests, hosts that wire only
@@ -459,15 +460,17 @@ func lookupRunTemplateRef(td *TemplateData, key string) (string, bool) {
 // runNamespaceValue resolves one `run.<member>` to its RAW value — the
 // single lookup behind both the prompt path (lookupRunTemplateRef, which
 // formats it) and the tool command / script / postcondition path
-// (resolveRunRefs, which shell-escapes or JSON-encodes it), so a member
-// cannot resolve in one and stay literal in the other.
+// (resolveTemplateWith, which shell-escapes or JSON-encodes it), so a
+// member cannot resolve in one and stay literal in the other.
 //
 // The TEMPLATE SNAPSHOT is the authority, including for `id`: it is the
 // only source a fan-out branch has, since the engine withholds the ctx run
 // identity there (a key that would alias sibling items — see pkg/runtime's
 // execContext). ctxRunID is the fallback for `id` alone, for hosts that
 // wire WithRunID and no snapshot. `id` resolves to the empty string rather
-// than to its own placeholder whenever either is wired.
+// than to its own placeholder whenever either is wired. A member neither
+// source carries is reported unresolved; each caller applies its own
+// missing-value rule.
 func runNamespaceValue(ctxRunID string, td *TemplateData, member string) (any, bool) {
 	if member == "id" {
 		if td != nil && td.RunID != "" {

--- a/pkg/backend/model/executor_test.go
+++ b/pkg/backend/model/executor_test.go
@@ -937,7 +937,7 @@ func TestResolveCommandTemplate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseRefs: %v", err)
 			}
-			got := resolveCommandTemplate(tt.command, refs, tt.input, nil, nil)
+			got := resolveCommandTemplate(tt.command, refs, tt.input, nil, nil, "")
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -1059,7 +1059,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 	t.Run("string JSON-quoted", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"name"}, Raw: "{{input.name}}"}}
 		input := map[string]any{"name": "@types/express"}
-		got := resolveScriptTemplate("const n = {{input.name}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const n = {{input.name}};", refs, input, nil, nil, "")
 		want := `const n = "@types/express";`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -1068,7 +1068,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 	t.Run("string with apostrophe survives", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"msg"}, Raw: "{{input.msg}}"}}
 		input := map[string]any{"msg": "Bob's note"}
-		got := resolveScriptTemplate("const m = {{input.msg}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const m = {{input.msg}};", refs, input, nil, nil, "")
 		want := `const m = "Bob's note";`
 		if got != want {
 			t.Errorf("got %q, want %q (shell-escape would have produced 'Bob'\\''s note' breaking JS)", got, want)
@@ -1077,7 +1077,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 	t.Run("map as object literal", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"obj"}, Raw: "{{input.obj}}"}}
 		input := map[string]any{"obj": map[string]any{"k": "v"}}
-		got := resolveScriptTemplate("const o = {{input.obj}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const o = {{input.obj}};", refs, input, nil, nil, "")
 		want := `const o = {"k":"v"};`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -1090,7 +1090,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 				map[string]any{"name": "@types/express", "target": "5.0.6"},
 			},
 		}
-		got := resolveScriptTemplate("const a = {{input.arr}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const a = {{input.arr}};", refs, input, nil, nil, "")
 		want := `const a = [{"name":"@types/express","target":"5.0.6"}];`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -1099,7 +1099,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 	t.Run("bang form still raw", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"name"}, Raw: "{{!input.name}}", Unquoted: true}}
 		input := map[string]any{"name": "foo"}
-		got := resolveScriptTemplate("var x = {{!input.name}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("var x = {{!input.name}};", refs, input, nil, nil, "")
 		// Bang form returns the string verbatim — author is
 		// responsible for any wrapping. Mirrors the shell-context
 		// bang behaviour.
@@ -1116,7 +1116,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 		// JS / Python / Ruby — so the script always parses.
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"attempted"}, Raw: "{{input.attempted}}"}}
 		input := map[string]any{} // attempted missing
-		got := resolveScriptTemplate("const x = {{input.attempted}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const x = {{input.attempted}};", refs, input, nil, nil, "")
 		want := `const x = null;`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
@@ -1129,7 +1129,7 @@ func TestResolveScriptTemplate(t *testing.T) {
 		// an empty expression.
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"attempted"}, Raw: "{{!input.attempted}}", Unquoted: true}}
 		input := map[string]any{} // attempted missing
-		got := resolveScriptTemplate("const x = {{!input.attempted}};", refs, input, nil, nil)
+		got := resolveScriptTemplate("const x = {{!input.attempted}};", refs, input, nil, nil, "")
 		want := `const x = null;`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)

--- a/pkg/backend/model/executor_tool.go
+++ b/pkg/backend/model/executor_tool.go
@@ -333,13 +333,11 @@ func (e *ClawExecutor) shellRecipe(ctx context.Context, node *ir.ToolNode, input
 			// shell-level variables (positional args, exit-status, captured
 			// stdout) survive into the resolved command for sh -c to interpret.
 			expandedCommand := expandBracedEnv(node.Command)
-			// One snapshot for both passes — the same one the prompts render
-			// from. {{run.*}} goes first (its own pre-pass); {{outputs.*}}
-			// resolves in the main pass beside {{input.*}}, under the same
-			// shell escaping and the same missing-value rule.
+			// One snapshot, one pass — the same snapshot the prompts render
+			// from. {{run.*}} and {{outputs.*}} resolve beside {{input.*}},
+			// under the same shell escaping and the same missing-value rule.
 			td := TemplateDataFromContext(ctx)
-			expandedCommand = resolveRunRefs(expandedCommand, RunIDFromContext(ctx), td, node.CommandRefs, shellEscapeValue)
-			resolved := resolveCommandTemplate(expandedCommand, node.CommandRefs, e.jsonFieldsAsText(node, input), e.vars, td, e.secretGuard)
+			resolved := resolveCommandTemplate(expandedCommand, node.CommandRefs, e.jsonFieldsAsText(node, input), e.vars, td, RunIDFromContext(ctx), e.secretGuard)
 			// Compression (tool nodes): node-level opt-in ONLY — compresses
 			// command output only when the node's own `compress:` is on/ultra (a
 			// run override can force-off as a kill switch, never force-on), so a
@@ -474,11 +472,11 @@ func (e *ClawExecutor) scriptRecipe(ctx context.Context, node *ir.ToolNode, inpu
 			// script-language string parsers when the value contains embedded
 			// apostrophes. No compression: a script body is not a shell command line.
 			expanded := expandBracedEnv(node.Script)
-			// Same two passes over one snapshot as the shell recipe: {{run.*}}
-			// first, {{outputs.*}} beside {{input.*}} as JSON literals.
+			// Same single pass over one snapshot as the shell recipe:
+			// {{run.*}} and {{outputs.*}} beside {{input.*}}, here as JSON
+			// literals.
 			td := TemplateDataFromContext(ctx)
-			expanded = resolveRunRefs(expanded, RunIDFromContext(ctx), td, node.ScriptRefs, jsonLiteralValue)
-			return resolveScriptTemplate(expanded, node.ScriptRefs, input, e.vars, td, e.secretGuard)
+			return resolveScriptTemplate(expanded, node.ScriptRefs, input, e.vars, td, RunIDFromContext(ctx), e.secretGuard)
 		},
 		func(resolved string) (*exec.Cmd, func(), error) {
 			interp, ext := scriptInterpreter(node.Language)
@@ -688,12 +686,14 @@ func looksLikeShellCommand(cmd string) bool {
 	return strings.ContainsAny(cmd, " \t|&;><$`(){}\"'/")
 }
 
-// resolveCommandTemplate substitutes {{input.X}}, {{vars.X}}, {{secrets.X}}
-// and {{outputs.<node>.<field>}} references in a command string — the input
-// map, the workflow variables, the secret guard's placeholders, and the
-// template snapshot td (the same one the prompts render from; nil-tolerant).
-// Values are shell-escaped to prevent command injection when the resolved
-// string is passed to sh -c.
+// resolveCommandTemplate substitutes {{input.X}}, {{vars.X}}, {{secrets.X}},
+// {{outputs.<node>.<field>}} and {{run.X}} references in a command string —
+// the input map, the workflow variables, the secret guard's placeholders,
+// and the template snapshot td (the same one the prompts render from;
+// nil-tolerant). ctxRunID is the run identity for hosts that wire only
+// WithRunID and no snapshot; it answers for `{{run.id}}` alone. Values are
+// shell-escaped to prevent command injection when the resolved string is
+// passed to sh -c.
 //
 // Refs flagged as `Raw` (authored as `{{!input.X}}` / `{{!vars.X}}`) bypass
 // shellEscape and are inserted verbatim. Use only for trusted values that
@@ -701,7 +701,7 @@ func looksLikeShellCommand(cmd string) bool {
 // command line that the wrapping tool needs to RE-INTERPRET as shell, not
 // pass as a single quoted token). Untrusted external inputs MUST keep the
 // default escaping.
-func resolveCommandTemplate(command string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, guards ...*secretguard.Guard) string {
+func resolveCommandTemplate(command string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, ctxRunID string, guards ...*secretguard.Guard) string {
 	var guard *secretguard.Guard
 	if len(guards) > 0 {
 		guard = guards[0]
@@ -710,11 +710,12 @@ func resolveCommandTemplate(command string, refs []*ir.Ref, input map[string]any
 	// values — sh -c sees the placeholder and either fails informatively
 	// or the operator notices. Substituting silently would lose that
 	// signal and could mask wiring bugs. An `{{outputs.*}}` ref whose node
-	// has not produced takes the same rule.
+	// has not produced, and a `{{run.*}}` member the namespace does not
+	// carry, take the same rule.
 	// Pinned by TestToolCommandRefsAreShellEscaped: the shell itself is the
 	// oracle there, because reading a bot's `VAR={{vars.x}}` as unquoted is a
 	// mistake that has already been made confidently.
-	return resolveTemplateWith(command, refs, input, vars, td, guard, shellEscapeValue, false)
+	return resolveTemplateWith(command, refs, input, vars, td, ctxRunID, guard, shellEscapeValue, false)
 }
 
 // resolveScriptTemplate substitutes refs in a tool node's `script:` body.
@@ -730,7 +731,7 @@ func resolveCommandTemplate(command string, refs []*ir.Ref, input map[string]any
 // The bang form `{{!input.X}}` keeps the legacy raw-passthrough
 // behaviour (strings inserted unquoted) for authors who need to drop
 // a snippet of source directly into the script body.
-func resolveScriptTemplate(script string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, guards ...*secretguard.Guard) string {
+func resolveScriptTemplate(script string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, ctxRunID string, guards ...*secretguard.Guard) string {
 	var guard *secretguard.Guard
 	if len(guards) > 0 {
 		guard = guards[0]
@@ -740,45 +741,7 @@ func resolveScriptTemplate(script string, refs []*ir.Ref, input map[string]any, 
 	// parse time before any user logic can react. Substitute with the
 	// language's null literal (rendered as JSON null = "null") so the
 	// script can still run and handle the missing input itself.
-	return resolveTemplateWith(script, refs, input, vars, td, guard, jsonLiteralValue, true)
-}
-
-// resolveRunRefs substitutes run-namespace refs ({{run.id}}) into a tool
-// command / script template. The shared resolveTemplateWith handles the
-// input / vars / secrets / outputs namespaces — values a tool node reads
-// from a map — so a *direct* {{run.id}} (there is no node output to map it
-// from) would otherwise survive verbatim and run as
-// the literal text "{{run.id}}". That bit sec-audit-source's
-// apply-mode prepare_branch, which named its temp branch
-// `iterion/sec-fix/{{run.id}}` and ended up on `iterion/sec-fix/run.id`
-// after its sanitiser stripped the braces. `render` formats the value for
-// the target context (shellEscapeValue for command bodies, jsonLiteralValue
-// for script bodies), matching the main resolver; the bang form keeps the
-// raw passthrough.
-//
-// The members are the engine's `run.*` namespace — identity plus the run's
-// consumption and effective budget caps — read through the same
-// runNamespaceValue the prompt path uses, so a shell guard on
-// `{{run.elapsed_seconds}}` cannot resolve in a prompt and stay literal in
-// a command. The snapshot answers for every member, `id` included, which is
-// what makes a command inside a fan-out branch render like the same command
-// on the trunk; runID is the fallback for hosts that wire only WithRunID.
-// An unknown member renders empty rather than as its placeholder. A run id
-// and the budget figures are plain tokens with no `{{` of their own, so the
-// literal ReplaceAll cannot re-trigger on a substituted value.
-func resolveRunRefs(template, runID string, td *TemplateData, refs []*ir.Ref, render func(any) string) string {
-	for _, r := range refs {
-		if r == nil || r.Kind != ir.RefRun || len(r.Path) == 0 {
-			continue
-		}
-		val, _ := runNamespaceValue(runID, td, r.Path[0])
-		rendered := render(val)
-		if r.Unquoted {
-			rendered = rawTemplateValue(val)
-		}
-		template = strings.ReplaceAll(template, r.Raw, rendered)
-	}
-	return template
+	return resolveTemplateWith(script, refs, input, vars, td, ctxRunID, guard, jsonLiteralValue, true)
 }
 
 // resolveTemplateWith is the shared core: walk refs, look up each value,
@@ -788,13 +751,15 @@ func resolveRunRefs(template, runID string, td *TemplateData, refs []*ir.Ref, re
 //
 // Substitution is single-pass over the original template: we build a
 // map[ref.Raw]rendered and then scan the template once, replacing
-// each {{...}} occurrence by its rendered value. The previous
-// strings.ReplaceAll loop fed each substitution's output back into
-// subsequent passes, so an input value that happened to contain a
-// {{...}} literal matching a later ref would be silently rewritten
-// (the "cascade" bug). The single-pass walk only touches positions
-// that were in the source template.
-func resolveTemplateWith(template string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, guard *secretguard.Guard, defaultRender func(any) string, substituteNil bool) string {
+// each {{...}} occurrence by its rendered value. A strings.ReplaceAll
+// loop would feed each substitution's output back into subsequent
+// passes, so a value that happened to contain a {{...}} literal
+// matching a later ref would be silently rewritten (the "cascade"
+// bug). The single-pass walk only touches positions that were in the
+// source template — which is why EVERY namespace a tool body can
+// reference resolves here, in this one walk, rather than in a pre-pass
+// of its own.
+func resolveTemplateWith(template string, refs []*ir.Ref, input map[string]any, vars map[string]any, td *TemplateData, ctxRunID string, guard *secretguard.Guard, defaultRender func(any) string, substituteNil bool) string {
 	if len(refs) == 0 {
 		return template
 	}
@@ -816,6 +781,20 @@ func resolveTemplateWith(template string, refs []*ir.Ref, input map[string]any, 
 			// placeholder in a shell body, `null` in a script body — so
 			// the two namespaces cannot disagree about a hole.
 			val, _ = outputsTemplateValue(td, ref.Path)
+			handled = true
+		case ref.Kind == ir.RefRun && len(ref.Path) > 0:
+			// The engine's `run.*` namespace — identity plus the run's
+			// consumption and effective budget caps — read through the
+			// same runNamespaceValue the prompt path uses, so a member
+			// cannot resolve in a prompt and stay literal in a command.
+			// The snapshot answers for every member, `id` included, which
+			// is what makes a command inside a fan-out branch render like
+			// the same command on the trunk; ctxRunID is the fallback for
+			// hosts that wire only WithRunID. A member the namespace does
+			// not carry is nil here and takes the shared missing-value
+			// rule below — the placeholder in a shell body, `null` in a
+			// script body — instead of vanishing from the command line.
+			val, _ = runNamespaceValue(ctxRunID, td, ref.Path[0])
 			handled = true
 		case ref.Kind == ir.RefSecrets && len(ref.Path) > 0:
 			// Render the opaque placeholder into the command; the real

--- a/pkg/backend/model/executor_tool_escaping_test.go
+++ b/pkg/backend/model/executor_tool_escaping_test.go
@@ -33,7 +33,7 @@ func TestToolCommandRefsAreShellEscaped(t *testing.T) {
 		{"redirect", "x>/tmp/iterion-escape-sentinel"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			resolved := resolveCommandTemplate(command, []*ir.Ref{ref}, nil, map[string]any{"branch": tc.value}, nil)
+			resolved := resolveCommandTemplate(command, []*ir.Ref{ref}, nil, map[string]any{"branch": tc.value}, nil, "")
 			if strings.Contains(resolved, "{{vars.branch}}") {
 				t.Fatalf("ref was not substituted at all: %s", resolved)
 			}
@@ -56,7 +56,7 @@ func TestToolCommandRefsAreShellEscaped(t *testing.T) {
 // bots.TestCatalogHasNoRawRefs); this pins WHY that rule exists.
 func TestRawRefsBypassEscapingByDesign(t *testing.T) {
 	ref := &ir.Ref{Kind: ir.RefVars, Path: []string{"branch"}, Raw: "{{!vars.branch}}", Unquoted: true}
-	resolved := resolveCommandTemplate(`BRANCH={{!vars.branch}} true`, []*ir.Ref{ref}, nil, map[string]any{"branch": "x;id"}, nil)
+	resolved := resolveCommandTemplate(`BRANCH={{!vars.branch}} true`, []*ir.Ref{ref}, nil, map[string]any{"branch": "x;id"}, nil, "")
 	if !strings.Contains(resolved, "BRANCH=x;id") {
 		t.Fatalf("raw ref was escaped after all — the catalog rule against it would be pointless: %s", resolved)
 	}
@@ -76,7 +76,7 @@ func TestAuthorQuotedRefsAreNotContained(t *testing.T) {
 	t.Run("single quotes cancel — the value becomes syntax", func(t *testing.T) {
 		sentinel := filepath.Join(t.TempDir(), "pwned")
 		resolved := resolveCommandTemplate(`BASE_REF='{{vars.base_ref}}' true`, []*ir.Ref{ref}, nil,
-			map[string]any{"base_ref": "x;touch " + sentinel + ";#"}, nil)
+			map[string]any{"base_ref": "x;touch " + sentinel + ";#"}, nil, "")
 		_ = exec.Command("sh", "-c", resolved).Run()
 		if _, err := os.Stat(sentinel); err != nil {
 			t.Errorf("no sentinel (%v) — if the runtime learned to see the author's quotes, C137 can be reconsidered; resolved: %s", err, resolved)
@@ -85,7 +85,7 @@ func TestAuthorQuotedRefsAreNotContained(t *testing.T) {
 
 	t.Run("double quotes corrupt a benign value", func(t *testing.T) {
 		resolved := resolveCommandTemplate(`BASE_REF="{{vars.base_ref}}" sh -c 'printf %s "$BASE_REF"'`,
-			[]*ir.Ref{ref}, nil, map[string]any{"base_ref": "main"}, nil)
+			[]*ir.Ref{ref}, nil, map[string]any{"base_ref": "main"}, nil, "")
 		out, err := exec.Command("sh", "-c", resolved).Output()
 		if err != nil {
 			t.Fatalf("resolved command failed (%v): %s", err, resolved)
@@ -100,7 +100,7 @@ func TestAuthorQuotedRefsAreNotContained(t *testing.T) {
 	t.Run("double quotes inject when the value carries one", func(t *testing.T) {
 		sentinel := filepath.Join(t.TempDir(), "pwned")
 		resolved := resolveCommandTemplate(`BASE_REF="{{vars.base_ref}}" true`, []*ir.Ref{ref}, nil,
-			map[string]any{"base_ref": `a";touch ` + sentinel + `;"b`}, nil)
+			map[string]any{"base_ref": `a";touch ` + sentinel + `;"b`}, nil, "")
 		_ = exec.Command("sh", "-c", resolved).Run()
 		if _, err := os.Stat(sentinel); err != nil {
 			t.Errorf("no sentinel (%v) — resolved: %s", err, resolved)

--- a/pkg/backend/model/executor_tool_jsonfield_test.go
+++ b/pkg/backend/model/executor_tool_jsonfield_test.go
@@ -172,7 +172,7 @@ func TestPostconditionRecipe_PreEncodesJSONFields(t *testing.T) {
 
 	expanded := expandBracedEnv(node.Postcondition)
 	got := resolveCommandTemplate(expanded, node.PostcondRefs,
-		e.jsonFieldsAsText(node, map[string]any{"ids": []any{"T-1", "T-2"}}), nil, nil)
+		e.jsonFieldsAsText(node, map[string]any{"ids": []any{"T-1", "T-2"}}), nil, nil, "")
 
 	if want := `IDS='["T-1","T-2"]'`; !strings.Contains(got, want) {
 		t.Errorf("postcondition resolved to %q, want it to contain %q", got, want)

--- a/pkg/backend/model/executor_tool_run_refs_test.go
+++ b/pkg/backend/model/executor_tool_run_refs_test.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// resolveToolCommandUnderTest reproduces how a tool node's `command:` (and
+// its `postcondition:`) is resolved in production — shellRecipe /
+// runPostcondition — so these assertions bind the shipped path, not a
+// helper's private behaviour.
+func resolveToolCommandUnderTest(cmd string, refs []*ir.Ref, input, vars map[string]any, td *TemplateData, ctxRunID string) string {
+	return resolveCommandTemplate(cmd, refs, input, vars, td, ctxRunID)
+}
+
+// resolveToolScriptUnderTest is the same for a tool node's `script:` body
+// (scriptRecipe).
+func resolveToolScriptUnderTest(script string, refs []*ir.Ref, input, vars map[string]any, td *TemplateData, ctxRunID string) string {
+	return resolveScriptTemplate(script, refs, input, vars, td, ctxRunID)
+}
+
+func runTemplateData() *TemplateData {
+	return &TemplateData{
+		RunID: "019ec1d3-f3b2-7a90-ae2f-bba543558786",
+		Run: map[string]any{
+			"id":              "019ec1d3-f3b2-7a90-ae2f-bba543558786",
+			"elapsed_seconds": 42.5,
+			"max_cost_usd":    12.0,
+		},
+	}
+}
+
+// TestRunRefUnknownMemberKeepsPlaceholderInShellBody: the `run.*`
+// namespace must follow the SAME missing-ref rule as `input.*` and
+// `outputs.*` — an unresolvable ref keeps its `{{…}}` placeholder in a
+// shell body, so `sh -c` fails on visible braces instead of silently
+// running one argument short.
+func TestRunRefUnknownMemberKeepsPlaceholderInShellBody(t *testing.T) {
+	refs := []*ir.Ref{{Kind: ir.RefRun, Path: []string{"no_such_member"}, Raw: "{{run.no_such_member}}"}}
+	got := resolveToolCommandUnderTest("git checkout {{run.no_such_member}}", refs, nil, nil, runTemplateData(), "run-abc")
+	if got != "git checkout {{run.no_such_member}}" {
+		t.Errorf("unknown run member rendered %q, want the placeholder kept so the command fails visibly", got)
+	}
+}
+
+// TestRunRefUnknownMemberRendersNullInScriptBody: in a script body the
+// missing-ref rule is the language's null literal — a bare `{{…}}` would
+// crash the interpreter at parse time before any script logic runs.
+func TestRunRefUnknownMemberRendersNullInScriptBody(t *testing.T) {
+	refs := []*ir.Ref{{Kind: ir.RefRun, Path: []string{"no_such_member"}, Raw: "{{run.no_such_member}}"}}
+	got := resolveToolScriptUnderTest("const v = {{run.no_such_member}};", refs, nil, nil, runTemplateData(), "run-abc")
+	if got != "const v = null;" {
+		t.Errorf("unknown run member rendered %q, want `const v = null;`", got)
+	}
+}
+
+// TestRunRefValueIsNotReExpanded: a `run.*` value that happens to contain
+// `{{…}}` text matching a LATER ref must land in the command verbatim.
+// Substituting run refs in a pass of their own feeds their output back
+// into the next pass — the cascade the single-pass walk exists to kill.
+func TestRunRefValueIsNotReExpanded(t *testing.T) {
+	td := runTemplateData()
+	td.Run["note"] = "{{input.payload}}"
+	refs := []*ir.Ref{
+		{Kind: ir.RefRun, Path: []string{"note"}, Raw: "{{run.note}}"},
+		{Kind: ir.RefInput, Path: []string{"payload"}, Raw: "{{input.payload}}"},
+	}
+	input := map[string]any{"payload": "INJECTED"}
+
+	got := resolveToolCommandUnderTest("echo {{run.note}} {{input.payload}}", refs, input, nil, td, "run-abc")
+	if got != "echo '{{input.payload}}' 'INJECTED'" {
+		t.Errorf("run value was re-expanded: got %q, want the run value substituted once, verbatim", got)
+	}
+}
+
+// TestRunRefKnownMemberResolvesInBothBodies pins what already worked:
+// `run.*` reaches tool commands and scripts, rendered for the target
+// context (shell-escaped / JSON literal). Folding the namespace into the
+// shared resolver must not cost that.
+func TestRunRefKnownMemberResolvesInBothBodies(t *testing.T) {
+	td := runTemplateData()
+	refs := []*ir.Ref{
+		{Kind: ir.RefRun, Path: []string{"id"}, Raw: "{{run.id}}"},
+		{Kind: ir.RefRun, Path: []string{"max_cost_usd"}, Raw: "{{run.max_cost_usd}}"},
+	}
+
+	cmd := resolveToolCommandUnderTest("branch iterion/x/{{run.id}} cap {{run.max_cost_usd}}", refs, nil, nil, td, "")
+	if want := "branch iterion/x/'" + td.RunID + "' cap '12'"; cmd != want {
+		t.Errorf("command = %q, want %q", cmd, want)
+	}
+
+	scr := resolveToolScriptUnderTest("const id = {{run.id}}; const cap = {{run.max_cost_usd}};", refs, nil, nil, td, "")
+	if want := `const id = "` + td.RunID + `"; const cap = 12;`; scr != want {
+		t.Errorf("script = %q, want %q", scr, want)
+	}
+}
+
+// TestRunRefIDFallsBackToTheContextRunID: a host that wires only
+// WithRunID (no template snapshot) still resolves `{{run.id}}` — the one
+// member the ctx identity answers for.
+func TestRunRefIDFallsBackToTheContextRunID(t *testing.T) {
+	refs := []*ir.Ref{{Kind: ir.RefRun, Path: []string{"id"}, Raw: "{{run.id}}"}}
+	got := resolveToolCommandUnderTest("b/{{run.id}}", refs, nil, nil, nil, "run-abc")
+	if got != "b/'run-abc'" {
+		t.Errorf("ctx run id fallback = %q, want b/'run-abc'", got)
+	}
+}
+
+// TestRunRefIDWithNoIdentityKeepsPlaceholder: with neither a snapshot nor
+// a ctx run id there is no value to render, so the shell body keeps its
+// placeholder like any other unresolvable ref. Rendering the empty string
+// instead would hand `sh -c` a command one argument short.
+func TestRunRefIDWithNoIdentityKeepsPlaceholder(t *testing.T) {
+	refs := []*ir.Ref{{Kind: ir.RefRun, Path: []string{"id"}, Raw: "{{run.id}}"}}
+	got := resolveToolCommandUnderTest("b/{{run.id}}", refs, nil, nil, nil, "")
+	if got != "b/{{run.id}}" {
+		t.Errorf("unresolvable run.id rendered %q, want the placeholder kept", got)
+	}
+}

--- a/pkg/backend/model/executor_tool_test.go
+++ b/pkg/backend/model/executor_tool_test.go
@@ -161,7 +161,7 @@ func ref(kind ir.RefKind, name, raw string, unquoted bool) *ir.Ref {
 func TestResolveCommandTemplate_BasicShellEscaping(t *testing.T) {
 	tmpl := "echo {{input.msg}}"
 	got := resolveCommandTemplate(tmpl, []*ir.Ref{ref(ir.RefInput, "msg", "{{input.msg}}", false)},
-		map[string]any{"msg": "hello world"}, nil, nil)
+		map[string]any{"msg": "hello world"}, nil, nil, "")
 	if got != "echo 'hello world'" {
 		t.Errorf("got %q", got)
 	}
@@ -170,7 +170,7 @@ func TestResolveCommandTemplate_BasicShellEscaping(t *testing.T) {
 func TestResolveCommandTemplate_VarsLookup(t *testing.T) {
 	tmpl := "echo {{vars.name}}"
 	got := resolveCommandTemplate(tmpl, []*ir.Ref{ref(ir.RefVars, "name", "{{vars.name}}", false)},
-		nil, map[string]any{"name": "Iterion"}, nil)
+		nil, map[string]any{"name": "Iterion"}, nil, "")
 	if got != "echo 'Iterion'" {
 		t.Errorf("got %q", got)
 	}
@@ -179,7 +179,7 @@ func TestResolveCommandTemplate_VarsLookup(t *testing.T) {
 func TestResolveCommandTemplate_RawBangBypassesShellEscape(t *testing.T) {
 	tmpl := "{{!input.snippet}}"
 	got := resolveCommandTemplate(tmpl, []*ir.Ref{ref(ir.RefInput, "snippet", "{{!input.snippet}}", true)},
-		map[string]any{"snippet": "echo $HOME; ls"}, nil, nil)
+		map[string]any{"snippet": "echo $HOME; ls"}, nil, nil, "")
 	// Raw form pastes verbatim — no shell-escaping.
 	if got != "echo $HOME; ls" {
 		t.Errorf("got %q", got)
@@ -190,7 +190,7 @@ func TestResolveCommandTemplate_MissingValueLeftAsRaw(t *testing.T) {
 	// substituteNil=false in shell context → unresolved refs stay literal.
 	tmpl := "echo {{input.missing}}"
 	got := resolveCommandTemplate(tmpl, []*ir.Ref{ref(ir.RefInput, "missing", "{{input.missing}}", false)},
-		map[string]any{}, nil, nil)
+		map[string]any{}, nil, nil, "")
 	if got != "echo {{input.missing}}" {
 		t.Errorf("missing input should leave placeholder, got %q", got)
 	}
@@ -216,7 +216,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 
 	t.Run("shell-escaped like an input", func(t *testing.T) {
 		got := resolveCommandTemplate("git checkout {{outputs.prev.branch}}",
-			[]*ir.Ref{outRef("{{outputs.prev.branch}}", "prev", "branch")}, nil, nil, td)
+			[]*ir.Ref{outRef("{{outputs.prev.branch}}", "prev", "branch")}, nil, nil, td, "")
 		if want := "git checkout 'x;touch /tmp/iterion-outputs-sentinel'"; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -224,7 +224,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 
 	t.Run("a deep path drills into a nested value", func(t *testing.T) {
 		got := resolveCommandTemplate("echo {{outputs.prev.obj.k}}",
-			[]*ir.Ref{outRef("{{outputs.prev.obj.k}}", "prev", "obj", "k")}, nil, nil, td)
+			[]*ir.Ref{outRef("{{outputs.prev.obj.k}}", "prev", "obj", "k")}, nil, nil, td, "")
 		if got != "echo 'v'" {
 			t.Errorf("got %q", got)
 		}
@@ -232,7 +232,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 
 	t.Run("a number renders as its digits, a whole output as JSON", func(t *testing.T) {
 		got := resolveCommandTemplate("N={{outputs.prev.n}} ALL={{outputs.prev}}",
-			[]*ir.Ref{outRef("{{outputs.prev.n}}", "prev", "n"), outRef("{{outputs.prev}}", "prev")}, nil, nil, td)
+			[]*ir.Ref{outRef("{{outputs.prev.n}}", "prev", "n"), outRef("{{outputs.prev}}", "prev")}, nil, nil, td, "")
 		if !strings.Contains(got, "N='3'") || !strings.Contains(got, `ALL='{"branch"`) {
 			t.Errorf("got %q", got)
 		}
@@ -244,7 +244,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 		// argument. With no snapshot at all the rule is the same.
 		refs := []*ir.Ref{outRef("{{outputs.absent.x}}", "absent", "x")}
 		for name, snapshot := range map[string]*TemplateData{"node has not produced": td, "no snapshot": nil} {
-			if got := resolveCommandTemplate("echo {{outputs.absent.x}}", refs, nil, nil, snapshot); got != "echo {{outputs.absent.x}}" {
+			if got := resolveCommandTemplate("echo {{outputs.absent.x}}", refs, nil, nil, snapshot, ""); got != "echo {{outputs.absent.x}}" {
 				t.Errorf("%s: got %q, want the placeholder kept", name, got)
 			}
 		}
@@ -252,7 +252,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 
 	t.Run("script body: JSON literal, null when not produced", func(t *testing.T) {
 		got := resolveScriptTemplate("const b = {{outputs.prev.branch}}; const m = {{outputs.absent.x}};",
-			[]*ir.Ref{outRef("{{outputs.prev.branch}}", "prev", "branch"), outRef("{{outputs.absent.x}}", "absent", "x")}, nil, nil, td)
+			[]*ir.Ref{outRef("{{outputs.prev.branch}}", "prev", "branch"), outRef("{{outputs.absent.x}}", "absent", "x")}, nil, nil, td, "")
 		if want := `const b = "x;touch /tmp/iterion-outputs-sentinel"; const m = null;`; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
@@ -260,7 +260,7 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 
 	t.Run("the raw form bypasses escaping, by design", func(t *testing.T) {
 		got := resolveCommandTemplate("{{!outputs.prev.branch}}",
-			[]*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"prev", "branch"}, Raw: "{{!outputs.prev.branch}}", Unquoted: true}}, nil, nil, td)
+			[]*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"prev", "branch"}, Raw: "{{!outputs.prev.branch}}", Unquoted: true}}, nil, nil, td, "")
 		if got != "x;touch /tmp/iterion-outputs-sentinel" {
 			t.Errorf("got %q", got)
 		}
@@ -270,45 +270,18 @@ func TestResolveCommandTemplate_OutputsRef(t *testing.T) {
 		got := resolveCommandTemplate("T={{!outputs.prev.text}} B={{outputs.prev.branch}}", []*ir.Ref{
 			{Kind: ir.RefOutputs, Path: []string{"prev", "text"}, Raw: "{{!outputs.prev.text}}", Unquoted: true},
 			outRef("{{outputs.prev.branch}}", "prev", "branch"),
-		}, nil, nil, td)
+		}, nil, nil, td, "")
 		if !strings.Contains(got, "T={{outputs.prev.branch}} ") {
 			t.Errorf("cascade replay rewrote an output value: %q", got)
 		}
 	})
 }
 
-func TestResolveRunRefs_CommandAndScript(t *testing.T) {
-	const runID = "019ec1d3-f3b2-7a90-ae2f-bba543558786"
-	runRef := []*ir.Ref{ref(ir.RefRun, "id", "{{run.id}}", false)}
-
-	// Command context: {{run.id}} is not an input/vars/secrets ref, so the
-	// shared resolver leaves it literal; resolveRunRefs must substitute it
-	// (otherwise sec-audit-source's apply-mode branch ends up literally
-	// named iterion/sec-fix/run.id after its sanitiser strips the braces).
-	cmd := resolveRunRefs("git checkout -b iterion/sec-fix/{{run.id}}", runID, nil, runRef, shellEscapeValue)
-	if strings.Contains(cmd, "{{run.id}}") || !strings.Contains(cmd, runID) {
-		t.Errorf("command run.id not substituted: %q", cmd)
-	}
-
-	// Script context: rendered as a JSON string literal so it parses.
-	scr := resolveRunRefs("RUN_ID = {{run.id}}", runID, nil, runRef, jsonLiteralValue)
-	if !strings.Contains(scr, `"`+runID+`"`) {
-		t.Errorf("script run.id should be a JSON string literal: %q", scr)
-	}
-
-	// Empty run id degrades to an empty rendering (the caller's sha
-	// fallback then takes over) — never the literal placeholder.
-	empty := resolveRunRefs("b/{{run.id}}", "", nil, runRef, shellEscapeValue)
-	if strings.Contains(empty, "{{run.id}}") {
-		t.Errorf("empty run id should not leave the literal placeholder: %q", empty)
-	}
-}
-
 func TestResolveScriptTemplate_NilBecomesJSONNull(t *testing.T) {
 	// substituteNil=true in script context — nil renders as JSON "null".
 	tmpl := "const v = {{input.missing}};"
 	got := resolveScriptTemplate(tmpl, []*ir.Ref{ref(ir.RefInput, "missing", "{{input.missing}}", false)},
-		map[string]any{"missing": nil}, nil, nil)
+		map[string]any{"missing": nil}, nil, nil, "")
 	if got != "const v = null;" {
 		t.Errorf("got %q", got)
 	}
@@ -317,7 +290,7 @@ func TestResolveScriptTemplate_NilBecomesJSONNull(t *testing.T) {
 func TestResolveScriptTemplate_StringJSONQuoted(t *testing.T) {
 	tmpl := "console.log({{input.s}});"
 	got := resolveScriptTemplate(tmpl, []*ir.Ref{ref(ir.RefInput, "s", "{{input.s}}", false)},
-		map[string]any{"s": `he said "hi"`}, nil, nil)
+		map[string]any{"s": `he said "hi"`}, nil, nil, "")
 	if got != `console.log("he said \"hi\"");` {
 		t.Errorf("got %q", got)
 	}
@@ -331,14 +304,14 @@ func TestResolveScriptTemplate_ObjectAndArray(t *testing.T) {
 	}, map[string]any{
 		"obj": map[string]any{"k": "v"},
 		"arr": []any{1.0, 2.0, 3.0},
-	}, nil, nil)
+	}, nil, nil, "")
 	if !strings.Contains(got, `{"k":"v"}`) || !strings.Contains(got, "[1,2,3]") {
 		t.Errorf("got %q", got)
 	}
 }
 
 func TestResolveTemplateWith_NoRefsPassthrough(t *testing.T) {
-	got := resolveTemplateWith("plain text {no template}", nil, nil, nil, nil, nil, shellEscapeValue, false)
+	got := resolveTemplateWith("plain text {no template}", nil, nil, nil, nil, "", nil, shellEscapeValue, false)
 	if got != "plain text {no template}" {
 		t.Errorf("got %q", got)
 	}
@@ -352,7 +325,7 @@ func TestResolveCommandTemplate_FileSecretPath(t *testing.T) {
 	}}, secretguard.DefaultConfig())
 	got := resolveCommandTemplate("kubectl --kubeconfig {{secrets.kubeconfig.path}} get pods", []*ir.Ref{
 		ref(ir.RefSecrets, "kubeconfig", "{{secrets.kubeconfig.path}}", false),
-	}, nil, nil, nil, guard)
+	}, nil, nil, nil, "", guard)
 	if got != "kubectl --kubeconfig '/run/iterion/secrets/kubeconfig' get pods" {
 		t.Fatalf("got %q", got)
 	}
@@ -369,7 +342,7 @@ func TestResolveTemplateWith_NoCascadeReplay(t *testing.T) {
 	}, map[string]any{
 		"a": "{{input.b}}", // literal that looks like a template
 		"b": "shouldNotLeak",
-	}, nil, nil)
+	}, nil, nil, "")
 	// Expected: X gets the raw literal text; Y gets escaped 'shouldNotLeak'.
 	if !strings.Contains(got, "X={{input.b}}") {
 		t.Errorf("cascade replay corrupted input.a value: %q", got)

--- a/pkg/backend/model/executor_verified_action.go
+++ b/pkg/backend/model/executor_verified_action.go
@@ -175,13 +175,12 @@ func (e *ClawExecutor) runPostcondition(ctx context.Context, node *ir.ToolNode, 
 	resolve := func() string {
 		expanded := expandBracedEnv(node.Postcondition)
 		td := TemplateDataFromContext(ctx)
-		expanded = resolveRunRefs(expanded, RunIDFromContext(ctx), td, node.PostcondRefs, shellEscapeValue)
 		// A postcondition is the node's second shell command body, resolved
 		// with the same escaper over the same snapshot, and its refs are
 		// validated against the same input schema — so a `json`-declared
 		// field holding a list breaks out of its assignment here exactly as
 		// it does in the command itself.
-		return resolveCommandTemplate(expanded, node.PostcondRefs, e.jsonFieldsAsText(node, input), e.vars, td, e.secretGuard)
+		return resolveCommandTemplate(expanded, node.PostcondRefs, e.jsonFieldsAsText(node, input), e.vars, td, RunIDFromContext(ctx), e.secretGuard)
 	}
 	buildCmd := func(resolved string) (*exec.Cmd, func(), error) {
 		materialized, env := e.secretGuard.MaterializeShellEnv(resolved)

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -108,23 +108,27 @@ type AttachmentWriter interface {
 	WriteAttachment(ctx context.Context, runID string, rec store.AttachmentRecord, body io.Reader) error
 }
 
-// ToolBlobWriter is the optional capability filesystem stores satisfy
-// for the per-tool-call sidecar I/O persistence path. When present, tool
-// inputs/outputs exceeding `toolInlineThreshold` are written through it
-// and the event carries a small head preview + a ref instead of the
-// full body. Mongo (cloud) stores don't satisfy it today; the hook
-// layer falls back to inline truncation in that case.
+// ToolBlobWriter is the optional capability for the per-tool-call
+// sidecar I/O persistence path. When present, tool inputs/outputs
+// exceeding `toolInlineThreshold` are written through it and the event
+// carries a small head preview + a ref instead of the full body. Both
+// store families satisfy it — the filesystem store writes a sidecar
+// file, the Mongo store PUTs the body to object storage — and in cloud
+// mode the runner's metricsEmitter forwards it to the wrapped store.
+// Emitters without it (test fakes) fall back to inline truncation.
 type ToolBlobWriter interface {
 	WriteToolBlob(ctx context.Context, runID, toolUseID, kind string, body []byte) (int64, error)
 }
 
-// TurnWriter is the optional capability filesystem stores satisfy for
-// the per-LLM-turn snapshot persistence path. Each tool-loop iteration
-// completing inside the claw backend (or a delegate-call boundary for
-// claude_code) is persisted as a store.TurnCheckpoint so the studio's
-// timeline + the Fork API have a stable anchor. Mongo (cloud) stores
-// don't satisfy it today; the hook layer skips the write when the
-// capability is missing rather than failing the LLM call.
+// TurnWriter is the optional capability for the per-LLM-turn snapshot
+// persistence path. Each tool-loop iteration completing inside the claw
+// backend (or a delegate-call boundary for claude_code) is persisted as
+// a store.TurnCheckpoint so the studio's timeline + the Fork API have a
+// stable anchor. Both store families satisfy it — the filesystem store
+// writes runs/<id>/turns/…, the Mongo store upserts one document per
+// (run, node, iter, turn) — and in cloud mode the runner's
+// metricsEmitter forwards it to the wrapped store. Emitters without it
+// (test fakes) skip the write rather than failing the LLM call.
 type TurnWriter interface {
 	WriteTurn(ctx context.Context, t *store.TurnCheckpoint) error
 }
@@ -164,9 +168,9 @@ type NodeServedRecorder interface {
 //     (total bytes), and `data[key+"_ref"]` (= toolUseID — the path is
 //     deterministic from run_id + tool_use_id + kind).
 //
-// When blobSink is nil or toolUseID is empty (legacy paths, cloud
-// stores), falls back to capped inline persistence so the studio still
-// shows *something*.
+// When blobSink is nil or toolUseID is empty (an emitter without the
+// capability, a call with no tool_use id), falls back to capped inline
+// persistence so the studio still shows *something*.
 func persistToolPayload(ctx context.Context, guard *secretguard.Guard, blobSink ToolBlobWriter, runID, toolUseID, key string, content []byte, data map[string]any) {
 	if len(content) == 0 {
 		return
@@ -713,9 +717,9 @@ func isLikelyStructuredPayload(text string) bool {
 // onLLMTurnCapture implements the OnLLMTurnCapture hook.
 func (h *storeHooks) onLLMTurnCapture(nodeID string, info LLMTurnCaptureInfo) {
 	if h.turnSink == nil {
-		// Cloud stores don't satisfy TurnWriter yet; skip silently
-		// so the timeline + fork features simply don't light up
-		// for those runs (the rest of the LLM loop is unaffected).
+		// An emitter without a TurnWriter (test fakes) skips silently
+		// so the timeline + fork features simply don't light up for
+		// those runs (the rest of the LLM loop is unaffected).
 		return
 	}
 	// info.Iteration is threaded through applyHooks /

--- a/pkg/backend/model/run_namespace_template_test.go
+++ b/pkg/backend/model/run_namespace_template_test.go
@@ -35,7 +35,7 @@ func TestRunNamespaceReachesPromptsAndToolCommands(t *testing.T) {
 
 	// Tool commands.
 	refs := []*ir.Ref{{Kind: ir.RefRun, Path: []string{"max_cost_usd"}, Raw: "{{run.max_cost_usd}}"}}
-	cmd := resolveRunRefs("test $(echo {{run.max_cost_usd}}) -gt 0", "run-abc", td, refs, shellEscapeValue)
+	cmd := resolveCommandTemplate("test $(echo {{run.max_cost_usd}}) -gt 0", refs, nil, nil, td, "run-abc")
 	if strings.Contains(cmd, "{{run.max_cost_usd}}") || !strings.Contains(cmd, "12") {
 		t.Errorf("tool command run.max_cost_usd not substituted: %q", cmd)
 	}


### PR DESCRIPTION
Two commits, one per ticket — cluster backend/model (#836, #817).

## #836 — `ChainHooks` composed 18 of the 22 hook fields
`pkg/runview/executor.go` chains every `ExtraHooks` entry through `ChainHooks`; the shipped case is the Prometheus exporter (`pkg/cli/run.go`, activated by `ITERION_PROMETHEUS_ADDR`). Four fields were dropped — `OnAssistantText`, `OnUsageCap`, `OnUsageProgress`, `OnOrchestrationStall` — so a run launched with the exporter silently lost those event families (no live `usage_progress` for a supervisor's `cost_gt` monitor, no `usage_cap`, no `delegate_stall`, no assistant text in the timeline). Blast radius verified as exactly that one link: all four have live producers (`claude_code_stream.go`, `pi_rpc.go`) and consumers, and the `EventHooks → delegate.TaskHooks` translation wires them; only the composer dropped them.
Fix: all 22 fields composed in declaration order, plus the reflective guard `TestChainHooksForwardsEveryField` / `TestChainHooksKeepsTheLoneSideOfEveryField` — walks the struct type, installs a recorder in both halves of each field, requires `[a b]`; a non-func field fails the test asking for the guard to be extended. Red first: `ChainHooks dropped EventHooks.OnAssistantText: both halves registered a callback and the composed hooks carry none` (×4 fields, ×2 lone sides). Class grep (every producer/copier/translator of `EventHooks`) in the commit body: `ChainHooks` was the only field-by-field copier.
Comment drift, same ticket: `TurnWriter`'s "Mongo stores don't satisfy it" was false (`pkg/store/mongo/turns.go` implements `WriteTurn`, `loop_metrics.go` forwards it); the identical stale claim on `ToolBlobWriter` and two dependent comments rewritten in the present tense.

## #817 — `resolveRunRefs` rendered an unknown `{{run.*}}` as nothing, and cascaded
Reproduced through the exact production composition (pre-pass then `resolveCommandTemplate`): `unknown run member rendered "git checkout ", want the placeholder kept so the command fails visibly`; and the cascade — `{{run.note}}` holding the literal `{{input.payload}}` was shell-escaped by the pre-pass, then the single-pass walk re-expanded the inner ref, yielding `''INJECTED''`, which `sh` reads as the bare word `INJECTED`: an input value substituted where the author wrote a run ref, unquoted.
Fix: `run.*` is a fifth namespace arm inside `resolveTemplateWith`, beside `input`/`vars`/`secrets`/`outputs`; the three shell surfaces (`CommandRefs`, `ScriptRefs`, `PostcondRefs`) resolve it in one pass under the same escaping and the same missing-ref rule (placeholder kept in a shell body, `null` in a script body); `resolveRunRefs` deleted. `{{run.id}}` still falls back to the context's run id for hosts wiring only `WithRunID`. Blast radius: `runNamespace` populates all 9 members non-nil; the shipped `.bot` corpus uses `run.id` ×17, `run.elapsed_seconds` ×8, `run.max_duration_seconds` ×2 — only a member the namespace does not carry changes behaviour, from vanishing to visible. Red-first tests in `executor_tool_run_refs_test.go` (6); e2e `TestToolCommandKeepsUnresolvableRunRefVisible` runs a real engine run whose tool command carries `{{run.no_such_member}}` and asserts the placeholder reaches `sh -c` (canaried: reintroducing `if val == nil { val = "" }` turns it red). The superseded `TestResolveRunRefs_CommandAndScript` encoded the hole ("empty run id should not leave the literal placeholder") and is deleted; `docs/dsl.md` § the run namespace states the rule per surface.
Class grep — every `{{…}}` resolver outside `resolveTemplateWith` (table in the commit body): all single-pass or `strings.NewReplacer`, except `pkg/dsl/ir/expand_groups.go` (`{{params.*}}` `ReplaceAll` loop over a map — random order, same cascade shape), filed as a follow-up, not touched here.

## Proof
`go build`, `go vet`, `task lint` (0 issues), `go test ./pkg/backend/model ./pkg/benchmark ./pkg/runview ./pkg/runtime ./pkg/cli`, `-race` on model + benchmark, full `go test -timeout 1800s ./e2e/...` (784 s), `-race` on the two e2e tests touched.

Closes #836, #817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
