### PR TITLE
feat(modernize): a lot QUALIFIES a moved reference before asking to re-record it

### DIFF
--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -66,7 +66,13 @@ prompt campaign_system:
   2. Never touch the oracle. The behavioural net that judges this work is
      off-limits: not its references, not its comparators, not its fixtures. A
      reference that moves is a REGRESSION YOU CAUSED until proven otherwise,
-     and the proof is not yours to write.
+     and the proof is not yours to write. QUALIFYING it is: a behaviour
+     someone chose is repaired in the product and its reference stays; an
+     artefact nobody specified (the order of ties, an id, a timestamp) is
+     made deterministic in the product, and the references that move then
+     are still announced. ONE written request per red episode, naming
+     exactly what the report shows, classified path by path inside it. See
+     `modernize-lots`.
   3. Never weaken the gate. Skipping a check, loosening a version constraint to
      dodge a conflict, or excluding a failing module are all ways of passing
      without having done the work.

--- a/bots/modernize/skills/modernize-lots.md
+++ b/bots/modernize/skills/modernize-lots.md
@@ -122,6 +122,59 @@ information. When a reference moves, exactly one of two things is true:
 
 Both are stop conditions for this bot. Neither is yours to resolve.
 
+### Qualify the divergence before you ask for anything
+
+Rewriting is not yours. **Naming what moved, and why, is** — and doing it
+first changes what you ask for, because two of the three readings are
+repaired in the PRODUCT: one of them with no reference touched at all, the
+other by moving them once, deliberately, instead of once per environment:
+
+- **A betrayed intention.** The reference carries a behaviour someone chose,
+  often said in as many words in the corpus beside it, and your change broke
+  it: an account that used to sign in stops signing in because the new engine
+  compares identifiers case-sensitively. The gesture is in the product —
+  normalise the identifier — and **the reference does not move**. Asking to
+  re-record it is asking to make the loss official.
+- **An unspecified artefact.** The reference froze a detail nobody chose:
+  the order of ties no `ORDER BY` decides, an auto-assigned id, a timestamp,
+  a hash of an iteration order. The gesture is to make the product
+  **deterministic** — and the references that move once you do are still
+  announced, in a written request, and re-recorded ONE time under a cause
+  that names the determinism. Both environments agree afterwards, from one
+  reference set: never one per engine, per platform, per environment, since
+  a second set doubles the net's maintenance and hides the non-determinism
+  instead of removing it.
+- **Genuinely ambiguous.** Both readings defend themselves — an accent-aware
+  sort whose order follows the schema's collation, a locale-dependent format.
+  Look for the **overlay that reproduces the wanted behaviour** (declare the
+  collation, a comparator in the product, a locale the deployed application
+  carries), and try it — but only where it would be present in production,
+  never in the launcher the judge invokes (see *the environment the judge
+  looks through*, below: a fix that lives only there is the same cheat under
+  another name). Only when no such overlay holds does this become a request,
+  and then the request carries the classification and the overlay you tried.
+
+An improvement to the tree beats a re-recording of the snapshot every time
+the snapshot only froze an accident.
+
+**One request per red episode, classified path by path inside it.** The
+party that consumes a request re-records and compares the observed diff to
+your announced `expected_paths` **as a whole** — so splitting one red oracle
+into several requests makes every one of them mismatch, and a refused
+request is not retried. Announce exactly what the red report shows, and put
+the classification in the cause, path by path: which paths moved because the
+product became deterministic, which you closed in the product instead, which
+you are not asking for at all. If, after everything the classification let
+you close, paths of two different classes are still moving, that is a stop —
+say so and block, rather than asking for a mixture nobody can act on. The
+grain that can ever be acted is the CLASS, never the path: a request is
+acted whole or stays pending, so two classes moving at the same time are
+one impossible request, not two.
+(Measured: one lot filed seventeen paths in a single block across three
+distinct causes — an order artefact, a collation ambiguity, and a betrayed
+login behaviour that had no business being re-recorded at all. The cure is
+the classification inside the request, not more requests.)
+
 The second case has a written next step, and it IS yours to write even though
 it is not yours to resolve. When the move is the behaviour change the lot
 intends — and the lot's contract says `rebaseline_allowed: true` — announce it

