### PR TITLE
feat(runner): a copy-based sandbox's work leaves the pod while the pod still answers

### DIFF
--- a/pkg/runner/file_secret_refresh_test.go
+++ b/pkg/runner/file_secret_refresh_test.go
@@ -256,7 +256,7 @@ func TestSandboxRunObserver(t *testing.T) {
 	r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelWarn, &buf)}}
 
 	// No refreshable refs: still registers, no warning.
-	obs := r.sandboxRunObserver(context.Background(), "run-1", "team-1", nil)
+	obs := r.sandboxRunObserver(context.Background(), sandboxObserverOpts{runID: "run-1", tenantID: "team-1"})
 	obs(fakeSandboxRun{})
 	if r.sandboxRunFor("run-1") == nil {
 		t.Fatal("observer must register the live sandbox run")
@@ -269,7 +269,8 @@ func TestSandboxRunObserver(t *testing.T) {
 		t.Fatal("unregister must drop the run from the registry")
 	}
 
-	obs = r.sandboxRunObserver(context.Background(), "run-2", "team-1", map[string]string{"forge_token": "id-1"})
+	obs = r.sandboxRunObserver(context.Background(), sandboxObserverOpts{
+		runID: "run-2", tenantID: "team-1", secretRefs: map[string]string{"forge_token": "id-1"}})
 	obs(fakeSandboxRun{})
 	out := buf.String()
 	if !strings.Contains(out, "does not support mid-run secret refresh") || !strings.Contains(out, "fake-driver") {

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2166,7 +2166,11 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	defer stopSbObs()
 	defer r.unregisterSandboxRun(msg.RunID)
 	engineOpts = append(engineOpts, runtime.WithSandboxRunObserver(
-		r.sandboxRunObserver(sbObsCtx, msg.RunID, msg.TenantID, r.sandboxFileSecretRefs(ctx, wf))))
+		r.sandboxRunObserver(sbObsCtx, sandboxObserverOpts{
+			runID: msg.RunID, tenantID: msg.TenantID, ownerID: msg.OwnerID,
+			secretRefs: r.sandboxFileSecretRefs(ctx, wf),
+			checkpoint: true,
+		})))
 	// Bundle resources: a bot-qualified run attaches its bundle so the
 	// engine mirrors skills/ into <workspace>/.claude/skills AND
 	// provisions the bot's devbox.json (host devbox provisioning — the

