### PR TITLE
fix(dsl,boardmongo): a group param expands in one pass, and a cascade budgets one round-trip per write instead of the whole sweep

### DIFF
--- a/pkg/dispatcher/boardmongo/admin.go
+++ b/pkg/dispatcher/boardmongo/admin.go
@@ -29,17 +29,68 @@ import (
 // partial-progress contract native documents on a mid-cascade failure.
 var _ native.BoardAdmin = (*Store)(nil)
 
+// sweepCtx is the parent context of a CASCADE — the O(N) walks below that
+// rewrite every card of the board (migrateState, applyFieldRewrite,
+// applyLabelRewrite). It deliberately carries NO deadline: opTimeout prices
+// ONE round-trip, so a whole walk priced at one round-trip renames the first
+// cards, errors on the rest, and hands the operator a half-applied
+// vocabulary change. Every Mongo call inside a walk derives its own bounded
+// context from this one (callCtx), which is what bounds a hung server
+// without bounding the walk. The BoardAdmin interface carries no context, so
+// the sweep's own bound is the caller's process.
+func sweepCtx() context.Context { return context.Background() }
+
+// callCtx bounds ONE Mongo round-trip inside a cascade while keeping the
+// sweep's own cancellation.
+func callCtx(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, opTimeout)
+}
+
+// The cascade walks read and write through these: each derives a fresh
+// per-round-trip budget from the sweep parent, so the walk's length never
+// eats the budget of the write that follows it.
+
+func (s *Store) cascadeListAll(parent context.Context) ([]native.Issue, error) {
+	ctx, cancel := callCtx(parent)
+	defer cancel()
+	return s.listAll(ctx)
+}
+
+func (s *Store) cascadeReplace(parent context.Context, iss *native.Issue, changed ...string) error {
+	ctx, cancel := callCtx(parent)
+	defer cancel()
+	return s.replace(ctx, iss, changed...)
+}
+
+func (s *Store) cascadeReplaceGuarded(parent context.Context, iss *native.Issue, guard bson.M, changed ...string) (bool, error) {
+	ctx, cancel := callCtx(parent)
+	defer cancel()
+	return s.replaceGuarded(ctx, iss, guard, changed...)
+}
+
+func (s *Store) cascadeGet(parent context.Context, id string) (*native.Issue, error) {
+	ctx, cancel := callCtx(parent)
+	defer cancel()
+	return s.get(ctx, id)
+}
+
 // persistBoard is the Mongo twin of native's setBoardLocked: it validates the
 // candidate board and writes it WITHOUT emitting an event. Each config mutator
 // emits its own precise op-discriminated EvtBoardUpdated after any per-issue
 // cascade completes (matching native's emit ordering exactly). SetBoard, by
 // contrast, emits the bare EvtBoardUpdated — so the config ops must not route
 // through it or they'd double-emit.
