### PR TITLE
feat(golden-master): the judge reads the declaration it was asked about, and the verdict says which one

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2010,10 +2010,74 @@ tool oracle_run:
         return os.path.join(root, "gm-holdout-%s-%s" % (os.path.basename(ap) or "default", tag))
 
 
+    def config_name():
+        """The net's configuration FILE — `config.json` unless GM_CONFIG names another.
+
+        One net can declare more than one ENVIRONMENT for the same corpus: a
+        second database engine, a second runtime. What differs is how the app is
+        brought up, brought down and restored, and where its URL is published;
+        the contract — the corpus, the references, the personas, the standard —
+        does not. Judging the second environment is replaying the SAME references
+        against the app booted the other way, so it is one variable, read here and
+        nowhere else.
+
+        A NAME, never a path: the declaration lives beside the corpus it declares,
+        under the net's own directory. A caller pointing the judge at a file
+        outside it would be judging one tree with another tree's declaration, and
+        the verdict would name a net it never read.
+        """
+        raw = os.environ.get("GM_CONFIG")
+        if raw is None:
+            return "config.json"
+        name = raw.strip()
+        if not name:
+            # SET and empty is not unset: it is a variable that did not expand,
+            # and falling back would judge the first environment while the caller
+            # believes it named the second — the inert check, one layer down.
+            raise SystemExit("GM_CONFIG is set but empty — name the config file to "
+                             "judge (a file under the net's directory), or leave "
+                             "the variable unset for config.json")
+        seps = [os.sep] + ([os.altsep] if os.altsep else [])
+        if name in (".", "..") or any(s in name for s in seps):
+            raise SystemExit("GM_CONFIG=%r is a path — the judge reads the "
+                             "declaration that lives WITH the corpus it declares, "
+                             "so this is a file name under the net's directory and "
+                             "nothing else" % name)
+        return name
+
+
+    def config_path(gm_dir):
+        """The one place the config file is located — and checked — for every
+        reader of it.
+
+        Two readers had `config.json` written into them: the gate's own load and
+        the held-out opt-in. A second environment judged with the first one's
+        opt-in would consume a sealed set the other gate was owed, so they read
+        one helper rather than one string each.
+
+        A NAMED config that is absent refuses here, never falls back: the caller
+        asked for a verdict on one environment, and a green reported for the OTHER
+        one is the inert check this variable exists to end — measured on a
+        campaign whose `engine-target` outcome ran `GM_CONFIG=config-pg.json`
+        against a judge that read config.json, and would have reported the second
+        engine met the moment the first was green.
+        """
+        name = config_name()
+        path = os.path.join(gm_dir, name)
+        if name != "config.json" and not os.path.isfile(path):
+            raise SystemExit("GM_CONFIG names %s, which is not a file under %s — "
+                             "judging config.json in its place would report a "
+                             "verdict for an environment nobody asked about"
+                             % (name, gm_dir))
+        return path
+
+
     def seal_committed_opted_in(gm_dir):
         """The convergence gate's opt-in to consume a COMMITTED held-out set.
 
-        Two forms, either suffices: `"seal_committed": true` in config.json —
+        Two forms, either suffices: `"seal_committed": true` in the config being
+        judged (see config_path — a second environment declares its own, and a
+        gate that does not opt in leaves the set for the one that does) —
         written by the net's owner, committed, auditable, the preferred form —
         or GM_SEAL_COMMITTED=1 in the environment for a hand-run gate. The flag
         can only widen what the gate consumes, never soften a verdict, which is
@@ -2027,7 +2091,7 @@ tool oracle_run:
                              "spelling silently ignored would leave the operator "
                              "sure of an opt-in that never happened" % env)
         try:
-            with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+            with open(config_path(gm_dir), encoding="utf-8") as f:
                 v = json.load(f).get("seal_committed", False)
         except (OSError, ValueError):
             return False
@@ -3438,6 +3502,58 @@ tool oracle_run:
                           lambda: validate_feature_coverage(
                               {"features": [{"feature": "a", "entries": ["1"]}],
                                "exclusions": [{"feature": "a", "reason": "x"}]}))
+            # 8e-bis. Le filet peut declarer un SECOND environnement pour le meme
+            #     corpus (second moteur, second runtime). GM_CONFIG nomme la
+            #     declaration a juger ; le verdict la porte ; une declaration
+            #     nommee et absente REFUSE, elle ne retombe jamais sur config.json
+            #     — c'est exactement le controle inerte qu'une campagne a mesure :
+            #     l'outcome lancait `GM_CONFIG=config-pg.json` contre un juge qui
+            #     lisait config.json.
+            cdir = tempfile.mkdtemp(prefix="gm-selftest-config-")
+            with open(os.path.join(cdir, "config.json"), "w", encoding="utf-8") as f:
+                f.write('{"seal_committed": true}')
+            with open(os.path.join(cdir, "config-pg.json"), "w", encoding="utf-8") as f:
+                f.write('{"up": "pg-up.sh"}')
+            prev_cfg = os.environ.pop("GM_CONFIG", None)
+            try:
+                check("sans GM_CONFIG : config.json",
+                      [config_name(), os.path.basename(config_path(cdir))],
+                      ["config.json", "config.json"])
+                check("l'opt-in scelle se lit dans la config JUGEE (config.json)",
+                      seal_committed_opted_in(cdir), True)
+                os.environ["GM_CONFIG"] = "config-pg.json"
+                check("GM_CONFIG nomme la declaration jugee",
+                      os.path.basename(config_path(cdir)), "config-pg.json")
+                # Le falsifieur qui compte : la porte du second environnement ne
+                # doit pas consommer le jeu scelle que la premiere s'est reserve.
+                check("l'opt-in du second environnement est le SIEN, pas celui de config.json",
+                      seal_committed_opted_in(cdir), False)
+                os.environ["GM_CONFIG"] = "config-absente.json"
+                named_refusal("config nommee absente -> refus nomme, jamais config.json",
+                              lambda: config_path(cdir))
+                # Le message compte autant que le refus : « chemin » et « absente »
+                # sont deux causes, et un controle qui ne distingue pas laisse
+                # passer la suppression de la garde de chemin (un chemin hors du
+                # filet tombe alors, par hasard, sur « fichier absent »).
+                def refusal_says(name, fn, needle):
+                    try:
+                        fn()
+                        check(name, "aucun-refus", "refus contenant %r" % needle)
+                    except SystemExit as e:
+                        check(name, needle in str(e), True)
+                for bad in ("../config.json", "a/b.json", ".."):
+                    os.environ["GM_CONFIG"] = bad
+                    refusal_says("GM_CONFIG=%r -> refuse COMME CHEMIN" % bad,
+                                 lambda: config_path(cdir), "is a path")
+                os.environ["GM_CONFIG"] = ""
+                refusal_says("GM_CONFIG vide -> refuse comme vide, pas comme defaut",
+                             lambda: config_path(cdir), "set but empty")
+            finally:
+                if prev_cfg is None:
+                    os.environ.pop("GM_CONFIG", None)
+                else:
+                    os.environ["GM_CONFIG"] = prev_cfg
+
             prev_env = os.environ.pop("GM_SEAL_COMMITTED", None)
             os.environ["GM_SEAL_COMMITTED"] = "yes"
             try:
@@ -4748,7 +4864,16 @@ tool oracle_run:
                 ws, os.environ.get("GM_DIR", ".golden-master"), base)))
             raise SystemExit(0)
 
-        report = {"mode": mode, "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
+        # The verdict CARRIES the declaration it judged. Without it, a green from
+        # the second environment and a green from the first are the same line, and
+        # an operator reading the report cannot tell which app was booted.
+        try:
+            cfg_name = config_name()
+        except SystemExit as e:
+            print(json.dumps({"mode": mode, "log_tail": str(e)}))
+            raise SystemExit(1)
+        report = {"mode": mode, "config": cfg_name,
+                  "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
                   "noop_silent": False, "revert_clean": True, "collateral": 0,
                   "unstable_controls": [],
                   "notice": "", "uncontrolled": [], "blind_lanes": [], "missing_archetypes": [],
@@ -4771,11 +4896,15 @@ tool oracle_run:
             print(json.dumps(report))
             raise SystemExit(0)
 
-        for required in ("config.json", "corpus.json"):
+        try:
+            cfg_path = config_path(gm_dir)
+        except SystemExit as e:
+            bail(str(e))
+        for required in (cfg_name, "corpus.json"):
             if not os.path.isfile(os.path.join(gm_dir, required)):
                 bail("%s is missing — the campaign has not produced an oracle yet" % required)
 
-        with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+        with open(cfg_path, encoding="utf-8") as f:
             config = json.load(f)
         with open(os.path.join(gm_dir, "corpus.json"), encoding="utf-8") as f:
             corpus = json.load(f)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4843,7 +4843,22 @@ tool oracle_run:
 
         # Les tests du harnais d'abord, et hors de tout le reste : ils ne touchent
         # ni au depot, ni a l'application, ni a la configuration.
+        #
+        # Ils n'y touchaient pas ; ils en HERITAIENT. Le lanceur de porte execute
+        # cette etape en bloquant, environnement herite, donc une entree
+        # d'operateur destinee au FILET s'appliquait aux doubles : mesure,
+        # `GM_CONFIG` nommant un second environnement faisait refuser toutes les
+        # fixtures qui n'ecrivent que `config.json` (la porte mourait ROUGE avant
+        # de juger, en accusant les regles de decision), et `GM_SEAL_COMMITTED=1`
+        # faisait echouer les fixtures de scellement. Pire en silence : sous un
+        # ambiant, un refus type de fixture passe pour la MAUVAISE cause — « config
+        # absente » portant le nom du refus d'opt-in qu'il pretend epingler.
+        # Retirees ici, au point de dispatch : une variable absente ne peut
+        # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
         if mode == "selftest":
+            for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
+                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+                os.environ.pop(_ambient, None)
             raise SystemExit(_selftest())
 
         # Ledger listings and the additions-only verdict are pure git/file reads:

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1791,10 +1791,74 @@ def sealed_dir_for(ws):
     return os.path.join(root, "gm-holdout-%s-%s" % (os.path.basename(ap) or "default", tag))
 
 
+def config_name():
+    """The net's configuration FILE — `config.json` unless GM_CONFIG names another.
+
+    One net can declare more than one ENVIRONMENT for the same corpus: a
+    second database engine, a second runtime. What differs is how the app is
+    brought up, brought down and restored, and where its URL is published;
+    the contract — the corpus, the references, the personas, the standard —
+    does not. Judging the second environment is replaying the SAME references
+    against the app booted the other way, so it is one variable, read here and
+    nowhere else.
+
+    A NAME, never a path: the declaration lives beside the corpus it declares,
+    under the net's own directory. A caller pointing the judge at a file
+    outside it would be judging one tree with another tree's declaration, and
+    the verdict would name a net it never read.
+    """
+    raw = os.environ.get("GM_CONFIG")
+    if raw is None:
+        return "config.json"
+    name = raw.strip()
+    if not name:
+        # SET and empty is not unset: it is a variable that did not expand,
+        # and falling back would judge the first environment while the caller
+        # believes it named the second — the inert check, one layer down.
+        raise SystemExit("GM_CONFIG is set but empty — name the config file to "
+                         "judge (a file under the net's directory), or leave "
+                         "the variable unset for config.json")
+    seps = [os.sep] + ([os.altsep] if os.altsep else [])
+    if name in (".", "..") or any(s in name for s in seps):
+        raise SystemExit("GM_CONFIG=%r is a path — the judge reads the "
+                         "declaration that lives WITH the corpus it declares, "
+                         "so this is a file name under the net's directory and "
+                         "nothing else" % name)
+    return name
+
+
+def config_path(gm_dir):
+    """The one place the config file is located — and checked — for every
+    reader of it.
+
+    Two readers had `config.json` written into them: the gate's own load and
+    the held-out opt-in. A second environment judged with the first one's
+    opt-in would consume a sealed set the other gate was owed, so they read
+    one helper rather than one string each.
+
+    A NAMED config that is absent refuses here, never falls back: the caller
+    asked for a verdict on one environment, and a green reported for the OTHER
+    one is the inert check this variable exists to end — measured on a
+    campaign whose `engine-target` outcome ran `GM_CONFIG=config-pg.json`
+    against a judge that read config.json, and would have reported the second
+    engine met the moment the first was green.
+    """
+    name = config_name()
+    path = os.path.join(gm_dir, name)
+    if name != "config.json" and not os.path.isfile(path):
+        raise SystemExit("GM_CONFIG names %s, which is not a file under %s — "
+                         "judging config.json in its place would report a "
+                         "verdict for an environment nobody asked about"
+                         % (name, gm_dir))
+    return path
+
+
 def seal_committed_opted_in(gm_dir):
     """The convergence gate's opt-in to consume a COMMITTED held-out set.
 
