### PR TITLE
fix(forge,server,credentials,runtime): a 404 is typed by resource, a publish grant refuses the launch it cannot serve and dies with its run, and a squash message stays in the run range

### DIFF
--- a/docs/forge-security-read.md
+++ b/docs/forge-security-read.md
@@ -29,9 +29,15 @@ Mind which store you write, they are different secrets:
 iterion remote api POST /api/teams/<team-id>/secrets \
   --data '{"name":"dependabot_tokens","value":"{\"my-org\":\"github_pat_…\"}"}'
 
-# LOCAL / desktop runs only (~/.iterion/secrets.json):
-iterion secret set dependabot_tokens '{"my-org": "github_pat_…"}'
+# LOCAL / desktop runs only (~/.iterion/secrets.json). The value never
+# rides argv — it comes from stdin, --from-env, or a masked prompt:
+printf '{"my-org": "github_pat_…"}' | iterion secret set dependabot_tokens --kind json
 ```
+
+`--kind json` names the shape so the ingestion gate checks the right
+one: a JSON credential document legitimately carries the spaces and
+newlines a bare token may not, and a truncated paste is refused here
+rather than discovered as a 401 in the middle of a poll.
 
 The consuming bot mounts it `as: file` and reads it only in its
 deterministic poll step (vuln-watch has no LLM node at all).

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -879,6 +879,37 @@ completed and then had no way to post the verdict it had computed. The grant's
 TTL is therefore derived from the max retry wait, plus a margin for the resumed
 run itself.
 
+### The grant's other two bounds: the run's own end, and a mint that fails
+
+A TTL sized for a seven-day quota wait is a long life for a credential that a
+normal review needs for minutes. So the run's terminal outcome brings the
+expiry forward: the same run-outcome event the reconciler consumes shortens the
+grant to the reconciler's own window (the sweep lookback plus a margin), after
+which nothing revisits the run and the grant has no reader left. Two shapes
+keep the full TTL, because something *will* come back and post their own
+verdict — a **paused** run, and a `failed_resumable` one with an **armed**
+retry. "Abandoned" is not re-derived here: the retry sweeper enforces the
+policy's `max_wait`, unsets the armed instant when it gives up, and
+**republishes the run outcome**, so the grant is shortened on that event
+instead.
+
+The other bound is the mint itself. A launch whose grant cannot be registered —
+a saturated in-memory registry, an unreachable Valkey — is **refused**, not
+degraded: the run would claim the repo's gate context and then have no way to
+answer it, and the reconciler reads the grant to know where to speak, so it
+would abstain and the claim would never be resolved. Refusing works because the
+claim is posted *after* the launch: nothing is left on the head to release. The
+webhook lane marks the delivery `launch_error` (redelivery re-enters), the
+studio/API launch answers `503`, and a board card is filed blocked with the
+reason.
+
+**Known gap — the registry is single-replica by default.** Without Valkey the
+grants live in one pod's memory, so a restart empties them: an in-flight run's
+publish then answers `401`, and the reconciler abstains on "its publish grant
+is expired or revoked". `pkg/valkey` is the cloud twin and is used when
+configured; making it the only backend (so an unknown token is a real refusal
+rather than a lost one) is not done.
+
 ### The dead review is re-run — once per head
 
 The synthetic `failure` makes the interruption visible; on an automated lane

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -344,8 +344,13 @@ it. An unknown `--kind` is an error, not a silent pass-through to no checking.
 
 Studio: the **Secrets** view (gated on `server_info.secrets_enabled`) offers
 the same CRUD over `/api/local/secrets` (unauthenticated single-operator
-routes — the local studio is trusted to its loopback TTY user). Neither the
-CLI nor the REST responses ever return a stored value.
+routes — the local studio is trusted to its loopback TTY user), **including
+the same gate**: the create/rotate request carries an optional `kind` (the
+view's *Kind* picker, defaulting to "detect from the value"), the shape is
+resolved by the same `secrets.ResolveSecretShape` the CLI calls, and a refusal
+answers `400` naming the kind and the `raw` opt-out. Two doors into one store
+must not disagree on what a value is. Neither the CLI nor the REST responses
+ever return a stored value.
 
 The desktop app's provider-API-key keychain (`ANTHROPIC_API_KEY`, … under
 `io.iterion.desktop`) is a **separate** concern — those are how iterion talks

--- a/pkg/backend/delegate/claude_code_cred_baseurl_test.go
+++ b/pkg/backend/delegate/claude_code_cred_baseurl_test.go
@@ -1,0 +1,56 @@
+package delegate
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// An operator who sets ANTHROPIC_BASE_URL means it: a self-hosted z.ai-
+// compatible endpoint, a regional facade, a debugging proxy. The two branches
+// that read the key from the process env honoured it; the two that read a
+// TENANT-provisioned key pinned the vendor default instead, so the same
+// deployment routed a team's key somewhere the operator's own key would never
+// go. One resolver for all four.
+func TestAnthropicCredEnv_ZAIHonoursTheOperatorsBaseURL(t *testing.T) {
+	const override = "https://zai.internal.example/api/anthropic"
+
+	t.Run("tenant key under the zai hint", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("ANTHROPIC_BASE_URL", override)
+		ctx := ctxWithCreds(t, map[secrets.Provider]string{secrets.ProviderZAI: "zai-tenant"}, nil)
+		got := anthropicCredEnvForCLI(ctx, "zai", false)
+		if got["ANTHROPIC_BASE_URL"] != override {
+			t.Errorf("ANTHROPIC_BASE_URL = %q, want the operator's %q", got["ANTHROPIC_BASE_URL"], override)
+		}
+		if got["ANTHROPIC_AUTH_TOKEN"] != "zai-tenant" {
+			t.Errorf("ANTHROPIC_AUTH_TOKEN = %q, want the tenant key", got["ANTHROPIC_AUTH_TOKEN"])
+		}
+	})
+
+	t.Run("tenant key under the default precedence", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("ANTHROPIC_BASE_URL", override)
+		ctx := ctxWithCreds(t, map[secrets.Provider]string{secrets.ProviderZAI: "zai-tenant"}, nil)
+		got := anthropicCredEnvForCLI(ctx, "", false)
+		if got["ANTHROPIC_BASE_URL"] != override {
+			t.Errorf("ANTHROPIC_BASE_URL = %q, want the operator's %q", got["ANTHROPIC_BASE_URL"], override)
+		}
+		if got["ANTHROPIC_AUTH_TOKEN"] != "zai-tenant" {
+			t.Errorf("ANTHROPIC_AUTH_TOKEN = %q, want the tenant key", got["ANTHROPIC_AUTH_TOKEN"])
+		}
+	})
+
+	// Unset, the vendor default stands — the override is an override, not a
+	// requirement.
+	t.Run("no override keeps the vendor default", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		ctx := ctxWithCreds(t, map[secrets.Provider]string{secrets.ProviderZAI: "zai-tenant"}, nil)
+		for _, hint := range []string{"zai", ""} {
+			got := anthropicCredEnvForCLI(ctx, hint, false)
+			if got["ANTHROPIC_BASE_URL"] != secrets.ZAIDefaultBaseURL {
+				t.Errorf("hint %q: ANTHROPIC_BASE_URL = %q, want %q", hint, got["ANTHROPIC_BASE_URL"], secrets.ZAIDefaultBaseURL)
+			}
+		}
+	})
+}

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -358,6 +358,23 @@ func readForfaitAccessToken(dir string) string {
 // sandboxed reports that the CLI subprocess will execute inside a REAL
 // sandbox container (docker/kubernetes — not the host-passthrough noop), so
 // forfait credential paths must resolve to in-container locations.
+// zaiEnv is the ONE place a z.ai key becomes CLI env, so the endpoint it is
+// sent to cannot depend on where the key came from. An operator's
+// ANTHROPIC_BASE_URL is an explicit routing choice — a self-hosted
+// z.ai-compatible endpoint, a regional facade, a debugging proxy — and it
+// applies to a tenant-provisioned key exactly as it does to one read from the
+// process env. Unset, the vendor default stands.
+func zaiEnv(key string) map[string]string {
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	if baseURL == "" {
+		baseURL = secrets.ZAIDefaultBaseURL
+	}
+	return map[string]string{
+		"ANTHROPIC_BASE_URL":   baseURL,
+		"ANTHROPIC_AUTH_TOKEN": key,
+	}
+}
+
 func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed bool) map[string]string {
 	creds, hasCreds := secrets.CredentialsFromContext(ctx)
 
@@ -397,21 +414,11 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed 
 	if providerHint == "zai" {
 		if hasCreds {
 			if k := creds.APIKey(secrets.ProviderZAI); k != "" {
-				return map[string]string{
-					"ANTHROPIC_BASE_URL":   secrets.ZAIDefaultBaseURL,
-					"ANTHROPIC_AUTH_TOKEN": k,
-				}
+				return zaiEnv(k)
 			}
 		}
 		if zai := os.Getenv("ZAI_API_KEY"); zai != "" {
-			baseURL := os.Getenv("ANTHROPIC_BASE_URL")
-			if baseURL == "" {
-				baseURL = secrets.ZAIDefaultBaseURL
-			}
-			return map[string]string{
-				"ANTHROPIC_BASE_URL":   baseURL,
-				"ANTHROPIC_AUTH_TOKEN": zai,
-			}
+			return zaiEnv(zai)
 		}
 		// No z.ai key reachable — clear hostile env and let downstream
 		// surface the "no credential" error rather than silently
@@ -426,10 +433,7 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed 
 	if hasCreds {
 		switch {
 		case creds.APIKey(secrets.ProviderZAI) != "":
-			return map[string]string{
-				"ANTHROPIC_BASE_URL":   secrets.ZAIDefaultBaseURL,
-				"ANTHROPIC_AUTH_TOKEN": creds.APIKey(secrets.ProviderZAI),
-			}
+			return zaiEnv(creds.APIKey(secrets.ProviderZAI))
 		case creds.APIKey(secrets.ProviderAnthropic) != "":
 			return map[string]string{"ANTHROPIC_API_KEY": creds.APIKey(secrets.ProviderAnthropic)}
 		case creds.OAuthDir(string(secrets.OAuthKindClaudeCode)) != "":
@@ -442,14 +446,7 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed 
 	// from the inherited env stays authoritative.
 	if os.Getenv("ANTHROPIC_API_KEY") == "" && os.Getenv("ANTHROPIC_AUTH_TOKEN") == "" {
 		if zai := os.Getenv("ZAI_API_KEY"); zai != "" {
-			baseURL := os.Getenv("ANTHROPIC_BASE_URL")
-			if baseURL == "" {
-				baseURL = secrets.ZAIDefaultBaseURL
-			}
-			return map[string]string{
-				"ANTHROPIC_BASE_URL":   baseURL,
-				"ANTHROPIC_AUTH_TOKEN": zai,
-			}
+			return zaiEnv(zai)
 		}
 	}
 	// Host path: nil = let the spawned CLI inherit whatever ambient

--- a/pkg/cli/secret.go
+++ b/pkg/cli/secret.go
@@ -119,13 +119,9 @@ func RunSecretSet(p *Printer, opts SecretOptions) error {
 // the explicit opt-out for a value that is none of the three — the
 // refusal names it, so the remedy travels with the message.
 func validateSecretShape(kind, name, value string) error {
-	shape := secrets.InferSecretShapeKind(value)
-	if strings.TrimSpace(kind) != "" {
-		parsed, err := secrets.ParseSecretShapeKind(kind)
-		if err != nil {
-			return err
-		}
-		shape = parsed
+	shape, err := secrets.ResolveSecretShape(kind, value)
+	if err != nil {
+		return err
 	}
 	if err := secrets.ValidateSecretShape(shape, name, value); err != nil {
 		var se *secrets.ShapeError

--- a/pkg/forge/forgejo/issues_ci_test.go
+++ b/pkg/forge/forgejo/issues_ci_test.go
@@ -448,7 +448,10 @@ func TestForgejoIssueErrorMapping(t *testing.T) {
 	}))
 	defer srv404.Close()
 	_, err = New(srv404.Client(), srv404.URL, "x").GetPullRequest(context.Background(), "o/r", 1)
-	if !errors.Is(err, forge.ErrHookNotFound) {
-		t.Errorf("404 → %v, want ErrHookNotFound", err)
+	if !errors.Is(err, forge.ErrNotFound) {
+		t.Errorf("404 → %v, want ErrNotFound", err)
+	}
+	if errors.Is(err, forge.ErrHookNotFound) {
+		t.Errorf("404 on a pull → %v: a missing PR is not a missing webhook", err)
 	}
 }

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -77,6 +77,25 @@ func DeliveryInstallationPermissions() map[string]string {
 	}
 }
 
+// RunCIReadPermissions are the READ grants a bot needs to inspect the CI of
+// the PR it is working on — `gh pr checks` / `gh run view`, the wait a
+// campaign bot does before it declares a lot delivered.
+//
+// Both halves are needed because `gh pr checks` unions them: check-runs
+// (GitHub Actions and Apps) and the legacy commit statuses. iterion's own
+// merge gate posts a commit STATUS (`revi/review`), so a token carrying only
+// `checks` cannot see the very verdict the bot is waiting on.
+//
+// They are intersected into the RUN token like the delivery grants rather
+// than folded into the baseline: the baseline is also what the MANAGEMENT
+// token narrows to, and a server-side hook or repo call has no use for them.
+func RunCIReadPermissions() map[string]string {
+	return map[string]string{
+		PermissionChecks:   "read",
+		PermissionStatuses: "read",
+	}
+}
+
 // SecurityReadInstallationPermissions is the grant set minted for the
 // security-read token (org-wide Dependabot alerts): the vulnerability_alerts
 // read permission plus the mandatory metadata baseline. It is a separate
@@ -374,9 +393,11 @@ func RuntimePermissionsFor(granted map[string]string) map[string]string {
 			out[name] = level
 		}
 	}
-	for name, level := range DeliveryInstallationPermissions() {
-		if _, ok := granted[name]; ok {
-			out[name] = level
+	for _, extra := range []map[string]string{DeliveryInstallationPermissions(), RunCIReadPermissions()} {
+		for name, level := range extra {
+			if _, ok := granted[name]; ok {
+				out[name] = level
+			}
 		}
 	}
 	// An installation that granted nothing we recognise would yield an empty

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -191,16 +191,18 @@ func tm(p *time.Time) time.Time {
 	return *p
 }
 
-// fetchCheckRuns returns the normalized check-runs for a ref (empty on 404,
-// which a repo without GitHub Actions returns).
+// fetchCheckRuns returns the normalized check-runs for a ref.
+//
+// "No CI" is 200 + an empty list — what GitHub answers for a commit nothing
+// ran on. A 404 is the ref being absent or invisible to the credential (a
+// fine-grained PAT short of `checks:read` gets one), and it surfaces: read
+// as "no check-runs" it would drop the only failing run from the aggregate
+// and render the card green.
 func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]forge.CIRun, error) {
 	var cr githubCheckRuns
 	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/check-runs", nil, &cr)
 	if err != nil {
 		return nil, err
-	}
-	if code == http.StatusNotFound {
-		return nil, nil
 	}
 	if code != http.StatusOK {
 		return nil, refusal("GET check-runs", code, errBody, "checks:read")
@@ -220,15 +222,15 @@ func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]f
 	return runs, nil
 }
 
-// fetchCommitStatuses returns the normalized legacy commit-statuses for a ref.
+// fetchCommitStatuses returns the normalized legacy commit-statuses for a
+// ref. Like the check-runs read, a commit with no status is 200 + an empty
+// list; a 404 surfaces (absent ref, or a credential short of
+// `statuses:read`).
 func (c *AdminClient) fetchCommitStatuses(ctx context.Context, repo, ref string) (sha string, _ []forge.CIRun, _ error) {
 	var cs githubCombinedStatus
 	code, errBody, err := c.doErr(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/status", nil, &cs)
 	if err != nil {
 		return "", nil, err
-	}
-	if code == http.StatusNotFound {
-		return "", nil, nil
 	}
 	if code != http.StatusOK {
 		return "", nil, refusal("GET commit status", code, errBody, "statuses:read")

--- a/pkg/forge/github/ci_404_test.go
+++ b/pkg/forge/github/ci_404_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// "No CI" is what GitHub answers 200 + an empty list: both
+// /commits/{ref}/check-runs and /commits/{ref}/status describe a commit with
+// nothing on it that way. A 404 means the ref is absent OR the credential is
+// short of the grant — a fine-grained PAT without `checks:read` gets exactly
+// that — and reading it as "no CI" renders a green-enough panel on data the
+// caller was never allowed to see.
+func TestGitHubCI_404IsNotNoCI(t *testing.T) {
+	cases := []struct {
+		name    string
+		miss    string // path suffix answered 404
+		wantOp  string
+		wantNee string
+	}{
+		{"check-runs", "/check-runs", "GET check-runs", "checks:read"},
+		{"commit status", "/status", "GET commit status", "statuses:read"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, tc.miss) {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if strings.HasSuffix(r.URL.Path, "/check-runs") {
+					_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "check_runs": []any{}})
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"state": "pending", "sha": "sha", "statuses": []any{}})
+			}))
+			defer srv.Close()
+
+			c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+			st, err := c.GetCIStatus(context.Background(), "o/r", "sha")
+			if err == nil {
+				t.Fatalf("a 404 on %s must surface, got state=%q runs=%d", tc.miss, st.State, len(st.Runs))
+			}
+			if !errors.Is(err, forge.ErrNotFound) {
+				t.Errorf("err = %v, want ErrNotFound", err)
+			}
+			var nf *forge.NotFoundError
+			if !errors.As(err, &nf) {
+				t.Fatalf("err = %v, want *forge.NotFoundError naming the grant", err)
+			}
+			if nf.Op != tc.wantOp {
+				t.Errorf("Op = %q, want %q", nf.Op, tc.wantOp)
+			}
+			if len(nf.MayNeed) != 1 || nf.MayNeed[0] != tc.wantNee {
+				t.Errorf("MayNeed = %v, want [%s]", nf.MayNeed, tc.wantNee)
+			}
+		})
+	}
+}
+
+// A commit with nothing on it stays the empty, non-error answer it always
+// was — the 404 fix must not turn "green repo, no CI configured" into a
+// failing panel.
+func TestGitHubCI_EmptyIsStillEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 0, "check_runs": []any{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"state": "pending", "sha": "sha", "statuses": []any{}})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	st, err := c.GetCIStatus(context.Background(), "o/r", "sha")
+	if err != nil {
+		t.Fatalf("200 + empty is not an error: %v", err)
+	}
+	if st.State != forge.CIUnknown || len(st.Runs) != 0 {
+		t.Errorf("state=%q runs=%d, want unknown/0", st.State, len(st.Runs))
+	}
+	if _, err := c.ListCIHistory(context.Background(), "o/r", "sha", 5); err != nil {
+		t.Fatalf("ListCIHistory on an empty ref: %v", err)
+	}
+}
+
+// The history read shares fetchCheckRuns, so it inherits the same rule.
+func TestGitHubListCIHistory_404Surfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	runs, err := c.ListCIHistory(context.Background(), "o/r", "sha", 5)
+	if err == nil {
+		t.Fatalf("a 404 must surface, got %d runs", len(runs))
+	}
+	if !errors.Is(err, forge.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/forge/github/ci_test.go
+++ b/pkg/forge/github/ci_test.go
@@ -104,8 +104,9 @@ func TestGitHubGetCIStatus_FailedWins(t *testing.T) {
 				},
 			})
 		case strings.HasSuffix(r.URL.Path, "/status"):
-			// No legacy statuses configured → 404 is the common case.
-			w.WriteHeader(http.StatusNotFound)
+			// No legacy statuses configured: GitHub answers 200 with an
+			// empty list, not 404.
+			_ = json.NewEncoder(w).Encode(map[string]any{"state": "pending", "sha": "sha", "statuses": []any{}})
 		}
 	}))
 	defer srv.Close()
@@ -119,7 +120,7 @@ func TestGitHubGetCIStatus_FailedWins(t *testing.T) {
 		t.Errorf("any failure → failed, got %q", st.State)
 	}
 	if len(st.Runs) != 2 {
-		t.Errorf("404 on /status must be empty, not error: runs=%d", len(st.Runs))
+		t.Errorf("an empty /status contributes nothing: runs=%d", len(st.Runs))
 	}
 }
 

--- a/pkg/forge/github/client.go
+++ b/pkg/forge/github/client.go
@@ -86,9 +86,14 @@ func (c *AdminClient) doErr(ctx context.Context, method, path string, body any, 
 // per-endpoint permission data — and the step that fits the credential kind
 // the body names. Any other 403 keeps its ErrForbidden identity with GitHub's
 // message attached; every other status maps as statusErr does.
+//
+// A 404 carries need too. GitHub answers 404, not 403, for a resource the
+// credential is not allowed to see (it will not confirm a private object
+// exists), so absence and a withheld grant look identical on the wire: the
+// typed 404 names both possibilities instead of asserting either.
 func refusal(op string, code int, errBody []byte, need ...string) error {
 	if code != http.StatusForbidden {
-		return statusErr(op, code)
+		return forge.StatusErrNeeding("github", op, code, need)
 	}
 	msg := githubErrorMessage(errBody)
 	grants := strings.Join(need, ", ")

--- a/pkg/forge/github/issues_test.go
+++ b/pkg/forge/github/issues_test.go
@@ -182,7 +182,7 @@ func TestGitHubCommentIssue_RoundTrip(t *testing.T) {
 
 func TestGitHubGetIssue_ErrorMapping(t *testing.T) {
 	cases := map[int]error{
-		http.StatusNotFound:     forge.ErrHookNotFound,
+		http.StatusNotFound:     forge.ErrNotFound,
 		http.StatusUnauthorized: forge.ErrUnauthorized,
 		http.StatusForbidden:    forge.ErrForbidden,
 	}
@@ -194,6 +194,9 @@ func TestGitHubGetIssue_ErrorMapping(t *testing.T) {
 		_, err := c.GetIssue(context.Background(), "o/r", 1)
 		if !errors.Is(err, want) {
 			t.Errorf("status %d → err %v, want %v", code, err, want)
+		}
+		if code == http.StatusNotFound && errors.Is(err, forge.ErrHookNotFound) {
+			t.Errorf("404 on an issue → %v: a missing issue is not a missing webhook", err)
 		}
 		srv.Close()
 	}

--- a/pkg/forge/github/permissions_ci_read_test.go
+++ b/pkg/forge/github/permissions_ci_read_test.go
@@ -1,0 +1,57 @@
+package github
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A bot that opens a PR then waits on its checks runs `gh pr checks` with the
+// RUN token. That token carried neither CI read grant, so the command failed
+// on an installation whose owner had already approved both — the manifest
+// requests them by default.
+func TestRuntimePermissionsForCarriesTheCIReadGrants(t *testing.T) {
+	granted := map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write",
+		"metadata": "read", "repository_hooks": "write",
+		PermissionChecks: "read", PermissionStatuses: "write",
+	}
+	got := RuntimePermissionsFor(granted)
+	if got[PermissionChecks] != "read" {
+		t.Errorf("checks = %q, want read — `gh pr checks` reads the check-runs list", got[PermissionChecks])
+	}
+	if got[PermissionStatuses] != "read" {
+		t.Errorf("statuses = %q, want read — iterion's own merge gate is a commit STATUS, not a check-run", got[PermissionStatuses])
+	}
+	if got["contents"] != "write" {
+		t.Errorf("the baseline must survive: %v", got)
+	}
+}
+
+// The same rule as every other grant: never request what the installation did
+// not approve — one over-request 422s the whole mint.
+func TestRuntimePermissionsForSkipsUngrantedCIReads(t *testing.T) {
+	granted := map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write",
+		"metadata": "read", "repository_hooks": "write",
+	}
+	got := RuntimePermissionsFor(granted)
+	for _, absent := range []string{PermissionChecks, PermissionStatuses} {
+		if _, ok := got[absent]; ok {
+			t.Errorf("requested %q which the installation did not grant", absent)
+		}
+	}
+}
+
+// The management token is a different token with a different job (hooks,
+// repos, the gate's own status write). The CI reads belong to the RUN token;
+// folding them into the baseline would hand them to every server-side call.
+func TestManagementPermissionsForDoesNotAcquireTheCIReads(t *testing.T) {
+	granted := map[string]string{
+		"contents": "write", "metadata": "read",
+		PermissionChecks: "read", PermissionStatuses: "read",
+	}
+	got := ManagementPermissionsFor(granted)
+	if !reflect.DeepEqual(got, map[string]string{"contents": "write", "metadata": "read"}) {
+		t.Errorf("got %v, want the baseline ∩ grant", got)
+	}
+}

--- a/pkg/forge/gitlab/capabilities_test.go
+++ b/pkg/forge/gitlab/capabilities_test.go
@@ -167,8 +167,11 @@ func TestGetIssue_404IsNotFound(t *testing.T) {
 	}))
 	defer srv.Close()
 	_, err := New(srv.Client(), srv.URL, "tok").GetIssue(context.Background(), "g/p", 99)
-	if !errors.Is(err, forge.ErrHookNotFound) {
-		t.Errorf("get 404 = %v, want ErrHookNotFound", err)
+	if !errors.Is(err, forge.ErrNotFound) {
+		t.Errorf("get 404 = %v, want ErrNotFound", err)
+	}
+	if errors.Is(err, forge.ErrHookNotFound) {
+		t.Errorf("404 on an issue = %v: a missing issue is not a missing webhook", err)
 	}
 }
 

--- a/pkg/forge/not_found.go
+++ b/pkg/forge/not_found.go
@@ -1,0 +1,69 @@
+package forge
+
+import (
+	"strings"
+)
+
+// NotFoundError is a forge call answered 404, naming the operation that
+// missed. Every provider's 404 used to collapse onto ErrHookNotFound, so a
+// pull request that does not exist reported a missing webhook.
+//
+// MayNeed is what makes the type more than a message. GitHub answers 404 —
+// not 403 — for a resource a credential is not allowed to see, so an object
+// that is absent and a grant that was never approved are indistinguishable
+// from the status alone. Naming the grants the endpoint is gated on lets an
+// operator tell them apart; claiming the permission gap outright (a
+// PermissionError) would assert what the status cannot prove.
+type NotFoundError struct {
+	Provider Provider
+	// Op is the call that missed ("GET pull", "GET check-runs").
+	Op string
+	// MayNeed are the "permission:level" grants the endpoint is gated on,
+	// when the caller knows them. Empty when it does not.
+	MayNeed []string
+}
+
+func (e *NotFoundError) Error() string {
+	var b strings.Builder
+	if e.Provider != "" {
+		b.WriteString(string(e.Provider))
+		b.WriteString(": ")
+	}
+	if e.Op != "" {
+		b.WriteString(e.Op)
+		b.WriteString(": ")
+	}
+	b.WriteString("not found")
+	if len(e.MayNeed) > 0 {
+		b.WriteString(" — absent, or not visible to this credential (the forge gates it on ")
+		b.WriteString(strings.Join(e.MayNeed, ", "))
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+// Unwrap makes errors.Is(err, ErrNotFound) hold for every typed 404.
+func (e *NotFoundError) Unwrap() error { return ErrNotFound }
+
+// notFoundFor maps a 404 by OPERATION. The hook operations keep
+// ErrHookNotFound — the orchestrator reads it as "the hook is already gone"
+// and treats deprovision as done; anything else is the resource its own
+// operation names.
+func notFoundFor(provider, op string, mayNeed []string) error {
+	if isHookOp(op) {
+		return ErrHookNotFound
+	}
+	return &NotFoundError{Provider: Provider(provider), Op: op, MayNeed: mayNeed}
+}
+
+// isHookOp reports whether an operation string names a webhook. The
+// operations are "<verb> hook" / "GET hooks", so the last word decides —
+// a substring match would catch any future op that merely mentions one.
+func isHookOp(op string) bool {
+	f := strings.Fields(op)
+	if len(f) == 0 {
+		return false
+	}
+	last := f[len(f)-1]
+	return last == "hook" || last == "hooks"
+}

--- a/pkg/forge/not_found_test.go
+++ b/pkg/forge/not_found_test.go
@@ -1,0 +1,57 @@
+package forge
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// StatusErr is the one place every provider maps a status onto an error, so
+// it is the one place a 404 can stop meaning "hook". A `GET pull` that misses
+// must not read "forge: hook not found" — the message an operator takes to
+// the webhook settings of a repo whose PR simply does not exist.
+func TestStatusErr_NotFoundIsTypedPerOperation(t *testing.T) {
+	for _, op := range []string{"GET hooks", "create hook", "update hook", "delete hook"} {
+		err := StatusErr("github", op, http.StatusNotFound)
+		if !errors.Is(err, ErrHookNotFound) {
+			t.Errorf("StatusErr(%q, 404) = %v, want ErrHookNotFound — deprovision reads it as \"already gone\"", op, err)
+		}
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("StatusErr(%q, 404) = %v, want it to answer errors.Is(ErrNotFound) too", op, err)
+		}
+	}
+	for _, op := range []string{"GET pull", "GET issue", "GET /user", "GET check-runs"} {
+		err := StatusErr("github", op, http.StatusNotFound)
+		if errors.Is(err, ErrHookNotFound) {
+			t.Errorf("StatusErr(%q, 404) = %v — a missing %s is not a missing hook", op, err, op)
+		}
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("StatusErr(%q, 404) = %v, want ErrNotFound", op, err)
+		}
+		if !strings.Contains(err.Error(), op) {
+			t.Errorf("StatusErr(%q, 404) = %q, want the operation named", op, err)
+		}
+	}
+}
+
+// A 404 whose caller knows the grants the endpoint is gated on carries them:
+// GitHub answers 404 (not 403) for a resource a credential may not see, so
+// naming the grants is what lets an operator tell an absent object from a
+// withheld permission.
+func TestNotFoundError_NamesTheGrantsWhenKnown(t *testing.T) {
+	err := error(&NotFoundError{Provider: ProviderGitHub, Op: "GET pull", MayNeed: []string{"pull_requests:read", "contents:read"}})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("NotFoundError must unwrap to ErrNotFound, got %v", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"github", "GET pull", "pull_requests:read", "contents:read"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("NotFoundError message %q must contain %q", msg, want)
+		}
+	}
+	var pe *PermissionError
+	if errors.As(err, &pe) {
+		t.Error("a 404 must not claim a permission gap it cannot prove")
+	}
+}

--- a/pkg/forge/transport.go
+++ b/pkg/forge/transport.go
@@ -77,14 +77,26 @@ func DoJSONErrBody(ctx context.Context, client *http.Client, method, url, errPre
 // StatusErr maps a non-2xx status to the appropriate forge sentinel,
 // falling back to a "<prefix>: <op>: HTTP <code>" error. Shared by every
 // AdminClient so the 401/403/404 mapping stays identical across providers.
+//
+// A 404 is typed by OPERATION (notFoundFor): only a hook operation yields
+// ErrHookNotFound, everything else a *NotFoundError naming its own call.
+// Every 404 still answers errors.Is(err, ErrNotFound).
 func StatusErr(errPrefix, op string, code int) error {
+	return StatusErrNeeding(errPrefix, op, code, nil)
+}
+
+// StatusErrNeeding is StatusErr for a caller that knows the grants the
+// endpoint is gated on: they ride the typed 404, where a forge that answers
+// 404 for a resource the credential may not see leaves an absent object and
+// a withheld permission indistinguishable from the status alone.
+func StatusErrNeeding(errPrefix, op string, code int, mayNeed []string) error {
 	switch code {
 	case http.StatusUnauthorized:
 		return ErrUnauthorized
 	case http.StatusForbidden:
 		return ErrForbidden
 	case http.StatusNotFound:
-		return ErrHookNotFound
+		return notFoundFor(errPrefix, op, mayNeed)
 	default:
 		return fmt.Errorf("%s: %s: HTTP %d", errPrefix, op, code)
 	}

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -23,6 +23,7 @@ package forge
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -318,7 +319,12 @@ var (
 	ErrIntegrationNotFound = errors.New("forge: repo integration not found")
 	ErrOAuthAppNotFound    = errors.New("forge: oauth app not found")
 	ErrOAuthAppExists      = errors.New("forge: oauth app already exists")
-	ErrHookNotFound        = errors.New("forge: hook not found")
+	// ErrNotFound is the class every 404 belongs to. A caller that only needs
+	// "the forge has no such thing" matches on it; one that acts on a
+	// specific absence matches the resource sentinel (ErrHookNotFound) or
+	// reads the *NotFoundError the operation carries.
+	ErrNotFound     = errors.New("forge: not found")
+	ErrHookNotFound = fmt.Errorf("%w: hook", ErrNotFound)
 	// ErrForbidden is returned by an admin client when the credential lacks
 	// the scope to perform an operation (e.g. create a webhook). The
 	// orchestrator surfaces it as a structured "insufficient_scope" error so

--- a/pkg/runtime/review.go
+++ b/pkg/runtime/review.go
@@ -328,7 +328,8 @@ func (e *Engine) performGateMerge(ctx context.Context, rs *runState, hn *ir.Huma
 	}
 
 	message := strutil.FirstNonBlank(stringAnswer(answers, reviewMessageKey),
-		buildSquashMessage(wtCtx.repoRoot, wtCtx.originalTip, finalSHA, e.runName))
+		BuildSquashMessageForMerge(wtCtx.repoRoot, wtCtx.originalTip,
+			resolveMergeTarget(mergeInto, wtCtx.originalBranch), finalSHA, e.runName))
 
 	res, mErr := PerformDeferredMerge(DeferredMergeRequest{
 		RepoRoot:      wtCtx.repoRoot,

--- a/pkg/runtime/squash_message_range_test.go
+++ b/pkg/runtime/squash_message_range_test.go
@@ -1,0 +1,116 @@
+package runtime
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A run's squash message must describe the RUN, and the range that bounds it
+// is the work branch — never the whole repository.
+//
+// Observed in production (run 01a07013, 2026-09-05): the merge landed the
+// right CONTENT (six files, one parent = the previous target head) under the
+// wrong MESSAGE — subject "Initial commit", body 204 lines of the target
+// repository's own past ending in "… and 5503 more commits". A repo-targeted
+// merge materialises its own clone, where the run's recorded base is not
+// necessarily resolvable; with no base `git log <head>` walks to the root, and
+// --reverse makes the OLDEST commit the title.
+func TestBuildSquashMessageForMerge_NeverEnumeratesFromTheRoot(t *testing.T) {
+	repo, _ := initBareishRepo(t)
+	// A target with real history: the shape the bug needs to be visible.
+	addCommit(t, repo, "history1.md", "one\n", "Add new directory")
+	addCommit(t, repo, "history2.md", "two\n", "chore: second commit on main")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+
+	addCommit(t, wt, "a.go", "package main\n// a\n", "feat(lot-1): the run's first unit")
+	finalSHA := addCommit(t, wt, "b.go", "package main\n// b\n", "feat(lot-1): the run's second unit")
+
+	// base = "" is exactly what the merge clone hands the builder.
+	got := BuildSquashMessageForMerge(repo, "", "main", finalSHA, "swift-cedar-a3f2")
+
+	if strings.HasPrefix(got, "init\n") || strings.Contains(got, "Initial commit") {
+		t.Fatalf("the subject is the repository's own first commit, not the run's delivery:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "feat(lot-1): the run's first unit\n") {
+		t.Errorf("subject = the run's first commit; got:\n%s", got)
+	}
+	for _, absent := range []string{"Add new directory", "chore: second commit on main", " init\n"} {
+		if strings.Contains(got, absent) {
+			t.Errorf("body enumerates the target's own history (%q):\n%s", absent, got)
+		}
+	}
+	for _, want := range []string{"the run's first unit", "the run's second unit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("body missing the run's commit %q:\n%s", want, got)
+		}
+	}
+}
+
+// A base that IS resolvable stays authoritative — it is the exact commit the
+// run started from, which merge-base only approximates once the target moved.
+func TestBuildSquashMessageForMerge_KeepsAResolvableBase(t *testing.T) {
+	repo, _ := initBareishRepo(t)
+	base := addCommit(t, repo, "history.md", "one\n", "chore: main moved on")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+
+	addCommit(t, wt, "a.go", "package main\n", "feat: only unit")
+	finalSHA := strings.TrimSpace(string(mustOutput(t, wt, "git", "rev-parse", "HEAD")))
+
+	got := BuildSquashMessageForMerge(repo, base, "main", finalSHA, "run")
+	if !strings.HasPrefix(got, "feat: only unit") {
+		t.Errorf("got:\n%s", got)
+	}
+	if strings.Contains(got, "chore: main moved on") {
+		t.Errorf("body reaches past the run's base:\n%s", got)
+	}
+}
+
+// A base recorded on the run but ABSENT from this repository (the merge clone
+// fetched only the branches it needs) must not degrade to the root walk.
+func TestBuildSquashMessageForMerge_UnreachableBaseFallsToMergeBase(t *testing.T) {
+	repo, _ := initBareishRepo(t)
+	addCommit(t, repo, "history.md", "one\n", "Add new directory")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+
+	finalSHA := addCommit(t, wt, "a.go", "package main\n", "feat: the run's unit")
+
+	got := BuildSquashMessageForMerge(repo, "0123456789abcdef0123456789abcdef01234567", "main", finalSHA, "run")
+	if !strings.HasPrefix(got, "feat: the run's unit") {
+		t.Errorf("got:\n%s", got)
+	}
+	if strings.Contains(got, "Add new directory") || strings.Contains(got, "init") {
+		t.Errorf("body reaches into the target's history:\n%s", got)
+	}
+}
+
+// A target that does not resolve at all — a greenfield run that `git init`s an
+// empty directory and commits from slice 0 — genuinely owns the whole history,
+// so the full walk is the right answer there and must be preserved.
+func TestBuildSquashMessageForMerge_GreenfieldKeepsTheWholeHistory(t *testing.T) {
+	dir := t.TempDir()
+	mustRun(t, dir, "git", "init", "-b", "main")
+	mustRun(t, dir, "git", "config", "user.email", "test@example.com")
+	mustRun(t, dir, "git", "config", "user.name", "Test")
+	mustRun(t, dir, "git", "config", "commit.gpgsign", "false")
+	addCommit(t, dir, "a.go", "package main\n", "feat: scaffold the app")
+	finalSHA := addCommit(t, dir, "b.go", "package main\n// b\n", "feat: first endpoint")
+
+	got := BuildSquashMessageForMerge(dir, "", "does-not-exist", finalSHA, "greenfield")
+	if !strings.HasPrefix(got, "feat: scaffold the app\n") {
+		t.Errorf("a greenfield run owns its whole history:\n%s", got)
+	}
+	if !strings.Contains(got, "feat: first endpoint") {
+		t.Errorf("body missing the second commit:\n%s", got)
+	}
+}

--- a/pkg/runtime/worktree.go
+++ b/pkg/runtime/worktree.go
@@ -534,7 +534,7 @@ func finalizeWorktree(wc worktreeContext, opts finalizeOptions, logger *iterlog.
 		return res
 
 	case "squash":
-		message := buildSquashMessage(wc.anchor(), wc.originalTip, finalSHA, opts.runName)
+		message := BuildSquashMessageForMerge(wc.anchor(), wc.originalTip, target, finalSHA, opts.runName)
 		merged, mergeErr := trySquashMerge(wc.anchor(), target, finalName, wc.originalBranch, message, logger)
 		if mergeErr != nil {
 			res.MergeStatus = "failed"
@@ -744,6 +744,66 @@ func trySquashMerge(repoRoot, target, branchToMerge, originalBranch, message str
 // Identical semantics — see buildSquashMessage docs.
 func BuildSquashMessage(repoRoot, base, head, runName string) string {
 	return buildSquashMessage(repoRoot, base, head, runName)
+}
+
+// BuildSquashMessageForMerge is BuildSquashMessage for a merge that knows its
+// TARGET, which is what lets the range be bounded when the run's recorded base
+// is missing or does not resolve in this repository.
+func BuildSquashMessageForMerge(repoRoot, base, target, head, runName string) string {
+	return buildSquashMessage(repoRoot, squashRangeBase(repoRoot, base, target, head), head, runName)
+}
+
+// squashRangeBase resolves the commit the squash message's range starts at.
+//
+// The run's recorded base is authoritative when it resolves HERE: it is the
+// exact commit the run started from, which merge-base only approximates once
+// the target has moved on. But a repo-targeted merge materialises its own
+// clone, where that base is frequently absent — and an unresolvable base makes
+// gitlib.Log walk `git log <head>`, i.e. the whole repository from its root,
+// whose --reverse ordering then makes the OLDEST commit the message's title.
+// That is how a lot delivery landed on a production target under the subject
+// "Initial commit" with 204 lines of the repository's own past.
+//
+// The rungs, in order:
+//
+//  1. base, when it names a commit head descends from;
+//  2. merge-base(target, head) — the point the work branch left the target;
+//  3. "" when the TARGET itself does not resolve. A greenfield run
+//     (`worktree: auto` degrading in place, the bot `git init`-ing from slice
+//  0. genuinely owns every commit in the repository, so the full walk is
+//     the right answer there — the only case where it is;
+//  4. head itself otherwise: the target exists but shares no history with the
+//     head, so no range describes the run. An empty range degrades to the
+//     run's own name as the title, which says nothing false — enumerating an
+//     unrelated history would.
+func squashRangeBase(repoRoot, base, target, head string) string {
+	if repoRoot == "" || head == "" {
+		return base
+	}
+	if base != "" && gitlib.IsAncestor(repoRoot, base, head) {
+		return base
+	}
+	if target != "" {
+		if mb := gitlib.MergeBase(repoRoot, target, head); mb != "" {
+			return mb
+		}
+		if resolveCommitish(repoRoot, target) != "" {
+			return head
+		}
+	}
+	return ""
+}
+
+// resolveCommitish returns the full SHA target names in repoRoot, or "" when
+// it names nothing (an unborn branch, a repository with no commits).
+func resolveCommitish(repoRoot, target string) string {
+	cmd, cancel := gitCmd("-C", repoRoot, "rev-parse", "--verify", "--quiet", target+"^{commit}")
+	out, err := cmd.Output()
+	cancel()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // BuildSquashMessageFromCommits is the cached-input form for callers

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -462,7 +462,11 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 
 	message := req.CommitMessage
 	if message == "" && strategy == store.MergeStrategySquash {
-		message = runtime.BuildSquashMessage(repoRoot, r.BaseCommit, r.FinalCommit, runtime.RunDisplayName(r))
+		// The TARGET bounds the range when the run's recorded base does not
+		// resolve here — a repo-targeted merge runs in a clone this server
+		// materialised, where it frequently does not.
+		message = runtime.BuildSquashMessageForMerge(repoRoot, r.BaseCommit,
+			resolveMergeTargetForPersistence(req.MergeInto, repoRoot), r.FinalCommit, runtime.RunDisplayName(r))
 	}
 
 	res, mergeErr := runtime.PerformDeferredMerge(runtime.DeferredMergeRequest{
@@ -808,7 +812,11 @@ func (s *Service) FinalizeMergeAfterConflict(ctx context.Context, runID, message
 		message = r.PendingMergeMessage
 	}
 	if message == "" {
-		message = runtime.BuildSquashMessage(repoRoot, r.BaseCommit, r.FinalCommit, runtime.RunDisplayName(r))
+		conflictTarget := r.PendingMergeInto
+		if conflictTarget == "" {
+			conflictTarget = resolveMergeTargetForPersistence("current", repoRoot)
+		}
+		message = runtime.BuildSquashMessageForMerge(repoRoot, r.BaseCommit, conflictTarget, r.FinalCommit, runtime.RunDisplayName(r))
 	}
 
 	sha, commitErr := runtime.FinalizeConflictMerge(repoRoot, message)

--- a/pkg/secrets/credential_shape.go
+++ b/pkg/secrets/credential_shape.go
@@ -175,6 +175,23 @@ func InferSecretShapeKind(value string) SecretShapeKind {
 	return SecretShapeToken
 }
 
+// ResolveSecretShape decides WHICH gate applies to a stored secret: the kind
+// the operator named, or — when they named none — the one the value itself
+// says (InferSecretShapeKind). An unrecognised kind is an error, never a
+// silent pass-through to no checking.
+//
+// It is shared by every door into the generic secret store (`iterion secret
+// set`, the studio's local Secrets view) so the two cannot disagree on what a
+// value is: the reason a check-free door existed at all is that the rule lived
+// at one of them. Each caller phrases its own remedy — the CLI names
+// `--kind raw`, an API names the field — from the kind returned here.
+func ResolveSecretShape(kind, value string) (SecretShapeKind, error) {
+	if strings.TrimSpace(kind) == "" {
+		return InferSecretShapeKind(value), nil
+	}
+	return ParseSecretShapeKind(kind)
+}
+
 // ValidateSecretShape is the ingestion gate for a stored secret whose
 // shape the operator named (or that InferSecretShapeKind read off the
 // value). field phrases the refusal — pass the secret's name so an

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -768,11 +768,26 @@ func (s *Server) handleIssuePullCI(w http.ResponseWriter, r *http.Request) {
 		writeForgePullError(w, "get ci status", err)
 		return
 	}