--- a/pkg/runner/loop_checkpoint.go
+++ b/pkg/runner/loop_checkpoint.go
@@ -1,0 +1,182 @@
+// Mid-run preservation of a copy-based sandbox's work.
+//
+// On a driver whose workspace is a tar COPY inside a pod (kubernetes),
+// NOTHING a run produces leaves that pod until teardown: the export runs
+// once, at the end, and every push the runner performs reads the exported
+// clone. So a pod that dies hard takes the whole run with it — measured on
+// a campaign lot that spent eight hours and 655 tool calls in one agent
+// node, died at its duration wall, and left `final_commit` empty with the
+// export refused ("pod-side HEAD unknown"): the store records commits, the
+// run had made none, and there was literally nothing left.
+//
+// Two halves of that loss, and this file closes both for the window it can
+// reach: work that was never committed is preserved anyway (a checkpoint
+// commit built from the working tree), and work that was committed leaves
+// the pod while the pod is still healthy instead of at teardown, when it
+// may no longer be.
+//
+// What it is NOT allowed to do, and does not: touch the run's own history.
+// The checkpoint never moves HEAD, never writes the run's index, never
+// touches the working tree, and lands on a ref of its own
+// (`iterion/run-<id>-checkpoint`) authored by iterion — so it cannot be
+// mistaken for the work of the party a gate judges, and a bot whose whole
+// contract is "the lot commits its own work" is not silently committed for.
+package runner
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// workspaceCheckpointInterval is how often a copy-based sandbox's work is
+// preserved outside the pod. The cost of a tick is one exec plus, when
+// something moved, one push; the cost of NOT ticking is everything since
+// the last one — so this is the maximum a hard pod death may destroy.
+const workspaceCheckpointInterval = 10 * time.Minute
+
+// workspaceCheckpointTimeout bounds one checkpoint round-trip (exec +
+// push). Generous: the push crosses the network from inside the pod.
+const workspaceCheckpointTimeout = 4 * time.Minute
+
+// checkpointScript builds — and prints — the commit that preserves the
+// sandbox workspace, WITHOUT touching anything the run owns.
+//
+// The tree is read into a TEMPORARY index (GIT_INDEX_FILE), so the run's
+// own index is never written and an agent running `git add` alongside is
+// not raced for the index lock. `commit-tree` writes an object and no ref:
+// HEAD, the branch and the working tree come out of this byte-identical.
+// When the tree matches HEAD's, there is nothing uncommitted to preserve
+// and HEAD itself is printed — the commits still need to leave the pod.
+//
+// The identity is iterion's, explicitly, and not the run's: a checkpoint
+// wearing the committer's name is evidence that lies about who did the
+// work — the exact confusion the extension gates spend their code refusing.
+const checkpointScript = `set -e
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not-a-git-repo" >&2; exit 3; }
+head=$(git rev-parse HEAD 2>/dev/null) || { echo "no-commit-yet" >&2; exit 3; }
+idx="${TMPDIR:-/tmp}/iterion-checkpoint-index.$$"
+rm -f "$idx"
+GIT_INDEX_FILE="$idx" git read-tree "$head"
+GIT_INDEX_FILE="$idx" git add -A
+tree=$(GIT_INDEX_FILE="$idx" git write-tree)
+rm -f "$idx"
+if [ "$tree" = "$(git rev-parse "$head^{tree}")" ]; then
+  echo "$head"
+  exit 0
+fi
+GIT_AUTHOR_NAME=iterion GIT_AUTHOR_EMAIL=checkpoint@iterion.invalid \
+GIT_COMMITTER_NAME=iterion GIT_COMMITTER_EMAIL=checkpoint@iterion.invalid \
+  git commit-tree "$tree" -p "$head" \
+    -m "iterion: workspace checkpoint — the run's uncommitted tree, preserved by the runner (not the run's own commit)"
+`
+
+// checkpointWorkspaceLoop preserves the sandbox's work on a cadence until
+// the run ends. Best-effort by construction: a tick that cannot read or
+// push is logged and retried at the next one, and no failure here may fail
+// a run — the run's own outcome is decided by its nodes, never by whether
+// its safety net could be laid.
+func (r *Runner) checkpointWorkspaceLoop(ctx context.Context, o sandboxObserverOpts, run sandbox.Run) {
+	tick := time.NewTicker(workspaceCheckpointInterval)
+	defer tick.Stop()
+	last := ""
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+		last = r.checkpointWorkspaceOnce(ctx, o, run, last)
+	}
+}
+
+// checkpointWorkspaceOnce is one tick: resolve what would be lost right
+// now, and push it if it moved since the last checkpoint. Returns the
+// commit now preserved (or `last` unchanged when nothing was).
+//
+// The push is forced on purpose: successive checkpoints are SIBLINGS, not
+// descendants (each is parented on the run's current HEAD), so a
+// fast-forward push would refuse every checkpoint after the first. The ref
+// is derived from the run's own id and contested by nobody.
+func (r *Runner) checkpointWorkspaceOnce(ctx context.Context, o sandboxObserverOpts, run sandbox.Run, last string) string {
+	ref := "iterion/run-" + o.runID + "-checkpoint"
+	cctx, cancel := context.WithTimeout(ctx, workspaceCheckpointTimeout)
+	defer cancel()
+
+	res, err := run.Exec(cctx, []string{"sh", "-c", checkpointScript}, sandbox.ExecOpts{})
+	if err != nil || res.ExitCode != 0 {
+		// Exit 3 is the script saying there is nothing a checkpoint could
+		// hold (no repository, or no commit yet to parent one on): a
+		// state, not a failure, and it must not read as one every ten
+		// minutes for the length of a run.
+		if err == nil && res.ExitCode == 3 {
+			return last
+		}
+		r.cfg.Logger.Warn("runner: run %s: workspace checkpoint: cannot read the sandbox tree (%v; exit %d): %s",
+			o.runID, err, res.ExitCode, strings.TrimSpace(string(res.Stderr)))
+		return last
+	}
+	sha := lastLine(string(res.Stdout))
+	if sha == "" || sha == last {
+		return last
+	}
+
+	push := "git push --force origin " + sha + ":refs/heads/" + ref
+	pres, perr := run.Exec(cctx, []string{"sh", "-c", push}, sandbox.ExecOpts{})
+	if perr != nil || pres.ExitCode != 0 {
+		r.cfg.Logger.Warn("runner: run %s: workspace checkpoint: push of %s to %s FAILED (%v; exit %d): %s — the work is still only inside the pod",
+			o.runID, sha[:min(12, len(sha))], ref, perr, pres.ExitCode, strings.TrimSpace(string(pres.Stderr)))
+		r.recordCheckpoint(o, map[string]any{
+			"ref":   ref,
+			"error": strutilFirstLine(string(pres.Stderr), perr),
+		})
+		return last
+	}
+	r.cfg.Logger.Info("runner: run %s: workspace checkpoint pushed: %s -> %s", o.runID, sha[:min(12, len(sha))], ref)
+	r.recordCheckpoint(o, map[string]any{"ref": ref, "commit": sha})
+	return sha
+}
+
+// recordCheckpoint puts the checkpoint on the run's timeline. A safety net
+// nobody can see is a safety net nobody trusts — and the operator who has
+// to recover a lost run needs the ref NAME, which lives nowhere else (the
+// run doc is deliberately untouched: a checkpoint is not a bank, and must
+// never make a half-done run look merge-eligible).
+func (r *Runner) recordCheckpoint(o sandboxObserverOpts, data map[string]any) {
+	wctx, cancel := context.WithTimeout(context.Background(), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, o.tenantID, o.ownerID)
+	if _, err := r.cfg.Store.AppendEvent(idCtx, o.runID, store.Event{
+		Type: store.EventRunWorkspaceCheckpoint,
+		Data: data,
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_workspace_checkpoint: %v", o.runID, err)
+	}
+}
+
+// lastLine is the last non-empty line of s, trimmed — git prints the sha
+// last, after whatever the credential helper or a hook wrote before it.
+func lastLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if v := strings.TrimSpace(lines[i]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// strutilFirstLine names a failure in one line: git's message when it said
+// something, the Go error otherwise.
+func strutilFirstLine(stderr string, err error) string {
+	if v := strings.TrimSpace(stderr); v != "" {
+		return lastLine(v)
+	}
+	if err != nil {
+		return err.Error()
+	}
+	return "push failed without a message"
+}

--- a/pkg/runner/loop_checkpoint_test.go
+++ b/pkg/runner/loop_checkpoint_test.go
@@ -1,0 +1,282 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// checkpointRunner is a Runner with a real store, so the timeline event
+// every checkpoint writes is exercised rather than stubbed: the ref name
+// lives in that event and nowhere else.
+func checkpointRunner(t *testing.T, runID string) *Runner {
+	t.Helper()
+	st, err := store.New(filepath.Join(t.TempDir(), "store"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if serr := st.SaveRun(context.Background(), &store.Run{ID: runID, TenantID: "team-a"}); serr != nil {
+		t.Fatalf("seed run: %v", serr)
+	}
+	return &Runner{cfg: Config{Logger: iterlog.Nop(), Store: st}}
+}
+
+// checkpointRun fakes a copy-based driver: it records every exec and
+// answers the checkpoint script with a scripted sha.
+type checkpointRun struct {
+	sandbox.Run
+	mu     sync.Mutex
+	execs  []string
+	shas   []string // answers for successive checkpoint-script execs
+	pushRC int      // exit code the push exec returns
+	pushEr string
+}
+
+func (f *checkpointRun) Driver() string { return "fake-k8s" }
+
+// ExportWorkspace makes this driver copy-based in the eyes of the observer.
+func (f *checkpointRun) ExportWorkspace(context.Context) error { return nil }
+
+func (f *checkpointRun) Exec(_ context.Context, cmd []string, _ sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	script := cmd[len(cmd)-1]
+	f.execs = append(f.execs, script)
+	if strings.HasPrefix(script, "git push") {
+		return sandbox.ExecResult{ExitCode: f.pushRC, Stderr: []byte(f.pushEr)}, nil
+	}
+	sha := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if len(f.shas) > 0 {
+		sha = f.shas[0]
+		f.shas = f.shas[1:]
+	}
+	return sandbox.ExecResult{Stdout: []byte(sha + "\n")}, nil
+}
+
+func (f *checkpointRun) pushes() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, e := range f.execs {
+		if strings.HasPrefix(e, "git push") {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestCheckpointOncePushesOnlyWhatMoved pins the cadence's cost: a tick
+// that finds the same commit as the last one pushes nothing, so a run that
+// sits idle for hours costs one exec per tick and no network.
+func TestCheckpointOncePushesOnlyWhatMoved(t *testing.T) {
+	r := checkpointRunner(t, "R1")
+	run := &checkpointRun{shas: []string{"c0ffee", "c0ffee", "beef01"}}
+	o := sandboxObserverOpts{runID: "R1", tenantID: "team-a", checkpoint: true}
+
+	last := r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+	if last != "c0ffee" || len(run.pushes()) != 1 {
+		t.Fatalf("first checkpoint must push: last=%q pushes=%v", last, run.pushes())
+	}
+	if !strings.Contains(run.pushes()[0], "c0ffee:refs/heads/iterion/run-R1-checkpoint") {
+		t.Fatalf("the checkpoint must land on the run's own ref: %q", run.pushes()[0])
+	}
+	last = r.checkpointWorkspaceOnce(context.Background(), o, run, last)
+	if len(run.pushes()) != 1 {
+		t.Fatalf("an unchanged tree must not push again: %v", run.pushes())
+	}
+	last = r.checkpointWorkspaceOnce(context.Background(), o, run, last)
+	if last != "beef01" || len(run.pushes()) != 2 {
+		t.Fatalf("a moved tree must push: last=%q pushes=%v", last, run.pushes())
+	}
+}
+
+// TestCheckpointOnceKeepsTheLastGoodOnAFailedPush: a failed push must not
+// record the sha as preserved, or the next tick would skip it and the work
+// would be lost with the pod anyway — silently, which is the failure mode
+// this whole file exists against.
+func TestCheckpointOnceKeepsTheLastGoodOnAFailedPush(t *testing.T) {
+	r := checkpointRunner(t, "R1")
+	run := &checkpointRun{shas: []string{"beef01", "beef01"}, pushRC: 128, pushEr: "fatal: could not read Username"}
+	o := sandboxObserverOpts{runID: "R1", tenantID: "team-a", checkpoint: true}
+
+	last := r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+	if last != "" {
+		t.Fatalf("a failed push must not read as preserved, got %q", last)
+	}
+	if r.checkpointWorkspaceOnce(context.Background(), o, run, last); len(run.pushes()) != 2 {
+		t.Fatalf("the next tick must try again: %v", run.pushes())
+	}
+}
+
+// TestCheckpointOnceIsQuietWhenThereIsNothingToHold: exit 3 is the script
+// saying "no repository, or no commit to parent a checkpoint on" — a state,
+// not a failure, and it must not push or warn every tick for a whole run.
+func TestCheckpointOnceIsQuietWhenThereIsNothingToHold(t *testing.T) {
+	var buf bytes.Buffer
+	r := checkpointRunner(t, "R1")
+	r.cfg.Logger = iterlog.New(iterlog.LevelWarn, &buf)
+	run := &nothingToHoldRun{}
+	o := sandboxObserverOpts{runID: "R1", tenantID: "team-a"}
+	last := r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+	if last != "" || run.pushed {
+		t.Fatalf("nothing to hold must be a quiet no-op: last=%q pushed=%v", last, run.pushed)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("a state is not a failure: warning every tick for a whole run would bury the ticks that matter, got %q", buf.String())
+	}
+	// A real failure to READ the tree, by contrast, is said: that one is
+	// the operator's signal that the net is not being laid.
+	run.exitCode = 1
+	r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+	if !strings.Contains(buf.String(), "cannot read the sandbox tree") {
+		t.Fatalf("a failed read must be reported, got %q", buf.String())
+	}
+}
+
+type nothingToHoldRun struct {
+	sandbox.Run
+	pushed   bool
+	exitCode int // 0 = the script's "nothing to hold" (3)
+}
+
+func (f *nothingToHoldRun) Driver() string                        { return "fake-k8s" }
+func (f *nothingToHoldRun) ExportWorkspace(context.Context) error { return nil }
+func (f *nothingToHoldRun) Exec(_ context.Context, cmd []string, _ sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	if strings.HasPrefix(cmd[len(cmd)-1], "git push") {
+		f.pushed = true
+	}
+	if f.exitCode != 0 {
+		return sandbox.ExecResult{ExitCode: f.exitCode, Stderr: []byte("fatal: not a git repository")}, nil
+	}
+	return sandbox.ExecResult{ExitCode: 3, Stderr: []byte("no-commit-yet")}, nil
+}
+
+// TestCheckpointScriptPreservesTheTreeAndTouchesNothing is the one that
+// matters: the script runs against a REAL repository, and the run's own
+// history must come out of it byte-identical. A checkpoint that moved HEAD,
+// wrote the index, or staged the agent's work would be a runner committing
+// on behalf of the party a gate judges.
+func TestCheckpointScriptPreservesTheTreeAndTouchesNothing(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "lot@run")
+	git("config", "user.name", "the lot")
+	if err := os.WriteFile(filepath.Join(ws, "committed.txt"), []byte("landed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-qm", "the lot's own commit")
+	head := git("rev-parse", "HEAD")
+
+	// Eight hours of uncommitted work, in one file and one staged change.
+	if err := os.WriteFile(filepath.Join(ws, "uncommitted.txt"), []byte("the work that would be lost\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "committed.txt"), []byte("landed, then edited\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "committed.txt")
+	statusBefore := git("status", "--porcelain")
+	indexBefore := git("rev-parse", ":committed.txt")
+
+	sh := exec.Command("sh", "-c", checkpointScript)
+	sh.Dir = ws
+	sh.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := sh.Output()
+	if err != nil {
+		t.Fatalf("checkpoint script: %v (%s)", err, out)
+	}
+	sha := strings.TrimSpace(string(out))
+	if sha == head {
+		t.Fatal("a dirty tree must produce a checkpoint commit, not HEAD")
+	}
+
+	// The run's own state: untouched, in all three places it lives.
+	if got := git("rev-parse", "HEAD"); got != head {
+		t.Fatalf("the checkpoint moved HEAD: %s -> %s", head, got)
+	}
+	if got := git("status", "--porcelain"); got != statusBefore {
+		t.Fatalf("the checkpoint changed the working tree state:\n%s\n---\n%s", statusBefore, got)
+	}
+	if got := git("rev-parse", ":committed.txt"); got != indexBefore {
+		t.Fatalf("the checkpoint wrote the run's index: %s -> %s", indexBefore, got)
+	}
+	if got := git("branch", "--contains", sha); got != "" {
+		t.Fatalf("the checkpoint commit is reachable from a branch: %q", got)
+	}
+
+	// And it holds what would have been lost, under iterion's name.
+	if got := git("show", sha+":uncommitted.txt"); got != "the work that would be lost" {
+		t.Fatalf("the checkpoint does not carry the uncommitted file: %q", got)
+	}
+	if got := git("show", sha+":committed.txt"); got != "landed, then edited" {
+		t.Fatalf("the checkpoint does not carry the edit: %q", got)
+	}
+	if got := git("log", "-1", "--format=%ae", sha); got != "checkpoint@iterion.invalid" {
+		t.Fatalf("a checkpoint must not wear the run's identity, got %q", got)
+	}
+	if got := git("rev-parse", sha+"^"); got != head {
+		t.Fatalf("the checkpoint must be parented on the run's HEAD, got %s", got)
+	}
+
+	// A clean tree has nothing uncommitted to hold: the script prints HEAD,
+	// so the commits still leave the pod and no empty commit is created.
+	git("add", "-A")
+	git("commit", "-qm", "the lot commits its work")
+	head2 := git("rev-parse", "HEAD")
+	sh2 := exec.Command("sh", "-c", checkpointScript)
+	sh2.Dir = ws
+	sh2.Env = sh.Env
+	out2, err := sh2.Output()
+	if err != nil {
+		t.Fatalf("checkpoint script on a clean tree: %v (%s)", err, out2)
+	}
+	if got := strings.TrimSpace(string(out2)); got != head2 {
+		t.Fatalf("a clean tree must checkpoint HEAD itself, got %q want %q", got, head2)
+	}
+}
+
+// TestCheckpointsWorkspaceOnlyWhereWorkCanBeLost pins both gates. The
+// first: a bind-mount driver's work is already on the host disk, which
+// outlives the container — a checkpoint there preserves nothing and costs
+// a push every ten minutes. The second: a subbot child under a SHARED
+// sandbox is handed its parent's handle, so a second loop would push the
+// same tree under a second name and tell two stories about one workspace.
+func TestCheckpointsWorkspaceOnlyWhereWorkCanBeLost(t *testing.T) {
+	copyBased := &checkpointRun{}
+	bindMount := fakeSandboxRun{}
+	owner := sandboxObserverOpts{runID: "R1", checkpoint: true}
+	child := sandboxObserverOpts{runID: "R2"}
+
+	if !checkpointsWorkspace(copyBased, owner) {
+		t.Fatal("a copy-based sandbox owned by this run must be checkpointed: its work is unreachable until teardown")
+	}
+	if checkpointsWorkspace(bindMount, owner) {
+		t.Fatal("a bind-mount workspace lives on the host and survives the container — nothing to preserve")
+	}
+	if checkpointsWorkspace(copyBased, child) {
+		t.Fatal("a shared child must not open a second loop on its parent's pod")
+	}
+}

--- a/pkg/runner/sandbox_registry.go
+++ b/pkg/runner/sandbox_registry.go
@@ -54,10 +54,58 @@ func (r *Runner) sandboxRunFor(runID string) sandbox.Run {
 // file-secret refresh loop (the previous sandboxSecretRefreshObserver
 // behaviour). The caller must defer unregisterSandboxRun(runID) and
 // cancel ctx when the run ends.
-func (r *Runner) sandboxRunObserver(ctx context.Context, runID, tenantID string, refs map[string]string) func(sandbox.Run) {
+// sandboxObserverOpts names what the observer needs about the run whose
+// sandbox it is watching. A struct rather than a parameter list because
+// the two callers differ on one field that MATTERS: a subbot child under
+// a shared sandbox is handed its PARENT's handle, and a second checkpoint
+// loop on the same pod would push the same tree twice, under two names.
+type sandboxObserverOpts struct {
+	runID    string
+	tenantID string
+	ownerID  string
+	// secretRefs are the run's refreshable file secrets (empty = none).
+	secretRefs map[string]string
+	// checkpoint preserves the sandbox workspace mid-run. True only for
+	// the run that OWNS the pod.
+	checkpoint bool
+}
+
+// checkpointsWorkspace answers the one question that decides whether this
+// run gets a safety net: is its work unreachable until teardown, and is
+// this the run that owns the pod?
+//
+// Copy-based drivers (kubernetes) are the ones whose workspace lives
+// inside the pod — the same type assertion the export path gates on, so
+// the two cannot disagree about what "copy-based" means. Bind-mount
+// drivers share the host inode: their work is already outside the
+// container and a checkpoint would preserve what cannot be lost.
+//
+// The second half is not an optimisation: a subbot child under a shared
+// sandbox is handed its PARENT's handle, so without it two loops would
+// push the same tree to two refs, doubling the cost and inventing a
+// second story about one workspace.
+func checkpointsWorkspace(run sandbox.Run, o sandboxObserverOpts) bool {
+	if !o.checkpoint {
+		return false
+	}
+	_, copyBased := run.(sandbox.WorkspaceExporter)
+	return copyBased
+}
+
+func (r *Runner) sandboxRunObserver(ctx context.Context, o sandboxObserverOpts) func(sandbox.Run) {
 	return func(run sandbox.Run) {
-		r.registerSandboxRun(runID, run)
-		if len(refs) == 0 {
+		r.registerSandboxRun(o.runID, run)
+		// A workspace that is a COPY inside a pod keeps every commit —
+		// and everything not yet committed — out of reach until the
+		// export at teardown, which is exactly the moment a dying pod
+		// stops answering. Bind-mount drivers share the host inode and
+		// need no net: their work is already outside the container.
+		if checkpointsWorkspace(run, o) {
+			errtrack.Go("runner.checkpointWorkspace", func() {
+				r.checkpointWorkspaceLoop(ctx, o, run)
+			})
+		}
+		if len(o.secretRefs) == 0 {
 			return
 		}
 		refresher, ok := run.(sandbox.SecretFileRefresher)
@@ -66,7 +114,7 @@ func (r *Runner) sandboxRunObserver(ctx context.Context, runID, tenantID string,
 			return
 		}
 		errtrack.Go("runner.refreshSandboxFileSecrets", func() {
-			r.refreshSandboxFileSecretsLoop(ctx, tenantID, refs, refresher)
+			r.refreshSandboxFileSecretsLoop(ctx, o.tenantID, o.secretRefs, refresher)
 		})
 	}
 }

--- a/pkg/runner/subbot.go
+++ b/pkg/runner/subbot.go
@@ -221,7 +221,13 @@ func (r *Runner) subbotRunnerFor(msg *queue.RunMessage, parentDir, workDir strin
 			runtime.WithWorkflowHash(hash),
 			runtime.WithFilePath(childPath),
 			runtime.WithWorkDir(childWorkDir),
-			runtime.WithSandboxRunObserver(r.sandboxRunObserver(sbObsCtx, childRunID, msg.TenantID, r.sandboxFileSecretRefs(ctx, childWf))),
+			runtime.WithSandboxRunObserver(r.sandboxRunObserver(sbObsCtx, sandboxObserverOpts{
+				runID: childRunID, tenantID: msg.TenantID, ownerID: msg.OwnerID,
+				secretRefs: r.sandboxFileSecretRefs(ctx, childWf),
+				// No second checkpoint loop: a shared child is handed its
+				// parent's sandbox, and the parent's loop already preserves
+				// the one workspace they both work in.
+			})),
 			runtime.WithSandboxDefault(r.cfg.SandboxDefault),
 			runtime.WithSandboxDefaultImage(msg.SandboxImage),
 			runtime.WithSandboxHostStateDefault(r.cfg.SandboxHostState),

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -260,6 +260,21 @@ const (
 	//     stays recoverable from the git-meta snapshot) — the failure
 	//     shape; exactly one of ref/error is present
 	EventRunBankAttempt EventType = "run_bank_attempt"
+	// EventRunWorkspaceCheckpoint marks the runner preserving a
+	// COPY-BASED sandbox's work outside the pod, mid-run, on
+	// iterion/run-<id>-checkpoint. On such a driver nothing a run
+	// produces leaves the pod before teardown, so a hard pod death takes
+	// everything — measured: eight hours and 655 tool calls lost with an
+	// export that could no longer read the pod. The checkpoint is not a
+	// bank: the run doc is untouched (no FinalBranch — a half-done run
+	// must not read as merge-eligible), the commit is authored by
+	// iterion rather than by the run, and this event is the only durable
+	// record that the ref exists. Data:
+	//   - ref / commit: the checkpoint ref and what it holds — the
+	//     success shape
+	//   - ref / error: why the push failed and the work is still only
+	//     inside the pod — the failure shape
+	EventRunWorkspaceCheckpoint EventType = "run_workspace_checkpoint"
 	// EventRunRewound marks an in-place rewind: the operator re-anchored
 	// THIS run's checkpoint on an already-executed node and invalidated
 	// the outputs downstream of it, so the next resume re-executes from


### PR DESCRIPTION
## Eight hours, 655 tool calls, nothing left

On a driver whose workspace is a tar **copy** inside a pod (kubernetes), nothing a run produces leaves that pod before teardown: `ExportWorkspace` runs once, at the end, and every push the runner performs reads the *exported* clone. Its own doc says what that costs — "without a reverse copy, every commit the run made inside the pod is destroyed with the pod". What it does not say is that the reverse copy is the **only** moment, so a pod that dies hard takes the whole run with it, however well the run committed.

Measured on a campaign lot: eight hours and 655 tool calls inside one agent node, death at the duration wall, `final_commit` empty, bank refused with *"pod-side HEAD unknown … cannot tell 'no commits' from 'the export lost the work'"*. The store records commits; the run had made none; there was nothing left to recover. And the budget guard declined the next iteration **one second** before the export failed — so no end-of-run rescue could have run either. The only preservation that survives a dead pod is preservation that already happened.

## What this does

Every ten minutes, on copy-based drivers only, the runner asks the sandbox for what would be lost right now and pushes it to `iterion/run-<id>-checkpoint`. Both halves of the loss are covered: commits leave the pod **while it is healthy**, and work that was never committed is preserved anyway, as a commit built from the working tree.

It rides the seam that already exists for exactly this shape of problem — the runner's mid-run loop into a live sandbox (`sandboxRunObserver`, the file-secret refresh loop, `.git/iterion-credentials` kept fresh so the pod's own `git push` authenticates).

## What it may not do, and does not

- **It never touches the run's own history.** The tree is read into a temporary index (`GIT_INDEX_FILE`), and `commit-tree` writes an object and no ref. `TestCheckpointScriptPreservesTheTreeAndTouchesNothing` runs the real script against a real repository with both an unstaged file and a staged edit, and asserts HEAD, the porcelain status and the run's staged blob come out byte-identical — the run's index is not even locked, so an agent running `git add` alongside is not raced.
- **The checkpoint is authored by iterion, explicitly.** A checkpoint wearing the committer's name would be evidence that lies about who did the work — the exact confusion the extension gates spend their code refusing. The test asserts the author and that the commit is reachable from no branch.
- **It is not a bank.** The run doc is untouched — no `FinalBranch`, so a half-done run never reads as merge-eligible. The timeline event (`run_workspace_checkpoint`) is the only durable record that the ref exists, which is what an operator needs to recover from it.

## Bounded on both sides

- **Bind-mount drivers get no loop**: their workspace shares the host inode and already survives the container, so a checkpoint would preserve what cannot be lost. The gate is the same `WorkspaceExporter` assertion the export path uses, so the two cannot disagree about what "copy-based" means.
- **A subbot child under a shared sandbox gets none either**: it is handed its *parent's* handle, and two loops would push one workspace under two names and tell two stories about it.
- A tick that finds nothing moved pushes nothing (an idle run costs one exec per tick and no network). A failed push does **not** record the sha as preserved, so the next tick retries instead of skipping it — silently skipping is the failure mode this whole change exists against. "No repository yet, or no commit to parent one on" is a *state*, not a failure: it does not warn every ten minutes for the length of a run, while a genuine failure to read the tree does.

The push is forced on purpose: successive checkpoints are **siblings**, not descendants (each is parented on the run's current HEAD), so a fast-forward push would refuse every checkpoint after the first. The ref is derived from the run's own id and contested by nobody.

## Proof

- `go test ./pkg/runner/ ./pkg/store/` green; `golangci-lint` 0 issues; `gofmt` clean.
- Seven mutants, each red on its own test — including the two that would turn this into a runner committing on the run's behalf: the temporary index dropped (the run's index gets written), and the explicit identity dropped (the checkpoint wears the run's name). Plus: a failed push recorded as preserved; the quiet no-op made loud; the shared-child gate removed; the copy-based gate removed; the unchanged-tree skip removed.

## What it does not close

A checkpoint bounds the loss to one interval; it does not make an eight-hour node commit its work, and it cannot preserve anything once the pod stops answering. The interval is a constant here rather than a knob — ten minutes is the measured trade (one exec, one push when something moved) and a knob nobody sets is a knob that misleads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## One consequence a reviewer should weigh

The checkpoint pushes to the repository the run already banks to, with the credentials it already holds. On a private target that is the same exposure as the terminal bank, ten minutes earlier. On a **public** repository it publishes intermediate work that would otherwise only appear as a bank at the end — same destination, higher frequency. Refs are named `iterion/run-<id>-checkpoint`, which a pruning policy can tell from `-parked-` (a live run's parked work) and `-attempt-` (a dead attempt's archive) by name alone, as the existing convention requires.
