### PR TITLE
fix(board-sync): a human move out of Blocked on the roadmap board is the reopen, and a refused move out of Done becomes visible in the tool

### DIFF
--- a/docs/adr/096-board-claim-lease-and-watchdog.md
+++ b/docs/adr/096-board-claim-lease-and-watchdog.md
@@ -99,6 +99,12 @@ Automated writers use `SetStateFrom` (CAS on the declared source). Bots
 (`board.move`) get the refusal with **no** fallback — a run must not
 drag a card out of done.
 
+"Operator surfaces" gained one member in ADR-097 §7 (issue #839): a person's
+move out of a NON-completion sink on a bound roadmap board, which the project
+pass relays through this same `Reopen` when it can attribute the move to the
+board side having changed while the card did not. It is a caller of the exit,
+not a hole in the guard — the sink and every machine writer are unchanged.
+
 **6. The fence cannot repeat, and a lost fence is refused rather than
 guessed.** The epoch is floored at the server clock, so it is monotone
 even across a write that DROPS it: derived from the document alone it

--- a/docs/adr/097-github-projects-v2-board-sync.md
+++ b/docs/adr/097-github-projects-v2-board-sync.md
@@ -268,18 +268,66 @@ first — on the CLI output and the API response. "12 skipped" tells an operator
 nothing they can act on; "8 in SocialGouv/iterion, 4 in SocialGouv/infra" *is*
 the next two commands.
 
-### 7. A terminal card is never reopened by the import
+### 7. A person's move out of a sink is the reopen; a machine's never is
 
 Leaving a `Terminal: true` native column is a **reopen** — an operator surface
 op with a dependents check and an audit trail, and the native board's guard
 (`ValidateStateExit`) refuses it to every automated writer, deliberately: the
 silent resurrection of a closed card was the failure that guard exists for.
 
-The import does not carve an exception. A board Status that would drag a card
-out of `done`/`blocked` is **refused, counted (`refused_terminal`) and
-logged**; the two boards stay legitimately divergent until a human reopens the
-card. Making automation the one writer allowed to resurrect work would trade
-that invariant for a convenience.
+**Amended (issue #839).** The first shipping rule was "the import does not
+carve an exception", and production disproved it: an operator moved a card from
+*Blocked* to *Inbox* on the roadmap board, and every pass since logged a
+refusal while the two boards diverged for ever. The sink protects a card from a
+MACHINE — the watchdog, a sweep, a stale event. A drag on the roadmap board is
+not a machine; it is the operator's hand, arriving through the only channel
+they have. Dropping it was not conservatism, it was losing an instruction.
+
+So the rule now distinguishes WHO moved the card and WHICH sink it left:
+
+- **A person's move out of a non-completion sink is honoured**, through
+  `Reopen` — the sanctioned exit, with its own dependents check and its own
+  audit marker — never through the automated write the sink refused. Counted
+  as `reopened_terminal` (its own bucket, disjoint from `moved`) and stamped
+  `reopened_at` on the card's sync record. Nothing consumed a parked card's
+  state: only `StateDone` satisfies a dependent's hard blockers
+  (`BlockerSatisfied`), which is exactly the line `native.ReopenableByBoardMove`
+  draws.
+- **A move out of the COMPLETION column is still refused.** A done card may
+  have promoted dependents whose launch consumed its completion — the case
+  `ReopenBlockedByDependents` refuses one card at a time — and that arbitration
+  cannot be taken on a board the promoted work does not appear on. Reopening
+  finished work stays a native gesture.
+- **"A person" is not a guess.** The pass honours a move only where it can
+  attribute it: `projectStatusApply` over a RECORDED status — the pass's own
+  "only the board moved" arm, where the status iterion last synchronized still
+  maps to the card's column, so nothing but a hand on the board changed
+  anything. That is the same oracle the reflect direction uses to answer "who
+  moved?", so the two directions cannot disagree. A **contested** move (both
+  sides moved) is refused: something else moved the card, and a board that
+  cannot see what did must not arbitrate it into a resurrection. A **first
+  sight** is refused too — a card with no recorded status has nothing that
+  CHANGED, and without that rule binding a board would drag every parked card
+  out of its column at once.
+- **The sink itself is untouched.** `ValidateStateExit` is unchanged, and the
+  pass consults it by TRYING the ordinary CAS rather than re-deriving the rule
+  — a second copy would drift the day a board declares another terminal column.
+  Every other writer (`SetState`, `SetStateFrom`, the owned family, a bot's
+  `board.move`) meets it with no exemption.
+
+**A refusal is a fact in the tool, not a log line.** The symptom of the old
+rule was "I moved it and nothing happened", with the explanation in
+`kubectl logs`. A refused move is now written **on the card**
+(`ExternalProject.SyncConflict`: from/to, the board column, the item, when it
+was FIRST observed) and **on the binding's health** (`SyncConflictReason` /
+`SyncConflictAt`, a second readout beside `DegradedReason` — separate because
+that one is recomputed level-triggered from the status vocabulary on every pass
+and would clear a refusal it never looked at). Both are level-triggered: the
+pass that no longer meets the refusal clears them, so the readout describes the
+board now rather than the worst thing that ever happened to it. The card's
+record keeps its FIRST timestamp across repeats, because a re-stamped one would
+rewrite the card every tick — bumping `UpdatedAt` and emitting the
+`card.updated` the trigger spine relaunches subscriptions on.
 
 ### 8. Idempotency: the card id IS the key
 