-	history, _ := pc.ListCIHistory(r.Context(), repo, ref, 20)
+	// The two halves are read independently and only the STATUS one is the
+	// verdict: it answered, so the panel answers. A failed history read is
+	// named rather than dropped — an empty timeline is indistinguishable
+	// from "nothing ever ran", which is the wrong thing to tell an operator
+	// looking at a merge decision.
+	history, histErr := pc.ListCIHistory(r.Context(), repo, ref, 20)
+	historyError := ""
+	if histErr != nil {
+		history, historyError = nil, histErr.Error()
+		if s.logger != nil {
+			s.logger.Warn("board forge: ci history for %s@%s: %v", repo, ref, histErr)
+		}
+	}
 	writeJSON(w, struct {
 		Status  forge.CIStatus `json:"status"`
 		History []forge.CIRun  `json:"history"`
-	}{Status: status, History: history})
+		// HistoryError names why the history half is missing; absent when
+		// the read succeeded.
+		HistoryError string `json:"history_error,omitempty"`
+	}{Status: status, History: history, HistoryError: historyError})
 }
 
 // ---------------------------------------------------------------------------
@@ -858,11 +873,22 @@ func (s *Server) pullClientForConn(w http.ResponseWriter, ctx context.Context, t
 // `checks: read` was requested, a fine-grained PAT short of a permission) —
 // so it is answered 422 with the permission and the operator step, the same
 // mapping the create-repo and security-read routes give a withheld
-// installation grant. Anything else is the upstream failure it always was.
+// installation grant.
+//
+// A *forge.NotFoundError is the forge saying it has no such object under this
+// credential — a PR that was deleted, a ref that moved, or (GitHub answers
+// 404 rather than 403 for what a credential may not see) a grant that was
+// never approved. It is answered 404 with the operation and the grants it is
+// gated on, not the 502 a bare sentinel used to produce. Anything else is the
+// upstream failure it always was.
 func writeForgePullError(w http.ResponseWriter, op string, err error) {
 	var pe *forge.PermissionError
 	if errors.As(err, &pe) {
 		httpError(w, http.StatusUnprocessableEntity, "%s: %v", op, err)
+		return
+	}
+	if errors.Is(err, forge.ErrNotFound) {
+		httpError(w, http.StatusNotFound, "%s: %v", op, err)
 		return
 	}
 	httpError(w, http.StatusBadGateway, "%s: %v", op, err)

--- a/pkg/server/board_forge_ci_partial_test.go
+++ b/pkg/server/board_forge_ci_partial_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The card's CI panel reads two things: the aggregate state (the verdict a
+// merge decision is taken on) and the recent history (context). A failed
+// HISTORY read used to be dropped on the floor — `history, _ :=` — so the
+// panel showed an empty timeline that reads exactly like "nothing ever ran".
+// The status half still answers, so the request is not failed; the failure
+// is named in the payload instead.
+func TestCardPullPanelSurfacesAFailedHistoryRead(t *testing.T) {
+	f := newPullPanelForge(t, map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read",
+		"repository_hooks": "write", "statuses": "read", "checks": "read",
+	})
+	// The status read takes the first check-runs call; the history read takes
+	// the second, and that one breaks.
+	f.failCheckRunsFrom = 2
+	s, cardID := pullPanelFixture(t, f)
+
+	w := httptest.NewRecorder()
+	s.handleIssuePullCI(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls/7/ci", cardID, "7"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("the status half answered, so the panel answers: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Status       forge.CIStatus `json:"status"`
+		History      []forge.CIRun  `json:"history"`
+		HistoryError string         `json:"history_error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Status.State != forge.CISuccess {
+		t.Errorf("status = %+v, want the state the forge served", body.Status)
+	}
+	if body.HistoryError == "" {
+		t.Fatal("a failed history read must be named in the response, not swallowed into an empty timeline")
+	}
+	if !strings.Contains(body.HistoryError, "502") && !strings.Contains(body.HistoryError, "HTTP") {
+		t.Errorf("history_error = %q, want the upstream failure it came from", body.HistoryError)
+	}
+	if len(body.History) != 0 {
+		t.Errorf("history = %+v, want none: the read failed", body.History)
+	}
+}
+
+// The ordinary path carries no error field, so a client can read its presence
+// as "this half is missing".
+func TestCardPullPanelNoHistoryErrorWhenBothReadsSucceed(t *testing.T) {
+	f := newPullPanelForge(t, map[string]string{
+		"contents": "write", "pull_requests": "write", "issues": "write", "metadata": "read",
+		"repository_hooks": "write", "statuses": "read", "checks": "read",
+	})
+	s, cardID := pullPanelFixture(t, f)
+
+	w := httptest.NewRecorder()
+	s.handleIssuePullCI(w, pullPanelReq("GET", "/api/v1/native/issues/"+cardID+"/pulls/7/ci", cardID, "7"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "history_error") {
+		t.Errorf("body = %s, want no history_error when the history read worked", w.Body.String())
+	}
+}

--- a/pkg/server/board_forge_pulls_app_test.go
+++ b/pkg/server/board_forge_pulls_app_test.go
@@ -35,7 +35,12 @@ type pullPanelForge struct {
 	perms map[string]map[string]string
 	// refusedMints counts mints GitHub 422'd for want of a grant.
 	refusedMints int
-	srv          *httptest.Server
+	// checkRunCalls counts check-runs reads; failCheckRunsFrom (1-based, 0 =
+	// never) makes that call and every later one answer 502, so a test can
+	// fail the panel's HISTORY read while its status read succeeded.
+	checkRunCalls     int
+	failCheckRunsFrom int
+	srv               *httptest.Server
 }
 
 // grantCovers is GitHub's rule for a mint: a requested permission must be
@@ -122,6 +127,14 @@ func newPullPanelForge(t *testing.T, granted map[string]string) *pullPanelForge 
 	mux.HandleFunc("GET /api/v3/repos/acme/widgets/commits/{sha}/check-runs", func(w http.ResponseWriter, r *http.Request) {
 		if !bearerHas(r, "checks") {
 			notAccessible(w)
+			return
+		}
+		f.mu.Lock()
+		f.checkRunCalls++
+		fail := f.failCheckRunsFrom > 0 && f.checkRunCalls >= f.failCheckRunsFrom
+		f.mu.Unlock()
+		if fail {
+			reply(w, http.StatusBadGateway, map[string]any{"message": "upstream is having a moment"})
 			return
 		}
 		reply(w, http.StatusOK, map[string]any{"total_count": 1, "check_runs": []map[string]any{

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -182,9 +182,8 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 			}
 			return conn, "", &avatarRefusal{status: http.StatusUnprocessableEntity,
 				msg: fmt.Sprintf("%s rejected this connection's token — reconnect it first", conn.Host())}
-		case errors.Is(err, forge.ErrHookNotFound):
-			// StatusErr maps every 404 onto the hook sentinel; here the user
-			// endpoint is what is missing, i.e. the base URL is wrong.
+		case errors.Is(err, forge.ErrNotFound):
+			// The user endpoint itself is missing, i.e. the base URL is wrong.
 			return conn, "", fmt.Errorf("could not read the account behind connection %s: %s does not serve the user endpoint (HTTP 404) — check the forge base URL", conn.ID, conn.Host())
 		case errors.Is(err, forge.ErrForbidden) && force:
 			// The forge answered but would not describe the account: the

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -44,23 +44,27 @@ import (
 // actually been computed. The grant therefore has to outlive the longest wait
 // the retry machinery can schedule, plus a margin for the resumed run itself.
 //
-// The cost is a wider window for a leaked token, and it is NOT offset by early
-// revocation: nothing in this tree calls Revoke outside its own test, so the
-// TTL is the only bound there is. What limits the damage is what the grant can
-// do — post a review and a commit status on ONE repo, re-enforced against the
-// grant's (team, connection, repo) at every use.
+// This is the CEILING, not the ordinary life of a grant: a run's terminal
+// outcome brings the expiry forward to forgePublishPostRunGrace
+// (expireForgePublishGrantForRun), so only a run that is genuinely waiting out
+// a quota window keeps the full window. What limits the damage meanwhile is
+// what the grant can do — post a review and a commit status on ONE repo,
+// re-enforced against the grant's (team, connection, repo) at every use.
 const forgePublishDefaultTTL = retrypolicy.DefaultMaxWait + 24*time.Hour
 
 // forgePublishMaxTokens bounds the in-memory registry (the backend used when
 // no Valkey is configured).
 //
-// It scales with the TTL because Register only evicts EXPIRED entries before
-// checking the cap, so the ceiling is really "gating launches per TTL": at a
-// flat 1024 the 9-day TTL would saturate at ~114 launches/day, and saturation
-// is not graceful — Register errors, injectForgePublishVars hands the run no
-// grant, and the run cannot publish its verdict. Worse now that the launch has
-// already claimed the check: the reconciler needs the grant to speak, so it
-// abstains (no token ⇒ "not a gating run") and the claim is never answered.
+// It scales with the TTL because Register evicts only EXPIRED entries before
+// checking the cap: the ceiling is "live grants", and a grant lives at most
+// one TTL. The terminal-outcome eviction is what keeps the steady state near
+// "gating launches in flight" instead of "gating launches per TTL", but a
+// deployment whose runs all park on a quota window still accumulates, so the
+// cap keeps the TTL's shape.
+//
+// Saturation is no longer silent: Register's error refuses the launch
+// (errForgePublishGrantUnavailable) rather than starting a run that claims the
+// gate context and can never answer it.
 const forgePublishMaxTokens = 1024 * int(forgePublishDefaultTTL/(24*time.Hour))
 
 // ForgePublishGrant scopes one run's publish token: reviews may only be
@@ -147,6 +151,11 @@ func (s *Server) runOwnsGrant(run *store.Run, grant ForgePublishGrant, what stri
 type ForgePublishTokenStore interface {
 	Register(token string, g ForgePublishGrant) error
 	Revoke(token string)
+	// expireIn brings a live grant's expiry forward to now+d, never pushes it
+	// out, and does nothing for an unknown token. It is how a grant stops
+	// outliving its run without being revoked outright — the merge-gate
+	// repair still needs to read it for its own window after the run dies.
+	expireIn(token string, d time.Duration)
 	lookup(token string) (ForgePublishGrant, bool)
 }
 
@@ -185,6 +194,20 @@ func (r *ForgePublishTokenRegistry) Revoke(token string) {
 	r.mu.Lock()
 	delete(r.tokens, token)
 	r.mu.Unlock()
+}
+
+// expireIn brings the grant's expiry forward. Never later: a caller shortening
+// a window must not be able to extend one.
+func (r *ForgePublishTokenRegistry) expireIn(token string, d time.Duration) {
+	at := r.now().Add(d)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	g, ok := r.tokens[token]
+	if !ok || !at.Before(g.ExpiresAt) {
+		return
+	}
+	g.ExpiresAt = at
+	r.tokens[token] = g
 }
 
 func (r *ForgePublishTokenRegistry) lookup(token string) (ForgePublishGrant, bool) {
@@ -724,10 +747,18 @@ func (s *Server) injectForgePublishVars(ctx context.Context, teamID, preferredCo
 		return vars, nil
 	}
 	if err := s.forgePublishTokens.Register(token, ForgePublishGrant{TeamID: teamID, Bot: strings.TrimSpace(botID), ConnectionID: conn.ID, Repo: repo}); err != nil {
+		// A launch that reaches here has a connection covering the PR: it is
+		// gating-shaped, and the caller is about to claim the repo's gate
+		// context on this head. Proceeding without a grant is the "pending
+		// forever" shape — the run cannot publish its verdict, and the
+		// reconciler that repairs a dead claim reads the grant to know where
+		// to speak, so it abstains ("not a gating run") and nothing ever
+		// answers the claim. Refuse instead: the claim is posted AFTER the
+		// launch, so a launch refused here leaves nothing to release.
 		if s.logger != nil {
-			s.logger.Error("forge publish: %v; deterministic review publishing disabled for this launch", err)
+			s.logger.Error("forge publish: %v; refusing the launch on %s/%s rather than starting a run that cannot publish its verdict", err, host, repo)
 		}
-		return vars, nil
+		return vars, fmt.Errorf("%w: %s/%s: %w", errForgePublishGrantUnavailable, host, repo, err)
 	}
 	if vars == nil {
 		vars = map[string]string{}

--- a/pkg/server/forge_publish_expiry.go
+++ b/pkg/server/forge_publish_expiry.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/eventbus"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// errForgePublishGrantUnavailable marks a launch that could not be given the
+// publish grant it needs — the token store refused the registration (a
+// saturated in-memory registry, an unreachable Valkey).
+//
+// It is a REFUSAL, not a degradation, because of what the launch does next: it
+// claims the repo's gate context on the head (markGateInFlight), and the
+// reconciler that answers a dead claim needs the grant to know which repo and
+// connection to speak through. A run launched without one leaves a `pending`
+// nobody can resolve — the "pending forever" shape docs/merge-gate.md exists
+// to close. Refusing before the launch leaves no claim to release.
+var errForgePublishGrantUnavailable = errors.New("forge publish grant unavailable")
+
+// forgePublishPostRunGrace is how long a grant outlives the run it was minted
+// for.
+//
+// It is not zero because the run's death is exactly when the grant is needed
+// most: the merge-gate reconciler reads it to post the synthetic verdict a
+// dead review owes, and its net — the sweep — re-offers the same run for
+// gateSweepLookback afterwards. Revoking on the outcome event would race the
+// repair and silence it ("its publish grant is expired or revoked").
+//
+// Past that window nothing revisits the run, so the grant has no reader left.
+const forgePublishPostRunGrace = gateSweepLookback + 30*time.Minute
+
+// forgePublishExpiryName is the eventbus subscriber name (the NATS queue
+// group), so one replica shortens each grant.
+const forgePublishExpiryName = "forge-publish-grant-expiry"
+
+// startForgePublishGrantExpiry attaches the grant reaper to the event spine.
+func (s *Server) startForgePublishGrantExpiry() {
+	if s == nil || s.forgePublishTokens == nil || s.cfg.Store == nil {
+		return
+	}
+	bus := s.eventsBus()
+	if bus == nil {
+		return
+	}
+	cancel, err := s.attachForgePublishGrantExpiry(bus)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("server: forge publish grant expiry subscribe failed: %v — a finished run's grant stays live for its full TTL (%s)", err, forgePublishDefaultTTL)
+		}
+		return
+	}
+	s.forgePublishExpiryCancel = cancel
+}
+
+// attachForgePublishGrantExpiry subscribes the reaper to run-terminal events —
+// the same ones the notification dispatcher and the merge-gate reconciler
+// consume.
+func (s *Server) attachForgePublishGrantExpiry(bus eventbus.Bus) (func(), error) {
+	if s == nil || bus == nil {
+		return func() {}, nil
+	}
+	return bus.Subscribe(forgePublishExpiryName, trigger.Matcher{
+		Sources: []trigger.Source{trigger.SourceRun},
+		Kinds: []string{
+			trigger.KindRunFinished,
+			trigger.KindRunFailed,
+			trigger.KindRunCancelled,
+		},
+	}, func(ctx context.Context, ev trigger.Event) error {
+		return s.expireForgePublishGrantForRun(ctx, strings.TrimSpace(ev.Subject.ID))
+	})
+}
+
+// expireForgePublishGrantForRun shortens the publish grant of a run that has
+// nothing left to publish. It is the eviction the TTL alone could not do: the
+// TTL is sized for the longest usage-window retry (~10 days), so without this
+// every grant a deployment ever minted stays live for that long, and the
+// in-memory registry's cap is really "gating launches per TTL".
+//
+// Two shapes keep their grant at full length, because something WILL come back
+// and post their own verdict:
+//
+//   - a paused run — it is expected to resume;
+//   - a failed_resumable run with an ARMED retry (RetryAfter set, persisted
+//     before the outcome event fires). "Abandoned" is defined by the retry
+//     machinery, not re-derived here: the sweeper enforces the policy's
+//     max_wait, unsets retry_after when it gives up, and REPUBLISHES the run
+//     outcome — so this handler runs again on the abandon and shortens the
+//     grant then.
+//
+// Every other terminal shape is dead: budget exceeded, retries exhausted, a
+// plain execution failure, a cancel, a normal finish.
+func (s *Server) expireForgePublishGrantForRun(ctx context.Context, runID string) error {
+	if runID == "" || s == nil || s.forgePublishTokens == nil || s.cfg.Store == nil {
+		return nil
+	}
+	run, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), runID)
+	if err != nil || run == nil {
+		return nil
+	}
+	token := runInputString(run, forgePublishVarToken)
+	if token == "" {
+		return nil // the run held no grant
+	}
+	switch {
+	case run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator:
+		return nil
+	case run.Status == store.RunStatusFailedResumable &&
+		run.FailureCode != store.FailureDLQParked &&
+		run.RetryState != nil && run.RetryState.RetryAfter != nil:
+		// A DLQ park is final for automation whatever RetryState says, which
+		// is why it is excluded above: only an operator replay wakes it, and
+		// the reconciler already treats it as dead.
+		return nil
+	}
+	s.forgePublishTokens.expireIn(token, forgePublishPostRunGrace)
+	return nil
+}

--- a/pkg/server/forge_publish_lifecycle_test.go
+++ b/pkg/server/forge_publish_lifecycle_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/eventbus"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+)
+
+// A saturated registry used to be SILENT: Register errored, the launch went
+// ahead with no grant, and the reconciler then abstained ("not a gating run")
+// on a head the launch was about to claim — the "pending forever" shape. The
+// launch is refused instead, before it claims anything.
+func TestInjectForgePublishVarsRefusesTheLaunchWhenTheGrantCannotBeMinted(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.PublicURL = "https://iterion.example"
+	s.forgePublishTokens = &failingPublishTokenStore{
+		ForgePublishTokenStore: NewForgePublishTokenRegistry(),
+		err:                    fmt.Errorf("forge publish token registry full (%d tokens)", forgePublishMaxTokens),
+	}
+
+	vars := map[string]string{"pr_url": "https://github.com/o/r/pull/42"}
+	out, err := s.injectForgePublishVars(context.Background(), "team1", "", "review-pr", vars, nil)
+	if err == nil {
+		t.Fatalf("a grant that cannot be minted must refuse the launch, got vars=%v", out)
+	}
+	if !errors.Is(err, errForgePublishGrantUnavailable) {
+		t.Errorf("err = %v, want errForgePublishGrantUnavailable so the lanes can type it", err)
+	}
+	if _, ok := out[forgePublishVarToken]; ok {
+		t.Error("no token must be handed out when the registry refused it")
+	}
+}
+
+// failingPublishTokenStore fails every Register while delegating the rest.
+type failingPublishTokenStore struct {
+	ForgePublishTokenStore
+	err error
+}
+
+func (f *failingPublishTokenStore) Register(string, ForgePublishGrant) error { return f.err }
+
+// The grant's only bound was its TTL — ~10 days, because it has to outlive the
+// longest usage-window retry. A run that ENDED needs it only until the gate
+// reconciler's sweep has had its window, so the terminal outcome shortens it.
+func TestForgePublishGrantExpiresOnTheRunsTerminalOutcome(t *testing.T) {
+	cases := []struct {
+		name      string
+		mutate    func(*store.Run)
+		wantShort bool
+	}{
+		{"finished", func(r *store.Run) { r.Status = store.RunStatusFinished }, true},
+		{"failed", func(r *store.Run) { r.Status = store.RunStatusFailed }, true},
+		{"cancelled", func(r *store.Run) { r.Status = store.RunStatusCancelled }, true},
+		{
+			// Nothing is coming back for it: budget exceeded, retries
+			// exhausted, a plain execution failure. The retry sweeper's
+			// abandon leaves exactly this shape (retry_after unset).
+			"failed_resumable with no armed retry",
+			func(r *store.Run) { r.Status = store.RunStatusFailedResumable },
+			true,
+		},
+		{
+			// The retry sweeper will resume it and it will post its own
+			// verdict — it still needs the grant.
+			"failed_resumable with an armed retry",
+			func(r *store.Run) {
+				at := time.Now().UTC().Add(time.Hour)
+				r.Status = store.RunStatusFailedResumable
+				r.RetryState = &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"}
+			},
+			false,
+		},
+		{
+			// A paused run is expected to resume.
+			"paused",
+			func(r *store.Run) { r.Status = store.RunStatusPausedWaitingHuman },
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st, err := store.New(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			s, _ := newForgePublishTestServer(t)
+			s.cfg.Store = st
+			const token = "tok-life"
+			registerPublishToken(t, s, token, ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+			if _, err := st.CreateRun(context.Background(), "run-life", "review_pr", map[string]any{
+				forgePublishVarToken: token, "pr_url": "https://github.com/o/r/pull/42",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			run, err := st.LoadRun(context.Background(), "run-life")
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.mutate(run)
+			if err := st.SaveRun(context.Background(), run); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := s.expireForgePublishGrantForRun(context.Background(), "run-life"); err != nil {
+				t.Fatal(err)
+			}
+			g, ok := s.forgePublishTokens.lookup(token)
+			if !ok {
+				t.Fatal("the grant must stay usable through the repair window, not vanish")
+			}
+			left := time.Until(g.ExpiresAt)
+			switch {
+			case tc.wantShort && left > forgePublishPostRunGrace+time.Minute:
+				t.Errorf("grant still lives %s after a terminal outcome, want ≤ %s", left, forgePublishPostRunGrace)
+			case !tc.wantShort && left <= forgePublishPostRunGrace+time.Minute:
+				t.Errorf("grant shortened to %s on a run that will resume and publish its own verdict", left)
+			}
+		})
+	}
+}
+
+// The eventbus is the trigger: the same run-outcome event the notification
+// dispatcher and the gate reconciler consume.
+func TestForgePublishGrantExpiryRidesTheRunOutcomeEvent(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.Store = st
+	bus := eventbus.NewInProcBus(iterlog.New(iterlog.LevelError, nil))
+
+	const token = "tok-bus"
+	registerPublishToken(t, s, token, ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+	if _, err := st.CreateRun(context.Background(), "run-bus", "review_pr", map[string]any{
+		forgePublishVarToken: token, "pr_url": "https://github.com/o/r/pull/42",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	run, err := st.LoadRun(context.Background(), "run-bus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.RunStatusFinished
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel, err := s.attachForgePublishGrantExpiry(bus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+
+	if err := bus.Publish(context.Background(), trigger.Event{
+		Source:  trigger.SourceRun,
+		Kind:    trigger.KindRunFinished,
+		Subject: trigger.Subject{ID: "run-bus"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		g, ok := s.forgePublishTokens.lookup(token)
+		if ok && time.Until(g.ExpiresAt) <= forgePublishPostRunGrace+time.Minute {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the run-outcome event did not shorten the grant (ok=%v)", ok)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/server/local_secrets_routes.go
+++ b/pkg/server/local_secrets_routes.go
@@ -37,16 +37,50 @@ type localSecretView struct {
 }
 
 type createLocalSecretReq struct {
-	Name         string   `json:"name"`
-	Secret       string   `json:"secret"`
-	Scope        string   `json:"scope,omitempty"` // "global" (default) | "project"
+	Name   string `json:"name"`
+	Secret string `json:"secret"`
+	Scope  string `json:"scope,omitempty"` // "global" (default) | "project"
+	// Kind names the shape the value must have — "token" | "json" | "pem" |
+	// "raw". Empty infers it from the value (a PEM header, a JSON opener,
+	// else a bare token); "raw" stores it unchecked.
+	Kind         string   `json:"kind,omitempty"`
 	AllowedHosts []string `json:"allowed_hosts,omitempty"`
 }
 
 type updateLocalSecretReq struct {
-	Name         *string   `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// Secret rotates the value; when present it goes through the same shape
+	// gate as a create — a rotation is a fresh paste.
 	Secret       *string   `json:"secret,omitempty"`
+	Kind         string    `json:"kind,omitempty"`
 	AllowedHosts *[]string `json:"allowed_hosts,omitempty"`
+}
+
+// checkLocalSecretShape is the studio door's half of the ingestion gate
+// `iterion secret set` runs. Without it the local store had a checked door and
+// an unchecked one, and a value that could not possibly authenticate — a
+// terminal transcript pasted as a token, a truncated credential document —
+// reached disk through the studio and surfaced as a provider 401 in the middle
+// of a run hours later.
+//
+// The refusal names the kind the value was read as and the `raw` opt-out, so
+// the remedy travels with the message; the value never appears in it.
+func checkLocalSecretShape(w http.ResponseWriter, kind, name, value string) bool {
+	shape, err := secrets.ResolveSecretShape(kind, value)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return false
+	}
+	if err := secrets.ValidateSecretShape(shape, name, value); err != nil {
+		var se *secrets.ShapeError
+		if errors.As(err, &se) {
+			httpError(w, http.StatusBadRequest, `%s (read as kind %q; send "kind":"raw" to store it unchecked)`, se.Error(), shape)
+			return false
+		}
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return false
+	}
+	return true
 }
 
 func toLocalSecretView(rec secrets.GenericSecret, scope string) localSecretView {
@@ -93,6 +127,9 @@ func (s *Server) handleCreateLocalSecret(w http.ResponseWriter, r *http.Request)
 	name := strings.TrimSpace(req.Name)
 	if !validGenericSecretName(name) || req.Secret == "" {
 		httpError(w, http.StatusBadRequest, "name + secret required")
+		return
+	}
+	if !checkLocalSecretShape(w, req.Kind, name, req.Secret) {
 		return
 	}
 	// Resolve the effective scope: "project" degrades to "global" when no
@@ -150,6 +187,9 @@ func (s *Server) handleUpdateLocalSecret(w http.ResponseWriter, r *http.Request)
 		rec.AllowedHosts = *req.AllowedHosts
 	}
 	if req.Secret != nil && *req.Secret != "" {
+		if !checkLocalSecretShape(w, req.Kind, rec.Name, *req.Secret) {
+			return
+		}
 		if err := secrets.SealInto(s.sealer, &rec, *req.Secret); err != nil {
 			httpError(w, http.StatusInternalServerError, "seal: %v", err)
 			return

--- a/pkg/server/local_secrets_shape_test.go
+++ b/pkg/server/local_secrets_shape_test.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// The studio's Secrets view is the SECOND door into the local generic store,
+// and it was the ungated one: `iterion secret set` refuses a value that could
+// not possibly authenticate (a terminal transcript pasted as a token, a
+// truncated JSON credential document), while the same paste through the studio
+// landed on disk and surfaced hours later as a provider 401 mid-run.
+func TestLocalSecretsRefuseAValueThatCannotAuthenticate(t *testing.T) {
+	e := newLocalSecretsE2E(t)
+
+	cases := []struct {
+		name string
+		body string
+		want string // a fragment the refusal must carry
+	}{
+		{
+			"a pasted transcript is not a bearer token",
+			`{"name":"forge_token","secret":"ghp_abc123\nghp_second_line"}`,
+			"newline",
+		},
+		{
+			"a truncated JSON credential document",
+			`{"name":"dependabot_tokens","kind":"json","secret":"{\"my-org\": \"github_pat_x"}`,
+			"JSON document",
+		},
+		{
+			"an empty JSON credential document carries nothing",
+			`{"name":"dependabot_tokens","kind":"json","secret":"{}"}`,
+			"empty JSON document",
+		},
+		{
+			"a truncated PEM block",
+			`{"name":"app_key","kind":"pem","secret":"-----BEGIN RSA PRIVATE KEY-----\nMIIE"}`,
+			"PEM block",
+		},
+		{
+			"an unknown kind is an error, never a silent pass-through",
+			`{"name":"whatever","kind":"nonsense","secret":"abc"}`,
+			"unknown secret kind",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := e.call(t, http.MethodPost, "/api/local/secrets", tc.body)
+			if code != http.StatusBadRequest {
+				t.Fatalf("code = %d, want 400; body = %s", code, body)
+			}
+			if !strings.Contains(string(body), tc.want) {
+				t.Errorf("body = %s, want it to name %q", body, tc.want)
+			}
+			if strings.Contains(string(body), "ghp_abc123") || strings.Contains(string(body), "github_pat_x") {
+				t.Error("the refusal must never echo the value")
+			}
+		})
+	}
+}
+
+// `raw` is the escape hatch the gate needs to be usable: a passphrase, a
+// connection string, a blob is none of the three checked shapes, and without
+// an opt-out gating the studio door would make them unstorable.
+func TestLocalSecretsRawKindStoresAnythingAndTheGateNamesIt(t *testing.T) {
+	e := newLocalSecretsE2E(t)
+
+	code, body := e.call(t, http.MethodPost, "/api/local/secrets",
+		`{"name":"db_password","kind":"raw","secret":"correct horse battery staple"}`)
+	if code != http.StatusOK {
+		t.Fatalf("raw must store unchecked: code = %d body = %s", code, body)
+	}
+
+	// And the refusal on the default path points at it, so the remedy travels
+	// with the message.
+	code, body = e.call(t, http.MethodPost, "/api/local/secrets",
+		`{"name":"db_password2","secret":"correct horse battery staple"}`)
+	if code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400; body = %s", code, body)
+	}
+	if !strings.Contains(string(body), "raw") {
+		t.Errorf("body = %s, want the raw opt-out named", body)
+	}
+}
+
+// The gate is on the update door too: a rotation is a fresh paste.
+func TestLocalSecretsUpdateAppliesTheShapeGate(t *testing.T) {
+	e := newLocalSecretsE2E(t)
+
+	code, body := e.call(t, http.MethodPost, "/api/local/secrets", `{"name":"forge_token","secret":"ghp_valid_token"}`)
+	if code != http.StatusOK {
+		t.Fatalf("seed: code = %d body = %s", code, body)
+	}
+	var created localSecretView
+	if err := json.Unmarshal(body, &created); err != nil {
+		t.Fatal(err)
+	}
+
+	code, body = e.call(t, http.MethodPatch, "/api/local/secrets/"+created.ID,
+		`{"secret":"ghp_rotated\ntrailing"}`)
+	if code != http.StatusBadRequest {
+		t.Fatalf("rotation must be gated: code = %d body = %s", code, body)
+	}
+	if !strings.Contains(string(body), "newline") {
+		t.Errorf("body = %s, want the shape refusal", body)
+	}
+
+	// A rename with no new value is not a paste and must still work.
+	code, body = e.call(t, http.MethodPatch, "/api/local/secrets/"+created.ID, `{"name":"forge_token_renamed"}`)
+	if code != http.StatusOK {
+		t.Fatalf("rename without a value: code = %d body = %s", code, body)
+	}
+}

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -439,12 +439,17 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 		vars, err := s.applyPRLaunchContext(r.Context(), launchID.TeamID, req.ConnectionID, req.BotID, req.Vars, r)
 		if err != nil {
 			// The fork guard refuses the operator's pull request (422); a
-			// forge that could not be asked is an upstream failure (502).
-			// Either way nothing launches: the same door the webhook lanes
-			// keep closed is not left open for a hand-picked PR.
+			// publish grant the server could not mint is the server's own
+			// capacity, retriable as-is (503); a forge that could not be
+			// asked is an upstream failure (502). Either way nothing
+			// launches: the same door the webhook lanes keep closed is not
+			// left open for a hand-picked PR.
 			code := http.StatusBadGateway
-			if errors.Is(err, errPRLaunchForkGuard) {
+			switch {
+			case errors.Is(err, errPRLaunchForkGuard):
 				code = http.StatusUnprocessableEntity
+			case errors.Is(err, errForgePublishGrantUnavailable):
+				code = http.StatusServiceUnavailable
 			}
 			s.httpErrorFor(w, r, code, "%v", err)
 			span.SetStatus(codes.Error, "pr launch refused")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -427,6 +427,9 @@ type Server struct {
 
 	// gateReconcileCancel unsubscribes the merge-gate reconciler at shutdown.
 	gateReconcileCancel func()
+	// forgePublishExpiryCancel unsubscribes the publish-grant reaper — the
+	// consumer that shortens a grant once its run can no longer publish.
+	forgePublishExpiryCancel func()
 	// boardSyncCancel stops the project-board reconciliation worker at
 	// shutdown, so a drain does not leave a pass writing to a forge.
 	boardSyncCancel func()

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -166,6 +166,7 @@ func (s *Server) ListenAndServe() error {
 	s.startUserNotify()
 	s.startOperatorAlerts()
 	s.startGateReconciler()
+	s.startForgePublishGrantExpiry()
 	s.startBoardSync()
 	s.startGateAutofix()
 	s.startOutcomeRouter()
@@ -668,6 +669,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 	if s.gateReconcileCancel != nil {
 		s.gateReconcileCancel()
+	}
+	if s.forgePublishExpiryCancel != nil {
+		s.forgePublishExpiryCancel()
+		s.forgePublishExpiryCancel = nil
 	}
 	if s.watcher != nil {
 		s.watcher.Stop()

--- a/pkg/server/valkey_stores.go
+++ b/pkg/server/valkey_stores.go
@@ -197,6 +197,21 @@ func (s *valkeyForgePublishTokenStore) Revoke(token string) {
 	}
 }
 
+// expireIn shortens the key's TTL. ExpireLT, so a call can only bring the
+// expiry forward — never extend a grant that was already reaped or shortened.
+// Best-effort like Revoke: the original TTL is the backstop.
+func (s *valkeyForgePublishTokenStore) expireIn(token string, d time.Duration) {
+	ctx, cancel := valkeyCtx()
+	defer cancel()
+	if err := s.rdb.ExpireLT(ctx, forgePublishTokenKeyPrefix+token, d).Err(); err != nil && s.logger != nil {
+		prefix := token
+		if len(prefix) > 8 {
+			prefix = prefix[:8]
+		}
+		s.logger.Warn("forge publish: shorten token %s… to %s: %v (best-effort — Redis TTL %s is the backstop)", prefix, d, err, forgePublishDefaultTTL)
+	}
+}
+
 func (s *valkeyForgePublishTokenStore) lookup(token string) (ForgePublishGrant, bool) {
 	ctx, cancel := valkeyCtx()
 	defer cancel()

--- a/studio/src/api/secrets.ts
+++ b/studio/src/api/secrets.ts
@@ -118,16 +118,27 @@ export interface LocalSecretView {
   last_used_at?: string;
 }
 
+/**
+ * LocalSecretKind names the shape the stored value must have — the same gate
+ * `iterion secret set --kind` applies. Omitted, the server infers it from the
+ * value (a PEM header, a JSON opener, else a bare token); "raw" is the
+ * explicit opt-out for a value that is none of the three (a passphrase, a
+ * connection string, a blob).
+ */
+export type LocalSecretKind = "token" | "json" | "pem" | "raw";
+
 export interface CreateLocalSecretInput {
   name: string;
   secret: string;
   scope?: "global" | "project";
+  kind?: LocalSecretKind;
   allowed_hosts?: string[];
 }
 
 export interface UpdateLocalSecretInput {
   name?: string;
   secret?: string;
+  kind?: LocalSecretKind;
   allowed_hosts?: string[] | null;
 }
 

--- a/studio/src/views/Secrets.tsx
+++ b/studio/src/views/Secrets.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   type LocalSecretView,
+  type LocalSecretKind,
   createLocalSecret,
   deleteLocalSecret,
   isValidSecretName,
@@ -221,6 +222,10 @@ function UpsertSecretDialog({
   const [name, setName] = useState(rec?.name ?? "");
   const [secret, setSecret] = useState("");
   const [scope, setScope] = useState<"global" | "project">(rec?.scope ?? "global");
+  // Empty = let the server read the shape off the value. The record carries no
+  // kind (the local store is name-keyed), so a rotate starts from the same
+  // inference a create does.
+  const [kind, setKind] = useState<LocalSecretKind | "">("");
   const [hosts, setHosts] = useState((rec?.allowed_hosts ?? []).join(", "));
   const { busy, error: err, run } = useAsyncAction();
 
@@ -235,9 +240,19 @@ function UpsertSecretDialog({
       .filter(Boolean);
     return run(async () => {
       if (rotate) {
-        await updateLocalSecret(rec.id, { secret, allowed_hosts: allowedHosts });
+        await updateLocalSecret(rec.id, {
+          secret,
+          ...(kind ? { kind } : {}),
+          allowed_hosts: allowedHosts,
+        });
       } else {
-        await createLocalSecret({ name, secret, scope, allowed_hosts: allowedHosts });
+        await createLocalSecret({
+          name,
+          secret,
+          scope,
+          ...(kind ? { kind } : {}),
+          allowed_hosts: allowedHosts,
+        });
       }
       onDone();
     });
@@ -305,6 +320,25 @@ function UpsertSecretDialog({
             placeholder="paste here — never shown again"
             autoFocus={rotate}
           />
+        </label>
+        <label className="block">
+          <div className="text-xs text-fg-muted mb-1">Kind</div>
+          <Select
+            size="md"
+            value={kind}
+            onChange={(e) => setKind(e.target.value as LocalSecretKind | "")}
+          >
+            <option value="">Detect from the value</option>
+            <option value="token">Token (a bearer token / API key)</option>
+            <option value="json">JSON credential document</option>
+            <option value="pem">PEM block (a private key)</option>
+            <option value="raw">Raw — store unchecked</option>
+          </Select>
+          <div className="text-xs text-fg-muted mt-1">
+            A value that could not authenticate is refused here rather than
+            discovered as a provider 401 mid-run. Pick <em>Raw</em> for a
+            passphrase or a connection string.
+          </div>
         </label>
         <label className="block">
           <div className="text-xs text-fg-muted mb-1">Egress hosts (optional, comma-separated)</div>

--- a/studio/src/views/teams/tabs/integrations/EnableRepoPanel.tsx
+++ b/studio/src/views/teams/tabs/integrations/EnableRepoPanel.tsx
@@ -5,6 +5,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { BotEntryWithSchema } from "@/api/bots";
 import {
   type ForgeConnection,
+  type ForgeConnectionHealth,
   type ForgeRepo,
   enableForgeRepoBots,
   getForgeConnectionHealth,
@@ -185,6 +186,8 @@ export function EnableRepoPanel({
         </div>
       )}
 
+      {conn.kind === "github_app" && health && <MissingGrantLines health={health} />}
+
       <div>
         <label htmlFor="forge-repo-pick" className="sr-only">
           Repository
@@ -314,6 +317,59 @@ export function EnableRepoPanel({
         <Button variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
+      </div>
+    </div>
+  );
+}
+
+// MissingGrantLines names each permission gap the health probe found, with
+// what it costs and where it is approved — the same lines
+// `iterion remote forge connections refresh` prints. Without them the API and
+// the CLI were the only surfaces of a gap an operator meets as a dead panel
+// or a run that fails hours in, at push time.
+function MissingGrantLines({ health }: { health: ForgeConnectionHealth }) {
+  const install = health.manage_install_url;
+  const gaps: { key: string; text: string }[] = [];
+  if (health.missing_permissions?.length) {
+    gaps.push({
+      key: "delivery",
+      text: `Missing for app delivery (publishing the CI workflow and the image it builds): ${health.missing_permissions.join(", ")}.`,
+    });
+  }
+  if (health.missing_ci_permissions?.length) {
+    // Name every surface the gap darkens: `statuses` is also what the
+    // revi/review merge-gate verdict is posted and read with, so an operator
+    // told only about a card panel would not know the gate is dark too.
+    const surfaces = health.missing_ci_permissions.includes("statuses")
+      ? "the board card CI panel and the merge-gate verdict"
+      : "the board card CI panel";
+    gaps.push({
+      key: "ci",
+      text: `Missing for ${surfaces}: ${health.missing_ci_permissions.join(", ")}.`,
+    });
+  }
+  if (health.missing_security_permissions?.length) {
+    gaps.push({
+      key: "security",
+      text: `Missing for the org-wide Dependabot alerts read: ${health.missing_security_permissions.join(", ")}.`,
+    });
+  }
+  if (gaps.length === 0) return null;
+  return (
+    <div className="rounded border border-warning/40 bg-warning-soft text-warning-fg px-2.5 py-2 text-xs space-y-1">
+      {gaps.map((g) => (
+        <div key={g.key}>{g.text}</div>
+      ))}
+      <div>
+        An org owner approves the pending request{" "}
+        {install ? (
+          <a href={install} target="_blank" rel="noreferrer" className="text-accent-text underline">
+            on the App&rsquo;s installation page ↗
+          </a>
+        ) : (
+          "on the App’s installation page"
+        )}
+        .
       </div>
     </div>
   );


### PR DESCRIPTION
Four commits, one per ticket — cluster forge client / publish token / credentials (#812, #826, #820, #747). Rebased onto main; `git merge-tree --write-tree` against PR #875 (in flight, also touches `forge_publish.go` and `docs/merge-gate.md`) is a clean auto-merge — the hunks are disjoint.

## #812 — residues around the pull/CI path
**Every 404 read "hook not found".** `forge.StatusErr` mapped `404 → ErrHookNotFound` unconditionally at the one point all three providers funnel through, so a `GET pull` on a missing PR — and GitHub's 404-for-a-resource-a-token-may-not-see — surfaced as a webhook message. Now typed **by operation** (`notFoundFor`): hook ops keep `ErrHookNotFound` (deprovision reads it as "already gone"), everything else becomes a `*forge.NotFoundError` naming its own call; `ErrHookNotFound` wraps a new `ErrNotFound` so the class has one predicate. `StatusErrNeeding` carries the grants a caller knows, and `NotFoundError.MayNeed` names them **without** claiming a permission gap the status cannot prove (asserted).
**A 404 on check-runs / combined status read as "no CI".** The premise in the code was wrong: GitHub answers 200 + an empty list for a commit nothing ran on; a 404 is an absent ref or a PAT short of `checks:read` — read as empty it drops the only failing run from `aggregateState` and renders the card green.
**`history, _ := pc.ListCIHistory(...)`** → flagged partial (`history_error`, omitempty, + a `Warn`), not a failed request: `GetCIStatus` is the verdict half and already answered, and on GitHub both halves share `fetchCheckRuns`.
**Studio**: `MissingGrantLines` on the existing health banner, printing the same lines `iterion remote forge connections refresh` does, each pointing at `manage_install_url`.
**`checks: read` on the RUN token** via `RuntimePermissionsFor` — plus `statuses: read`, said why in the code: `gh pr checks` unions check-runs and commit statuses, and iterion's own merge gate (`revi/review`) IS a commit status, so a token with only `checks` cannot see the verdict the bot waits on. Kept out of `ManagementPermissionsFor` (asserted).
Red: `StatusErr("GET pull", 404) = forge: not found: hook — a missing GET pull is not a missing hook`; `a 404 on /check-runs must surface, got state="unknown" runs=0`; `a failed history read must be named in the response, not swallowed into an empty timeline`; `checks = "", want read`. Four existing tests **encoded the defect** (asserting `ErrHookNotFound` on `GET issue`/`GET pull`) and are updated with an explicit "not a hook" assertion.

## #826 — the publish-token registry
**Saturation was silent**: `Register` errors → `injectForgePublishVars` logged and returned `vars, nil` → the launch proceeded, `markGateInFlight` claimed the head, and the reconciler abstained on an empty token → "pending forever". Chose **fail the launch** over "release the claim with a synthetic verdict", and said why: the order is `injectForgePublishVars → launch → markGateInFlight`, so a launch refused here leaves nothing on the head to release, and `docs/merge-gate.md`'s own rule is that every status iterion writes names the run it speaks for — with no run there is nothing to name. Typed `errForgePublishGrantUnavailable`; `boarddispatch` files the card blocked with the reason, `runs_launch` answers **503** (a full registry is server capacity, not an inadmissible request).
**`Revoke` was never called** — a grant lived ≈216 h past its run. Straight revocation on the terminal outcome would have broken the reconciler, which reads the grant precisely when a run dies and whose sweep re-offers it for `gateSweepLookback`; so `expireIn` (new `ForgePublishTokenStore` method; in-memory `min(existing, now+d)`, Valkey `ExpireLT` — never extends) shortens to `gateSweepLookback + 30m` on the run-terminal event. A **paused** run and a `failed_resumable` with an **armed** retry keep the full TTL; "abandoned" is not re-derived — the retry sweeper enforces `max_wait` and republishes the outcome, which re-fires the handler. DLQ-parked excluded.
Red: `a grant that cannot be minted must refuse the launch, got vars=map[pr_url:…]`; `grant still lives 215h59m59s after a terminal outcome, want ≤ 1h30m`; `the run-outcome event did not shorten the grant`. The cloud-twin gap (the default registry is one pod's memory) is stated in `docs/merge-gate.md`.

## #820 — three credential residues
**z.ai base URL**: two branches (tenant-provisioned key, under the `zai` hint and under default precedence) pinned `ZAIDefaultBaseURL` while the two env-key branches honoured `ANTHROPIC_BASE_URL` — same deployment, two destinations depending on where the key came from. One `zaiEnv(key)` helper for all four. Red: `ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic", want the operator's "https://zai.internal.example/api/anthropic"`.
**Studio local-secrets door**: `kind` on create and update, a Kind picker in the Secrets view (empty = infer, `raw` = opt-out), `ValidateSecretShape` on both — and the resolution moved to a shared `secrets.ResolveSecretShape(kind, value)` the CLI now calls too, since a recopied guard is what let the two doors disagree; each surface phrases its own remedy. Red: `code = 200, want 400` on a truncated JSON credential document.
**`docs/forge-security-read.md`** rewritten to the stdin form + `--kind json` (the documented positional value cannot work).

## #747 — the run-merge squash message enumerated the repository from the root
`BuildSquashMessage` passed the recorded base verbatim and `gitlib.Log` treats an unresolvable base as "no range" → `git log <head>` to the root, `--reverse` making the OLDEST commit the title. A repo-targeted merge runs in a server-materialised clone where that base is frequently unresolvable — the ordinary path there. `BuildSquashMessageForMerge(repoRoot, base, target, head, runName)` + `squashRangeBase`, four rungs: the base when the head descends from it (still authoritative — merge-base only approximates once the target moved) → `merge-base(target, head)` → `""` when the TARGET itself does not resolve (a greenfield `git init` run genuinely owns every commit) → `head` otherwise (unrelated histories: no range, the title falls back to the run name rather than enumerating someone else's past). Red: `the subject is the repository's own first commit, not the run's delivery: init …`. Class: the deferred merge, the post-conflict finalize, `finalizeWorktree` and the gate squash all fixed; `runs_commits.go` left (already bounded).

## Proof
`go build`, `go vet`, `task lint` (0 issues), `go test` and `-race` on `pkg/forge/... pkg/secrets/... pkg/backend/delegate pkg/cli pkg/runtime/... pkg/runview/... pkg/server/...`, `task openapi:check` (no drift), studio `tsc --noEmit` clean and `eslint` 0 errors on the three touched files. Mongo conformance not needed: no `pkg/store/**` file is touched; the only store-shaped change is `ForgePublishTokenStore.expireIn`, whose two twins (memory + Valkey) are both implemented — ephemeral cross-replica state, not durable.

## Left out, stated
- The webhook lane's HTTP status for `errForgePublishGrantUnavailable` is 422 today where 503 would be right; the mapping lives in `webhooks_common.go`, owned by another PR in flight.
- `gitlab/ci.go`'s `404||403 → empty headProject` is a real silent degrade but optional fork-source enrichment, not a CI verdict — filed separately.
- The #826 cloud twin for the registry (out of scope; gap stated in the docs).

Closes #812, #826, #820, #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
