### PR TITLE
feat(golden-master): the two debts behind a 0/0 held-out figure are fields, not sentences

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2133,6 +2133,13 @@ tool oracle_run:
         only widen what the gate consumes, never soften a verdict.
 
         Returns True when the set now lives outside the workspace.
+
+        Sealing OUT of the tree is what makes the seal mechanical, and it is also
+        what makes a fresh set EPHEMERAL: the sealed pile is keyed on the
+        workspace path under the scratch directory, so a run whose workspace dies
+        with it — a pod — takes the set along. A set that must be scored by a
+        LATER run has exactly one durable home, the tree, and the caller says so
+        rather than letting the next gate report 0/0 for a set that was drawn.
         """
         src = os.path.join(gm_dir, "mutants", "holdout")
         if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
@@ -2200,6 +2207,40 @@ tool oracle_run:
                 if os.path.isdir(d):
                     out[mutant_fingerprint(d)] = cycle + "/" + name
         return out
+
+
+    def spent_cycles(gm_dir):
+        """How many held-out cycles were scored and published under mutants/audit/.
+
+        The figure is what turns a legitimate state into a DEBT: one spent cycle
+        is a set that did its work, thirteen with none pending is a campaign whose
+        strongest term has been vacuous for a while. The judge does not set the
+        policy — it publishes the count so the process that owns the cadence can.
+
+        Counted from the directory, not from `spent_fingerprints`: that map is
+        keyed by FINGERPRINT, so two cycles that drew the same mutation collapse
+        into one entry — the right behaviour for refusing a repeat, the wrong one
+        for counting history (measured: three published mutants over two cycles
+        counted as one).
+        """
+        root = os.path.join(gm_dir, "mutants", "audit")
+        if not os.path.isdir(root):
+            return 0
+        return len([c for c in sorted(os.listdir(root))
+                    if os.path.isdir(os.path.join(root, c))])
+
+
+    def sealed_but_ephemeral(committed_before, sealed_now):
+        """True when a held-out set left the tree WITHOUT a committed copy.
+
+        Sealing out of the tree is what makes the seal mechanical; it is also what
+        makes the set ephemeral, because the sealed pile is keyed on the workspace
+        path under the scratch directory. A workspace that dies with its run — a
+        pod — takes the set with it, and the next gate reports 0/0 for a set that
+        was drawn. A committed set is the exception: it is left in place, which is
+        the only home that crosses a run boundary.
+        """
+        return bool(sealed_now) and not committed_before
 
 
     def load_mutants(gm_dir, holdout, sealed_dir=None):
@@ -3616,6 +3657,23 @@ tool oracle_run:
                    os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                    os.path.isdir(sealed2)],
                   [False, True, False])
+            # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
+            # sont pas la meme, et aucune n'est un echec : ce sont des etats que
+            # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice
+            # est l'endroit ou les dettes se cachent.
+            check("jeu frais scelle hors de l'arbre -> ephemere ; jeu committe -> non",
+                  [sealed_but_ephemeral(False, True), sealed_but_ephemeral(True, True),
+                   sealed_but_ephemeral(False, False)],
+                  [True, False, False])
+            adir = os.path.join(sroot, "audited", ".golden-master")
+            for cyc, name in (("01a0-un", "m1"), ("01a0-un", "m2"), ("01a0-deux", "m3")):
+                d = os.path.join(adir, "mutants", "audit", cyc, name)
+                os.makedirs(d)
+                with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("true\n")
+            check("cycles depenses comptes par CYCLE, pas par mutant",
+                  [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
+
             prev_seal = os.environ.get("GM_SEAL_COMMITTED")
             os.environ["GM_SEAL_COMMITTED"] = "1"
             try:
@@ -4897,6 +4955,8 @@ tool oracle_run:
                   "standard": 2, "unmapped_features": [], "stale_features": [],
                   "features_total": 0, "features_excluded": 0,
                   "holdout_awaiting_gate": False,
+                  "holdout_spent_unreplaced": False, "holdout_spent_cycles": 0,
+                  "holdout_sealed_uncommitted": False,
                   "pending_rebaselines": [],
                   "pending_extensions": [],
                   "holdout_detected": 0, "holdout_total": 0, "stable": False,
@@ -5086,11 +5146,26 @@ tool oracle_run:
 
         if mode != "record":
             try:
-                seal_holdout(gm_dir, sealed_dir)
+                committed_before = holdout_committed_in_tree(gm_dir)
+                sealed_now = seal_holdout(gm_dir, sealed_dir)
                 awaiting = holdout_committed_in_tree(gm_dir) and \
                     not seal_committed_opted_in(gm_dir)
             except SystemExit as e:
                 bail(str(e))
+            # A set sealed out of an UNCOMMITTED state lives only as long as the
+            # sealed pile does, and that pile is keyed on the workspace path under
+            # the scratch directory: a run whose workspace dies with it takes the
+            # set along, and the next gate reports 0/0 for a set that was drawn.
+            # Said here, once, at the moment the set leaves the tree — the only
+            # moment anyone can still commit it.
+            if sealed_but_ephemeral(committed_before, sealed_now):
+                report["holdout_sealed_uncommitted"] = True
+                note(report, "the held-out set was sealed OUT of the tree into %s and is "
+                             "NOT committed: it survives exactly as long as that directory "
+                             "does. A set a LATER run must score has one durable home — "
+                             "commit it under mutants/holdout/ and let the gate that owns "
+                             "it opt in (`\"seal_committed\": true`). Otherwise this run is "
+                             "the only one that will ever see it." % sealed_dir)
             if awaiting:
                 # Machine-readable, not only prose: a set nobody ever consumes is
                 # a debt of the NET's owner, and a supervising process needs a
@@ -5116,16 +5191,27 @@ tool oracle_run:
             holdout_spent = bool(spent_fingerprints(gm_dir))
             if not held_meta and not os.path.isdir(os.path.join(gm_dir, "mutants", "holdout")):
                 if holdout_spent:
-                    # Legitimate: this cycle's set was scored once and published as
-                    # evidence. The blindness proof was MADE and is replayable from
-                    # mutants/audit/ — it is simply not being re-made here, and the
-                    # report must say so rather than let 0 == 0 read as a pass.
+                    # Legitimate for ONE replay: this cycle's set was scored once
+                    # and published as evidence, and the blindness proof is
+                    # replayable from mutants/audit/. It stops being legitimate
+                    # when nobody draws the next one — and THAT is a debt, so it
+                    # gets a field. A notice string is where debts go to hide: the
+                    # sibling debt (a committed set nobody consumes) has carried
+                    # `holdout_awaiting_gate` since it was measured, while this one
+                    # was prose only. Measured on a live campaign: thirteen spent
+                    # cycles, no set committed, every landing reporting 0/0 through
+                    # a term the wrapper checks as `detected == total` — vacuously
+                    # true, announced in a sentence nothing reads.
+                    cycles = spent_cycles(gm_dir)
+                    report["holdout_spent_unreplaced"] = True
+                    report["holdout_spent_cycles"] = cycles
                     note(report, "the held-out set for this cycle is SPENT and published "
-                                 "under mutants/audit/. This replay re-checks the visible "
+                                 "under mutants/audit/ (%d cycle(s) there, none pending). "
+                                 "This replay re-checks the visible "
                                  "counter-test only; the held-out figure below is 0/0 and "
                                  "proves nothing on its own. Draw a fresh set to harden "
                                  "again — the gate refuses one that repeats a published "
-                                 "fingerprint.")
+                                 "fingerprint." % cycles)
                 else:
                     bail("the sealed held-out set is missing from %s and no longer in the "
                          "workspace. It was relocated by an earlier gate and the sealed "

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1914,6 +1914,13 @@ def seal_holdout(gm_dir, sealed_dir):
     only widen what the gate consumes, never soften a verdict.
 
     Returns True when the set now lives outside the workspace.
+
+    Sealing OUT of the tree is what makes the seal mechanical, and it is also
+    what makes a fresh set EPHEMERAL: the sealed pile is keyed on the
+    workspace path under the scratch directory, so a run whose workspace dies
+    with it — a pod — takes the set along. A set that must be scored by a
+    LATER run has exactly one durable home, the tree, and the caller says so
+    rather than letting the next gate report 0/0 for a set that was drawn.
     """
     src = os.path.join(gm_dir, "mutants", "holdout")
     if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