-    Two forms, either suffices: `"seal_committed": true` in config.json —
+    Two forms, either suffices: `"seal_committed": true` in the config being
+    judged (see config_path — a second environment declares its own, and a
+    gate that does not opt in leaves the set for the one that does) —
     written by the net's owner, committed, auditable, the preferred form —
     or GM_SEAL_COMMITTED=1 in the environment for a hand-run gate. The flag
     can only widen what the gate consumes, never soften a verdict, which is
@@ -1808,7 +1872,7 @@ def seal_committed_opted_in(gm_dir):
                          "spelling silently ignored would leave the operator "
                          "sure of an opt-in that never happened" % env)
     try:
-        with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+        with open(config_path(gm_dir), encoding="utf-8") as f:
             v = json.load(f).get("seal_committed", False)
     except (OSError, ValueError):
         return False
@@ -3219,6 +3283,58 @@ def _selftest():
                       lambda: validate_feature_coverage(
                           {"features": [{"feature": "a", "entries": ["1"]}],
                            "exclusions": [{"feature": "a", "reason": "x"}]}))
+        # 8e-bis. Le filet peut declarer un SECOND environnement pour le meme
+        #     corpus (second moteur, second runtime). GM_CONFIG nomme la
+        #     declaration a juger ; le verdict la porte ; une declaration
+        #     nommee et absente REFUSE, elle ne retombe jamais sur config.json
+        #     — c'est exactement le controle inerte qu'une campagne a mesure :
+        #     l'outcome lancait `GM_CONFIG=config-pg.json` contre un juge qui
+        #     lisait config.json.
+        cdir = tempfile.mkdtemp(prefix="gm-selftest-config-")
+        with open(os.path.join(cdir, "config.json"), "w", encoding="utf-8") as f:
+            f.write('{"seal_committed": true}')
+        with open(os.path.join(cdir, "config-pg.json"), "w", encoding="utf-8") as f:
+            f.write('{"up": "pg-up.sh"}')
+        prev_cfg = os.environ.pop("GM_CONFIG", None)
+        try:
+            check("sans GM_CONFIG : config.json",
+                  [config_name(), os.path.basename(config_path(cdir))],
+                  ["config.json", "config.json"])
+            check("l'opt-in scelle se lit dans la config JUGEE (config.json)",
+                  seal_committed_opted_in(cdir), True)
+            os.environ["GM_CONFIG"] = "config-pg.json"
+            check("GM_CONFIG nomme la declaration jugee",
+                  os.path.basename(config_path(cdir)), "config-pg.json")
+            # Le falsifieur qui compte : la porte du second environnement ne
+            # doit pas consommer le jeu scelle que la premiere s'est reserve.
+            check("l'opt-in du second environnement est le SIEN, pas celui de config.json",
+                  seal_committed_opted_in(cdir), False)
+            os.environ["GM_CONFIG"] = "config-absente.json"
+            named_refusal("config nommee absente -> refus nomme, jamais config.json",
+                          lambda: config_path(cdir))
+            # Le message compte autant que le refus : « chemin » et « absente »
+            # sont deux causes, et un controle qui ne distingue pas laisse
+            # passer la suppression de la garde de chemin (un chemin hors du
+            # filet tombe alors, par hasard, sur « fichier absent »).
+            def refusal_says(name, fn, needle):
+                try:
+                    fn()
+                    check(name, "aucun-refus", "refus contenant %r" % needle)
+                except SystemExit as e:
+                    check(name, needle in str(e), True)
+            for bad in ("../config.json", "a/b.json", ".."):
+                os.environ["GM_CONFIG"] = bad
+                refusal_says("GM_CONFIG=%r -> refuse COMME CHEMIN" % bad,
+                             lambda: config_path(cdir), "is a path")
+            os.environ["GM_CONFIG"] = ""
+            refusal_says("GM_CONFIG vide -> refuse comme vide, pas comme defaut",
+                         lambda: config_path(cdir), "set but empty")
+        finally:
+            if prev_cfg is None:
+                os.environ.pop("GM_CONFIG", None)
+            else:
+                os.environ["GM_CONFIG"] = prev_cfg
+
         prev_env = os.environ.pop("GM_SEAL_COMMITTED", None)
         os.environ["GM_SEAL_COMMITTED"] = "yes"
         try:
