### PR TITLE
fix(golden-master,modernize): an extension is acted by the net's subbot only — the gate knows it by the subbot's commits and certified blobs

### DIFF
--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -646,6 +646,41 @@ func TestGoldenMasterExtendBaseRefusesAnIdentityRepairGitDidNotTake(t *testing.T
 	}
 }
 
+// The THIRD site of the class the two above close. `extend_base` SETS the
+// net's identity, and that `git config` dropped its exit code too: on a
+// workspace where the write cannot take, the run went on committing under
+// the OPERATOR's identity while every line it published claimed the net's —
+// the attribution the whole marker dance exists to make legible, wrong and
+// silent. A guard on two of three sites is a guard the third walks past.
+func TestGoldenMasterExtendBaseRefusesAnIdentityGitWouldNotTake(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": [{"id": "E-L29-1", "lot": "L29"}]}`)
+	gitDir := gitInNet(t, ws, "rev-parse", "--absolute-git-dir")
+	marker := filepath.Join(gitDir, "iterion-extend-prev-identity")
+	// No marker: nothing was displaced before this run, which is the shape
+	// that makes the dropped exit code invisible — there is no repair path
+	// to trip over it later.
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("the fixture must start with no marker: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config.lock"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendBase(t, ws)
+	if res.Clean || len(res.Pending) != 0 {
+		t.Fatalf("a net whose identity never took read as startable: %+v", res)
+	}
+	if !strings.HasPrefix(res.Notice, "REFUSED") {
+		t.Fatalf("the refusal must be stated, not implied: %q", res.Notice)
+	}
+	// The marker goes with the refusal: nothing was displaced, so leaving one
+	// behind makes the NEXT run read a leak that never happened and "restore"
+	// over a live identity.
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("a marker survived a refusal that displaced nothing: %v", err)
+	}
+}
+
 // runExtendRestore runs the subbot's terminal restore node against ws.
 func runExtendRestore(t *testing.T, ws string) map[string]any {
 	t.Helper()

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -359,19 +359,22 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 			t.Fatalf("a run under the engine's identity on a clean net must converge: %+v", res)
 		}
 	})
-	// The marker is the repair channel for a run that DIES; it must not
-	// outlive one that lives, or the next extension "repairs" a leak that is
-	// not there and restores a stale identity over the current one.
-	t.Run("the identity marker does not outlive the run that set it", func(t *testing.T) {
+	// extend_verify runs on the repair loop's body, so it must NOT restore:
+	// the loop re-enters the agent, and a restored identity there disarms
+	// every pass after the first.
+	t.Run("the identity stays set while the loop can still run", func(t *testing.T) {
 		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
-		act(t, ws, "extend@golden-master.iterion")
-		marker := filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"), "iterion-extend-prev-identity")
-		if err := os.WriteFile(marker, []byte(`{"name": "t", "email": "t@example.com"}`), 0o644); err != nil {
+		// The state extend_base leaves behind: the net's identity on the
+		// workspace, and the marker holding the one it displaced.
+		gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+		if err := os.WriteFile(filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"),
+			"iterion-extend-prev-identity"), []byte(`{"name": "t", "email": "t@example.com"}`), 0o644); err != nil {
 			t.Fatal(err)
 		}
+		act(t, ws, "extend@golden-master.iterion")
 		runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
-		if _, err := os.Stat(marker); !os.IsNotExist(err) {
-			t.Fatalf("the marker survived the restore: the next run would repair a leak that is not there (%v)", err)
+		if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "extend@golden-master.iterion" {
+			t.Fatalf("the identity was restored inside the loop body — pass 2's agent would commit as %q and identity_ok could never hold again", got)
 		}
 	})
 	t.Run("a commit under another identity is said", func(t *testing.T) {
@@ -417,5 +420,165 @@ func TestGoldenMasterExtendBaseRepairsALeakedIdentity(t *testing.T) {
 	}
 	if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "extend@golden-master.iterion" {
 		t.Fatalf("this run still commits under the net's identity, got %q", got)
+	}
+}
+
+// runExtendRestore runs the subbot's terminal restore node against ws.
+func runExtendRestore(t *testing.T, ws string) map[string]any {
+	t.Helper()
+	body := toolScript(t, "golden-master/extend.bot", "extend_restore")
+	body = strings.ReplaceAll(body, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in extend_restore near %q", body[i:min(i+40, len(body))])
+	}
+	p := filepath.Join(t.TempDir(), "extend_restore.py")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", p).Output()
+	if err != nil {
+		t.Fatalf("extend_restore failed: %v (out %q)", err, out)
+	}
+	var res map[string]any
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("extend_restore output is not JSON: %v (%q)", uerr, out)
+	}
+	return res
+}
+
+// TestGoldenMasterExtendVerifyNamesTheRightCauseForAReportFile pins the
+// production finding: a subbot that REFUSES everything and writes its refusal
+// to a file has acted nothing, and calling that "smuggling" sends the operator
+// hunting for an act nobody made.
+func TestGoldenMasterExtendVerifyNamesTheRightCauseForAReportFile(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	write := func(t *testing.T, ws, rel, body string) {
+		t.Helper()
+		p := filepath.Join(ws, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		gitInNet(t, ws, "add", "-A")
+		gitInNet(t, ws, "-c", "user.email=extend@golden-master.iterion", "-c", "user.name=x",
+			"commit", "-qm", "refusal")
+	}
+	t.Run("acted nothing: the file is not an act that overreached", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		write(t, ws, ".modernize/E-1-refusal.md", "the request needs judge code\n")
+		res := runExtendVerify(t, ws, base, `[{"id": "E-1"}]`)
+		if res.ScopeClean {
+			t.Fatalf("a path outside the surface must still refuse: %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "acted NOTHING on the surface") ||
+			strings.Contains(res.LogTail, "may write through it") {
+			t.Fatalf("the reason must name the real situation, not smuggling: %q", res.LogTail)
+		}
+	})
+	t.Run("acted on the surface too: the boundary is stated as smuggling", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		write(t, ws, ".modernize/E-1-note.md", "and a file beside it\n")
+		res := runExtendVerify(t, ws, base, `[{"id": "E-1"}]`)
+		if res.ScopeClean || !strings.Contains(res.LogTail, "may write through it") {
+			t.Fatalf("an act PLUS an outside path is the smuggling case: %+v", res)
+		}
+	})
+}
+
+// TestGoldenMasterExtendRestoreReturnsTheIdentityOnce pins the terminal node:
+// the identity comes back on the way OUT of the subbot — once, from the
+// marker, idempotently — instead of at the end of every verify pass, which is
+// inside the repair loop's body.
+func TestGoldenMasterExtendRestoreReturnsTheIdentityOnce(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": []}`)
+	gitInNet(t, ws, "config", "user.name", "golden-master extend")
+	gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+	marker := filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"), "iterion-extend-prev-identity")
+	if err := os.WriteFile(marker, []byte(`{"name": "t", "email": "t@example.com"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendRestore(t, ws)
+	if res["restored"] != true {
+		t.Fatalf("the identity was not restored: %+v", res)
+	}
+	if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "t@example.com" {
+		t.Fatalf("the lot's later commits would still wear the net's name, got %q", got)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("the marker survived: the next run would repair a leak that is not there (%v)", err)
+	}
+	// Idempotent: nothing to restore is said, not guessed at.
+	again := runExtendRestore(t, ws)
+	if again["restored"] != false || !strings.Contains(again["notice"].(string), "no identity marker") {
+		t.Fatalf("a second restore must be a stated no-op: %+v", again)
+	}
+}
+
+// TestGoldenMasterExtendRestoreIsOnEveryWayOut pins the WIRING the finding
+// named: the repair loop re-enters the agent, so a restore anywhere in the
+// loop body disarms the identity for every pass after the first. Every
+// non-loop edge out of the gate must reach the restore.
+func TestGoldenMasterExtendRestoreIsOnEveryWayOut(t *testing.T) {
+	const rel = "golden-master/extend.bot"
+	src, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr := parser.Parse(rel, string(src))
+	if pr.File == nil {
+		t.Fatal("extend.bot does not parse")
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatal("extend.bot does not compile")
+	}
+	seen := 0
+	for _, e := range cr.Workflow.Edges {
+		if e.From != "extend_gate" {
+			continue
+		}
+		if e.LoopName != "" {
+			continue // the repair pass, which must NOT restore
+		}
+		seen++
+		if e.To != "extend_restore" {
+			t.Fatalf("edge extend_gate -> %q leaves the subbot without restoring the identity it set", e.To)
+		}
+	}
+	if seen < 2 {
+		t.Fatalf("expected both exits of the gate (converged and exhausted), saw %d", seen)
+	}
+	for _, e := range cr.Workflow.Edges {
+		if e.From == "extend_restore" && e.To != "extend_result" {
+			t.Fatalf("extend_restore -> %q: the restore must sit between the gate and the report", e.To)
+		}
+	}
+
+	// The refusal the subbot states must travel with the verdict, or an agent
+	// told to "report in summary" writes a file to make its reasoning survive
+	// — and its own gate then refuses the file (production finding).
+	node, ok := cr.Workflow.Nodes["extend_result"].(*ir.ComputeNode)
+	if !ok {
+		t.Fatal("extend_result is not a compute node")
+	}
+	var notice string
+	for _, ex := range node.Exprs {
+		if ex.Key == "notice" {
+			notice = ex.Raw
+		}
+	}
+	if notice == "" {
+		t.Fatal("extend_result publishes no notice")
+	}
+	for _, want := range []string{"outputs.extend_campaign.summary", "outputs.extend_gate.fail_log"} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("the published notice drops %s — the subbot's stated cause and the gate's deterministic verdict travel together, never one without the other: %s", want, notice)
+		}
 	}
 }

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -932,6 +932,60 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 			t.Fatalf("an id with a space lost its cover — the parser split it out of the set: %+v", v.Acted)
 		}
 	})
+	// The twin of the test above, and its opposite: an id must not inherit the
+	// cover of one that merely LOOKS like it. The reader normalised each line
+	// while the verdict compares the id verbatim, so two ids differing only by
+	// surrounding whitespace collapsed into one — and the act the subbot
+	// REFUSED came back covered by the id it had acted. That is a refused
+	// extension converging, reopened by an encoding.
+	t.Run("a near-identical id does not inherit the cover of the acted one", func(t *testing.T) {
+		ws, base, blob := extensionLedgerRepo(t, "E-2")
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_MODE=extend-verify", "GM_WORKSPACE="+ws,
+			"GM_DIR=.golden-master", "GM_BASE="+base, "GM_ACTED_COMMITS=",
+			// The subbot acted " E-2". The ledger's act is "E-2" — a DIFFERENT
+			// id, written by the constrained party in its own commit.
+			"GM_ACTED_IDS= E-2",
+			"GM_ACTED_BLOBS=.golden-master/refs/2.txt="+blob)
+		out, _ := cmd.Output()
+		var v struct {
+			Acted []struct {
+				OK     bool `json:"ok"`
+				Forged bool `json:"forged"`
+			} `json:"acted"`
+		}
+		if uerr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &v); uerr != nil {
+			t.Fatalf("no verdict: %v (%q)", uerr, out)
+		}
+		if len(v.Acted) != 1 || !v.Acted[0].Forged {
+			t.Fatalf("the lot's own act rode the certificate of a DIFFERENT id — "+
+				"the reader normalised what the verdict compares raw: %+v", v.Acted)
+		}
+	})
+	// The other shape the encoding leaves open: an id carrying a line break
+	// publishes as TWO lines, and the reader seeds the covered set with a
+	// fragment no subbot ever acted. It cannot round-trip, so it is refused at
+	// the parse point rather than repaired.
+	t.Run("an id carrying a line break is refused, not split into fragments", func(t *testing.T) {
+		ws, base, blob := extensionLedgerRepo(t, "E\n2")
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_MODE=extend-verify", "GM_WORKSPACE="+ws,
+			"GM_DIR=.golden-master", "GM_BASE="+base, "GM_ACTED_COMMITS=",
+			"GM_ACTED_IDS=E\n2",
+			"GM_ACTED_BLOBS=.golden-master/refs/2.txt="+blob)
+		out, _ := cmd.Output()
+		var v struct {
+			Problems []string `json:"problems"`
+		}
+		if uerr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &v); uerr != nil {
+			t.Fatalf("no verdict: %v (%q)", uerr, out)
+		}
+		if !strings.Contains(strings.Join(v.Problems, " | "), "one-id-per-line") {
+			t.Fatalf("an id that cannot survive the line transport was accepted: %+v", v.Problems)
+		}
+	})
 	t.Run("an entry the judge cannot read is refused, not dropped", func(t *testing.T) {
 		v, exit := run(t, "GM_ACTED_COMMITS=", "GM_ACTED_BLOBS=no-equals-sign-here")
 		if exit == 0 {
@@ -942,4 +996,64 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 			t.Fatalf("the refusal must name what it could not read: %q", msg)
 		}
 	})
+}
+
+// extensionLedgerRepo builds the smallest repo an extension verdict can judge:
+// a base commit, a request filed by the lot, then an act answering it and the
+// reference it records — both introduced by the LOT's own commit, so only the
+// content rule can ever cover the act. Returns the workspace, the base sha and
+// the blob of the recorded reference. The id is marshalled, never interpolated:
+// a test whose id carries a line break must produce a LEGAL JSON block, or it
+// would prove the escape rather than the guard.
+func extensionLedgerRepo(t *testing.T, id string) (ws, base, blob string) {
+	t.Helper()
+	ws = t.TempDir()
+	gm := filepath.Join(ws, ".golden-master")
+	if err := os.MkdirAll(filepath.Join(gm, "refs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	g := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		out, gerr := cmd.CombinedOutput()
+		if gerr != nil {
+			t.Fatalf("git %v: %v (%s)", args, gerr, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	g("init", "-q", "-b", "main")
+	g("config", "user.email", "t@t")
+	g("config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(gm, "corpus.json"), []byte(`{"entries": []}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g("add", "-A")
+	g("commit", "-qm", "base")
+	base = g("rev-parse", "HEAD")
+
+	jid, err := json.Marshal(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := func(blocks string) {
+		if werr := os.WriteFile(filepath.Join(gm, "EXTENSIONS.md"), []byte(blocks), 0o644); werr != nil {
+			t.Fatal(werr)
+		}
+	}
+	req := "<!-- iterion:extension-request\n" +
+		`{"id": ` + string(jid) + `, "lot": "L", "type": "add-file", "paths": [".golden-master/refs/2.txt"]}` +
+		"\n-->\n"
+	ledger(req)
+	g("add", "-A")
+	g("commit", "-qm", "the lot files it")
+	ledger(req + "<!-- iterion:extension-act\n" +
+		`{"id": ` + string(jid) + `, "lot": "L", "recorded_paths": [".golden-master/refs/2.txt"]}` +
+		"\n-->\n")
+	if err := os.WriteFile(filepath.Join(gm, "refs", "2.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g("add", "-A")
+	g("commit", "-qm", "acted")
+	return ws, base, g("rev-parse", "HEAD:.golden-master/refs/2.txt")
 }

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -323,6 +323,50 @@ func TestGoldenMasterExtendBaseRefusesADirtyNet(t *testing.T) {
 	})
 }
 
+// TestGoldenMasterExtendBaseSeesQuotedAndRenamedDirt pins the refusal against
+// the shapes git does not print plainly. `--porcelain` QUOTES a path with a
+// non-ASCII byte, so a raw prefix match read a planted reference as a clean
+// net — and the absorption attack the refusal exists to stop needs exactly
+// one accented file name. A rename prints its origin as a second token, and a
+// reference moved OUT of the net dirties it as surely as one moved in.
+func TestGoldenMasterExtendBaseSeesQuotedAndRenamedDirt(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	const pending = `{"pending": [{"id": "E-1", "lot": "L"}]}`
+
+	t.Run("a planted reference with a non-ASCII name", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "é.txt"),
+			[]byte("planted by the lot\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := runExtendBase(t, ws)
+		if res.Clean || len(res.Pending) != 0 || !strings.HasPrefix(res.Notice, "REFUSED") {
+			t.Fatalf("a quoted path read as a clean net — the absorption attack is open: %+v", res)
+		}
+	})
+	t.Run("a reference renamed OUT of the net", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		gitInNet(t, ws, "mv", ".golden-master/refs/001.txt", "moved-away.txt")
+		res := runExtendBase(t, ws)
+		if res.Clean || !strings.HasPrefix(res.Notice, "REFUSED") {
+			t.Fatalf("a reference moved out of the net left it reading clean: %+v", res)
+		}
+	})
+	t.Run("dirt outside the net is still only SAID", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		if err := os.WriteFile(filepath.Join(ws, "élan.txt"), []byte("the lot's own work\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := runExtendBase(t, ws)
+		if !res.Clean || len(res.Pending) != 1 {
+			t.Fatalf("a quoted path OUTSIDE the net must not refuse the run: %+v", res)
+		}
+		if !strings.Contains(res.Notice, "already dirty") {
+			t.Fatalf("outside dirt must still be said: %q", res.Notice)
+		}
+	})
+}
+
 // TestGoldenMasterExtendVerifyPublishesItsProvenance pins the subbot's half:
 // the commits of this run (base..HEAD), the blob certified per surface path,
 // the ids acted, the identity of every commit — and that its own harness
@@ -589,6 +633,36 @@ func TestGoldenMasterExtendRestoreIsOnEveryWayOut(t *testing.T) {
 		}
 	}
 
+	// A deterministic refusal must not buy an LLM pass. `clean` is read once
+	// and carried unchanged, so the conjunct it feeds is false forever: the
+	// campaign edge would pay a full agent run, then max_passes more of them,
+	// to report what node 1 already knew — and would hand the workspace to an
+	// agent on a start that was refused.
+	var refusedAt, campaignAt = -1, -1
+	for i, e := range cr.Workflow.Edges {
+		if e.From != "extend_base" {
+			continue
+		}
+		switch e.To {
+		case "extend_refused":
+			refusedAt = i
+			if e.Condition != "clean" || !e.Negated {
+				t.Fatalf("the refusal edge must be `when not clean`, got condition=%q negated=%v", e.Condition, e.Negated)
+			}
+		case "extend_campaign":
+			campaignAt = i
+		}
+	}
+	if refusedAt < 0 {
+		t.Fatal("no `extend_base -> extend_refused when not clean` edge: a refused start still buys an agent pass")
+	}
+	if campaignAt >= 0 && campaignAt < refusedAt {
+		t.Fatal("the campaign edge is declared before the refusal: the engine takes the first `when` that holds, and an unconditional edge is only the fallback — but declaration order is what the reader checks")
+	}
+	if _, ok := cr.Workflow.Nodes["extend_refused"]; !ok {
+		t.Fatal("extend_refused is not a node")
+	}
+
 	// The refusal the subbot states must travel with the verdict, or an agent
 	// told to "report in summary" writes a file to make its reasoning survive
 	// — and its own gate then refuses the file (production finding).
@@ -605,7 +679,11 @@ func TestGoldenMasterExtendRestoreIsOnEveryWayOut(t *testing.T) {
 	if notice == "" {
 		t.Fatal("extend_result publishes no notice")
 	}
-	for _, want := range []string{"outputs.extend_campaign.summary", "outputs.extend_gate.fail_log"} {
+	// Read from extend_verify, not from the agent node: a summary the agent
+	// omitted renders null, and `string + null` is a typed error that would
+	// fail the compute and take down a run that was only reporting a refusal.
+	// The tool node makes it a string once.
+	for _, want := range []string{"outputs.extend_verify.agent_summary", "outputs.extend_gate.fail_log"} {
 		if !strings.Contains(notice, want) {
 			t.Fatalf("the published notice drops %s — the subbot's stated cause and the gate's deterministic verdict travel together, never one without the other: %s", want, notice)
 		}

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -1,0 +1,220 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The provenance of an extension act: the net's subbot reports the commits it
+// made and the blobs it certified, the parent hands them to the harness at
+// its gate, and an act outside them — the constrained party acting its own
+// request — is a typed refusal. Measured on a live campaign: a lot filed a
+// request in one commit, acted it in the next, and its own file became a
+// reference of the net that judges it.
+
+// TestModernizeLotVerifyHandsProvenanceToTheCertifier pins the parent's half:
+// GM_ACTED_COMMITS / GM_ACTED_BLOBS reach the certifier on EVERY pass — empty
+// before any subbot ran, which is exactly the pass that judges a self-act —
+// and a forged act comes back typed (`extension_forged`), never as a repair.
+func TestModernizeLotVerifyHandsProvenanceToTheCertifier(t *testing.T) {
+	requireModernizeTools(t)
+	script := toolScript(t, "modernize/main.bot", "lot_verify")
+	const plan = `version: 1
+oracle:
+  refs_dir: .golden-master/refs
+lots:
+  - id: L1
+    title: "raise the build tool"
+    status: todo
+    exit_gate:
+      - "true"
+`
+	const gate = "sh -c 'echo ran > gate.marker'"
+	setup := func(t *testing.T, harness string) (string, string) {
+		t.Helper()
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		hp := filepath.Join(ws, ".golden-master", "harness.py")
+		if err := os.WriteFile(hp, []byte(harness), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		git("add", "-A", ".golden-master")
+		git("commit", "-qm", "net")
+		return ws, git("rev-parse", "HEAD")
+	}
+	// A certifier that REFUSES unless the parent handed it provenance — the
+	// presence of the variable, even empty, is the contract.
+	const strictStub = `import json, os
+mode = os.environ.get("GM_MODE")
+if mode == "extend-verify":
+    if "GM_ACTED_COMMITS" in os.environ and "GM_ACTED_BLOBS" in os.environ:
+        print(json.dumps({"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+    else:
+        print(json.dumps({"acted": [{"id": "E-1", "ok": False, "forged": True, "problems": ["no provenance handed: the certifier cannot tell the net's act from the lot's"]}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`
+	t.Run("the provenance reaches the certifier before any subbot ran", func(t *testing.T) {
+		ws, base := setup(t, strictStub)
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.RefsUntouched || res.ExtensionForged {
+			t.Fatalf("the certifier was not handed the provenance (empty, present): %+v", res)
+		}
+	})
+	// A certifier that reports a FORGED act: the parent types it.
+	const forgedStub = `import json, os
+mode = os.environ.get("GM_MODE")
+if mode == "extend-verify":
+    print(json.dumps({"acted": [{"id": "E-1", "ok": False, "forged": True, "introduced_by": "abc123def456", "author": "lot@run", "problems": ["the act was introduced by abc123def456 (author lot@run), which is not one of the net subbot's commits (none reported)"]}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`
+	t.Run("a forged act is a typed refusal, not a red to repair", func(t *testing.T) {
+		ws, base := setup(t, forgedStub)
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.ExtensionForged || res.RefsUntouched {
+			t.Fatalf("a forged act must be typed and refuse the references: %+v", res)
+		}
+		if !strings.HasPrefix(res.BlockReason, "EXTENSION_FORGED:") || !strings.Contains(res.BlockReason, "lot@run") {
+			t.Fatalf("block_reason must name the forged act and its author: %q", res.BlockReason)
+		}
+	})
+}
+
+type extendBaseOut struct {
+	Head      string `json:"head"`
+	Pending   []any  `json:"pending"`
+	Notice    string `json:"notice"`
+	Clean     bool   `json:"clean"`
+	PrevName  string `json:"prev_name"`
+	PrevEmail string `json:"prev_email"`
+}
+
+func runExtendBase(t *testing.T, ws string) extendBaseOut {
+	t.Helper()
+	body := toolScript(t, "golden-master/extend.bot", "extend_base")
+	body = strings.ReplaceAll(body, "{{vars.workspace_dir}}", strconv.Quote(ws))
+	body = strings.ReplaceAll(body, "{{vars.oracle_dir}}", strconv.Quote(".golden-master"))
+	body = strings.ReplaceAll(body, "{{vars.actor_name}}", strconv.Quote("golden-master extend"))
+	body = strings.ReplaceAll(body, "{{vars.actor_email}}", strconv.Quote("extend@golden-master.iterion"))
+	if i := strings.Index(body, "{{"); i >= 0 {
+		t.Fatalf("unresolved template ref in extend_base near %q", body[i:min(i+40, len(body))])
+	}
+	scriptPath := filepath.Join(t.TempDir(), "extend_base.py")
+	if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("python3", scriptPath).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("extend_base exited %d: %s (out %q)", ee.ExitCode(), ee.Stderr, out)
+		}
+		t.Fatalf("extend_base failed to execute: %v", err)
+	}
+	var res extendBaseOut
+	if uerr := json.Unmarshal(out, &res); uerr != nil {
+		t.Fatalf("extend_base output is not JSON: %v (out %q)", uerr, out)
+	}
+	return res
+}
+
+func gitInNet(t *testing.T, ws string, args ...string) string {
+	t.Helper()
+	full := append([]string{"-C", ws}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v (%s)", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestGoldenMasterExtendBaseRefusesADirtyNet pins the subbot's start: a
+// clean net gets the engine's identity (the parent's gate attributes acts
+// to their author) and its pending requests; an uncommitted path under the
+// net refuses the run before the agent — this run committing it would
+// certify the constrained party's file as the net's own (the absorption
+// attack of the plan review).
+func TestGoldenMasterExtendBaseRefusesADirtyNet(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	const pending = `{"pending": [{"id": "E-L29-1", "lot": "L29"}]}`
+	t.Run("a clean net: identity set, pending handed to the agent", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		res := runExtendBase(t, ws)
+		if !res.Clean || len(res.Pending) != 1 || res.PrevEmail != "t@example.com" {
+			t.Fatalf("clean start expected: %+v", res)
+		}
+		if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "extend@golden-master.iterion" {
+			t.Fatalf("the engine must set the net's identity for this run, got %q", got)
+		}
+	})
+	t.Run("an uncommitted path under the net: refused, nothing handed, identity untouched", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("forged by the lot\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := runExtendBase(t, ws)
+		if res.Clean || len(res.Pending) != 0 || !strings.HasPrefix(res.Notice, "REFUSED") {
+			t.Fatalf("a dirty net must be refused before the agent: %+v", res)
+		}
+		if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "t@example.com" {
+			t.Fatalf("a refused start must not touch the identity, got %q", got)
+		}
+	})
+}
+
+// TestGoldenMasterExtendVerifyPublishesItsProvenance pins the subbot's half:
+// the commits of this run (base..HEAD), the blob certified per surface path,
+// the ids acted, the identity of every commit — and that its own harness
+// call carries the same provenance the parent will hand it.
+func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
+	// The certifier refuses unless handed provenance: the subbot must pass its
+	// own commits to its own call, or passing here and failing there is back.
+	const verdict = `{"acted": [{"id": "E-L29-1", "ok": True, "paths": [".golden-master/refs/002.txt"]}], "ok_paths": [".golden-master/refs/002.txt"], "ledger_append_only": True, "requests_added": 0, "problems": ([] if "GM_ACTED_COMMITS" in os.environ else ["no provenance handed"])}`
+	act := func(t *testing.T, ws, email string) (string, string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.OpenFile(filepath.Join(ws, ".golden-master", "EXTENSIONS.md"), os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString("<!-- iterion:extension-act\n{\"id\": \"E-L29-1\", \"lot\": \"L29\", \"recorded_paths\": [\".golden-master/refs/002.txt\"]}\n-->\n"); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		gitInNet(t, ws, "add", "-A")
+		gitInNet(t, ws, "-c", "user.email="+email, "-c", "user.name=x", "commit", "-qm", "act")
+		return gitInNet(t, ws, "rev-parse", "HEAD"), gitInNet(t, ws, "rev-parse", "HEAD:.golden-master/refs/002.txt")
+	}
+	t.Run("commits, blobs, ids and identity are published", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		sha, blob := act(t, ws, "extend@golden-master.iterion")
+		res := runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
+		if res.ActedCommits != sha || res.ActedBlobs != ".golden-master/refs/002.txt="+blob || res.ActedIds != "E-L29-1" {
+			t.Fatalf("provenance not published: %+v (sha %s blob %s)", res, sha, blob)
+		}
+		if !res.IdentityOk || !res.CleanStart || !res.AdditionsOK {
+			t.Fatalf("a run under the engine's identity on a clean net must converge: %+v", res)
+		}
+	})
+	t.Run("a commit under another identity is said", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		act(t, ws, "lot@run")
+		res := runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
+		if res.IdentityOk || !strings.Contains(res.LogTail, "another identity") {
+			t.Fatalf("a commit under the lot's identity must be reported: %+v", res)
+		}
+	})
+}

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -986,6 +986,47 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 			t.Fatalf("an id that cannot survive the line transport was accepted: %+v", v.Problems)
 		}
 	})
+	// Containment: refusing the poisoned block is only half the defence. While
+	// it was merely REPORTED, the readable blocks beside it went on exempting
+	// their paths — so a ledger that escalates still handed out the exemption,
+	// and any caller reading ok_paths without also reading problems never saw
+	// the escalation at all.
+	t.Run("an unreadable block stops the ledger certifying anything beside it", func(t *testing.T) {
+		poison := "<!-- iterion:extension-act\n" +
+			`{"id": "E\n9", "lot": "L", "recorded_paths": [".golden-master/refs/2.txt"]}` +
+			"\n-->\n"
+		ws, base, blob := extensionLedgerRepo(t, "E-2", poison)
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_MODE=extend-verify", "GM_WORKSPACE="+ws,
+			"GM_DIR=.golden-master", "GM_BASE="+base, "GM_ACTED_COMMITS=",
+			// The subbot really did act E-2 and certify its blob: without the
+			// poisoned block beside it, this act would be covered.
+			"GM_ACTED_IDS=E-2",
+			"GM_ACTED_BLOBS=.golden-master/refs/2.txt="+blob)
+		out, _ := cmd.Output()
+		var v struct {
+			OKPaths  []string `json:"ok_paths"`
+			Problems []string `json:"problems"`
+			Acted    []struct {
+				OK bool `json:"ok"`
+			} `json:"acted"`
+		}
+		if uerr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &v); uerr != nil {
+			t.Fatalf("no verdict: %v (%q)", uerr, out)
+		}
+		if len(v.Problems) == 0 {
+			t.Fatalf("the unreadable block was not escalated at all: %+v", v)
+		}
+		if len(v.OKPaths) != 0 {
+			t.Fatalf("a ledger the judge cannot read still exempted paths: %+v", v.OKPaths)
+		}
+		for _, a := range v.Acted {
+			if a.OK {
+				t.Fatalf("an act was certified from a ledger carrying an unreadable block: %+v", v.Acted)
+			}
+		}
+	})
 	t.Run("an entry the judge cannot read is refused, not dropped", func(t *testing.T) {
 		v, exit := run(t, "GM_ACTED_COMMITS=", "GM_ACTED_BLOBS=no-equals-sign-here")
 		if exit == 0 {
@@ -1005,7 +1046,7 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 // the blob of the recorded reference. The id is marshalled, never interpolated:
 // a test whose id carries a line break must produce a LEGAL JSON block, or it
 // would prove the escape rather than the guard.
-func extensionLedgerRepo(t *testing.T, id string) (ws, base, blob string) {
+func extensionLedgerRepo(t *testing.T, id string, extraBlocks ...string) (ws, base, blob string) {
 	t.Helper()
 	ws = t.TempDir()
 	gm := filepath.Join(ws, ".golden-master")
@@ -1044,6 +1085,10 @@ func extensionLedgerRepo(t *testing.T, id string) (ws, base, blob string) {
 	req := "<!-- iterion:extension-request\n" +
 		`{"id": ` + string(jid) + `, "lot": "L", "type": "add-file", "paths": [".golden-master/refs/2.txt"]}` +
 		"\n-->\n"
+	// Extra blocks are appended to EVERY revision of the ledger, so a block
+	// that cannot be read stands beside the readable ones from the first
+	// commit — an append-only trail, exactly as the judge requires.
+	req += strings.Join(extraBlocks, "")
 	ledger(req)
 	g("add", "-A")
 	g("commit", "-qm", "the lot files it")

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -344,6 +344,23 @@ func TestGoldenMasterExtendBaseSeesQuotedAndRenamedDirt(t *testing.T) {
 			t.Fatalf("a quoted path read as a clean net — the absorption attack is open: %+v", res)
 		}
 	})
+	t.Run("a status git cannot read is not a clean net", func(t *testing.T) {
+		ws, _ := extendVerifyRepo(t, verdict, pending)
+		// The repository made unreadable: git exits non-zero, and whether
+		// the net is clean becomes unknown. Every other unknown in this
+		// feature fails closed; this one used to fail OPEN, granting exactly
+		// the window the refusal exists to close.
+		if err := os.Rename(filepath.Join(ws, ".git"), filepath.Join(ws, ".git-moved")); err != nil {
+			t.Fatal(err)
+		}
+		res := runExtendBase(t, ws)
+		if res.Clean || len(res.Pending) != 0 {
+			t.Fatalf("an unreadable status read as a clean net: %+v", res)
+		}
+		if !strings.Contains(res.Notice, "UNKNOWN") {
+			t.Fatalf("the refusal must name the unknown: %q", res.Notice)
+		}
+	})
 	t.Run("a reference renamed OUT of the net", func(t *testing.T) {
 		ws, _ := extendVerifyRepo(t, verdict, pending)
 		gitInNet(t, ws, "mv", ".golden-master/refs/001.txt", "moved-away.txt")
@@ -448,6 +465,47 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 		}
 		if !seen[spaced] || !seen[".golden-master/refs/002.txt"] {
 			t.Fatalf("a path with a space did not survive the encoding: %q", lines)
+		}
+	})
+	// The same thing driven through the real tool: an ambient identity is
+	// REPORTED and the provenance is published all the same, so the acts stay
+	// certifiable. Reported, not refused.
+	t.Run("an ambient git identity is said, and certifies all the same", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		cmd := exec.Command("git", "-C", ws, "add", "-A")
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.OpenFile(filepath.Join(ws, ".golden-master", "EXTENSIONS.md"), os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, werr := f.WriteString("<!-- iterion:extension-act\n{\"id\": \"E-L29-1\", \"lot\": \"L29\", \"recorded_paths\": [\".golden-master/refs/002.txt\"]}\n-->\n"); werr != nil {
+			t.Fatal(werr)
+		}
+		f.Close()
+		if out, aerr := cmd.CombinedOutput(); aerr != nil {
+			t.Fatalf("git add: %v (%s)", aerr, out)
+		}
+		// The environment wins over `-c user.email`, which is the whole point.
+		commit := exec.Command("git", "-C", ws, "-c", "user.email=extend@golden-master.iterion",
+			"-c", "user.name=x", "commit", "-qm", "act")
+		commit.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_EMAIL=ambient@host", "GIT_COMMITTER_EMAIL=ambient@host",
+			"GIT_AUTHOR_NAME=ambient", "GIT_COMMITTER_NAME=ambient")
+		if out, cerr := commit.CombinedOutput(); cerr != nil {
+			t.Fatalf("git commit: %v (%s)", cerr, out)
+		}
+		res := runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
+		if res.IdentityOk {
+			t.Fatal("an ambient identity must be reported, not hidden")
+		}
+		if res.ActedCommits == "" || res.ActedBlobs == "" {
+			t.Fatalf("the provenance must still be published: the lock is the commit set, not the author: %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "attribution only") {
+			t.Fatalf("the report must say what the difference costs: %q", res.LogTail)
 		}
 	})
 	t.Run("a commit under another identity is said", func(t *testing.T) {
@@ -661,6 +719,22 @@ func TestGoldenMasterExtendRestoreIsOnEveryWayOut(t *testing.T) {
 	}
 	if _, ok := cr.Workflow.Nodes["extend_refused"]; !ok {
 		t.Fatal("extend_refused is not a node")
+	}
+
+	// Attribution is EVIDENCE, never a term of convergence. Git's identity
+	// ENV outranks every config source and the agent cannot change the
+	// process environment, so a conjunct on it is unsatisfiable wherever a
+	// host exports it — the subbot would burn max_passes campaigns against a
+	// wall no pass can move. The lock is the commit set; this PR's own
+	// doctrine says the author is prose.
+	gate, ok := cr.Workflow.Nodes["extend_gate"].(*ir.ComputeNode)
+	if !ok {
+		t.Fatal("extend_gate is not a compute node")
+	}
+	for _, ex := range gate.Exprs {
+		if ex.Key == "converged" && strings.Contains(ex.Raw, "identity_ok") {
+			t.Fatalf("identity_ok is a conjunct of convergence: an ambient GIT_AUTHOR_EMAIL would make it unsatisfiable, and no pass of the agent can move it — %s", ex.Raw)
+		}
 	}
 
 	// The refusal the subbot states must travel with the verdict, or an agent

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -554,6 +554,98 @@ func TestGoldenMasterExtendBaseRepairsALeakedIdentity(t *testing.T) {
 	}
 }
 
+// TestGoldenMasterExtendBaseRefusesAnUnreadableIdentityMarker pins the one
+// unknown of this feature that failed OPEN. The marker is the DURABLE record
+// of the identity a previous extension displaced, and a run that reads it
+// unreadable is exactly the run whose local config already holds the NET's
+// name. Reading that config as "the previous identity" recorded the LEAK as
+// the thing to restore — extend_restore then put it back, the operator's
+// checkout committed under the net's name for good, and the one record that
+// could have repaired it had just been deleted on the way past.
+func TestGoldenMasterExtendBaseRefusesAnUnreadableIdentityMarker(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	const pending = `{"pending": [{"id": "E-L29-1", "lot": "L29"}]}`
+	for _, tc := range []struct {
+		name, body string
+	}{
+		{"a truncated marker", `{"name": "t", "ema`},
+		{"a marker that is not an identity object", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws, _ := extendVerifyRepo(t, verdict, pending)
+			// The state the repair exists for: the net's name on the
+			// workspace, and a marker that cannot say what it displaced.
+			gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+			marker := filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"),
+				"iterion-extend-prev-identity")
+			if err := os.WriteFile(marker, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			res := runExtendBase(t, ws)
+			if res.Clean || len(res.Pending) != 0 {
+				t.Fatalf("an unreadable marker read as a startable net: %+v", res)
+			}
+			if !strings.HasPrefix(res.Notice, "REFUSED") || !strings.Contains(res.Notice, marker) {
+				t.Fatalf("the refusal must name the record it could not read: %q", res.Notice)
+			}
+			// The two halves that made the leak permanent, neither taken:
+			// the record survives, and the identity is not mutated on top
+			// of it. (`user.name` is the oracle: the fixture leaked only
+			// the email, so the net's name appearing here can only have
+			// come from this node writing it.)
+			b, err := os.ReadFile(marker)
+			if err != nil || string(b) != tc.body {
+				t.Fatalf("the only record of the operator's identity was destroyed: %s (%v)", b, err)
+			}
+			if got := gitInNet(t, ws, "config", "--get", "user.name"); got != "t" {
+				t.Fatalf("a refused start must not touch the identity, got %q", got)
+			}
+		})
+	}
+}
+
+// TestGoldenMasterExtendBaseRefusesAnIdentityRepairGitDidNotTake pins the same
+// rule one branch over: the marker parses, so the repair runs — and `git
+// config` fails. Its exit code was dropped, so the workspace kept the net's
+// name, the `prev_email` read just below recorded THAT as the operator's
+// identity, and the marker that could have repaired it was deleted on the way
+// past. The unreadable-marker case refuses for exactly this outcome; a repair
+// that silently did not happen must reach the same door.
+func TestGoldenMasterExtendBaseRefusesAnIdentityRepairGitDidNotTake(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": [{"id": "E-L29-1", "lot": "L29"}]}`)
+	gitInNet(t, ws, "config", "user.name", "golden-master extend")
+	gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+	gitDir := gitInNet(t, ws, "rev-parse", "--absolute-git-dir")
+	marker := filepath.Join(gitDir, "iterion-extend-prev-identity")
+	const body = `{"name": "t", "email": "t@example.com"}`
+	if err := os.WriteFile(marker, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The failure, taken from git's own vocabulary rather than simulated: a
+	// stale lock is what a killed `git config` leaves behind, and it refuses
+	// every write to the config while it stands — whoever the test runs as.
+	if err := os.WriteFile(filepath.Join(gitDir, "config.lock"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendBase(t, ws)
+	if res.Clean || len(res.Pending) != 0 {
+		t.Fatalf("a workspace this run could not repair read as a startable net: %+v", res)
+	}
+	if !strings.HasPrefix(res.Notice, "REFUSED") || !strings.Contains(res.Notice, marker) {
+		t.Fatalf("the refusal must name the record it could not apply: %q", res.Notice)
+	}
+	// The half that made the leak permanent, not taken: the marker still
+	// holds the operator's identity, where a run that had gone on would have
+	// overwritten it with the net's own name — the record and the repair, both
+	// gone in one pass. (What the refused report SAYS about `prev_*` is inert:
+	// no node reads those fields, the marker is what the next run repairs
+	// from.)
+	if b, err := os.ReadFile(marker); err != nil || string(b) != body {
+		t.Fatalf("the only record of the operator's identity was destroyed: %s (%v)", b, err)
+	}
+}
+
 // runExtendRestore runs the subbot's terminal restore node against ws.
 func runExtendRestore(t *testing.T, ws string) map[string]any {
 	t.Helper()
@@ -648,6 +740,63 @@ func TestGoldenMasterExtendRestoreReturnsTheIdentityOnce(t *testing.T) {
 	again := runExtendRestore(t, ws)
 	if again["restored"] != false || !strings.Contains(again["notice"].(string), "no identity marker") {
 		t.Fatalf("a second restore must be a stated no-op: %+v", again)
+	}
+}
+
+// TestGoldenMasterExtendRestoreKeepsAnUnreadableMarker pins the other end of
+// the same rule: the marker is removed only once the identity it held is
+// BACK. A marker this node could not read is the last remaining record of
+// what the operator's identity was, on a workspace still wearing the net's —
+// deleting it there ends the repair for good, where keeping it makes the next
+// extend_base refuse and say so.
+func TestGoldenMasterExtendRestoreKeepsAnUnreadableMarker(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": []}`)
+	gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+	marker := filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"), "iterion-extend-prev-identity")
+	const corrupt = `{"name": "t", "ema`
+	if err := os.WriteFile(marker, []byte(corrupt), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendRestore(t, ws)
+	if res["restored"] != false || !strings.Contains(res["notice"].(string), "unreadable") {
+		t.Fatalf("an unreadable marker must be said, never reported restored: %+v", res)
+	}
+	b, err := os.ReadFile(marker)
+	if err != nil || string(b) != corrupt {
+		t.Fatalf("the record the next run repairs from was deleted: %s (%v)", b, err)
+	}
+}
+
+// TestGoldenMasterExtendRestoreKeepsAMarkerGitDidNotHonour pins the third case
+// of that same rule: the marker READS, so the restore runs — and `git config`
+// fails. Its exit code was dropped, so the node reported `restored: true` and
+// deleted the last record of the operator's identity on a workspace still
+// wearing the net's. "Back" is what git says, not what this node asked for.
+func TestGoldenMasterExtendRestoreKeepsAMarkerGitDidNotHonour(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": []}`)
+	gitInNet(t, ws, "config", "user.name", "golden-master extend")
+	gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+	gitDir := gitInNet(t, ws, "rev-parse", "--absolute-git-dir")
+	marker := filepath.Join(gitDir, "iterion-extend-prev-identity")
+	const body = `{"name": "t", "email": "t@example.com"}`
+	if err := os.WriteFile(marker, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config.lock"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendRestore(t, ws)
+	if res["restored"] != false {
+		t.Fatalf("a restore git did not honour was reported done: %+v", res)
+	}
+	if n, _ := res["notice"].(string); !strings.Contains(n, "could NOT be put back") ||
+		!strings.Contains(n, marker) {
+		t.Fatalf("the notice must name the record and the failure: %q", res["notice"])
+	}
+	if b, err := os.ReadFile(marker); err != nil || string(b) != body {
+		t.Fatalf("the record the next run repairs from was deleted: %s (%v)", b, err)
 	}
 }
 

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 )
 
 // The provenance of an extension act: the net's subbot reports the commits it
@@ -280,7 +281,7 @@ func runExtendBase(t *testing.T, ws string) extendBaseOut {
 func gitInNet(t *testing.T, ws string, args ...string) string {
 	t.Helper()
 	full := append([]string{"-C", ws}, args...)
-	cmd := exec.Command("git", full...)
+	cmd := exec.Command("git", gitlib.NoAutoMaintenance(full...)...)
 	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -472,7 +473,7 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 	// certifiable. Reported, not refused.
 	t.Run("an ambient git identity is said, and certifies all the same", func(t *testing.T) {
 		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
-		cmd := exec.Command("git", "-C", ws, "add", "-A")
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance("-C", ws, "add", "-A")...)
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
 			t.Fatal(err)
@@ -489,8 +490,9 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 			t.Fatalf("git add: %v (%s)", aerr, out)
 		}
 		// The environment wins over `-c user.email`, which is the whole point.
-		commit := exec.Command("git", "-C", ws, "-c", "user.email=extend@golden-master.iterion",
-			"-c", "user.name=x", "commit", "-qm", "act")
+		commit := exec.Command("git", gitlib.NoAutoMaintenance("-C", ws,
+			"-c", "user.email=extend@golden-master.iterion",
+			"-c", "user.name=x", "commit", "-qm", "act")...)
 		commit.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
 			"GIT_AUTHOR_EMAIL=ambient@host", "GIT_COMMITTER_EMAIL=ambient@host",
 			"GIT_AUTHOR_NAME=ambient", "GIT_COMMITTER_NAME=ambient")
@@ -1003,7 +1005,7 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 		}
 		g := func(args ...string) {
 			t.Helper()
-			cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+			cmd := exec.Command("git", gitlib.NoAutoMaintenance(append([]string{"-C", ws}, args...)...)...)
 			cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 			if out, gerr := cmd.CombinedOutput(); gerr != nil {
 				t.Fatalf("git %v: %v (%s)", args, gerr, out)
@@ -1059,7 +1061,7 @@ func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
 		}
 		g := func(args ...string) string {
 			t.Helper()
-			cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+			cmd := exec.Command("git", gitlib.NoAutoMaintenance(append([]string{"-C", ws}, args...)...)...)
 			cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 			out, gerr := cmd.CombinedOutput()
 			if gerr != nil {
@@ -1239,7 +1241,7 @@ func extensionLedgerRepo(t *testing.T, id string, extraBlocks ...string) (ws, ba
 	}
 	g := func(args ...string) string {
 		t.Helper()
-		cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+		cmd := exec.Command("git", gitlib.NoAutoMaintenance(append([]string{"-C", ws}, args...)...)...)
 		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 		out, gerr := cmd.CombinedOutput()
 		if gerr != nil {

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -348,6 +348,10 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 		gitInNet(t, ws, "-c", "user.email="+email, "-c", "user.name=x", "commit", "-qm", "act")
 		return gitInNet(t, ws, "rev-parse", "HEAD"), gitInNet(t, ws, "rev-parse", "HEAD:.golden-master/refs/002.txt")
 	}
+	res := func(t *testing.T, ws, base string) extendVerifyOut {
+		t.Helper()
+		return runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
+	}
 	t.Run("commits, blobs, ids and identity are published", func(t *testing.T) {
 		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
 		sha, blob := act(t, ws, "extend@golden-master.iterion")
@@ -375,6 +379,31 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 		runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
 		if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "extend@golden-master.iterion" {
 			t.Fatalf("the identity was restored inside the loop body — pass 2's agent would commit as %q and identity_ok could never hold again", got)
+		}
+	})
+	// Two certified paths, one of them carrying a SPACE: the certificate must
+	// come back as one entry per LINE. Space-joined, those two entries are
+	// indistinguishable from four tokens, and the reader drops the halves —
+	// which is how a certified reference loses its content binding and can be
+	// rewritten later while keeping its exemption.
+	t.Run("the certificate is one entry per line, spaces and all", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		spaced := ".golden-master/refs/a b.txt"
+		if err := os.WriteFile(filepath.Join(ws, filepath.FromSlash(spaced)), []byte("STATUS 200\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		act(t, ws, "extend@golden-master.iterion")
+		lines := strings.Split(res(t, ws, base).ActedBlobs, "\n")
+		if len(lines) != 2 {
+			t.Fatalf("two certified paths must publish two lines, got %q", lines)
+		}
+		seen := map[string]bool{}
+		for _, l := range lines {
+			p := l[:strings.LastIndex(l, "=")]
+			seen[p] = true
+		}
+		if !seen[spaced] || !seen[".golden-master/refs/002.txt"] {
+			t.Fatalf("a path with a space did not survive the encoding: %q", lines)
 		}
 	})
 	t.Run("a commit under another identity is said", func(t *testing.T) {
@@ -581,4 +610,184 @@ func TestGoldenMasterExtendRestoreIsOnEveryWayOut(t *testing.T) {
 			t.Fatalf("the published notice drops %s — the subbot's stated cause and the gate's deterministic verdict travel together, never one without the other: %s", want, notice)
 		}
 	}
+}
+
+// TestGoldenMasterExtendVerifyCertifiesNothingOnARefusedStart pins the second
+// half of the absorption refusal. extend_base refuses a dirty net by handing
+// the agent no pending request — prose, which the agent may ignore — while
+// this node published the run's commits as the net subbot's provenance
+// regardless. The lot's route: leave the reference and its act block
+// uncommitted, commit only the request so it routes here, and let the
+// subbot's tidy-up commit introduce the act inside `acted_commits`.
+func TestGoldenMasterExtendVerifyCertifiesNothingOnARefusedStart(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+	// Whatever gets committed in that window — here, the very content that
+	// made the net dirty.
+	if err := os.WriteFile(filepath.Join(ws, ".golden-master", "refs", "002.txt"), []byte("the lot's own file\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInNet(t, ws, "add", "-A")
+	gitInNet(t, ws, "-c", "user.email=extend@golden-master.iterion", "-c", "user.name=x",
+		"commit", "-qm", "tidy-up")
+
+	clean := runExtendVerifyClean(t, ws, base, `[{"id": "E-1"}]`, true)
+	if clean.ActedCommits == "" {
+		t.Fatal("fixture is wrong: a CLEAN start must publish the run's commits")
+	}
+	refused := runExtendVerifyClean(t, ws, base, `[{"id": "E-1"}]`, false)
+	if refused.ActedCommits != "" || refused.ActedIds != "" || refused.ActedBlobs != "" {
+		t.Fatalf("a refused start certified something: %+v", refused)
+	}
+	if refused.CleanStart {
+		t.Fatalf("clean_start must carry the refusal: %+v", refused)
+	}
+}
+
+// TestHarnessReadsTheCertificateOneEntryPerLine pins the parser against the
+// encoding, end to end: a surface path with a SPACE (both ids and paths are
+// lot-authored, and their guards reject slashes and dots, not whitespace) used
+// to split into two tokens — the left dropped, the right a bogus key — so the
+// real path had no certified blob and the post-act rewrite check never fired
+// for it. An entry the judge cannot read is now refused, not dropped.
+func TestHarnessReadsTheCertificateOneEntryPerLine(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	harness, err := filepath.Abs("golden-master/oracle-harness.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := func(t *testing.T, env ...string) (map[string]any, int) {
+		t.Helper()
+		ws := t.TempDir()
+		gm := filepath.Join(ws, ".golden-master")
+		if merr := os.MkdirAll(gm, 0o755); merr != nil {
+			t.Fatal(merr)
+		}
+		g := func(args ...string) {
+			t.Helper()
+			cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+			cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+			if out, gerr := cmd.CombinedOutput(); gerr != nil {
+				t.Fatalf("git %v: %v (%s)", args, gerr, out)
+			}
+		}
+		g("init", "-q", "-b", "main")
+		g("config", "user.email", "t@t")
+		g("config", "user.name", "t")
+		if werr := os.WriteFile(filepath.Join(gm, "corpus.json"), []byte(`{"entries": []}`), 0o644); werr != nil {
+			t.Fatal(werr)
+		}
+		g("add", "-A")
+		g("commit", "-qm", "base")
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(append(os.Environ(),
+			"GM_MODE=extend-verify", "GM_WORKSPACE="+ws, "GM_DIR=.golden-master",
+			"GM_BASE=HEAD"), env...)
+		out, _ := cmd.Output()
+		exit := 0
+		if cmd.ProcessState != nil {
+			exit = cmd.ProcessState.ExitCode()
+		}
+		var v map[string]any
+		if uerr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &v); uerr != nil {
+			t.Fatalf("no verdict: %v (out %q)", uerr, out)
+		}
+		return v, exit
+	}
+
+	t.Run("a path with a space keeps its certificate", func(t *testing.T) {
+		v, exit := run(t, "GM_ACTED_COMMITS=", "GM_ACTED_IDS=E 1",
+			"GM_ACTED_BLOBS=.golden-master/refs/a b.txt=1111111111111111111111111111111111111111")
+		if exit != 0 || v["error"] != nil {
+			t.Fatalf("a legal path was refused: exit %d %v", exit, v["error"])
+		}
+		// The proof the entry survived whole: `provenance` says the strict
+		// rule ran, and nothing was dropped on the floor.
+		if v["provenance"] != "strict" {
+			t.Fatalf("the provenance was not honoured: %v", v)
+		}
+	})
+	// The ids carry the same defect as the blobs, and it is the one Revi's
+	// finding did not name: an id with a space split OUT of the set, so the
+	// act it covers silently lost the content rule's protection. Driven
+	// through a real ledger, because only an act that NEEDS the hatch can
+	// show whether its id survived the parser.
+	t.Run("an act id with a space keeps its cover", func(t *testing.T) {
+		ws := t.TempDir()
+		gm := filepath.Join(ws, ".golden-master")
+		if err := os.MkdirAll(filepath.Join(gm, "refs"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		g := func(args ...string) string {
+			t.Helper()
+			cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+			cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+			out, gerr := cmd.CombinedOutput()
+			if gerr != nil {
+				t.Fatalf("git %v: %v (%s)", args, gerr, out)
+			}
+			return strings.TrimSpace(string(out))
+		}
+		g("init", "-q", "-b", "main")
+		g("config", "user.email", "t@t")
+		g("config", "user.name", "t")
+		if err := os.WriteFile(filepath.Join(gm, "corpus.json"), []byte(`{"entries": []}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		g("add", "-A")
+		g("commit", "-qm", "base")
+		base := g("rev-parse", "HEAD")
+		ledger := func(blocks string) {
+			if err := os.WriteFile(filepath.Join(gm, "EXTENSIONS.md"), []byte(blocks), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		const id = "E 1"
+		req := "<!-- iterion:extension-request\n" + `{"id": "` + id + `", "lot": "L", "type": "add-file", "paths": [".golden-master/refs/2.txt"]}` + "\n-->\n"
+		ledger(req)
+		g("add", "-A")
+		g("commit", "-qm", "the lot files it")
+		ledger(req + "<!-- iterion:extension-act\n" + `{"id": "` + id + `", "lot": "L", "recorded_paths": [".golden-master/refs/2.txt"]}` + "\n-->\n")
+		if err := os.WriteFile(filepath.Join(gm, "refs", "2.txt"), []byte("STATUS 200\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		g("add", "-A")
+		g("commit", "-qm", "acted")
+		blob := g("rev-parse", "HEAD:.golden-master/refs/2.txt")
+
+		// Strict provenance, no subbot commit reported: only the CONTENT rule
+		// can cover this act, and only if its id survived the parser.
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_MODE=extend-verify", "GM_WORKSPACE="+ws,
+			"GM_DIR=.golden-master", "GM_BASE="+base, "GM_ACTED_COMMITS=",
+			"GM_ACTED_IDS="+id,
+			"GM_ACTED_BLOBS=.golden-master/refs/2.txt="+blob)
+		out, _ := cmd.Output()
+		var v struct {
+			Acted []struct {
+				OK     bool `json:"ok"`
+				Forged bool `json:"forged"`
+			} `json:"acted"`
+		}
+		if uerr := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &v); uerr != nil {
+			t.Fatalf("no verdict: %v (%q)", uerr, out)
+		}
+		if len(v.Acted) != 1 || !v.Acted[0].OK || v.Acted[0].Forged {
+			t.Fatalf("an id with a space lost its cover — the parser split it out of the set: %+v", v.Acted)
+		}
+	})
+	t.Run("an entry the judge cannot read is refused, not dropped", func(t *testing.T) {
+		v, exit := run(t, "GM_ACTED_COMMITS=", "GM_ACTED_BLOBS=no-equals-sign-here")
+		if exit == 0 {
+			t.Fatalf("an unreadable certificate passed: %v", v)
+		}
+		msg, _ := v["error"].(string)
+		if !strings.Contains(msg, "not `path=blob`") {
+			t.Fatalf("the refusal must name what it could not read: %q", msg)
+		}
+	})
 }

--- a/bots/extension_provenance_test.go
+++ b/bots/extension_provenance_test.go
@@ -8,6 +8,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 )
 
 // The provenance of an extension act: the net's subbot reports the commits it
@@ -72,7 +75,7 @@ else:
 	const forgedStub = `import json, os
 mode = os.environ.get("GM_MODE")
 if mode == "extend-verify":
-    print(json.dumps({"acted": [{"id": "E-1", "ok": False, "forged": True, "introduced_by": "abc123def456", "author": "lot@run", "problems": ["the act was introduced by abc123def456 (author lot@run), which is not one of the net subbot's commits (none reported)"]}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+    print(json.dumps({"provenance": "strict", "acted": [{"id": "E-1", "ok": False, "forged": True, "introduced_by": "abc123def456", "author": "lot@run", "problems": ["the act was introduced by abc123def456 (author lot@run), which is not one of the net subbot's commits (none reported)"]}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
 elif mode == "extensions":
     print(json.dumps({"pending": []}))
 else:
@@ -88,6 +91,153 @@ else:
 			t.Fatalf("block_reason must name the forged act and its author: %q", res.BlockReason)
 		}
 	})
+	// The escape the two older refusals already guard against: `stop` is
+	// `converged || lot_blocked`, `lot_blocked` is what the CONSTRAINED party
+	// wrote into its own contract, and `lot_gate -> done when stop` is
+	// declared ahead of the fail edges — so a lot that forges an act AND
+	// declares itself blocked would end `finished`, its forged reference
+	// banked and mergeable.
+	t.Run("a forged act cannot ride out through a self-declared blocked lot", func(t *testing.T) {
+		ws, _, git := modernizeRepo(t, plan)
+		modernizeNet(t, ws)
+		if err := os.WriteFile(filepath.Join(ws, ".golden-master", "harness.py"), []byte(forgedStub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		git("add", "-A", ".golden-master")
+		git("commit", "-qm", "net")
+		base := git("rev-parse", "HEAD")
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"),
+			[]byte(strings.Replace(plan, "status: todo", "status: blocked", 1)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("commit", "-qam", "the worker declares its own lot blocked")
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.ExtensionForged || res.RefsUntouched {
+			t.Fatalf("the forged act must still be typed and refuse the references: %+v", res)
+		}
+		if res.LotBlocked {
+			t.Fatalf("a refused verdict is never a clean stop — lot_blocked must be cleared: %+v", res)
+		}
+	})
+	// The certifier is the TARGET's harness copy — a file the lot could write.
+	// One that CERTIFIES an act it also calls forged is the modelled hostile
+	// shape, and the parent's own term must refuse the references on it rather
+	// than read `ok` and exempt the path.
+	const hostileStub = `import json, os
+mode = os.environ.get("GM_MODE")
+if mode == "extend-verify":
+    print(json.dumps({"provenance": "strict", "acted": [{"id": "E-1", "ok": True, "forged": True, "introduced_by": "abc123def456", "author": "lot@run", "paths": [".golden-master/refs/002.txt"], "problems": []}], "ok_paths": [".golden-master/refs/002.txt"], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`
+	t.Run("a certifier that calls an act both ok and forged refuses the references", func(t *testing.T) {
+		ws, base := setup(t, hostileStub)
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.ExtensionForged || res.RefsUntouched {
+			t.Fatalf("a forged act refuses the references whatever the certifier calls it: %+v", res)
+		}
+	})
+	// A net synced BEFORE the provenance rule answers `extend-verify` and
+	// passes the capability probe, while judging by the same-commit rule
+	// alone — the rule a lot passes by acting in a second commit. Nothing in
+	// its answer says so, so the parent asserts the echo.
+	const legacyStub = `import json, os
+mode = os.environ.get("GM_MODE")
+if mode == "extend-verify":
+    print(json.dumps({"acted": [{"id": "E-1", "ok": True, "paths": [".golden-master/refs/002.txt"]}], "ok_paths": [".golden-master/refs/002.txt"], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`
+	t.Run("a certifier that never says it applied the rule is refused, not believed", func(t *testing.T) {
+		ws, base := setup(t, legacyStub)
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if !res.ExtensionForged || res.RefsUntouched || res.LotBlocked {
+			t.Fatalf("an unechoed provenance must refuse the lot: %+v", res)
+		}
+		if !strings.HasPrefix(res.BlockReason, "EXTENSION_UNCERTIFIED:") || !strings.Contains(res.BlockReason, "Sync the") {
+			t.Fatalf("block_reason must name the missing sync: %q", res.BlockReason)
+		}
+	})
+	// ... and an act ALREADY certified at the base needs no echo: an older net
+	// whose ledger carries one must not refuse every lot launched from it.
+	const legacyAtBaseStub = `import json, os
+mode = os.environ.get("GM_MODE")
+if mode == "extend-verify":
+    print(json.dumps({"acted": [{"id": "E-1", "ok": True, "acted_at_base": True, "paths": [], "problems": []}], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}))
+elif mode == "extensions":
+    print(json.dumps({"pending": []}))
+else:
+    print(json.dumps({"error": "stub answers only the extension modes"}))
+`
+	t.Run("an act already certified at the base is not re-refused", func(t *testing.T) {
+		ws, base := setup(t, legacyAtBaseStub)
+		res := modernizeLotVerify(t, script, ws, "L1", base, gate)
+		if res.ExtensionForged || !res.RefsUntouched {
+			t.Fatalf("an act certified at the base needs no echo: %+v", res)
+		}
+	})
+}
+
+// TestModernizeProvenanceRefusalIsTerminalAndDeclaredFirst pins the WIRING,
+// not the verdict: the refusal must be routed by an edge declared ahead of the
+// subbot edges and the repair loop — a verdict no pass can repair, on a tree
+// that may also carry a pending request the net's own subbot would act on. It
+// lands on a TYPED terminal, so the operator reads a code instead of the
+// FAIL_NODE a forged `done` also produces.
+func TestModernizeProvenanceRefusalIsTerminalAndDeclaredFirst(t *testing.T) {
+	const rel = "modernize/main.bot"
+	src, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr := parser.Parse(rel, string(src))
+	if pr.File == nil {
+		t.Fatal("main.bot does not parse")
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatal("main.bot does not compile")
+	}
+	forgedAt, target := -1, ""
+	var i int
+	var after []string
+	for _, e := range cr.Workflow.Edges {
+		if e.From != "lot_gate" {
+			continue
+		}
+		if e.Condition == "forged" && !e.Negated {
+			forgedAt, target = i, e.To
+		} else if forgedAt < 0 {
+			after = append(after, e.To)
+		}
+		i++
+	}
+	if forgedAt < 0 {
+		t.Fatal("no `lot_gate -> ... when forged` edge: a provenance refusal would fall through to the repair loop")
+	}
+	for _, before := range after {
+		switch before {
+		case "gate_timeout", "oracle_environment", "contract_unreadable":
+			// The other typed terminals may precede: each is its own wall.
+		default:
+			t.Fatalf("edge to %q is declared before the provenance refusal — the engine takes the first `when` that holds, so that verdict would route to %q first", before, before)
+		}
+	}
+	node, ok := cr.Workflow.Nodes[target]
+	if !ok {
+		t.Fatalf("the provenance refusal targets %q, which is not a node", target)
+	}
+	fail, isFail := node.(*ir.FailNode)
+	if !isFail {
+		t.Fatalf("the provenance refusal must be terminal, targets a %v node", node.NodeKind())
+	}
+	if fail.Code == "" {
+		t.Fatal("the provenance refusal must carry its own failure code: on the bare `fail` the operator reads the same FAIL_NODE a forged `done` produces")
+	}
 }
 
 type extendBaseOut struct {
@@ -209,6 +359,21 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 			t.Fatalf("a run under the engine's identity on a clean net must converge: %+v", res)
 		}
 	})
+	// The marker is the repair channel for a run that DIES; it must not
+	// outlive one that lives, or the next extension "repairs" a leak that is
+	// not there and restores a stale identity over the current one.
+	t.Run("the identity marker does not outlive the run that set it", func(t *testing.T) {
+		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
+		act(t, ws, "extend@golden-master.iterion")
+		marker := filepath.Join(gitInNet(t, ws, "rev-parse", "--absolute-git-dir"), "iterion-extend-prev-identity")
+		if err := os.WriteFile(marker, []byte(`{"name": "t", "email": "t@example.com"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runExtendVerify(t, ws, base, `[{"id": "E-L29-1"}]`)
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("the marker survived the restore: the next run would repair a leak that is not there (%v)", err)
+		}
+	})
 	t.Run("a commit under another identity is said", func(t *testing.T) {
 		ws, base := extendVerifyRepo(t, verdict, `{"pending": []}`)
 		act(t, ws, "lot@run")
@@ -217,4 +382,40 @@ func TestGoldenMasterExtendVerifyPublishesItsProvenance(t *testing.T) {
 			t.Fatalf("a commit under the lot's identity must be reported: %+v", res)
 		}
 	})
+}
+
+// TestGoldenMasterExtendBaseRepairsALeakedIdentity pins the failure path:
+// extend_base writes the net's identity into the workspace's local git config
+// and only extend_verify restores it, so an LLM error, a budget stop or a
+// cancel in between leaves the LOT committing under the net's name — and the
+// next run would read that leak as the state to restore, making it permanent.
+func TestGoldenMasterExtendBaseRepairsALeakedIdentity(t *testing.T) {
+	const verdict = `{"acted": [], "ok_paths": [], "ledger_append_only": True, "requests_added": 0, "problems": []}`
+	ws, _ := extendVerifyRepo(t, verdict, `{"pending": []}`)
+	// A previous extension died after setting the identity: the net's name is
+	// on the workspace, and the marker holds the identity it displaced.
+	gitInNet(t, ws, "config", "user.name", "golden-master extend")
+	gitInNet(t, ws, "config", "user.email", "extend@golden-master.iterion")
+	gitDir := gitInNet(t, ws, "rev-parse", "--absolute-git-dir")
+	marker := filepath.Join(gitDir, "iterion-extend-prev-identity")
+	if err := os.WriteFile(marker, []byte(`{"name": "t", "email": "t@example.com"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := runExtendBase(t, ws)
+	if res.PrevEmail != "t@example.com" || res.PrevName != "t" {
+		t.Fatalf("the leak must be repaired BEFORE this run reads the identity it will restore: %+v", res)
+	}
+	if !strings.Contains(res.Notice, "did not restore") {
+		t.Fatalf("a repaired leak must be said, not silently fixed: %q", res.Notice)
+	}
+	b, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("this run must leave its own marker for the next one: %v", err)
+	}
+	if !strings.Contains(string(b), "t@example.com") {
+		t.Fatalf("the marker must hold the repaired identity, not the leak: %s", b)
+	}
+	if got := gitInNet(t, ws, "config", "--get", "user.email"); got != "extend@golden-master.iterion" {
+		t.Fatalf("this run still commits under the net's identity, got %q", got)
+	}
 }

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -251,11 +251,51 @@ tool extend_base:
         p = subprocess.run(["git", "-C", ws] + list(args), capture_output=True, text=True)
         return (p.stdout or "").strip() if p.returncode == 0 else ""
 
+    # The identity is written into the workspace's LOCAL git config and only
+    # extend_verify restores it — so a run that dies in between (an LLM error,
+    # a budget stop, a cancel: ordinary failed_resumable outcomes) leaves the
+    # net's name on the LOT's later commits, and the next run would read the
+    # leak as the state to restore, making it permanent (review finding,
+    # executed). The pre-run identity is recorded in the git DIR — never the
+    # worktree: nothing there is committable, and nothing the gate judges —
+    # and re-applied by whichever run comes next.
+    git_dir = git_out("rev-parse", "--absolute-git-dir")
+    marker = os.path.join(git_dir, "iterion-extend-prev-identity") if git_dir else ""
+    if marker and os.path.isfile(marker):
+        leaked = None
+        try:
+            with open(marker, encoding="utf-8") as f:
+                leaked = json.load(f)
+        except (OSError, ValueError) as e:
+            notice = ((notice + " | ") if notice else "") + (
+                "the identity marker %s is unreadable (%s): this workspace may "
+                "still be committing under the net's name — check `git config "
+                "user.email` before trusting any attribution here" % (marker, e))
+        if isinstance(leaked, dict):
+            for key, val in (("user.name", leaked.get("name") or ""),
+                             ("user.email", leaked.get("email") or "")):
+                if val:
+                    subprocess.run(["git", "-C", ws, "config", key, val])
+                else:
+                    subprocess.run(["git", "-C", ws, "config", "--unset", key])
+            notice = ((notice + " | ") if notice else "") + (
+                "a previous extension did not restore the workspace identity; "
+                "the pre-run identity it recorded was re-applied before this "
+                "run read its own.")
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+
     prev_name = git_out("config", "--local", "--get", "user.name")
     prev_email = git_out("config", "--local", "--get", "user.email")
     if clean:
         # The identity the parent's gate attributes this run's acts to —
-        # set by the engine, restored by extend_verify, never by prose.
+        # set by the engine, restored by extend_verify, never by prose. The
+        # marker restores it when this run never reaches that node.
+        if marker:
+            with open(marker, "w", encoding="utf-8") as f:
+                json.dump({"name": prev_name, "email": prev_email}, f)
         subprocess.run(["git", "-C", ws, "config", "user.name", {{vars.actor_name}}])
         subprocess.run(["git", "-C", ws, "config", "user.email", {{vars.actor_email}}])
 
@@ -468,6 +508,15 @@ tool extend_verify:
             subprocess.run(["git", "-C", ws, "config", key, val])
         else:
             subprocess.run(["git", "-C", ws, "config", "--unset", key])
+    # Restored here, so the marker extend_base left for the run that would
+    # have had to repair a leak has nothing left to repair.
+    gd = subprocess.run(["git", "-C", ws, "rev-parse", "--absolute-git-dir"],
+                        capture_output=True, text=True)
+    if gd.returncode == 0 and gd.stdout.strip():
+        try:
+            os.remove(os.path.join(gd.stdout.strip(), "iterion-extend-prev-identity"))
+        except OSError:
+            pass
 
     report["log_tail"] = "\n".join(problems)[-6000:]
     print(json.dumps(report))

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -117,7 +117,16 @@ prompt extend_user:
   {{input.fail_log}}
 
   Report ONE short line in `summary` — including which requests you REFUSED
-  and why, if any. Anything longer belongs in the commit message.
+  and why, if any. That line is PUBLISHED to the run that asked: it is how a
+  refusal reaches the operator, so make it name the cause.
+
+  Write NOTHING outside the extension surface — not even a report of your own
+  refusal. The `golden-master` skill tells the rite that a `REPORT.md` of its
+  own is welcome; that freedom is the RITE's, not yours. Measured in
+  production: a refusal written to a report file made this bot's own gate say
+  «paths OUTSIDE the extension surface were changed … acting more than was
+  asked is smuggling», so the verdict was right and the reason an operator
+  read was false. When you refuse everything, commit nothing at all.
 
 ## ─── Schemas ───────────────────────────────────────────────────────
 
@@ -335,7 +344,6 @@ tool extend_verify:
     base = {{input.head}}
     before = {p.get("id") for p in ({{input.pending}} or []) if p.get("id")}
     clean = bool({{input.clean}})
-    prev_name, prev_email = ({{input.prev_name}} or ""), ({{input.prev_email}} or "")
     actor_email = {{vars.actor_email}}
 
     report = {"committed": False, "scope_clean": False, "out_of_scope": [],
@@ -407,11 +415,26 @@ tool extend_verify:
         report["out_of_scope"] = outside
         report["scope_clean"] = not outside
         if outside:
+            # A run that touched NO surface path acted nothing: its only
+            # change is the out-of-scope file, and calling that smuggling
+            # sends the operator hunting for an act that was never made —
+            # the true cause is in the refusal the summary carries
+            # (production finding: a refusal written to a report file read
+            # as an attempt to smuggle it in).
+            acted_any = any(p.startswith(allowed_prefix) or p in allowed_exact
+                            for p in touched)
             problems.append(
-                "%d path(s) OUTSIDE the extension surface were changed: %s. "
-                "This bot runs inside the lot's own workspace — anything it "
-                "may write, the lot may write through it. The check is the "
-                "boundary." % (len(outside), ", ".join(outside[:20])))
+                ("%d path(s) OUTSIDE the extension surface were changed: %s. "
+                 % (len(outside), ", ".join(outside[:20])))
+                + ("This bot runs inside the lot's own workspace — anything it "
+                   "may write, the lot may write through it. The check is the "
+                   "boundary."
+                   if acted_any else
+                   "This run acted NOTHING on the surface, so this is not an "
+                   "act that overreached: it is a file written beside the "
+                   "work — a refusal belongs in `summary`, which is "
+                   "published, and in nothing else. Drop the file; the "
+                   "refusal itself is not the failure."))
 
     def harness(mode, **extra):
         env = dict(os.environ, GM_MODE=mode, GM_WORKSPACE=ws, GM_DIR=gm, **extra)
@@ -501,22 +524,13 @@ tool extend_verify:
         still = {p_.get("id") for p_ in report["still_pending"]}
         report["acted_ids"] = " ".join(sorted(i for i in before if i not in still))
 
-    # The workspace identity goes back to what it was: the lot's later
-    # commits must not wear the net's name.
-    for key, val in (("user.name", prev_name), ("user.email", prev_email)):
-        if val:
-            subprocess.run(["git", "-C", ws, "config", key, val])
-        else:
-            subprocess.run(["git", "-C", ws, "config", "--unset", key])
-    # Restored here, so the marker extend_base left for the run that would
-    # have had to repair a leak has nothing left to repair.
-    gd = subprocess.run(["git", "-C", ws, "rev-parse", "--absolute-git-dir"],
-                        capture_output=True, text=True)
-    if gd.returncode == 0 and gd.stdout.strip():
-        try:
-            os.remove(os.path.join(gd.stdout.strip(), "iterion-extend-prev-identity"))
-        except OSError:
-            pass
+    # The identity is NOT restored here: this node is on the repair loop's
+    # body, and the loop re-enters the AGENT, not extend_base. Restoring at
+    # the end of every pass left pass 2 committing under the ambient identity
+    # — `identity_ok` false for good, so a first-pass refusal could never be
+    # repaired, and in a workspace with no ambient identity the agent could
+    # not commit at all (review finding, executed). It is restored once, on
+    # the way out, by extend_restore.
 
     report["log_tail"] = "\n".join(problems)[-6000:]
     print(json.dumps(report))
@@ -525,8 +539,6 @@ schema verify_input:
   head: string
   pending: json
   clean: bool
-  prev_name: string
-  prev_email: string
 
 ## A pure CONJUNCTION, never an aggregate. An extension that is additions-ok
 ## but out of scope is not "mostly fine" — it is a lot writing in the judge's
@@ -536,6 +548,64 @@ schema verify_input:
 ## written) leaves the run not converged — the parent's gate keeps refusing
 ## on the pending term either way, and this verdict must not read greener
 ## than that gate will.
+## The identity comes back ONCE, on the way out — the only place both exits
+## of the gate pass through. Its source is the marker extend_base wrote, not
+## an edge input: the marker is the durable record (a run that dies never
+## reaches this node, and the next extend_base repairs from it), and reading
+## it here makes the restore idempotent whatever path the run took.
+tool extend_restore:
+  output: restore_report
+  language: py
+  script: |
+    import json
+    import os
+    import subprocess
+
+    ws = {{vars.workspace_dir}}
+
+    def git_out(*args):
+        p = subprocess.run(["git", "-C", ws] + list(args), capture_output=True, text=True)
+        return (p.stdout or "").strip() if p.returncode == 0 else ""
+
+    git_dir = git_out("rev-parse", "--absolute-git-dir")
+    marker = os.path.join(git_dir, "iterion-extend-prev-identity") if git_dir else ""
+    report = {"restored": False, "notice": ""}
+    if not marker or not os.path.isfile(marker):
+        # No marker: extend_base refused the start (dirty net) and never set
+        # an identity, so there is nothing to put back. Said, not guessed.
+        report["notice"] = ("no identity marker under %s — this run set no "
+                            "identity to restore" % (git_dir or ws))
+    else:
+        try:
+            with open(marker, encoding="utf-8") as f:
+                prev = json.load(f)
+        except (OSError, ValueError) as e:
+            prev = None
+            report["notice"] = ("the identity marker %s is unreadable (%s): the "
+                                "workspace may still commit under the net's name "
+                                "— check `git config user.email`" % (marker, e))
+        if isinstance(prev, dict):
+            for key, val in (("user.name", prev.get("name") or ""),
+                             ("user.email", prev.get("email") or "")):
+                if val:
+                    subprocess.run(["git", "-C", ws, "config", key, val])
+                else:
+                    subprocess.run(["git", "-C", ws, "config", "--unset", key])
+            report["restored"] = True
+            report["notice"] = ("the workspace identity is back to %r: the lot's "
+                                "later commits must not wear the net's name"
+                                % (prev.get("email") or "unset"))
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+
+    print(json.dumps(report))
+
+schema restore_report:
+  restored: bool
+  notice: string
+
 compute extend_gate:
   output: gate_state
   expr:
@@ -550,7 +620,12 @@ compute extend_result:
   expr:
     converged: "outputs.extend_gate.converged"
     extended: "outputs.extend_verify.extended"
-    notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say', 'the extension was REFUSED: ' + outputs.extend_gate.fail_log)"
+    ## The subbot's own line travels with the deterministic verdict, plainly
+    ## attributed: without it the cause a refusal states reaches nobody, and
+    ## an agent told to «report in summary» writes a file instead to make its
+    ## reasoning survive — a file its own gate then refuses (production
+    ## finding). Evidence beside the verdict, never in place of it.
+    notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say. The subbot said: ' + outputs.extend_campaign.summary, 'the extension was REFUSED. The subbot said: ' + outputs.extend_campaign.summary + ' — the gate says: ' + outputs.extend_gate.fail_log)"
     acted_commits: "outputs.extend_verify.acted_commits"
     acted_ids: "outputs.extend_verify.acted_ids"
     acted_blobs: "outputs.extend_verify.acted_blobs"
@@ -572,15 +647,17 @@ workflow extend:
   }
 
   extend_campaign -> extend_verify with {
-    head:       "{{outputs.extend_base.head}}",
-    pending:    "{{outputs.extend_base.pending}}",
-    clean:      "{{outputs.extend_base.clean}}",
-    prev_name:  "{{outputs.extend_base.prev_name}}",
-    prev_email: "{{outputs.extend_base.prev_email}}"
+    head:    "{{outputs.extend_base.head}}",
+    pending: "{{outputs.extend_base.pending}}",
+    clean:   "{{outputs.extend_base.clean}}"
   }
 
   extend_verify -> extend_gate
-  extend_gate -> extend_result when converged
+
+  ## Every way out of the gate goes through the restore — converged or not,
+  ## first pass or last. The loop re-enters the AGENT, so a restore inside
+  ## the loop body disarms the identity for every pass after the first.
+  extend_gate -> extend_restore when converged
 
   ## Refused → one more pass, carrying the deterministic refusal so the agent
   ## fixes the cause instead of re-deriving it.
@@ -592,6 +669,7 @@ workflow extend:
   ## Loop exhausted → report the refusal rather than swallow it. The parent's
   ## gate keeps refusing on the pending requests, so this bot failing must
   ## never be quieter than this bot not existing.
-  extend_gate -> extend_result
+  extend_gate -> extend_restore
 
+  extend_restore -> extend_result
   extend_result -> done

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -316,36 +316,97 @@ tool extend_base:
     git_dir = git_out("rev-parse", "--absolute-git-dir")
     marker = os.path.join(git_dir, "iterion-extend-prev-identity") if git_dir else ""
     if marker and os.path.isfile(marker):
-        leaked = None
+        leaked, why = None, ""
         try:
             with open(marker, encoding="utf-8") as f:
                 leaked = json.load(f)
+            if not isinstance(leaked, dict):
+                why = "it holds %s, not an identity object" % type(leaked).__name__
         except (OSError, ValueError) as e:
-            notice = ((notice + " | ") if notice else "") + (
-                "the identity marker %s is unreadable (%s): this workspace may "
-                "still be committing under the net's name — check `git config "
-                "user.email` before trusting any attribution here" % (marker, e))
-        if isinstance(leaked, dict):
-            for key, val in (("user.name", leaked.get("name") or ""),
-                             ("user.email", leaked.get("email") or "")):
+            why = str(e)
+        if why:
+            # REFUSED, not guessed. This marker is the DURABLE record of the
+            # identity a previous extension displaced, and the run that reads
+            # it unreadable is exactly the run on whose path the local config
+            # already holds the NET's name. Reading the config as "the
+            # previous identity" would record the leak as the thing to
+            # restore, extend_restore would put it back, and the operator's
+            # checkout would commit under the net's name FOR GOOD — with the
+            # one record that could have repaired it deleted on the way past.
+            # So: the identity is not touched, the marker is not removed, no
+            # request is handed to the agent, and the unknown is said. Same
+            # rule as the status above ("an unknown is refused, not assumed")
+            # and as the certifier's ("a certificate the judge cannot read is
+            # refused, not dropped"); this was the one unknown of the feature
+            # that failed OPEN.
+            clean = False
+            pending = []
+            notice = ("REFUSED at start: the identity marker %s cannot be read "
+                      "(%s), so the identity this workspace must be restored TO "
+                      "is UNKNOWN — and guessing it from `git config` would "
+                      "record the net's own name as the operator's and make the "
+                      "leak permanent. The marker is kept, nothing is acted, the "
+                      "identity is untouched. Check `git config user.email`, put "
+                      "the operator's identity back by hand, delete %s, then "
+                      "relaunch." % (marker, why, marker)) + \
+                     ((" | " + notice) if notice else "")
+        else:
+            want = {"user.name": leaked.get("name") or "",
+                    "user.email": leaked.get("email") or ""}
+            for key, val in want.items():
                 if val:
                     subprocess.run(["git", "-C", ws, "config", key, val])
                 else:
                     subprocess.run(["git", "-C", ws, "config", "--unset", key])
-            notice = ((notice + " | ") if notice else "") + (
-                "a previous extension did not restore the workspace identity; "
-                "the pre-run identity it recorded was re-applied before this "
-                "run read its own.")
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
+            # git must AGREE the repair took, before the record of it is
+            # destroyed. `git config` can fail — a stale `config.lock`, a
+            # read-only `.git` — and its exit code was dropped here: the
+            # workspace kept the net's name, `prev_email` twenty lines below
+            # read THAT as the operator's identity, extend_restore put it back,
+            # and the marker that could have repaired it was already gone. The
+            # unreadable-marker branch just above refuses for exactly this
+            # outcome; a repair that silently did not happen reaches it too.
+            back = {k: git_out("config", "--local", "--get", k) for k in want}
+            if back != want:
+                clean = False
+                pending = []
+                notice = ("REFUSED at start: the identity marker %s records %r, "
+                          "but git still reports %r after re-applying it — this "
+                          "workspace commits under someone else's name and this "
+                          "run cannot repair it, so it will not record that name "
+                          "as the operator's. The marker is kept, nothing is "
+                          "acted. Check for a stale %s, put the identity back by "
+                          "hand, delete %s, then relaunch."
+                          % (marker, want, back,
+                             os.path.join(git_dir, "config.lock"), marker)) + \
+                         ((" | " + notice) if notice else "")
+            else:
+                notice = ((notice + " | ") if notice else "") + (
+                    "a previous extension did not restore the workspace identity; "
+                    "the pre-run identity it recorded was re-applied before this "
+                    "run read its own.")
+                try:
+                    os.remove(marker)
+                except OSError:
+                    pass
+
+    # No git dir, no marker, and no marker means no durable record of the
+    # identity this run would displace — so setting one would be a leak by
+    # construction, repairable by nothing. Refused for the same reason.
+    if clean and not marker:
+        clean = False
+        pending = []
+        notice = ("REFUSED at start: `git rev-parse --absolute-git-dir` gave "
+                  "nothing on %s, so this run has nowhere to record the identity "
+                  "it would displace — an identity set with no durable record to "
+                  "restore it from is a leak by construction" % ws) + \
+                 ((" | " + notice) if notice else "")
 
     prev_name = git_out("config", "--local", "--get", "user.name")
     prev_email = git_out("config", "--local", "--get", "user.email")
     if clean:
         # The identity the parent's gate attributes this run's acts to —
-        # set by the engine, restored by extend_verify, never by prose. The
+        # set by the engine, restored by extend_restore, never by prose. The
         # marker restores it when this run never reaches that node.
         if marker:
             with open(marker, "w", encoding="utf-8") as f:
@@ -692,20 +753,39 @@ tool extend_restore:
                                 "workspace may still commit under the net's name "
                                 "— check `git config user.email`" % (marker, e))
         if isinstance(prev, dict):
-            for key, val in (("user.name", prev.get("name") or ""),
-                             ("user.email", prev.get("email") or "")):
+            want = {"user.name": prev.get("name") or "",
+                    "user.email": prev.get("email") or ""}
+            for key, val in want.items():
                 if val:
                     subprocess.run(["git", "-C", ws, "config", key, val])
                 else:
                     subprocess.run(["git", "-C", ws, "config", "--unset", key])
-            report["restored"] = True
-            report["notice"] = ("the workspace identity is back to %r: the lot's "
-                                "later commits must not wear the net's name"
-                                % (prev.get("email") or "unset"))
-        try:
-            os.remove(marker)
-        except OSError:
-            pass
+            # Removed only once the identity it held is BACK — and "back" is
+            # what git says, not what this node asked for. `git config` can
+            # fail (a stale `config.lock`, a read-only `.git`) and its exit
+            # code was dropped, so a restore that never happened reported
+            # `restored: true` and deleted the last record of the operator's
+            # identity, on a workspace still wearing the net's — the very
+            # outcome the unreadable-marker branch below refuses.
+            back = {k: git_out("config", "--local", "--get", k) for k in want}
+            if back == want:
+                report["restored"] = True
+                report["notice"] = ("the workspace identity is back to %r: the "
+                                    "lot's later commits must not wear the net's "
+                                    "name" % (prev.get("email") or "unset"))
+                try:
+                    os.remove(marker)
+                except OSError:
+                    pass
+            else:
+                report["notice"] = ("the identity could NOT be put back: the "
+                                    "marker %s records %r and git still reports "
+                                    "%r — this workspace may keep committing "
+                                    "under the net's name. The marker is kept so "
+                                    "the next run repairs from it; check for a "
+                                    "stale %s and `git config user.email`."
+                                    % (marker, want, back,
+                                       os.path.join(git_dir, "config.lock")))
 
     print(json.dumps(report))
 

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -36,6 +36,12 @@ vars:
   ## One acting pass, then a second only if the first was refused. A third
   ## pass on the same refusal is an agent arguing with a deterministic check.
   max_passes: int = 2
+  ## The git identity the ENGINE sets for this run's commits (extend_base
+  ## sets it, extend_verify checks it and restores the previous one): the
+  ## parent's gate attributes every act to its author. Prose could set an
+  ## author too — attribution, not the lock; the lock is `acted_commits`.
+  actor_name:  string = "golden-master extend"
+  actor_email: string = "extend@golden-master.iterion"
 
 ## ─── Prompts ───────────────────────────────────────────────────────
 
@@ -80,7 +86,13 @@ prompt extend_system:
   in the act: a claimed entry claims its derived refs/<id>.txt.
 
   Commit your work. The verdict is read from git; uncommitted work is
-  invisible to it.
+  invisible to it. Commit under the identity the engine set for this run —
+  do not change it: the parent's gate attributes every act to its author,
+  and every commit of this run is reported to the parent as the net's.
+
+  If the pending list is EMPTY, act nothing and end: either nothing was
+  pending, or the net's directory was already dirty when this run started
+  and the extension was refused before you — the verdict says which.
 
 prompt extend_user:
   Repository: `{{vars.workspace_dir}}`. Net: `{{vars.oracle_dir}}`.
@@ -123,6 +135,15 @@ schema base_state:
   dirty: string
   pending: json
   notice: string
+  ## The net's directory was clean when this run started. False refuses
+  ## the run before the agent: an uncommitted file under the net could be
+  ## the constrained party's write, and this run committing it would
+  ## certify it as the net's — nothing this run commits could be told from
+  ## what was already there.
+  clean: bool
+  ## The workspace identity before this run set its own, restored after.
+  prev_name: string
+  prev_email: string
 
 ## Not one field here is an opinion.
 schema verify_report:
@@ -135,16 +156,34 @@ schema verify_report:
   still_pending: json
   extended: int
   log_tail: string
+  ## The run started on a clean net (extend_base's word, carried into the
+  ## conjunction so a refused start cannot read as a converged run).
+  clean_start: bool
+  ## Every commit of this run carries the identity the engine set.
+  identity_ok: bool
+  ## What the parent cross-checks in the harness: the commits this run
+  ## made (base..HEAD, 40-hex, space-separated), the request ids it acted,
+  ## and the blob it certified for each surface path (`path=blob`, space-
+  ## separated). Strings: they travel through the parent's edges as text.
+  acted_commits: string
+  acted_ids: string
+  acted_blobs: string
 
 schema gate_state:
   converged: bool
   fail_log: string
 
-## What the parent reads back.
+## What the parent reads back. The three strings are the provenance the
+## parent hands to the harness at its own gate: an act introduced by any
+## commit outside `acted_commits`, or a certified path whose blob moved,
+## is refused there.
 schema extend_result:
   converged: bool
   extended: int
   notice: string
+  acted_commits: string
+  acted_ids: string
+  acted_blobs: string
 
 ## ─── Nodes ─────────────────────────────────────────────────────────
 
@@ -184,17 +223,45 @@ tool extend_base:
         except (ValueError, IndexError):
             notice = ("the harness did not answer GM_MODE=extensions (exit %d): %s"
                       % (p.returncode, (p.stdout + p.stderr)[-400:]))
-    if dirty.returncode == 0 and dirty.stdout.strip() and not notice:
-        # Said, not refused: the parent commits its lot before verifying, so a
-        # dirty tree here means something else is in flight — and this run's
-        # additions would be indistinguishable from it in the diff.
+    dirty_paths = [l[3:] for l in dirty.stdout.splitlines() if l.strip()] if dirty.returncode == 0 else []
+    net_dirty = [q for q in dirty_paths if q.startswith(gm.rstrip("/") + "/")]
+    clean = not net_dirty
+    if net_dirty:
+        # REFUSED, not said: an uncommitted file under the net is either the
+        # constrained party's write into the judge's territory or a leftover,
+        # and this run committing it would certify it as the net's own —
+        # measured as the absorption attack in the plan review. Nothing is
+        # acted: the agent receives no pending request.
+        notice = ("REFUSED at start: the net's directory was already dirty when "
+                  "this extension started (%d path(s) under %s: %s). Nothing this "
+                  "run commits could be told from what was already there, so "
+                  "nothing is acted. The parent commits its lot before verifying; "
+                  "commit or drop those paths, then relaunch."
+                  % (len(net_dirty), gm, ", ".join(net_dirty[:12])))
+        pending = []
+    elif dirty_paths and not notice:
+        # Said, not refused: dirt OUTSIDE the net cannot become a reference;
+        # the checks below compare against HEAD, so it is read as this run's.
         notice = ("the workspace was already dirty when this extension started "
-                  "(%d path(s)); the checks below compare against HEAD, so those "
-                  "changes will be read as this run's."
-                  % len([l for l in dirty.stdout.splitlines() if l.strip()]))
+                  "(%d path(s) outside the net); the checks below compare against "
+                  "HEAD, so those changes will be read as this run's."
+                  % len(dirty_paths))
+
+    def git_out(*args):
+        p = subprocess.run(["git", "-C", ws] + list(args), capture_output=True, text=True)
+        return (p.stdout or "").strip() if p.returncode == 0 else ""
+
+    prev_name = git_out("config", "--local", "--get", "user.name")
+    prev_email = git_out("config", "--local", "--get", "user.email")
+    if clean:
+        # The identity the parent's gate attributes this run's acts to —
+        # set by the engine, restored by extend_verify, never by prose.
+        subprocess.run(["git", "-C", ws, "config", "user.name", {{vars.actor_name}}])
+        subprocess.run(["git", "-C", ws, "config", "user.email", {{vars.actor_email}}])
 
     print(json.dumps({"head": head.stdout.strip(), "dirty": dirty.stdout.strip(),
-                      "pending": pending, "notice": notice}))
+                      "pending": pending, "notice": notice, "clean": clean,
+                      "prev_name": prev_name, "prev_email": prev_email}))
 
 agent extend_campaign:
   backend: "claude_code"
@@ -223,19 +290,47 @@ tool extend_verify:
     import subprocess
 
     ws = {{vars.workspace_dir}}
+    null = None; true = True; false = False  # JSON-literal shim for missing refs
     gm = {{vars.oracle_dir}}
     base = {{input.head}}
     before = {p.get("id") for p in ({{input.pending}} or []) if p.get("id")}
+    clean = bool({{input.clean}})
+    prev_name, prev_email = ({{input.prev_name}} or ""), ({{input.prev_email}} or "")
+    actor_email = {{vars.actor_email}}
 
     report = {"committed": False, "scope_clean": False, "out_of_scope": [],
               "additions_ok": False, "refused": [], "no_new_requests": False,
-              "still_pending": [], "extended": 0, "log_tail": ""}
+              "still_pending": [], "extended": 0, "log_tail": "",
+              "clean_start": clean, "identity_ok": False,
+              "acted_commits": "", "acted_ids": "", "acted_blobs": ""}
     problems = []
+    if not clean:
+        problems.append("REFUSED at start: the net's directory was dirty when this run "
+                        "started (see extend_base) — nothing was acted, nothing is certified")
 
     def git(*args):
         p = subprocess.run(["git", "-C", ws] + list(args),
                            capture_output=True, text=True, timeout=120)
         return p.returncode, p.stdout, p.stderr
+
+    # The run's own commits, what the parent cross-checks at its gate: every
+    # commit of base..HEAD is this run's (the parent committed its lot before
+    # this subbot started), reported as 40-hex shas — and each must carry the
+    # identity the engine set, or the attribution the parent reads is a lie.
+    code, out, err = git("rev-list", "%s..HEAD" % base)
+    if code != 0:
+        problems.append("cannot list this run's commits (%s..HEAD): %s" % (base, err.strip()))
+        run_commits = []
+    else:
+        run_commits = [l.strip() for l in out.splitlines() if l.strip()]
+    report["acted_commits"] = " ".join(run_commits)
+    code, out, _ = git("log", "--format=%H %ae", "%s..HEAD" % base)
+    others = [l for l in (out.splitlines() if code == 0 else []) if l.strip() and l.split()[-1] != actor_email]
+    report["identity_ok"] = code == 0 and not others
+    if others:
+        problems.append("%d commit(s) of this run carry another identity than the engine set "
+                        "(%s): %s — the parent attributes acts to their author"
+                        % (len(others), actor_email, ", ".join(o[:12] for o in others[:6])))
 
     # 1. Committed. The verdict below reads git; uncommitted work is a tree
     #    the verdict never sees.
@@ -290,10 +385,24 @@ tool extend_verify:
                             % (mode, p.returncode, (p.stdout + p.stderr)[-400:]))
             return None
 
+    # The blob this run certified for each surface path: the parent's gate
+    # exempts a path only while HEAD still carries that blob — the
+    # certificate covers the content, not the path forever.
+    blobs = []
+    for p_ in touched:
+        if p_.startswith(allowed_prefix) or p_ == gmp + "/corpus.json":
+            code, out, _ = git("rev-parse", "HEAD:%s" % p_)
+            if code == 0 and out.strip():
+                blobs.append("%s=%s" % (p_, out.strip()))
+    report["acted_blobs"] = " ".join(blobs)
+
     # 3. Additions-only, decided by the harness's own code — the same code
-    #    that refuses at the gate, so passing here and failing there is not a
-    #    state that exists.
-    verdict = harness("extend-verify", GM_BASE=base)
+    #    that refuses at the gate, and called with the same provenance the
+    #    parent will hand it (this run's commits and blobs), so passing here
+    #    and failing there is not a state that exists.
+    verdict = harness("extend-verify", GM_BASE=base,
+                      GM_ACTED_COMMITS=report["acted_commits"],
+                      GM_ACTED_BLOBS=report["acted_blobs"])
     if verdict is not None:
         if verdict.get("error"):
             problems.append(str(verdict["error"]))
@@ -349,6 +458,16 @@ tool extend_verify:
         report["still_pending"] = listing.get("pending") or []
         report["refused"] = [p_ for p_ in report["still_pending"]
                              if p_.get("id") in before]
+        still = {p_.get("id") for p_ in report["still_pending"]}
+        report["acted_ids"] = " ".join(sorted(i for i in before if i not in still))
+
+    # The workspace identity goes back to what it was: the lot's later
+    # commits must not wear the net's name.
+    for key, val in (("user.name", prev_name), ("user.email", prev_email)):
+        if val:
+            subprocess.run(["git", "-C", ws, "config", key, val])
+        else:
+            subprocess.run(["git", "-C", ws, "config", "--unset", key])
 
     report["log_tail"] = "\n".join(problems)[-6000:]
     print(json.dumps(report))
@@ -356,6 +475,9 @@ tool extend_verify:
 schema verify_input:
   head: string
   pending: json
+  clean: bool
+  prev_name: string
+  prev_email: string
 
 ## A pure CONJUNCTION, never an aggregate. An extension that is additions-ok
 ## but out of scope is not "mostly fine" — it is a lot writing in the judge's
@@ -368,7 +490,7 @@ schema verify_input:
 compute extend_gate:
   output: gate_state
   expr:
-    converged: "outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests && length(outputs.extend_verify.still_pending) == 0"
+    converged: "outputs.extend_verify.clean_start && outputs.extend_verify.identity_ok && outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests && length(outputs.extend_verify.still_pending) == 0"
     fail_log: "outputs.extend_verify.log_tail"
 
 ## What the parent reads back. `extended` is the harness's count, never the
@@ -380,6 +502,9 @@ compute extend_result:
     converged: "outputs.extend_gate.converged"
     extended: "outputs.extend_verify.extended"
     notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say', 'the extension was REFUSED: ' + outputs.extend_gate.fail_log)"
+    acted_commits: "outputs.extend_verify.acted_commits"
+    acted_ids: "outputs.extend_verify.acted_ids"
+    acted_blobs: "outputs.extend_verify.acted_blobs"
 
 workflow extend:
   entry: extend_base
@@ -398,8 +523,11 @@ workflow extend:
   }
 
   extend_campaign -> extend_verify with {
-    head:    "{{outputs.extend_base.head}}",
-    pending: "{{outputs.extend_base.pending}}"
+    head:       "{{outputs.extend_base.head}}",
+    pending:    "{{outputs.extend_base.pending}}",
+    clean:      "{{outputs.extend_base.clean}}",
+    prev_name:  "{{outputs.extend_base.prev_name}}",
+    prev_email: "{{outputs.extend_base.prev_email}}"
   }
 
   extend_verify -> extend_gate

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -457,7 +457,14 @@ tool extend_verify:
             code, out, _ = git("rev-parse", "HEAD:%s" % p_)
             if code == 0 and out.strip():
                 blobs.append("%s=%s" % (p_, out.strip()))
-    report["acted_blobs"] = " ".join(blobs)
+    # ONE ENTRY PER LINE: a surface path or a request id may contain a space
+    # (both are lot-authored, and their guards reject `/`, `\\`, `.` and `..`,
+    # not whitespace), and a space-delimited certificate splits such an entry
+    # into two unreadable tokens — the path then has no certified blob and the
+    # act loses the content binding that closes the masking vector (review
+    # finding). The reader refuses an entry it cannot parse; here we make sure
+    # there is none to refuse.
+    report["acted_blobs"] = "\n".join(blobs)
 
     # 3. Additions-only, decided by the harness's own code — the same code
     #    that refuses at the gate, and called with the same provenance the
@@ -522,7 +529,24 @@ tool extend_verify:
         report["refused"] = [p_ for p_ in report["still_pending"]
                              if p_.get("id") in before]
         still = {p_.get("id") for p_ in report["still_pending"]}
-        report["acted_ids"] = " ".join(sorted(i for i in before if i not in still))
+        report["acted_ids"] = "\n".join(sorted(i for i in before if i not in still))
+
+    # A REFUSED start certifies NOTHING. extend_base hands the agent no
+    # pending request when the net was already dirty, so anything committed in
+    # this window is the dirty net's own content — the constrained party's
+    # file — absorbed into this run's commits. Published as provenance, it
+    # would make the parent's gate exempt exactly the path the refusal exists
+    # to reject: the lot leaves `refs/<x>` and its act block uncommitted,
+    # commits only the request, and the subbot's tidy-up commit introduces the
+    # act inside `acted_commits` (review finding). `clean_start` was computed
+    # and fed only the subbot's own gate, which nothing downstream reads — so
+    # the defence rested on the agent obeying prose. It rests here now.
+    #
+    # Deliberately NOT extended to identity_ok: the lock is the commit SET,
+    # and an identity that leaked is an attribution defect, not a claim that
+    # someone else committed — the parent's gate already refuses on it.
+    if not clean:
+        report["acted_commits"] = report["acted_ids"] = report["acted_blobs"] = ""
 
     # The identity is NOT restored here: this node is on the repair loop's
     # body, and the loop re-enters the AGENT, not extend_base. Restoring at

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -411,8 +411,32 @@ tool extend_base:
         if marker:
             with open(marker, "w", encoding="utf-8") as f:
                 json.dump({"name": prev_name, "email": prev_email}, f)
-        subprocess.run(["git", "-C", ws, "config", "user.name", {{vars.actor_name}}])
-        subprocess.run(["git", "-C", ws, "config", "user.email", {{vars.actor_email}}])
+        want = {"user.name": {{vars.actor_name}}, "user.email": {{vars.actor_email}}}
+        for key, val in want.items():
+            subprocess.run(["git", "-C", ws, "config", key, val])
+        # The THIRD site of the class the two above closed: git must agree it
+        # took. A `config` that silently failed here left the workspace on the
+        # operator's identity while every notice this run publishes says the
+        # net's — the attribution the whole marker dance exists to make legible
+        # would be wrong, and quietly. The marker is dropped with the refusal
+        # because nothing was displaced: keeping it would make the NEXT run
+        # read a leak that never happened and "restore" over a live identity.
+        back = {k: git_out("config", "--local", "--get", k) for k in want}
+        if back != want:
+            clean = False
+            pending = []
+            if marker:
+                try:
+                    os.remove(marker)
+                except OSError:
+                    pass
+            notice = ("REFUSED at start: the net's identity could not be set — "
+                      "asked for %r, git reports %r. Acting now would commit the "
+                      "net's work under someone else's name while every line "
+                      "this run publishes claims otherwise. Check for a stale %s "
+                      "and that %s is writable, then relaunch."
+                      % (want, back, os.path.join(git_dir, "config.lock"), ws)) + \
+                     ((" | " + notice) if notice else "")
 
     print(json.dumps({"head": head.stdout.strip(), "dirty": "\n".join(dirty_paths),
                       "pending": pending, "notice": notice, "clean": clean,

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -156,6 +156,8 @@ schema base_state:
 
 ## Not one field here is an opinion.
 schema verify_report:
+  ## The agent's own line, as a string whatever it produced.
+  agent_summary: string
   committed: bool
   scope_clean: bool
   out_of_scope: string[]
@@ -216,7 +218,7 @@ tool extend_base:
 
     head = subprocess.run(["git", "-C", ws, "rev-parse", "HEAD"],
                           capture_output=True, text=True)
-    dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+    dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain", "-z"],
                            capture_output=True, text=True)
 
     pending, notice = [], ""
@@ -232,7 +234,27 @@ tool extend_base:
         except (ValueError, IndexError):
             notice = ("the harness did not answer GM_MODE=extensions (exit %d): %s"
                       % (p.returncode, (p.stdout + p.stderr)[-400:]))
-    dirty_paths = [l[3:] for l in dirty.stdout.splitlines() if l.strip()] if dirty.returncode == 0 else []
+    # `--porcelain` QUOTES any path carrying a non-ASCII byte, a quote, a
+    # backslash or a control character: `.golden-master/refs/é.txt` comes back
+    # as `".golden-master/refs/\303\251.txt"`, so a raw prefix match misses it
+    # and a dirty net reads CLEAN — the absorption this refusal exists to
+    # stop, reachable with a single accented file name (review finding,
+    # reproduced against real git). `-z` never quotes. A rename carries its
+    # ORIGIN as the next token, and a reference moved OUT of the net dirties
+    # it as surely as one moved in — `R  old -> new` matched neither side.
+    # extend_verify already passes `-c core.quotePath=false` for this exact
+    # reason; the two halves of one file disagreed.
+    dirty_paths = []
+    if dirty.returncode == 0:
+        toks = [t for t in dirty.stdout.split("\0") if t]
+        i = 0
+        while i < len(toks):
+            xy, path = toks[i][:2], toks[i][3:]
+            dirty_paths.append(path)
+            i += 1
+            if ("R" in xy or "C" in xy) and i < len(toks):
+                dirty_paths.append(toks[i])
+                i += 1
     net_dirty = [q for q in dirty_paths if q.startswith(gm.rstrip("/") + "/")]
     clean = not net_dirty
     if net_dirty:
@@ -308,7 +330,7 @@ tool extend_base:
         subprocess.run(["git", "-C", ws, "config", "user.name", {{vars.actor_name}}])
         subprocess.run(["git", "-C", ws, "config", "user.email", {{vars.actor_email}}])
 
-    print(json.dumps({"head": head.stdout.strip(), "dirty": dirty.stdout.strip(),
+    print(json.dumps({"head": head.stdout.strip(), "dirty": "\n".join(dirty_paths),
                       "pending": pending, "notice": notice, "clean": clean,
                       "prev_name": prev_name, "prev_email": prev_email}))
 
@@ -344,13 +366,18 @@ tool extend_verify:
     base = {{input.head}}
     before = {p.get("id") for p in ({{input.pending}} or []) if p.get("id")}
     clean = bool({{input.clean}})
+    # The agent's own line, made a STRING here so nothing downstream adds a
+    # null: `{{input.agent_summary}}` renders `null` for a node that produced
+    # none, and the graph's `+` refuses to concatenate that.
+    agent_summary = ({{input.agent_summary}} or "")
     actor_email = {{vars.actor_email}}
 
     report = {"committed": False, "scope_clean": False, "out_of_scope": [],
               "additions_ok": False, "refused": [], "no_new_requests": False,
               "still_pending": [], "extended": 0, "log_tail": "",
               "clean_start": clean, "identity_ok": False,
-              "acted_commits": "", "acted_ids": "", "acted_blobs": ""}
+              "acted_commits": "", "acted_ids": "", "acted_blobs": "",
+              "agent_summary": agent_summary}
     problems = []
     if not clean:
         problems.append("REFUSED at start: the net's directory was dirty when this run "
@@ -563,6 +590,9 @@ schema verify_input:
   head: string
   pending: json
   clean: bool
+  ## The agent's own one-line report, carried through so the verdict can
+  ## publish it as a string (see extend_result.notice).
+  agent_summary: string
 
 ## A pure CONJUNCTION, never an aggregate. An extension that is additions-ok
 ## but out of scope is not "mostly fine" — it is a lot writing in the judge's
@@ -572,6 +602,30 @@ schema verify_input:
 ## written) leaves the run not converged — the parent's gate keeps refusing
 ## on the pending term either way, and this verdict must not read greener
 ## than that gate will.
+## A start REFUSED before the agent leaves by its own door.
+##
+## `clean` is read once, in extend_base, and carried unchanged onto every
+## pass — so the conjunct it feeds is false forever and no pass can flip it.
+## Routing it through the campaign anyway paid a full claude_code run, then
+## `max_passes` more of them, to report a refusal node 1 already knew (review
+## finding, executed). Worse than the cost: extend_base says "the agent
+## receives no pending request", and the agent still got the workspace with
+## commit access — that half rested on the prompt line "act nothing and end",
+## which is prose.
+##
+## No identity was set on this path (extend_base only sets it when clean), so
+## there is nothing to restore either.
+compute extend_refused:
+  output: extend_result
+  publish: notice
+  expr:
+    converged: "false"
+    extended: "0"
+    notice: "'the extension was REFUSED before the agent ran. ' + outputs.extend_base.notice"
+    acted_commits: "''"
+    acted_ids: "''"
+    acted_blobs: "''"
+
 ## The identity comes back ONCE, on the way out — the only place both exits
 ## of the gate pass through. Its source is the marker extend_base wrote, not
 ## an edge input: the marker is the durable record (a run that dies never
@@ -649,7 +703,19 @@ compute extend_result:
     ## an agent told to «report in summary» writes a file instead to make its
     ## reasoning survive — a file its own gate then refuses (production
     ## finding). Evidence beside the verdict, never in place of it.
-    notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say. The subbot said: ' + outputs.extend_campaign.summary, 'the extension was REFUSED. The subbot said: ' + outputs.extend_campaign.summary + ' — the gate says: ' + outputs.extend_gate.fail_log)"
+    ## The subbot's own line travels with the deterministic verdict, plainly
+    ## attributed: without it the cause a refusal states reaches nobody, and
+    ## an agent told to «report in summary» writes a file instead to make its
+    ## reasoning survive — a file its own gate then refuses (production
+    ## finding). Evidence beside the verdict, never in place of it.
+    ##
+    ## Read from extend_verify, not from the agent node: `if()` evaluates
+    ## BOTH branches (its arguments are computed before the call), so a
+    ## summary the agent omitted would render null and `string + null` is a
+    ## typed error — the compute would fail and take down a run that was only
+    ## reporting a refusal. A tool node's `or ""` makes it a string once, and
+    ## everything downstream can add it.
+    notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say. The subbot said: ' + outputs.extend_verify.agent_summary, 'the extension was REFUSED. The subbot said: ' + outputs.extend_verify.agent_summary + ' — the gate says: ' + outputs.extend_gate.fail_log)"
     acted_commits: "outputs.extend_verify.acted_commits"
     acted_ids: "outputs.extend_verify.acted_ids"
     acted_blobs: "outputs.extend_verify.acted_blobs"
@@ -665,15 +731,19 @@ workflow extend:
     max_duration: "1h"
     max_cost_usd: 20
 
+  ## Declared FIRST: a deterministic refusal must not buy an LLM pass.
+  extend_base -> extend_refused when not clean
+
   extend_base -> extend_campaign with {
     pending:  "{{outputs.extend_base.pending}}",
     fail_log: ""
   }
 
   extend_campaign -> extend_verify with {
-    head:    "{{outputs.extend_base.head}}",
-    pending: "{{outputs.extend_base.pending}}",
-    clean:   "{{outputs.extend_base.clean}}"
+    head:          "{{outputs.extend_base.head}}",
+    pending:       "{{outputs.extend_base.pending}}",
+    clean:         "{{outputs.extend_base.clean}}",
+    agent_summary: "{{outputs.extend_campaign.summary}}"
   }
 
   extend_verify -> extend_gate
@@ -696,4 +766,5 @@ workflow extend:
   extend_gate -> extend_restore
 
   extend_restore -> extend_result
+  extend_refused -> done
   extend_result -> done

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -170,7 +170,14 @@ schema verify_report:
   ## The run started on a clean net (extend_base's word, carried into the
   ## conjunction so a refused start cannot read as a converged run).
   clean_start: bool
-  ## Every commit of this run carries the identity the engine set.
+  ## Every commit of this run carries the identity the engine set —
+  ## REPORTED, never a term of convergence. The lock is `acted_commits`;
+  ## the author is prose, and this PR's own doctrine says so. Making it a
+  ## conjunct also made it UNSATISFIABLE wherever the environment exports
+  ## GIT_AUTHOR_EMAIL / GIT_COMMITTER_EMAIL — those outrank every config
+  ## source, the agent cannot change the process environment, and the
+  ## subbot would burn max_passes campaigns against a wall no pass can
+  ## move (review finding, reproduced).
   identity_ok: bool
   ## What the parent cross-checks in the harness: the commits this run
   ## made (base..HEAD, 40-hex, space-separated), the request ids it acted,
@@ -244,8 +251,18 @@ tool extend_base:
     # it as surely as one moved in — `R  old -> new` matched neither side.
     # extend_verify already passes `-c core.quotePath=false` for this exact
     # reason; the two halves of one file disagreed.
+    #
+    # And a status this run cannot READ is not a clean net. `clean` decides
+    # whether the identity is set, whether the agent is handed the pending
+    # requests, and — through extend_verify — whether any certificate is
+    # published at all: its unknown must fail CLOSED, like every other
+    # unknown in this feature ("an unprovable act is refused, not assumed";
+    # "a certificate the judge cannot read is refused, not dropped"). It
+    # failed OPEN: a locked index granted exactly the window the refusal
+    # exists to close (review finding).
     dirty_paths = []
-    if dirty.returncode == 0:
+    status_ok = dirty.returncode == 0
+    if status_ok:
         toks = [t for t in dirty.stdout.split("\0") if t]
         i = 0
         while i < len(toks):
@@ -256,8 +273,14 @@ tool extend_base:
                 dirty_paths.append(toks[i])
                 i += 1
     net_dirty = [q for q in dirty_paths if q.startswith(gm.rstrip("/") + "/")]
-    clean = not net_dirty
-    if net_dirty:
+    clean = status_ok and not net_dirty
+    if not status_ok:
+        why = ((dirty.stderr or "").strip() or "exit %d" % dirty.returncode)[:300]
+        notice = ("REFUSED at start: git could not report the workspace state "
+                  "(%s) — whether the net is clean is UNKNOWN, and an unknown "
+                  "is refused, not assumed" % why)
+        pending = []
+    elif net_dirty:
         # REFUSED, not said: an uncommitted file under the net is either the
         # constrained party's write into the judge's territory or a leftover,
         # and this run committing it would certify it as the net's own —
@@ -403,8 +426,14 @@ tool extend_verify:
     others = [l for l in (out.splitlines() if code == 0 else []) if l.strip() and l.split()[-1] != actor_email]
     report["identity_ok"] = code == 0 and not others
     if others:
+        # SAID, not refused: attribution is evidence and the lock is the
+        # commit set. An environment that exports GIT_AUTHOR_EMAIL outranks
+        # every config source, so a refusal here would be one no pass could
+        # repair — and the acts would be exactly as certifiable.
         problems.append("%d commit(s) of this run carry another identity than the engine set "
-                        "(%s): %s — the parent attributes acts to their author"
+                        "(%s): %s — attribution only; the lock is the commit set, "
+                        "and an environment exporting GIT_AUTHOR_EMAIL/GIT_COMMITTER_EMAIL "
+                        "outranks the identity this run configured"
                         % (len(others), actor_email, ", ".join(o[:12] for o in others[:6])))
 
     # 1. Committed. The verdict below reads git; uncommitted work is a tree
@@ -687,7 +716,7 @@ schema restore_report:
 compute extend_gate:
   output: gate_state
   expr:
-    converged: "outputs.extend_verify.clean_start && outputs.extend_verify.identity_ok && outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests && length(outputs.extend_verify.still_pending) == 0"
+    converged: "outputs.extend_verify.clean_start && outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests && length(outputs.extend_verify.still_pending) == 0"
     fail_log: "outputs.extend_verify.log_tail"
 
 ## What the parent reads back. `extended` is the harness's count, never the

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -584,9 +584,14 @@ tool extend_verify:
     report["acted_blobs"] = "\n".join(blobs)
 
     # 3. Additions-only, decided by the harness's own code — the same code
-    #    that refuses at the gate, and called with the same provenance the
-    #    parent will hand it (this run's commits and blobs), so passing here
-    #    and failing there is not a state that exists.
+    #    that refuses at the gate, and called with this run's commits and
+    #    blobs, so passing here and failing there is not a state that exists.
+    #
+    #    Not identical to the parent's call, and deliberately: `GM_ACTED_IDS`
+    #    is unknown until the listing below says what is STILL pending, and
+    #    the id clause only ever EXEMPTS. Absent, it is the stricter call —
+    #    this check can refuse what the parent would certify, never the
+    #    reverse, which is the direction that keeps the sentence above true.
     verdict = harness("extend-verify", GM_BASE=base,
                       GM_ACTED_COMMITS=report["acted_commits"],
                       GM_ACTED_BLOBS=report["acted_blobs"])

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1295,6 +1295,17 @@ tool oracle_run:
             if not isinstance(obj, dict) or \
                     not (isinstance(obj.get("id"), str) and obj.get("id")):
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+                # An id reaches the gate through a LINE-ORIENTED transport
+                # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
+                # arrives as two fragments and seeds the covered set with an id no
+                # subbot ever acted; one made only of whitespace cannot be told
+                # from a blank line. Refused at this single parse point rather
+                # than repaired downstream — a repair is precisely what collapses
+                # two distinct ids into one, and the collapse re-opens the
+                # smuggling this file exists to close. An INTERIOR space stays
+                # legal: it round-trips whole, and a lot-authored id may carry one.
+                obj = {"id": "UNPARSEABLE", "raw": body[:120]}
             else:
                 # The list-shaped fields are iterated by every judgement below. A
                 # scalar here raised TypeError inside the verdict, and a verdict
@@ -1356,7 +1367,9 @@ tool oracle_run:
         acts = _extension_blocks(text, "act")
         if any(b.get("id") == "UNPARSEABLE" for b in requests + acts):
             return [{"id": "UNPARSEABLE",
-                     "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+                     "why": "a ledger block does not parse as JSON, or carries an "
+                            "id that cannot survive the one-id-per-line "
+                            "certificate — escalate, do not guess"}]
         # Only a WELL-FORMED act closes a request: an act with no recorded path
         # acted nothing, and letting it close the term would let the constrained
         # party silence the conjunction with four lines of JSON — the
@@ -1515,7 +1528,9 @@ tool oracle_run:
                       _extension_blocks(head_txt, "act"))
         if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
             verdict["problems"].append(
-                "a ledger block does not parse as JSON — escalate, do not guess")
+                "a ledger block does not parse as JSON, or carries an id that "
+                "cannot survive the one-id-per-line certificate — escalate, do "
+                "not guess")
         requests = {b["id"]: b for b in _extension_blocks(head_txt, "request")
                     if b.get("id") != "UNPARSEABLE"}
         acts = [b for b in _extension_blocks(head_txt, "act")
@@ -5265,7 +5280,14 @@ tool oracle_run:
             # rule only ever EXEMPTS.
             acted_ids = None
             if "GM_ACTED_IDS" in os.environ:
-                acted_ids = {l.strip() for l in
+                # The RAW line, exactly as the blob certificate above reads its
+                # own: `.strip()` is an emptiness test here, never a repair.
+                # Normalising the id while `extension_verdict` compares it
+                # verbatim made two ids differing only by surrounding whitespace
+                # collapse into one — the act the subbot REFUSED came back covered
+                # by the id it had acted, which is the smuggling of a refused
+                # extension, reopened by an encoding.
+                acted_ids = {l for l in
                              os.environ.get("GM_ACTED_IDS", "").splitlines()
                              if l.strip()}
             print(json.dumps(extension_verdict(

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1431,9 +1431,12 @@ tool oracle_run:
         the same-commit rule saw nothing, and the lot's own file became a
         reference of the net that judges it.
 
-        `acted_blobs` also bounds the exemption: a certified path whose blob at
-        HEAD moved since the act was rewritten by someone after the subbot —
-        the certificate covers the content it certified, not the path forever.
+        `acted_blobs` also bounds the exemption, on the path SET as much as on
+        the content: a certified path whose blob at HEAD moved since the act was
+        rewritten by someone after the subbot, and a recorded path the subbot
+        certified no blob for was never acted at all — the act's own block is
+        above the run's base, so append-only leaves it mutable and first-wins
+        provenance keeps naming the subbot's commit however it is edited.
         `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
         reports having acted, and no other. Without it the content rule exempts
         any act naming a certified path, which a lot reaches by filing two
@@ -1812,15 +1815,32 @@ tool oracle_run:
                     "the act records no path on the extension surface (refs/ or "
                     "corpus.json) — filing paperwork is not an extension")
             if acted_blobs is not None and req is not None:
-                # The certificate covers the CONTENT the subbot committed, not
-                # the path forever: a reference rewritten after the act — by the
-                # lot, in its own later commit — is the masking vector again, and
-                # the exemption must not follow it.
+                # The certificate binds the act's recorded path SET, not only the
+                # content of the paths it happens to name. Both halves are the same
+                # masking vector, reached through the same door:
+                #   - a certified path whose blob moved was rewritten after the
+                #     act, by the lot, in its own later commit;
+                #   - a recorded path with NO certificate was never acted at all.
+                #     `introducing_commits` resolves an act FIRST-WINS on
+                #     (kind, id), so it keeps naming the subbot's commit however
+                #     the block is edited afterwards, and append-only only pins the
+                #     text below the RUN's base — the subbot's own block sits above
+                #     it, in the mutable region. Widening that block with the lot's
+                #     own path made an uncertified file a reference of the net that
+                #     judges it. The strict provenance arm already demands a
+                #     certificate for every surface path; this is that same demand
+                #     on the arm standing in for it.
                 for p in paths:
                     if p == ledger_rel or p == corpus_rel:
                         continue
                     certified = acted_blobs.get(p)
-                    if certified and blob_id("HEAD", p) != certified:
+                    if not certified:
+                        row["forged"] = True
+                        row["problems"].append(
+                            "%s is recorded by the act but the subbot certified no "
+                            "blob for it — a path appended to the record after the "
+                            "act is not part of the act" % p)
+                    elif blob_id("HEAD", p) != certified:
                         row["forged"] = True
                         row["problems"].append(
                             "%s was rewritten after the act: HEAD carries blob %s, "
@@ -4128,6 +4148,44 @@ tool oracle_run:
             check("l'acte du subbot reste certifie, lui",
                   [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
+
+            # LE MEME TROU PAR L'AUTRE BATTANT : au lieu d'apposer un SECOND bloc,
+            # le lot ELARGIT celui du subbot. La provenance se resout premier-gagnant
+            # sur (kind, id), donc `act_sha` reste le commit du subbot quoi qu'il
+            # arrive au bloc ; l'append-only ne fige que le texte sous la base, et le
+            # bloc du subbot est au-dessus. Le chemin ajoute n'a aucun blob certifie
+            # — et une absence de certificat passait, la garde ne mordant que sur un
+            # certificat present.
+            act_widened = ('{"id": "E-1", "lot": "L",'
+                           ' "recorded_paths": [".golden-master/refs/2.txt",'
+                           ' ".golden-master/refs/9.txt"]}')
+            xreset()
+            xledger(("request", req_two))
+            xcommit()                                          # le lot depose
+            xledger(("request", req_two), ("act", act_one))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("acte par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")      # le subbot acte
+            sha_w = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_w = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                         xroot, timeout=60)[1].strip()
+            xledger(("request", req_two), ("act", act_widened))
+            with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+                f.write("ecrit par le lot\n")
+            xcommit(email="lot@run")                           # le lot elargit l'acte
+            v_wide = extension_verdict(xroot, ".golden-master", xbase,
+                                       acted_commits={sha_w},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_w},
+                                       acted_ids={"E-1"})
+            wide = v_wide["acted"][0]
+            check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+                  "et le chemin ajoute n'est pas exempte",
+                  [wide["ok"], wide.get("forged"),
+                   ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
+                  [False, True, False])
+            check("et le chemin que le subbot a bien certifie n'exempte plus rien "
+                  "non plus : c'est l'acte entier qui est refuse",
+                  v_wide["ok_paths"], [])
 
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1389,9 +1389,27 @@ tool oracle_run:
                           sort_keys=True, ensure_ascii=False)
 
 
-    def extension_verdict(ws, gm_rel, base):
+    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
         """Judge every ACTED extension against `base`, in git — never against the
         acting party's word.
+
+        `acted_commits` (None, or a set of 40-hex shas) is what the NET's own
+        subbot reports having committed in this segment — read by main() from
+        GM_ACTED_COMMITS, which the parent bot defines even when empty. None
+        means the caller predates provenance (today's rule only: request and
+        act in one commit refuse); a set means STRICT: an act introduced in
+        base..HEAD by a commit outside it was written by the constrained party,
+        whatever author it carries, and is refused — unless every path it
+        records carries at HEAD the exact blob the subbot certified
+        (`acted_blobs`, path → blob id): a history rewritten after the subbot
+        ran keeps its certified content and loses its shas. Measured on a live
+        campaign: a lot filed a request in one commit and acted it in the next,
+        the same-commit rule saw nothing, and the lot's own file became a
+        reference of the net that judges it.
+
+        `acted_blobs` also bounds the exemption: a certified path whose blob at
+        HEAD moved since the act was rewritten by someone after the subbot —
+        the certificate covers the content it certified, not the path forever.
 
         Per acted request, every recorded path must be a pure addition:
           - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1420,6 +1438,11 @@ tool oracle_run:
             code, out, _ = git("ls-tree", ref, "--", path)
             return out.split()[0] if code == 0 and out.strip() else ""
 
+        def blob_id(ref, path):
+            code, out, _ = git("ls-tree", ref, "--", path)
+            parts = out.split() if code == 0 else []
+            return parts[2] if len(parts) >= 3 else ""
+
         ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
         corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
         refs_prefix = gm_rel.rstrip("/") + "/refs/"
@@ -1434,11 +1457,15 @@ tool oracle_run:
             subbot never ran — production cannot produce that shape, because the
             parent commits its lot before the subbot starts (adversarial finding,
             executed)."""
-            code, out, _ = git("log", "--format=%H", "--reverse", "--", ledger_rel)
+            code, out, _ = git("log", "--format=%H%x00%ae", "--reverse", "--", ledger_rel)
             if code != 0:
                 return None
             first = {}
-            for sha in out.split():
+            for line in out.splitlines():
+                sha, _, email = line.partition("\0")
+                sha = sha.strip()
+                if not sha:
+                    continue
                 text = at(sha, ledger_rel)
                 if text is None:
                     continue
@@ -1447,6 +1474,7 @@ tool oracle_run:
                         bid = b.get("id")
                         if isinstance(bid, str) and bid:
                             first.setdefault((kind, bid), sha)
+                            first.setdefault(("author", kind, bid), email.strip())
             return first
 
         # An unresolvable base and an honest "absent at base" both read as None
@@ -1613,9 +1641,36 @@ tool oracle_run:
                     "request and the act, so the net's subbot never judged it — "
                     "filing and answering are different powers"
                     % intro[("act", act.get("id"))][:12])
+                row["forged"] = True
             paths = [p for p in (act.get("recorded_paths") or [])
                      if isinstance(p, str) and p]
             row["paths"] = paths
+            act_sha = (intro or {}).get(("act", act.get("id")))
+            if act_sha:
+                row["introduced_by"] = act_sha[:12]
+                row["author"] = (intro or {}).get(("author", "act", act.get("id"))) or ""
+            # Provenance, when the parent states what the net's subbot committed:
+            # an act introduced by any other commit was written by the party the
+            # oracle constrains — whatever author it carries, an author is prose.
+            # The one way back in is the CONTENT: every recorded path carrying at
+            # HEAD the exact blob the subbot certified (a history rewritten after
+            # the subbot ran).
+            if acted_commits is not None and req is not None and act_sha \
+                    and act_sha not in acted_commits:
+                blobs_match = bool(paths) and acted_blobs is not None and all(
+                    acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                    for p in paths if p != ledger_rel)
+                if not blobs_match:
+                    row["forged"] = True
+                    row["problems"].append(
+                        "the act was introduced by %s (author %s), which is not one "
+                        "of the net subbot's commits%s — an act the constrained party "
+                        "wrote is a refusal, not an extension. If the history was "
+                        "rewritten after the subbot ran, relaunch on a fresh base; "
+                        "otherwise remove the act block and file the request only."
+                        % (act_sha[:12], row.get("author") or "?",
+                           (" (%s)" % ", ".join(sorted(c[:12] for c in acted_commits)))
+                           if acted_commits else " (none reported)"))
             if req is not None and not paths:
                 row["problems"].append(
                     "the act records no path — an extension that touched "
@@ -1675,6 +1730,21 @@ tool oracle_run:
                 row["problems"].append(
                     "the act records no path on the extension surface (refs/ or "
                     "corpus.json) — filing paperwork is not an extension")
+            if acted_blobs is not None and req is not None:
+                # The certificate covers the CONTENT the subbot committed, not
+                # the path forever: a reference rewritten after the act — by the
+                # lot, in its own later commit — is the masking vector again, and
+                # the exemption must not follow it.
+                for p in paths:
+                    if p == ledger_rel or p == corpus_rel:
+                        continue
+                    certified = acted_blobs.get(p)
+                    if certified and blob_id("HEAD", p) != certified:
+                        row["forged"] = True
+                        row["problems"].append(
+                            "%s was rewritten after the act: HEAD carries blob %s, "
+                            "the subbot certified %s — the certificate covers the "
+                            "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
             row["ok"] = (req is not None and not row["problems"]
                          and verdict["ledger_append_only"])
             if row["ok"]:
@@ -3769,9 +3839,11 @@ tool oracle_run:
                     f.write("\n".join("<!-- iterion:extension-%s\n%s\n-->" % b
                                       for b in blks))
 
-            def xcommit():
+            def xcommit(email="t@t"):
+                # fixture_git already sets a committer; a later -c wins, so the
+                # override rides it instead of bypassing the failure check.
                 fixture_git(xroot, "add", "-A")
-                fixture_git(xroot, "commit", "-qm", "x")
+                fixture_git(xroot, "-c", "user.email=%s" % email, "commit", "-qm", "x")
 
             def xrequest(req):
                 """The lot files its request and commits. A fixture that stages a
@@ -3841,6 +3913,44 @@ tool oracle_run:
             v_touch = xverdict(xbase_acted)
             check("acte a la base + ref reecrite -> le certificat n'exempte rien",
                   [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
+
+            # 8f. Provenance : un acte doit venir des commits du subbot du filet
+            #     (publies par le parent), ou porter EXACTEMENT le contenu certifie
+            #     (historique reecrit apres le subbot). L'auteur est de la prose.
+            xreset()
+            xrequest(req2)                                   # commit A, le lot
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("forge par le lot\n")
+            xcommit(email="lot@run")                         # commit B, le lot acte
+            sha_b = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_b = run("git rev-parse HEAD:.golden-master/refs/2.txt", xroot, timeout=60)[1].strip()
+            v_old = extension_verdict(xroot, ".golden-master", xbase)
+            check("sans provenance (appelant d'avant) : l'auto-acte en deux commits passe encore",
+                  v_old["acted"][0]["ok"], True)
+            v_strict = extension_verdict(xroot, ".golden-master", xbase, acted_commits=set())
+            check("provenance stricte, aucun commit du subbot : l'auto-acte est refuse, forge, auteur nomme",
+                  [v_strict["acted"][0]["ok"], v_strict["acted"][0].get("forged"),
+                   v_strict["acted"][0].get("author"), v_strict["ok_paths"]],
+                  [False, True, "lot@run", []])
+            v_sub = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b})
+            check("l'acte introduit par un commit du subbot passe, chemin exempte",
+                  [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
+            v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
+                  v_blob["acted"][0]["ok"], True)
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("reecrit apres l'acte\n")
+            xcommit(email="lot@run")                         # commit C, le lot reecrit
+            v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
+                                     acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+                  [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
+                  [False, True, []])
+            v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                      acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
 
             # Reecriture deguisee : la ref existait a la base.
             xreset()
@@ -4951,8 +5061,25 @@ tool oracle_run:
                                   "additions against nothing would pass by "
                                   "construction"}))
                 raise SystemExit(1)
+            # Provenance from the PARENT: present (even empty) means strict —
+            # the parent bot always defines it, because the only pass that
+            # judges a self-act is the one where no subbot ran at all. Absent
+            # means a caller that predates provenance: today's rule only.
+            acted_commits = acted_blobs = None
+            if "GM_ACTED_COMMITS" in os.environ:
+                acted_commits = set()
+                for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
+                    full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
+                    acted_commits.add(full if len(full) == 40 else tok)
+            if "GM_ACTED_BLOBS" in os.environ:
+                acted_blobs = {}
+                for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
+                    path, sep, sha = tok.rpartition("=")
+                    if sep and path and sha:
+                        acted_blobs[path] = sha
             print(json.dumps(extension_verdict(
-                ws, os.environ.get("GM_DIR", ".golden-master"), base)))
+                ws, os.environ.get("GM_DIR", ".golden-master"), base,
+                acted_commits=acted_commits, acted_blobs=acted_blobs)))
             raise SystemExit(0)
 
         # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3562,14 +3562,16 @@ tool oracle_run:
         # check_output all reach the kernel through it; hooking run alone would
         # leave the other four unseen. os.system reaches neither and is refused
         # outright rather than watched, so the door nobody guards fails closed.
-        _git_audit = {"seen": 0, "offenders": []}
+        _git_audit = {"direct": 0, "shell": 0, "offenders": []}
         _real_popen = subprocess.Popen
         _real_system = os.system
 
         class _AuditedPopen(_real_popen):
             def __init__(self, args, *rest, **kw):
+                program = args[0] if isinstance(args, (list, tuple)) and args else args
+                spawns_git = os.path.basename(str(program)) == "git"
                 for tokens in _git_command_lines(args):
-                    _git_audit["seen"] += 1
+                    _git_audit["direct" if spawns_git else "shell"] += 1
                     if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
                         _git_audit["offenders"].append(" ".join(tokens)[:120])
                 super().__init__(args, *rest, **kw)
@@ -5377,10 +5379,17 @@ tool oracle_run:
         # spawns git its own way is caught by having RUN, which is the only thing
         # that found the one this replaces.
         check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-              " (%d invocations vues)" % _git_audit["seen"],
+              " (%d invocations vues : %d en argv, %d via sh -c)"
+              % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
               _git_audit["offenders"], [])
-        check("le selftest lance bien des commandes git (l'audit a une prise)",
-              _git_audit["seen"] > 0, True)
+        # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
+        # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
+        # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
+        # propre. C'est le plancher d'un banc, pas une mesure de couverture.
+        check("l'audit voit les commandes git lancees en argv direct",
+              _git_audit["direct"] > 0, True)
+        check("l'audit voit les commandes git lancees a travers un shell",
+              _git_audit["shell"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3593,13 +3593,29 @@ tool oracle_run:
             raise AssertionError(
                 "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
 
-        saved_git_env = {k: os.environ.get(k) for k in
-                         ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
-                          "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+        # APPENDED after whatever is already declared, never written at index 0:
+        # the engine injects the workspace's safe.directory entry through this same
+        # environment (runtime/sandbox_mounts.go sets GIT_CONFIG_COUNT=1), so
+        # writing slot 0 destroys it and every git of the selftest then refuses the
+        # workspace for dubious ownership. Measured: safe.directory=/tmp/x became
+        # whatever the operator's global config said, or nothing.
+        raw_count = os.environ.get("GIT_CONFIG_COUNT", "0") or "0"
+        try:
+            base_count = int(raw_count)
+        except ValueError:
+            raise SystemExit(
+                "selftest: GIT_CONFIG_COUNT=%r is not a count — refusing to guess "
+                "where to append the auto-maintenance switches" % raw_count)
+        if base_count < 0:
+            raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+        saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
         for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
-            os.environ["GIT_CONFIG_KEY_%d" % i] = key
-            os.environ["GIT_CONFIG_VALUE_%d" % i] = value
-        os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+            slot = base_count + i
+            for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
+                                   ("GIT_CONFIG_VALUE_%d" % slot, value)):
+                saved_git_env[name] = os.environ.get(name)
+                os.environ[name] = declared
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
         subprocess.Popen = _AuditedPopen
         os.system = _refuse_system
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1389,7 +1389,8 @@ tool oracle_run:
                           sort_keys=True, ensure_ascii=False)
 
 
-    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
+    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
+                          acted_ids=None):
         """Judge every ACTED extension against `base`, in git — never against the
         acting party's word.
 
@@ -1410,6 +1411,11 @@ tool oracle_run:
         `acted_blobs` also bounds the exemption: a certified path whose blob at
         HEAD moved since the act was rewritten by someone after the subbot —
         the certificate covers the content it certified, not the path forever.
+        `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
+        reports having acted, and no other. Without it the content rule exempts
+        any act naming a certified path, which a lot reaches by filing two
+        requests, getting the second REFUSED, and appending its own act for it
+        recording the first one's path (review finding, executed).
 
         Per acted request, every recorded path must be a pure addition:
           - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1664,14 +1670,22 @@ tool oracle_run:
             # the subbot ran).
             if acted_commits is not None and req is not None and act_sha \
                     and act_sha not in acted_commits:
-                # The way back in is CONTENT, so there must BE content: an act
-                # recording only the ledger leaves the generator empty, `all([])`
-                # is true, and the escape hatch opens for an act that certified
-                # no surface path at all (review finding, executed).
-                surface = [p for p in paths if p != ledger_rel]
-                blobs_match = bool(surface) and acted_blobs is not None and all(
-                    acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                    for p in surface)
+                # The way back in is CONTENT, so there must BE content, it must
+                # be the content of an act the subbot ACTUALLY acted, and the
+                # comparison must be over paths whose blob is expected to stand
+                # still. Each clause was a hole: an act recording only the ledger
+                # left the generator empty and `all([])` true; an act naming a
+                # path the subbot certified for ANOTHER request rode that
+                # request's certificate (the lot writes its own request, so the
+                # paths it declares are its own); corpus.json legitimately moves
+                # when a later act adds entries, so comparing its blob would
+                # refuse a rewritten history for the one file expected to change
+                # (review findings, executed).
+                surface = [p for p in paths if p not in (ledger_rel, corpus_rel)]
+                blobs_match = bool(surface) and acted_blobs is not None \
+                    and act.get("id") in (acted_ids or set()) and all(
+                        acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                        for p in surface)
                 if not blobs_match:
                     row["forged"] = True
                     row["problems"].append(
@@ -3949,9 +3963,18 @@ tool oracle_run:
             check("l'acte introduit par un commit du subbot passe, chemin exempte",
                   [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
             v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
-                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b},
+                                       acted_ids={"E-1"})
             check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
                   v_blob["acted"][0]["ok"], True)
+            # Le certificat couvre l'ACTE que le subbot a acte, pas n'importe quel
+            # acte nommant un chemin certifie : sans l'id, l'echappatoire par
+            # contenu s'ouvre pour un acte que le subbot n'a jamais rendu.
+            v_noid = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("meme contenu, acte NON acte par le subbot : refuse",
+                  [v_noid["acted"][0]["ok"], v_noid["acted"][0].get("forged")],
+                  [False, True])
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("reecrit apres l'acte\n")
             xcommit(email="lot@run")                         # commit C, le lot reecrit
@@ -3972,6 +3995,41 @@ tool oracle_run:
                   [v_old.get("provenance"), v_strict.get("provenance"),
                    v_sub.get("provenance"), v_rw2.get("provenance")],
                   ["legacy", "strict", "strict", "strict"])
+
+            # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
+            # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
+            # s'acte la refusee en enregistrant le chemin que le subbot a
+            # certifie pour la premiere. Tous les controles de contenu passent —
+            # seul l'id ferme la porte.
+            req_e2 = ('{"id": "E-2", "lot": "L", "type": "add-file",'
+                      ' "paths": [".golden-master/refs/2.txt"]}')
+            act_e2 = ('{"id": "E-2", "lot": "L",'
+                      ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+            xreset()
+            # Les DEUX demandes sont deposees d'abord : l'acte de E-2 arrivera dans
+            # un commit ulterieur, donc la regle du commit unique ne le voit pas —
+            # c'est ce qui rend la contrebande possible.
+            xledger(("request", req2), ("request", req_e2))
+            xcommit()                                        # le lot depose E-1 et E-2
+            xledger(("request", req2), ("request", req_e2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2 certifiee par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")     # le subbot acte E-1, REFUSE E-2
+            sha_sub = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_sub = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                           xroot, timeout=60)[1].strip()
+            xledger(("request", req2), ("request", req_e2),
+                    ("act", act2), ("act", act_e2))
+            xcommit(email="lot@run")                          # le lot s'acte la refusee
+            v_smug = extension_verdict(xroot, ".golden-master", xbase,
+                                       acted_commits={sha_sub},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_sub},
+                                       acted_ids={"E-1"})
+            smug = [r for r in v_smug["acted"] if r["id"] == "E-2"][0]
+            check("acte auto-appose sur un chemin certifie pour UNE AUTRE demande : refuse",
+                  [smug["ok"], smug.get("forged")], [False, True])
+            check("l'acte du subbot, lui, reste certifie",
+                  [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.
@@ -5112,9 +5170,16 @@ tool oracle_run:
                     path, sep, sha = tok.rpartition("=")
                     if sep and path and sha:
                         acted_blobs[path] = sha
+            # The ids the subbot reports having acted. Absent = no act is
+            # covered by the content rule, which is the safe direction: the
+            # rule only ever EXEMPTS.
+            acted_ids = None
+            if "GM_ACTED_IDS" in os.environ:
+                acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
             print(json.dumps(extension_verdict(
                 ws, os.environ.get("GM_DIR", ".golden-master"), base,
-                acted_commits=acted_commits, acted_blobs=acted_blobs)))
+                acted_commits=acted_commits, acted_blobs=acted_blobs,
+                acted_ids=acted_ids)))
             raise SystemExit(0)
 
         # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1633,8 +1633,28 @@ tool oracle_run:
         base_act_ids = {b.get("id") for b in _extension_blocks(base_txt, "act")
                         if b.get("id") != "UNPARSEABLE"}
         intro = introducing_commits()
+        # An id is acted ONCE. `introducing_commits` keys first-wins, so a SECOND
+        # act block carrying an id the subbot already acted resolves its
+        # provenance on the subbot's commit — the whole provenance branch is
+        # skipped, no certified blob exists for its paths so the rewrite check
+        # skips too, and the lot's own commit writes a reference into the net that
+        # judges it, exempted (review finding, executed: both rows came back ok
+        # and the second act's path landed in ok_paths). The ledger's ids are the
+        # audit trail's keys; a duplicate key is a refusal, like the corpus's.
+        seen_act_ids = set()
         for act in acts:
             row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
+            if act.get("id") in seen_act_ids:
+                row["forged"] = True
+                row["problems"].append(
+                    "a SECOND act block for %r — an id is acted once. Its "
+                    "provenance would resolve on the FIRST act's commit, so any "
+                    "later block rides the subbot's certificate: remove it, and "
+                    "file a new request if something more must be acted"
+                    % act.get("id"))
+                verdict["acted"].append(row)
+                continue
+            seen_act_ids.add(act.get("id"))
             if act.get("id") in base_act_ids:
                 row["ok"] = True
                 row["acted_at_base"] = True
@@ -4031,6 +4051,45 @@ tool oracle_run:
             check("l'acte du subbot, lui, reste certifie",
                   [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
+            # LE DOUBLON D'ACTE, rejoue en entier : la demande du lot declare DEUX
+            # chemins, le subbot en acte UN, puis le lot appose un SECOND bloc
+            # `act` portant le meme id pour le chemin restant. La provenance du
+            # doublon se resout sur le commit du subbot (premier gagnant), donc
+            # sans refus du doublon tout passe et le chemin du lot est exempte.
+            req_two = ('{"id": "E-1", "lot": "L", "type": "add-file",'
+                       ' "paths": [".golden-master/refs/2.txt",'
+                       ' ".golden-master/refs/9.txt"]}')
+            act_one = ('{"id": "E-1", "lot": "L",'
+                       ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+            act_dup = ('{"id": "E-1", "lot": "L",'
+                       ' "recorded_paths": [".golden-master/refs/9.txt"]}')
+            xreset()
+            xledger(("request", req_two))
+            xcommit()                                         # le lot depose
+            xledger(("request", req_two), ("act", act_one))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("acte par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")      # le subbot acte
+            sha_one = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_one = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                           xroot, timeout=60)[1].strip()
+            xledger(("request", req_two), ("act", act_one), ("act", act_dup))
+            with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+                f.write("ecrit par le lot\n")
+            xcommit(email="lot@run")                           # le lot double l'acte
+            v_dup = extension_verdict(xroot, ".golden-master", xbase,
+                                      acted_commits={sha_one},
+                                      acted_blobs={".golden-master/refs/2.txt": blob_one},
+                                      acted_ids={"E-1"})
+            dup = v_dup["acted"][1]
+            check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+                  [dup["ok"], dup.get("forged"),
+                   ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
+                  [False, True, False])
+            check("l'acte du subbot reste certifie, lui",
+                  [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
+                  [True, [".golden-master/refs/2.txt"]])
+
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.
             xreset()
@@ -5164,18 +5223,39 @@ tool oracle_run:
                 for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
                     full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
                     acted_commits.add(full if len(full) == 40 else tok)
+            # ONE ENTRY PER LINE, for both certificates. Whitespace-delimited,
+            # a surface path containing a space split into two tokens: the left
+            # had no `=` and was DROPPED, the right registered a bogus key — so
+            # the real path had no certified blob, the post-act rewrite check
+            # skipped it, and the lot could rewrite that reference in a later
+            # commit and keep the exemption (review finding). The same defect sat
+            # on the ids, where a space in an id split it out of the set and the
+            # act silently lost its cover. Both ids and paths are lot-authored
+            # and a space passes their guards, so the encoding is what has to be
+            # unambiguous — and an entry that cannot be read is a REFUSAL, never
+            # a silent drop.
             if "GM_ACTED_BLOBS" in os.environ:
                 acted_blobs = {}
-                for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
-                    path, sep, sha = tok.rpartition("=")
-                    if sep and path and sha:
-                        acted_blobs[path] = sha
+                for line in os.environ.get("GM_ACTED_BLOBS", "").splitlines():
+                    if not line.strip():
+                        continue
+                    path, sep, sha = line.rpartition("=")
+                    if not (sep and path and sha):
+                        print(json.dumps({"error":
+                                          "GM_ACTED_BLOBS carries an entry that is "
+                                          "not `path=blob`: %r — a certificate the "
+                                          "judge cannot read is refused, not dropped"
+                                          % line}))
+                        raise SystemExit(1)
+                    acted_blobs[path] = sha
             # The ids the subbot reports having acted. Absent = no act is
             # covered by the content rule, which is the safe direction: the
             # rule only ever EXEMPTS.
             acted_ids = None
             if "GM_ACTED_IDS" in os.environ:
-                acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
+                acted_ids = {l.strip() for l in
+                             os.environ.get("GM_ACTED_IDS", "").splitlines()
+                             if l.strip()}
             print(json.dumps(extension_verdict(
                 ws, os.environ.get("GM_DIR", ".golden-master"), base,
                 acted_commits=acted_commits, acted_blobs=acted_blobs,

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4528,6 +4528,16 @@ tool oracle_run:
             os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
+                    # Same reason fixture_git carries them: this repo is a temp dir
+                    # deleted on the way out, and a writing command (init, add,
+                    # commit, checkout) detaches `git maintenance run --auto`, which
+                    # goes on writing under .git/objects afterwards. Both buttons:
+                    # maintenance.auto is Git >= 2.48, gc.auto is the older one AND
+                    # what a recent Git falls back to when the first is absent — the
+                    # local Git here is 2.43, so one button alone would hold on one
+                    # version and not the other.
+                    if a and a[0] == "git":
+                        a = ("git", "-c", "gc.auto=0", "-c", "maintenance.auto=false") + tuple(a[1:])
                     return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
                 sub("git", "init", "-q")
                 sub("git", "config", "user.email", "t@t")

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3618,13 +3618,26 @@ tool oracle_run:
         canary_key = "iterion.selftestcanary"
         canary_value = "alive-%d" % os.getpid()
         saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-        for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
-            slot = base_count + i
+
+        def _declare(slot, key, value):
             for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                    ("GIT_CONFIG_VALUE_%d" % slot, value)):
-                saved_git_env[name] = os.environ.get(name)
+                saved_git_env.setdefault(name, os.environ.get(name))
                 os.environ[name] = declared
-        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+
+        # The canary is declared FIRST and counted, so that what follows faces a
+        # declaration that was already there — which is the situation in a run,
+        # where the engine has declared the workspace's safe.directory. A canary
+        # placed beside the switches instead would survive its own displacement of
+        # the neighbour, and prove nothing: measured, that version stayed green
+        # under a faithful reproduction of the defect.
+        _declare(base_count, canary_key, canary_value)
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1)
+        declared_count = base_count + 1
+
+        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+            _declare(declared_count + i, key, value)
+        os.environ["GIT_CONFIG_COUNT"] = str(declared_count + len(_GIT_MAINTENANCE_OFF))
         canary_seen = subprocess.run(
             ["git", "config", "--get-all", canary_key],
             capture_output=True, text=True).stdout.split()

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3465,6 +3465,71 @@ tool oracle_run:
 
     # ─── Self-test ──────────────────────────────────────────────────────────────
 
+    # ─── Auto-maintenance audit (selftest) ──────────────────────────────────────
+
+    _GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
+
+
+    def _git_command_lines(argv):
+        """The git command lines an argv spawns.
+
+        Two forms, because both occur here: the argv IS git, or it is a shell
+        running a script in which `git` stands in command position. Split on the
+        separators a shell uses, so `cd x && git commit` is seen as a git command
+        and `rm -rf .git` is not.
+        """
+        if isinstance(argv, (list, tuple)):
+            parts = [str(a) for a in argv]
+        elif isinstance(argv, str):
+            parts = ["sh", "-c", argv]
+        else:
+            return []
+        if not parts:
+            return []
+        found = []
+        if os.path.basename(parts[0]) == "git":
+            found.append(parts)
+        if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
+                and parts[1] == "-c":
+            for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
+                tokens = segment.strip().lstrip("(").strip().split()
+                if tokens and os.path.basename(tokens[0]) == "git":
+                    found.append(tokens)
+        return found
+
+
+    def _git_refuses_auto_maintenance(tokens, env):
+        """Whether a git command line turns BOTH switches off — by `-c` in its own
+        argv, or by git's environment form of the same thing.
+
+        Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
+        the older one AND the fallback a recent Git consults when the first is
+        absent, so a single switch holds on one version and not the other.
+
+        Both idioms, not one: the argv is what a call site writes, the environment
+        is what a chokepoint sets for every call site at once. Accepting only the
+        idiom in use here would refuse the other the day someone moves the guard.
+
+        env is None when the child inherits the parent's — that inherited
+        environment is the one that will decide, so it is what gets read.
+        """
+        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+        environ = os.environ if env is None else env
+        try:
+            count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
+        except ValueError:
+            count = 0
+        from_env = {}
+        for i in range(count):
+            key = environ.get("GIT_CONFIG_KEY_%d" % i)
+            if key:
+                from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+        for key, value in _GIT_MAINTENANCE_OFF:
+            if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
+                return False
+        return True
+
+
     def _selftest():
         """GM_MODE=selftest — teste la moitie qui DECIDE, pas celle qui compare.
 
@@ -3482,6 +3547,46 @@ tool oracle_run:
         """
         failures, checked = [], [0]
         skipped_under_root = []
+
+        # A writing git command in a scratch repo detaches `git maintenance run
+        # --auto` (Git >= 2.48), which goes on writing under .git/objects after the
+        # command returned — while the fixture's temp dir is being removed.
+        #
+        # The switches are set HERE, once, in the environment every child git
+        # inherits, rather than at each call site: enumerating the call sites is
+        # what failed. Two sweeps read this file and both missed a helper defined
+        # four hundred lines below fixture_git, inside a block.
+        #
+        # And the audit below does not read the source either — it WATCHES what the
+        # selftest spawns. Popen is the hook because run, call, check_call and
+        # check_output all reach the kernel through it; hooking run alone would
+        # leave the other four unseen. os.system reaches neither and is refused
+        # outright rather than watched, so the door nobody guards fails closed.
+        _git_audit = {"seen": 0, "offenders": []}
+        _real_popen = subprocess.Popen
+        _real_system = os.system
+
+        class _AuditedPopen(_real_popen):
+            def __init__(self, args, *rest, **kw):
+                for tokens in _git_command_lines(args):
+                    _git_audit["seen"] += 1
+                    if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
+                        _git_audit["offenders"].append(" ".join(tokens)[:120])
+                super().__init__(args, *rest, **kw)
+
+        def _refuse_system(command):
+            raise AssertionError(
+                "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
+
+        saved_git_env = {k: os.environ.get(k) for k in
+                         ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+                          "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+            os.environ["GIT_CONFIG_KEY_%d" % i] = key
+            os.environ["GIT_CONFIG_VALUE_%d" % i] = value
+        os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+        subprocess.Popen = _AuditedPopen
+        os.system = _refuse_system
 
         def check(name, got, want):
             checked[0] += 1
@@ -5260,6 +5365,22 @@ tool oracle_run:
                     os.environ["GM_SCRATCH"] = saved_scratch
         finally:
             g.update(saved)
+            subprocess.Popen = _real_popen
+            os.system = _real_system
+            for key, value in saved_git_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        # Judged on what ran, not on what the source says. A future helper that
+        # spawns git its own way is caught by having RUN, which is the only thing
+        # that found the one this replaces.
+        check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
+              " (%d invocations vues)" % _git_audit["seen"],
+              _git_audit["offenders"], [])
+        check("le selftest lance bien des commandes git (l'audit a une prise)",
+              _git_audit["seen"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3470,64 +3470,60 @@ tool oracle_run:
     _GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
 
 
-    def _git_command_lines(argv):
-        """The git command lines an argv spawns.
+    def _spawned_program(argv, shell):
+        """The program a Popen actually launches.
 
-        Two forms, because both occur here: the argv IS git, or it is a shell
-        running a script in which `git` stands in command position. Split on the
-        separators a shell uses, so `cd x && git commit` is seen as a git command
-        and `rm -rf .git` is not.
+        shell=True runs the string through /bin/sh, so the program is the shell —
+        not the first word of the string, which is what a reader assumes and what
+        an audit keyed on argv[0] would record.
         """
+        if shell:
+            return "sh"
         if isinstance(argv, (list, tuple)):
-            parts = [str(a) for a in argv]
-        elif isinstance(argv, str):
-            parts = ["sh", "-c", argv]
-        else:
-            return []
-        if not parts:
-            return []
-        found = []
-        if os.path.basename(parts[0]) == "git":
-            found.append(parts)
-        if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
-                and parts[1] == "-c":
-            for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
-                tokens = segment.strip().lstrip("(").strip().split()
-                if tokens and os.path.basename(tokens[0]) == "git":
-                    found.append(tokens)
-        return found
+            if not argv:
+                return ""
+            return os.path.basename(str(argv[0]))
+        return os.path.basename(str(argv).split()[0]) if str(argv).strip() else ""
 
 
-    def _git_refuses_auto_maintenance(tokens, env):
-        """Whether a git command line turns BOTH switches off — by `-c` in its own
-        argv, or by git's environment form of the same thing.
+    def _env_refuses_auto_maintenance(env):
+        """Whether an environment turns BOTH switches off through git's own
+        GIT_CONFIG_* form — the environment every descendant inherits, whatever
+        path it takes to reach git.
 
         Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
         the older one AND the fallback a recent Git consults when the first is
         absent, so a single switch holds on one version and not the other.
 
-        Both idioms, not one: the argv is what a call site writes, the environment
-        is what a chokepoint sets for every call site at once. Accepting only the
-        idiom in use here would refuse the other the day someone moves the guard.
-
         env is None when the child inherits the parent's — that inherited
-        environment is the one that will decide, so it is what gets read.
+        environment is the one git will actually read, so that is what gets read
+        here. Reading `env or {}` instead would call a correct inherited call
+        faulty.
         """
-        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
         environ = os.environ if env is None else env
         try:
             count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
-        except ValueError:
+        except (TypeError, ValueError):
             count = 0
-        from_env = {}
+        declared = {}
         for i in range(count):
             key = environ.get("GIT_CONFIG_KEY_%d" % i)
             if key:
-                from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
-        for key, value in _GIT_MAINTENANCE_OFF:
-            if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
-                return False
-        return True
+                declared[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+        return all(declared.get(key) == value for key, value in _GIT_MAINTENANCE_OFF)
+
+
+    def _argv_refuses_auto_maintenance(argv):
+        """Whether a git argv turns both switches off with its own `-c` flags.
+
+        The other accepted idiom: the argv is what a call site writes, the
+        environment is what a chokepoint sets for every call site at once.
+        Accepting only the one in use here would refuse the other the day someone
+        moves the guard.
+        """
+        tokens = [str(a) for a in argv] if isinstance(argv, (list, tuple)) else []
+        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+        return all("%s=%s" % (key, value) in flags for key, value in _GIT_MAINTENANCE_OFF)
 
 
     def _selftest():
@@ -3557,23 +3553,40 @@ tool oracle_run:
         # what failed. Two sweeps read this file and both missed a helper defined
         # four hundred lines below fixture_git, inside a block.
         #
-        # And the audit below does not read the source either — it WATCHES what the
-        # selftest spawns. Popen is the hook because run, call, check_call and
-        # check_output all reach the kernel through it; hooking run alone would
-        # leave the other four unseen. os.system reaches neither and is refused
-        # outright rather than watched, so the door nobody guards fails closed.
-        _git_audit = {"direct": 0, "shell": 0, "offenders": []}
+        # And this does not read the source either — it WATCHES what the selftest
+        # spawns. Popen is the hook because run, call, check_call and check_output
+        # all reach the kernel through it; hooking run alone would leave four forms
+        # unseen. os.system reaches neither and is refused outright rather than
+        # watched, so the door nobody guards fails closed.
+        #
+        # What is judged is not "the git command lines we recognise" — recognising
+        # git by the program name is the same enumeration one level up, and it lets
+        # `env git`, `xargs git` or a git called through a shell variable walk past.
+        # Instead: a WHITELIST of what may be launched at all (git and the shell,
+        # the two the selftest uses — measured: 426 and 236), and the environment
+        # judged on EVERY launch, because that environment is what git reads
+        # whatever path reaches it. A future helper that spawns anything else is
+        # named, not missed.
+        #
+        # Deliberate hostility (`env -i`, unsetting GIT_CONFIG_COUNT inside a
+        # script) is out of scope and stated as such: the adversary here is an
+        # ordinary helper written without knowing the rule, not someone evading it.
+        _git_audit = {"git": 0, "sh": 0, "offenders": []}
         _real_popen = subprocess.Popen
         _real_system = os.system
 
         class _AuditedPopen(_real_popen):
             def __init__(self, args, *rest, **kw):
-                program = args[0] if isinstance(args, (list, tuple)) and args else args
-                spawns_git = os.path.basename(str(program)) == "git"
-                for tokens in _git_command_lines(args):
-                    _git_audit["direct" if spawns_git else "shell"] += 1
-                    if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
-                        _git_audit["offenders"].append(" ".join(tokens)[:120])
+                program = _spawned_program(args, kw.get("shell"))
+                env = kw.get("env")
+                if program not in _git_audit:
+                    _git_audit["offenders"].append(
+                        "programme hors liste blanche : %s (%s)" % (program, str(args)[:80]))
+                else:
+                    _git_audit[program] += 1
+                    if not _env_refuses_auto_maintenance(env) and not (
+                            program == "git" and _argv_refuses_auto_maintenance(args)):
+                        _git_audit["offenders"].append(str(args)[:120])
                 super().__init__(args, *rest, **kw)
 
         def _refuse_system(command):
@@ -5378,18 +5391,14 @@ tool oracle_run:
         # Judged on what ran, not on what the source says. A future helper that
         # spawns git its own way is caught by having RUN, which is the only thing
         # that found the one this replaces.
-        check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-              " (%d invocations vues : %d en argv, %d via sh -c)"
-              % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
+        check("aucun lancement du selftest ne laisse la maintenance automatique detachee"
+              " (%d git, %d sh)" % (_git_audit["git"], _git_audit["sh"]),
               _git_audit["offenders"], [])
-        # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
-        # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
-        # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
-        # propre. C'est le plancher d'un banc, pas une mesure de couverture.
-        check("l'audit voit les commandes git lancees en argv direct",
-              _git_audit["direct"] > 0, True)
-        check("l'audit voit les commandes git lancees a travers un shell",
-              _git_audit["shell"] > 0, True)
+        # Les DEUX compteurs, pas leur somme : le selftest lance les deux
+        # programmes, et un compteur mort laisse l'autre porter le total — un audit
+        # a moitie aveugle passerait pour un arbre propre.
+        check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
+        check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -5195,7 +5195,19 @@ tool oracle_run:
         # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
         if mode == "selftest":
             for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
-                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS",
+                             # Git's identity ENV outranks every config source,
+                             # `-c user.email` included, so a host that exports
+                             # it (devcontainer, CI image, agent sandbox) made
+                             # every fixture commit under the caller's name and
+                             # turned the author checks red — in a step the gate
+                             # wrapper runs BLOCKING, so a campaign's exit gate
+                             # failed for a reason unrelated to the code under
+                             # test (review finding, reproduced). Same class as
+                             # the GM_* above: the doubles are the selftest's,
+                             # and nothing about the caller may reach them.
+                             "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+                             "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"):
                 os.environ.pop(_ambient, None)
             raise SystemExit(_selftest())
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3608,14 +3608,26 @@ tool oracle_run:
                 "where to append the auto-maintenance switches" % raw_count)
         if base_count < 0:
             raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+        # A canary takes the slot a pre-existing declaration would occupy, because
+        # overwriting one is SILENT here: the selftest's own fixtures do not need
+        # safe.directory, so destroying the engine's entry changes nothing it
+        # measures — it only bites in the sandbox, where the workspace is owned by
+        # someone else. What is checked below is that git still resolves the canary
+        # once the switches are in place, which is the same question asked of a
+        # declaration that was there first.
+        canary_key = "iterion.selftestcanary"
+        canary_value = "alive-%d" % os.getpid()
         saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+        for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
             slot = base_count + i
             for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                    ("GIT_CONFIG_VALUE_%d" % slot, value)):
                 saved_git_env[name] = os.environ.get(name)
                 os.environ[name] = declared
-        os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+        canary_seen = subprocess.run(
+            ["git", "config", "--get-all", canary_key],
+            capture_output=True, text=True).stdout.split()
         subprocess.Popen = _AuditedPopen
         os.system = _refuse_system
 
@@ -5413,6 +5425,10 @@ tool oracle_run:
         # Les DEUX compteurs, pas leur somme : le selftest lance les deux
         # programmes, et un compteur mort laisse l'autre porter le total — un audit
         # a moitie aveugle passerait pour un arbre propre.
+        # Ce que git RESOUT, pas ce que le dict dit avoir posé : une declaration
+        # anterieure survit a la pose des boutons.
+        check("une declaration git anterieure survit a la pose des boutons",
+              canary_value in canary_seen, True)
         check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
         check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1295,7 +1295,8 @@ tool oracle_run:
             if not isinstance(obj, dict) or \
                     not (isinstance(obj.get("id"), str) and obj.get("id")):
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
-            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip() \
+                    or any(ord(c) < 0x20 or ord(c) == 0x7f for c in obj["id"]):
                 # An id reaches the gate through a LINE-ORIENTED transport
                 # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
                 # arrives as two fragments and seeds the covered set with an id no
@@ -1305,6 +1306,15 @@ tool oracle_run:
                 # two distinct ids into one, and the collapse re-opens the
                 # smuggling this file exists to close. An INTERIOR space stays
                 # legal: it round-trips whole, and a lot-authored id may carry one.
+                #
+                # The test is stated TWICE on purpose, and neither half covers the
+                # other. `splitlines()` is the transport's own reader, so asking it
+                # to round-trip catches every separator it honours — including
+                # U+0085, U+2028 and U+2029, which are NOT control characters and
+                # which a `ord(c) < 0x20` rule lets straight through. The control
+                # rule in turn refuses TAB, NUL and DEL, which round-trip fine here
+                # but have no business in a lot-authored identifier that a human
+                # reads in a ledger and a machine compares byte for byte.
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
             else:
                 # The list-shaped fields are iterated by every judgement below. A
@@ -1526,7 +1536,17 @@ tool oracle_run:
 
         all_blocks = (_extension_blocks(head_txt, "request") +
                       _extension_blocks(head_txt, "act"))
-        if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
+        # An unreadable block is not merely REPORTED: it makes this judge unable to
+        # read the ledger it certifies from, so nothing that ledger holds is
+        # certified while the block stands — the same shape as
+        # `ledger_append_only`, for the same reason. Reported only, the readable
+        # blocks beside it went on exempting their paths, so a ledger that
+        # escalates handed out exemptions all the same, and a caller reading
+        # `ok_paths` without also reading `problems` never saw the escalation. An
+        # ESCALATION, never a forgery: the requester fixes the block, no history
+        # was rewritten.
+        ledger_readable = not any(b.get("id") == "UNPARSEABLE" for b in all_blocks)
+        if not ledger_readable:
             verdict["problems"].append(
                 "a ledger block does not parse as JSON, or carries an id that "
                 "cannot survive the one-id-per-line certificate — escalate, do "
@@ -1806,6 +1826,10 @@ tool oracle_run:
                             "%s was rewritten after the act: HEAD carries blob %s, "
                             "the subbot certified %s — the certificate covers the "
                             "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
+            if not ledger_readable:
+                row["problems"].append(
+                    "the ledger carries a block this judge cannot read — nothing "
+                    "it holds is certified until that block is fixed")
             row["ok"] = (req is not None and not row["problems"]
                          and verdict["ledger_append_only"])
             if row["ok"]:

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1487,8 +1487,15 @@ tool oracle_run:
                              "judging additions against nothing would pass by "
                              "construction" % (base, err.strip() or "unknown ref")}
 
+        # `provenance` is the verdict SAYING which rule it applied. A net whose
+        # harness predates this feature answers `extend-verify` and passes a
+        # caller's capability probe all the same, while judging by the
+        # same-commit rule alone — the bypassable one — and nothing in its answer
+        # said so: the gate reverted to the hole in silence (review finding,
+        # executed). A caller that hands provenance asserts this echo.
         verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
-                   "requests_added": 0, "problems": []}
+                   "requests_added": 0, "problems": [],
+                   "provenance": "strict" if acted_commits is not None else "legacy"}
 
         head_txt = at("HEAD", ledger_rel) or ""
         base_txt = at(base, ledger_rel) or ""
@@ -1657,9 +1664,14 @@ tool oracle_run:
             # the subbot ran).
             if acted_commits is not None and req is not None and act_sha \
                     and act_sha not in acted_commits:
-                blobs_match = bool(paths) and acted_blobs is not None and all(
+                # The way back in is CONTENT, so there must BE content: an act
+                # recording only the ledger leaves the generator empty, `all([])`
+                # is true, and the escape hatch opens for an act that certified
+                # no surface path at all (review finding, executed).
+                surface = [p for p in paths if p != ledger_rel]
+                blobs_match = bool(surface) and acted_blobs is not None and all(
                     acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                    for p in paths if p != ledger_rel)
+                    for p in surface)
                 if not blobs_match:
                     row["forged"] = True
                     row["problems"].append(
@@ -3951,6 +3963,29 @@ tool oracle_run:
             v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
             check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
+
+            # Le verdict ANNONCE la regle qu'il a appliquee : sans cet echo, un
+            # filet synchronise avant la provenance repond `extend-verify`, ignore
+            # les deux variables et rend l'ancienne regle — le trou que ce terme
+            # ferme, revenu en silence. L'appelant l'exige (main.bot).
+            check("le verdict annonce la regle appliquee",
+                  [v_old.get("provenance"), v_strict.get("provenance"),
+                   v_sub.get("provenance"), v_rw2.get("provenance")],
+                  ["legacy", "strict", "strict", "strict"])
+
+            # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
+            # a certifier, donc aucune echappatoire par contenu.
+            xreset()
+            xrequest(req2)
+            xledger(("request", req2),
+                    ("act", '{"id": "E-1", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/EXTENSIONS.md"]}'))
+            xcommit(email="lot@run")
+            v_led = extension_verdict(xroot, ".golden-master", xbase,
+                                      acted_commits=set(), acted_blobs={})
+            check("acte n'enregistrant que le registre, hors commits du subbot : forge",
+                  [v_led["acted"][0]["ok"], v_led["acted"][0].get("forged")],
+                  [False, True])
 
             # Reecriture deguisee : la ref existait a la base.
             xreset()

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -4976,7 +4976,19 @@ def main():
     # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
     if mode == "selftest":
         for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
-                         "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+                         "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS",
+                         # Git's identity ENV outranks every config source,
+                         # `-c user.email` included, so a host that exports
+                         # it (devcontainer, CI image, agent sandbox) made
+                         # every fixture commit under the caller's name and
+                         # turned the author checks red — in a step the gate
+                         # wrapper runs BLOCKING, so a campaign's exit gate
+                         # failed for a reason unrelated to the code under
+                         # test (review finding, reproduced). Same class as
+                         # the GM_* above: the doubles are the selftest's,
+                         # and nothing about the caller may reach them.
+                         "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+                         "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"):
             os.environ.pop(_ambient, None)
         raise SystemExit(_selftest())
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3343,14 +3343,16 @@ def _selftest():
     # check_output all reach the kernel through it; hooking run alone would
     # leave the other four unseen. os.system reaches neither and is refused
     # outright rather than watched, so the door nobody guards fails closed.
-    _git_audit = {"seen": 0, "offenders": []}
+    _git_audit = {"direct": 0, "shell": 0, "offenders": []}
     _real_popen = subprocess.Popen
     _real_system = os.system
 
     class _AuditedPopen(_real_popen):
         def __init__(self, args, *rest, **kw):
+            program = args[0] if isinstance(args, (list, tuple)) and args else args
+            spawns_git = os.path.basename(str(program)) == "git"
             for tokens in _git_command_lines(args):
-                _git_audit["seen"] += 1
+                _git_audit["direct" if spawns_git else "shell"] += 1
                 if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
                     _git_audit["offenders"].append(" ".join(tokens)[:120])
             super().__init__(args, *rest, **kw)
@@ -5158,10 +5160,17 @@ def _selftest():
     # spawns git its own way is caught by having RUN, which is the only thing
     # that found the one this replaces.
     check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-          " (%d invocations vues)" % _git_audit["seen"],
+          " (%d invocations vues : %d en argv, %d via sh -c)"
+          % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
           _git_audit["offenders"], [])
-    check("le selftest lance bien des commandes git (l'audit a une prise)",
-          _git_audit["seen"] > 0, True)
+    # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
+    # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
+    # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
+    # propre. C'est le plancher d'un banc, pas une mesure de couverture.
+    check("l'audit voit les commandes git lancees en argv direct",
+          _git_audit["direct"] > 0, True)
+    check("l'audit voit les commandes git lancees a travers un shell",
+          _git_audit["shell"] > 0, True)
 
     if failures:
         log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3389,14 +3389,26 @@ def _selftest():
             "where to append the auto-maintenance switches" % raw_count)
     if base_count < 0:
         raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+    # A canary takes the slot a pre-existing declaration would occupy, because
+    # overwriting one is SILENT here: the selftest's own fixtures do not need
+    # safe.directory, so destroying the engine's entry changes nothing it
+    # measures — it only bites in the sandbox, where the workspace is owned by
+    # someone else. What is checked below is that git still resolves the canary
+    # once the switches are in place, which is the same question asked of a
+    # declaration that was there first.
+    canary_key = "iterion.selftestcanary"
+    canary_value = "alive-%d" % os.getpid()
     saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-    for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+    for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
         slot = base_count + i
         for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                ("GIT_CONFIG_VALUE_%d" % slot, value)):
             saved_git_env[name] = os.environ.get(name)
             os.environ[name] = declared
-    os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
+    os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+    canary_seen = subprocess.run(
+        ["git", "config", "--get-all", canary_key],
+        capture_output=True, text=True).stdout.split()
     subprocess.Popen = _AuditedPopen
     os.system = _refuse_system
 
@@ -5194,6 +5206,10 @@ def _selftest():
     # Les DEUX compteurs, pas leur somme : le selftest lance les deux
     # programmes, et un compteur mort laisse l'autre porter le total — un audit
     # a moitie aveugle passerait pour un arbre propre.
+    # Ce que git RESOUT, pas ce que le dict dit avoir posé : une declaration
+    # anterieure survit a la pose des boutons.
+    check("une declaration git anterieure survit a la pose des boutons",
+          canary_value in canary_seen, True)
     check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
     check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -4309,6 +4309,16 @@ def _selftest():
         os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
         try:
             def sub(*a):
+                # Same reason fixture_git carries them: this repo is a temp dir
+                # deleted on the way out, and a writing command (init, add,
+                # commit, checkout) detaches `git maintenance run --auto`, which
+                # goes on writing under .git/objects afterwards. Both buttons:
+                # maintenance.auto is Git >= 2.48, gc.auto is the older one AND
+                # what a recent Git falls back to when the first is absent — the
+                # local Git here is 2.43, so one button alone would hold on one
+                # version and not the other.
+                if a and a[0] == "git":
+                    a = ("git", "-c", "gc.auto=0", "-c", "maintenance.auto=false") + tuple(a[1:])
                 return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
             sub("git", "init", "-q")
             sub("git", "config", "user.email", "t@t")

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1170,9 +1170,27 @@ def _entry_observation_key(entry):
                       sort_keys=True, ensure_ascii=False)
 
 
-def extension_verdict(ws, gm_rel, base):
+def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
     """Judge every ACTED extension against `base`, in git — never against the
     acting party's word.
+
+    `acted_commits` (None, or a set of 40-hex shas) is what the NET's own
+    subbot reports having committed in this segment — read by main() from
+    GM_ACTED_COMMITS, which the parent bot defines even when empty. None
+    means the caller predates provenance (today's rule only: request and
+    act in one commit refuse); a set means STRICT: an act introduced in
+    base..HEAD by a commit outside it was written by the constrained party,
+    whatever author it carries, and is refused — unless every path it
+    records carries at HEAD the exact blob the subbot certified
+    (`acted_blobs`, path → blob id): a history rewritten after the subbot
+    ran keeps its certified content and loses its shas. Measured on a live
+    campaign: a lot filed a request in one commit and acted it in the next,
+    the same-commit rule saw nothing, and the lot's own file became a
+    reference of the net that judges it.
+
+    `acted_blobs` also bounds the exemption: a certified path whose blob at
+    HEAD moved since the act was rewritten by someone after the subbot —
+    the certificate covers the content it certified, not the path forever.
 
     Per acted request, every recorded path must be a pure addition:
       - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1201,6 +1219,11 @@ def extension_verdict(ws, gm_rel, base):
         code, out, _ = git("ls-tree", ref, "--", path)
         return out.split()[0] if code == 0 and out.strip() else ""
 
+    def blob_id(ref, path):
+        code, out, _ = git("ls-tree", ref, "--", path)
+        parts = out.split() if code == 0 else []
+        return parts[2] if len(parts) >= 3 else ""
+
     ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
     corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
     refs_prefix = gm_rel.rstrip("/") + "/refs/"
@@ -1215,11 +1238,15 @@ def extension_verdict(ws, gm_rel, base):
         subbot never ran — production cannot produce that shape, because the
         parent commits its lot before the subbot starts (adversarial finding,
         executed)."""
-        code, out, _ = git("log", "--format=%H", "--reverse", "--", ledger_rel)
+        code, out, _ = git("log", "--format=%H%x00%ae", "--reverse", "--", ledger_rel)
         if code != 0:
             return None
         first = {}
-        for sha in out.split():
+        for line in out.splitlines():
+            sha, _, email = line.partition("\0")
+            sha = sha.strip()
+            if not sha:
+                continue
             text = at(sha, ledger_rel)
             if text is None:
                 continue
@@ -1228,6 +1255,7 @@ def extension_verdict(ws, gm_rel, base):
                     bid = b.get("id")
                     if isinstance(bid, str) and bid:
                         first.setdefault((kind, bid), sha)
+                        first.setdefault(("author", kind, bid), email.strip())
         return first
 
     # An unresolvable base and an honest "absent at base" both read as None
@@ -1394,9 +1422,36 @@ def extension_verdict(ws, gm_rel, base):
                 "request and the act, so the net's subbot never judged it — "
                 "filing and answering are different powers"
                 % intro[("act", act.get("id"))][:12])
+            row["forged"] = True
         paths = [p for p in (act.get("recorded_paths") or [])
                  if isinstance(p, str) and p]
         row["paths"] = paths
+        act_sha = (intro or {}).get(("act", act.get("id")))
+        if act_sha:
+            row["introduced_by"] = act_sha[:12]
+            row["author"] = (intro or {}).get(("author", "act", act.get("id"))) or ""
+        # Provenance, when the parent states what the net's subbot committed:
+        # an act introduced by any other commit was written by the party the
+        # oracle constrains — whatever author it carries, an author is prose.
+        # The one way back in is the CONTENT: every recorded path carrying at
+        # HEAD the exact blob the subbot certified (a history rewritten after
+        # the subbot ran).
+        if acted_commits is not None and req is not None and act_sha \
+                and act_sha not in acted_commits:
+            blobs_match = bool(paths) and acted_blobs is not None and all(
+                acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                for p in paths if p != ledger_rel)
+            if not blobs_match:
+                row["forged"] = True
+                row["problems"].append(
+                    "the act was introduced by %s (author %s), which is not one "
+                    "of the net subbot's commits%s — an act the constrained party "
+                    "wrote is a refusal, not an extension. If the history was "
+                    "rewritten after the subbot ran, relaunch on a fresh base; "
+                    "otherwise remove the act block and file the request only."
+                    % (act_sha[:12], row.get("author") or "?",
+                       (" (%s)" % ", ".join(sorted(c[:12] for c in acted_commits)))
+                       if acted_commits else " (none reported)"))
         if req is not None and not paths:
             row["problems"].append(
                 "the act records no path — an extension that touched "
@@ -1456,6 +1511,21 @@ def extension_verdict(ws, gm_rel, base):
             row["problems"].append(
                 "the act records no path on the extension surface (refs/ or "
                 "corpus.json) — filing paperwork is not an extension")
+        if acted_blobs is not None and req is not None:
+            # The certificate covers the CONTENT the subbot committed, not
+            # the path forever: a reference rewritten after the act — by the
+            # lot, in its own later commit — is the masking vector again, and
+            # the exemption must not follow it.
+            for p in paths:
+                if p == ledger_rel or p == corpus_rel:
+                    continue
+                certified = acted_blobs.get(p)
+                if certified and blob_id("HEAD", p) != certified:
+                    row["forged"] = True
+                    row["problems"].append(
+                        "%s was rewritten after the act: HEAD carries blob %s, "
+                        "the subbot certified %s — the certificate covers the "
+                        "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
         row["ok"] = (req is not None and not row["problems"]
                      and verdict["ledger_append_only"])
         if row["ok"]:
@@ -3550,9 +3620,11 @@ def _selftest():
                 f.write("\n".join("<!-- iterion:extension-%s\n%s\n-->" % b
                                   for b in blks))
 
-        def xcommit():
+        def xcommit(email="t@t"):
+            # fixture_git already sets a committer; a later -c wins, so the
+            # override rides it instead of bypassing the failure check.
             fixture_git(xroot, "add", "-A")
-            fixture_git(xroot, "commit", "-qm", "x")
+            fixture_git(xroot, "-c", "user.email=%s" % email, "commit", "-qm", "x")
 
         def xrequest(req):
             """The lot files its request and commits. A fixture that stages a
@@ -3622,6 +3694,44 @@ def _selftest():
         v_touch = xverdict(xbase_acted)
         check("acte a la base + ref reecrite -> le certificat n'exempte rien",
               [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
+
+        # 8f. Provenance : un acte doit venir des commits du subbot du filet
+        #     (publies par le parent), ou porter EXACTEMENT le contenu certifie
+        #     (historique reecrit apres le subbot). L'auteur est de la prose.
+        xreset()
+        xrequest(req2)                                   # commit A, le lot
+        xledger(("request", req2), ("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("forge par le lot\n")
+        xcommit(email="lot@run")                         # commit B, le lot acte
+        sha_b = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        blob_b = run("git rev-parse HEAD:.golden-master/refs/2.txt", xroot, timeout=60)[1].strip()
+        v_old = extension_verdict(xroot, ".golden-master", xbase)
+        check("sans provenance (appelant d'avant) : l'auto-acte en deux commits passe encore",
+              v_old["acted"][0]["ok"], True)
+        v_strict = extension_verdict(xroot, ".golden-master", xbase, acted_commits=set())
+        check("provenance stricte, aucun commit du subbot : l'auto-acte est refuse, forge, auteur nomme",
+              [v_strict["acted"][0]["ok"], v_strict["acted"][0].get("forged"),
+               v_strict["acted"][0].get("author"), v_strict["ok_paths"]],
+              [False, True, "lot@run", []])
+        v_sub = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b})
+        check("l'acte introduit par un commit du subbot passe, chemin exempte",
+              [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
+        v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                   acted_blobs={".golden-master/refs/2.txt": blob_b})
+        check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
+              v_blob["acted"][0]["ok"], True)
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("reecrit apres l'acte\n")
+        xcommit(email="lot@run")                         # commit C, le lot reecrit
+        v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
+                                 acted_blobs={".golden-master/refs/2.txt": blob_b})
+        check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+              [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
+              [False, True, []])
+        v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                  acted_blobs={".golden-master/refs/2.txt": blob_b})
+        check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
 
         # Reecriture deguisee : la ref existait a la base.
         xreset()
@@ -4732,8 +4842,25 @@ def main():
                               "additions against nothing would pass by "
                               "construction"}))
             raise SystemExit(1)
+        # Provenance from the PARENT: present (even empty) means strict —
+        # the parent bot always defines it, because the only pass that
+        # judges a self-act is the one where no subbot ran at all. Absent
+        # means a caller that predates provenance: today's rule only.
+        acted_commits = acted_blobs = None
+        if "GM_ACTED_COMMITS" in os.environ:
+            acted_commits = set()
+            for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
+                full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
+                acted_commits.add(full if len(full) == 40 else tok)
+        if "GM_ACTED_BLOBS" in os.environ:
+            acted_blobs = {}
+            for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
+                path, sep, sha = tok.rpartition("=")
+                if sep and path and sha:
+                    acted_blobs[path] = sha
         print(json.dumps(extension_verdict(
-            ws, os.environ.get("GM_DIR", ".golden-master"), base)))
+            ws, os.environ.get("GM_DIR", ".golden-master"), base,
+            acted_commits=acted_commits, acted_blobs=acted_blobs)))
         raise SystemExit(0)
 
     # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1076,6 +1076,17 @@ def _extension_blocks(text, kind):
         if not isinstance(obj, dict) or \
                 not (isinstance(obj.get("id"), str) and obj.get("id")):
             obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+        elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+            # An id reaches the gate through a LINE-ORIENTED transport
+            # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
+            # arrives as two fragments and seeds the covered set with an id no
+            # subbot ever acted; one made only of whitespace cannot be told
+            # from a blank line. Refused at this single parse point rather
+            # than repaired downstream — a repair is precisely what collapses
+            # two distinct ids into one, and the collapse re-opens the
+            # smuggling this file exists to close. An INTERIOR space stays
+            # legal: it round-trips whole, and a lot-authored id may carry one.
+            obj = {"id": "UNPARSEABLE", "raw": body[:120]}
         else:
             # The list-shaped fields are iterated by every judgement below. A
             # scalar here raised TypeError inside the verdict, and a verdict
@@ -1137,7 +1148,9 @@ def pending_extensions(gm_dir, text=None):
     acts = _extension_blocks(text, "act")
     if any(b.get("id") == "UNPARSEABLE" for b in requests + acts):
         return [{"id": "UNPARSEABLE",
-                 "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+                 "why": "a ledger block does not parse as JSON, or carries an "
+                        "id that cannot survive the one-id-per-line "
+                        "certificate — escalate, do not guess"}]
     # Only a WELL-FORMED act closes a request: an act with no recorded path
     # acted nothing, and letting it close the term would let the constrained
     # party silence the conjunction with four lines of JSON — the
@@ -1296,7 +1309,9 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                   _extension_blocks(head_txt, "act"))
     if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
         verdict["problems"].append(
-            "a ledger block does not parse as JSON — escalate, do not guess")
+            "a ledger block does not parse as JSON, or carries an id that "
+            "cannot survive the one-id-per-line certificate — escalate, do "
+            "not guess")
     requests = {b["id"]: b for b in _extension_blocks(head_txt, "request")
                 if b.get("id") != "UNPARSEABLE"}
     acts = [b for b in _extension_blocks(head_txt, "act")
@@ -5046,7 +5061,14 @@ def main():
         # rule only ever EXEMPTS.
         acted_ids = None
         if "GM_ACTED_IDS" in os.environ:
-            acted_ids = {l.strip() for l in
+            # The RAW line, exactly as the blob certificate above reads its
+            # own: `.strip()` is an emptiness test here, never a repair.
+            # Normalising the id while `extension_verdict` compares it
+            # verbatim made two ids differing only by surrounding whitespace
+            # collapse into one — the act the subbot REFUSED came back covered
+            # by the id it had acted, which is the smuggling of a refused
+            # extension, reopened by an encoding.
+            acted_ids = {l for l in
                          os.environ.get("GM_ACTED_IDS", "").splitlines()
                          if l.strip()}
         print(json.dumps(extension_verdict(

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3251,64 +3251,60 @@ def stability(config, corpus, canon, ws):
 _GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
 
 
-def _git_command_lines(argv):
-    """The git command lines an argv spawns.
+def _spawned_program(argv, shell):
+    """The program a Popen actually launches.
 
-    Two forms, because both occur here: the argv IS git, or it is a shell
-    running a script in which `git` stands in command position. Split on the
-    separators a shell uses, so `cd x && git commit` is seen as a git command
-    and `rm -rf .git` is not.
+    shell=True runs the string through /bin/sh, so the program is the shell —
+    not the first word of the string, which is what a reader assumes and what
+    an audit keyed on argv[0] would record.
     """
+    if shell:
+        return "sh"
     if isinstance(argv, (list, tuple)):
-        parts = [str(a) for a in argv]
-    elif isinstance(argv, str):
-        parts = ["sh", "-c", argv]
-    else:
-        return []
-    if not parts:
-        return []
-    found = []
-    if os.path.basename(parts[0]) == "git":
-        found.append(parts)
-    if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
-            and parts[1] == "-c":
-        for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
-            tokens = segment.strip().lstrip("(").strip().split()
-            if tokens and os.path.basename(tokens[0]) == "git":
-                found.append(tokens)
-    return found
+        if not argv:
+            return ""
+        return os.path.basename(str(argv[0]))
+    return os.path.basename(str(argv).split()[0]) if str(argv).strip() else ""
 
 
-def _git_refuses_auto_maintenance(tokens, env):
-    """Whether a git command line turns BOTH switches off — by `-c` in its own
-    argv, or by git's environment form of the same thing.
+def _env_refuses_auto_maintenance(env):
+    """Whether an environment turns BOTH switches off through git's own
+    GIT_CONFIG_* form — the environment every descendant inherits, whatever
+    path it takes to reach git.
 
     Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
     the older one AND the fallback a recent Git consults when the first is
     absent, so a single switch holds on one version and not the other.
 
-    Both idioms, not one: the argv is what a call site writes, the environment
-    is what a chokepoint sets for every call site at once. Accepting only the
-    idiom in use here would refuse the other the day someone moves the guard.
-
     env is None when the child inherits the parent's — that inherited
-    environment is the one that will decide, so it is what gets read.
+    environment is the one git will actually read, so that is what gets read
+    here. Reading `env or {}` instead would call a correct inherited call
+    faulty.
     """
-    flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
     environ = os.environ if env is None else env
     try:
         count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
-    except ValueError:
+    except (TypeError, ValueError):
         count = 0
-    from_env = {}
+    declared = {}
     for i in range(count):
         key = environ.get("GIT_CONFIG_KEY_%d" % i)
         if key:
-            from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
-    for key, value in _GIT_MAINTENANCE_OFF:
-        if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
-            return False
-    return True
+            declared[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+    return all(declared.get(key) == value for key, value in _GIT_MAINTENANCE_OFF)
+
+
+def _argv_refuses_auto_maintenance(argv):
+    """Whether a git argv turns both switches off with its own `-c` flags.
+
+    The other accepted idiom: the argv is what a call site writes, the
+    environment is what a chokepoint sets for every call site at once.
+    Accepting only the one in use here would refuse the other the day someone
+    moves the guard.
+    """
+    tokens = [str(a) for a in argv] if isinstance(argv, (list, tuple)) else []
+    flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+    return all("%s=%s" % (key, value) in flags for key, value in _GIT_MAINTENANCE_OFF)
 
 
 def _selftest():
@@ -3338,23 +3334,40 @@ def _selftest():
     # what failed. Two sweeps read this file and both missed a helper defined
     # four hundred lines below fixture_git, inside a block.
     #
-    # And the audit below does not read the source either — it WATCHES what the
-    # selftest spawns. Popen is the hook because run, call, check_call and
-    # check_output all reach the kernel through it; hooking run alone would
-    # leave the other four unseen. os.system reaches neither and is refused
-    # outright rather than watched, so the door nobody guards fails closed.
-    _git_audit = {"direct": 0, "shell": 0, "offenders": []}
+    # And this does not read the source either — it WATCHES what the selftest
+    # spawns. Popen is the hook because run, call, check_call and check_output
+    # all reach the kernel through it; hooking run alone would leave four forms
+    # unseen. os.system reaches neither and is refused outright rather than
+    # watched, so the door nobody guards fails closed.
+    #
+    # What is judged is not "the git command lines we recognise" — recognising
+    # git by the program name is the same enumeration one level up, and it lets
+    # `env git`, `xargs git` or a git called through a shell variable walk past.
+    # Instead: a WHITELIST of what may be launched at all (git and the shell,
+    # the two the selftest uses — measured: 426 and 236), and the environment
+    # judged on EVERY launch, because that environment is what git reads
+    # whatever path reaches it. A future helper that spawns anything else is
+    # named, not missed.
+    #
+    # Deliberate hostility (`env -i`, unsetting GIT_CONFIG_COUNT inside a
+    # script) is out of scope and stated as such: the adversary here is an
+    # ordinary helper written without knowing the rule, not someone evading it.
+    _git_audit = {"git": 0, "sh": 0, "offenders": []}
     _real_popen = subprocess.Popen
     _real_system = os.system
 
     class _AuditedPopen(_real_popen):
         def __init__(self, args, *rest, **kw):
-            program = args[0] if isinstance(args, (list, tuple)) and args else args
-            spawns_git = os.path.basename(str(program)) == "git"
-            for tokens in _git_command_lines(args):
-                _git_audit["direct" if spawns_git else "shell"] += 1
-                if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
-                    _git_audit["offenders"].append(" ".join(tokens)[:120])
+            program = _spawned_program(args, kw.get("shell"))
+            env = kw.get("env")
+            if program not in _git_audit:
+                _git_audit["offenders"].append(
+                    "programme hors liste blanche : %s (%s)" % (program, str(args)[:80]))
+            else:
+                _git_audit[program] += 1
+                if not _env_refuses_auto_maintenance(env) and not (
+                        program == "git" and _argv_refuses_auto_maintenance(args)):
+                    _git_audit["offenders"].append(str(args)[:120])
             super().__init__(args, *rest, **kw)
 
     def _refuse_system(command):
@@ -5159,18 +5172,14 @@ def _selftest():
     # Judged on what ran, not on what the source says. A future helper that
     # spawns git its own way is caught by having RUN, which is the only thing
     # that found the one this replaces.
-    check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-          " (%d invocations vues : %d en argv, %d via sh -c)"
-          % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
+    check("aucun lancement du selftest ne laisse la maintenance automatique detachee"
+          " (%d git, %d sh)" % (_git_audit["git"], _git_audit["sh"]),
           _git_audit["offenders"], [])
-    # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
-    # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
-    # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
-    # propre. C'est le plancher d'un banc, pas une mesure de couverture.
-    check("l'audit voit les commandes git lancees en argv direct",
-          _git_audit["direct"] > 0, True)
-    check("l'audit voit les commandes git lancees a travers un shell",
-          _git_audit["shell"] > 0, True)
+    # Les DEUX compteurs, pas leur somme : le selftest lance les deux
+    # programmes, et un compteur mort laisse l'autre porter le total — un audit
+    # a moitie aveugle passerait pour un arbre propre.
+    check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
+    check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
     if failures:
         log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3374,13 +3374,29 @@ def _selftest():
         raise AssertionError(
             "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
 
-    saved_git_env = {k: os.environ.get(k) for k in
-                     ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
-                      "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+    # APPENDED after whatever is already declared, never written at index 0:
+    # the engine injects the workspace's safe.directory entry through this same
+    # environment (runtime/sandbox_mounts.go sets GIT_CONFIG_COUNT=1), so
+    # writing slot 0 destroys it and every git of the selftest then refuses the
+    # workspace for dubious ownership. Measured: safe.directory=/tmp/x became
+    # whatever the operator's global config said, or nothing.
+    raw_count = os.environ.get("GIT_CONFIG_COUNT", "0") or "0"
+    try:
+        base_count = int(raw_count)
+    except ValueError:
+        raise SystemExit(
+            "selftest: GIT_CONFIG_COUNT=%r is not a count — refusing to guess "
+            "where to append the auto-maintenance switches" % raw_count)
+    if base_count < 0:
+        raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+    saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
     for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
-        os.environ["GIT_CONFIG_KEY_%d" % i] = key
-        os.environ["GIT_CONFIG_VALUE_%d" % i] = value
-    os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+        slot = base_count + i
+        for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
+                               ("GIT_CONFIG_VALUE_%d" % slot, value)):
+            saved_git_env[name] = os.environ.get(name)
+            os.environ[name] = declared
+    os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
     subprocess.Popen = _AuditedPopen
     os.system = _refuse_system
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1268,8 +1268,15 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
                          "judging additions against nothing would pass by "
                          "construction" % (base, err.strip() or "unknown ref")}
 
+    # `provenance` is the verdict SAYING which rule it applied. A net whose
+    # harness predates this feature answers `extend-verify` and passes a
+    # caller's capability probe all the same, while judging by the
+    # same-commit rule alone — the bypassable one — and nothing in its answer
+    # said so: the gate reverted to the hole in silence (review finding,
+    # executed). A caller that hands provenance asserts this echo.
     verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
-               "requests_added": 0, "problems": []}
+               "requests_added": 0, "problems": [],
+               "provenance": "strict" if acted_commits is not None else "legacy"}
 
     head_txt = at("HEAD", ledger_rel) or ""
     base_txt = at(base, ledger_rel) or ""
@@ -1438,9 +1445,14 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
         # the subbot ran).
         if acted_commits is not None and req is not None and act_sha \
                 and act_sha not in acted_commits:
-            blobs_match = bool(paths) and acted_blobs is not None and all(
+            # The way back in is CONTENT, so there must BE content: an act
+            # recording only the ledger leaves the generator empty, `all([])`
+            # is true, and the escape hatch opens for an act that certified
+            # no surface path at all (review finding, executed).
+            surface = [p for p in paths if p != ledger_rel]
+            blobs_match = bool(surface) and acted_blobs is not None and all(
                 acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                for p in paths if p != ledger_rel)
+                for p in surface)
             if not blobs_match:
                 row["forged"] = True
                 row["problems"].append(
@@ -3732,6 +3744,29 @@ def _selftest():
         v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                   acted_blobs={".golden-master/refs/2.txt": blob_b})
         check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
+
+        # Le verdict ANNONCE la regle qu'il a appliquee : sans cet echo, un
+        # filet synchronise avant la provenance repond `extend-verify`, ignore
+        # les deux variables et rend l'ancienne regle — le trou que ce terme
+        # ferme, revenu en silence. L'appelant l'exige (main.bot).
+        check("le verdict annonce la regle appliquee",
+              [v_old.get("provenance"), v_strict.get("provenance"),
+               v_sub.get("provenance"), v_rw2.get("provenance")],
+              ["legacy", "strict", "strict", "strict"])
+
+        # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
+        # a certifier, donc aucune echappatoire par contenu.
+        xreset()
+        xrequest(req2)
+        xledger(("request", req2),
+                ("act", '{"id": "E-1", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/EXTENSIONS.md"]}'))
+        xcommit(email="lot@run")
+        v_led = extension_verdict(xroot, ".golden-master", xbase,
+                                  acted_commits=set(), acted_blobs={})
+        check("acte n'enregistrant que le registre, hors commits du subbot : forge",
+              [v_led["acted"][0]["ok"], v_led["acted"][0].get("forged")],
+              [False, True])
 
         # Reecriture deguisee : la ref existait a la base.
         xreset()

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3399,13 +3399,26 @@ def _selftest():
     canary_key = "iterion.selftestcanary"
     canary_value = "alive-%d" % os.getpid()
     saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-    for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
-        slot = base_count + i
+
+    def _declare(slot, key, value):
         for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                ("GIT_CONFIG_VALUE_%d" % slot, value)):
-            saved_git_env[name] = os.environ.get(name)
+            saved_git_env.setdefault(name, os.environ.get(name))
             os.environ[name] = declared
-    os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+
+    # The canary is declared FIRST and counted, so that what follows faces a
+    # declaration that was already there — which is the situation in a run,
+    # where the engine has declared the workspace's safe.directory. A canary
+    # placed beside the switches instead would survive its own displacement of
+    # the neighbour, and prove nothing: measured, that version stayed green
+    # under a faithful reproduction of the defect.
+    _declare(base_count, canary_key, canary_value)
+    os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1)
+    declared_count = base_count + 1
+
+    for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+        _declare(declared_count + i, key, value)
+    os.environ["GIT_CONFIG_COUNT"] = str(declared_count + len(_GIT_MAINTENANCE_OFF))
     canary_seen = subprocess.run(
         ["git", "config", "--get-all", canary_key],
         capture_output=True, text=True).stdout.split()

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1076,7 +1076,8 @@ def _extension_blocks(text, kind):
         if not isinstance(obj, dict) or \
                 not (isinstance(obj.get("id"), str) and obj.get("id")):
             obj = {"id": "UNPARSEABLE", "raw": body[:120]}
-        elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+        elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip() \
+                or any(ord(c) < 0x20 or ord(c) == 0x7f for c in obj["id"]):
             # An id reaches the gate through a LINE-ORIENTED transport
             # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
             # arrives as two fragments and seeds the covered set with an id no
@@ -1086,6 +1087,15 @@ def _extension_blocks(text, kind):
             # two distinct ids into one, and the collapse re-opens the
             # smuggling this file exists to close. An INTERIOR space stays
             # legal: it round-trips whole, and a lot-authored id may carry one.
+            #
+            # The test is stated TWICE on purpose, and neither half covers the
+            # other. `splitlines()` is the transport's own reader, so asking it
+            # to round-trip catches every separator it honours — including
+            # U+0085, U+2028 and U+2029, which are NOT control characters and
+            # which a `ord(c) < 0x20` rule lets straight through. The control
+            # rule in turn refuses TAB, NUL and DEL, which round-trip fine here
+            # but have no business in a lot-authored identifier that a human
+            # reads in a ledger and a machine compares byte for byte.
             obj = {"id": "UNPARSEABLE", "raw": body[:120]}
         else:
             # The list-shaped fields are iterated by every judgement below. A
@@ -1307,7 +1317,17 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
 
     all_blocks = (_extension_blocks(head_txt, "request") +
                   _extension_blocks(head_txt, "act"))
-    if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
+    # An unreadable block is not merely REPORTED: it makes this judge unable to
+    # read the ledger it certifies from, so nothing that ledger holds is
+    # certified while the block stands — the same shape as
+    # `ledger_append_only`, for the same reason. Reported only, the readable
+    # blocks beside it went on exempting their paths, so a ledger that
+    # escalates handed out exemptions all the same, and a caller reading
+    # `ok_paths` without also reading `problems` never saw the escalation. An
+    # ESCALATION, never a forgery: the requester fixes the block, no history
+    # was rewritten.
+    ledger_readable = not any(b.get("id") == "UNPARSEABLE" for b in all_blocks)
+    if not ledger_readable:
         verdict["problems"].append(
             "a ledger block does not parse as JSON, or carries an id that "
             "cannot survive the one-id-per-line certificate — escalate, do "
@@ -1587,6 +1607,10 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                         "%s was rewritten after the act: HEAD carries blob %s, "
                         "the subbot certified %s — the certificate covers the "
                         "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
+        if not ledger_readable:
+            row["problems"].append(
+                "the ledger carries a block this judge cannot read — nothing "
+                "it holds is certified until that block is fixed")
         row["ok"] = (req is not None and not row["problems"]
                      and verdict["ledger_append_only"])
         if row["ok"]:

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1170,7 +1170,8 @@ def _entry_observation_key(entry):
                       sort_keys=True, ensure_ascii=False)
 
 
-def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
+def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
+                      acted_ids=None):
     """Judge every ACTED extension against `base`, in git — never against the
     acting party's word.
 
@@ -1191,6 +1192,11 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
     `acted_blobs` also bounds the exemption: a certified path whose blob at
     HEAD moved since the act was rewritten by someone after the subbot —
     the certificate covers the content it certified, not the path forever.
+    `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
+    reports having acted, and no other. Without it the content rule exempts
+    any act naming a certified path, which a lot reaches by filing two
+    requests, getting the second REFUSED, and appending its own act for it
+    recording the first one's path (review finding, executed).
 
     Per acted request, every recorded path must be a pure addition:
       - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1445,14 +1451,22 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
         # the subbot ran).
         if acted_commits is not None and req is not None and act_sha \
                 and act_sha not in acted_commits:
-            # The way back in is CONTENT, so there must BE content: an act
-            # recording only the ledger leaves the generator empty, `all([])`
-            # is true, and the escape hatch opens for an act that certified
-            # no surface path at all (review finding, executed).
-            surface = [p for p in paths if p != ledger_rel]
-            blobs_match = bool(surface) and acted_blobs is not None and all(
-                acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                for p in surface)
+            # The way back in is CONTENT, so there must BE content, it must
+            # be the content of an act the subbot ACTUALLY acted, and the
+            # comparison must be over paths whose blob is expected to stand
+            # still. Each clause was a hole: an act recording only the ledger
+            # left the generator empty and `all([])` true; an act naming a
+            # path the subbot certified for ANOTHER request rode that
+            # request's certificate (the lot writes its own request, so the
+            # paths it declares are its own); corpus.json legitimately moves
+            # when a later act adds entries, so comparing its blob would
+            # refuse a rewritten history for the one file expected to change
+            # (review findings, executed).
+            surface = [p for p in paths if p not in (ledger_rel, corpus_rel)]
+            blobs_match = bool(surface) and acted_blobs is not None \
+                and act.get("id") in (acted_ids or set()) and all(
+                    acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                    for p in surface)
             if not blobs_match:
                 row["forged"] = True
                 row["problems"].append(
@@ -3730,9 +3744,18 @@ def _selftest():
         check("l'acte introduit par un commit du subbot passe, chemin exempte",
               [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
         v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
-                                   acted_blobs={".golden-master/refs/2.txt": blob_b})
+                                   acted_blobs={".golden-master/refs/2.txt": blob_b},
+                                   acted_ids={"E-1"})
         check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
               v_blob["acted"][0]["ok"], True)
+        # Le certificat couvre l'ACTE que le subbot a acte, pas n'importe quel
+        # acte nommant un chemin certifie : sans l'id, l'echappatoire par
+        # contenu s'ouvre pour un acte que le subbot n'a jamais rendu.
+        v_noid = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                   acted_blobs={".golden-master/refs/2.txt": blob_b})
+        check("meme contenu, acte NON acte par le subbot : refuse",
+              [v_noid["acted"][0]["ok"], v_noid["acted"][0].get("forged")],
+              [False, True])
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("reecrit apres l'acte\n")
         xcommit(email="lot@run")                         # commit C, le lot reecrit
@@ -3753,6 +3776,41 @@ def _selftest():
               [v_old.get("provenance"), v_strict.get("provenance"),
                v_sub.get("provenance"), v_rw2.get("provenance")],
               ["legacy", "strict", "strict", "strict"])
+
+        # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
+        # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
+        # s'acte la refusee en enregistrant le chemin que le subbot a
+        # certifie pour la premiere. Tous les controles de contenu passent —
+        # seul l'id ferme la porte.
+        req_e2 = ('{"id": "E-2", "lot": "L", "type": "add-file",'
+                  ' "paths": [".golden-master/refs/2.txt"]}')
+        act_e2 = ('{"id": "E-2", "lot": "L",'
+                  ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+        xreset()
+        # Les DEUX demandes sont deposees d'abord : l'acte de E-2 arrivera dans
+        # un commit ulterieur, donc la regle du commit unique ne le voit pas —
+        # c'est ce qui rend la contrebande possible.
+        xledger(("request", req2), ("request", req_e2))
+        xcommit()                                        # le lot depose E-1 et E-2
+        xledger(("request", req2), ("request", req_e2), ("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2 certifiee par le subbot\n")
+        xcommit(email="extend@golden-master.iterion")     # le subbot acte E-1, REFUSE E-2
+        sha_sub = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        blob_sub = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                       xroot, timeout=60)[1].strip()
+        xledger(("request", req2), ("request", req_e2),
+                ("act", act2), ("act", act_e2))
+        xcommit(email="lot@run")                          # le lot s'acte la refusee
+        v_smug = extension_verdict(xroot, ".golden-master", xbase,
+                                   acted_commits={sha_sub},
+                                   acted_blobs={".golden-master/refs/2.txt": blob_sub},
+                                   acted_ids={"E-1"})
+        smug = [r for r in v_smug["acted"] if r["id"] == "E-2"][0]
+        check("acte auto-appose sur un chemin certifie pour UNE AUTRE demande : refuse",
+              [smug["ok"], smug.get("forged")], [False, True])
+        check("l'acte du subbot, lui, reste certifie",
+              [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
         # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
         # a certifier, donc aucune echappatoire par contenu.
@@ -4893,9 +4951,16 @@ def main():
                 path, sep, sha = tok.rpartition("=")
                 if sep and path and sha:
                     acted_blobs[path] = sha
+        # The ids the subbot reports having acted. Absent = no act is
+        # covered by the content rule, which is the safe direction: the
+        # rule only ever EXEMPTS.
+        acted_ids = None
+        if "GM_ACTED_IDS" in os.environ:
+            acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
         print(json.dumps(extension_verdict(
             ws, os.environ.get("GM_DIR", ".golden-master"), base,
-            acted_commits=acted_commits, acted_blobs=acted_blobs)))
+            acted_commits=acted_commits, acted_blobs=acted_blobs,
+            acted_ids=acted_ids)))
         raise SystemExit(0)
 
     # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1212,9 +1212,12 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
     the same-commit rule saw nothing, and the lot's own file became a
     reference of the net that judges it.
 
-    `acted_blobs` also bounds the exemption: a certified path whose blob at
-    HEAD moved since the act was rewritten by someone after the subbot —
-    the certificate covers the content it certified, not the path forever.
+    `acted_blobs` also bounds the exemption, on the path SET as much as on
+    the content: a certified path whose blob at HEAD moved since the act was
+    rewritten by someone after the subbot, and a recorded path the subbot
+    certified no blob for was never acted at all — the act's own block is
+    above the run's base, so append-only leaves it mutable and first-wins
+    provenance keeps naming the subbot's commit however it is edited.
     `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
     reports having acted, and no other. Without it the content rule exempts
     any act naming a certified path, which a lot reaches by filing two
@@ -1593,15 +1596,32 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                 "the act records no path on the extension surface (refs/ or "
                 "corpus.json) — filing paperwork is not an extension")
         if acted_blobs is not None and req is not None:
-            # The certificate covers the CONTENT the subbot committed, not
-            # the path forever: a reference rewritten after the act — by the
-            # lot, in its own later commit — is the masking vector again, and
-            # the exemption must not follow it.
+            # The certificate binds the act's recorded path SET, not only the
+            # content of the paths it happens to name. Both halves are the same
+            # masking vector, reached through the same door:
+            #   - a certified path whose blob moved was rewritten after the
+            #     act, by the lot, in its own later commit;
+            #   - a recorded path with NO certificate was never acted at all.
+            #     `introducing_commits` resolves an act FIRST-WINS on
+            #     (kind, id), so it keeps naming the subbot's commit however
+            #     the block is edited afterwards, and append-only only pins the
+            #     text below the RUN's base — the subbot's own block sits above
+            #     it, in the mutable region. Widening that block with the lot's
+            #     own path made an uncertified file a reference of the net that
+            #     judges it. The strict provenance arm already demands a
+            #     certificate for every surface path; this is that same demand
+            #     on the arm standing in for it.
             for p in paths:
                 if p == ledger_rel or p == corpus_rel:
                     continue
                 certified = acted_blobs.get(p)
-                if certified and blob_id("HEAD", p) != certified:
+                if not certified:
+                    row["forged"] = True
+                    row["problems"].append(
+                        "%s is recorded by the act but the subbot certified no "
+                        "blob for it — a path appended to the record after the "
+                        "act is not part of the act" % p)
+                elif blob_id("HEAD", p) != certified:
                     row["forged"] = True
                     row["problems"].append(
                         "%s was rewritten after the act: HEAD carries blob %s, "
@@ -3909,6 +3929,44 @@ def _selftest():
         check("l'acte du subbot reste certifie, lui",
               [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
               [True, [".golden-master/refs/2.txt"]])
+
+        # LE MEME TROU PAR L'AUTRE BATTANT : au lieu d'apposer un SECOND bloc,
+        # le lot ELARGIT celui du subbot. La provenance se resout premier-gagnant
+        # sur (kind, id), donc `act_sha` reste le commit du subbot quoi qu'il
+        # arrive au bloc ; l'append-only ne fige que le texte sous la base, et le
+        # bloc du subbot est au-dessus. Le chemin ajoute n'a aucun blob certifie
+        # — et une absence de certificat passait, la garde ne mordant que sur un
+        # certificat present.
+        act_widened = ('{"id": "E-1", "lot": "L",'
+                       ' "recorded_paths": [".golden-master/refs/2.txt",'
+                       ' ".golden-master/refs/9.txt"]}')
+        xreset()
+        xledger(("request", req_two))
+        xcommit()                                          # le lot depose
+        xledger(("request", req_two), ("act", act_one))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("acte par le subbot\n")
+        xcommit(email="extend@golden-master.iterion")      # le subbot acte
+        sha_w = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        blob_w = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                     xroot, timeout=60)[1].strip()
+        xledger(("request", req_two), ("act", act_widened))
+        with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+            f.write("ecrit par le lot\n")
+        xcommit(email="lot@run")                           # le lot elargit l'acte
+        v_wide = extension_verdict(xroot, ".golden-master", xbase,
+                                   acted_commits={sha_w},
+                                   acted_blobs={".golden-master/refs/2.txt": blob_w},
+                                   acted_ids={"E-1"})
+        wide = v_wide["acted"][0]
+        check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+              "et le chemin ajoute n'est pas exempte",
+              [wide["ok"], wide.get("forged"),
+               ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
+              [False, True, False])
+        check("et le chemin que le subbot a bien certifie n'exempte plus rien "
+              "non plus : c'est l'acte entier qui est refuse",
+              v_wide["ok_paths"], [])
 
         # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
         # a certifier, donc aucune echappatoire par contenu.

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3246,6 +3246,71 @@ def stability(config, corpus, canon, ws):
 
 # ─── Self-test ──────────────────────────────────────────────────────────────
 
+# ─── Auto-maintenance audit (selftest) ──────────────────────────────────────
+
+_GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
+
+
+def _git_command_lines(argv):
+    """The git command lines an argv spawns.
+
+    Two forms, because both occur here: the argv IS git, or it is a shell
+    running a script in which `git` stands in command position. Split on the
+    separators a shell uses, so `cd x && git commit` is seen as a git command
+    and `rm -rf .git` is not.
+    """
+    if isinstance(argv, (list, tuple)):
+        parts = [str(a) for a in argv]
+    elif isinstance(argv, str):
+        parts = ["sh", "-c", argv]
+    else:
+        return []
+    if not parts:
+        return []
+    found = []
+    if os.path.basename(parts[0]) == "git":
+        found.append(parts)
+    if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
+            and parts[1] == "-c":
+        for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
+            tokens = segment.strip().lstrip("(").strip().split()
+            if tokens and os.path.basename(tokens[0]) == "git":
+                found.append(tokens)
+    return found
+
+
+def _git_refuses_auto_maintenance(tokens, env):
+    """Whether a git command line turns BOTH switches off — by `-c` in its own
+    argv, or by git's environment form of the same thing.
+
+    Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
+    the older one AND the fallback a recent Git consults when the first is
+    absent, so a single switch holds on one version and not the other.
+
+    Both idioms, not one: the argv is what a call site writes, the environment
+    is what a chokepoint sets for every call site at once. Accepting only the
+    idiom in use here would refuse the other the day someone moves the guard.
+
+    env is None when the child inherits the parent's — that inherited
+    environment is the one that will decide, so it is what gets read.
+    """
+    flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+    environ = os.environ if env is None else env
+    try:
+        count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
+    except ValueError:
+        count = 0
+    from_env = {}
+    for i in range(count):
+        key = environ.get("GIT_CONFIG_KEY_%d" % i)
+        if key:
+            from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+    for key, value in _GIT_MAINTENANCE_OFF:
+        if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
+            return False
+    return True
+
+
 def _selftest():
     """GM_MODE=selftest — teste la moitie qui DECIDE, pas celle qui compare.
 
@@ -3263,6 +3328,46 @@ def _selftest():
     """
     failures, checked = [], [0]
     skipped_under_root = []
+
+    # A writing git command in a scratch repo detaches `git maintenance run
+    # --auto` (Git >= 2.48), which goes on writing under .git/objects after the
+    # command returned — while the fixture's temp dir is being removed.
+    #
+    # The switches are set HERE, once, in the environment every child git
+    # inherits, rather than at each call site: enumerating the call sites is
+    # what failed. Two sweeps read this file and both missed a helper defined
+    # four hundred lines below fixture_git, inside a block.
+    #
+    # And the audit below does not read the source either — it WATCHES what the
+    # selftest spawns. Popen is the hook because run, call, check_call and
+    # check_output all reach the kernel through it; hooking run alone would
+    # leave the other four unseen. os.system reaches neither and is refused
+    # outright rather than watched, so the door nobody guards fails closed.
+    _git_audit = {"seen": 0, "offenders": []}
+    _real_popen = subprocess.Popen
+    _real_system = os.system
+
+    class _AuditedPopen(_real_popen):
+        def __init__(self, args, *rest, **kw):
+            for tokens in _git_command_lines(args):
+                _git_audit["seen"] += 1
+                if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
+                    _git_audit["offenders"].append(" ".join(tokens)[:120])
+            super().__init__(args, *rest, **kw)
+
+    def _refuse_system(command):
+        raise AssertionError(
+            "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
+
+    saved_git_env = {k: os.environ.get(k) for k in
+                     ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+                      "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+    for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+        os.environ["GIT_CONFIG_KEY_%d" % i] = key
+        os.environ["GIT_CONFIG_VALUE_%d" % i] = value
+    os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+    subprocess.Popen = _AuditedPopen
+    os.system = _refuse_system
 
     def check(name, got, want):
         checked[0] += 1
@@ -5041,6 +5146,22 @@ def _selftest():
                 os.environ["GM_SCRATCH"] = saved_scratch
     finally:
         g.update(saved)
+        subprocess.Popen = _real_popen
+        os.system = _real_system
+        for key, value in saved_git_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    # Judged on what ran, not on what the source says. A future helper that
+    # spawns git its own way is caught by having RUN, which is the only thing
+    # that found the one this replaces.
+    check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
+          " (%d invocations vues)" % _git_audit["seen"],
+          _git_audit["offenders"], [])
+    check("le selftest lance bien des commandes git (l'audit a une prise)",
+          _git_audit["seen"] > 0, True)
 
     if failures:
         log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1414,8 +1414,28 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
     base_act_ids = {b.get("id") for b in _extension_blocks(base_txt, "act")
                     if b.get("id") != "UNPARSEABLE"}
     intro = introducing_commits()
+    # An id is acted ONCE. `introducing_commits` keys first-wins, so a SECOND
+    # act block carrying an id the subbot already acted resolves its
+    # provenance on the subbot's commit — the whole provenance branch is
+    # skipped, no certified blob exists for its paths so the rewrite check
+    # skips too, and the lot's own commit writes a reference into the net that
+    # judges it, exempted (review finding, executed: both rows came back ok
+    # and the second act's path landed in ok_paths). The ledger's ids are the
+    # audit trail's keys; a duplicate key is a refusal, like the corpus's.
+    seen_act_ids = set()
     for act in acts:
         row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
+        if act.get("id") in seen_act_ids:
+            row["forged"] = True
+            row["problems"].append(
+                "a SECOND act block for %r — an id is acted once. Its "
+                "provenance would resolve on the FIRST act's commit, so any "
+                "later block rides the subbot's certificate: remove it, and "
+                "file a new request if something more must be acted"
+                % act.get("id"))
+            verdict["acted"].append(row)
+            continue
+        seen_act_ids.add(act.get("id"))
         if act.get("id") in base_act_ids:
             row["ok"] = True
             row["acted_at_base"] = True
@@ -3812,6 +3832,45 @@ def _selftest():
         check("l'acte du subbot, lui, reste certifie",
               [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
+        # LE DOUBLON D'ACTE, rejoue en entier : la demande du lot declare DEUX
+        # chemins, le subbot en acte UN, puis le lot appose un SECOND bloc
+        # `act` portant le meme id pour le chemin restant. La provenance du
+        # doublon se resout sur le commit du subbot (premier gagnant), donc
+        # sans refus du doublon tout passe et le chemin du lot est exempte.
+        req_two = ('{"id": "E-1", "lot": "L", "type": "add-file",'
+                   ' "paths": [".golden-master/refs/2.txt",'
+                   ' ".golden-master/refs/9.txt"]}')
+        act_one = ('{"id": "E-1", "lot": "L",'
+                   ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+        act_dup = ('{"id": "E-1", "lot": "L",'
+                   ' "recorded_paths": [".golden-master/refs/9.txt"]}')
+        xreset()
+        xledger(("request", req_two))
+        xcommit()                                         # le lot depose
+        xledger(("request", req_two), ("act", act_one))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("acte par le subbot\n")
+        xcommit(email="extend@golden-master.iterion")      # le subbot acte
+        sha_one = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        blob_one = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                       xroot, timeout=60)[1].strip()
+        xledger(("request", req_two), ("act", act_one), ("act", act_dup))
+        with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+            f.write("ecrit par le lot\n")
+        xcommit(email="lot@run")                           # le lot double l'acte
+        v_dup = extension_verdict(xroot, ".golden-master", xbase,
+                                  acted_commits={sha_one},
+                                  acted_blobs={".golden-master/refs/2.txt": blob_one},
+                                  acted_ids={"E-1"})
+        dup = v_dup["acted"][1]
+        check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+              [dup["ok"], dup.get("forged"),
+               ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
+              [False, True, False])
+        check("l'acte du subbot reste certifie, lui",
+              [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
+              [True, [".golden-master/refs/2.txt"]])
+
         # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
         # a certifier, donc aucune echappatoire par contenu.
         xreset()
@@ -4945,18 +5004,39 @@ def main():
             for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
                 full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
                 acted_commits.add(full if len(full) == 40 else tok)
+        # ONE ENTRY PER LINE, for both certificates. Whitespace-delimited,
+        # a surface path containing a space split into two tokens: the left
+        # had no `=` and was DROPPED, the right registered a bogus key — so
+        # the real path had no certified blob, the post-act rewrite check
+        # skipped it, and the lot could rewrite that reference in a later
+        # commit and keep the exemption (review finding). The same defect sat
+        # on the ids, where a space in an id split it out of the set and the
+        # act silently lost its cover. Both ids and paths are lot-authored
+        # and a space passes their guards, so the encoding is what has to be
+        # unambiguous — and an entry that cannot be read is a REFUSAL, never
+        # a silent drop.
         if "GM_ACTED_BLOBS" in os.environ:
             acted_blobs = {}
-            for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
-                path, sep, sha = tok.rpartition("=")
-                if sep and path and sha:
-                    acted_blobs[path] = sha
+            for line in os.environ.get("GM_ACTED_BLOBS", "").splitlines():
+                if not line.strip():
+                    continue
+                path, sep, sha = line.rpartition("=")
+                if not (sep and path and sha):
+                    print(json.dumps({"error":
+                                      "GM_ACTED_BLOBS carries an entry that is "
+                                      "not `path=blob`: %r — a certificate the "
+                                      "judge cannot read is refused, not dropped"
+                                      % line}))
+                    raise SystemExit(1)
+                acted_blobs[path] = sha
         # The ids the subbot reports having acted. Absent = no act is
         # covered by the content rule, which is the safe direction: the
         # rule only ever EXEMPTS.
         acted_ids = None
         if "GM_ACTED_IDS" in os.environ:
-            acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
+            acted_ids = {l.strip() for l in
+                         os.environ.get("GM_ACTED_IDS", "").splitlines()
+                         if l.strip()}
         print(json.dumps(extension_verdict(
             ws, os.environ.get("GM_DIR", ".golden-master"), base,
             acted_commits=acted_commits, acted_blobs=acted_blobs,

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -365,3 +365,27 @@ Three rules, and each of them was learned by paying for it:
 If the net cannot be made to see something, **write that down** rather than narrowing the corpus
 until it goes green. A documented blind spot is a usable engineering artefact. A green run
 obtained by removing what failed is a lie with a timestamp on it.
+
+## Extensions: who may act, and how the gate knows
+
+A lot may **ask** for a new observation point (a request block in the ledger); only
+the net's own subbot (`extend`) may **act** it. The gate does not take anyone's word
+for who acted: the subbot reports the commits it made (`acted_commits`), the request
+ids it acted and the blob it certified per surface path (`acted_blobs`); the parent
+hands them to the harness on every pass, and an act introduced by any other commit —
+or a certified path whose blob moved since — is a typed refusal (`EXTENSION_FORGED`),
+never a repair pass and never certified later by a resume from the banked branch.
+
+Practical consequences for the constrained party (the lot):
+
+- File the request, commit, and stop. Do not write refs, corpus entries or an act
+  block yourself — the gate refuses them whatever author your commits carry.
+- Do not leave anything uncommitted under the net's directory: the subbot refuses
+  to start on a dirty net, since it could not tell its own additions from yours.
+- Do not merge or rebase the base into your branch while a lot runs: the acts the
+  subbot certified are known by commit and by content; a history rewritten after
+  the subbot ran keeps its certified content and loses its shas.
+
+The git identity of the subbot's commits is set by the engine for its run and restored
+after (`golden-master extend <extend@golden-master.iterion>` by default): it is
+attribution the gate reports, not the lock — the lock is the list of commits.

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -97,7 +97,9 @@ notice that the bytes reaching the browser changed, and a scan of source files c
 6. **Stop.** The runner and the report are emitted by the workflow, not by you. Writing a
    `REPORT.md` of your own is welcome when you have something the template cannot say — your
    documented blind spots, the causes behind your canonicalisation rules — and it will not be
-   overwritten. Do not write `verify-oracle.sh`.
+   overwritten. Do not write `verify-oracle.sh`. This freedom is the RITE's: inside the extension
+   subbot the only writable paths are the extension surface, and a refusal is reported in the
+   node's `summary`, never in a file (see «Extensions: who may act, and how the gate knows»).
 
 ## Putting the runner in CI, and the three ways that job goes green without judging
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -5143,7 +5143,19 @@ tool sync_harness:
         # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
         if mode == "selftest":
             for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
-                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS",
+                             # Git's identity ENV outranks every config source,
+                             # `-c user.email` included, so a host that exports
+                             # it (devcontainer, CI image, agent sandbox) made
+                             # every fixture commit under the caller's name and
+                             # turned the author checks red — in a step the gate
+                             # wrapper runs BLOCKING, so a campaign's exit gate
+                             # failed for a reason unrelated to the code under
+                             # test (review finding, reproduced). Same class as
+                             # the GM_* above: the doubles are the selftest's,
+                             # and nothing about the caller may reach them.
+                             "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL",
+                             "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"):
                 os.environ.pop(_ambient, None)
             raise SystemExit(_selftest())
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1379,9 +1379,12 @@ tool sync_harness:
         the same-commit rule saw nothing, and the lot's own file became a
         reference of the net that judges it.
 
-        `acted_blobs` also bounds the exemption: a certified path whose blob at
-        HEAD moved since the act was rewritten by someone after the subbot —
-        the certificate covers the content it certified, not the path forever.
+        `acted_blobs` also bounds the exemption, on the path SET as much as on
+        the content: a certified path whose blob at HEAD moved since the act was
+        rewritten by someone after the subbot, and a recorded path the subbot
+        certified no blob for was never acted at all — the act's own block is
+        above the run's base, so append-only leaves it mutable and first-wins
+        provenance keeps naming the subbot's commit however it is edited.
         `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
         reports having acted, and no other. Without it the content rule exempts
         any act naming a certified path, which a lot reaches by filing two
@@ -1760,15 +1763,32 @@ tool sync_harness:
                     "the act records no path on the extension surface (refs/ or "
                     "corpus.json) — filing paperwork is not an extension")
             if acted_blobs is not None and req is not None:
-                # The certificate covers the CONTENT the subbot committed, not
-                # the path forever: a reference rewritten after the act — by the
-                # lot, in its own later commit — is the masking vector again, and
-                # the exemption must not follow it.
+                # The certificate binds the act's recorded path SET, not only the
+                # content of the paths it happens to name. Both halves are the same
+                # masking vector, reached through the same door:
+                #   - a certified path whose blob moved was rewritten after the
+                #     act, by the lot, in its own later commit;
+                #   - a recorded path with NO certificate was never acted at all.
+                #     `introducing_commits` resolves an act FIRST-WINS on
+                #     (kind, id), so it keeps naming the subbot's commit however
+                #     the block is edited afterwards, and append-only only pins the
+                #     text below the RUN's base — the subbot's own block sits above
+                #     it, in the mutable region. Widening that block with the lot's
+                #     own path made an uncertified file a reference of the net that
+                #     judges it. The strict provenance arm already demands a
+                #     certificate for every surface path; this is that same demand
+                #     on the arm standing in for it.
                 for p in paths:
                     if p == ledger_rel or p == corpus_rel:
                         continue
                     certified = acted_blobs.get(p)
-                    if certified and blob_id("HEAD", p) != certified:
+                    if not certified:
+                        row["forged"] = True
+                        row["problems"].append(
+                            "%s is recorded by the act but the subbot certified no "
+                            "blob for it — a path appended to the record after the "
+                            "act is not part of the act" % p)
+                    elif blob_id("HEAD", p) != certified:
                         row["forged"] = True
                         row["problems"].append(
                             "%s was rewritten after the act: HEAD carries blob %s, "
@@ -4076,6 +4096,44 @@ tool sync_harness:
             check("l'acte du subbot reste certifie, lui",
                   [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
+
+            # LE MEME TROU PAR L'AUTRE BATTANT : au lieu d'apposer un SECOND bloc,
+            # le lot ELARGIT celui du subbot. La provenance se resout premier-gagnant
+            # sur (kind, id), donc `act_sha` reste le commit du subbot quoi qu'il
+            # arrive au bloc ; l'append-only ne fige que le texte sous la base, et le
+            # bloc du subbot est au-dessus. Le chemin ajoute n'a aucun blob certifie
+            # — et une absence de certificat passait, la garde ne mordant que sur un
+            # certificat present.
+            act_widened = ('{"id": "E-1", "lot": "L",'
+                           ' "recorded_paths": [".golden-master/refs/2.txt",'
+                           ' ".golden-master/refs/9.txt"]}')
+            xreset()
+            xledger(("request", req_two))
+            xcommit()                                          # le lot depose
+            xledger(("request", req_two), ("act", act_one))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("acte par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")      # le subbot acte
+            sha_w = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_w = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                         xroot, timeout=60)[1].strip()
+            xledger(("request", req_two), ("act", act_widened))
+            with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+                f.write("ecrit par le lot\n")
+            xcommit(email="lot@run")                           # le lot elargit l'acte
+            v_wide = extension_verdict(xroot, ".golden-master", xbase,
+                                       acted_commits={sha_w},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_w},
+                                       acted_ids={"E-1"})
+            wide = v_wide["acted"][0]
+            check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+                  "et le chemin ajoute n'est pas exempte",
+                  [wide["ok"], wide.get("forged"),
+                   ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
+                  [False, True, False])
+            check("et le chemin que le subbot a bien certifie n'exempte plus rien "
+                  "non plus : c'est l'acte entier qui est refuse",
+                  v_wide["ok_paths"], [])
 
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1243,7 +1243,8 @@ tool sync_harness:
             if not isinstance(obj, dict) or \
                     not (isinstance(obj.get("id"), str) and obj.get("id")):
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
-            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip() \
+                    or any(ord(c) < 0x20 or ord(c) == 0x7f for c in obj["id"]):
                 # An id reaches the gate through a LINE-ORIENTED transport
                 # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
                 # arrives as two fragments and seeds the covered set with an id no
@@ -1253,6 +1254,15 @@ tool sync_harness:
                 # two distinct ids into one, and the collapse re-opens the
                 # smuggling this file exists to close. An INTERIOR space stays
                 # legal: it round-trips whole, and a lot-authored id may carry one.
+                #
+                # The test is stated TWICE on purpose, and neither half covers the
+                # other. `splitlines()` is the transport's own reader, so asking it
+                # to round-trip catches every separator it honours — including
+                # U+0085, U+2028 and U+2029, which are NOT control characters and
+                # which a `ord(c) < 0x20` rule lets straight through. The control
+                # rule in turn refuses TAB, NUL and DEL, which round-trip fine here
+                # but have no business in a lot-authored identifier that a human
+                # reads in a ledger and a machine compares byte for byte.
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
             else:
                 # The list-shaped fields are iterated by every judgement below. A
@@ -1474,7 +1484,17 @@ tool sync_harness:
 
         all_blocks = (_extension_blocks(head_txt, "request") +
                       _extension_blocks(head_txt, "act"))
-        if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
+        # An unreadable block is not merely REPORTED: it makes this judge unable to
+        # read the ledger it certifies from, so nothing that ledger holds is
+        # certified while the block stands — the same shape as
+        # `ledger_append_only`, for the same reason. Reported only, the readable
+        # blocks beside it went on exempting their paths, so a ledger that
+        # escalates handed out exemptions all the same, and a caller reading
+        # `ok_paths` without also reading `problems` never saw the escalation. An
+        # ESCALATION, never a forgery: the requester fixes the block, no history
+        # was rewritten.
+        ledger_readable = not any(b.get("id") == "UNPARSEABLE" for b in all_blocks)
+        if not ledger_readable:
             verdict["problems"].append(
                 "a ledger block does not parse as JSON, or carries an id that "
                 "cannot survive the one-id-per-line certificate — escalate, do "
@@ -1754,6 +1774,10 @@ tool sync_harness:
                             "%s was rewritten after the act: HEAD carries blob %s, "
                             "the subbot certified %s — the certificate covers the "
                             "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
+            if not ledger_readable:
+                row["problems"].append(
+                    "the ledger carries a block this judge cannot read — nothing "
+                    "it holds is certified until that block is fixed")
             row["ok"] = (req is not None and not row["problems"]
                          and verdict["ledger_append_only"])
             if row["ok"]:

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3556,14 +3556,26 @@ tool sync_harness:
                 "where to append the auto-maintenance switches" % raw_count)
         if base_count < 0:
             raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+        # A canary takes the slot a pre-existing declaration would occupy, because
+        # overwriting one is SILENT here: the selftest's own fixtures do not need
+        # safe.directory, so destroying the engine's entry changes nothing it
+        # measures — it only bites in the sandbox, where the workspace is owned by
+        # someone else. What is checked below is that git still resolves the canary
+        # once the switches are in place, which is the same question asked of a
+        # declaration that was there first.
+        canary_key = "iterion.selftestcanary"
+        canary_value = "alive-%d" % os.getpid()
         saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+        for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
             slot = base_count + i
             for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                    ("GIT_CONFIG_VALUE_%d" % slot, value)):
                 saved_git_env[name] = os.environ.get(name)
                 os.environ[name] = declared
-        os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+        canary_seen = subprocess.run(
+            ["git", "config", "--get-all", canary_key],
+            capture_output=True, text=True).stdout.split()
         subprocess.Popen = _AuditedPopen
         os.system = _refuse_system
 
@@ -5361,6 +5373,10 @@ tool sync_harness:
         # Les DEUX compteurs, pas leur somme : le selftest lance les deux
         # programmes, et un compteur mort laisse l'autre porter le total — un audit
         # a moitie aveugle passerait pour un arbre propre.
+        # Ce que git RESOUT, pas ce que le dict dit avoir posé : une declaration
+        # anterieure survit a la pose des boutons.
+        check("une declaration git anterieure survit a la pose des boutons",
+              canary_value in canary_seen, True)
         check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
         check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1243,6 +1243,17 @@ tool sync_harness:
             if not isinstance(obj, dict) or \
                     not (isinstance(obj.get("id"), str) and obj.get("id")):
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+            elif obj["id"].splitlines() != [obj["id"]] or not obj["id"].strip():
+                # An id reaches the gate through a LINE-ORIENTED transport
+                # (`GM_ACTED_IDS`, one id per line). One carrying a line separator
+                # arrives as two fragments and seeds the covered set with an id no
+                # subbot ever acted; one made only of whitespace cannot be told
+                # from a blank line. Refused at this single parse point rather
+                # than repaired downstream — a repair is precisely what collapses
+                # two distinct ids into one, and the collapse re-opens the
+                # smuggling this file exists to close. An INTERIOR space stays
+                # legal: it round-trips whole, and a lot-authored id may carry one.
+                obj = {"id": "UNPARSEABLE", "raw": body[:120]}
             else:
                 # The list-shaped fields are iterated by every judgement below. A
                 # scalar here raised TypeError inside the verdict, and a verdict
@@ -1304,7 +1315,9 @@ tool sync_harness:
         acts = _extension_blocks(text, "act")
         if any(b.get("id") == "UNPARSEABLE" for b in requests + acts):
             return [{"id": "UNPARSEABLE",
-                     "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+                     "why": "a ledger block does not parse as JSON, or carries an "
+                            "id that cannot survive the one-id-per-line "
+                            "certificate — escalate, do not guess"}]
         # Only a WELL-FORMED act closes a request: an act with no recorded path
         # acted nothing, and letting it close the term would let the constrained
         # party silence the conjunction with four lines of JSON — the
@@ -1463,7 +1476,9 @@ tool sync_harness:
                       _extension_blocks(head_txt, "act"))
         if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
             verdict["problems"].append(
-                "a ledger block does not parse as JSON — escalate, do not guess")
+                "a ledger block does not parse as JSON, or carries an id that "
+                "cannot survive the one-id-per-line certificate — escalate, do "
+                "not guess")
         requests = {b["id"]: b for b in _extension_blocks(head_txt, "request")
                     if b.get("id") != "UNPARSEABLE"}
         acts = [b for b in _extension_blocks(head_txt, "act")
@@ -5213,7 +5228,14 @@ tool sync_harness:
             # rule only ever EXEMPTS.
             acted_ids = None
             if "GM_ACTED_IDS" in os.environ:
-                acted_ids = {l.strip() for l in
+                # The RAW line, exactly as the blob certificate above reads its
+                # own: `.strip()` is an emptiness test here, never a repair.
+                # Normalising the id while `extension_verdict` compares it
+                # verbatim made two ids differing only by surrounding whitespace
+                # collapse into one — the act the subbot REFUSED came back covered
+                # by the id it had acted, which is the smuggling of a refused
+                # extension, reopened by an encoding.
+                acted_ids = {l for l in
                              os.environ.get("GM_ACTED_IDS", "").splitlines()
                              if l.strip()}
             print(json.dumps(extension_verdict(

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3413,6 +3413,71 @@ tool sync_harness:
 
     # ─── Self-test ──────────────────────────────────────────────────────────────
 
+    # ─── Auto-maintenance audit (selftest) ──────────────────────────────────────
+
+    _GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
+
+
+    def _git_command_lines(argv):
+        """The git command lines an argv spawns.
+
+        Two forms, because both occur here: the argv IS git, or it is a shell
+        running a script in which `git` stands in command position. Split on the
+        separators a shell uses, so `cd x && git commit` is seen as a git command
+        and `rm -rf .git` is not.
+        """
+        if isinstance(argv, (list, tuple)):
+            parts = [str(a) for a in argv]
+        elif isinstance(argv, str):
+            parts = ["sh", "-c", argv]
+        else:
+            return []
+        if not parts:
+            return []
+        found = []
+        if os.path.basename(parts[0]) == "git":
+            found.append(parts)
+        if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
+                and parts[1] == "-c":
+            for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
+                tokens = segment.strip().lstrip("(").strip().split()
+                if tokens and os.path.basename(tokens[0]) == "git":
+                    found.append(tokens)
+        return found
+
+
+    def _git_refuses_auto_maintenance(tokens, env):
+        """Whether a git command line turns BOTH switches off — by `-c` in its own
+        argv, or by git's environment form of the same thing.
+
+        Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
+        the older one AND the fallback a recent Git consults when the first is
+        absent, so a single switch holds on one version and not the other.
+
+        Both idioms, not one: the argv is what a call site writes, the environment
+        is what a chokepoint sets for every call site at once. Accepting only the
+        idiom in use here would refuse the other the day someone moves the guard.
+
+        env is None when the child inherits the parent's — that inherited
+        environment is the one that will decide, so it is what gets read.
+        """
+        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+        environ = os.environ if env is None else env
+        try:
+            count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
+        except ValueError:
+            count = 0
+        from_env = {}
+        for i in range(count):
+            key = environ.get("GIT_CONFIG_KEY_%d" % i)
+            if key:
+                from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+        for key, value in _GIT_MAINTENANCE_OFF:
+            if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
+                return False
+        return True
+
+
     def _selftest():
         """GM_MODE=selftest — teste la moitie qui DECIDE, pas celle qui compare.
 
@@ -3430,6 +3495,46 @@ tool sync_harness:
         """
         failures, checked = [], [0]
         skipped_under_root = []
+
+        # A writing git command in a scratch repo detaches `git maintenance run
+        # --auto` (Git >= 2.48), which goes on writing under .git/objects after the
+        # command returned — while the fixture's temp dir is being removed.
+        #
+        # The switches are set HERE, once, in the environment every child git
+        # inherits, rather than at each call site: enumerating the call sites is
+        # what failed. Two sweeps read this file and both missed a helper defined
+        # four hundred lines below fixture_git, inside a block.
+        #
+        # And the audit below does not read the source either — it WATCHES what the
+        # selftest spawns. Popen is the hook because run, call, check_call and
+        # check_output all reach the kernel through it; hooking run alone would
+        # leave the other four unseen. os.system reaches neither and is refused
+        # outright rather than watched, so the door nobody guards fails closed.
+        _git_audit = {"seen": 0, "offenders": []}
+        _real_popen = subprocess.Popen
+        _real_system = os.system
+
+        class _AuditedPopen(_real_popen):
+            def __init__(self, args, *rest, **kw):
+                for tokens in _git_command_lines(args):
+                    _git_audit["seen"] += 1
+                    if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
+                        _git_audit["offenders"].append(" ".join(tokens)[:120])
+                super().__init__(args, *rest, **kw)
+
+        def _refuse_system(command):
+            raise AssertionError(
+                "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
+
+        saved_git_env = {k: os.environ.get(k) for k in
+                         ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
+                          "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+            os.environ["GIT_CONFIG_KEY_%d" % i] = key
+            os.environ["GIT_CONFIG_VALUE_%d" % i] = value
+        os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+        subprocess.Popen = _AuditedPopen
+        os.system = _refuse_system
 
         def check(name, got, want):
             checked[0] += 1
@@ -5208,6 +5313,22 @@ tool sync_harness:
                     os.environ["GM_SCRATCH"] = saved_scratch
         finally:
             g.update(saved)
+            subprocess.Popen = _real_popen
+            os.system = _real_system
+            for key, value in saved_git_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        # Judged on what ran, not on what the source says. A future helper that
+        # spawns git its own way is caught by having RUN, which is the only thing
+        # that found the one this replaces.
+        check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
+              " (%d invocations vues)" % _git_audit["seen"],
+              _git_audit["offenders"], [])
+        check("le selftest lance bien des commandes git (l'audit a une prise)",
+              _git_audit["seen"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1435,8 +1435,15 @@ tool sync_harness:
                              "judging additions against nothing would pass by "
                              "construction" % (base, err.strip() or "unknown ref")}
 
+        # `provenance` is the verdict SAYING which rule it applied. A net whose
+        # harness predates this feature answers `extend-verify` and passes a
+        # caller's capability probe all the same, while judging by the
+        # same-commit rule alone — the bypassable one — and nothing in its answer
+        # said so: the gate reverted to the hole in silence (review finding,
+        # executed). A caller that hands provenance asserts this echo.
         verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
-                   "requests_added": 0, "problems": []}
+                   "requests_added": 0, "problems": [],
+                   "provenance": "strict" if acted_commits is not None else "legacy"}
 
         head_txt = at("HEAD", ledger_rel) or ""
         base_txt = at(base, ledger_rel) or ""
@@ -1605,9 +1612,14 @@ tool sync_harness:
             # the subbot ran).
             if acted_commits is not None and req is not None and act_sha \
                     and act_sha not in acted_commits:
-                blobs_match = bool(paths) and acted_blobs is not None and all(
+                # The way back in is CONTENT, so there must BE content: an act
+                # recording only the ledger leaves the generator empty, `all([])`
+                # is true, and the escape hatch opens for an act that certified
+                # no surface path at all (review finding, executed).
+                surface = [p for p in paths if p != ledger_rel]
+                blobs_match = bool(surface) and acted_blobs is not None and all(
                     acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                    for p in paths if p != ledger_rel)
+                    for p in surface)
                 if not blobs_match:
                     row["forged"] = True
                     row["problems"].append(
@@ -3899,6 +3911,29 @@ tool sync_harness:
             v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
             check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
+
+            # Le verdict ANNONCE la regle qu'il a appliquee : sans cet echo, un
+            # filet synchronise avant la provenance repond `extend-verify`, ignore
+            # les deux variables et rend l'ancienne regle — le trou que ce terme
+            # ferme, revenu en silence. L'appelant l'exige (main.bot).
+            check("le verdict annonce la regle appliquee",
+                  [v_old.get("provenance"), v_strict.get("provenance"),
+                   v_sub.get("provenance"), v_rw2.get("provenance")],
+                  ["legacy", "strict", "strict", "strict"])
+
+            # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
+            # a certifier, donc aucune echappatoire par contenu.
+            xreset()
+            xrequest(req2)
+            xledger(("request", req2),
+                    ("act", '{"id": "E-1", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/EXTENSIONS.md"]}'))
+            xcommit(email="lot@run")
+            v_led = extension_verdict(xroot, ".golden-master", xbase,
+                                      acted_commits=set(), acted_blobs={})
+            check("acte n'enregistrant que le registre, hors commits du subbot : forge",
+                  [v_led["acted"][0]["ok"], v_led["acted"][0].get("forged")],
+                  [False, True])
 
             # Reecriture deguisee : la ref existait a la base.
             xreset()

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3510,14 +3510,16 @@ tool sync_harness:
         # check_output all reach the kernel through it; hooking run alone would
         # leave the other four unseen. os.system reaches neither and is refused
         # outright rather than watched, so the door nobody guards fails closed.
-        _git_audit = {"seen": 0, "offenders": []}
+        _git_audit = {"direct": 0, "shell": 0, "offenders": []}
         _real_popen = subprocess.Popen
         _real_system = os.system
 
         class _AuditedPopen(_real_popen):
             def __init__(self, args, *rest, **kw):
+                program = args[0] if isinstance(args, (list, tuple)) and args else args
+                spawns_git = os.path.basename(str(program)) == "git"
                 for tokens in _git_command_lines(args):
-                    _git_audit["seen"] += 1
+                    _git_audit["direct" if spawns_git else "shell"] += 1
                     if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
                         _git_audit["offenders"].append(" ".join(tokens)[:120])
                 super().__init__(args, *rest, **kw)
@@ -5325,10 +5327,17 @@ tool sync_harness:
         # spawns git its own way is caught by having RUN, which is the only thing
         # that found the one this replaces.
         check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-              " (%d invocations vues)" % _git_audit["seen"],
+              " (%d invocations vues : %d en argv, %d via sh -c)"
+              % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
               _git_audit["offenders"], [])
-        check("le selftest lance bien des commandes git (l'audit a une prise)",
-              _git_audit["seen"] > 0, True)
+        # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
+        # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
+        # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
+        # propre. C'est le plancher d'un banc, pas une mesure de couverture.
+        check("l'audit voit les commandes git lancees en argv direct",
+              _git_audit["direct"] > 0, True)
+        check("l'audit voit les commandes git lancees a travers un shell",
+              _git_audit["shell"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4476,6 +4476,16 @@ tool sync_harness:
             os.environ["GM_SCRATCH"] = tempfile.mkdtemp(prefix="gm-scratch-")
             try:
                 def sub(*a):
+                    # Same reason fixture_git carries them: this repo is a temp dir
+                    # deleted on the way out, and a writing command (init, add,
+                    # commit, checkout) detaches `git maintenance run --auto`, which
+                    # goes on writing under .git/objects afterwards. Both buttons:
+                    # maintenance.auto is Git >= 2.48, gc.auto is the older one AND
+                    # what a recent Git falls back to when the first is absent — the
+                    # local Git here is 2.43, so one button alone would hold on one
+                    # version and not the other.
+                    if a and a[0] == "git":
+                        a = ("git", "-c", "gc.auto=0", "-c", "maintenance.auto=false") + tuple(a[1:])
                     return subprocess.run(a, cwd=tmp, capture_output=True, text=True, check=True)
                 sub("git", "init", "-q")
                 sub("git", "config", "user.email", "t@t")

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3418,64 +3418,60 @@ tool sync_harness:
     _GIT_MAINTENANCE_OFF = (("gc.auto", "0"), ("maintenance.auto", "false"))
 
 
-    def _git_command_lines(argv):
-        """The git command lines an argv spawns.
+    def _spawned_program(argv, shell):
+        """The program a Popen actually launches.
 
-        Two forms, because both occur here: the argv IS git, or it is a shell
-        running a script in which `git` stands in command position. Split on the
-        separators a shell uses, so `cd x && git commit` is seen as a git command
-        and `rm -rf .git` is not.
+        shell=True runs the string through /bin/sh, so the program is the shell —
+        not the first word of the string, which is what a reader assumes and what
+        an audit keyed on argv[0] would record.
         """
+        if shell:
+            return "sh"
         if isinstance(argv, (list, tuple)):
-            parts = [str(a) for a in argv]
-        elif isinstance(argv, str):
-            parts = ["sh", "-c", argv]
-        else:
-            return []
-        if not parts:
-            return []
-        found = []
-        if os.path.basename(parts[0]) == "git":
-            found.append(parts)
-        if len(parts) > 2 and os.path.basename(parts[0]) in ("sh", "bash", "dash", "zsh") \
-                and parts[1] == "-c":
-            for segment in re.split(r"&&|\|\||[;|\n]", parts[2]):
-                tokens = segment.strip().lstrip("(").strip().split()
-                if tokens and os.path.basename(tokens[0]) == "git":
-                    found.append(tokens)
-        return found
+            if not argv:
+                return ""
+            return os.path.basename(str(argv[0]))
+        return os.path.basename(str(argv).split()[0]) if str(argv).strip() else ""
 
 
-    def _git_refuses_auto_maintenance(tokens, env):
-        """Whether a git command line turns BOTH switches off — by `-c` in its own
-        argv, or by git's environment form of the same thing.
+    def _env_refuses_auto_maintenance(env):
+        """Whether an environment turns BOTH switches off through git's own
+        GIT_CONFIG_* form — the environment every descendant inherits, whatever
+        path it takes to reach git.
 
         Both switches, not one: `maintenance.auto` is Git >= 2.48 and `gc.auto` is
         the older one AND the fallback a recent Git consults when the first is
         absent, so a single switch holds on one version and not the other.
 
-        Both idioms, not one: the argv is what a call site writes, the environment
-        is what a chokepoint sets for every call site at once. Accepting only the
-        idiom in use here would refuse the other the day someone moves the guard.
-
         env is None when the child inherits the parent's — that inherited
-        environment is the one that will decide, so it is what gets read.
+        environment is the one git will actually read, so that is what gets read
+        here. Reading `env or {}` instead would call a correct inherited call
+        faulty.
         """
-        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
         environ = os.environ if env is None else env
         try:
             count = int(environ.get("GIT_CONFIG_COUNT", "0") or "0")
-        except ValueError:
+        except (TypeError, ValueError):
             count = 0
-        from_env = {}
+        declared = {}
         for i in range(count):
             key = environ.get("GIT_CONFIG_KEY_%d" % i)
             if key:
-                from_env[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
-        for key, value in _GIT_MAINTENANCE_OFF:
-            if "%s=%s" % (key, value) not in flags and from_env.get(key) != value:
-                return False
-        return True
+                declared[key] = environ.get("GIT_CONFIG_VALUE_%d" % i)
+        return all(declared.get(key) == value for key, value in _GIT_MAINTENANCE_OFF)
+
+
+    def _argv_refuses_auto_maintenance(argv):
+        """Whether a git argv turns both switches off with its own `-c` flags.
+
+        The other accepted idiom: the argv is what a call site writes, the
+        environment is what a chokepoint sets for every call site at once.
+        Accepting only the one in use here would refuse the other the day someone
+        moves the guard.
+        """
+        tokens = [str(a) for a in argv] if isinstance(argv, (list, tuple)) else []
+        flags = [tokens[i + 1] for i, a in enumerate(tokens[:-1]) if a == "-c"]
+        return all("%s=%s" % (key, value) in flags for key, value in _GIT_MAINTENANCE_OFF)
 
 
     def _selftest():
@@ -3505,23 +3501,40 @@ tool sync_harness:
         # what failed. Two sweeps read this file and both missed a helper defined
         # four hundred lines below fixture_git, inside a block.
         #
-        # And the audit below does not read the source either — it WATCHES what the
-        # selftest spawns. Popen is the hook because run, call, check_call and
-        # check_output all reach the kernel through it; hooking run alone would
-        # leave the other four unseen. os.system reaches neither and is refused
-        # outright rather than watched, so the door nobody guards fails closed.
-        _git_audit = {"direct": 0, "shell": 0, "offenders": []}
+        # And this does not read the source either — it WATCHES what the selftest
+        # spawns. Popen is the hook because run, call, check_call and check_output
+        # all reach the kernel through it; hooking run alone would leave four forms
+        # unseen. os.system reaches neither and is refused outright rather than
+        # watched, so the door nobody guards fails closed.
+        #
+        # What is judged is not "the git command lines we recognise" — recognising
+        # git by the program name is the same enumeration one level up, and it lets
+        # `env git`, `xargs git` or a git called through a shell variable walk past.
+        # Instead: a WHITELIST of what may be launched at all (git and the shell,
+        # the two the selftest uses — measured: 426 and 236), and the environment
+        # judged on EVERY launch, because that environment is what git reads
+        # whatever path reaches it. A future helper that spawns anything else is
+        # named, not missed.
+        #
+        # Deliberate hostility (`env -i`, unsetting GIT_CONFIG_COUNT inside a
+        # script) is out of scope and stated as such: the adversary here is an
+        # ordinary helper written without knowing the rule, not someone evading it.
+        _git_audit = {"git": 0, "sh": 0, "offenders": []}
         _real_popen = subprocess.Popen
         _real_system = os.system
 
         class _AuditedPopen(_real_popen):
             def __init__(self, args, *rest, **kw):
-                program = args[0] if isinstance(args, (list, tuple)) and args else args
-                spawns_git = os.path.basename(str(program)) == "git"
-                for tokens in _git_command_lines(args):
-                    _git_audit["direct" if spawns_git else "shell"] += 1
-                    if not _git_refuses_auto_maintenance(tokens, kw.get("env")):
-                        _git_audit["offenders"].append(" ".join(tokens)[:120])
+                program = _spawned_program(args, kw.get("shell"))
+                env = kw.get("env")
+                if program not in _git_audit:
+                    _git_audit["offenders"].append(
+                        "programme hors liste blanche : %s (%s)" % (program, str(args)[:80]))
+                else:
+                    _git_audit[program] += 1
+                    if not _env_refuses_auto_maintenance(env) and not (
+                            program == "git" and _argv_refuses_auto_maintenance(args)):
+                        _git_audit["offenders"].append(str(args)[:120])
                 super().__init__(args, *rest, **kw)
 
         def _refuse_system(command):
@@ -5326,18 +5339,14 @@ tool sync_harness:
         # Judged on what ran, not on what the source says. A future helper that
         # spawns git its own way is caught by having RUN, which is the only thing
         # that found the one this replaces.
-        check("aucune commande git du selftest ne laisse la maintenance automatique detachee"
-              " (%d invocations vues : %d en argv, %d via sh -c)"
-              % (_git_audit["direct"] + _git_audit["shell"], _git_audit["direct"], _git_audit["shell"]),
+        check("aucun lancement du selftest ne laisse la maintenance automatique detachee"
+              " (%d git, %d sh)" % (_git_audit["git"], _git_audit["sh"]),
               _git_audit["offenders"], [])
-        # Les DEUX detecteurs, pas leur somme : le selftest lance les deux formes
-        # (mesure : 426 en argv, 173 via sh -c), donc une branche cassee laisse
-        # l'autre porter le total et un audit a moitie aveugle passe pour un arbre
-        # propre. C'est le plancher d'un banc, pas une mesure de couverture.
-        check("l'audit voit les commandes git lancees en argv direct",
-              _git_audit["direct"] > 0, True)
-        check("l'audit voit les commandes git lancees a travers un shell",
-              _git_audit["shell"] > 0, True)
+        # Les DEUX compteurs, pas leur somme : le selftest lance les deux
+        # programmes, et un compteur mort laisse l'autre porter le total — un audit
+        # a moitie aveugle passerait pour un arbre propre.
+        check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
+        check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1581,8 +1581,28 @@ tool sync_harness:
         base_act_ids = {b.get("id") for b in _extension_blocks(base_txt, "act")
                         if b.get("id") != "UNPARSEABLE"}
         intro = introducing_commits()
+        # An id is acted ONCE. `introducing_commits` keys first-wins, so a SECOND
+        # act block carrying an id the subbot already acted resolves its
+        # provenance on the subbot's commit — the whole provenance branch is
+        # skipped, no certified blob exists for its paths so the rewrite check
+        # skips too, and the lot's own commit writes a reference into the net that
+        # judges it, exempted (review finding, executed: both rows came back ok
+        # and the second act's path landed in ok_paths). The ledger's ids are the
+        # audit trail's keys; a duplicate key is a refusal, like the corpus's.
+        seen_act_ids = set()
         for act in acts:
             row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
+            if act.get("id") in seen_act_ids:
+                row["forged"] = True
+                row["problems"].append(
+                    "a SECOND act block for %r — an id is acted once. Its "
+                    "provenance would resolve on the FIRST act's commit, so any "
+                    "later block rides the subbot's certificate: remove it, and "
+                    "file a new request if something more must be acted"
+                    % act.get("id"))
+                verdict["acted"].append(row)
+                continue
+            seen_act_ids.add(act.get("id"))
             if act.get("id") in base_act_ids:
                 row["ok"] = True
                 row["acted_at_base"] = True
@@ -3979,6 +3999,45 @@ tool sync_harness:
             check("l'acte du subbot, lui, reste certifie",
                   [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
+            # LE DOUBLON D'ACTE, rejoue en entier : la demande du lot declare DEUX
+            # chemins, le subbot en acte UN, puis le lot appose un SECOND bloc
+            # `act` portant le meme id pour le chemin restant. La provenance du
+            # doublon se resout sur le commit du subbot (premier gagnant), donc
+            # sans refus du doublon tout passe et le chemin du lot est exempte.
+            req_two = ('{"id": "E-1", "lot": "L", "type": "add-file",'
+                       ' "paths": [".golden-master/refs/2.txt",'
+                       ' ".golden-master/refs/9.txt"]}')
+            act_one = ('{"id": "E-1", "lot": "L",'
+                       ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+            act_dup = ('{"id": "E-1", "lot": "L",'
+                       ' "recorded_paths": [".golden-master/refs/9.txt"]}')
+            xreset()
+            xledger(("request", req_two))
+            xcommit()                                         # le lot depose
+            xledger(("request", req_two), ("act", act_one))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("acte par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")      # le subbot acte
+            sha_one = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_one = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                           xroot, timeout=60)[1].strip()
+            xledger(("request", req_two), ("act", act_one), ("act", act_dup))
+            with open(os.path.join(xgm, "refs", "9.txt"), "w", encoding="utf-8") as f:
+                f.write("ecrit par le lot\n")
+            xcommit(email="lot@run")                           # le lot double l'acte
+            v_dup = extension_verdict(xroot, ".golden-master", xbase,
+                                      acted_commits={sha_one},
+                                      acted_blobs={".golden-master/refs/2.txt": blob_one},
+                                      acted_ids={"E-1"})
+            dup = v_dup["acted"][1]
+            check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+                  [dup["ok"], dup.get("forged"),
+                   ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
+                  [False, True, False])
+            check("l'acte du subbot reste certifie, lui",
+                  [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
+                  [True, [".golden-master/refs/2.txt"]])
+
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.
             xreset()
@@ -5112,18 +5171,39 @@ tool sync_harness:
                 for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
                     full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
                     acted_commits.add(full if len(full) == 40 else tok)
+            # ONE ENTRY PER LINE, for both certificates. Whitespace-delimited,
+            # a surface path containing a space split into two tokens: the left
+            # had no `=` and was DROPPED, the right registered a bogus key — so
+            # the real path had no certified blob, the post-act rewrite check
+            # skipped it, and the lot could rewrite that reference in a later
+            # commit and keep the exemption (review finding). The same defect sat
+            # on the ids, where a space in an id split it out of the set and the
+            # act silently lost its cover. Both ids and paths are lot-authored
+            # and a space passes their guards, so the encoding is what has to be
+            # unambiguous — and an entry that cannot be read is a REFUSAL, never
+            # a silent drop.
             if "GM_ACTED_BLOBS" in os.environ:
                 acted_blobs = {}
-                for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
-                    path, sep, sha = tok.rpartition("=")
-                    if sep and path and sha:
-                        acted_blobs[path] = sha
+                for line in os.environ.get("GM_ACTED_BLOBS", "").splitlines():
+                    if not line.strip():
+                        continue
+                    path, sep, sha = line.rpartition("=")
+                    if not (sep and path and sha):
+                        print(json.dumps({"error":
+                                          "GM_ACTED_BLOBS carries an entry that is "
+                                          "not `path=blob`: %r — a certificate the "
+                                          "judge cannot read is refused, not dropped"
+                                          % line}))
+                        raise SystemExit(1)
+                    acted_blobs[path] = sha
             # The ids the subbot reports having acted. Absent = no act is
             # covered by the content rule, which is the safe direction: the
             # rule only ever EXEMPTS.
             acted_ids = None
             if "GM_ACTED_IDS" in os.environ:
-                acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
+                acted_ids = {l.strip() for l in
+                             os.environ.get("GM_ACTED_IDS", "").splitlines()
+                             if l.strip()}
             print(json.dumps(extension_verdict(
                 ws, os.environ.get("GM_DIR", ".golden-master"), base,
                 acted_commits=acted_commits, acted_blobs=acted_blobs,

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3566,13 +3566,26 @@ tool sync_harness:
         canary_key = "iterion.selftestcanary"
         canary_value = "alive-%d" % os.getpid()
         saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
-        for i, (key, value) in enumerate(((canary_key, canary_value),) + _GIT_MAINTENANCE_OFF):
-            slot = base_count + i
+
+        def _declare(slot, key, value):
             for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
                                    ("GIT_CONFIG_VALUE_%d" % slot, value)):
-                saved_git_env[name] = os.environ.get(name)
+                saved_git_env.setdefault(name, os.environ.get(name))
                 os.environ[name] = declared
-        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1 + len(_GIT_MAINTENANCE_OFF))
+
+        # The canary is declared FIRST and counted, so that what follows faces a
+        # declaration that was already there — which is the situation in a run,
+        # where the engine has declared the workspace's safe.directory. A canary
+        # placed beside the switches instead would survive its own displacement of
+        # the neighbour, and prove nothing: measured, that version stayed green
+        # under a faithful reproduction of the defect.
+        _declare(base_count, canary_key, canary_value)
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + 1)
+        declared_count = base_count + 1
+
+        for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
+            _declare(declared_count + i, key, value)
+        os.environ["GIT_CONFIG_COUNT"] = str(declared_count + len(_GIT_MAINTENANCE_OFF))
         canary_seen = subprocess.run(
             ["git", "config", "--get-all", canary_key],
             capture_output=True, text=True).stdout.split()

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1337,7 +1337,8 @@ tool sync_harness:
                           sort_keys=True, ensure_ascii=False)
 
 
-    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
+    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
+                          acted_ids=None):
         """Judge every ACTED extension against `base`, in git — never against the
         acting party's word.
 
@@ -1358,6 +1359,11 @@ tool sync_harness:
         `acted_blobs` also bounds the exemption: a certified path whose blob at
         HEAD moved since the act was rewritten by someone after the subbot —
         the certificate covers the content it certified, not the path forever.
+        `acted_ids` bounds WHICH act the certificate covers: the ones the subbot
+        reports having acted, and no other. Without it the content rule exempts
+        any act naming a certified path, which a lot reaches by filing two
+        requests, getting the second REFUSED, and appending its own act for it
+        recording the first one's path (review finding, executed).
 
         Per acted request, every recorded path must be a pure addition:
           - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1612,14 +1618,22 @@ tool sync_harness:
             # the subbot ran).
             if acted_commits is not None and req is not None and act_sha \
                     and act_sha not in acted_commits:
-                # The way back in is CONTENT, so there must BE content: an act
-                # recording only the ledger leaves the generator empty, `all([])`
-                # is true, and the escape hatch opens for an act that certified
-                # no surface path at all (review finding, executed).
-                surface = [p for p in paths if p != ledger_rel]
-                blobs_match = bool(surface) and acted_blobs is not None and all(
-                    acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
-                    for p in surface)
+                # The way back in is CONTENT, so there must BE content, it must
+                # be the content of an act the subbot ACTUALLY acted, and the
+                # comparison must be over paths whose blob is expected to stand
+                # still. Each clause was a hole: an act recording only the ledger
+                # left the generator empty and `all([])` true; an act naming a
+                # path the subbot certified for ANOTHER request rode that
+                # request's certificate (the lot writes its own request, so the
+                # paths it declares are its own); corpus.json legitimately moves
+                # when a later act adds entries, so comparing its blob would
+                # refuse a rewritten history for the one file expected to change
+                # (review findings, executed).
+                surface = [p for p in paths if p not in (ledger_rel, corpus_rel)]
+                blobs_match = bool(surface) and acted_blobs is not None \
+                    and act.get("id") in (acted_ids or set()) and all(
+                        acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                        for p in surface)
                 if not blobs_match:
                     row["forged"] = True
                     row["problems"].append(
@@ -3897,9 +3911,18 @@ tool sync_harness:
             check("l'acte introduit par un commit du subbot passe, chemin exempte",
                   [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
             v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
-                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b},
+                                       acted_ids={"E-1"})
             check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
                   v_blob["acted"][0]["ok"], True)
+            # Le certificat couvre l'ACTE que le subbot a acte, pas n'importe quel
+            # acte nommant un chemin certifie : sans l'id, l'echappatoire par
+            # contenu s'ouvre pour un acte que le subbot n'a jamais rendu.
+            v_noid = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("meme contenu, acte NON acte par le subbot : refuse",
+                  [v_noid["acted"][0]["ok"], v_noid["acted"][0].get("forged")],
+                  [False, True])
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("reecrit apres l'acte\n")
             xcommit(email="lot@run")                         # commit C, le lot reecrit
@@ -3920,6 +3943,41 @@ tool sync_harness:
                   [v_old.get("provenance"), v_strict.get("provenance"),
                    v_sub.get("provenance"), v_rw2.get("provenance")],
                   ["legacy", "strict", "strict", "strict"])
+
+            # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
+            # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
+            # s'acte la refusee en enregistrant le chemin que le subbot a
+            # certifie pour la premiere. Tous les controles de contenu passent —
+            # seul l'id ferme la porte.
+            req_e2 = ('{"id": "E-2", "lot": "L", "type": "add-file",'
+                      ' "paths": [".golden-master/refs/2.txt"]}')
+            act_e2 = ('{"id": "E-2", "lot": "L",'
+                      ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+            xreset()
+            # Les DEUX demandes sont deposees d'abord : l'acte de E-2 arrivera dans
+            # un commit ulterieur, donc la regle du commit unique ne le voit pas —
+            # c'est ce qui rend la contrebande possible.
+            xledger(("request", req2), ("request", req_e2))
+            xcommit()                                        # le lot depose E-1 et E-2
+            xledger(("request", req2), ("request", req_e2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2 certifiee par le subbot\n")
+            xcommit(email="extend@golden-master.iterion")     # le subbot acte E-1, REFUSE E-2
+            sha_sub = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_sub = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                           xroot, timeout=60)[1].strip()
+            xledger(("request", req2), ("request", req_e2),
+                    ("act", act2), ("act", act_e2))
+            xcommit(email="lot@run")                          # le lot s'acte la refusee
+            v_smug = extension_verdict(xroot, ".golden-master", xbase,
+                                       acted_commits={sha_sub},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_sub},
+                                       acted_ids={"E-1"})
+            smug = [r for r in v_smug["acted"] if r["id"] == "E-2"][0]
+            check("acte auto-appose sur un chemin certifie pour UNE AUTRE demande : refuse",
+                  [smug["ok"], smug.get("forged")], [False, True])
+            check("l'acte du subbot, lui, reste certifie",
+                  [r["ok"] for r in v_smug["acted"] if r["id"] == "E-1"], [True])
 
             # Un acte qui n'enregistre QUE le registre : aucun chemin de surface
             # a certifier, donc aucune echappatoire par contenu.
@@ -5060,9 +5118,16 @@ tool sync_harness:
                     path, sep, sha = tok.rpartition("=")
                     if sep and path and sha:
                         acted_blobs[path] = sha
+            # The ids the subbot reports having acted. Absent = no act is
+            # covered by the content rule, which is the safe direction: the
+            # rule only ever EXEMPTS.
+            acted_ids = None
+            if "GM_ACTED_IDS" in os.environ:
+                acted_ids = set(os.environ.get("GM_ACTED_IDS", "").split())
             print(json.dumps(extension_verdict(
                 ws, os.environ.get("GM_DIR", ".golden-master"), base,
-                acted_commits=acted_commits, acted_blobs=acted_blobs)))
+                acted_commits=acted_commits, acted_blobs=acted_blobs,
+                acted_ids=acted_ids)))
             raise SystemExit(0)
 
         # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3541,13 +3541,29 @@ tool sync_harness:
             raise AssertionError(
                 "selftest: os.system(%r) bypasses the git audit — use subprocess" % command)
 
-        saved_git_env = {k: os.environ.get(k) for k in
-                         ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0",
-                          "GIT_CONFIG_KEY_1", "GIT_CONFIG_VALUE_1")}
+        # APPENDED after whatever is already declared, never written at index 0:
+        # the engine injects the workspace's safe.directory entry through this same
+        # environment (runtime/sandbox_mounts.go sets GIT_CONFIG_COUNT=1), so
+        # writing slot 0 destroys it and every git of the selftest then refuses the
+        # workspace for dubious ownership. Measured: safe.directory=/tmp/x became
+        # whatever the operator's global config said, or nothing.
+        raw_count = os.environ.get("GIT_CONFIG_COUNT", "0") or "0"
+        try:
+            base_count = int(raw_count)
+        except ValueError:
+            raise SystemExit(
+                "selftest: GIT_CONFIG_COUNT=%r is not a count — refusing to guess "
+                "where to append the auto-maintenance switches" % raw_count)
+        if base_count < 0:
+            raise SystemExit("selftest: GIT_CONFIG_COUNT=%r is negative" % raw_count)
+        saved_git_env = {"GIT_CONFIG_COUNT": os.environ.get("GIT_CONFIG_COUNT")}
         for i, (key, value) in enumerate(_GIT_MAINTENANCE_OFF):
-            os.environ["GIT_CONFIG_KEY_%d" % i] = key
-            os.environ["GIT_CONFIG_VALUE_%d" % i] = value
-        os.environ["GIT_CONFIG_COUNT"] = str(len(_GIT_MAINTENANCE_OFF))
+            slot = base_count + i
+            for name, declared in (("GIT_CONFIG_KEY_%d" % slot, key),
+                                   ("GIT_CONFIG_VALUE_%d" % slot, value)):
+                saved_git_env[name] = os.environ.get(name)
+                os.environ[name] = declared
+        os.environ["GIT_CONFIG_COUNT"] = str(base_count + len(_GIT_MAINTENANCE_OFF))
         subprocess.Popen = _AuditedPopen
         os.system = _refuse_system
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1337,9 +1337,27 @@ tool sync_harness:
                           sort_keys=True, ensure_ascii=False)
 
 
-    def extension_verdict(ws, gm_rel, base):
+    def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None):
         """Judge every ACTED extension against `base`, in git — never against the
         acting party's word.
+
+        `acted_commits` (None, or a set of 40-hex shas) is what the NET's own
+        subbot reports having committed in this segment — read by main() from
+        GM_ACTED_COMMITS, which the parent bot defines even when empty. None
+        means the caller predates provenance (today's rule only: request and
+        act in one commit refuse); a set means STRICT: an act introduced in
+        base..HEAD by a commit outside it was written by the constrained party,
+        whatever author it carries, and is refused — unless every path it
+        records carries at HEAD the exact blob the subbot certified
+        (`acted_blobs`, path → blob id): a history rewritten after the subbot
+        ran keeps its certified content and loses its shas. Measured on a live
+        campaign: a lot filed a request in one commit and acted it in the next,
+        the same-commit rule saw nothing, and the lot's own file became a
+        reference of the net that judges it.
+
+        `acted_blobs` also bounds the exemption: a certified path whose blob at
+        HEAD moved since the act was rewritten by someone after the subbot —
+        the certificate covers the content it certified, not the path forever.
 
         Per acted request, every recorded path must be a pure addition:
           - under refs/: absent at base, present at HEAD. A path that existed at
@@ -1368,6 +1386,11 @@ tool sync_harness:
             code, out, _ = git("ls-tree", ref, "--", path)
             return out.split()[0] if code == 0 and out.strip() else ""
 
+        def blob_id(ref, path):
+            code, out, _ = git("ls-tree", ref, "--", path)
+            parts = out.split() if code == 0 else []
+            return parts[2] if len(parts) >= 3 else ""
+
         ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
         corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
         refs_prefix = gm_rel.rstrip("/") + "/refs/"
@@ -1382,11 +1405,15 @@ tool sync_harness:
             subbot never ran — production cannot produce that shape, because the
             parent commits its lot before the subbot starts (adversarial finding,
             executed)."""
-            code, out, _ = git("log", "--format=%H", "--reverse", "--", ledger_rel)
+            code, out, _ = git("log", "--format=%H%x00%ae", "--reverse", "--", ledger_rel)
             if code != 0:
                 return None
             first = {}
-            for sha in out.split():
+            for line in out.splitlines():
+                sha, _, email = line.partition("\0")
+                sha = sha.strip()
+                if not sha:
+                    continue
                 text = at(sha, ledger_rel)
                 if text is None:
                     continue
@@ -1395,6 +1422,7 @@ tool sync_harness:
                         bid = b.get("id")
                         if isinstance(bid, str) and bid:
                             first.setdefault((kind, bid), sha)
+                            first.setdefault(("author", kind, bid), email.strip())
             return first
 
         # An unresolvable base and an honest "absent at base" both read as None
@@ -1561,9 +1589,36 @@ tool sync_harness:
                     "request and the act, so the net's subbot never judged it — "
                     "filing and answering are different powers"
                     % intro[("act", act.get("id"))][:12])
+                row["forged"] = True
             paths = [p for p in (act.get("recorded_paths") or [])
                      if isinstance(p, str) and p]
             row["paths"] = paths
+            act_sha = (intro or {}).get(("act", act.get("id")))
+            if act_sha:
+                row["introduced_by"] = act_sha[:12]
+                row["author"] = (intro or {}).get(("author", "act", act.get("id"))) or ""
+            # Provenance, when the parent states what the net's subbot committed:
+            # an act introduced by any other commit was written by the party the
+            # oracle constrains — whatever author it carries, an author is prose.
+            # The one way back in is the CONTENT: every recorded path carrying at
+            # HEAD the exact blob the subbot certified (a history rewritten after
+            # the subbot ran).
+            if acted_commits is not None and req is not None and act_sha \
+                    and act_sha not in acted_commits:
+                blobs_match = bool(paths) and acted_blobs is not None and all(
+                    acted_blobs.get(p) and blob_id("HEAD", p) == acted_blobs.get(p)
+                    for p in paths if p != ledger_rel)
+                if not blobs_match:
+                    row["forged"] = True
+                    row["problems"].append(
+                        "the act was introduced by %s (author %s), which is not one "
+                        "of the net subbot's commits%s — an act the constrained party "
+                        "wrote is a refusal, not an extension. If the history was "
+                        "rewritten after the subbot ran, relaunch on a fresh base; "
+                        "otherwise remove the act block and file the request only."
+                        % (act_sha[:12], row.get("author") or "?",
+                           (" (%s)" % ", ".join(sorted(c[:12] for c in acted_commits)))
+                           if acted_commits else " (none reported)"))
             if req is not None and not paths:
                 row["problems"].append(
                     "the act records no path — an extension that touched "
@@ -1623,6 +1678,21 @@ tool sync_harness:
                 row["problems"].append(
                     "the act records no path on the extension surface (refs/ or "
                     "corpus.json) — filing paperwork is not an extension")
+            if acted_blobs is not None and req is not None:
+                # The certificate covers the CONTENT the subbot committed, not
+                # the path forever: a reference rewritten after the act — by the
+                # lot, in its own later commit — is the masking vector again, and
+                # the exemption must not follow it.
+                for p in paths:
+                    if p == ledger_rel or p == corpus_rel:
+                        continue
+                    certified = acted_blobs.get(p)
+                    if certified and blob_id("HEAD", p) != certified:
+                        row["forged"] = True
+                        row["problems"].append(
+                            "%s was rewritten after the act: HEAD carries blob %s, "
+                            "the subbot certified %s — the certificate covers the "
+                            "content it certified, not the path" % (p, (blob_id("HEAD", p) or "?")[:12], certified[:12]))
             row["ok"] = (req is not None and not row["problems"]
                          and verdict["ledger_append_only"])
             if row["ok"]:
@@ -3717,9 +3787,11 @@ tool sync_harness:
                     f.write("\n".join("<!-- iterion:extension-%s\n%s\n-->" % b
                                       for b in blks))
 
-            def xcommit():
+            def xcommit(email="t@t"):
+                # fixture_git already sets a committer; a later -c wins, so the
+                # override rides it instead of bypassing the failure check.
                 fixture_git(xroot, "add", "-A")
-                fixture_git(xroot, "commit", "-qm", "x")
+                fixture_git(xroot, "-c", "user.email=%s" % email, "commit", "-qm", "x")
 
             def xrequest(req):
                 """The lot files its request and commits. A fixture that stages a
@@ -3789,6 +3861,44 @@ tool sync_harness:
             v_touch = xverdict(xbase_acted)
             check("acte a la base + ref reecrite -> le certificat n'exempte rien",
                   [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
+
+            # 8f. Provenance : un acte doit venir des commits du subbot du filet
+            #     (publies par le parent), ou porter EXACTEMENT le contenu certifie
+            #     (historique reecrit apres le subbot). L'auteur est de la prose.
+            xreset()
+            xrequest(req2)                                   # commit A, le lot
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("forge par le lot\n")
+            xcommit(email="lot@run")                         # commit B, le lot acte
+            sha_b = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_b = run("git rev-parse HEAD:.golden-master/refs/2.txt", xroot, timeout=60)[1].strip()
+            v_old = extension_verdict(xroot, ".golden-master", xbase)
+            check("sans provenance (appelant d'avant) : l'auto-acte en deux commits passe encore",
+                  v_old["acted"][0]["ok"], True)
+            v_strict = extension_verdict(xroot, ".golden-master", xbase, acted_commits=set())
+            check("provenance stricte, aucun commit du subbot : l'auto-acte est refuse, forge, auteur nomme",
+                  [v_strict["acted"][0]["ok"], v_strict["acted"][0].get("forged"),
+                   v_strict["acted"][0].get("author"), v_strict["ok_paths"]],
+                  [False, True, "lot@run", []])
+            v_sub = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b})
+            check("l'acte introduit par un commit du subbot passe, chemin exempte",
+                  [v_sub["acted"][0]["ok"], v_sub["ok_paths"]], [True, [".golden-master/refs/2.txt"]])
+            v_blob = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("sha inconnu mais contenu certifie identique (historique reecrit) : passe",
+                  v_blob["acted"][0]["ok"], True)
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("reecrit apres l'acte\n")
+            xcommit(email="lot@run")                         # commit C, le lot reecrit
+            v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
+                                     acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+                  [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
+                  [False, True, []])
+            v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
+                                      acted_blobs={".golden-master/refs/2.txt": blob_b})
+            check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
 
             # Reecriture deguisee : la ref existait a la base.
             xreset()
@@ -4899,8 +5009,25 @@ tool sync_harness:
                                   "additions against nothing would pass by "
                                   "construction"}))
                 raise SystemExit(1)
+            # Provenance from the PARENT: present (even empty) means strict —
+            # the parent bot always defines it, because the only pass that
+            # judges a self-act is the one where no subbot ran at all. Absent
+            # means a caller that predates provenance: today's rule only.
+            acted_commits = acted_blobs = None
+            if "GM_ACTED_COMMITS" in os.environ:
+                acted_commits = set()
+                for tok in os.environ.get("GM_ACTED_COMMITS", "").split():
+                    full = run("git rev-parse --verify --quiet %s^{commit}" % shlex.quote(tok), ws, timeout=60)[1].strip()
+                    acted_commits.add(full if len(full) == 40 else tok)
+            if "GM_ACTED_BLOBS" in os.environ:
+                acted_blobs = {}
+                for tok in os.environ.get("GM_ACTED_BLOBS", "").split():
+                    path, sep, sha = tok.rpartition("=")
+                    if sep and path and sha:
+                        acted_blobs[path] = sha
             print(json.dumps(extension_verdict(
-                ws, os.environ.get("GM_DIR", ".golden-master"), base)))
+                ws, os.environ.get("GM_DIR", ".golden-master"), base,
+                acted_commits=acted_commits, acted_blobs=acted_blobs)))
             raise SystemExit(0)
 
         # The verdict CARRIES the declaration it judged. Without it, a green from

--- a/bots/golden_master_config_test.go
+++ b/bots/golden_master_config_test.go
@@ -106,6 +106,12 @@ func TestGoldenMasterHarnessNamesTheConfig(t *testing.T) {
 			{"GM_SEALED_DIR=" + filepath.Join(t.TempDir(), "pile")},
 			{"GM_MUTATION_FLOOR=1"},
 			{"GM_CONFIG=config-pg.json", "GM_SEAL_COMMITTED=1"},
+			// Not only the judge's own variables: git's identity ENV
+			// outranks every config source, so a host that exports it made
+			// every fixture commit under the caller's name and turned the
+			// author checks red — in a step the gate wrapper runs BLOCKING.
+			{"GIT_AUTHOR_EMAIL=ambient@host", "GIT_COMMITTER_EMAIL=ambient@host",
+				"GIT_AUTHOR_NAME=ambient", "GIT_COMMITTER_NAME=ambient"},
 		} {
 			cmd := exec.Command("python3", harness)
 			cmd.Dir = t.TempDir()

--- a/bots/golden_master_extend_verify_test.go
+++ b/bots/golden_master_extend_verify_test.go
@@ -76,12 +76,19 @@ func extendVerifyRepo(t *testing.T, verdict, pending string) (string, string) {
 
 func runExtendVerify(t *testing.T, ws, head, pendingJSON string) extendVerifyOut {
 	t.Helper()
+	return runExtendVerifyClean(t, ws, head, pendingJSON, true)
+}
+
+// runExtendVerifyClean is runExtendVerify with extend_base's verdict on the
+// net's cleanliness — the term a refused start carries into this node.
+func runExtendVerifyClean(t *testing.T, ws, head, pendingJSON string, clean bool) extendVerifyOut {
+	t.Helper()
 	body := toolScript(t, "golden-master/extend.bot", "extend_verify")
 	body = strings.ReplaceAll(body, "{{vars.workspace_dir}}", strconv.Quote(ws))
 	body = strings.ReplaceAll(body, "{{vars.oracle_dir}}", strconv.Quote(".golden-master"))
 	body = strings.ReplaceAll(body, "{{input.head}}", strconv.Quote(head))
 	body = strings.ReplaceAll(body, "{{input.pending}}", pendingJSON)
-	body = strings.ReplaceAll(body, "{{input.clean}}", "true")
+	body = strings.ReplaceAll(body, "{{input.clean}}", map[bool]string{true: "true", false: "false"}[clean])
 	body = strings.ReplaceAll(body, "{{input.prev_name}}", strconv.Quote(""))
 	body = strings.ReplaceAll(body, "{{input.prev_email}}", strconv.Quote(""))
 	body = strings.ReplaceAll(body, "{{vars.actor_name}}", strconv.Quote("golden-master extend"))

--- a/bots/golden_master_extend_verify_test.go
+++ b/bots/golden_master_extend_verify_test.go
@@ -89,6 +89,8 @@ func runExtendVerifyClean(t *testing.T, ws, head, pendingJSON string, clean bool
 	body = strings.ReplaceAll(body, "{{input.head}}", strconv.Quote(head))
 	body = strings.ReplaceAll(body, "{{input.pending}}", pendingJSON)
 	body = strings.ReplaceAll(body, "{{input.clean}}", map[bool]string{true: "true", false: "false"}[clean])
+	// What an edge renders for an agent that produced no line.
+	body = strings.ReplaceAll(body, "{{input.agent_summary}}", "null")
 	body = strings.ReplaceAll(body, "{{input.prev_name}}", strconv.Quote(""))
 	body = strings.ReplaceAll(body, "{{input.prev_email}}", strconv.Quote(""))
 	body = strings.ReplaceAll(body, "{{vars.actor_name}}", strconv.Quote("golden-master extend"))

--- a/bots/golden_master_extend_verify_test.go
+++ b/bots/golden_master_extend_verify_test.go
@@ -20,6 +20,11 @@ type extendVerifyOut struct {
 	Extended      int      `json:"extended"`
 	LogTail       string   `json:"log_tail"`
 	OutOfScope    []string `json:"out_of_scope"`
+	CleanStart    bool     `json:"clean_start"`
+	IdentityOk    bool     `json:"identity_ok"`
+	ActedCommits  string   `json:"acted_commits"`
+	ActedIds      string   `json:"acted_ids"`
+	ActedBlobs    string   `json:"acted_blobs"`
 }
 
 // extendVerifyRepo is a target tree whose net carries a STUB harness: the
@@ -76,6 +81,11 @@ func runExtendVerify(t *testing.T, ws, head, pendingJSON string) extendVerifyOut
 	body = strings.ReplaceAll(body, "{{vars.oracle_dir}}", strconv.Quote(".golden-master"))
 	body = strings.ReplaceAll(body, "{{input.head}}", strconv.Quote(head))
 	body = strings.ReplaceAll(body, "{{input.pending}}", pendingJSON)
+	body = strings.ReplaceAll(body, "{{input.clean}}", "true")
+	body = strings.ReplaceAll(body, "{{input.prev_name}}", strconv.Quote(""))
+	body = strings.ReplaceAll(body, "{{input.prev_email}}", strconv.Quote(""))
+	body = strings.ReplaceAll(body, "{{vars.actor_name}}", strconv.Quote("golden-master extend"))
+	body = strings.ReplaceAll(body, "{{vars.actor_email}}", strconv.Quote("extend@golden-master.iterion"))
 	if i := strings.Index(body, "{{"); i >= 0 {
 		t.Fatalf("unresolved template ref in extend_verify near %q", body[i:min(i+40, len(body))])
 	}

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -176,6 +176,11 @@ schema lot_report:
   ## harness's own code, and routed to the net's extension subbot. A lot may
   ## ASK for a new observation point; it may never write one.
   extension_pending: json
+  ## An act in the ledger was not the net subbot's: introduced by a commit
+  ## the subbot did not report, or a certified path rewritten since. Refused
+  ## and TYPED — a resume from the banked branch would find the act at its
+  ## base and certify it, so this is a stop, never a repair pass.
+  extension_forged: bool
   ## The worker wrote `done` into the contract. `done` is the gate's word: this
   ## verdict is refused BEFORE any gate command runs, so the revert costs the
   ## worker seconds, never the hour a full gate would spend confirming a
@@ -241,6 +246,11 @@ schema verify_input:
   base_sha: string
   refs_dir: string
   exit_gate: string
+  ## The net subbot's provenance (see extend_result) — empty until the
+  ## subbot has run, and passed to the harness EVEN THEN: the only pass that
+  ## judges a lot acting its own extension is the one where no subbot ran.
+  acted_commits: string
+  acted_blobs: string
 
 schema mark_input:
   lot_id: string
@@ -634,15 +644,21 @@ tool lot_verify:
     import time
     import sys
 
+    null = None; true = True; false = False  # JSON-literal shim for missing refs
     ws = {{vars.workspace_dir}}
     base = {{input.base_sha}}
     refs_dir = {{input.refs_dir}}
+    # The net subbot's provenance: `null` (rendered for a node that has not
+    # run) reads as "none reported", and is STILL handed to the harness —
+    # presence, even empty, is what makes the certifier strict.
+    acted_commits = ({{input.acted_commits}} or "")
+    acted_blobs = ({{input.acted_blobs}} or "")
     gate_cmds = [c for c in {{input.exit_gate}}.split("\n") if c.strip()]
 
     report = {"gate_passed": False, "oracle_passed": False, "refs_untouched": False,
               "gate_timed_out": False, "contract_unreadable": False,
               "refs_changed": [], "lot_blocked": False, "block_reason": "", "log_tail": "",
-              "oracle_invalid": [], "oracle_not_run": False, "oracle_report": {}, "extension_pending": [], "done_self_written": False,
+              "oracle_invalid": [], "oracle_not_run": False, "oracle_report": {}, "extension_pending": [], "extension_forged": False, "done_self_written": False,
               "contract_rewritten": []}
     problems = []
 
@@ -1157,7 +1173,8 @@ tool lot_verify:
         if listing is not None and listing is not CAPABILITY_ABSENT:
             report["extension_pending"] = listing.get("pending") or []
         exempt = set()
-        verdict = harness_json("extend-verify", GM_BASE=base)
+        verdict = harness_json("extend-verify", GM_BASE=base,
+                               GM_ACTED_COMMITS=acted_commits, GM_ACTED_BLOBS=acted_blobs)
         if verdict is not None and verdict is not CAPABILITY_ABSENT and not verdict.get("error"):
             exempt = set(verdict.get("ok_paths") or [])
 
@@ -1266,6 +1283,15 @@ tool lot_verify:
                                    "; ".join(r.get("problems") or []))
                                 for r in bad)
                 report["refs_untouched"] = False
+            # Provenance refused = the constrained party acted its own request,
+            # or rewrote a certified reference: typed and terminal, never a
+            # repair pass — a resume from the banked branch would find the act
+            # at its base and certify it.
+            if any(r.get("forged") for r in (verdict.get("acted") or [])):
+                report["extension_forged"] = True
+                report["block_reason"] = ("EXTENSION_FORGED: " + "; ".join(
+                    "%s: %s" % (r.get("id"), "; ".join(r.get("problems") or []))
+                    for r in (verdict.get("acted") or []) if r.get("forged")))[:600]
         else:
             # No verdict is not "nothing to refuse". The certifier runs on
             # ledger content the constrained party writes, so a crash there
@@ -1290,7 +1316,7 @@ compute lot_gate:
   expr:
     converged: "outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched"
     stop: "(outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched) || outputs.lot_verify.lot_blocked"
-    refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0"
+    refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0 || outputs.lot_verify.extension_forged"
     timed_out: "outputs.lot_verify.gate_timed_out"
     oracle_not_run: "outputs.lot_verify.oracle_not_run"
     unreadable: "outputs.lot_verify.contract_unreadable"
@@ -1385,6 +1411,12 @@ schema extend_result:
   converged: bool
   extended: int
   notice: string
+  ## The net subbot's provenance, handed to the harness at this bot's gate:
+  ## the commits it made, the request ids it acted, the blob it certified
+  ## per surface path. Strings, so they travel through edges as text.
+  acted_commits: string
+  acted_ids: string
+  acted_blobs: string
 
 ## mark_done — `done` is the GATE's word, and this is where it is written.
 ##
@@ -1650,11 +1682,13 @@ workflow modernize:
   ## touched the tree. Comparing the references against anything later would
   ## compare the work with itself and always pass.
   upgrade_campaign -> lot_verify with {
-    lot_id:    "{{outputs.work_gate.lot_id}}",
-    plan_path: "{{vars.plan_path}}",
-    base_sha:  "{{outputs.work_gate.base_sha}}",
-    refs_dir:  "{{outputs.work_gate.refs_dir}}",
-    exit_gate: "{{outputs.work_gate.exit_gate}}"
+    lot_id:        "{{outputs.work_gate.lot_id}}",
+    plan_path:     "{{vars.plan_path}}",
+    base_sha:      "{{outputs.work_gate.base_sha}}",
+    refs_dir:      "{{outputs.work_gate.refs_dir}}",
+    exit_gate:     "{{outputs.work_gate.exit_gate}}",
+    acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 
   lot_verify -> lot_gate
@@ -1682,11 +1716,13 @@ workflow modernize:
   ## is part of that verdict, so reading it again is what stops a failed repair
   ## from looking like a successful one.
   reanchor -> lot_verify with {
-    lot_id:    "{{outputs.work_gate.lot_id}}",
-    plan_path: "{{vars.plan_path}}",
-    base_sha:  "{{outputs.work_gate.base_sha}}",
-    refs_dir:  "{{outputs.work_gate.refs_dir}}",
-    exit_gate: "{{outputs.work_gate.exit_gate}}"
+    lot_id:        "{{outputs.work_gate.lot_id}}",
+    plan_path:     "{{vars.plan_path}}",
+    base_sha:      "{{outputs.work_gate.base_sha}}",
+    refs_dir:      "{{outputs.work_gate.refs_dir}}",
+    exit_gate:     "{{outputs.work_gate.exit_gate}}",
+    acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 
   ## Act the lot's extension requests, after any reanchor and before the lot
@@ -1701,11 +1737,13 @@ workflow modernize:
   ## the additions inside lot_verify — exemption is re-derived every pass,
   ## never remembered.
   extend -> lot_verify with {
-    lot_id:    "{{outputs.work_gate.lot_id}}",
-    plan_path: "{{vars.plan_path}}",
-    base_sha:  "{{outputs.work_gate.base_sha}}",
-    refs_dir:  "{{outputs.work_gate.refs_dir}}",
-    exit_gate: "{{outputs.work_gate.exit_gate}}"
+    lot_id:        "{{outputs.work_gate.lot_id}}",
+    plan_path:     "{{vars.plan_path}}",
+    base_sha:      "{{outputs.work_gate.base_sha}}",
+    refs_dir:      "{{outputs.work_gate.refs_dir}}",
+    exit_gate:     "{{outputs.work_gate.exit_gate}}",
+    acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 
   ## Converged: the gate writes `done` — one line, one commit — then the run

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -176,10 +176,15 @@ schema lot_report:
   ## harness's own code, and routed to the net's extension subbot. A lot may
   ## ASK for a new observation point; it may never write one.
   extension_pending: json
-  ## An act in the ledger was not the net subbot's: introduced by a commit
-  ## the subbot did not report, or a certified path rewritten since. Refused
-  ## and TYPED — a resume from the banked branch would find the act at its
-  ## base and certify it, so this is a stop, never a repair pass.
+  ## An act in the ledger was not the net subbot's — introduced by a commit
+  ## the subbot did not report, or a certified path rewritten since — or the
+  ## net's harness could not say it applied the provenance rule at all (an
+  ## older copy, which judges by the bypassable same-commit rule). Refused and
+  ## TYPED, and terminal on its own edge: neither shape is repairable by a
+  ## pass. Dropping the act block breaks ledger_append_only, deleting the
+  ## reference makes the recorded path absent at HEAD, amending yields a sha
+  ## still outside the subbot's commits, and a harness sync is the net
+  ## owner's act, not the worker's.
   extension_forged: bool
   ## The worker wrote `done` into the contract. `done` is the gate's word: this
   ## verdict is refused BEFORE any gate command runs, so the revert costs the
@@ -236,6 +241,11 @@ schema gate_state:
   oracle_not_run: bool
   ## The verifier could not read the contract. Fails the run at once.
   unreadable: bool
+  ## An extension act the certifier refused on PROVENANCE — written by the
+  ## constrained party, or judged by a harness that could not say it applied
+  ## the rule. Terminal on its own edge, ahead of the repair loop: no pass of
+  ## this lot can produce the missing commit or the missing sync.
+  forged: bool
   fail_log: string
   needs_reanchor: bool
   needs_extend: bool
@@ -662,6 +672,24 @@ tool lot_verify:
               "contract_rewritten": []}
     problems = []
 
+    def emit():
+        """The ONE exit of this node — and the one place this rule holds.
+
+        A refused verdict is never a clean stop. `stop` is
+        `converged || lot_blocked`, `lot_blocked` is what the CONSTRAINED
+        party wrote into its own contract, and `lot_gate -> done when stop`
+        is declared ahead of the fail edges: a lot that writes
+        `status: blocked` for itself would carry ANY refusal out through the
+        green door — run `finished`, work banked, mergeable. Two refusals
+        cleared the flag at their own site, the third did not, and two of the
+        three early exits are prints a rule written at the tail never reaches
+        (review finding, executed). One rule, on the one path out.
+        """
+        if report["done_self_written"] or report["contract_rewritten"] \
+                or report["extension_forged"]:
+            report["lot_blocked"] = False
+        print(json.dumps(report))
+
     # 0. Who wrote the status? The contract is read at HEAD and at the run's
     #    base, and the two claims it can carry are believed asymmetrically.
     #    `blocked` is believed as a STOP: it had to be committed to be said, and
@@ -692,7 +720,7 @@ tool lot_verify:
         sys.stderr.write("modernize: CONTRACT_UNREADABLE: %s\n" % why)
         report["contract_unreadable"] = True
         report["log_tail"] = "CONTRACT_UNREADABLE: %s" % why
-        print(json.dumps(report))
+        emit()
         raise SystemExit(0)
 
     def plan_doc(text, what):
@@ -770,9 +798,9 @@ tool lot_verify:
         report["block_reason"] = ((head_lot or {}).get("title") or "") + " -- see the committed report"
     if head_status == "done" and (base_lot or {}).get("status") != "done":
         report["done_self_written"] = True
-        # Not a stop: a self-written verdict goes back to the worker with the
-        # refusal in fail_log, whatever else the contract says.
-        report["lot_blocked"] = False
+        # Not a stop — cleared once, at the end of this node, for every
+        # refusal: the verdict goes back to the worker with the refusal in
+        # fail_log, whatever else the contract says.
         report["block_reason"] = ""
         problems.append(
             "the contract marks lot %s `done` in the working tree while it was `%s` at base "
@@ -782,7 +810,7 @@ tool lot_verify:
             "ran no command."
             % ({{input.lot_id}}, (base_lot or {}).get("status") or "absent", base[:12]))
         report["log_tail"] = "\n".join(problems)[-6000:]
-        print(json.dumps(report))
+        emit()
         raise SystemExit(0)
 
     # 0b. The contract is read-only inside a lot — and that is checked in git,
@@ -830,11 +858,10 @@ tool lot_verify:
                                  % (bl.get("id"), bl.get("status"), hl.get("status")))
         if rewritten:
             report["contract_rewritten"] = rewritten
-            # A rewritten contract is never a clean stop, even under a lot the
-            # worker declared blocked: `stop` would end the run with the rewrite
-            # landed (adversarial finding, executed). It goes back to the
-            # worker with the refusal in fail_log.
-            report["lot_blocked"] = False
+            # Never a clean stop either, even under a lot the worker declared
+            # blocked: `stop` would end the run with the rewrite landed
+            # (adversarial finding, executed). Cleared at the same one point
+            # as every other refusal; the worker gets it in fail_log.
             report["block_reason"] = ""
             problems.append(
                 "the contract was rewritten during lot %s (%s). The plan is "
@@ -845,7 +872,7 @@ tool lot_verify:
                 "This verdict ran no command."
                 % ({{input.lot_id}}, "; ".join(rewritten)[:1500]))
             report["log_tail"] = "\n".join(problems)[-6000:]
-            print(json.dumps(report))
+            emit()
             raise SystemExit(0)
 
     def run(cmd, timeout=None):
@@ -1289,9 +1316,31 @@ tool lot_verify:
             # at its base and certify it.
             if any(r.get("forged") for r in (verdict.get("acted") or [])):
                 report["extension_forged"] = True
+                report["refs_untouched"] = False
                 report["block_reason"] = ("EXTENSION_FORGED: " + "; ".join(
                     "%s: %s" % (r.get("id"), "; ".join(r.get("problems") or []))
                     for r in (verdict.get("acted") or []) if r.get("forged")))[:600]
+            # The certifier must SAY it honoured the provenance it was handed.
+            # A net synced before the rule answers `extend-verify`, passes the
+            # capability probe, and judges by the same-commit rule alone — the
+            # one a lot passes by acting in a second commit. Nothing in the run
+            # report said so, and the deploy order makes the net's sync a step
+            # of its own AFTER the engine's (review finding, executed). Acts to
+            # certify + no echo = refused, terminal: the remedy is the net
+            # owner's sync, and no pass of this lot can produce it.
+            fresh = [r for r in (verdict.get("acted") or [])
+                     if not r.get("acted_at_base")]
+            if fresh and verdict.get("provenance") != "strict":
+                report["extension_forged"] = True
+                report["refs_untouched"] = False
+                report["block_reason"] = (
+                    "EXTENSION_UNCERTIFIED: the net's harness answered without "
+                    "honouring the provenance handed to it (provenance=%r), so "
+                    "%d act(s) were judged by the same-commit rule alone — the "
+                    "rule a lot passes by acting in a second commit. Sync the "
+                    "net's harness from the bot (a lot may not: it is judged), "
+                    "then relaunch."
+                    % (verdict.get("provenance"), len(fresh)))[:600]
         else:
             # No verdict is not "nothing to refuse". The certifier runs on
             # ledger content the constrained party writes, so a crash there
@@ -1307,7 +1356,7 @@ tool lot_verify:
             report["refs_untouched"] = False
 
     report["log_tail"] = "\n".join(problems)[-6000:]
-    print(json.dumps(report))
+    emit()
 
 ## A pure CONJUNCTION, never an aggregate. Two of three green is not "mostly
 ## done" — it is a lot that built and lies, or one that behaves and cheated.
@@ -1317,6 +1366,9 @@ compute lot_gate:
     converged: "outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched"
     stop: "(outputs.lot_verify.gate_passed && outputs.lot_verify.oracle_passed && outputs.lot_verify.refs_untouched) || outputs.lot_verify.lot_blocked"
     refused: "outputs.lot_verify.done_self_written || length(outputs.lot_verify.contract_rewritten) > 0 || outputs.lot_verify.extension_forged"
+    ## Its own term, because it takes its own door: a refusal no pass can
+    ## repair must not be paid for max_passes times (see the edge below).
+    forged: "outputs.lot_verify.extension_forged"
     timed_out: "outputs.lot_verify.gate_timed_out"
     oracle_not_run: "outputs.lot_verify.oracle_not_run"
     unreadable: "outputs.lot_verify.contract_unreadable"
@@ -1352,6 +1404,18 @@ fail gate_timeout:
 fail oracle_environment:
   description: "the behavioural oracle delivered no verdict"
   code: ORACLE_NOT_RUN
+  message: "{{outputs.lot_verify.block_reason}}"
+  resumable: false
+
+## extension_provenance — an act in the extension ledger was not the net
+## subbot's, or the net's harness could not say it applied the provenance
+## rule. Typed rather than left on the bare `fail`, because the operator's
+## action differs per shape and the code is what routes it: a forged act is a
+## finding about the lot, an uncertified one is a net whose harness is behind
+## the bot. Terminal: no pass produces the missing commit or the missing sync.
+fail extension_provenance:
+  description: "an extension act was refused on provenance"
+  code: EXTENSION_PROVENANCE
   message: "{{outputs.lot_verify.block_reason}}"
   resumable: false
 
@@ -1704,6 +1768,20 @@ workflow modernize:
   lot_gate -> gate_timeout when timed_out
   lot_gate -> oracle_environment when oracle_not_run
   lot_gate -> contract_unreadable when unreadable
+
+  ## An extension act refused on PROVENANCE — written by the constrained
+  ## party, or judged by a net harness that could not say it applied the rule.
+  ## Declared here, ahead of the subbot and loop edges, for the same reason
+  ## the timeout is: the engine takes the first `when` that holds, and this
+  ## verdict may ALSO carry a pending request — routed to `extend`, the net's
+  ## own subbot would act on a tree that already carries a forged reference.
+  ## And it is structurally unrepairable by a pass: dropping the act block
+  ## breaks `ledger_append_only`, deleting the reference makes the recorded
+  ## path absent at HEAD, amending yields a sha still outside the subbot's
+  ## commits, and a harness sync is the net owner's act — so each repair pass
+  ## would be a guaranteed-red campaign plus a full exit gate, paid
+  ## max_passes times (review finding, executed).
+  lot_gate -> extension_provenance when forged
 
   ## Repair the net BEFORE deciding the lot, and on every outcome — a converged
   ## lot is exactly the case where a lost mutant would never be noticed. Bounded

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -260,6 +260,11 @@ schema verify_input:
   ## subbot has run, and passed to the harness EVEN THEN: the only pass that
   ## judges a lot acting its own extension is the one where no subbot ran.
   acted_commits: string
+  ## The request ids the subbot reports having ACTED. The content rule that
+  ## lets a rewritten history through covers the act the subbot judged, not
+  ## any act naming a path it certified — without this the lot files a second
+  ## request, has it REFUSED, and acts it itself on the first one's path.
+  acted_ids: string
   acted_blobs: string
 
 schema mark_input:
@@ -662,6 +667,7 @@ tool lot_verify:
     # run) reads as "none reported", and is STILL handed to the harness —
     # presence, even empty, is what makes the certifier strict.
     acted_commits = ({{input.acted_commits}} or "")
+    acted_ids = ({{input.acted_ids}} or "")
     acted_blobs = ({{input.acted_blobs}} or "")
     gate_cmds = [c for c in {{input.exit_gate}}.split("\n") if c.strip()]
 
@@ -1201,7 +1207,8 @@ tool lot_verify:
             report["extension_pending"] = listing.get("pending") or []
         exempt = set()
         verdict = harness_json("extend-verify", GM_BASE=base,
-                               GM_ACTED_COMMITS=acted_commits, GM_ACTED_BLOBS=acted_blobs)
+                               GM_ACTED_COMMITS=acted_commits,
+                               GM_ACTED_IDS=acted_ids, GM_ACTED_BLOBS=acted_blobs)
         if verdict is not None and verdict is not CAPABILITY_ABSENT and not verdict.get("error"):
             exempt = set(verdict.get("ok_paths") or [])
 
@@ -1752,6 +1759,7 @@ workflow modernize:
     refs_dir:      "{{outputs.work_gate.refs_dir}}",
     exit_gate:     "{{outputs.work_gate.exit_gate}}",
     acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_ids:     "{{outputs.extend.acted_ids}}",
     acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 
@@ -1800,6 +1808,7 @@ workflow modernize:
     refs_dir:      "{{outputs.work_gate.refs_dir}}",
     exit_gate:     "{{outputs.work_gate.exit_gate}}",
     acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_ids:     "{{outputs.extend.acted_ids}}",
     acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 
@@ -1821,6 +1830,7 @@ workflow modernize:
     refs_dir:      "{{outputs.work_gate.refs_dir}}",
     exit_gate:     "{{outputs.work_gate.exit_gate}}",
     acted_commits: "{{outputs.extend.acted_commits}}",
+    acted_ids:     "{{outputs.extend.acted_ids}}",
     acted_blobs:   "{{outputs.extend.acted_blobs}}"
   }
 

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -25,6 +25,7 @@ type modernizeLotVerifyOut struct {
 	OracleNotRun    bool           `json:"oracle_not_run"`
 	OracleInvalid   []any          `json:"oracle_invalid"`
 	OracleReport    map[string]any `json:"oracle_report"`
+	ExtensionForged bool           `json:"extension_forged"`
 }
 
 // modernizeNet drops the smallest net lot_verify accepts into ws: a runner
@@ -79,6 +80,9 @@ func modernizeLotVerifyEnv(t *testing.T, script, ws, lotID, base, exitGate strin
 	body = strings.ReplaceAll(body, "{{input.base_sha}}", strconv.Quote(base))
 	body = strings.ReplaceAll(body, "{{input.refs_dir}}", strconv.Quote(".golden-master/refs"))
 	body = strings.ReplaceAll(body, "{{input.exit_gate}}", strconv.Quote(exitGate))
+	// The net subbot's provenance: what an edge renders before the subbot ran.
+	body = strings.ReplaceAll(body, "{{input.acted_commits}}", "null")
+	body = strings.ReplaceAll(body, "{{input.acted_blobs}}", "null")
 	if i := strings.Index(body, "{{"); i >= 0 {
 		t.Fatalf("unresolved template ref in lot_verify near %q", body[i:min(i+40, len(body))])
 	}

--- a/bots/modernize_lot_verify_status_test.go
+++ b/bots/modernize_lot_verify_status_test.go
@@ -82,6 +82,7 @@ func modernizeLotVerifyEnv(t *testing.T, script, ws, lotID, base, exitGate strin
 	body = strings.ReplaceAll(body, "{{input.exit_gate}}", strconv.Quote(exitGate))
 	// The net subbot's provenance: what an edge renders before the subbot ran.
 	body = strings.ReplaceAll(body, "{{input.acted_commits}}", "null")
+	body = strings.ReplaceAll(body, "{{input.acted_ids}}", "null")
 	body = strings.ReplaceAll(body, "{{input.acted_blobs}}", "null")
 	if i := strings.Index(body, "{{"); i >= 0 {
 		t.Fatalf("unresolved template ref in lot_verify near %q", body[i:min(i+40, len(body))])

--- a/e2e/bot_golden_master_extend_test.go
+++ b/e2e/bot_golden_master_extend_test.go
@@ -14,6 +14,10 @@ import (
 // the verifier answers with what `report` returns for the pass. The compute
 // nodes (extend_gate, extend_result) are the engine's own — they are what
 // these tests pin.
+//
+// The defaults must carry EVERY term the gate reads: a term missing here
+// renders false, so a test expecting a refusal would pass without ever
+// exercising the term it names.
 func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
 	exec.on("extend_base", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{
@@ -31,6 +35,10 @@ func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
 			"committed": true, "scope_clean": true, "out_of_scope": []any{},
 			"additions_ok": true, "refused": []any{}, "no_new_requests": true,
 			"still_pending": []any{}, "extended": 1, "log_tail": "", "_tokens": 1,
+			"clean_start": true, "identity_ok": true,
+			"acted_commits": "fedcba9876543210fedcba9876543210fedcba98",
+			"acted_ids":     "E-1",
+			"acted_blobs":   "captures/E-1.json=1111111111111111111111111111111111111111",
 		}
 		for k, v := range report(pass) {
 			out[k] = v

--- a/e2e/bot_golden_master_extend_test.go
+++ b/e2e/bot_golden_master_extend_test.go
@@ -22,6 +22,10 @@ func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
 	exec.on("extend_base", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{
 			"head": "0123456789abcdef", "dirty": "", "notice": "",
+			// `clean` routes the run: false sends it straight out, past the
+			// agent. A default that omitted it would render false and every
+			// scenario below would test the refusal path instead of its own.
+			"clean": true, "prev_name": "", "prev_email": "",
 			"pending": []any{map[string]any{"id": "E-1", "lot": "L1"}}, "_tokens": 1,
 		}, nil
 	})
@@ -29,6 +33,12 @@ func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
 	exec.on("extend_campaign", func(_ map[string]any) (map[string]any, error) {
 		pass++
 		return map[string]any{"summary": "acted what could be acted", "_tokens": 10}, nil
+	})
+	// The terminal restore is a tool node like the others: without a stub it
+	// falls through to the executor's default {} and the run reads a node
+	// that never spoke.
+	exec.on("extend_restore", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"restored": true, "notice": "identity restored", "_tokens": 1}, nil
 	})
 	exec.on("extend_verify", func(_ map[string]any) (map[string]any, error) {
 		out := map[string]any{
@@ -39,6 +49,7 @@ func extendStubs(exec *scenarioExecutor, report func(pass int) map[string]any) {
 			"acted_commits": "fedcba9876543210fedcba9876543210fedcba98",
 			"acted_ids":     "E-1",
 			"acted_blobs":   "captures/E-1.json=1111111111111111111111111111111111111111",
+			"agent_summary": "acted what could be acted",
 		}
 		for k, v := range report(pass) {
 			out[k] = v

--- a/pkg/backend/model/executor_test.go
+++ b/pkg/backend/model/executor_test.go
@@ -1096,6 +1096,25 @@ func TestResolveScriptTemplate(t *testing.T) {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})
+	// The other half of the contract a tool script depends on: an input the
+	// edge did not provide (a node that never ran) renders as the language's
+	// null literal, so the script PARSES and can read the absence itself. A
+	// bare `{{input.x}}` left as text, or rendered as the empty token, is a
+	// SyntaxError before any user logic runs — and a bot that hands a
+	// subbot's provenance to a deterministic gate would die at the gate
+	// instead of judging with "none reported".
+	t.Run("absent input renders the null literal", func(t *testing.T) {
+		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"acted_commits"}, Raw: "{{input.acted_commits}}"}}
+		got := resolveScriptTemplate("x = ({{input.acted_commits}} or \"\")", refs, map[string]any{}, nil, nil)
+		want := `x = (null or "")`
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+		gotNil := resolveScriptTemplate("x = {{input.acted_commits}}", refs, map[string]any{"acted_commits": nil}, nil, nil)
+		if gotNil != "x = null" {
+			t.Errorf("explicit nil rendered %q, want %q", gotNil, "x = null")
+		}
+	})
 	t.Run("bang form still raw", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"name"}, Raw: "{{!input.name}}", Unquoted: true}}
 		input := map[string]any{"name": "foo"}

--- a/pkg/backend/model/executor_test.go
+++ b/pkg/backend/model/executor_test.go
@@ -1105,12 +1105,12 @@ func TestResolveScriptTemplate(t *testing.T) {
 	// instead of judging with "none reported".
 	t.Run("absent input renders the null literal", func(t *testing.T) {
 		refs := []*ir.Ref{{Kind: ir.RefInput, Path: []string{"acted_commits"}, Raw: "{{input.acted_commits}}"}}
-		got := resolveScriptTemplate("x = ({{input.acted_commits}} or \"\")", refs, map[string]any{}, nil, nil)
+		got := resolveScriptTemplate("x = ({{input.acted_commits}} or \"\")", refs, map[string]any{}, nil, nil, "")
 		want := `x = (null or "")`
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
-		gotNil := resolveScriptTemplate("x = {{input.acted_commits}}", refs, map[string]any{"acted_commits": nil}, nil, nil)
+		gotNil := resolveScriptTemplate("x = {{input.acted_commits}}", refs, map[string]any{"acted_commits": nil}, nil, nil, "")
 		if gotNil != "x = null" {
 			t.Errorf("explicit nil rendered %q, want %q", gotNil, "x = null")
 		}

--- a/pkg/runtime/engine_resolve_mapping_test.go
+++ b/pkg/runtime/engine_resolve_mapping_test.go
@@ -137,6 +137,27 @@ func TestResolveMapping_MissingReferenceRendersEmpty(t *testing.T) {
 	}
 }
 
+// A WHOLE-value reference to a node that never ran resolves to nil, not to
+// the empty string — the half of the contract a tool script depends on: the
+// script renderer turns nil into the language's null literal, so
+// `x = ({{input.x}} or "")` parses and reads as absent. Were it "" or the
+// literal text, a bot handing a subbot's output to a gate would either fail
+// to parse or hand the gate a bogus value that reads as PRESENT (golden-master
+// hands the net subbot's commits to the certifier this way; present-even-empty
+// is what makes the certifier strict, so the difference is a verdict).
+func TestResolveMapping_WholeReferenceToAnUnrunNodeIsNil(t *testing.T) {
+	e := &Engine{}
+	sc := resolveScope{outputs: map[string]map[string]any{}}
+	if got := e.resolveMapping(mapping(t, "{{outputs.extend.acted_commits}}"), sc); got != nil {
+		t.Errorf("resolveMapping of a whole reference to an unrun node = %#v (%T), want nil", got, got)
+	}
+	// And a node that ran without the field: same answer, same reason.
+	sc = resolveScope{outputs: map[string]map[string]any{"extend": {"other": "x"}}}
+	if got := e.resolveMapping(mapping(t, "{{outputs.extend.acted_commits}}"), sc); got != nil {
+		t.Errorf("resolveMapping of a missing field = %#v (%T), want nil", got, got)
+	}
+}
+
 // Structured values spliced into a larger template render as compact
 // JSON, matching what the prompt renderer does.
 func TestResolveMapping_StructuredValueRendersAsJSON(t *testing.T) {


### PR DESCRIPTION
## Measured

On a live campaign, a lot filed an extension request in one commit and **acted it in the next** — added the reference under the net, appended the act block — and the harness's provenance rule, which refuses a request and an act introduced by the *same* commit, saw nothing. The lot's own file became a reference of the net that judges it, exempted as a pure addition, and the lot landed with a caveat. Filing and answering are different powers; the gate could not tell them apart.

## One mechanism, three parties

- **The subbot** (`extend.bot`) refuses to start on a net with uncommitted paths under it — this run committing them would certify the constrained party's file as the net's own (the absorption attack the plan review found) — sets the engine's git identity for its commits and restores the previous one, and **publishes what it did**: the commits of `base..HEAD`, the request ids it acted, the blob it certified per surface path. It hands the same provenance to its own harness call, so passing there and failing at the parent's gate is not a state that exists.
- **The parent** (`modernize/main.bot`) carries that provenance to `lot_verify` on every edge — rendered `null` before the subbot ran, hence the JSON-literal shim the other bots already use — and hands it to the harness on **every pass, empty included**: the only pass that judges a self-act is the one where no subbot ran. A forged act is a **typed refusal** (`extension_forged` → `lot_gate.refused` → `fail`), never a repair pass: a resume from the banked branch would find the act at its base and certify it.
- **The harness** (`extension_verdict`) reads the provenance once in `main()` — presence means strict, absence means a caller that predates provenance and gets today's rule — and refuses an act introduced by a commit outside the subbot's, whatever author it carries, unless every recorded path carries at HEAD the exact blob the subbot certified (a history rewritten after the subbot ran). The exemption follows the **certified content**, not the path: a reference rewritten after the act is refused. Every act row reports its introducing commit and author.

## Plan review before the code

The plan was attacked by a second model before implementation (report kept with the campaign): three critical findings changed it — a `with {}` template over a node that has not run renders `null`, not `""` (the shim); a lot can leave its forged file **uncommitted** for the subbot to commit (the dirty-net refusal); the certificate covered commits and paths but never **content** (the certified blobs) — plus the non-durable refusal (typed now) and the deploy order below. Two questions became limits stated in the skill: no merge or rebase of the base while a lot runs; the identity is attribution, the commits are the lock.

## Deploy order

The subbot ships with the **runner** image (the baked catalogue resolves a child bot), the parent with the **server** (compiled at launch). A new parent with an old subbot fails the subbot node on a missing required field. Order: merge → runner digest bump → server rollout → harness sync into the target trees → relaunches. Between the runner bump and the server rollout, the extra fields are ignored — harmless.

## Proof

- Harness self-test 204 → 210: a self-act in two commits is refused with its author named, the subbot's commit passes, a rewritten history with identical certified blobs passes, a reference rewritten after the act is refused, no provenance keeps today's rule; `acted_at_base` unchanged. Mutants: membership ignored; exemption not content-bound; author not recorded; blob match forced — each red.
- Go tests drive `lot_verify`, `extend_base` and `extend_verify` against real repos with stub certifiers that **refuse unless handed provenance**: the parent hands it before any subbot ran; a forged act is typed with its author in `block_reason`; a dirty net is refused before the agent and the identity untouched; the subbot publishes commits, blobs and ids, and reports a commit under another identity. Mutants: the parent handing no provenance; the forged act not typed; the dirty net not refused; the subbot handing no provenance to its own call; the identity check dropped; the blobs not published — each red.
- `go test ./bots/` green (the byte-identity test covers the two inlined harness copies); the doctrine is in `skills/golden-master.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Round 1 (four findings, each reproduced; two open questions turned into code)

- **A forged act rode out through the green door** (high, R10870f): `stop` is `converged || lot_blocked`, `lot_blocked` is what the CONSTRAINED party writes into its own contract, and `lot_gate -> done when stop` is declared ahead of the fail edges — so a lot that forges an act AND writes `status: blocked` for itself ended `finished`, its forged reference banked and mergeable. The two older refusals (`done_self_written`, `contract_rewritten`) each cleared the flag at their own site; the third did not. Fixed at the class, not at the site: `lot_verify` now has ONE exit, `emit()`, which clears `lot_blocked` on any refusal — and that matters, because two of the three exits are early prints a rule written at the tail never reaches (measured: the first patch, written at the tail, left `contract_rewritten` failing its own test). `TestModernizeLotVerifyHandsProvenanceToTheCertifier/a_forged_act_cannot_ride_out_through_a_self-declared_blocked_lot`; mutant M1 (the rule dropped from `emit`) turns that test AND the pre-existing rewritten-contract test red.
- **The refusal was routed through the repair loop** (medium, Reada6a): folded into `refused`, it only reached `fail` after `max_passes` guaranteed-red campaign passes plus a full exit gate each. It now has its own term (`forged`) and its own edge, declared with the typed terminals ahead of the subbot and loop edges — the same reason the timeout is declared first: the engine takes the first `when` that holds, and this verdict may also carry a pending request, which would route to `extend` and have the net's own subbot act on a tree that already carries a forged reference. It lands on a named terminal (`EXTENSION_PROVENANCE`), not the bare `fail` that reports the same `FAIL_NODE` as a forged `done`. `TestModernizeProvenanceRefusalIsTerminalAndDeclaredFirst` reads the compiled IR: the edge exists, nothing but the other typed terminals precedes it, its target is a `fail` node with a code of its own. Mutant M2 (edge dropped) — red.
- **Provenance handed to a net that silently ignored it** (medium, Rcfc573): the capability probe passes on a net synced before the rule, whose `extension_verdict` takes no provenance and applies the same-commit rule alone — the bypassable one, reverted in silence, and the deploy order makes the net's sync a step of its own AFTER the engine's. The verdict now SAYS which rule it applied (`provenance: "strict" | "legacy"`), and the parent asserts the echo: acts to certify + no echo = `EXTENSION_UNCERTIFIED`, terminal, naming the sync as the remedy — the net owner's act, not one a pass of this lot could produce. Bounded on purpose: an act already certified at the base needs no echo, so an older net carrying one does not refuse every lot launched from it. Mutants M3 (echo removed → harness selftest red) and M4 (parent stops asserting → test red); a fifth stub pins the hostile shape (a certifier calling one act both `ok` and `forged`) now that the forged branch also refuses the references (M7).
- **The engine-set identity leaked on every failure path** (medium, R649b8f): `extend_base` writes it into the workspace's local git config and only `extend_verify` restores it, so an LLM error, a budget stop or a cancel in between left the LOT committing under the net's name — and sticky, because the next run read the leak as the state to restore. The displaced identity is now recorded in the git DIR (never the worktree: nothing there is committable, nothing the gate judges) and re-applied by whichever run comes next, which SAYS it repaired a leak instead of inheriting it; `extend_verify` clears the marker on the restore path. `TestGoldenMasterExtendBaseRepairsALeakedIdentity`; mutants M6 (marker not written) and M8 (marker not cleared) — red. The lock is unaffected either way: `acted_commits` is the lock, the author is prose — which is why the leak was an attribution defect and not a hole.

Open questions, answered:

- *Edge selection semantics.* Confirmed in the engine, not assumed: `evaluateEdgesWithLoopsRS` (`pkg/runtime/edges.go`) walks `workflow.Edges` in declaration order and RETURNS the first conditional edge whose condition holds; unconditional and `else` edges are kept aside as fallback. So both findings stand as written, and the fix relies on the same ordering the timeout edge already relies on.
- *Could a second `extend` overwrite `acted_commits` within one lot?* No. `extend_loop("1")` allows one crossing, and the counter resets only when a non-loop edge targets a loop ENTRY (`loop.Entries[selected.To]`, same file). The only entry of `extend_loop` is `extend`, and no non-loop edge targets it — the repair loop re-enters at `upgrade_campaign`, which is not an entry. One subbot per run, so the first act cannot be re-typed by a second report.
- *What guarantees nothing else commits into that workspace during the subbot's window?* The parent is parked on the subbot node while the child runs, and a subbot node is a mutating branch — the workspace-safety rule serialises them on every driver. Anything that did commit there would be certified, which is why the window is now bounded by the marker rather than by trust.
- *The ledger-only act.* Fixed rather than argued: the content escape hatch generated over `paths` minus the ledger, so an act recording only the ledger left the generator empty, `all([])` true, and the hatch open for an act that certified no surface path. It now requires a surface path to certify; the act is refused as forged, which is what it is. Mutant M5 — harness selftest red.
- *Is anything enforcing the harness sync into the target trees?* Now yes, by refusal rather than by discipline: that is the third finding's fix. The certifier is still the target's own file, so a hostile copy could echo `strict` — the two mechanical bounds that already govern its word (only the extension surface is exemptible; any judged path moving outside that surface voids the certificate entirely, harness included) are what keep that from mattering.

Scope stated rather than hidden: the echo is asserted by the PARENT only. The subbot passes provenance to its own call too, but that call certifies the subbot's own commits — self-certification either way — and the gate that lands the lot is the parent's. A net whose harness predates the rule is refused there, once, with the sync named.

`GM_MODE=selftest` 214 checks; `go test ./bots/` green; `gofmt` clean; eight mutants, each red on the test it belongs to.


## Round 2 (two findings, both reproduced — and one from production on the same surface)

- **The certificate covered a PATH, not the act** (high): the content escape hatch — how a rewritten history keeps its certificate — let any act introduced outside the subbot's commits through as long as its recorded paths were paths the subbot certified in this segment. The lot writes its own request blocks, so it writes its own paths: file E-1 and E-2, have the subbot grant E-1 and REFUSE E-2, then append your own act for E-2 recording E-1's certified path. Reproduced against the pre-fix code on this branch: the smuggled act came out `ok: True` and its path landed in `ok_paths` — the refused extension converges, which is the exact separation this PR exists to enforce. The datum that closes it was already computed and published by the subbot (`acted_ids`) and already declared by the parent, and was forwarded nowhere; it is now (`GM_ACTED_IDS`), and the hatch requires the act to be one the subbot actually judged. Selftest: the whole three-commit scenario is replayed, plus the narrow case; mutant N1 (id clause dropped) turns both red.
- **The identity restore sat on the loop's body** (high): `extend_verify` restored the engine-set identity at the end of EVERY pass, and `extend_gate -> extend_campaign as repair_loop(...)` re-enters the AGENT, not `extend_base`. So pass 2 committed under the ambient identity, `identity_ok` could never hold again — a first-pass refusal became permanently unrepairable — and in a workspace with no ambient identity the `--unset` left the agent unable to commit at all. The restore is now a terminal node (`extend_restore`) that both exits of the gate pass through, sourced from the marker rather than from an edge, so it is idempotent whatever path the run took and a dying run still leaves the next one able to repair. `TestGoldenMasterExtendRestoreIsOnEveryWayOut` reads the compiled IR: every non-loop edge out of the gate reaches the restore, and the loop edge does not. Mutants N3 (restore moved back onto a gate exit) and N4 — red.
- **From production, same surface** (reported by the campaign's piloting session): a subbot that REFUSED a request for a correct reason, wrote that reason to a report file and committed it, was told by its own gate «paths OUTSIDE the extension surface were changed … acting more than was asked is smuggling». The verdict was right and the reason an operator reads was false. Two halves, because the file was a symptom: the subbot's own line is now published beside the deterministic verdict (an agent told to «report in `summary`» wrote a file precisely because that line reached nobody — `extend_result.notice` dropped it), and a run that touched no surface path is no longer described as an act that overreached. The `golden-master` skill said a `REPORT.md` of your own is welcome; it now says that freedom is the rite's, not the extension subbot's. Mutants N5 and N6 — red.
- Also: the hatch no longer compares `corpus.json`'s blob, which a later act legitimately moves — the per-path rewrite check already exempted it, and the asymmetry would have refused a rewritten history for the one file expected to change.

Open questions, answered against the engine rather than assumed:

- *Do the subbot's outputs survive a `repair_loop` re-entry?* Yes. `rs.outputs` is keyed by node and is cleared in exactly one place — `pkg/runtime/routing.go`, for the unselected targets of a **round_robin** router, which this bot does not use. Loop re-entry resets counters and the loop's own snapshots, never node outputs. So `{{outputs.extend.acted_commits}}` keeps the subbot's value on later passes and a legitimate earlier act is not re-typed as forged.
- *Is the `null` rendering asserted end-to-end?* It is now, in both links, because the shim's correctness is not a schema-level claim: `TestResolveMapping_WholeReferenceToAnUnrunNodeIsNil` (a whole-value mapping over a node that never ran resolves to nil, not to `""`) and `TestResolveScriptTemplate/absent_input_renders_the_null_literal` (a tool script renders an absent input as the language's null literal, so `x = ({{input.x}} or "")` parses). The second is the contract `executor_tool.go` documents deliberately; mutant N7 (the null-rendering flag flipped) turns it red.
- *Only one `extend` per lot?* `extend_loop("1")` allows one crossing and the counter resets only when a non-loop edge targets a loop ENTRY (`loop.Entries[selected.To]`). The only entry of `extend_loop` is `extend`, and no non-loop edge targets it — the repair loop re-enters at `upgrade_campaign`. So the first report cannot be overwritten by a second.
- *What else could commit into the workspace during the subbot's window?* The parent is parked on the subbot node while the child runs, and a subbot node is a mutating branch: the workspace-safety rule serialises them on every driver. The window is now also bounded by the identity marker rather than by trust.
- *The deploy window for `EXTENSION_UNCERTIFIED`.* Removed rather than accepted, by inverting the order: the harness sync into the target trees goes BEFORE the server rollout, not after. The new harness is compatible with the old parent (no `GM_ACTED_COMMITS` → the previous rule, plus a field the old parent ignores), while the new parent is not compatible with an old harness — so syncing first leaves no window at all. Measured on the campaign this comes from: the sync is one file and a full gate, 26 to 55 minutes.
- *Acts already at base skip provenance.* Intended, and load-bearing: an extension certified one day would otherwise block every lot launched from the next day's base — measured, and the reason `acted_at_base` exists. Provenance is judged once, in the segment that introduces the act, by the gate that decides whether that segment lands.

Selftest 220; `go test ./bots/ ./pkg/runtime/ ./pkg/backend/model/` green; gofmt clean; seven mutants, each red on its own test.


## Round 3 (three findings, all reproduced — plus a second site the review did not name)

- **A duplicate act block shared one provenance** (high, Rd716b6): `introducing_commits` keys first-wins on `(kind, id)` and `acts` is a LIST, so a SECOND act block carrying an id the subbot already acted resolved its provenance on the **subbot's** commit. The whole provenance branch was skipped; no certified blob existed for its paths, so the rewrite check skipped too; and the lot's own commit wrote a reference into the net that judges it, exempted from `refs_changed`. The precondition is entirely lot-controlled — it authors the request's `paths`, and nothing requires one act to cover them all. An id is acted **once** now, the way a duplicate corpus entry id is already refused, and the repeat is typed forged. The three-commit scenario is replayed in the selftest; mutant Q1 (the duplicate check dropped) turns it red.
- **A refused start still certified its window** (medium, R5668bc): `extend_base` refuses a dirty net by handing the agent no pending request — prose, which an agent may ignore — while `extend_verify` published `base..HEAD` as the net subbot's provenance regardless. The route the finding names: leave the reference and its act block uncommitted, commit only the request so it routes to the subbot, and let the subbot's tidy-up commit introduce the act *inside* `acted_commits`. `clean_start` was computed and fed only the subbot's own gate, which nothing downstream reads — the defence rested on the agent obeying the prompt. A refused start now certifies nothing at all. Deliberately not extended to `identity_ok`: the lock is the commit SET, a leaked identity is an attribution defect rather than a claim that someone else committed, and the parent's gate already refuses on it.
- **The certificate was whitespace-delimited** (medium, Rff8c57): a surface path containing a space split into two tokens — the left dropped for having no `=`, the right registering a bogus key — leaving the real path with no certified blob, so the post-act rewrite check never fired for it. That is the masking vector round 2's content binding closed, reopened by an encoding. One entry per **line** now, and an entry the judge cannot read is a refusal, never a silent drop.

**The same defect sat on the act IDS, and the finding did not name it.** Ids are lot-authored too, and their guard rejects `/`, `\`, `.` and `..` — not whitespace. An id with a space split OUT of the parsed set, so `act.id in acted_ids` went false and the act silently lost the content rule's cover: the round-2 fix, undone by the round-3 encoding, on the second of two sites. Same fix, both sites. The test drives a real ledger rather than the parser directly, because only an act that NEEDS the hatch can show whether its id survived parsing.

Selftest 222; `go test ./bots/ ./pkg/backend/model/ ./pkg/runtime/` green; `go vet` clean; six mutants, each red on its own test — including the two that pin the encoding on both ends (the reader split by whitespace again, the publisher joined by spaces again).


## Round 4 (two findings, both reproduced)

- **The absorption attack was still reachable — through a file name** (high, Raa7bbb). `extend_base` decided `clean` by prefix-matching the raw lines of `git status --porcelain`, and git QUOTES any path carrying a non-ASCII byte, a quote or a backslash: `.golden-master/refs/é.txt` comes back as `".golden-master/refs/\303\251.txt"`, the prefix match misses it, and a dirty net reads CLEAN. From there the lot plants the reference content itself, commits only the request, and the subbot's `git add -A` absorbs the planted file into ITS commit — the constrained party's own content becomes a certified reference of the net that judges it, which is the attack this refusal exists to stop. Staged renames leaked the same way: `R  old -> new` matched neither side, so a reference moved OUT of the net left it reading clean. Read with `-z` now — which never quotes — with a rename's origin consumed as the token it is.
- **A refused start still bought an LLM pass, then `max_passes` more** (medium, R2a2abf). `clean` is read once and carried unchanged onto every pass, so the conjunct it feeds is false forever and no pass can flip it — yet the graph routed the refusal through a full claude_code campaign and then re-entered the AGENT through the repair loop. Worse than the cost: `extend_base` states "the agent receives no pending request", and the agent still got the workspace with commit access; that half rested on a prompt line. A refused start now leaves by its own door, declared ahead of the campaign edge, with nothing to restore (no identity is set on that path).

The first finding's real lesson is that the rule was already written in this family and the new site did not follow it. `reanchor.bot`'s scope check passes `core.quotePath=false` with a comment stating this exact failure; `lot_verify` scopes its status with `--` and passes the flag too. The distinction that explains why the other porcelain readers are safe: **an emptiness check is safe without it, a PREFIX match never is.**

Open questions, answered in code rather than in prose:

- *Can the notice evaluate `string + null`?* It could, and that was a live hazard: `if()` evaluates BOTH branches (its arguments are computed before the call), so a `summary` the agent omitted would render null, `string + null` is a typed error, and the compute would have taken down a run that was only reporting a refusal. The line now comes from the verifier, where a tool node's `or ""` makes it a string once and everything downstream can add it.
- *Was the e2e suite run on this branch?* It is now, and it needed the stubs the review names: `clean` (whose absence would have routed every scenario through the refusal path rather than the one it means to test — the same "green for free" shape as the round-1 stub gap) and the new terminal restore node. `go test ./e2e/` green.
- *Does `acted_at_base` cover every relaunch shape?* A relaunch takes the run's base from the plan's `base_sha`, which is the commit the run starts from; an act certified in an earlier run landed before that base, so it reads `acted_at_base` and is not re-judged. The shape that would break it — a base predating a landed act — is a base moving BACKWARDS, which the campaign's merge discipline does not produce and which would already break `refs_untouched` for every reference that act added.
- *Why does the subbot's own call pass no `GM_ACTED_IDS`?* Deliberate, and now stated: the subbot certifies its own commits, so every act it made is covered by `acted_commits` and the content hatch is not needed. Passing nothing keeps its self-check strictly stricter than the parent's, which is the safe direction for a party judging itself.
- *Does a test pin `sync-harness.bot`'s copy too?* Yes — `sync-harness.py` regenerates both copies from `oracle-harness.py`, and `TestGoldenMasterHarnessCopiesStayInSync` compares each against the standalone file.

Selftest 231; `go test ./bots/ ./e2e/` green; four mutants, each red on its own test — including the two shapes the finding named, a quoted path and a rename.


## Round 5 (three findings, all reproduced — one of them against this PR's own doctrine)

- **`identity_ok` was unsatisfiable wherever the environment exports git's identity** (high, R716f27). `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_EMAIL` outrank every config source — the `git config` this bot sets and `-c user.email` alike — so on a devcontainer, a CI image or an agent sandbox every commit carries the ambient address. As a hard conjunct of `converged`, that meant the subbot could **never converge on correct work**: `repair_loop` re-enters the agent, burns `max_passes` full campaigns against a wall the agent cannot move (it cannot change the process environment), and the parent receives a refusal naming a cause the operator did not create. It also contradicted this PR's own doctrine, written three rounds earlier: **`acted_commits` is the lock, the author is prose.** Making prose a blocking term was the error. It is reported now, with what the difference costs said in the log, and the gate no longer requires it.
- **The selftest inherited the caller's git identity** (high, R359288). `xcommit` sets the committer with `-c user.email`, which the environment outranks, so round 3's author assertion went red on any host exporting those variables — and the gate wrapper runs the selftest as a **blocking** step, so a campaign's exit gate would fail for a reason unrelated to the code under test. Cleared at the same dispatch point as the `GM_*` variables, for the same reason: the doubles belong to the selftest, and nothing about the caller may reach them. That list is now the one place this class is handled.
- **A failing `git status` read as a CLEAN net** (medium, Rc5ef1c). `clean` decides whether the identity is set, whether the agent is handed the pending requests, and — through `extend_verify` — whether a certificate is published at all. Its unknown failed **open**, granting exactly the window the refusal exists to close. Every neighbouring unknown in this feature fails closed ("an unprovable act is refused, not assumed"; "a certificate the judge cannot read is refused, not dropped"); this one now does too.

The third mutant is worth naming: dropping the demotion survived at first, because the e2e scenario stubs `extend_verify` and its default returns `identity_ok: true` — the stub hid the wall. It is red now because the test reads the **compiled IR** and asserts `converged` does not mention the term, and because a second test drives the real tool under an ambient identity and requires the provenance to be published all the same.

Selftest 231 — and 231 again under an ambient `GIT_AUTHOR_EMAIL`, which is the whole point; `go test ./bots/ ./e2e/` green.