@@ -1981,6 +1988,40 @@ def spent_fingerprints(gm_dir):
             if os.path.isdir(d):
                 out[mutant_fingerprint(d)] = cycle + "/" + name
     return out
+
+
+def spent_cycles(gm_dir):
+    """How many held-out cycles were scored and published under mutants/audit/.
+
+    The figure is what turns a legitimate state into a DEBT: one spent cycle
+    is a set that did its work, thirteen with none pending is a campaign whose
+    strongest term has been vacuous for a while. The judge does not set the
+    policy — it publishes the count so the process that owns the cadence can.
+
+    Counted from the directory, not from `spent_fingerprints`: that map is
+    keyed by FINGERPRINT, so two cycles that drew the same mutation collapse
+    into one entry — the right behaviour for refusing a repeat, the wrong one
+    for counting history (measured: three published mutants over two cycles
+    counted as one).
+    """
+    root = os.path.join(gm_dir, "mutants", "audit")
+    if not os.path.isdir(root):
+        return 0
+    return len([c for c in sorted(os.listdir(root))
+                if os.path.isdir(os.path.join(root, c))])
+
+
+def sealed_but_ephemeral(committed_before, sealed_now):
+    """True when a held-out set left the tree WITHOUT a committed copy.
+
+    Sealing out of the tree is what makes the seal mechanical; it is also what
+    makes the set ephemeral, because the sealed pile is keyed on the workspace
+    path under the scratch directory. A workspace that dies with its run — a
+    pod — takes the set with it, and the next gate reports 0/0 for a set that
+    was drawn. A committed set is the exception: it is left in place, which is
+    the only home that crosses a run boundary.
+    """
+    return bool(sealed_now) and not committed_before
 
 
 def load_mutants(gm_dir, holdout, sealed_dir=None):