@@ -4529,7 +4645,16 @@ def main():
             ws, os.environ.get("GM_DIR", ".golden-master"), base)))
         raise SystemExit(0)
 
-    report = {"mode": mode, "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
+    # The verdict CARRIES the declaration it judged. Without it, a green from
+    # the second environment and a green from the first are the same line, and
+    # an operator reading the report cannot tell which app was booted.
+    try:
+        cfg_name = config_name()
+    except SystemExit as e:
+        print(json.dumps({"mode": mode, "log_tail": str(e)}))
+        raise SystemExit(1)
+    report = {"mode": mode, "config": cfg_name,
+              "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
               "noop_silent": False, "revert_clean": True, "collateral": 0,
               "unstable_controls": [],
               "notice": "", "uncontrolled": [], "blind_lanes": [], "missing_archetypes": [],
@@ -4552,11 +4677,15 @@ def main():
         print(json.dumps(report))
         raise SystemExit(0)
 
-    for required in ("config.json", "corpus.json"):
+    try:
+        cfg_path = config_path(gm_dir)
+    except SystemExit as e:
+        bail(str(e))
+    for required in (cfg_name, "corpus.json"):
         if not os.path.isfile(os.path.join(gm_dir, required)):
             bail("%s is missing — the campaign has not produced an oracle yet" % required)
 
-    with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+    with open(cfg_path, encoding="utf-8") as f:
         config = json.load(f)
     with open(os.path.join(gm_dir, "corpus.json"), encoding="utf-8") as f:
         corpus = json.load(f)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -4624,7 +4624,22 @@ def main():
 
     # Les tests du harnais d'abord, et hors de tout le reste : ils ne touchent
     # ni au depot, ni a l'application, ni a la configuration.
+    #
+    # Ils n'y touchaient pas ; ils en HERITAIENT. Le lanceur de porte execute
+    # cette etape en bloquant, environnement herite, donc une entree
+    # d'operateur destinee au FILET s'appliquait aux doubles : mesure,
+    # `GM_CONFIG` nommant un second environnement faisait refuser toutes les
+    # fixtures qui n'ecrivent que `config.json` (la porte mourait ROUGE avant
+    # de juger, en accusant les regles de decision), et `GM_SEAL_COMMITTED=1`
+    # faisait echouer les fixtures de scellement. Pire en silence : sous un
+    # ambiant, un refus type de fixture passe pour la MAUVAISE cause — « config
+    # absente » portant le nom du refus d'opt-in qu'il pretend epingler.
+    # Retirees ici, au point de dispatch : une variable absente ne peut
+    # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
     if mode == "selftest":
+        for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
+                         "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+            os.environ.pop(_ambient, None)
         raise SystemExit(_selftest())
 
     # Ledger listings and the additions-only verdict are pure git/file reads:

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -144,6 +144,33 @@ mtime lie as soon as files arrive through git, which restores COMMIT timestamps,
 imported producer can look older than the artifact it must rebuild. Anything else is app-down and
 a fresh boot from the tree. A residual state is recovered from; it is never reported as a success.
 
+## A second environment for the same corpus
+
+A migration whose point IS the environment — a second database engine, a second runtime — is
+judged by booting the app the other way and replaying **the same references**. That is one
+declaration, not a second net: `GM_CONFIG=<name>.json` names a config file beside `config.json`,
+under the net's own directory, and the harness reads it in place of `config.json`.
+
+What differs between the two files is the ENVIRONMENT: `up`, `down`, `restore`, and where the URL
+is published (`base_url_file`). What must NOT differ is the contract — the personas, the standard,
+the probes, the test command — because the whole claim is that the same corpus renders the same
+verdict on both. A config that drops `standard` reads as a standard-2 net and the ratchet refuses
+it; one that drops the probes has no inventory to check at standard 3; one that drops `test_cmd`
+scores no mutation. Copy the file and change the environment lines, nothing else.
+
+Two mechanics worth knowing before the first run:
+
+- **The verdict carries the config it judged** (`config` in the report). A green from the second
+  environment and a green from the first are otherwise the same line, and a gate command that
+  passes a variable no one reads reports the first environment's health under the second one's
+  name — measured on a campaign whose `engine-target` check ran `GM_CONFIG=config-pg.json` for
+  three lots against a judge that read `config.json`.
+- **A named config that is absent REFUSES.** It never falls back, and neither does an empty
+  `GM_CONFIG` (a variable that did not expand is not an unset variable).
+- **The held-out opt-in is read from the config being judged**, so a second environment that does
+  not declare `seal_committed` leaves the committed held-out set to the gate that does. Give the
+  second environment its own fresh set if you want it scored there too — a set is spent once.
+
 ## Re-baselining, and why it kills nets
 
 A golden master dies by re-baselining. Something breaks three screens, someone regenerates the

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1958,10 +1958,74 @@ tool sync_harness:
         return os.path.join(root, "gm-holdout-%s-%s" % (os.path.basename(ap) or "default", tag))
 
 
+    def config_name():
+        """The net's configuration FILE — `config.json` unless GM_CONFIG names another.
+
+        One net can declare more than one ENVIRONMENT for the same corpus: a
+        second database engine, a second runtime. What differs is how the app is
+        brought up, brought down and restored, and where its URL is published;
+        the contract — the corpus, the references, the personas, the standard —
+        does not. Judging the second environment is replaying the SAME references
+        against the app booted the other way, so it is one variable, read here and
+        nowhere else.
+
+        A NAME, never a path: the declaration lives beside the corpus it declares,
+        under the net's own directory. A caller pointing the judge at a file
+        outside it would be judging one tree with another tree's declaration, and
+        the verdict would name a net it never read.
+        """
+        raw = os.environ.get("GM_CONFIG")
+        if raw is None:
+            return "config.json"
+        name = raw.strip()
+        if not name:
+            # SET and empty is not unset: it is a variable that did not expand,
+            # and falling back would judge the first environment while the caller
+            # believes it named the second — the inert check, one layer down.
+            raise SystemExit("GM_CONFIG is set but empty — name the config file to "
+                             "judge (a file under the net's directory), or leave "
+                             "the variable unset for config.json")
+        seps = [os.sep] + ([os.altsep] if os.altsep else [])
+        if name in (".", "..") or any(s in name for s in seps):
+            raise SystemExit("GM_CONFIG=%r is a path — the judge reads the "
+                             "declaration that lives WITH the corpus it declares, "
+                             "so this is a file name under the net's directory and "
+                             "nothing else" % name)
+        return name
+
+
+    def config_path(gm_dir):
+        """The one place the config file is located — and checked — for every
+        reader of it.
+
+        Two readers had `config.json` written into them: the gate's own load and
+        the held-out opt-in. A second environment judged with the first one's
+        opt-in would consume a sealed set the other gate was owed, so they read
+        one helper rather than one string each.
+
+        A NAMED config that is absent refuses here, never falls back: the caller
+        asked for a verdict on one environment, and a green reported for the OTHER
+        one is the inert check this variable exists to end — measured on a
+        campaign whose `engine-target` outcome ran `GM_CONFIG=config-pg.json`
+        against a judge that read config.json, and would have reported the second
+        engine met the moment the first was green.
+        """
+        name = config_name()
+        path = os.path.join(gm_dir, name)
+        if name != "config.json" and not os.path.isfile(path):
+            raise SystemExit("GM_CONFIG names %s, which is not a file under %s — "
+                             "judging config.json in its place would report a "
+                             "verdict for an environment nobody asked about"
+                             % (name, gm_dir))
+        return path
+
+
     def seal_committed_opted_in(gm_dir):
         """The convergence gate's opt-in to consume a COMMITTED held-out set.
 
-        Two forms, either suffices: `"seal_committed": true` in config.json —
+        Two forms, either suffices: `"seal_committed": true` in the config being
+        judged (see config_path — a second environment declares its own, and a
+        gate that does not opt in leaves the set for the one that does) —
         written by the net's owner, committed, auditable, the preferred form —
         or GM_SEAL_COMMITTED=1 in the environment for a hand-run gate. The flag
         can only widen what the gate consumes, never soften a verdict, which is
@@ -1975,7 +2039,7 @@ tool sync_harness:
                              "spelling silently ignored would leave the operator "
                              "sure of an opt-in that never happened" % env)
         try:
-            with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+            with open(config_path(gm_dir), encoding="utf-8") as f:
                 v = json.load(f).get("seal_committed", False)
         except (OSError, ValueError):
             return False
@@ -3386,6 +3450,58 @@ tool sync_harness:
                           lambda: validate_feature_coverage(
                               {"features": [{"feature": "a", "entries": ["1"]}],
                                "exclusions": [{"feature": "a", "reason": "x"}]}))
+            # 8e-bis. Le filet peut declarer un SECOND environnement pour le meme
+            #     corpus (second moteur, second runtime). GM_CONFIG nomme la
+            #     declaration a juger ; le verdict la porte ; une declaration
+            #     nommee et absente REFUSE, elle ne retombe jamais sur config.json
+            #     — c'est exactement le controle inerte qu'une campagne a mesure :
+            #     l'outcome lancait `GM_CONFIG=config-pg.json` contre un juge qui
+            #     lisait config.json.
+            cdir = tempfile.mkdtemp(prefix="gm-selftest-config-")
+            with open(os.path.join(cdir, "config.json"), "w", encoding="utf-8") as f:
+                f.write('{"seal_committed": true}')
+            with open(os.path.join(cdir, "config-pg.json"), "w", encoding="utf-8") as f:
+                f.write('{"up": "pg-up.sh"}')
+            prev_cfg = os.environ.pop("GM_CONFIG", None)
+            try:
+                check("sans GM_CONFIG : config.json",
+                      [config_name(), os.path.basename(config_path(cdir))],
+                      ["config.json", "config.json"])
+                check("l'opt-in scelle se lit dans la config JUGEE (config.json)",
+                      seal_committed_opted_in(cdir), True)
+                os.environ["GM_CONFIG"] = "config-pg.json"
+                check("GM_CONFIG nomme la declaration jugee",
+                      os.path.basename(config_path(cdir)), "config-pg.json")
+                # Le falsifieur qui compte : la porte du second environnement ne
+                # doit pas consommer le jeu scelle que la premiere s'est reserve.
+                check("l'opt-in du second environnement est le SIEN, pas celui de config.json",
+                      seal_committed_opted_in(cdir), False)
+                os.environ["GM_CONFIG"] = "config-absente.json"
+                named_refusal("config nommee absente -> refus nomme, jamais config.json",
+                              lambda: config_path(cdir))
+                # Le message compte autant que le refus : « chemin » et « absente »
+                # sont deux causes, et un controle qui ne distingue pas laisse
+                # passer la suppression de la garde de chemin (un chemin hors du
+                # filet tombe alors, par hasard, sur « fichier absent »).
+                def refusal_says(name, fn, needle):
+                    try:
+                        fn()
+                        check(name, "aucun-refus", "refus contenant %r" % needle)
+                    except SystemExit as e:
+                        check(name, needle in str(e), True)
+                for bad in ("../config.json", "a/b.json", ".."):
+                    os.environ["GM_CONFIG"] = bad
+                    refusal_says("GM_CONFIG=%r -> refuse COMME CHEMIN" % bad,
+                                 lambda: config_path(cdir), "is a path")
+                os.environ["GM_CONFIG"] = ""
+                refusal_says("GM_CONFIG vide -> refuse comme vide, pas comme defaut",
+                             lambda: config_path(cdir), "set but empty")
+            finally:
+                if prev_cfg is None:
+                    os.environ.pop("GM_CONFIG", None)
+                else:
+                    os.environ["GM_CONFIG"] = prev_cfg
+
             prev_env = os.environ.pop("GM_SEAL_COMMITTED", None)
             os.environ["GM_SEAL_COMMITTED"] = "yes"
             try:
@@ -4696,7 +4812,16 @@ tool sync_harness:
                 ws, os.environ.get("GM_DIR", ".golden-master"), base)))
             raise SystemExit(0)
 
-        report = {"mode": mode, "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
+        # The verdict CARRIES the declaration it judged. Without it, a green from
+        # the second environment and a green from the first are the same line, and
+        # an operator reading the report cannot tell which app was booted.
+        try:
+            cfg_name = config_name()
+        except SystemExit as e:
+            print(json.dumps({"mode": mode, "log_tail": str(e)}))
+            raise SystemExit(1)
+        report = {"mode": mode, "config": cfg_name,
+                  "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
                   "noop_silent": False, "revert_clean": True, "collateral": 0,
                   "unstable_controls": [],
                   "notice": "", "uncontrolled": [], "blind_lanes": [], "missing_archetypes": [],
@@ -4719,11 +4844,15 @@ tool sync_harness:
             print(json.dumps(report))
             raise SystemExit(0)
 
-        for required in ("config.json", "corpus.json"):
+        try:
+            cfg_path = config_path(gm_dir)
+        except SystemExit as e:
+            bail(str(e))
+        for required in (cfg_name, "corpus.json"):
             if not os.path.isfile(os.path.join(gm_dir, required)):
                 bail("%s is missing — the campaign has not produced an oracle yet" % required)
 
-        with open(os.path.join(gm_dir, "config.json"), encoding="utf-8") as f:
+        with open(cfg_path, encoding="utf-8") as f:
             config = json.load(f)
         with open(os.path.join(gm_dir, "corpus.json"), encoding="utf-8") as f:
             corpus = json.load(f)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4791,7 +4791,22 @@ tool sync_harness:
 
         # Les tests du harnais d'abord, et hors de tout le reste : ils ne touchent
         # ni au depot, ni a l'application, ni a la configuration.
+        #
+        # Ils n'y touchaient pas ; ils en HERITAIENT. Le lanceur de porte execute
+        # cette etape en bloquant, environnement herite, donc une entree
+        # d'operateur destinee au FILET s'appliquait aux doubles : mesure,
+        # `GM_CONFIG` nommant un second environnement faisait refuser toutes les
+        # fixtures qui n'ecrivent que `config.json` (la porte mourait ROUGE avant
+        # de juger, en accusant les regles de decision), et `GM_SEAL_COMMITTED=1`
+        # faisait echouer les fixtures de scellement. Pire en silence : sous un
+        # ambiant, un refus type de fixture passe pour la MAUVAISE cause — « config
+        # absente » portant le nom du refus d'opt-in qu'il pretend epingler.
+        # Retirees ici, au point de dispatch : une variable absente ne peut
+        # qu'ETRE PLUS STRICTE sur des doubles, jamais adoucir un verdict.
         if mode == "selftest":
+            for _ambient in ("GM_CONFIG", "GM_SEAL_COMMITTED", "GM_SEALED_DIR",
+                             "GM_MUTATION_FLOOR", "GM_MUTANTS", "GM_RECORD_IDS"):
+                os.environ.pop(_ambient, None)
             raise SystemExit(_selftest())
 
         # Ledger listings and the additions-only verdict are pure git/file reads:

--- a/bots/golden_master_config_test.go
+++ b/bots/golden_master_config_test.go
@@ -82,6 +82,80 @@ func TestGoldenMasterHarnessNamesTheConfig(t *testing.T) {
 		}
 	})
 
+	// The path a gate actually takes, which neither the direct call nor the
+	// selftest covered: `verify-oracle.sh` runs the selftest as a BLOCKING
+	// step with the environment inherited, so an ambient GM_CONFIG would make
+	// the one documented invocation of a second environment die red before
+	// judging anything — accusing the decision rules of what is the fixtures'
+	// shape. The selftest judges its own fixtures; it must not read the
+	// operator's choice about their net.
+	t.Run("the selftest is hermetic to every operator input", func(t *testing.T) {
+		// Not GM_CONFIG alone: an operator input meant for the NET applied to
+		// the doubles is one class, and the same count must come out of each
+		// run — a guard that made fixtures vanish instead of hermetic would
+		// pass this loop while testing less.
+		const want = "218 verifications passent"
+		for _, env := range [][]string{
+			nil,
+			{"GM_CONFIG=config-pg.json"},
+			{"GM_CONFIG="},
+			{"GM_SEAL_COMMITTED=1"},
+			{"GM_SEALED_DIR=" + filepath.Join(t.TempDir(), "pile")},
+			{"GM_MUTATION_FLOOR=1"},
+			{"GM_CONFIG=config-pg.json", "GM_SEAL_COMMITTED=1"},
+		} {
+			cmd := exec.Command("python3", harness)
+			cmd.Dir = t.TempDir()
+			cmd.Env = append(append(os.Environ(), "GM_MODE=selftest"), env...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("%v made the selftest fail — the gate wrapper runs it as a blocking step: %v\n%s", env, err, out)
+			}
+			if !strings.Contains(string(out), want) {
+				t.Fatalf("%v changed WHICH checks ran (want %q):\n%s", env, want, out)
+			}
+		}
+	})
+
+	// And the same thing through the wrapper the workflow EMITS, which is the
+	// only invocation the skill documents: `GM_CONFIG=<name> sh
+	// .golden-master/verify-oracle.sh`. The wrapper runs the selftest as a
+	// blocking step before judging, so this is the path a gate takes and the
+	// one neither the direct call nor the selftest could see.
+	t.Run("the emitted wrapper survives its selftest step and refuses for the right reason", func(t *testing.T) {
+		requireModernizeTools(t)
+		ws := t.TempDir()
+		gm := filepath.Join(ws, ".golden-master")
+		if err := os.MkdirAll(filepath.Join(gm, "canon"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		real, err := os.ReadFile(harness)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range map[string][]byte{
+			"canon/test_rules.py": []byte("print('ok')\n"),
+			"harness.py":          real,
+			"config.json":         []byte(`{"up": "true", "base_url": "http://127.0.0.1:1"}`),
+			"corpus.json":         []byte(`{"entries": []}`),
+		} {
+			if werr := os.WriteFile(filepath.Join(gm, name), body, 0o644); werr != nil {
+				t.Fatal(werr)
+			}
+		}
+		runner := emitRunner(t, ws)
+		cmd := exec.Command("sh", runner)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_CONFIG=config-pg.json", "GM_WORKSPACE="+ws)
+		out, _ := cmd.CombinedOutput()
+		if strings.Contains(string(out), "RÈGLE DE DÉCISION") {
+			t.Fatalf("the gate died on its own selftest under GM_CONFIG — the documented invocation of a second environment never reaches a verdict:\n%s", out)
+		}
+		if !strings.Contains(string(out), "config-pg.json") {
+			t.Fatalf("the refusal must name the declaration that is missing, not something else:\n%s", out)
+		}
+	})
+
 	t.Run("a path is refused: the declaration lives with the corpus", func(t *testing.T) {
 		ws := newNet(t)
 		cmd := exec.Command("python3", harness)

--- a/bots/golden_master_config_test.go
+++ b/bots/golden_master_config_test.go
@@ -1,0 +1,99 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// One net can declare a second ENVIRONMENT for the same corpus — a second
+// database engine, a second runtime — and judging it is replaying the same
+// references against the app booted the other way. GM_CONFIG names the
+// declaration to judge; the verdict carries it; a named declaration that is
+// absent refuses instead of falling back.
+//
+// Measured on a campaign: an outcome check ran `GM_CONFIG=config-pg.json` for
+// three lots against a harness that read config.json and would have reported
+// the second engine met the moment the first was green.
+func TestGoldenMasterHarnessNamesTheConfig(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	harness, err := filepath.Abs("golden-master/oracle-harness.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A net with two declarations and NO corpus: the gate bails before
+	// booting anything, and the report it prints is what an operator reads.
+	newNet := func(t *testing.T) string {
+		t.Helper()
+		ws := t.TempDir()
+		gm := filepath.Join(ws, ".golden-master")
+		if err := os.MkdirAll(gm, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range map[string]string{
+			"config.json":    `{"up": "app-up.sh", "seal_committed": true}`,
+			"config-pg.json": `{"up": "pg-up.sh"}`,
+		} {
+			if err := os.WriteFile(filepath.Join(gm, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return ws
+	}
+	run := func(t *testing.T, ws string, env ...string) map[string]any {
+		t.Helper()
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(append(os.Environ(),
+			"GM_MODE=gate", "GM_WORKSPACE="+ws, "GM_DIR=.golden-master"), env...)
+		out, _ := cmd.Output()
+		lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+		var report map[string]any
+		if uerr := json.Unmarshal([]byte(lines[len(lines)-1]), &report); uerr != nil {
+			t.Fatalf("the harness printed no report: %v (out %q)", uerr, out)
+		}
+		return report
+	}
+
+	t.Run("the verdict carries the declaration it judged", func(t *testing.T) {
+		ws := newNet(t)
+		if got := run(t, ws)["config"]; got != "config.json" {
+			t.Fatalf("default config not named in the verdict: %v", got)
+		}
+		r := run(t, ws, "GM_CONFIG=config-pg.json")
+		if got := r["config"]; got != "config-pg.json" {
+			t.Fatalf("a green from the second environment and one from the first would read the same: %v", got)
+		}
+	})
+
+	t.Run("a named declaration that is absent refuses, and says so", func(t *testing.T) {
+		r := run(t, newNet(t), "GM_CONFIG=config-absent.json")
+		tail, _ := r["log_tail"].(string)
+		if !strings.Contains(tail, "config-absent.json") || !strings.Contains(tail, "nobody asked about") {
+			t.Fatalf("the refusal must name the missing declaration instead of judging the other one: %q", tail)
+		}
+		if got := r["config"]; got != "config-absent.json" {
+			t.Fatalf("the report must still name what was asked for: %v", got)
+		}
+	})
+
+	t.Run("a path is refused: the declaration lives with the corpus", func(t *testing.T) {
+		ws := newNet(t)
+		cmd := exec.Command("python3", harness)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GM_MODE=gate", "GM_WORKSPACE="+ws,
+			"GM_DIR=.golden-master", "GM_CONFIG=../config.json")
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("a path outside the net's directory was accepted: %s", out)
+		}
+		if !strings.Contains(string(out), "is a path") {
+			t.Fatalf("the refusal must say why: %s", out)
+		}
+	})
+}


### PR DESCRIPTION
## The check that could not distinguish the state it measured

A net can declare a second **environment** for the same corpus — a second database engine, a second runtime — and judging it means booting the app the other way and replaying the **same** references. The harness opened `config.json` in two places, hard-coded, so a gate command passing `GM_CONFIG=<other>.json` ran a judge that never read the variable.

Measured on a live campaign: an outcome whose `check` is `GM_CONFIG=<second>.json <gate>` sat in the contract while three lots reported, one after another, that the variable is read nowhere. It would have reported the second engine met the moment the single-engine net went green. Not an outcome starved by a blocked lot — a check that cannot tell apart the two states it exists to separate.

## What changes

`GM_CONFIG` names a file **under the net's directory** — a name, never a path: the declaration lives with the corpus it declares, and a judge pointed at a file outside it would judge one tree with another tree's declaration. What differs between two declarations is the environment (`up`, `down`, `restore`, where the URL is published); the contract — personas, standard, probes, test command — does not, because "the same corpus renders the same verdict on both" is the claim being tested.

Three refusals rather than three silences:

- **A named declaration that is absent refuses**, naming it, instead of falling back to `config.json` and reporting a verdict for an environment nobody asked about.
- **An empty `GM_CONFIG` refuses too.** A variable that did not expand is not an unset variable — the inert check, one layer down. Found by this file's own selftest: the guard existed and `(os.environ.get(...) or "config.json")` had made it unreachable. Dead code documented as a refusal is worse than no refusal.
- **A value with a separator refuses as a PATH**, and the selftest asserts the *cause*, not just the exception: `../config.json` is also "absent", so a check that only counts refusals lets the path guard be deleted without turning red (measured — that mutant survived the first version of the test).

The verdict carries `config`, so a green from the second environment and a green from the first are no longer the same line in a report.

Both readers of the declaration — the gate's own load and the held-out opt-in — now go through one helper. That one matters on its own: a second environment judged with the first one's `seal_committed` would consume a sealed held-out set the other gate was owed. A second environment that does not declare the opt-in leaves the set where it belongs, with no new code.

`GM_ENGINE` stays what it was: a variable of the target's own scripts (which already receive the environment — the harness runs `up`/`down`/`restore` through `sh -c` with the environment inherited). The judge does not need it; it needs to know *which declaration it read*.

## Proof

- Selftest **218** (`GM_MODE=selftest`), including: the default is `config.json`; `GM_CONFIG` names the judged declaration; the seal opt-in is read from the judged declaration and not from `config.json`; a named-and-absent declaration refuses; `../config.json`, `a/b.json` and `..` refuse **as paths**; an empty value refuses **as empty**.
- `TestGoldenMasterHarnessNamesTheConfig` runs the real harness end to end: the report names the declaration it judged (default and named), a missing named declaration is refused in the report an operator reads, and a path is refused before anything is judged.
- Five mutants, each red on its own check: the absent-declaration fallback restored; the opt-in drifted back to `config.json`; the path guard removed; the empty value defaulted; the `config` field dropped from the verdict.
- `go test ./bots/` green, `gofmt` clean, both inlined copies regenerated by `bots/golden-master/sync-harness.py`.

## Deploying it

The harness is a file of each target net, materialised there by the sync node — this change is backward compatible with every caller: a gate that sets no `GM_CONFIG` reads `config.json` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