--- a/docs/github-board-sync.md
+++ b/docs/github-board-sync.md
@@ -43,19 +43,38 @@ bug until you know it is a decision:
    at issue ingest. Items with no card are counted and their **repositories are
    named**, so you know which issue syncs to run — the cloud one on a cloud
    instance, see [Troubleshooting](#troubleshooting).
-2. **It never reopens a closed card.** Leaving a terminal column (`done`,
-   `blocked`) is a *reopen* — an operator gesture with a dependents check and
-   an audit trail. Dragging a card out of *Done* on GitHub is reported
-   (`refused_terminal`, and the log line `project import: state write refused
-   … is terminal — leaving it requires an explicit reopen`) and the two boards
-   stay divergent until a human reopens the card in iterion. **The sanctioned
-   reopen is the API transition** — `iterion remote issues transition
-   <card-id> <state>`, or the studio move — because `SetStateOrReopen`
-   treats a transition OUT of a terminal state through the HTTP surface as
-   the explicit reopen the sink demands, while the project import
-   deliberately does not take that path. Whether a human's move on the
-   GitHub board should count as that reopen is an open decision:
-   [#839](https://github.com/SocialGouv/iterion/issues/839).
+2. **It never reopens a card out of *Done*.** Leaving a terminal column is a
+   *reopen* — an operator gesture with a dependents check and an audit trail —
+   and the two terminal columns are treated differently, because only one of
+   them promotes anyone:
+
+   - **Out of *Blocked*: honoured.** A parked card is one its operator parked,
+     and nothing consumed that state (only `done` satisfies a dependent's hard
+     blockers). Dragging it to *Inbox* / *Planned* on GitHub IS the explicit
+     reopen the sink demands: the pass applies it through `Reopen` — the one
+     sanctioned exit — counts it as `reopened_terminal`, stamps `reopened_at`
+     on the card's sync record, and logs `project import: a board move
+     reopened a terminal card`.
+   - **Out of *Done*: still refused.** A finished card may already have
+     promoted dependents whose launch consumed its completion, and that
+     arbitration cannot be taken on a board the promoted work does not
+     appear on. The move is reported (`refused_terminal`), **written on the
+     card** (`external.project.sync_conflict` — from/to, the column, the
+     item, when) and **on the binding's health** (`sync_conflict_reason`, shown
+     by the studio's Project board card, `GET /api/teams/{id}/board-binding`
+     and `iterion remote board show`). The sanctioned gesture is the native
+     one: `iterion remote issues transition <card-id> <state>`, or the studio
+     move — both route through `SetStateOrReopen`.
+
+   The honoured case is narrow ON PURPOSE, and the sink itself is untouched.
+   Only a move this pass can attribute to a person reopens: the board's status
+   changed while the card did not (`native.ReopenableByBoardMove` +
+   the pass's own "only the board moved" arm). A **contested** move (something
+   moved the card too — a run's verdict, the watchdog) and a **first sight**
+   (a card this board has never synchronized, so nothing has *changed*) both
+   stay refused, and every machine writer — `SetState`, the CAS, the owned
+   family, a bot's `board.move` — still meets the sink with no exemption.
+   Decision: [#839](https://github.com/SocialGouv/iterion/issues/839).
 3. **Unmapped states are inert.** A card in `review` or `waiting_deps` leaves
    the board showing the last true thing it was told, rather than being
    collapsed onto *In progress* — which the next pass would read back and undo.
@@ -314,10 +333,16 @@ permanent divergence.
 - **Logs**: one line per pass.
 
 ```
-board sync: team=t_123 board=SocialGouv/203 items=214 moved=2 reflected=1 \
-  labelled=3 conflicts=0 refused_terminal=0 reflect_failed=0 reflect_no_column=0 \
-  reflect_machine=0 skipped_no_card=4 skipped_archived=3 skipped=11 took=812ms
+board sync: team=t_123 board=SocialGouv/203 items=214 moved=2 reopened_terminal=0 \
+  reflected=1 labelled=3 conflicts=0 refused_terminal=0 reflect_failed=0 \
+  reflect_no_column=0 reflect_machine=0 skipped_no_card=4 skipped_archived=3 \
+  skipped=11 took=812ms
 ```
+
+The buckets are **disjoint** — every item is accounted for exactly once, so
+"nothing happened" is always explainable. `reopened_terminal` is not part of
+`moved`: leaving a sink is not an ordinary move, and a pass that performed one
+has to say so in its own numbers.
 
 A failed pass logs `Warn` and **does not block the next tick**; one team's
 revoked token skips that team, not the sweep.
@@ -416,11 +441,19 @@ repository under a supported one is the fix.
 
 **A card moved on GitHub but not in iterion.**
 Check the column is in the map (`iterion remote board show` — a `!` marks a
-mapped column the board lacks). Then check it is not a terminal card:
-`refused_terminal > 0` means automation declined to resurrect a closed card,
-which is by design — reopen it in iterion: `iterion remote issues transition
-<card-id> <state>` (or the studio move) is the explicit reopen the terminal
-sink accepts; see [What syncs](#what-syncs-and-which-way), item 2, and #839.
+mapped column the board lacks). Then read the binding's **Refused moves** line
+(same command; `sync_conflict_reason` on the API, a banner on the studio's
+Project board card): it names the cards whose move the terminal sink refused
+and how to land them. That is the *Done* case — reopening finished work stays a
+native gesture: `iterion remote issues transition <card-id> <state>`, or the
+studio move.
+
+A drag out of *Blocked* needs none of that: the pass takes it as the reopen
+(`reopened_terminal > 0` in the pass line). If one did not land, the pass could
+not attribute it — the card was moved on BOTH sides since the last sync
+(`conflicts > 0`), or this board had never synchronized that card before, in
+which case one pass records it and the next honours a real move. See
+[What syncs](#what-syncs-and-which-way), item 2.
 
 **A card moved in iterion but not on GitHub.**
 Five causes, in order of likelihood: the state is unmapped (`review`,

--- a/openapi.json
+++ b/openapi.json
@@ -173,6 +173,13 @@
             },
             "type": "object"
           },
+          "sync_conflict_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "sync_conflict_reason": {
+            "type": "string"
+          },
           "sync_every": {
             "type": "integer"
           },
@@ -824,6 +831,10 @@
           "owner": {
             "type": "string"
           },
+          "reopened_at": {
+            "format": "date-time",
+            "type": "string"
+          },
           "state_at": {
             "format": "date-time",
             "type": "string"
@@ -834,6 +845,9 @@
           "status_at": {
             "format": "date-time",
             "type": "string"
+          },
+          "sync_conflict": {
+            "$ref": "#/components/schemas/ProjectSyncConflict"
           }
         },
         "type": "object"
@@ -1680,6 +1694,34 @@
           "active",
           "waiting",
           "reserved"
+        ],
+        "type": "object"
+      },
+      "ProjectSyncConflict": {
+        "properties": {
+          "at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "item_id": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
         ],
         "type": "object"
       },

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -517,8 +517,16 @@ func RunIssueImport(p *Printer, opts IssueImportOptions) error {
 		if projectRes.Conflicts > 0 {
 			p.KV("Conflicts", strconv.Itoa(projectRes.Conflicts))
 		}
+		if projectRes.ReopenedTerminal > 0 {
+			p.KV("Reopened (board move)", strconv.Itoa(projectRes.ReopenedTerminal))
+		}
 		if projectRes.RefusedTerminal > 0 {
 			p.KV("Refused (terminal)", strconv.Itoa(projectRes.RefusedTerminal))
+			// Name the cards: reopening a finished one is a native gesture, and
+			// the ids ARE the command that performs it.
+			for _, id := range projectRes.RefusedCards {
+				p.Line("    %s — iterion issue move %s <state>", id, id)
+			}
 		}
 		if projectRes.SkippedArchived > 0 {
 			p.KV("Skipped (archived)", strconv.Itoa(projectRes.SkippedArchived))

--- a/pkg/cli/remote_board_binding.go
+++ b/pkg/cli/remote_board_binding.go
@@ -195,6 +195,17 @@ func printBoardBinding(p *Printer, b forge.BoardBinding) {
 		}
 		p.KV("Degraded", b.DegradedReason+since)
 	}
+	if b.SyncConflicted() {
+		// A move a person made on the forge board that the native board's
+		// terminal sink refuses. Not a degradation — the board reads fine —
+		// but the one shape whose only symptom is "I moved it and nothing
+		// happened", so it has to be readable here rather than in the log.
+		since := ""
+		if b.SyncConflictAt != nil {
+			since = " (since " + b.SyncConflictAt.Format(time.RFC3339) + ")"
+		}
+		p.KV("Refused moves", b.SyncConflictReason+since)
+	}
 	p.Blank()
 	p.Line("Status map:")
 	if b.StatusFieldID == "" {

--- a/pkg/cli/remote_board_binding_test.go
+++ b/pkg/cli/remote_board_binding_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
@@ -54,6 +55,39 @@ func TestPrintBoardBindingMarksALostColumnThatKeptItsID(t *testing.T) {
 		if strings.Contains(line, "→ ready") && strings.HasPrefix(line, "! ") {
 			t.Errorf("a column the board still carries must render unmarked, got %q", line)
 		}
+	}
+}
+
+// A board move the native board's terminal sink refuses has exactly one
+// symptom for the operator — "I moved it and nothing happened" — so `board
+// show` has to name it. It is NOT a degradation: the board reads fine, and a
+// binding that renders the two the same way sends the operator hunting a
+// column that is not missing.
+func TestPrintBoardBindingShowsRefusedMoves(t *testing.T) {
+	var out bytes.Buffer
+	p := NewPrinter(OutputHuman)
+	p.W = &out
+
+	at := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	printBoardBinding(p, forge.BoardBinding{
+		TenantID: "team-a", Provider: forge.ProviderGitHub,
+		Owner: "SocialGouv", OwnerKind: forge.ProjectOwnerOrg, Number: 203,
+		ConnectionID: "conn-1", ProjectID: "PVT_p", StatusFieldID: "PVTSSF_status",
+		StatusMapping:      []forge.StatusMapping{{Status: "Done", State: "done"}},
+		StatusOptions:      map[string]string{"done": "o_done"},
+		SyncConflictReason: "1 board move(s) refused: native:abc",
+		SyncConflictAt:     &at,
+	})
+
+	rendered := out.String()
+	if !strings.Contains(rendered, "native:abc") {
+		t.Errorf("the refused move must name the card, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, at.Format(time.RFC3339)) {
+		t.Errorf("the refused move must say since when, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "Degraded") {
+		t.Errorf("a refused move is not a broken column, got:\n%s", rendered)
 	}
 }
 

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -706,6 +706,51 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	if _, changed, err := store.SetStateFrom(sink.ID, native.StateInProgress, native.StateInProgress); err != nil || changed {
 		t.Fatalf("SetStateFrom(x→x) = (changed=%t, %v), want a no-op reported as unchanged", changed, err)
 	}
+	// The project-board sync state, INCLUDING the terminal-sink arbitration
+	// (ADR-097 §7): the reopen a board move performed, and the refusal it met.
+	// Both are durable operator-facing facts — the studio and
+	// `iterion remote issues get` read them — so a twin that drops them tells
+	// half the fleet "I moved it and nothing happened" with nothing to show.
+	syncAt := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+	if _, err := store.Update(sink.ID, native.Patch{External: &native.ExternalRef{
+		Provider: "github", Repo: "SocialGouv/iterion", Number: 613,
+		Project: &native.ExternalProject{
+			Owner: "SocialGouv", Number: 203, ItemID: "PVTI_1",
+			Status: "Done", StatusAt: syncAt, StateAt: syncAt,
+			ReopenedAt: syncAt.Add(time.Minute),
+			SyncConflict: &native.ProjectSyncConflict{
+				From: native.StateDone, To: native.StateInbox, Status: "Inbox",
+				ItemID: "PVTI_1", At: syncAt.Add(2 * time.Minute), Reason: "terminal state is a sink",
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("write the project sync state: %v", err)
+	}
+	synced := mustGetIssue(t, store, sink.ID)
+	if synced.External == nil || synced.External.Project == nil {
+		t.Fatalf("the project sync state did not round-trip: %+v", synced.External)
+	}
+	if got := synced.External.Project.ReopenedAt; !got.Equal(syncAt.Add(time.Minute)) {
+		t.Errorf("ExternalProject.ReopenedAt = %v, want %v", got, syncAt.Add(time.Minute))
+	}
+	sc := synced.External.Project.SyncConflict
+	if sc == nil {
+		t.Fatalf("ExternalProject.SyncConflict did not round-trip: %+v", synced.External.Project)
+	}
+	if sc.From != native.StateDone || sc.To != native.StateInbox || sc.Status != "Inbox" ||
+		sc.ItemID != "PVTI_1" || sc.Reason == "" || !sc.At.Equal(syncAt.Add(2*time.Minute)) {
+		t.Errorf("SyncConflict round-tripped lossily: %+v", sc)
+	}
+	// Clearing it is the remedy landing — a nil must persist as absent, not be
+	// read as "leave what you had".
+	cleared := synced.External.Clone()
+	cleared.Project.SyncConflict = nil
+	if _, err := store.Update(sink.ID, native.Patch{External: cleared}); err != nil {
+		t.Fatalf("clear the sync conflict: %v", err)
+	}
+	if got := mustGetIssue(t, store, sink.ID).External.Project.SyncConflict; got != nil {
+		t.Errorf("SyncConflict survived its clear: %+v", got)
+	}
 	// The sink guard must hold under CONCURRENCY, which is the only place
 	// it can be broken: a read-then-validate-then-unguarded-write is
 	// check-then-act, and the Mongo twin's ordinary SetState was exactly

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -287,6 +287,7 @@ func (e *ExternalRef) Clone() *ExternalRef {
 	out := *e
 	if e.Project != nil {
 		p := *e.Project
+		p.SyncConflict = e.Project.SyncConflict.Clone()
 		out.Project = &p
 	}
 	return &out
@@ -319,6 +320,62 @@ type ExternalProject struct {
 	// rule reads the card's own Issue.StateAt; this stays as the fallback for
 	// a card whose last transition predates that stamp.
 	StateAt time.Time `json:"state_at,omitempty"`
+	// ReopenedAt is when a move on the bound board last took this card OUT of
+	// a terminal column — the operator's drag standing as the explicit reopen
+	// the sink demands (ADR-097 §7). Zero on every card no board move ever
+	// reopened, which is nearly all of them.
+	ReopenedAt time.Time `json:"reopened_at,omitempty"`
+	// SyncConflict is the last board move the terminal sink REFUSED, or nil.
+	// Cleared by the pass that no longer meets the refusal — the operator
+	// reopened the card natively, or moved the item back.
+	SyncConflict *ProjectSyncConflict `json:"sync_conflict,omitempty"`
+}
+
+// ProjectSyncConflict is one board move iterion could not apply, kept ON THE
+// CARD so the operator reads it where they made the gesture rather than in the
+// server's log.
+//
+// It exists for exactly one shape today: a drag out of the COMPLETION column,
+// which stays a deliberate native reopen (see ReopenableByBoardMove). The
+// symptom it answers — "I moved it and nothing happened" — has no other
+// channel: the pass declines to record the status it could not apply, so every
+// later pass re-derives the same divergence and changes nothing on either side.
+type ProjectSyncConflict struct {
+	// From / To are the native columns: where the card sits, and where the
+	// board's status would have taken it.
+	From string `json:"from"`
+	To   string `json:"to"`
+	// Status is the board column the operator moved the item into, in the
+	// board's own vocabulary, and ItemID the item they moved.
+	Status string `json:"status,omitempty"`
+	ItemID string `json:"item_id,omitempty"`
+	// At is when this refusal was FIRST observed. A refusal that keeps
+	// repeating keeps its original stamp: the pass runs on its interval, and
+	// re-stamping would rewrite the card every tick — which bumps UpdatedAt
+	// and emits card.updated, relaunching every label-matching subscription.
+	At time.Time `json:"at,omitempty"`
+	// Reason is the store's own refusal, verbatim.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Equal reports whether two refusals describe the same fact. Deliberately NOT
+// comparing At: it is the first-observation stamp, so an equal refusal keeps
+// the older one.
+func (c *ProjectSyncConflict) Equal(o *ProjectSyncConflict) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+	return c.From == o.From && c.To == o.To && c.Status == o.Status &&
+		c.ItemID == o.ItemID && c.Reason == o.Reason
+}
+
+// Clone returns a deep copy, or nil.
+func (c *ProjectSyncConflict) Clone() *ProjectSyncConflict {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	return &out
 }
 
 // Equal reports whether two sync states carry the same information.
@@ -342,7 +399,9 @@ func (p *ExternalProject) Equal(o ExternalProject) bool {
 		p.ItemID == o.ItemID &&
 		p.Status == o.Status &&
 		p.StatusAt.Equal(o.StatusAt) &&
-		p.StateAt.Equal(o.StateAt)
+		p.StateAt.Equal(o.StateAt) &&
+		p.ReopenedAt.Equal(o.ReopenedAt) &&
+		p.SyncConflict.Equal(o.SyncConflict)
 }
 
 // Comment is a single append-only note on a native issue. Author is a

--- a/pkg/dispatcher/native/state_guard.go
+++ b/pkg/dispatcher/native/state_guard.go
@@ -30,6 +30,12 @@ import (
 // but it is held to Reopen's dependents check (see
 // reopenMigrationAllowedLocked), because a bulk reopen must not be a way
 // around the refusal a single-card reopen would get.
+//
+// "Operator surface" includes a person's move on a BOUND roadmap board,
+// which the project sync relays through Reopen (ADR-097 §7) under
+// ReopenableByBoardMove below. That is a caller of the exit, not a hole in
+// the guard: it is still Reopen, still refused for the completion column,
+// and every machine writer still meets ValidateStateExit unchanged.
 
 // ValidateStateExit is the shared gate both twins' SetState family
 // calls. from == to never reaches it (no-ops return earlier).
@@ -48,6 +54,28 @@ func ValidateStateExit(b *Board, from, to string) error {
 	return fmt.Errorf("%w: %q is terminal — leaving it requires an explicit reopen (state %q refused)",
 		tracker.ErrTerminalStateExit, from, to)
 }
+
+// ReopenableByBoardMove reports whether a PERSON's move out of `from` on a
+// bound roadmap board (ADR-097) stands as the explicit reopen the sink
+// demands. It answers about the operator's own gesture arriving through the
+// only channel they have — never about a machine writer, which still meets
+// ValidateStateExit above with no exemption of any kind.
+//
+// A parked card qualifies: nothing consumed its terminal state, because only
+// StateDone satisfies a dependent's hard blockers (BlockerSatisfied), so the
+// drag un-parks a ticket the operator parked themselves.
+//
+// The COMPLETION column does not. A done card may already have promoted
+// dependents whose launch consumed its completion, which is exactly what
+// ReopenBlockedByDependents refuses one card at a time — and a reopen taken
+// from a board the promoted work never appears on could not be arbitrated
+// there. Reopening finished work stays a native gesture (`iterion remote
+// issues transition <card> <state>`, or the studio move, both of which route
+// through SetStateOrReopen).
+//
+// The caller supplies the source column of a move the sink already refused;
+// on any other move the answer is meaningless and unused.
+func ReopenableByBoardMove(from string) bool { return from != StateDone }
 
 // TerminalStateNames lists the board's sink columns. The Mongo twin
 // needs them as a CAS precondition: it cannot check-then-act without

--- a/pkg/forge/board_binding_store.go
+++ b/pkg/forge/board_binding_store.go
@@ -176,6 +176,21 @@ type BoardBinding struct {
 	DegradedReason string     `bson:"degraded_reason,omitempty" json:"degraded_reason,omitempty"`
 	DegradedAt     *time.Time `bson:"degraded_at,omitempty" json:"degraded_at,omitempty"`
 
+	// SyncConflictReason is the SECOND health readout: board moves the native
+	// board's terminal sink refused on the last pass — a drag out of the
+	// completion column, which stays a deliberate native reopen (ADR-097 §7).
+	// Without it the operator's only symptom is "I moved it and nothing
+	// happened", with the explanation in the server's log.
+	//
+	// A channel of its own, not a second use of DegradedReason: that one is
+	// recomputed level-triggered from the status vocabulary on every pass, so
+	// a refusal written there would be cleared by the next reconciliation that
+	// never looked at it. Level-triggered all the same — a pass that refuses
+	// nothing clears it, so the readout describes the board NOW rather than
+	// the worst thing that ever happened to it.
+	SyncConflictReason string     `bson:"sync_conflict_reason,omitempty" json:"sync_conflict_reason,omitempty"`
+	SyncConflictAt     *time.Time `bson:"sync_conflict_at,omitempty" json:"sync_conflict_at,omitempty"`
+
 	CreatedAt time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
@@ -225,6 +240,11 @@ func (b BoardBinding) OptionForState(state string) (string, bool) {
 // board no longer carries. A degraded binding still syncs every state it CAN
 // resolve — it is a partial outage, not a stop.
 func (b BoardBinding) Degraded() bool { return b.DegradedReason != "" }
+
+// SyncConflicted reports whether the last pass met a board move the native
+// board's terminal sink refused. Orthogonal to Degraded: the board is fully
+// readable, one card's move simply cannot be applied by automation.
+func (b BoardBinding) SyncConflicted() bool { return b.SyncConflictReason != "" }
 
 // DueAt reports when this binding's next periodic pass is due. The zero time
 // means "not scheduled" (SyncEvery == 0).
@@ -330,6 +350,14 @@ type BoardBindingStore interface {
 	// the readout has exactly two writers (the pluginsource precedent).
 	MarkDegraded(ctx context.Context, tenantID, reason string) error
 	ClearDegraded(ctx context.Context, tenantID string) error
+
+	// MarkSyncConflict / ClearSyncConflict write the terminal-sink readout —
+	// board moves automation may not apply, and their disappearance. Separate
+	// from the degradation pair because the two are recomputed from different
+	// evidence on every pass, and either clearing the other would erase a
+	// standing fact the operator still has to act on.
+	MarkSyncConflict(ctx context.Context, tenantID, reason string) error
+	ClearSyncConflict(ctx context.Context, tenantID string) error
 }
 
 // ---- in-memory store (tests / local) ----
@@ -362,6 +390,11 @@ func (m *MemoryBoardBindingStore) Upsert(_ context.Context, b BoardBinding) erro
 		// never names the field in its $set, so dropping it here would make
 		// the two twins disagree on whether the board is held.
 		b.SyncLeaseUntil, b.SyncLeaseOwner = prev.SyncLeaseUntil, prev.SyncLeaseOwner
+		// A re-bind re-reads the board's SCHEMA; it does not un-refuse a move
+		// the sink still refuses. Carried over explicitly because the Mongo
+		// twin's $set never names these fields, so dropping them here would
+		// make the two twins disagree.
+		b.SyncConflictReason, b.SyncConflictAt = prev.SyncConflictReason, prev.SyncConflictAt
 	}
 	// A re-bind CLEARS the degradation: it re-read the board and re-resolved
 	// every column by name, which is the documented remedy. Written explicitly
@@ -410,6 +443,36 @@ func (m *MemoryBoardBindingStore) ClearDegraded(_ context.Context, tenantID stri
 		return ErrBoardBindingNotFound
 	}
 	b.DegradedReason, b.DegradedAt = "", nil
+	b.UpdatedAt = time.Now().UTC()
+	m.items[tenantID] = b
+	return nil
+}
+
+func (m *MemoryBoardBindingStore) MarkSyncConflict(_ context.Context, tenantID, reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("forge: board binding: a sync conflict needs a reason")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.items[tenantID]
+	if !ok {
+		return ErrBoardBindingNotFound
+	}
+	now := time.Now().UTC()
+	b.SyncConflictReason, b.SyncConflictAt = reason, &now
+	b.UpdatedAt = now
+	m.items[tenantID] = b
+	return nil
+}
+
+func (m *MemoryBoardBindingStore) ClearSyncConflict(_ context.Context, tenantID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.items[tenantID]
+	if !ok {
+		return ErrBoardBindingNotFound
+	}
+	b.SyncConflictReason, b.SyncConflictAt = "", nil
 	b.UpdatedAt = time.Now().UTC()
 	m.items[tenantID] = b
 	return nil
@@ -633,6 +696,42 @@ func (s *MongoBoardBindingStore) ClearDegraded(ctx context.Context, tenantID str
 		})
 	if err != nil {
 		return fmt.Errorf("forge: clear board binding degraded: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrBoardBindingNotFound
+	}
+	return nil
+}
+
+// MarkSyncConflict records that the last pass met a board move the native
+// board's terminal sink refused, and why.
+func (s *MongoBoardBindingStore) MarkSyncConflict(ctx context.Context, tenantID, reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("forge: board binding: a sync conflict needs a reason")
+	}
+	now := time.Now().UTC()
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID},
+		bson.M{"$set": bson.M{"sync_conflict_reason": reason, "sync_conflict_at": now, "updated_at": now}})
+	if err != nil {
+		return fmt.Errorf("forge: mark board binding sync conflict: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrBoardBindingNotFound
+	}
+	return nil
+}
+
+// ClearSyncConflict records a pass that refused nothing.
+func (s *MongoBoardBindingStore) ClearSyncConflict(ctx context.Context, tenantID string) error {
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"_id": tenantID},
+		bson.M{
+			"$unset": bson.M{"sync_conflict_reason": "", "sync_conflict_at": ""},
+			"$set":   bson.M{"updated_at": time.Now().UTC()},
+		})
+	if err != nil {
+		return fmt.Errorf("forge: clear board binding sync conflict: %w", err)
 	}
 	if res.MatchedCount == 0 {
 		return ErrBoardBindingNotFound

--- a/pkg/forge/board_binding_store_test.go
+++ b/pkg/forge/board_binding_store_test.go
@@ -486,6 +486,69 @@ func runBoardBindingStoreSuite(t *testing.T, store forge.BoardBindingStore) {
 		}
 	})
 
+	// The sync-conflict readout is the SECOND health channel, and it has to be
+	// its own: `DegradedReason` is recomputed level-triggered from the status
+	// vocabulary on every pass, so a refused board move written there would be
+	// cleared two minutes later by a reconciliation that never looked at it.
+	t.Run("the sync-conflict readout is independent of the degradation", func(t *testing.T) {
+		if err := store.Upsert(ctx, binding("team-cf", time.Minute)); err != nil {
+			t.Fatalf("Upsert: %v", err)
+		}
+		if err := store.MarkSyncConflict(ctx, "team-cf", ""); err == nil {
+			t.Error("a sync conflict with no reason must be refused — the reason IS what the operator reads")
+		}
+		const reason = `1 board move refused: "done" is terminal`
+		if err := store.MarkSyncConflict(ctx, "team-cf", reason); err != nil {
+			t.Fatalf("MarkSyncConflict: %v", err)
+		}
+		got, err := store.GetByTenant(ctx, "team-cf")
+		if err != nil {
+			t.Fatalf("GetByTenant: %v", err)
+		}
+		if !got.SyncConflicted() || got.SyncConflictReason != reason || got.SyncConflictAt == nil {
+			t.Fatalf("binding must carry the refusal with a timestamp: %+v", got)
+		}
+		if got.Degraded() {
+			t.Error("a refused board move is not a broken column — it must not read as degraded")
+		}
+
+		// Neither health channel may clear the other.
+		if err := store.MarkDegraded(ctx, "team-cf", "the Status field no longer carries \"Blocked\""); err != nil {
+			t.Fatalf("MarkDegraded: %v", err)
+		}
+		if err := store.ClearDegraded(ctx, "team-cf"); err != nil {
+			t.Fatalf("ClearDegraded: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-cf"); !got.SyncConflicted() {
+			t.Error("clearing the degradation cleared the sync conflict — the two readouts must be independent")
+		}
+
+		// A re-bind re-reads the board's SCHEMA; it does not un-refuse a move
+		// the sink still refuses, and the next pass re-derives or clears it.
+		if err := store.Upsert(ctx, binding("team-cf", time.Minute)); err != nil {
+			t.Fatalf("re-bind: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-cf"); !got.SyncConflicted() {
+			t.Error("a re-bind dropped the sync conflict; the sink still refuses the move")
+		}
+
+		if err := store.ClearSyncConflict(ctx, "team-cf"); err != nil {
+			t.Fatalf("ClearSyncConflict: %v", err)
+		}
+		if got, _ := store.GetByTenant(ctx, "team-cf"); got.SyncConflicted() || got.SyncConflictAt != nil {
+			t.Errorf("ClearSyncConflict left %+v", got)
+		}
+
+		for _, err := range []error{
+			store.MarkSyncConflict(ctx, "nobody", "why"),
+			store.ClearSyncConflict(ctx, "nobody"),
+		} {
+			if !errors.Is(err, forge.ErrBoardBindingNotFound) {
+				t.Errorf("health write on a missing binding: want ErrBoardBindingNotFound, got %v", err)
+			}
+		}
+	})
+
 	t.Run("tenants are isolated", func(t *testing.T) {
 		if err := store.Upsert(ctx, binding("team-x", time.Minute)); err != nil {
 			t.Fatalf("Upsert: %v", err)

--- a/pkg/server/board_project.go
+++ b/pkg/server/board_project.go
@@ -149,10 +149,24 @@ type ProjectImportResult struct {
 	// repository names ARE the next command they have to run.
 	MissingRepos []MissingRepo `json:"missing_repos,omitempty"`
 	// RefusedTerminal is the moves the native board's terminal-state sink
-	// refused. Leaving done/blocked is a REOPEN — an operator gesture with its
-	// own audit trail and dependents check — and automation never reopens. The
-	// two boards stay legitimately divergent until someone reopens the card.
+	// refused: a drag out of the COMPLETION column, which stays a deliberate
+	// native reopen (a done card may have promoted dependents whose launch
+	// consumed its completion). The two boards stay legitimately divergent
+	// until someone reopens the card — and the refusal is written on the card
+	// and on the binding's health so they can find out why.
 	RefusedTerminal int `json:"refused_terminal,omitempty"`
+	// ReopenedTerminal is the moves the sink refused and a PERSON's drag on
+	// the roadmap board authorised anyway: a parked card its operator
+	// un-parked, applied through Reopen — the one sanctioned exit — rather
+	// than through the automated CAS. Its own bucket, disjoint from Moved:
+	// leaving a sink is not an ordinary move, and a pass that performs one has
+	// to say so in its own numbers.
+	ReopenedTerminal int `json:"reopened_terminal,omitempty"`
+	// RefusedCards names the cards behind RefusedTerminal, capped at
+	// maxNamedRefusals. "3 refused" is not something an operator can act on;
+	// the card ids ARE the next command (`iterion remote issues transition
+	// <card> <state>`). Same reading as MissingRepos.
+	RefusedCards []string `json:"refused_cards,omitempty"`
 	// SkippedArchived is the items the operator archived. The forge removes
 	// them from every board view but PRESERVES their field values, so one
 	// archived mid-column keeps reading as that column forever — driving a
@@ -217,8 +231,86 @@ func ImportProjectBoard(
 		cursor = page.NextCursor
 	}
 	res.MissingRepos = rankMissingRepos(missing)
+	recordSinkHealth(ctx, opts, res)
 	return res, nil
 }
+
+// maxNamedRefusals bounds how many refused cards the pass names. One drag is
+// the ordinary case; a bulk column move on the board would otherwise write a
+// list as long as the board onto the binding record.
+const maxNamedRefusals = 5
+
+// recordSinkHealth publishes this pass's terminal-sink refusals on the
+// binding, which is where an operator can read them — `GET
+// /api/teams/{id}/board-binding`, `iterion remote board show`, the studio.
+// Before it, the only trace was a server log line and a counter in a pass
+// summary, so the whole symptom was "I moved it and nothing happened".
+//
+// LEVEL-triggered, like the degradation beside it: the reason is recomputed
+// from THIS pass, and a pass that refused nothing clears it. An edge-triggered
+// flag would outlive its own remedy — the operator reopens the card, the next
+// pass applies the status, and the binding would still read conflicted.
+//
+// Only reached when the item loop completed: a pass abandoned on a card-store
+// outage saw an arbitrary prefix of the board, and a health readout derived
+// from a prefix is a guess.
+//
+// Persisting is best-effort, like the vocabulary repair: a store outage must
+// not abandon the reconciliation the operator is watching. The in-memory
+// binding is updated either way, which is what the one-shot CLI reads.
+func recordSinkHealth(ctx context.Context, opts *ProjectImportOptions, res ProjectImportResult) {
+	binding := opts.binding()
+	if binding == nil {
+		return
+	}
+	was := binding.SyncConflictReason
+	reason := sinkConflictReason(res)
+	store := opts.bindingStore()
+	switch {
+	case reason != "":
+		binding.SyncConflictReason = reason
+		if was == reason {
+			return // unchanged standing state: no store write, no second Warn
+		}
+		binding.SyncConflictAt = ptrTime(opts.now())
+		logProjectWarn(opts, "project board: a board move the terminal sink refuses",
+			"team", binding.TenantID, "board", binding.Ref().String(), "reason", reason)
+		if store != nil {
+			if err := store.MarkSyncConflict(ctx, binding.TenantID, reason); err != nil {
+				logProjectWarn(opts, "project board: the refused move could not be recorded on the binding",
+					"team", binding.TenantID, "error", err.Error())
+			}
+		}
+	case was != "":
+		binding.SyncConflictReason, binding.SyncConflictAt = "", nil
+		if store != nil {
+			if err := store.ClearSyncConflict(ctx, binding.TenantID); err != nil {
+				logProjectWarn(opts, "project board: the refused-move readout could not be cleared",
+					"team", binding.TenantID, "error", err.Error())
+			}
+		}
+	}
+}
+
+// sinkConflictReason renders the readout an operator acts on: how many moves
+// did not land, which cards, and the gesture that lands them.
+func sinkConflictReason(res ProjectImportResult) string {
+	if res.RefusedTerminal == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d board move(s) refused: leaving a terminal column is a reopen, which stays a native gesture", res.RefusedTerminal)
+	if len(res.RefusedCards) > 0 {
+		fmt.Fprintf(&b, " — %s", strings.Join(res.RefusedCards, ", "))
+		if res.RefusedTerminal > len(res.RefusedCards) {
+			fmt.Fprintf(&b, " and %d more", res.RefusedTerminal-len(res.RefusedCards))
+		}
+	}
+	b.WriteString(` (iterion remote issues transition <card> <state>)`)
+	return b.String()
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
 
 // repairBinding re-resolves the binding's cached status vocabulary — the
 // (state → option id) map and the column NAMES those ids carried — against the
@@ -456,7 +548,8 @@ func applyProjectItem(
 		logProjectConflict(opts, cardID, it, statusName, statusAt, nativeAt, sync, decision)
 	}
 
-	applied, refused := false, false
+	applied, refused, reopened := false, false, false
+	var sinkRefusal *native.ProjectSyncConflict
 	if targetState != "" && targetState != card.State {
 		// CAS on the snapshot: an operator who moved the card between our read
 		// and this write wins — the board must not clobber a fresh decision
@@ -469,12 +562,48 @@ func applyProjectItem(
 		// one-shot `iterion issue import --project` path nothing ever repairs
 		// it. A refused write and a lost CAS are the same fact here: nothing
 		// landed.
+		//
+		// The CAS is also how this pass ASKS whether the move leaves a sink:
+		// the guard's own answer, never a second copy of it (a copy drifts the
+		// day a board declares another terminal column). The write is validated
+		// before anything is touched on both twins, so a refusal costs nothing.
 		switch _, changed, err := board.SetStateFrom(cardID, card.State, targetState); {
+		case errors.Is(err, tracker.ErrTerminalStateExit) && boardMoveIsAReopen(card.State, decision, sync):
+			// A person dragged a PARKED card out of its column on the roadmap
+			// board. That gesture is the explicit reopen the sink demands, and
+			// it is honoured through Reopen — the one sanctioned exit, with its
+			// own dependents check and its own audit marker — never through the
+			// automated write the sink just refused.
+			if _, rerr := board.Reopen(cardID, targetState); rerr != nil {
+				// Not the sink: the dependents check, or the card moving under
+				// the reopen's own CAS. Declining to record the status keeps
+				// the next pass re-deriving it.
+				refused = true
+				logProjectWarn(opts, "project import: board-originated reopen refused", "card", cardID,
+					"from", card.State, "to", targetState, "error", rerr.Error())
+				break
+			}
+			reopened = true
+			res.ReopenedTerminal++
+			logProjectWarn(opts, "project import: a board move reopened a terminal card",
+				"card", cardID, "item", it.ID, "from", card.State, "to", targetState, "status", statusName)
+		case errors.Is(err, tracker.ErrTerminalStateExit):
+			// The completion column, a contested move, or a card this board has
+			// never synchronized. The refusal stands — and is recorded on the
+			// card below, so the operator reads it where they made the gesture.
+			refused = true
+			res.RefusedTerminal++
+			if len(res.RefusedCards) < maxNamedRefusals {
+				res.RefusedCards = append(res.RefusedCards, cardID)
+			}
+			sinkRefusal = &native.ProjectSyncConflict{
+				From: card.State, To: targetState, Status: statusName,
+				ItemID: it.ID, Reason: err.Error(),
+			}
+			logProjectWarn(opts, "project import: state write refused", "card", cardID,
+				"from", card.State, "to", targetState, "error", err.Error())
 		case err != nil:
 			refused = true
-			if errors.Is(err, tracker.ErrTerminalStateExit) {
-				res.RefusedTerminal++
-			}
 			logProjectWarn(opts, "project import: state write refused", "card", cardID,
 				"from", card.State, "to", targetState, "error", err.Error())
 		case !changed:
@@ -508,9 +637,17 @@ func applyProjectItem(
 		sync.Status = statusName
 		sync.StatusAt = statusAt
 	}
-	if applied {
+	if applied || reopened {
 		sync.StateAt = opts.now()
 	}
+	if reopened {
+		sync.ReopenedAt = opts.now()
+	}
+	// The sink's arbitration, kept where the operator made the gesture. A
+	// refusal the pass no longer meets is CLEARED here by the same assignment
+	// — the record describes this pass, not the worst thing that ever happened
+	// to the card.
+	sync.SyncConflict = carryProjectConflict(sync.SyncConflict, sinkRefusal, opts.now())
 
 	// The OTHER direction, on the same pass and the same board read. It runs
 	// in exactly the two cases where the native side holds the truth:
@@ -568,6 +705,51 @@ func applyProjectItem(
 		logProjectWarn(opts, "project import: card update failed", "card", cardID, "error", err.Error())
 	}
 	return nil
+}
+
+// boardMoveIsAReopen reports whether this pass may take a card OUT of its
+// terminal column on the strength of the board move it just read (ADR-097 §7).
+// The sink stands unless both halves hold.
+//
+// **The move is attributable to a person.** `projectStatusApply` over a
+// RECORDED status is the pass's own "only the board moved" arm: the status
+// iterion last synchronized still maps to the card's column, so nothing but a
+// hand on the roadmap board changed anything — the same oracle that answers
+// "who moved?" for the reflect direction. A first sight (no recorded status)
+// is not a move: binding a board would otherwise drag every parked card out of
+// its column at once. A contested move is not one either — something else moved
+// the card too, and a board that cannot see what did must not arbitrate it into
+// a resurrection.
+//
+// **The column allows it** (native.ReopenableByBoardMove): a parked card its
+// operator un-parks, never the completion column.
+//
+// Machine writers never reach here: they meet the sink through the ordinary
+// SetState family and are refused with no exemption.
+func boardMoveIsAReopen(from string, decision projectStatusDecision, sync native.ExternalProject) bool {
+	return decision == projectStatusApply &&
+		strings.TrimSpace(sync.Status) != "" &&
+		native.ReopenableByBoardMove(from)
+}
+
+// carryProjectConflict folds this pass's refusal (nil = none) into the record
+// the card already carried.
+//
+// A repeat of the SAME refusal keeps its FIRST stamp. The card is rewritten
+// only when ExternalProject.Equal reports a change, and a re-stamped `At`
+// would rewrite it on every tick — bumping UpdatedAt and emitting an
+// EvtIssueUpdated the trigger spine consumes as `card.updated`, relaunching
+// every label-matching board subscription. A quiet pass has to be silent.
+func carryProjectConflict(prev, next *native.ProjectSyncConflict, now time.Time) *native.ProjectSyncConflict {
+	if next == nil {
+		return nil
+	}
+	if prev.Equal(next) {
+		return prev
+	}
+	out := *next
+	out.At = now
+	return &out
 }
 
 // reflectNativeState pushes a native move onto the board (ADR-097 §2, the

--- a/pkg/server/board_project_terminal_test.go
+++ b/pkg/server/board_project_terminal_test.go
@@ -1,0 +1,310 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The terminal sink, seen from the project pass (ADR-097 §7, ADR-096 §5).
+//
+// The sink refuses every MACHINE exit from a done/blocked column. A drag on
+// the bound roadmap board is not one: it is a person's decision, arriving
+// through the only channel they have. These tests pin where that line falls —
+// a parked card the operator un-parks is honoured as the explicit reopen the
+// sink demands, a finished one is still refused, and the refusal is a fact on
+// the card and on the binding rather than a line in the server log.
+
+// boundOpts builds a write-authority pass over a fresh binding store, and
+// hands back both so a test can read the binding's health afterwards.
+func boundOpts(t *testing.T, now time.Time) (*ProjectImportOptions, *forge.MemoryBoardBindingStore, *forge.BoardBinding) {
+	t.Helper()
+	bindings := forge.NewMemoryBoardBindingStore()
+	b := testBinding()
+	if err := bindings.Upsert(context.Background(), *b); err != nil {
+		t.Fatalf("seed binding: %v", err)
+	}
+	return &ProjectImportOptions{
+		Binding:  b,
+		Bindings: bindings,
+		Now:      func() time.Time { return now },
+	}, bindings, b
+}
+
+// lastStateEvent returns the most recent EvtIssueState payload for a card.
+func lastStateEvent(t *testing.T, board *native.Store, id string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := board.ScanEvents(func(e *native.Event) bool {
+		if e.Type == native.EvtIssueState && e.IssueID == id {
+			out = e.Payload
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("scan events: %v", err)
+	}
+	return out
+}
+
+// TestImportProjectBoardHumanMoveOutOfBlockedReopens: an operator dragging a
+// parked card out of Blocked on the roadmap board IS the explicit reopen the
+// sink demands. The pass honours it — through Reopen, the one sanctioned exit
+// — and records it, so the two boards converge instead of diverging for ever
+// behind a `refused_terminal` counter nobody reads.
+func TestImportProjectBoardHumanMoveOutOfBlockedReopens(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+	now := at.Add(time.Minute)
+	// The two boards agreed on Blocked; then the human moved the item.
+	id := seedSynced(t, board, 613, native.StateBlocked, "Blocked", at)
+	opts, bindings, binding := boundOpts(t, now)
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Inbox", at.Add(30*time.Second))),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	iss := mustGet(t, board, id)
+	if iss.State != native.StateInbox {
+		t.Errorf("state = %q, want %q — a human's move out of a parked column is the reopen", iss.State, native.StateInbox)
+	}
+	if res.ReopenedTerminal != 1 {
+		t.Errorf("ReopenedTerminal = %d, want 1 (%+v)", res.ReopenedTerminal, res)
+	}
+	if res.RefusedTerminal != 0 {
+		t.Errorf("RefusedTerminal = %d, want 0 — the move landed", res.RefusedTerminal)
+	}
+	if res.Moved != 0 {
+		t.Errorf("Moved = %d, want 0 — a reopen has its own bucket, so the counters stay disjoint", res.Moved)
+	}
+
+	// Recorded as a board-originated reopen, on the card.
+	if iss.External == nil || iss.External.Project == nil {
+		t.Fatal("the sync state must survive a reopen")
+	}
+	p := iss.External.Project
+	if p.ReopenedAt.IsZero() {
+		t.Error("ReopenedAt is zero — the reopen must be attributable to the board move that caused it")
+	}
+	if p.SyncConflict != nil {
+		t.Errorf("SyncConflict = %+v, want none — nothing was refused", p.SyncConflict)
+	}
+	if p.Status != "Inbox" {
+		t.Errorf("recorded status = %q, want %q so the next pass is quiet", p.Status, "Inbox")
+	}
+	// …and in the board's own audit trail, as a reopen and not an ordinary move.
+	if ev := lastStateEvent(t, board, id); ev == nil || ev["reopened"] != true {
+		t.Errorf("state event = %v, want a reopened marker", ev)
+	}
+	// The binding is healthy: nothing was refused.
+	got, err := bindings.GetByTenant(context.Background(), binding.TenantID)
+	if err != nil {
+		t.Fatalf("GetByTenant: %v", err)
+	}
+	if got.SyncConflictReason != "" {
+		t.Errorf("SyncConflictReason = %q, want none", got.SyncConflictReason)
+	}
+}
+
+// TestImportProjectBoardRefusedMoveOutOfDoneIsVisibleInTheTool: reopening a
+// FINISHED card stays a deliberate native gesture (a done card satisfies its
+// dependents' blockers). The refusal is unchanged — what changes is that the
+// operator can see it without `kubectl logs`: it is written on the card and on
+// the binding's health.
+func TestImportProjectBoardRefusedMoveOutOfDoneIsVisibleInTheTool(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+	now := at.Add(time.Minute)
+	id := seedSynced(t, board, 613, native.StateDone, "Done", at)
+	opts, bindings, binding := boundOpts(t, now)
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Inbox", at.Add(30*time.Second))),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if got := mustGet(t, board, id).State; got != native.StateDone {
+		t.Errorf("state = %q: reopening a finished card must stay a native gesture", got)
+	}
+	if res.RefusedTerminal != 1 || res.ReopenedTerminal != 0 {
+		t.Errorf("RefusedTerminal = %d / ReopenedTerminal = %d, want 1 / 0 (%+v)",
+			res.RefusedTerminal, res.ReopenedTerminal, res)
+	}
+
+	iss := mustGet(t, board, id)
+	if iss.External == nil || iss.External.Project == nil || iss.External.Project.SyncConflict == nil {
+		t.Fatalf("the refusal must be recorded on the card: %+v", iss.External)
+	}
+	c := iss.External.Project.SyncConflict
+	if c.From != native.StateDone || c.To != native.StateInbox {
+		t.Errorf("SyncConflict from/to = %q/%q, want %q/%q", c.From, c.To, native.StateDone, native.StateInbox)
+	}
+	if c.Status != "Inbox" || c.ItemID != "PVTI_1" {
+		t.Errorf("SyncConflict must name the board column and item: %+v", c)
+	}
+	if !c.At.Equal(now) {
+		t.Errorf("SyncConflict.At = %v, want %v", c.At, now)
+	}
+	if c.Reason == "" {
+		t.Error("SyncConflict.Reason is empty — the operator needs to read WHY it did not land")
+	}
+
+	// …and on the binding's health, which is what `GET /api/teams/{id}/board-binding`
+	// and `iterion remote board show` read.
+	got, err := bindings.GetByTenant(context.Background(), binding.TenantID)
+	if err != nil {
+		t.Fatalf("GetByTenant: %v", err)
+	}
+	if !got.SyncConflicted() || got.SyncConflictAt == nil {
+		t.Fatalf("the binding must carry the refusal: %+v", got)
+	}
+	if binding.SyncConflictReason == "" {
+		t.Error("the in-memory binding must carry it too — the CLI one-shot reads the value it passed in")
+	}
+
+	// A repeat of the SAME refusal must not rewrite the card: the pass runs on
+	// its interval, and a rewritten ExternalRef bumps UpdatedAt and emits
+	// card.updated, which relaunches every label-matching board subscription.
+	before := mustGet(t, board, id).UpdatedAt
+	opts.Now = func() time.Time { return now.Add(2 * time.Minute) }
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	again := mustGet(t, board, id)
+	if !again.UpdatedAt.Equal(before) {
+		t.Errorf("the card was rewritten by a repeat of the same refusal (%v → %v)", before, again.UpdatedAt)
+	}
+	if c2 := again.External.Project.SyncConflict; c2 == nil || !c2.At.Equal(now) {
+		t.Errorf("SyncConflict.At must stay the FIRST observation, got %+v", c2)
+	}
+
+	// The operator reopens the card natively — the sanctioned gesture. The next
+	// pass applies the board's status and clears both readouts.
+	if _, err := board.Reopen(id, native.StateInbox); err != nil {
+		t.Fatalf("native reopen: %v", err)
+	}
+	if _, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts); err != nil {
+		t.Fatalf("third pass: %v", err)
+	}
+	if p := mustGet(t, board, id).External.Project; p.SyncConflict != nil {
+		t.Errorf("SyncConflict survived the remedy: %+v", p.SyncConflict)
+	}
+	healthy, err := bindings.GetByTenant(context.Background(), binding.TenantID)
+	if err != nil {
+		t.Fatalf("GetByTenant: %v", err)
+	}
+	if healthy.SyncConflicted() {
+		t.Errorf("the binding still reads conflicted after the remedy: %q", healthy.SyncConflictReason)
+	}
+}
+
+// TestTerminalSinkStillRefusesMachineExits is the guard that keeps the reopen
+// above from becoming "terminal states are not terminal any more". The narrow
+// path is the HUMAN's move on the bound board, attributable because the board
+// side changed and the native side did not; everything else still meets the
+// sink.
+func TestTerminalSinkStillRefusesMachineExits(t *testing.T) {
+	t.Run("an automated writer cannot leave a sink", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedCard(t, board, 613, native.StateBlocked)
+		if _, _, err := board.SetStateFrom(id, native.StateBlocked, native.StateInbox); !errors.Is(err, tracker.ErrTerminalStateExit) {
+			t.Fatalf("SetStateFrom out of blocked: want ErrTerminalStateExit, got %v", err)
+		}
+		if _, err := board.SetState(id, native.StateInbox); !errors.Is(err, tracker.ErrTerminalStateExit) {
+			t.Fatalf("SetState out of blocked: want ErrTerminalStateExit, got %v", err)
+		}
+		if got := mustGet(t, board, id).State; got != native.StateBlocked {
+			t.Fatalf("state = %q, want it parked", got)
+		}
+	})
+
+	// The reopen is attributable ONLY when the native side did not move. When
+	// BOTH moved, the board's newer value still wins the arbitration — but a
+	// move iterion itself made out of a working column is not a gesture the
+	// board can overrule into a resurrection.
+	t.Run("a contested move out of a sink is still refused", func(t *testing.T) {
+		board := newTestBoard(t)
+		at := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+		// Recorded "In progress"; a run has since filed the card blocked, so
+		// the native side moved too.
+		id := seedSynced(t, board, 613, native.StateInProgress, "In progress", at)
+		if _, err := board.SetState(id, native.StateBlocked); err != nil {
+			t.Fatalf("file blocked: %v", err)
+		}
+		opts, _, _ := boundOpts(t, at.Add(time.Hour))
+		bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+			item("PVTI_1", 613, statusValue("Inbox", time.Now().UTC().Add(time.Hour))),
+		}}}
+
+		res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+		if err != nil {
+			t.Fatalf("ImportProjectBoard: %v", err)
+		}
+		if got := mustGet(t, board, id).State; got != native.StateBlocked {
+			t.Errorf("state = %q, want %q — only an uncontested board move reopens", got, native.StateBlocked)
+		}
+		if res.ReopenedTerminal != 0 || res.RefusedTerminal != 1 {
+			t.Errorf("ReopenedTerminal = %d / RefusedTerminal = %d, want 0 / 1 (%+v)",
+				res.ReopenedTerminal, res.RefusedTerminal, res)
+		}
+	})
+
+	// FIRST SIGHT is not a move. A card this pass has never synchronized has
+	// no recorded status to have CHANGED, so the column the roadmap happens to
+	// show it in is not evidence anybody moved it — and binding a board would
+	// otherwise drag every parked card out of Blocked at once.
+	t.Run("first sight of a card is not a move", func(t *testing.T) {
+		board := newTestBoard(t)
+		id := seedCard(t, board, 613, native.StateBlocked)
+		opts, _, _ := boundOpts(t, time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC))
+		bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+			item("PVTI_1", 613, statusValue("Inbox", time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC))),
+		}}}
+
+		res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, opts)
+		if err != nil {
+			t.Fatalf("ImportProjectBoard: %v", err)
+		}
+		if got := mustGet(t, board, id).State; got != native.StateBlocked {
+			t.Errorf("state = %q, want %q", got, native.StateBlocked)
+		}
+		if res.ReopenedTerminal != 0 || res.RefusedTerminal != 1 {
+			t.Errorf("ReopenedTerminal = %d / RefusedTerminal = %d, want 0 / 1", res.ReopenedTerminal, res.RefusedTerminal)
+		}
+	})
+}
+
+// TestImportProjectBoardReopensWithoutABinding: the reopen's oracle is the
+// CARD's own sync record, not the binding — so the local one-shot
+// (`iterion issue import --project`, no write authority on the forge side)
+// honours an operator's move exactly like the cloud reconciliation. Only the
+// health readout needs a binding.
+func TestImportProjectBoardReopensWithoutABinding(t *testing.T) {
+	board := newTestBoard(t)
+	at := time.Date(2026, 9, 6, 11, 0, 0, 0, time.UTC)
+	id := seedSynced(t, board, 613, native.StateBlocked, "Blocked", at)
+	bc := &fakeBoardClient{project: testProject(), pages: [][]forge.ProjectItem{{
+		item("PVTI_1", 613, statusValue("Inbox", at.Add(time.Minute))),
+	}}}
+
+	res, err := ImportProjectBoard(context.Background(), bc, testProjectRef, forge.ProviderGitHub, board, nil)
+	if err != nil {
+		t.Fatalf("ImportProjectBoard: %v", err)
+	}
+	if got := mustGet(t, board, id).State; got != native.StateInbox {
+		t.Errorf("state = %q, want %q", got, native.StateInbox)
+	}
+	if res.ReopenedTerminal != 1 || res.RefusedTerminal != 0 {
+		t.Errorf("ReopenedTerminal = %d / RefusedTerminal = %d, want 1 / 0 (%+v)",
+			res.ReopenedTerminal, res.RefusedTerminal, res)
+	}
+}

--- a/pkg/server/board_sync_worker.go
+++ b/pkg/server/board_sync_worker.go
@@ -211,8 +211,8 @@ func (w *BoardSyncWorker) runPass(ctx context.Context, b forge.BoardBinding, own
 		w.warn("board sync: team=%s board=%s failed after %s: %v", b.TenantID, b.Ref(), took.Round(time.Millisecond), err)
 		return false
 	}
-	w.info("board sync: team=%s board=%s items=%d moved=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d reflect_no_column=%d reflect_machine=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
-		b.TenantID, b.Ref(), res.Items, res.Moved, res.Reflected, res.Labelled,
+	w.info("board sync: team=%s board=%s items=%d moved=%d reopened_terminal=%d reflected=%d labelled=%d conflicts=%d refused_terminal=%d reflect_failed=%d reflect_no_column=%d reflect_machine=%d skipped_no_card=%d skipped_archived=%d skipped=%d took=%s",
+		b.TenantID, b.Ref(), res.Items, res.Moved, res.ReopenedTerminal, res.Reflected, res.Labelled,
 		res.Conflicts, res.RefusedTerminal, res.ReflectFailed, res.ReflectNoColumn, res.ReflectMachine,
 		res.SkippedNoCard, res.SkippedArchived, res.Skipped,
 		took.Round(time.Millisecond))

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5426,6 +5426,9 @@ export interface components {
             status_options?: {
                 [key: string]: string;
             };
+            /** Format: date-time */
+            sync_conflict_at?: string;
+            sync_conflict_reason?: string;
             sync_every: number;
             sync_every_seconds: number;
             sync_lease_owner?: string;
@@ -5663,10 +5666,13 @@ export interface components {
             number?: number;
             owner?: string;
             /** Format: date-time */
+            reopened_at?: string;
+            /** Format: date-time */
             state_at?: string;
             status?: string;
             /** Format: date-time */
             status_at?: string;
+            sync_conflict?: components["schemas"]["ProjectSyncConflict"];
         };
         ExternalRef: {
             author?: string;
@@ -5925,6 +5931,15 @@ export interface components {
             max: number;
             reserved: number;
             waiting: number;
+        };
+        ProjectSyncConflict: {
+            /** Format: date-time */
+            at?: string;
+            from: string;
+            item_id?: string;
+            reason?: string;
+            status?: string;
+            to: string;
         };
         RepoSummary: {
             can_admin: boolean;

--- a/studio/src/views/integrations/BindingSummary.test.tsx
+++ b/studio/src/views/integrations/BindingSummary.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BoardBinding } from "@/api/boardBinding";
+import { BindingSummary } from "./ProjectBoardTab";
+
+// The binding's two HEALTH readouts. They answer different questions and must
+// not be rendered as one: a degradation is a column the board no longer
+// carries, a sync conflict is a move a person made that the native board's
+// terminal sink refuses (ADR-097 §7). Confusing them sends the operator
+// hunting a column that is not missing.
+
+function binding(over: Partial<BoardBinding> = {}): BoardBinding {
+  return {
+    tenant_id: "team-a",
+    provider: "github",
+    owner: "SocialGouv",
+    owner_kind: "org",
+    number: 203,
+    connection_id: "conn-1",
+    project_id: "PVT_p",
+    status_field_id: "PVTSSF_status",
+    status_mapping: [{ status: "Done", state: "done" }],
+    sync_every_seconds: 120,
+    created_at: "2026-09-06T10:00:00Z",
+    updated_at: "2026-09-06T12:00:00Z",
+    ...over,
+  } as BoardBinding;
+}
+
+afterEach(cleanup);
+
+describe("BindingSummary health readouts", () => {
+  it("names a board move the terminal sink refused, and how to land it", () => {
+    render(
+      <BindingSummary
+        binding={binding({
+          sync_conflict_reason:
+            "1 board move(s) refused: leaving a terminal column is a reopen — native:abc",
+          sync_conflict_at: "2026-09-06T12:00:00Z",
+        })}
+      />,
+    );
+    expect(screen.getByText(/native:abc/)).toBeTruthy();
+    // The refusal is not a broken column: the operator must not be sent
+    // looking for a Status option that is perfectly present.
+    expect(screen.queryByText(/no longer carries/)).toBeNull();
+  });
+
+  it("renders a lost column as a degradation, separately", () => {
+    render(
+      <BindingSummary
+        binding={binding({
+          degraded_reason: 'the Status field no longer carries "Done"',
+        })}
+      />,
+    );
+    expect(screen.getByText(/no longer carries/)).toBeTruthy();
+  });
+
+  it("shows neither on a healthy binding", () => {
+    const { container } = render(<BindingSummary binding={binding()} />);
+    expect(container.textContent).not.toMatch(/refused/i);
+    expect(container.textContent).not.toMatch(/no longer carries/);
+  });
+});

--- a/studio/src/views/integrations/ProjectBoardTab.tsx
+++ b/studio/src/views/integrations/ProjectBoardTab.tsx
@@ -269,8 +269,14 @@ export default function ProjectBoardTab({
  * BindingSummary renders what is actually bound: the board, the cadence, and
  * the EFFECTIVE column map with the columns the board does not carry flagged —
  * a mapped-but-absent column is silently inert, so it has to be visible here.
+ *
+ * It also carries the binding's two HEALTH readouts, which answer different
+ * questions and are rendered apart: a DEGRADATION is a bound column the board
+ * no longer has, a SYNC CONFLICT is a move a person made on the board that the
+ * native board's terminal sink refuses (ADR-097 §7). The second one's only
+ * other symptom is "I moved it and nothing happened".
  */
-function BindingSummary({ binding }: { binding: BoardBinding }) {
+export function BindingSummary({ binding }: { binding: BoardBinding }) {
   const missing = new Set(binding.missing_statuses ?? []);
   const sync = binding.sync_every_seconds ?? 0;
   return (
@@ -299,6 +305,19 @@ function BindingSummary({ binding }: { binding: BoardBinding }) {
         <InlineBanner tone="warning" layout="inline">
           This board has no <code>Status</code> field — labels are imported, but there is no
           status projection in either direction.
+        </InlineBanner>
+      )}
+
+      {binding.degraded_reason && (
+        <InlineBanner tone="warning" layout="inline">
+          {binding.degraded_reason}
+        </InlineBanner>
+      )}
+
+      {binding.sync_conflict_reason && (
+        <InlineBanner tone="warning" layout="inline">
+          {binding.sync_conflict_reason} Moving a card out of a terminal column is a
+          reopen, so it stays a deliberate action on the iterion board.
         </InlineBanner>
       )}
 


### PR DESCRIPTION
Closes #839. The arbitration is taken (option 1 for `blocked`, option 2 for `done`) — this implements it.

## What was wrong
`pkg/server/board_project.go` wrote every board-originated status change through `board.SetStateFrom`, the automated CAS, which meets `native.ValidateStateExit` and refuses any exit from a `Terminal: true` column. So an operator dragging a card out of *Blocked* on the GitHub board hit the machine-resurrection guard: the move was dropped, the pass logged `state write refused … terminal state is a sink`, and because the pass also (correctly) declines to record a status it could not apply, **every** later pass re-derived the same refusal. The boards diverged permanently, with a counter and a server log line as the only trace — the shape the runbook lists first under "I moved it and nothing happened".

## What changes
The pass now distinguishes **who** moved the card and **which** sink it leaves.
- **Out of a non-completion sink, an attributable move is honoured** through `board.Reopen` — the exit the tracker already sanctions, with its dependents check and its `reopened: true` audit marker. Counted as `ReopenedTerminal` (its own bucket, disjoint from `Moved`), stamped `reopened_at` on the card's sync record, logged by name.
- **Out of the completion column it stays refused**, and the refusal becomes a fact in the tool: `ExternalProject.SyncConflict` on the card (from/to, board column, item id, first-observed timestamp, the store's verbatim reason) and `BoardBinding.SyncConflictReason`/`SyncConflictAt` on the binding — surfaced in the studio's Project board card, `GET /api/teams/{id}/board-binding`, and `iterion remote board show` ("Refused moves"). The sanctioned native reopen is named there and in the runbook.
- **"Attributable" is `boardMoveIsAReopen`**: `projectStatusApply` over a *recorded* status (the pass's own "only the board moved" arm, the same oracle the reflect direction uses) **and** `native.ReopenableByBoardMove(from)`. A contested move and a first sight both stay refused.
- **The sink is untouched.** The pass asks the guard by *trying* the ordinary CAS and branching on `ErrTerminalStateExit` — no second copy of the rule to drift.

Three design points worth reviewing: the conflict record keeps its **first** timestamp across repeats (a re-stamp would rewrite the card every 2-minute tick, bump `UpdatedAt` and fire `card.updated` at the trigger spine, relaunching every label-matching subscription); the health readout is **level-triggered**, so the operator's native reopen clears it; and `SyncConflictReason` is a **separate** channel from `DegradedReason`, which is recomputed from the status vocabulary each pass and would have cleared a refusal it never looked at.

## Proof (red first)
- `TestImportProjectBoardHumanMoveOutOfBlockedReopens`: `state = "blocked", want "inbox" — a human's move out of a parked column is the reopen`; `ReopenedTerminal = 0, want 1`; `ReopenedAt is zero`; `state event = map[], want a reopened marker`.
- `TestImportProjectBoardRefusedMoveOutOfDoneIsVisibleInTheTool`: compile-level red first (`store.MarkSyncConflict undefined`), then `the refusal must be recorded on the card`.
- `TestTerminalSinkStillRefusesMachineExits` — the guard: it passes before AND after, which is the point. `SetStateFrom`/`SetState` out of `blocked` still return `ErrTerminalStateExit`; a contested move out of a sink is still refused; first sight of a card is not a move.
- Plus `TestImportProjectBoardReopensWithoutABinding` (the local one-shot honours it too — the oracle is the card, not the binding), `TestPrintBoardBindingShowsRefusedMoves` (red verified by removing the printer block), and 3 studio cases in `BindingSummary.test.tsx`.

Class grep table in the commit body: the guard, the three native setters, the four boardmongo CAS writers, `Reopen` (gains exactly one caller), the operator HTTP/CLI surfaces, the reflect direction (not even reached — the decision is `projectStatusApply`), the watchdog `DecideStuckCard` (verified: no terminal→working row), `boardops` — all unchanged. The new `native.ReopenableByBoardMove` has two call sites, so the policy is greppable in one hop.

## Store twins
`SyncConflict`/`ReopenedAt` ride `ExternalRef.Project` on both twins. I fixed `ExternalRef.Clone` (it shallow-copied the inner struct, so the new pointer field would have aliased) and extended `ExternalProject.Equal` — the file's own comment warns that a field added without touching `Equal` goes stale silently. New conformance row round-trips both fields and asserts a nil **clears** rather than reading as "leave what you had". `MarkSyncConflict`/`ClearSyncConflict` land on both binding stores with a conformance row proving the two health channels are independent and that a re-bind preserves the conflict.

## Commands
`go build`, `go vet`, `task lint` (0 issues), `go test ./... -count=1` full suite green, `-race` on `pkg/server pkg/forge pkg/dispatcher/native pkg/dispatcher/boardmongo pkg/cli`, Mongo conformance on a real replica set with the two new rows verified **by name** as executed (not skipped), `task openapi:gen` + `check` (no drift), studio `vitest` 1335 tests and `tsc --noEmit` clean.

## Left out
No live dogfood against project 203 — validating the reopen end to end means moving a real card on the roadmap board; the session does that after deploy. (The operator command the docs name, `iterion remote issues transition`, is verified to exist on the current binary.)

## Found on the way (not fixed)
`ExternalRef.Clone` was already shallow for a nested pointer — latent until this change added one. The general shape (a hand-written `Clone` with no test pinning that a mutation through a clone cannot reach the original) is untested across `pkg/dispatcher/native`; a one-assertion test per `Clone` would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