@@ -3397,6 +3438,23 @@ def _selftest():
                os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                os.path.isdir(sealed2)],
               [False, True, False])
+        # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
+        # sont pas la meme, et aucune n'est un echec : ce sont des etats que
+        # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice
+        # est l'endroit ou les dettes se cachent.
+        check("jeu frais scelle hors de l'arbre -> ephemere ; jeu committe -> non",
+              [sealed_but_ephemeral(False, True), sealed_but_ephemeral(True, True),
+               sealed_but_ephemeral(False, False)],
+              [True, False, False])
+        adir = os.path.join(sroot, "audited", ".golden-master")
+        for cyc, name in (("01a0-un", "m1"), ("01a0-un", "m2"), ("01a0-deux", "m3")):
+            d = os.path.join(adir, "mutants", "audit", cyc, name)
+            os.makedirs(d)
+            with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write("true\n")
+        check("cycles depenses comptes par CYCLE, pas par mutant",
+              [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
+
         prev_seal = os.environ.get("GM_SEAL_COMMITTED")
         os.environ["GM_SEAL_COMMITTED"] = "1"
         try:
@@ -4678,6 +4736,8 @@ def main():
               "standard": 2, "unmapped_features": [], "stale_features": [],
               "features_total": 0, "features_excluded": 0,
               "holdout_awaiting_gate": False,
+              "holdout_spent_unreplaced": False, "holdout_spent_cycles": 0,
+              "holdout_sealed_uncommitted": False,
               "pending_rebaselines": [],
               "pending_extensions": [],
               "holdout_detected": 0, "holdout_total": 0, "stable": False,
@@ -4867,11 +4927,26 @@ def main():
 
     if mode != "record":
         try:
-            seal_holdout(gm_dir, sealed_dir)
+            committed_before = holdout_committed_in_tree(gm_dir)
+            sealed_now = seal_holdout(gm_dir, sealed_dir)
             awaiting = holdout_committed_in_tree(gm_dir) and \
                 not seal_committed_opted_in(gm_dir)
         except SystemExit as e:
             bail(str(e))
+        # A set sealed out of an UNCOMMITTED state lives only as long as the
+        # sealed pile does, and that pile is keyed on the workspace path under
+        # the scratch directory: a run whose workspace dies with it takes the
+        # set along, and the next gate reports 0/0 for a set that was drawn.
+        # Said here, once, at the moment the set leaves the tree — the only
+        # moment anyone can still commit it.
+        if sealed_but_ephemeral(committed_before, sealed_now):
+            report["holdout_sealed_uncommitted"] = True
+            note(report, "the held-out set was sealed OUT of the tree into %s and is "
+                         "NOT committed: it survives exactly as long as that directory "
+                         "does. A set a LATER run must score has one durable home — "
+                         "commit it under mutants/holdout/ and let the gate that owns "
+                         "it opt in (`\"seal_committed\": true`). Otherwise this run is "
+                         "the only one that will ever see it." % sealed_dir)
         if awaiting:
             # Machine-readable, not only prose: a set nobody ever consumes is
             # a debt of the NET's owner, and a supervising process needs a
@@ -4897,16 +4972,27 @@ def main():
         holdout_spent = bool(spent_fingerprints(gm_dir))
         if not held_meta and not os.path.isdir(os.path.join(gm_dir, "mutants", "holdout")):
             if holdout_spent:
-                # Legitimate: this cycle's set was scored once and published as
-                # evidence. The blindness proof was MADE and is replayable from
-                # mutants/audit/ — it is simply not being re-made here, and the
-                # report must say so rather than let 0 == 0 read as a pass.
+                # Legitimate for ONE replay: this cycle's set was scored once
+                # and published as evidence, and the blindness proof is
+                # replayable from mutants/audit/. It stops being legitimate
+                # when nobody draws the next one — and THAT is a debt, so it
+                # gets a field. A notice string is where debts go to hide: the
+                # sibling debt (a committed set nobody consumes) has carried
+                # `holdout_awaiting_gate` since it was measured, while this one
+                # was prose only. Measured on a live campaign: thirteen spent
+                # cycles, no set committed, every landing reporting 0/0 through
+                # a term the wrapper checks as `detected == total` — vacuously
+                # true, announced in a sentence nothing reads.
+                cycles = spent_cycles(gm_dir)
+                report["holdout_spent_unreplaced"] = True
+                report["holdout_spent_cycles"] = cycles
                 note(report, "the held-out set for this cycle is SPENT and published "
-                             "under mutants/audit/. This replay re-checks the visible "
+                             "under mutants/audit/ (%d cycle(s) there, none pending). "
+                             "This replay re-checks the visible "
                              "counter-test only; the held-out figure below is 0/0 and "
                              "proves nothing on its own. Draw a fresh set to harden "
                              "again — the gate refuses one that repeats a published "
-                             "fingerprint.")
+                             "fingerprint." % cycles)
             else:
                 bail("the sealed held-out set is missing from %s and no longer in the "
                      "workspace. It was relocated by an earlier gate and the sealed "

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -171,6 +171,34 @@ Two mechanics worth knowing before the first run:
   not declare `seal_committed` leaves the committed held-out set to the gate that does. Give the
   second environment its own fresh set if you want it scored there too — a set is spent once.
 
+## The held-out set has to survive the run that drew it
+
+Sealing the set out of the tree is what makes the seal mechanical — the hardening loop cannot
+learn from mutants it cannot read. It is also what makes a fresh set **ephemeral**: the sealed
+pile lives under the scratch directory, keyed on the workspace path, so a workspace that dies
+with its run takes the set with it. On a pod, that is every run.
+
+A set a LATER gate must score therefore has one durable home, the tree: commit it under
+`mutants/holdout/`, and let the gate that owns it opt in (`"seal_committed": true`, or
+`GM_SEAL_COMMITTED=1` for a hand-run gate). A committed set is left in place by the seal
+precisely so it can wait for that gate.
+
+Two debts a `0/0` held-out figure can carry, both reported as FIELDS rather than prose, because
+a supervising process needs to see them:
+
+- `holdout_awaiting_gate` — a set is committed and no gate has claimed it. It narrows the
+  counter-test while reading as prepared.
+- `holdout_spent_unreplaced` with `holdout_spent_cycles` — the last set was scored and published
+  under `mutants/audit/`, and no fresh one has been drawn. One cycle is a set that did its work;
+  a long run of them is a campaign whose strongest term has been vacuously true for a while.
+  Measured on a live campaign: thirteen published cycles, nothing committed, every landing
+  reporting `0/0` through a gate line that checks `detected == total`.
+- `holdout_sealed_uncommitted` — a fresh set just left the tree without a committed copy. Said at
+  the one moment anyone can still commit it.
+
+None of the three is a refusal: the judge publishes the state and the count, and the process that
+owns the campaign's cadence decides what a debt costs.
+
 ## Re-baselining, and why it kills nets
 
 A golden master dies by re-baselining. Something breaks three screens, someone regenerates the

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2081,6 +2081,13 @@ tool sync_harness:
         only widen what the gate consumes, never soften a verdict.
 
         Returns True when the set now lives outside the workspace.
+
+        Sealing OUT of the tree is what makes the seal mechanical, and it is also
+        what makes a fresh set EPHEMERAL: the sealed pile is keyed on the
+        workspace path under the scratch directory, so a run whose workspace dies
+        with it — a pod — takes the set along. A set that must be scored by a
+        LATER run has exactly one durable home, the tree, and the caller says so
+        rather than letting the next gate report 0/0 for a set that was drawn.
         """
         src = os.path.join(gm_dir, "mutants", "holdout")
         if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
@@ -2148,6 +2155,40 @@ tool sync_harness:
                 if os.path.isdir(d):
                     out[mutant_fingerprint(d)] = cycle + "/" + name
         return out
+
+
+    def spent_cycles(gm_dir):
+        """How many held-out cycles were scored and published under mutants/audit/.
+
+        The figure is what turns a legitimate state into a DEBT: one spent cycle
+        is a set that did its work, thirteen with none pending is a campaign whose
+        strongest term has been vacuous for a while. The judge does not set the
+        policy — it publishes the count so the process that owns the cadence can.
+
+        Counted from the directory, not from `spent_fingerprints`: that map is
+        keyed by FINGERPRINT, so two cycles that drew the same mutation collapse
+        into one entry — the right behaviour for refusing a repeat, the wrong one
+        for counting history (measured: three published mutants over two cycles
+        counted as one).
+        """
+        root = os.path.join(gm_dir, "mutants", "audit")
+        if not os.path.isdir(root):
+            return 0
+        return len([c for c in sorted(os.listdir(root))
+                    if os.path.isdir(os.path.join(root, c))])
+
+
+    def sealed_but_ephemeral(committed_before, sealed_now):
+        """True when a held-out set left the tree WITHOUT a committed copy.
+
+        Sealing out of the tree is what makes the seal mechanical; it is also what
+        makes the set ephemeral, because the sealed pile is keyed on the workspace
+        path under the scratch directory. A workspace that dies with its run — a
+        pod — takes the set with it, and the next gate reports 0/0 for a set that
+        was drawn. A committed set is the exception: it is left in place, which is
+        the only home that crosses a run boundary.
+        """
+        return bool(sealed_now) and not committed_before
 
 
     def load_mutants(gm_dir, holdout, sealed_dir=None):
@@ -3564,6 +3605,23 @@ tool sync_harness:
                    os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                    os.path.isdir(sealed2)],
                   [False, True, False])
+            # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
+            # sont pas la meme, et aucune n'est un echec : ce sont des etats que
+            # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice
+            # est l'endroit ou les dettes se cachent.
+            check("jeu frais scelle hors de l'arbre -> ephemere ; jeu committe -> non",
+                  [sealed_but_ephemeral(False, True), sealed_but_ephemeral(True, True),
+                   sealed_but_ephemeral(False, False)],
+                  [True, False, False])
+            adir = os.path.join(sroot, "audited", ".golden-master")
+            for cyc, name in (("01a0-un", "m1"), ("01a0-un", "m2"), ("01a0-deux", "m3")):
+                d = os.path.join(adir, "mutants", "audit", cyc, name)
+                os.makedirs(d)
+                with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write("true\n")
+            check("cycles depenses comptes par CYCLE, pas par mutant",
+                  [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
+
             prev_seal = os.environ.get("GM_SEAL_COMMITTED")
             os.environ["GM_SEAL_COMMITTED"] = "1"
             try:
@@ -4845,6 +4903,8 @@ tool sync_harness:
                   "standard": 2, "unmapped_features": [], "stale_features": [],
                   "features_total": 0, "features_excluded": 0,
                   "holdout_awaiting_gate": False,
+                  "holdout_spent_unreplaced": False, "holdout_spent_cycles": 0,
+                  "holdout_sealed_uncommitted": False,
                   "pending_rebaselines": [],
                   "pending_extensions": [],
                   "holdout_detected": 0, "holdout_total": 0, "stable": False,
@@ -5034,11 +5094,26 @@ tool sync_harness:
 
         if mode != "record":
             try:
-                seal_holdout(gm_dir, sealed_dir)
+                committed_before = holdout_committed_in_tree(gm_dir)
+                sealed_now = seal_holdout(gm_dir, sealed_dir)
                 awaiting = holdout_committed_in_tree(gm_dir) and \
                     not seal_committed_opted_in(gm_dir)
             except SystemExit as e:
                 bail(str(e))
+            # A set sealed out of an UNCOMMITTED state lives only as long as the
+            # sealed pile does, and that pile is keyed on the workspace path under
+            # the scratch directory: a run whose workspace dies with it takes the
+            # set along, and the next gate reports 0/0 for a set that was drawn.
+            # Said here, once, at the moment the set leaves the tree — the only
+            # moment anyone can still commit it.
+            if sealed_but_ephemeral(committed_before, sealed_now):
+                report["holdout_sealed_uncommitted"] = True
+                note(report, "the held-out set was sealed OUT of the tree into %s and is "
+                             "NOT committed: it survives exactly as long as that directory "
+                             "does. A set a LATER run must score has one durable home — "
+                             "commit it under mutants/holdout/ and let the gate that owns "
+                             "it opt in (`\"seal_committed\": true`). Otherwise this run is "
+                             "the only one that will ever see it." % sealed_dir)
             if awaiting:
                 # Machine-readable, not only prose: a set nobody ever consumes is
                 # a debt of the NET's owner, and a supervising process needs a
@@ -5064,16 +5139,27 @@ tool sync_harness:
             holdout_spent = bool(spent_fingerprints(gm_dir))
             if not held_meta and not os.path.isdir(os.path.join(gm_dir, "mutants", "holdout")):
                 if holdout_spent:
-                    # Legitimate: this cycle's set was scored once and published as
-                    # evidence. The blindness proof was MADE and is replayable from
-                    # mutants/audit/ — it is simply not being re-made here, and the
-                    # report must say so rather than let 0 == 0 read as a pass.
+                    # Legitimate for ONE replay: this cycle's set was scored once
+                    # and published as evidence, and the blindness proof is
+                    # replayable from mutants/audit/. It stops being legitimate
+                    # when nobody draws the next one — and THAT is a debt, so it
+                    # gets a field. A notice string is where debts go to hide: the
+                    # sibling debt (a committed set nobody consumes) has carried
+                    # `holdout_awaiting_gate` since it was measured, while this one
+                    # was prose only. Measured on a live campaign: thirteen spent
+                    # cycles, no set committed, every landing reporting 0/0 through
+                    # a term the wrapper checks as `detected == total` — vacuously
+                    # true, announced in a sentence nothing reads.
+                    cycles = spent_cycles(gm_dir)
+                    report["holdout_spent_unreplaced"] = True
+                    report["holdout_spent_cycles"] = cycles
                     note(report, "the held-out set for this cycle is SPENT and published "
-                                 "under mutants/audit/. This replay re-checks the visible "
+                                 "under mutants/audit/ (%d cycle(s) there, none pending). "
+                                 "This replay re-checks the visible "
                                  "counter-test only; the held-out figure below is 0/0 and "
                                  "proves nothing on its own. Draw a fresh set to harden "
                                  "again — the gate refuses one that repeats a published "
-                                 "fingerprint.")
+                                 "fingerprint." % cycles)
                 else:
                     bail("the sealed held-out set is missing from %s and no longer in the "
                          "workspace. It was relocated by an earlier gate and the sealed "

--- a/bots/golden_master_config_test.go
+++ b/bots/golden_master_config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -93,8 +94,10 @@ func TestGoldenMasterHarnessNamesTheConfig(t *testing.T) {
 		// Not GM_CONFIG alone: an operator input meant for the NET applied to
 		// the doubles is one class, and the same count must come out of each
 		// run — a guard that made fixtures vanish instead of hermetic would
-		// pass this loop while testing less.
-		const want = "218 verifications passent"
+		// pass this loop while testing less. The count is read from the
+		// unset run rather than written here: pinning a number would fail
+		// every branch that adds a check, and the claim is EQUALITY.
+		want := ""
 		for _, env := range [][]string{
 			nil,
 			{"GM_CONFIG=config-pg.json"},
@@ -111,8 +114,16 @@ func TestGoldenMasterHarnessNamesTheConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%v made the selftest fail — the gate wrapper runs it as a blocking step: %v\n%s", env, err, out)
 			}
-			if !strings.Contains(string(out), want) {
-				t.Fatalf("%v changed WHICH checks ran (want %q):\n%s", env, want, out)
+			m := regexp.MustCompile(`harnais : (\d+) verifications passent`).FindStringSubmatch(string(out))
+			if m == nil {
+				t.Fatalf("%v: no check count in the selftest output:\n%s", env, out)
+			}
+			if want == "" {
+				want = m[1]
+				continue
+			}
+			if m[1] != want {
+				t.Fatalf("%v changed WHICH checks ran: %s instead of %s", env, m[1], want)
 			}
 		}
 	})


### PR DESCRIPTION
## A term that reads as satisfied, and a debt that lived in a sentence

The gate line checks `holdout_detected == holdout_total`, which is **vacuously true at 0/0**. The report already said so — in a `notice` — and this file's own comment names why that is not enough: *"a notice string is where debts go to hide"*. One of the two debts got a field when it was measured (`holdout_awaiting_gate`, for a committed set no gate has claimed); the other stayed prose.

Measured on a live campaign: **thirteen** held-out cycles scored and published under `mutants/audit/`, **no set committed anywhere**, and every landing since reporting `0/0` through a term that reads as satisfied. Nobody was lied to — the notice said it every time — but nothing a supervising process reads carried it, so the strongest term of the oracle was vacuous for days without any process being able to see it.

## Two states, two fields, and a count

- **`holdout_spent_unreplaced` + `holdout_spent_cycles`** — the last set did its work and was published; no fresh one has been drawn. One cycle is a healthy state; a long run of them is a debt. The judge publishes the figure rather than deciding what it costs: the cadence belongs to the process that owns the campaign, and a judge that refused here would block every lot until a hardening run happened.
- **`holdout_sealed_uncommitted`** — a fresh set just left the tree with no committed copy. Sealing out of the tree is what makes the seal mechanical (the hardening loop cannot learn from mutants it cannot read) and it is also what makes the set **ephemeral**: the sealed pile is keyed on the workspace path under the scratch directory, so a workspace that dies with its run takes the set along and the next gate reports `0/0` for a set that was drawn. On a pod, that is every run. Said at the one moment anyone can still commit it.

## Falsifiable, because both decisions are named

They are functions, not expressions buried in `main()`:

- `sealed_but_ephemeral(committed_before, sealed_now)` — a committed set is the exception, and losing that exception turns every seal into a warning. Two mutants: the exception dropped, and the whole predicate dead.
- `spent_cycles(gm_dir)` — counted from the audit **directory**, not from `spent_fingerprints`. That map is keyed by fingerprint, so two cycles drawing the same mutation collapse into one entry: right for refusing a repeat, wrong for counting history. Measured while writing the test — three published mutants over two cycles counted as one. Two mutants: the fingerprint counting restored, and a net with no audit reporting a debt.

Selftest 211; `go test ./bots/` green; both inlined copies regenerated by `sync-harness.py`.

The skill gains the section this state deserves: the held-out set has to survive the run that drew it, the tree is its only durable home, and the three fields are what a supervisor reads instead of parsing prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