-func (s *Store) persistBoard(ctx context.Context, b *native.Board) error {
+//
+// parent is the caller's scope, not the write's budget: the single ReplaceOne
+// gets its own opTimeout so a config mutator that also runs a cascade prices
+// this write like any other round-trip.
+func (s *Store) persistBoard(parent context.Context, b *native.Board) error {
 	if err := b.Validate(); err != nil {
 		return err
 	}
 	b.UpdatedAt = time.Now().UTC()
+	ctx, cancel := callCtx(parent)
+	defer cancel()
 	if _, err := s.config.ReplaceOne(ctx, bson.M{"_id": s.tenant}, configDoc{Tenant: s.tenant, Board: *b}, options.Replace().SetUpsert(true)); err != nil {
 		return fmt.Errorf("boardmongo: persist board: %w", err)
 	}
@@ -54,10 +105,10 @@ func (s *Store) persistBoard(ctx context.Context, b *native.Board) error {
 // migrateState rewrites every tenant issue in state `from` to `to`, emitting
 // one EvtIssueState per touched issue with the given reason. Mirrors native's
 // migrateStateLocked, including the per-issue partial-progress contract.
-func (s *Store) migrateState(ctx context.Context, from, to, reason string) (int, error) {
-	all, err := s.listAll(ctx)
+func (s *Store) migrateState(parent context.Context, from, to, reason string) (int, error) {
+	all, err := s.cascadeListAll(parent)
 	if err != nil {
-		return 0, err
+		return 0, cascadeErrf(0, "", "state migration", "read the board", err)
 	}
 	touched := 0
 	for i := range all {
@@ -68,19 +119,31 @@ func (s *Store) migrateState(ctx context.Context, from, to, reason string) (int,
 		iss.State = to
 		iss.StateReason = reason
 		iss.UpdatedAt = time.Now().UTC()
-		if err := s.replace(ctx, &iss, "state"); err != nil {
-			return touched, fmt.Errorf("boardmongo: write %s during state migration: %w", iss.ID, err)
+		if err := s.cascadeReplace(parent, &iss, "state"); err != nil {
+			return touched, cascadeErrf(touched, iss.ID, "state migration", "write", err)
 		}
 		if err := s.emit(native.Event{
 			Type:    native.EvtIssueState,
 			IssueID: iss.ID,
 			Payload: map[string]any{"from": from, "to": to, "reason": reason},
 		}); err != nil {
-			return touched, err
+			return touched, cascadeErrf(touched, iss.ID, "state migration", "record the event for", err)
 		}
 		touched++
 	}
 	return touched, nil
+}
+
+// cascadeErrf wraps a cascade failure with the progress an operator needs to
+// resume by hand: how many cards the walk already rewrote, and which one it
+// stopped at. A cascade is a partial write with no rollback, so a bare driver
+// error ("context deadline exceeded") leaves the board in a state nobody can
+// name. card may be empty when the walk failed before reaching one.
+func cascadeErrf(touched int, card, op, what string, err error) error {
+	if card == "" {
+		return fmt.Errorf("boardmongo: %s stopped after %d card(s): could not %s: %w", op, touched, what, err)
+	}
+	return fmt.Errorf("boardmongo: %s stopped after %d card(s): could not %s %s: %w", op, touched, what, card, err)
 }
 
 // AddState appends a new column to the board. Rejects an empty or duplicate
@@ -116,8 +179,7 @@ func (s *Store) RenameState(from, to string) (int, error) {
 	if from == to {
 		return 0, nil
 	}
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
+	sweep := sweepCtx()
 	board := s.Board()
 	idx := stateIndex(board, from)
 	if idx < 0 {
@@ -127,10 +189,10 @@ func (s *Store) RenameState(from, to string) (int, error) {
 		return 0, fmt.Errorf("boardmongo: target state %q already exists; delete-with-migrate to merge columns", to)
 	}
 	board.States[idx].Name = to
-	if err := s.persistBoard(ctx, board); err != nil {
+	if err := s.persistBoard(sweep, board); err != nil {
 		return 0, err
 	}
-	touched, err := s.migrateState(ctx, from, to, tracker.ReasonStateRename)
+	touched, err := s.migrateState(sweep, from, to, tracker.ReasonStateRename)
 	if err != nil {
 		return touched, err
 	}
@@ -145,8 +207,7 @@ func (s *Store) RenameState(from, to string) (int, error) {
 // the last column. Issues are migrated first, then the column is dropped.
 // Mirrors native.Store.DeleteState.
 func (s *Store) DeleteState(name, migrateTo string) (int, error) {
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
+	sweep := sweepCtx()
 	board := s.Board()
 	if stateIndex(board, name) < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown state %q", name)
@@ -154,9 +215,9 @@ func (s *Store) DeleteState(name, migrateTo string) (int, error) {
 	if len(board.States) <= 1 {
 		return 0, errors.New("boardmongo: cannot delete the last column")
 	}
-	all, err := s.listAll(ctx)
+	all, err := s.cascadeListAll(sweep)
 	if err != nil {
-		return 0, err
+		return 0, cascadeErrf(0, "", "state delete", "read the board", err)
 	}
 	count := 0
 	for i := range all {
@@ -185,14 +246,14 @@ func (s *Store) DeleteState(name, migrateTo string) (int, error) {
 		if err := native.ReopenMigrationAllowed(board, ptrs, name, migrateTo); err != nil {
 			return 0, err
 		}
-		touched, err = s.migrateState(ctx, name, migrateTo, tracker.ReasonStateDelete)
+		touched, err = s.migrateState(sweep, name, migrateTo, tracker.ReasonStateDelete)
 		if err != nil {
 			return touched, err
 		}
 	}
 	idx := stateIndex(board, name)
 	board.States = append(board.States[:idx], board.States[idx+1:]...)
-	if err := s.persistBoard(ctx, board); err != nil {
+	if err := s.persistBoard(sweep, board); err != nil {
 		return touched, err
 	}
 	return touched, s.emit(native.Event{
@@ -262,10 +323,10 @@ func (s *Store) ReorderStates(order []string) error {
 // applyFieldRewrite rewrites each tenant issue's Fields map via transform,
 // persisting + emitting EvtIssueUpdated per changed issue. Mirrors native's
 // applyFieldRewriteLocked, including the partial-progress contract.
-func (s *Store) applyFieldRewrite(ctx context.Context, transform func(fields map[string]any) (map[string]any, bool), reason string) (int, error) {
-	all, err := s.listAll(ctx)
+func (s *Store) applyFieldRewrite(parent context.Context, transform func(fields map[string]any) (map[string]any, bool), reason string) (int, error) {
+	all, err := s.cascadeListAll(parent)
 	if err != nil {
-		return 0, err
+		return 0, cascadeErrf(0, "", reason, "read the board", err)
 	}
 	touched := 0
 	for i := range all {
@@ -279,15 +340,15 @@ func (s *Store) applyFieldRewrite(ctx context.Context, transform func(fields map
 		}
 		iss.Fields = nextFields
 		iss.UpdatedAt = time.Now().UTC()
-		if err := s.replace(ctx, &iss, "fields"); err != nil {
-			return touched, fmt.Errorf("boardmongo: write %s during %s: %w", iss.ID, reason, err)
+		if err := s.cascadeReplace(parent, &iss, "fields"); err != nil {
+			return touched, cascadeErrf(touched, iss.ID, reason, "write", err)
 		}
 		if err := s.emit(native.Event{
 			Type:    native.EvtIssueUpdated,
 			IssueID: iss.ID,
 			Payload: map[string]any{"changed": []string{"fields"}, "reason": reason},
 		}); err != nil {
-			return touched, err
+			return touched, cascadeErrf(touched, iss.ID, reason, "record the event for", err)
 		}
 		touched++
 	}
@@ -360,8 +421,7 @@ func (s *Store) RenameField(from, to string) (int, error) {
 	if from == to {
 		return 0, nil
 	}
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
+	sweep := sweepCtx()
 	board := s.Board()
 	idx := fieldIndex(board, from)
 	if idx < 0 {
@@ -371,10 +431,10 @@ func (s *Store) RenameField(from, to string) (int, error) {
 		return 0, fmt.Errorf("boardmongo: target field %q already exists", to)
 	}
 	board.Fields[idx].Name = to
-	if err := s.persistBoard(ctx, board); err != nil {
+	if err := s.persistBoard(sweep, board); err != nil {
 		return 0, err
 	}
-	touched, err := s.applyFieldRewrite(ctx, func(fields map[string]any) (map[string]any, bool) {
+	touched, err := s.applyFieldRewrite(sweep, func(fields map[string]any) (map[string]any, bool) {
 		v, ok := fields[from]
 		if !ok {
 			return fields, false
@@ -401,14 +461,13 @@ func (s *Store) RenameField(from, to string) (int, error) {
 // DeleteField removes a field definition and strips its key from every issue.
 // Mirrors native.Store.DeleteField.
 func (s *Store) DeleteField(name string) (int, error) {
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
+	sweep := sweepCtx()
 	board := s.Board()
 	idx := fieldIndex(board, name)
 	if idx < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown field %q", name)
 	}
-	touched, err := s.applyFieldRewrite(ctx, func(fields map[string]any) (map[string]any, bool) {
+	touched, err := s.applyFieldRewrite(sweep, func(fields map[string]any) (map[string]any, bool) {
 		if _, ok := fields[name]; !ok {
 			return fields, false
 		}
@@ -424,7 +483,7 @@ func (s *Store) DeleteField(name string) (int, error) {
 		return touched, err
 	}
 	board.Fields = append(board.Fields[:idx], board.Fields[idx+1:]...)
-	if err := s.persistBoard(ctx, board); err != nil {
+	if err := s.persistBoard(sweep, board); err != nil {
 		return touched, err
 	}
 	return touched, s.emit(native.Event{
@@ -525,10 +584,10 @@ func (s *Store) DeleteView(name string) error {
 // and a per-issue label event is appended. Mirrors native's
 // applyLabelRewriteLocked, including its event payload shape ({issue_id} +
 // the op fields).
-func (s *Store) applyLabelRewrite(ctx context.Context, transform func(labels []string) ([]string, bool), eventType native.EventType, payload map[string]any) (touched int, err error) {
-	all, err := s.listAll(ctx)
+func (s *Store) applyLabelRewrite(parent context.Context, transform func(labels []string) ([]string, bool), eventType native.EventType, payload map[string]any) (touched int, err error) {
+	all, err := s.cascadeListAll(parent)
 	if err != nil {
-		return 0, err
+		return 0, cascadeErrf(0, "", string(eventType), "read the board", err)
 	}
 	var lost []string
 	// The lost report survives EVERY exit: an I/O error later in the walk
@@ -558,20 +617,20 @@ func (s *Store) applyLabelRewrite(ctx context.Context, transform func(labels []s
 			preLabels := append([]string(nil), iss.Labels...)
 			iss.Labels = newLabels
 			iss.UpdatedAt = time.Now().UTC()
-			matched, err := s.replaceGuarded(ctx, &iss, bson.M{"issue.labels": preLabels}, "labels")
+			matched, err := s.cascadeReplaceGuarded(parent, &iss, bson.M{"issue.labels": preLabels}, "labels")
 			if err != nil {
-				return touched, fmt.Errorf("boardmongo: write %s during %s: %w", iss.ID, eventType, err)
+				return touched, cascadeErrf(touched, iss.ID, string(eventType), "write", err)
 			}
 			if matched {
 				wrote = true
 				break
 			}
-			fresh, err := s.get(ctx, iss.ID)
+			fresh, err := s.cascadeGet(parent, iss.ID)
 			if err != nil {
 				if errors.Is(err, tracker.ErrNotFound) {
 					break // deleted mid-sweep — a benign race, like the FS twin
 				}
-				return touched, fmt.Errorf("boardmongo: re-read %s during %s: %w", iss.ID, eventType, err)
+				return touched, cascadeErrf(touched, iss.ID, string(eventType), "re-read", err)
 			}
 			iss = *fresh
 			exhausted = attempt == attempts-1
@@ -595,7 +654,7 @@ func (s *Store) applyLabelRewrite(ctx context.Context, transform func(labels []s
 			evtPayload[k] = v
 		}
 		if err := s.emit(native.Event{Type: eventType, IssueID: iss.ID, Payload: evtPayload}); err != nil {
-			return touched, err
+			return touched, cascadeErrf(touched, iss.ID, string(eventType), "record the event for", err)
 		}
 		touched++
 	}
@@ -612,9 +671,8 @@ func (s *Store) RenameLabel(from, to string) (int, error) {
 	if from == to {
 		return 0, nil
 	}
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
-	return s.applyLabelRewrite(ctx, func(labels []string) ([]string, bool) {
+	sweep := sweepCtx()
+	return s.applyLabelRewrite(sweep, func(labels []string) ([]string, bool) {
 		out := make([]string, 0, len(labels))
 		changed := false
 		seenTo := slices.Contains(labels, to)
@@ -645,9 +703,8 @@ func (s *Store) MergeLabels(from, to string) (int, error) {
 	if from == to {
 		return 0, nil
 	}
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
-	return s.applyLabelRewrite(ctx, func(labels []string) ([]string, bool) {
+	sweep := sweepCtx()
+	return s.applyLabelRewrite(sweep, func(labels []string) ([]string, bool) {
 		out := make([]string, 0, len(labels))
 		changed := false
 		seenTo := slices.Contains(labels, to)
@@ -672,9 +729,8 @@ func (s *Store) DeleteLabel(label string) (int, error) {
 	if label == "" {
 		return 0, native.ErrLabelEmpty
 	}
-	ctx, cancel := ctxWithTimeout()
-	defer cancel()
-	return s.applyLabelRewrite(ctx, func(labels []string) ([]string, bool) {
+	sweep := sweepCtx()
+	return s.applyLabelRewrite(sweep, func(labels []string) ([]string, bool) {
 		out := make([]string, 0, len(labels))
 		changed := false
 		for _, l := range labels {

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -42,8 +42,10 @@ const (
 	EffectsCollection = "trigger_effects"
 )
 
-// opTimeout bounds every Mongo call (the BoardStore interface carries no
-// context, so each op uses a fresh bounded background context).
+// opTimeout bounds ONE Mongo round-trip (the BoardStore interface carries no
+// context, so each op uses a fresh bounded background context). It is NOT a
+// budget for a whole operation: an O(N) cascade priced at one round-trip
+// half-applies as soon as the board outgrows it — see sweepCtx.
 const opTimeout = 10 * time.Second
 
 // Store is a tenant-scoped Mongo board.

--- a/pkg/dispatcher/boardmongo/sweep_budget_test.go
+++ b/pkg/dispatcher/boardmongo/sweep_budget_test.go
@@ -1,0 +1,307 @@
+package boardmongo
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/event"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// A CASCADE (RenameLabel / MergeLabels / DeleteLabel / RenameState /
+// DeleteState / RenameField / DeleteField) rewrites every card of the board.
+// opTimeout prices ONE Mongo round-trip; a walk that threads a single
+// opTimeout context through listAll plus a write per card spends that one
+// budget on the WHOLE walk, so it renames the first cards, errors on the
+// rest, and leaves a half-applied board with no rollback.
+//
+// The oracle here is the deadline each per-card write actually carries on
+// the wire. The driver renders the context deadline as `maxTimeMS`, so a
+// shared deadline is directly observable: it BURNS DOWN across the walk (the
+// last card's budget is short by the walk's whole duration), while a
+// per-round-trip deadline is the same on every card. Reading the wire instead
+// of racing a stopwatch keeps the assertion exact — a loaded runner's
+// latency spike moves neither figure.
+
+// budgetSpread is the tolerated variation, in milliseconds, between the
+// largest and smallest wire deadline of one cascade. Per-round-trip
+// derivation lands every write within a millisecond or two of opTimeout; a
+// shared deadline burns down by the walk's own duration, seconds over a
+// board of sweepCards.
+const budgetSpread = 250
+
+// sweepCards is the fixture size. It only has to make the walk's duration
+// exceed budgetSpread by a wide margin, which a few hundred round-trips do
+// on any host.
+const sweepCards = 400
+
+// deadlineProbe records the wire deadline of every `update` the cascade
+// issues against the issues collection — one per rewritten card.
+type deadlineProbe struct {
+	mu       sync.Mutex
+	watching bool
+	seen     []int64
+}
+
+func (p *deadlineProbe) monitor() *event.CommandMonitor {
+	return &event.CommandMonitor{
+		Started: func(_ context.Context, e *event.CommandStartedEvent) {
+			if e.CommandName != "update" {
+				return
+			}
+			if coll, ok := e.Command.Lookup("update").StringValueOK(); !ok || coll != IssuesCollection {
+				return
+			}
+			ms, ok := e.Command.Lookup("maxTimeMS").AsInt64OK()
+			if !ok {
+				return
+			}
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if p.watching {
+				p.seen = append(p.seen, ms)
+			}
+		},
+	}
+}
+
+// watch arms the probe for the cascade about to run, discarding anything the
+// fixture seeding produced.
+func (p *deadlineProbe) watch() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.watching, p.seen = true, nil
+}
+
+// assertPerCallBudget fails unless the cascade rewrote every card under a
+// deadline it did not share with the rest of the walk.
+func (p *deadlineProbe) assertPerCallBudget(t *testing.T, wantWrites int) {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.watching = false
+	if len(p.seen) < wantWrites {
+		t.Fatalf("cascade issued %d card writes, want at least %d — the fixture did not exercise the walk", len(p.seen), wantWrites)
+	}
+	lo, hi := p.seen[0], p.seen[0]
+	for _, ms := range p.seen {
+		if ms < lo {
+			lo = ms
+		}
+		if ms > hi {
+			hi = ms
+		}
+	}
+	if spread := hi - lo; spread > budgetSpread {
+		t.Fatalf("per-card write deadlines span %d ms over %d writes (%d..%d): the walk shares ONE budget and burns it down — a board large enough exhausts it mid-cascade and half-applies",
+			spread, len(p.seen), lo, hi)
+	}
+}
+
+// sweepBudgetStore opens a throwaway database with the probe attached.
+func sweepBudgetStore(t *testing.T, prefix string) (*Store, *deadlineProbe) {
+	t.Helper()
+	uri := os.Getenv("ITERION_TEST_MONGO_URI")
+	if uri == "" {
+		t.Skip("ITERION_TEST_MONGO_URI not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	probe := &deadlineProbe{}
+	client, err := mongo.Connect(options.Client().ApplyURI(uri).SetMonitor(probe.monitor()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := make([]byte, 4)
+	_, _ = rand.Read(nonce)
+	db := client.Database(prefix + hex.EncodeToString(nonce))
+	t.Cleanup(func() {
+		c, cc := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cc()
+		_ = db.Drop(c)
+		_ = client.Disconnect(c)
+	})
+	if err := EnsureSchema(ctx, db); err != nil {
+		t.Fatal(err)
+	}
+	return New(db, "t1"), probe
+}
+
+func seedCards(t *testing.T, s *Store, n int, decorate func(iss *native.Issue)) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		iss := native.Issue{Title: fmt.Sprintf("card-%03d", i), State: native.StateReady}
+		decorate(&iss)
+		if _, err := s.Create(iss); err != nil {
+			t.Fatalf("seed card %d: %v", i, err)
+		}
+	}
+}
+
+func labelled(label string) func(*native.Issue) {
+	return func(iss *native.Issue) { iss.Labels = []string{label} }
+}
+
+func TestRenameLabelSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_rename_")
+	seedCards(t, s, sweepCards, labelled("old"))
+
+	probe.watch()
+	touched, err := s.RenameLabel("old", "new")
+	if err != nil {
+		t.Fatalf("RenameLabel touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("RenameLabel touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// DeleteLabel is the cascade a consume_labels trigger depends on: a card that
+// keeps a label the operator retired stays armed.
+func TestDeleteLabelSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_delete_")
+	seedCards(t, s, sweepCards, labelled("retire-me"))
+
+	probe.watch()
+	touched, err := s.DeleteLabel("retire-me")
+	if err != nil {
+		t.Fatalf("DeleteLabel touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("DeleteLabel touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+func TestMergeLabelsSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_merge_")
+	seedCards(t, s, sweepCards, labelled("from"))
+
+	probe.watch()
+	touched, err := s.MergeLabels("from", "into")
+	if err != nil {
+		t.Fatalf("MergeLabels touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("MergeLabels touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// RenameState drives migrateState, the second walk family.
+func TestRenameStateSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_state_")
+	seedCards(t, s, sweepCards, func(*native.Issue) {})
+
+	probe.watch()
+	touched, err := s.RenameState(native.StateReady, "queued")
+	if err != nil {
+		t.Fatalf("RenameState touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("RenameState touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// DeleteState drives migrateState behind an extra listAll of its own.
+func TestDeleteStateSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_statedel_")
+	seedCards(t, s, sweepCards, func(*native.Issue) {})
+
+	probe.watch()
+	touched, err := s.DeleteState(native.StateReady, native.StateInProgress)
+	if err != nil {
+		t.Fatalf("DeleteState touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("DeleteState touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// RenameField drives applyFieldRewrite, the third walk family.
+func TestRenameFieldSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_field_")
+	if err := s.AddField(native.Field{Name: "sprint", Type: native.FieldText}); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+	seedCards(t, s, sweepCards, func(iss *native.Issue) {
+		iss.Fields = map[string]any{"sprint": "s1"}
+	})
+
+	probe.watch()
+	touched, err := s.RenameField("sprint", "iteration")
+	if err != nil {
+		t.Fatalf("RenameField touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("RenameField touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// DeleteField is applyFieldRewrite's second entry point.
+func TestDeleteFieldSweepBudgetsEachCallSeparately(t *testing.T) {
+	s, probe := sweepBudgetStore(t, "sweepbudget_fielddel_")
+	if err := s.AddField(native.Field{Name: "sprint", Type: native.FieldText}); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+	seedCards(t, s, sweepCards, func(iss *native.Issue) {
+		iss.Fields = map[string]any{"sprint": "s1"}
+	})
+
+	probe.watch()
+	touched, err := s.DeleteField("sprint")
+	if err != nil {
+		t.Fatalf("DeleteField touched %d/%d cards and failed: %v", touched, sweepCards, err)
+	}
+	if touched != sweepCards {
+		t.Fatalf("DeleteField touched %d cards, want %d", touched, sweepCards)
+	}
+	probe.assertPerCallBudget(t, sweepCards)
+}
+
+// TestSweepErrorNamesItsProgress asserts a cascade that fails reports the
+// operation and how far it got, not a bare driver error: a cascade is a
+// partial write with no rollback, so an operator who cannot name the boundary
+// cannot finish it by hand. Runs against an unreachable server, so the read
+// fails for certain and no harness is needed.
+func TestSweepErrorNamesItsProgress(t *testing.T) {
+	client, err := mongo.Connect(options.Client().
+		ApplyURI("mongodb://127.0.0.1:1/").
+		SetServerSelectionTimeout(200 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		c, cc := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cc()
+		_ = client.Disconnect(c)
+	})
+	s := New(client.Database("unreachable"), "t1")
+
+	touched, err := s.RenameLabel("old", "new")
+	if err == nil {
+		t.Fatal("expected the cascade to fail against an unreachable server")
+	}
+	if touched != 0 {
+		t.Fatalf("touched=%d, want 0 (the read never returned)", touched)
+	}
+	for _, want := range []string{"label_rename", "0 card(s)", "read the board"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error does not report %q: %v", want, err)
+		}
+	}
+}

--- a/pkg/dsl/ir/expand_groups.go
+++ b/pkg/dsl/ir/expand_groups.go
@@ -72,15 +72,7 @@ func (c *compiler) instantiateGroup(g *ast.GroupDecl, internal map[string]bool, 
 		}
 		return name // terminals (done/fail) and external refs stay as-is
 	}
-	subst := func(s string) string {
-		if s == "" || !strings.Contains(s, "{{params.") {
-			return s
-		}
-		for k, v := range binds {
-			s = strings.ReplaceAll(s, "{{params."+k+"}}", v)
-		}
-		return s
-	}
+	subst := func(s string) string { return substParams(s, binds) }
 
 	for _, a := range g.Agents {
 		na := *a
@@ -151,6 +143,46 @@ func (c *compiler) instantiateGroup(g *ast.GroupDecl, internal map[string]bool, 
 		}
 		wf.Edges = append(wf.Edges, ne)
 	}
+}
+
+// substParams replaces every `{{params.<key>}}` marker in s with its bound
+// value, in ONE pass over s: the scan walks the source once and a
+// substituted value is never re-examined, so a bound value that reads like
+// another parameter reference is inserted verbatim. That also makes the
+// result independent of the bind map's iteration order.
+//
+// A `{{params.x}}` with no binding — and any other `{{...}}` namespace —
+// is copied through unchanged, leaving the reference validator to report
+// it. An unterminated `{{` ends the scan with the remainder copied as-is.
+func substParams(s string, binds map[string]string) string {
+	if s == "" || !strings.Contains(s, "{{params.") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if i+1 < len(s) && s[i] == '{' && s[i+1] == '{' {
+			end := strings.Index(s[i:], "}}")
+			if end == -1 {
+				b.WriteString(s[i:])
+				return b.String()
+			}
+			raw := s[i : i+end+2]
+			if key, ok := strings.CutPrefix(raw[2:len(raw)-2], "params."); ok {
+				if v, bound := binds[key]; bound {
+					b.WriteString(v)
+					i += end + 2
+					continue
+				}
+			}
+			b.WriteString(raw)
+			i += end + 2
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
 }
 
 // groupNodeNames returns the set of node names declared inside a group.

--- a/pkg/dsl/ir/expand_groups_params_test.go
+++ b/pkg/dsl/ir/expand_groups_params_test.go
@@ -1,0 +1,139 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+)
+
+// cascadeGroupSrc binds `a` to text that itself reads like a reference to
+// `b`. Only `{{params.a}}` appears in the group body, so a single-pass
+// expansion can only ever produce the literal `{{params.b}}` — a second
+// pass over the substituted text is what turns it into `X`.
+const cascadeGroupSrc = `
+schema empty:
+  ok: bool
+
+group blk(a, b):
+  tool t:
+    command: "echo {{params.a}}"
+    output: empty
+
+tool start:
+  command: "true"
+  output: empty
+
+use blk as g1 with { a: "{{params.b}}", b: "X" }
+
+workflow w:
+  entry: start
+  start -> g1.t
+  g1.t -> done
+`
+
+// expandedCommand compiles src and returns the command of the expanded
+// group node `name`, reading the AST the compiler instantiated (the
+// substitution's own output, independent of any downstream diagnostic the
+// residual text may raise).
+func expandedCommand(t *testing.T, src, name string) string {
+	t.Helper()
+	file := parseFile(t, src)
+	Compile(file)
+	for _, tl := range file.Tools {
+		if tl.Name == name {
+			return tl.Command
+		}
+	}
+	t.Fatalf("expanded tool %q not found; tools=%v", name, toolNames(file))
+	return ""
+}
+
+func toolNames(file *ast.File) []string {
+	var names []string
+	for _, tl := range file.Tools {
+		names = append(names, tl.Name)
+	}
+	return names
+}
+
+// TestGroupParamSubstitutionIsSinglePass asserts a bound value is never
+// itself scanned for `{{params.*}}`: substituting `{{params.a}}` yields the
+// bound text verbatim, even when that text reads like another parameter
+// reference.
+func TestGroupParamSubstitutionIsSinglePass(t *testing.T) {
+	got := expandedCommand(t, cascadeGroupSrc, "g1.t")
+	if want := "echo {{params.b}}"; got != want {
+		t.Fatalf("bound value was re-expanded: got %q, want %q", got, want)
+	}
+}
+
+// TestGroupParamSubstitutionIsDeterministic asserts the expansion of one
+// source is byte-identical across repeated compiles — the bind map's
+// iteration order must not reach the output.
+func TestGroupParamSubstitutionIsDeterministic(t *testing.T) {
+	first := expandedCommand(t, cascadeGroupSrc, "g1.t")
+	for i := 1; i < 50; i++ {
+		if got := expandedCommand(t, cascadeGroupSrc, "g1.t"); got != first {
+			t.Fatalf("compile %d differs: got %q, first compile got %q", i, got, first)
+		}
+	}
+}
+
+// TestGroupParamUnboundStaysLiteral asserts a `{{params.x}}` with no
+// binding survives verbatim, so the reference validator can report it.
+func TestGroupParamUnboundStaysLiteral(t *testing.T) {
+	src := `
+schema empty:
+  ok: bool
+
+group blk(a):
+  tool t:
+    command: "echo {{params.a}} {{params.ghost}}"
+    output: empty
+
+tool start:
+  command: "true"
+  output: empty
+
+use blk as g1 with { a: "alpha" }
+
+workflow w:
+  entry: start
+  start -> g1.t
+  g1.t -> done
+`
+	got := expandedCommand(t, src, "g1.t")
+	if want := "echo alpha {{params.ghost}}"; got != want {
+		t.Fatalf("unbound param not left literal: got %q, want %q", got, want)
+	}
+}
+
+// TestGroupParamSubstitutionKeepsUnterminatedTail asserts a malformed
+// `{{` with no closing fence is copied through unchanged rather than
+// truncating the rest of the value.
+func TestGroupParamSubstitutionKeepsUnterminatedTail(t *testing.T) {
+	src := `
+schema empty:
+  ok: bool
+
+group blk(a):
+  tool t:
+    command: "echo {{params.a}} tail {{ oops"
+    output: empty
+
+tool start:
+  command: "true"
+  output: empty
+
+use blk as g1 with { a: "alpha" }
+
+workflow w:
+  entry: start
+  start -> g1.t
+  g1.t -> done
+`
+	got := expandedCommand(t, src, "g1.t")
+	if want := "echo alpha tail {{ oops"; got != want {
+		t.Fatalf("unterminated template tail lost: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Two commits, one per ticket (#879, #883). No existing `pkg/dispatcher/boardmongo/*_test.go` touched — the whole test surface is one new file — so this composes with PR #880, which rewrites those budgets and fixtures.

## #879 — `{{params.*}}` expansion was a `ReplaceAll` cascade over a map
`pkg/dsl/ir/expand_groups.go` looped `for k, v := range binds { s = strings.ReplaceAll(s, "{{params."+k+"}}", v) }` — two defects in one line, both reproduced: with `a = "{{params.b}}"`, `b = "X"`, expanding `{{params.a}}` produced `echo X` instead of the literal `echo {{params.b}}`; and Go's random map order decided which value won, the determinism test catching the flip on the **second** compile of the same source.
Fix: a package-level `substParams` that walks the source ONCE — on `{{` it finds the closing `}}`, looks the key up, writes the bound value, and resumes AFTER the placeholder, so a substituted value is never re-examined. Unbound `{{params.x}}` and every other namespace are copied verbatim for the reference validator to report; an unterminated `{{` copies the remainder as-is. Same shape as `resolveTemplateWith`, read rather than imported across the layer boundary.
Red: `bound value was re-expanded: got "echo X", want "echo {{params.b}}"` and `compile 2 differs: got "echo {{params.b}}", first compile got "echo X"`. Tests exercise the real `ir.Compile` path and read the AST the compiler instantiated: single-pass, deterministic over 50 compiles, unbound stays literal, unterminated tail preserved.
**Correction to the ticket's impact claim** (mine, filed from the earlier PR): #879 said the workflow hash could differ for an unchanged file. It cannot — `computeWorkflowHash` hashes the SOURCE bytes plus the bundle prompt/preset dirs, and its `*ast.File` parameter is deliberately unused, so `iterion resume` change detection was never affected. The non-determinism was real in the **compiled IR** (node commands, edge `when` exprs, loop caps, router `over:`, human `review_url`, compute exprs) and therefore in the executed graph, `iterion diagram`, `unparse` and the studio's compiled view.

## #883 — `opTimeout` (10 s) bounded a whole O(N) sweep, not one call
Seven entry points, not the five the ticket named: `RenameLabel` / `MergeLabels` / `DeleteLabel` / `RenameState` / `DeleteState` **and `RenameField` / `DeleteField`** took one `ctxWithTimeout()` at entry and threaded it through `listAll` + a `replace` per card. Reproduced at N=120 with a shrunk budget — the operator-visible consequence on all of them: `RenameLabel touched 29/120 cards in 100ms and failed: … calculated server-side timeout (0 ms)`; at 400 cards, 108–139/400.
**The committed guard reads the wire instead of racing a stopwatch.** Two earlier oracles (shrink `opTimeout`; derive it from a measured walk) went red on the FIXED code under full-suite load — a single round-trip spiked past 200 ms / 565 ms against a ~2–5 ms mean. Host noise, not a defect, but a flaky test. So the oracle is now a driver `CommandMonitor` recording the `maxTimeMS` each per-card `update` carries: a shared deadline **burns down**, a per-round-trip one does not. Deterministic and spike-immune (a spike can only widen the burn-down, never fake a narrow spread), and `opTimeout` stays a `const`. Red on the unfixed code for all seven: `per-card write deadlines span 2033 ms over 400 writes (7960..9993): the walk shares ONE budget and burns it down — a board large enough exhausts it mid-cascade and half-applies`. Green: under 2 ms spread.
Fix: `sweepCtx()` (the cascade parent, deliberately deadline-free, with the reason in its doc comment so nobody "fixes" it back), `callCtx(parent)` + four thin wrappers giving one fresh `opTimeout` per round-trip while keeping the sweep's cancellation, `persistBoard` deriving its own per-round-trip budget, and `cascadeErrf` so every cascade exit reports the operation, the count already rewritten and the card it stopped at — including the two paths that returned a bare error before: `boardmongo: state migration stopped after 310 card(s): could not record the event for native:e17c940e…`.
**Why not `bulkWrite`** (asked in the ticket): `applyLabelRewrite` is CAS-guarded per card with a re-read-and-re-transform on a miss — the guard that stops a sweep from resurrecting a one-shot label the trigger spine atomically consumed. A bulk `matchedCount` is an aggregate and cannot say WHICH card lost the CAS, so it cannot drive the retry; each touched card also emits its own sequenced event, so the walk costs a round-trip per card regardless.
Class table in the commit body: the 7 hits fixed; `AdjustLabels`, `ClaimForLaunch`, `ConsumeLabels` verified single-document as the ticket asked; the multi-document READ paths left (a timeout yields an error, never a partial write); `ClaimDue` bounded by its limit with claimed rows returned on error.

## Proof
`go build`, `go vet`, `task lint` (0 issues), `go test ./pkg/... -count=1` against a real replica set (boardmongo 111 s), `-race` on `pkg/dispatcher/...` and `pkg/dsl/...` (boardmongo 203 s).

## Found on the way (filed separately)
`boardmongo.Store.AggregateLabels` returns `[]native.LabelUsage` with no error, so a transient Mongo failure renders the board's label vocabulary as "no labels exist" rather than "could not be read", silently, on every consumer.

Closes #879, #883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