--- a/bots/modernize_rebaseline_doctrine_test.go
+++ b/bots/modernize_rebaseline_doctrine_test.go
@@ -1,0 +1,113 @@
+package bots
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRebaselineDoctrineTeachesQualification pins the doctrine a lot reads
+// before it asks for a re-baseline. It is a documentary test and claims
+// nothing about a run: what it prevents is a rewrite of these two files
+// that DROPS one of the three readings or MOVES the guidance out of the
+// section that gives it its meaning — which is how guidance decays. It
+// cannot catch a rewrite that keeps the phrases and inverts the advice;
+// only a reader does. Whitespace is normalised first, so a reflow of the
+// same words is not a failure.
+//
+// The gap it closes was measured: a lot met seventeen moved references,
+// filed ONE request for all of them, and blocked. Three causes were hiding
+// inside — an order no ORDER BY decided (an artefact: make the product
+// deterministic, re-record once), a collation-dependent sort (ambiguous: an
+// overlay reproduces the wanted order), and a login that stopped working
+// under a case-sensitive engine (a betrayed intention: repair the product,
+// the reference stays). Acting the request as filed would have recorded the
+// lost login as contract and created a second reference set per engine.
+func TestRebaselineDoctrineTeachesQualification(t *testing.T) {
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Whitespace-insensitive: a reflow of the same words must not fail, and
+	// a phrase that straddles a line break must still be found.
+	flat := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+	read := func(rel string) string {
+		b, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		return string(b)
+	}
+	// section returns the body of a markdown heading, so guidance that is
+	// moved out of the section giving it its meaning reads as lost — the
+	// qualification is doctrine of "Never touch the oracle", not a fifth way
+	// a lot goes green.
+	section := func(doc, heading string) string {
+		i := strings.Index(doc, heading)
+		if i < 0 {
+			t.Fatalf("heading %q not found", heading)
+		}
+		body := doc[i+len(heading):]
+		if j := strings.Index(body, "\n## "); j > 0 {
+			body = body[:j]
+		}
+		return flat(body)
+	}
+
+	skill := read("bots/modernize/skills/modernize-lots.md")
+	oracle := section(skill, "\n## Never touch the oracle\n")
+	for _, want := range []struct{ what, phrase string }{
+		{"the qualification step itself", "Qualify the divergence before you ask"},
+		{"the betrayed-intention class", "betrayed intention"},
+		{"the artefact class", "unspecified artefact"},
+		{"the ambiguous class", "ambiguous"},
+		{"making the product deterministic", "deterministic"},
+		{"the overlay for the ambiguous class", "overlay"},
+		{"the one-reference-set rule", "one reference set"},
+		{"its teeth (the second set is what is refused)", "never one per engine, per platform, per environment"},
+		{"that a repaired intention keeps its reference", "the reference does not move"},
+		{"that a determinism fix is still announced", "still announced, in a written request"},
+		{"one request per red episode, not one per path", "One request per red episode"},
+		{"why splitting is refused", "makes every one of them mismatch"},
+		{"the stop when two classes remain", "that is a stop"},
+		{"that the actable grain is the class, not the path", "grain that can ever be acted is the CLASS, never the path"},
+	} {
+		if !strings.Contains(oracle, want.phrase) {
+			t.Errorf("the \"Never touch the oracle\" doctrine no longer teaches %s (looked for %q)", want.what, want.phrase)
+		}
+	}
+
+	// The prompt is what an agent reads when it never opens the skill: the
+	// pointer and the two product-side gestures must survive there too.
+	bot := read("bots/modernize/main.bot")
+	system := bot
+	if i := strings.Index(bot, "prompt campaign_system:"); i >= 0 {
+		system = bot[i:]
+		if j := strings.Index(system, "\nprompt "); j > 0 {
+			system = system[:j]
+		}
+	} else {
+		t.Fatal("prompt campaign_system not found in bots/modernize/main.bot")
+	}
+	system = flat(system)
+	for _, want := range []struct{ what, phrase string }{
+		{"the qualification duty", "QUALIFYING it is"},
+		{"the product-side repair", "repaired in the product and its reference stays"},
+		{"the determinism gesture", "made deterministic in the product"},
+		{"that a determinism fix is still announced", "are still announced"},
+		{"one request per red episode", "ONE written request per red episode"},
+		{"the per-path classification inside it", "classified path by path inside it"},
+		{"the pointer to the doctrine", "modernize-lots"},
+	} {
+		if !strings.Contains(system, want.phrase) {
+			t.Errorf("campaign_system no longer carries %s (looked for %q)", want.what, want.phrase)
+		}
+	}
+	// The rule it refines must still be there: qualifying never licenses
+	// editing the net.
+	if !strings.Contains(system, "Never touch the oracle") ||
+		!strings.Contains(system, "REGRESSION YOU CAUSED") {
+		t.Error("campaign_system lost the rule qualification refines: the net stays off-limits")
+	}
+}


### PR DESCRIPTION
The net stays off-limits and a moved reference stays a regression until
proven otherwise; what the doctrine did not say is that naming WHICH of
three things moved is the lot's job, and that the gesture differs:

- a betrayed intention (an account that signed in stops signing in under a
  case-sensitive engine) — repair the product, the reference does not move;
  asking to re-record it makes the loss official;
- an unspecified artefact (the order of ties no ORDER BY decides, an id, a
  timestamp) — make the product deterministic; the references that move
  then are still announced and re-recorded ONE time, under a cause that
  names the determinism. One reference set afterwards, never one per engine
  or per environment: a second set doubles the net's maintenance and hides
  the non-determinism instead of removing it;
- genuinely ambiguous (a sort whose order follows the schema's collation) —
  look for the overlay that reproduces the wanted behaviour, and only where
  it would be present in production, never in the launcher the judge
  invokes; only then a request carrying the classification.

The request stays ONE per red episode, naming exactly what the report
shows, with the classification path by path inside it: the consuming side
re-records and compares the observed diff AS A WHOLE (bots/campaign
main.bot: `observed == expected` over a repo-wide status, a refused request
never retried), so splitting a red oracle into several requests would make
every one of them mismatch — permanently. When paths of two classes are
still moving after everything the classification let the lot close, that is
a stop, not two requests.

Measured: one lot filed seventeen paths in a single block across those
three causes and blocked; acting it as filed would have recorded a lost
login as contract and created a second reference set per engine.

The prompt carries the duty and the pointer for an agent that never opens
the skill. The test is documentary and says so: it pins the three readings,
the announcement of a determinism fix, the one-request rule and the refusal
of a second reference set, inside the section that gives them their meaning
— whitespace-normalised, so a reflow is not a failure. Mutants red: each
class dropped, the one-set rule dropped OR inverted, "still announced"
dropped, one-request-per-path restored, the subsection moved under another
heading, the prompt duty dropped. A reflow at 68 columns survives, as it
must. Full `go test ./bots/` green.

An earlier draft of this change said "one request per path, never a batch";
an adversarial pass on the consuming side proved that would have made every
request unactable. The rule is one request, classified inside.