### PR TITLE
fix(forge,server): a head repository the credential may not read is declared, and a forge refusal answers as the forge, not as an iterion fault

### DIFF
--- a/pkg/forge/admin_http.go
+++ b/pkg/forge/admin_http.go
@@ -2,6 +2,7 @@ package forge
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
 )
@@ -46,6 +47,26 @@ func (h AdminHTTP) Do(ctx context.Context, method, path string, body, out any) (
 // the calls whose refusal reason must reach the operator verbatim.
 func (h AdminHTTP) DoErrBody(ctx context.Context, method, path string, body, out any) (int, []byte, error) {
 	return DoJSONErrBody(ctx, h.client, method, h.apiBase+path, h.provider, h.setHeaders, body, out)
+}
+
+// DoTyped performs one call and TYPES a non-2xx answer itself, instead of
+// handing the status back for the call site to map. It is the only path that
+// can carry a Retry-After: the header lives on the response, which nothing
+// above this layer ever sees. Returns nil on 2xx (out is decoded as in Do).
+func (h AdminHTTP) DoTyped(ctx context.Context, method, path, op string, body, out any) error {
+	code, _, hdr, err := DoJSONFull(ctx, h.client, method, h.apiBase+path, h.provider, h.setHeaders, body, out)
+	if err != nil {
+		return err
+	}
+	if code/100 == 2 {
+		return nil
+	}
+	statusErr := h.StatusErr(op, code)
+	var se *StatusError
+	if errors.As(statusErr, &se) {
+		se.RetryAfter = ParseRetryAfter(hdr.Get("Retry-After"))
+	}
+	return statusErr
 }
 
 // DoMultipartFile uploads one file part by delegating to DoMultipartFile,

--- a/pkg/forge/declared.go
+++ b/pkg/forge/declared.go
@@ -1,0 +1,28 @@
+package forge
+
+import "encoding/json"
+
+// UnmarshalDeclaring decodes b into v and reports whether the JSON object
+// carried key at all — true even when its value is null. v must be a type
+// with no UnmarshalJSON of its own (the callers pass a `type plain T` alias),
+// or this recurses.
+//
+// `null` and an absent key both decode to the zero value, and for a pull
+// request's head repository the two are different facts: a forge that models
+// forks sends `"repo": null` once the head repo is DELETED or blocked, while
+// an answer that omits the key never had one. Collapsing them leaves a
+// refusal that cannot name its cause — and an empty name one careless step
+// from "therefore the base repo". prforge.Ref draws the same line on the
+// webhook side; this is the shared form for the API adapters, so the two
+// sides cannot drift on what an absence means.
+func UnmarshalDeclaring(b []byte, v any, key string) (bool, error) {
+	if err := json.Unmarshal(b, v); err != nil {
+		return false, err
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(b, &keys); err != nil {
+		return false, err
+	}
+	_, declared := keys[key]
+	return declared, nil
+}

--- a/pkg/forge/forgejo/ci.go
+++ b/pkg/forge/forgejo/ci.go
@@ -19,6 +19,10 @@ import (
 // (ListCIHistory) — which is portable across Gitea and every Forgejo version.
 var _ forge.PullClient = (*AdminClient)(nil)
 
+// forgejoBranchInfo is one side of a pull request. RepoDeclared reports
+// whether the answer carried the `repo` key at all: Forgejo/Gitea sends it as
+// null once a fork is DELETED or blocked, which is not the same fact as an
+// answer that never named a repository — and neither is the base repo.
 type forgejoBranchInfo struct {
 	Ref  string `json:"ref"`
 	Sha  string `json:"sha"`
@@ -26,6 +30,19 @@ type forgejoBranchInfo struct {
 		FullName string `json:"full_name"`
 		CloneURL string `json:"clone_url"`
 	} `json:"repo,omitempty"`
+	RepoDeclared bool `json:"-"`
+}
+
+func (b *forgejoBranchInfo) UnmarshalJSON(raw []byte) error {
+	type plain forgejoBranchInfo // no method set ⇒ no recursion
+	var v plain
+	declared, err := forge.UnmarshalDeclaring(raw, &v, "repo")
+	if err != nil {
+		return err
+	}
+	*b = forgejoBranchInfo(v)
+	b.RepoDeclared = declared
+	return nil
 }
 
 // forgejoPull mirrors the Gitea API PullRequest shape (subset we normalize).
@@ -62,6 +79,7 @@ func (p forgejoPull) toRef() forge.PullRef {
 	if p.Head != nil {
 		ref.SourceBranch = p.Head.Ref
 		ref.HeadSHA = p.Head.Sha
+		ref.HeadRepoDeclared = p.Head.RepoDeclared
 		if p.Head.Repo != nil {
 			ref.HeadRepoFullName = p.Head.Repo.FullName
 			ref.HeadCloneURL = p.Head.Repo.CloneURL

--- a/pkg/forge/forgejo/client.go
+++ b/pkg/forge/forgejo/client.go
@@ -256,12 +256,10 @@ func (c *AdminClient) CreateOAuthApp(ctx context.Context, spec forge.OAuthAppSpe
 		ClientID     string `json:"client_id"`
 		ClientSecret string `json:"client_secret"`
 	}
-	code, err := c.do(ctx, http.MethodPost, "/user/applications/oauth2", body, &out)
-	if err != nil {
+	// DoTyped, not do+statusErr: only the response carries the Retry-After a
+	// rate-limited create is owed, and the call site never sees it.
+	if err := c.http().DoTyped(ctx, http.MethodPost, "/user/applications/oauth2", "create oauth app", body, &out); err != nil {
 		return forge.OAuthAppCredentials{}, err
-	}
-	if code/100 != 2 {
-		return forge.OAuthAppCredentials{}, statusErr("create oauth app", code)
 	}
 	if out.ClientID == "" || out.ClientSecret == "" {
 		return forge.OAuthAppCredentials{}, fmt.Errorf("forgejo: create oauth app: empty credentials in response")

--- a/pkg/forge/forgejo/pulls_head_declared_test.go
+++ b/pkg/forge/forgejo/pulls_head_declared_test.go
@@ -1,0 +1,65 @@
+package forgejo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Forgejo/Gitea sends the head branch's `repo` as null once the fork is gone.
+// The ref keeps the distinction the empty name loses: a head repository that
+// was DECLARED and could not be named is not "no head repository", and
+// neither is the base repo.
+func TestForgejoPullHeadRepoDeclared(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantDeclared bool
+		wantWithheld bool
+		wantHead     string
+	}{
+		{
+			name:         "fork head names its repo",
+			body:         `{"number":7,"state":"open","head":{"ref":"f","sha":"s","repo":{"full_name":"mallory/widgets","clone_url":"https://fj/mallory/widgets.git"}},"base":{"ref":"main"}}`,
+			wantDeclared: true,
+			wantHead:     "mallory/widgets",
+		},
+		{
+			name:         "deleted fork sends repo: null",
+			body:         `{"number":7,"state":"open","head":{"ref":"f","sha":"s","repo":null},"base":{"ref":"main"}}`,
+			wantDeclared: true,
+			wantWithheld: true,
+		},
+		{
+			name: "an answer that never carried the key declares nothing",
+			body: `{"number":7,"state":"open","head":{"ref":"f","sha":"s"},"base":{"ref":"main"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			c := New(srv.Client(), srv.URL, "tok")
+			pr, err := c.GetPullRequest(context.Background(), "acme/widgets", 7)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pr.HeadRepoFullName != tc.wantHead {
+				t.Errorf("head = %q, want %q", pr.HeadRepoFullName, tc.wantHead)
+			}
+			if pr.HeadRepoDeclared != tc.wantDeclared {
+				t.Errorf("declared = %v, want %v", pr.HeadRepoDeclared, tc.wantDeclared)
+			}
+			if pr.HeadRepoWithheld() != tc.wantWithheld {
+				t.Errorf("withheld = %v, want %v", pr.HeadRepoWithheld(), tc.wantWithheld)
+			}
+			if pr.SameRepoAs("acme/widgets") {
+				t.Error("none of these heads is the base repo — same-repo must never be assumed from an empty field")
+			}
+		})
+	}
+}

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -20,23 +20,42 @@ import (
 // the operator as the permission to approve, not as a bare status.
 var _ forge.PullClient = (*AdminClient)(nil)
 
+// githubHead is a pull request's head ref. GitHub always models the head
+// repository and sends `"repo": null` once a fork is DELETED or blocked;
+// RepoDeclared keeps that apart from an answer that never carried the key,
+// which a plain struct collapses onto the same empty name.
+type githubHead struct {
+	Ref  string `json:"ref"`
+	SHA  string `json:"sha"`
+	Repo struct {
+		FullName string `json:"full_name"`
+		CloneURL string `json:"clone_url"`
+	} `json:"repo"`
+	RepoDeclared bool `json:"-"`
+}
+
+func (h *githubHead) UnmarshalJSON(b []byte) error {
+	type plain githubHead // no method set ⇒ no recursion
+	var v plain
+	declared, err := forge.UnmarshalDeclaring(b, &v, "repo")
+	if err != nil {
+		return err
+	}
+	*h = githubHead(v)
+	h.RepoDeclared = declared
+	return nil
+}
+
 // githubPull is the slice of the GitHub pull-request object we map to PullRef.
 type githubPull struct {
-	Number  int    `json:"number"`
-	Title   string `json:"title"`
-	Body    string `json:"body"`
-	State   string `json:"state"` // "open" | "closed"
-	HTMLURL string `json:"html_url"`
-	Draft   bool   `json:"draft"`
-	Head    struct {
-		Ref  string `json:"ref"`
-		SHA  string `json:"sha"`
-		Repo struct {
-			FullName string `json:"full_name"`
-			CloneURL string `json:"clone_url"`
-		} `json:"repo"`
-	} `json:"head"`
-	Base struct {
+	Number  int        `json:"number"`
+	Title   string     `json:"title"`
+	Body    string     `json:"body"`
+	State   string     `json:"state"` // "open" | "closed"
+	HTMLURL string     `json:"html_url"`
+	Draft   bool       `json:"draft"`
+	Head    githubHead `json:"head"`
+	Base    struct {
 		Ref string `json:"ref"`
 	} `json:"base"`
 	User struct {
@@ -62,6 +81,7 @@ func (gp githubPull) toRef() forge.PullRef {
 		HeadSHA:          gp.Head.SHA,
 		HeadRepoFullName: gp.Head.Repo.FullName,
 		HeadCloneURL:     gp.Head.Repo.CloneURL,
+		HeadRepoDeclared: gp.Head.RepoDeclared,
 		Author:           gp.User.Login,
 		Draft:            gp.Draft,
 		CreatedAt:        gp.CreatedAt,

--- a/pkg/forge/github/pulls_head_declared_test.go
+++ b/pkg/forge/github/pulls_head_declared_test.go
@@ -1,0 +1,66 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// GitHub always models a pull request's head repository, and sends
+// `"repo": null` once a fork is DELETED or blocked. Read as "no head
+// repository" that is indistinguishable from an answer that never carried
+// one, and one step from "therefore the base repo" — so the ref says the
+// head WAS declared, which is what makes the refusal name the right cause.
+func TestGitHubPullHeadRepoDeclared(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantDeclared bool
+		wantWithheld bool
+		wantHead     string
+	}{
+		{
+			name:         "fork head names its repo",
+			body:         `{"number":7,"state":"open","head":{"ref":"f","sha":"s","repo":{"full_name":"mallory/widgets","clone_url":"https://github.com/mallory/widgets.git"}},"base":{"ref":"main"}}`,
+			wantDeclared: true,
+			wantHead:     "mallory/widgets",
+		},
+		{
+			name:         "deleted fork sends repo: null",
+			body:         `{"number":7,"state":"open","head":{"ref":"f","sha":"s","repo":null},"base":{"ref":"main"}}`,
+			wantDeclared: true,
+			wantWithheld: true,
+		},
+		{
+			name: "an answer that never carried the key declares nothing",
+			body: `{"number":7,"state":"open","head":{"ref":"f","sha":"s"},"base":{"ref":"main"}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+			pr, err := c.GetPullRequest(context.Background(), "acme/widgets", 7)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pr.HeadRepoFullName != tc.wantHead {
+				t.Errorf("head = %q, want %q", pr.HeadRepoFullName, tc.wantHead)
+			}
+			if pr.HeadRepoDeclared != tc.wantDeclared {
+				t.Errorf("declared = %v, want %v", pr.HeadRepoDeclared, tc.wantDeclared)
+			}
+			if pr.HeadRepoWithheld() != tc.wantWithheld {
+				t.Errorf("withheld = %v, want %v", pr.HeadRepoWithheld(), tc.wantWithheld)
+			}
+			if pr.SameRepoAs("acme/widgets") {
+				t.Error("none of these heads is the base repo — same-repo must never be assumed from an empty field")
+			}
+		})
+	}
+}

--- a/pkg/forge/gitlab/ci.go
+++ b/pkg/forge/gitlab/ci.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -39,9 +40,17 @@ type gitlabMR struct {
 // headProject is where a merge request's head branch lives, as far as it is
 // proven: the project's path, and — for a fork — its own clone URL. The zero
 // value is UNPROVEN, which every same-project lane reads as a refusal.
+//
+// declared says the merge request NAMES a source project (its ids), whether
+// or not the lookup could name it; err carries the forge's own refusal of
+// that lookup, typed. Together they are what keeps an unreadable fork from
+// arriving at a caller looking like "no head repository", one step from
+// "therefore the base project".
 type headProject struct {
 	path     string
 	cloneURL string
+	declared bool
+	err      error
 }
 
 // sourceProjectTTL bounds how long a resolved source project is reused: the
@@ -73,16 +82,20 @@ type sourceProjectEntry struct {
 // names and a refusal can name the fork.
 //
 // Two shapes stay UNPROVEN on purpose rather than failing the read: an MR
-// object without the ids, and a source project the token cannot see (404 /
-// 403 — a private or deleted fork). Every same-project lane refuses an
-// unproven head, which is the right answer for a fork it cannot inspect,
-// and the MR's own fields still serve the lanes that only need its branches.
+// object without the ids, and a source project the credential cannot read
+// (404 — gone; 403 — refused). Every same-project lane refuses an unproven
+// head, which is the right answer for a fork it cannot inspect, and the MR's
+// own fields still serve the lanes that only need its branches. The two are
+// not the same fact and are not returned as one: the second is DECLARED (the
+// MR names a source project id) and carries the forge's typed refusal, so a
+// lane says which of "the fork is gone" and "this credential may not read
+// it" it met — and neither can be mistaken for the target project.
 func (c *AdminClient) headProjectFor(ctx context.Context, project string, mr gitlabMR) (headProject, error) {
 	switch {
 	case mr.SourceProjectID <= 0 || mr.TargetProjectID <= 0:
 		return headProject{}, nil
 	case mr.SourceProjectID == mr.TargetProjectID:
-		return headProject{path: strings.TrimSpace(project)}, nil
+		return headProject{path: strings.TrimSpace(project), declared: true}, nil
 	}
 	key := c.BaseURL + "#" + strconv.FormatInt(mr.SourceProjectID, 10)
 	sourceProjects.mu.Lock()
@@ -95,19 +108,26 @@ func (c *AdminClient) headProjectFor(ctx context.Context, project string, mr git
 		PathWithNamespace string `json:"path_with_namespace"`
 		HTTPURLToRepo     string `json:"http_url_to_repo"`
 	}
+	op := "get source project " + strconv.FormatInt(mr.SourceProjectID, 10)
 	code, err := c.do(ctx, http.MethodGet, "/projects/"+strconv.FormatInt(mr.SourceProjectID, 10), nil, &out)
 	if err != nil {
 		return headProject{}, err
 	}
 	switch {
-	case code == http.StatusNotFound || code == http.StatusForbidden:
-		return headProject{}, nil
+	case code == http.StatusNotFound:
+		// The project is gone, or GitLab will not confirm it exists.
+		return headProject{declared: true, err: statusErr(op, code)}, nil
+	case code == http.StatusForbidden:
+		// A permission ANSWER, not an absence: the project exists and this
+		// credential may not read it. Typed on ErrForbidden and naming its
+		// own operation, so a lane refuses on what the forge said.
+		return headProject{declared: true, err: fmt.Errorf("%w: gitlab: %s: the credential may not read the merge request's source project", forge.ErrForbidden, op)}, nil
 	case code != http.StatusOK:
-		return headProject{}, statusErr("get source project", code)
+		return headProject{}, statusErr(op, code)
 	}
-	head := headProject{path: strings.TrimSpace(out.PathWithNamespace), cloneURL: strings.TrimSpace(out.HTTPURLToRepo)}
+	head := headProject{path: strings.TrimSpace(out.PathWithNamespace), cloneURL: strings.TrimSpace(out.HTTPURLToRepo), declared: true}
 	if head.path == "" {
-		return headProject{}, nil
+		return headProject{declared: true, err: fmt.Errorf("gitlab: %s: the project answered with no path", op)}, nil
 	}
 	sourceProjects.mu.Lock()
 	sourceProjects.m[key] = sourceProjectEntry{headProject: head, at: time.Now()}
@@ -129,6 +149,8 @@ func (mr gitlabMR) toRef(head headProject) forge.PullRef {
 		HeadSHA:          mr.SHA,
 		HeadRepoFullName: head.path,
 		HeadCloneURL:     head.cloneURL,
+		HeadRepoDeclared: head.declared,
+		HeadRepoErr:      head.err,
 		Author:           mr.Author.Username,
 		Draft:            mr.Draft || mr.WorkInProgress,
 		CreatedAt:        mr.CreatedAt,

--- a/pkg/forge/gitlab/client.go
+++ b/pkg/forge/gitlab/client.go
@@ -280,12 +280,11 @@ func (c *AdminClient) CreateOAuthApp(ctx context.Context, spec forge.OAuthAppSpe
 		ApplicationID string `json:"application_id"`
 		Secret        string `json:"secret"`
 	}
-	code, err := c.do(ctx, http.MethodPost, "/applications", body, &out)
-	if err != nil {
+	// DoTyped, not do+statusErr: this endpoint is rate-limited in practice
+	// (measured 34 refusals in 60 calls), and only the response carries the
+	// Retry-After the operator is owed.
+	if err := c.http().DoTyped(ctx, http.MethodPost, "/applications", "create oauth app", body, &out); err != nil {
 		return forge.OAuthAppCredentials{}, err
-	}
-	if code/100 != 2 {
-		return forge.OAuthAppCredentials{}, statusErr("create oauth app", code)
 	}
 	if out.ApplicationID == "" || out.Secret == "" {
 		return forge.OAuthAppCredentials{}, fmt.Errorf("gitlab: create oauth app: empty credentials in response")

--- a/pkg/forge/gitlab/pulls_source_denied_test.go
+++ b/pkg/forge/gitlab/pulls_source_denied_test.go
@@ -1,0 +1,116 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// deniedSourceForge serves one target project (42) whose merge requests come
+// from three source projects the credential is answered differently about:
+// 9 resolves, 13 is 404 (gone), 17 is 403 (a permission answer).
+func deniedSourceForge(t *testing.T) *httptest.Server {
+	t.Helper()
+	mr := func(iid int, source int64) map[string]any {
+		return map[string]any{
+			"iid": iid, "state": "opened", "title": "t",
+			"web_url":       "https://gitlab.example/acme/widgets/-/merge_requests/" + strconv.Itoa(iid),
+			"source_branch": "feature/x", "target_branch": "main", "sha": "abc" + strconv.Itoa(iid),
+			"source_project_id": source, "target_project_id": 42,
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		p := r.URL.EscapedPath()
+		switch {
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/17"):
+			_ = json.NewEncoder(w).Encode(mr(17, 17))
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/13"):
+			_ = json.NewEncoder(w).Encode(mr(13, 13))
+		case strings.HasSuffix(p, "/projects/acme%2Fwidgets/merge_requests/8"):
+			_ = json.NewEncoder(w).Encode(mr(8, 42))
+		case p == "/api/v4/projects/17":
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "403 Forbidden"})
+		case p == "/api/v4/projects/13":
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "404 Project Not Found"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A fork MR whose source project the credential is REFUSED (403) must not
+// hand back a head that reads like the base project's. It stays unnamed, it
+// says the forge declared one, and it carries the forge's own refusal typed
+// — a permission answer, not "the project is gone" — so the lane that
+// refuses can say which of the two it met.
+func TestGitLabForkSourceProject403IsATypedPermissionAnswer(t *testing.T) {
+	srv := deniedSourceForge(t)
+	pr, err := New(srv.Client(), srv.URL, "tok").GetPullRequest(context.Background(), "acme/widgets", 17)
+	if err != nil {
+		t.Fatalf("a refused source project must not fail the MR read: %v", err)
+	}
+	if pr.HeadRepoFullName != "" || pr.HeadCloneURL != "" {
+		t.Fatalf("head = %q clone = %q, want neither named — a head the credential may not read is NOT the base project",
+			pr.HeadRepoFullName, pr.HeadCloneURL)
+	}
+	if pr.SameRepoAs("acme/widgets") {
+		t.Fatal("a fork MR with an unreadable source project must never read as same-project")
+	}
+	if !pr.HeadRepoDeclared || !pr.HeadRepoWithheld() {
+		t.Fatalf("declared = %v withheld = %v, want both: the MR names a source project id the read could not resolve",
+			pr.HeadRepoDeclared, pr.HeadRepoWithheld())
+	}
+	if !errors.Is(pr.HeadRepoErr, forge.ErrForbidden) {
+		t.Fatalf("HeadRepoErr = %v, want a typed ErrForbidden so a caller refuses on the permission answer instead of guessing", pr.HeadRepoErr)
+	}
+	if !strings.Contains(pr.HeadRepoErr.Error(), "source project") {
+		t.Errorf("HeadRepoErr = %v, want the operation named (the per-operation error vocabulary)", pr.HeadRepoErr)
+	}
+}
+
+// A source project that is GONE answers 404. Same unproven head, but the
+// refusal is typed as an absence, not a permission.
+func TestGitLabForkSourceProject404IsATypedAbsence(t *testing.T) {
+	srv := deniedSourceForge(t)
+	pr, err := New(srv.Client(), srv.URL, "tok").GetPullRequest(context.Background(), "acme/widgets", 13)
+	if err != nil {
+		t.Fatalf("a missing source project must not fail the MR read: %v", err)
+	}
+	if pr.HeadRepoFullName != "" || pr.SameRepoAs("acme/widgets") {
+		t.Fatalf("head = %q, want unproven", pr.HeadRepoFullName)
+	}
+	if !pr.HeadRepoWithheld() {
+		t.Fatal("a declared source project that could not be read is withheld, not absent")
+	}
+	if !errors.Is(pr.HeadRepoErr, forge.ErrNotFound) || errors.Is(pr.HeadRepoErr, forge.ErrForbidden) {
+		t.Fatalf("HeadRepoErr = %v, want a typed 404 and NOT a permission answer", pr.HeadRepoErr)
+	}
+}
+
+// A same-project MR declares its head and proves it: nothing is withheld.
+func TestGitLabSameProjectMRDeclaresAProvenHead(t *testing.T) {
+	srv := deniedSourceForge(t)
+	pr, err := New(srv.Client(), srv.URL, "tok").GetPullRequest(context.Background(), "acme/widgets", 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pr.HeadRepoDeclared || pr.HeadRepoWithheld() || !pr.SameRepoAs("acme/widgets") {
+		t.Fatalf("same-project MR = declared %v withheld %v same %v, want declared, not withheld, same-project",
+			pr.HeadRepoDeclared, pr.HeadRepoWithheld(), pr.SameRepoAs("acme/widgets"))
+	}
+	if pr.HeadRepoErr != nil {
+		t.Errorf("HeadRepoErr = %v, want none: nothing was refused", pr.HeadRepoErr)
+	}
+}

--- a/pkg/forge/issues.go
+++ b/pkg/forge/issues.go
@@ -114,6 +114,24 @@ type PullRef struct {
 	// it — a fork's, on a fork PR; empty when unknown. It is what a lane that
 	// chooses to work on a fork's code would clone; no launch lane does today.
 	HeadCloneURL string `json:"head_clone_url,omitempty"`
+	// HeadRepoDeclared reports whether the provider's answer NAMES a head
+	// repository for this pull request at all — the API-side twin of
+	// prforge.Parsed.HeadRepoDeclared, so the payload side and this side
+	// speak one vocabulary. Declared with an EMPTY HeadRepoFullName is a head
+	// repository the forge HAS and iterion could not name (a deleted or
+	// blocked fork; a GitLab source project this credential may not read);
+	// undeclared is a provider that reports none. Neither is the base repo,
+	// which is the assumption a bare empty field invites.
+	HeadRepoDeclared bool `json:"head_repo_declared,omitempty"`
+	// HeadRepoErr is the forge's own refusal of a head-repository read that
+	// took its own call — GitLab's merge request names its source project by
+	// id, so naming it is a second request that can be answered 403 (a
+	// permission) or 404 (an absence). Kept TYPED, so a lane classifies the
+	// refusal (errors.Is(err, ErrForbidden)) instead of guessing from an
+	// empty name; nil when no separate read was needed or it succeeded.
+	// Never serialised: it is the refusing lane's diagnosis, not a field of
+	// the pull request.
+	HeadRepoErr error `json:"-"`
 	// LinkedIssues are issue numbers this PR references / closes, best-effort
 	// parsed from the title/body ("fixes #12", "Closes #7", "!?").
 	LinkedIssues []int `json:"linked_issues,omitempty"`
@@ -132,6 +150,19 @@ type PullRef struct {
 // and the gate-relaunch lane all consult this before launching.
 func (p PullRef) SameRepoAs(baseRepo string) bool {
 	return SameRepo(p.HeadRepoFullName, baseRepo)
+}
+
+// HeadRepoWithheld reports a head repository the forge HAS and iterion could
+// not name: declared, with no name. Mirrors prforge.Parsed.HeadRepoWithheld
+// on the payload side, where the same fact arrives as `head.repo: null`.
+//
+// Both refuse — SameRepoAs is false on an empty head either way — so this is
+// not a second decision but the WORDING and the diagnosis: "the credential
+// could not read the fork" is an operator action, "the provider reports no
+// head repository" is a legacy or minimal answer, and collapsing them leaves
+// a refusal nobody can act on.
+func (p PullRef) HeadRepoWithheld() bool {
+	return p.HeadRepoDeclared && p.HeadRepoFullName == ""
 }
 
 // SameRepo reports whether two "owner/repo" identifiers name the same

--- a/pkg/forge/status_error.go
+++ b/pkg/forge/status_error.go
@@ -1,0 +1,73 @@
+package forge
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// StatusError is a forge call the sentinels do not cover: the answer's own
+// status, kept as a NUMBER instead of only as text in a message. It is the
+// type that lets a handler tell "the forge is rate-limiting us" from "iterion
+// is broken" — a 429 read as an untyped error becomes a 500, and the
+// operator, the logs and the alerting all learn the wrong thing.
+//
+// 401/403/404 never arrive here: they carry their own sentinels and typed
+// forms (ErrUnauthorized, ErrForbidden, *NotFoundError).
+type StatusError struct {
+	Provider Provider
+	// Op is the call that failed ("create oauth app").
+	Op string
+	// Code is the upstream HTTP status, verbatim.
+	Code int
+	// RetryAfter is what the forge asked us to wait, when it said so
+	// (Retry-After, delta-seconds or HTTP-date). Zero = it said nothing;
+	// never a guess.
+	RetryAfter time.Duration
+}
+
+// Error keeps the wording every log line and operator already reads.
+func (e *StatusError) Error() string {
+	var b strings.Builder
+	if e.Provider != "" {
+		b.WriteString(string(e.Provider))
+		b.WriteString(": ")
+	}
+	if e.Op != "" {
+		b.WriteString(e.Op)
+		b.WriteString(": ")
+	}
+	fmt.Fprintf(&b, "HTTP %d", e.Code)
+	return b.String()
+}
+
+// RateLimited reports the one upstream status a caller can act on by waiting.
+func (e *StatusError) RateLimited() bool { return e.Code == http.StatusTooManyRequests }
+
+// Upstream5xx reports a fault on the forge's side — never iterion's.
+func (e *StatusError) Upstream5xx() bool { return e.Code >= 500 }
+
+// ParseRetryAfter reads a Retry-After header value: delta-seconds, or an
+// HTTP-date, whichever the forge sent. Anything unparsable, negative or
+// already past yields 0 — "the forge said nothing" is the honest answer, and
+// a guessed delay would be worse than none.
+func ParseRetryAfter(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if at, err := http.ParseTime(v); err == nil {
+		if d := time.Until(at); d > 0 {
+			return d
+		}
+	}
+	return 0
+}

--- a/pkg/forge/status_error_test.go
+++ b/pkg/forge/status_error_test.go
@@ -1,0 +1,136 @@
+package forge
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Everything the sentinels do not cover used to become a bare
+// fmt.Errorf("…: HTTP %d"), so a caller could only re-parse the message —
+// and every handler that could not classify it answered 500. The status is
+// the fact; it is typed.
+func TestStatusErrTypesTheUpstreamStatus(t *testing.T) {
+	cases := []struct {
+		code     int
+		wantType bool
+		wantIs   error
+	}{
+		{http.StatusUnauthorized, false, ErrUnauthorized},
+		{http.StatusForbidden, false, ErrForbidden},
+		{http.StatusNotFound, false, ErrNotFound},
+		{http.StatusTooManyRequests, true, nil},
+		{http.StatusServiceUnavailable, true, nil},
+		{http.StatusInternalServerError, true, nil},
+		{http.StatusConflict, true, nil},
+	}
+	for _, tc := range cases {
+		err := StatusErr("gitlab", "create oauth app", tc.code)
+		var se *StatusError
+		if got := errors.As(err, &se); got != tc.wantType {
+			t.Errorf("HTTP %d: typed as *StatusError = %v, want %v (err=%v)", tc.code, got, tc.wantType, err)
+			continue
+		}
+		if tc.wantIs != nil && !errors.Is(err, tc.wantIs) {
+			t.Errorf("HTTP %d: err = %v, want errors.Is %v", tc.code, err, tc.wantIs)
+		}
+		if !tc.wantType {
+			continue
+		}
+		if se.Code != tc.code {
+			t.Errorf("HTTP %d: Code = %d", tc.code, se.Code)
+		}
+		if se.Op != "create oauth app" || se.Provider != "gitlab" {
+			t.Errorf("HTTP %d: %+v, want the operation and provider named", tc.code, se)
+		}
+		// The message is the one every log and every operator already reads.
+		if want := "gitlab: create oauth app: HTTP " + itoa(tc.code); se.Error() != want {
+			t.Errorf("HTTP %d: message = %q, want %q", tc.code, se.Error(), want)
+		}
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// A rate limiter says how long to wait, in a header only the response
+// carries. Dropped at the call site, the caller can only guess.
+func TestDoTypedCarriesRetryAfter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	h := NewAdminHTTP(srv.Client(), srv.URL, "gitlab", nil)
+	err := h.DoTyped(context.Background(), http.MethodPost, "/applications", "create oauth app", nil, nil)
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("err = %v, want *StatusError", err)
+	}
+	if se.Code != http.StatusTooManyRequests {
+		t.Errorf("Code = %d, want 429", se.Code)
+	}
+	if se.RetryAfter != 42*time.Second {
+		t.Errorf("RetryAfter = %v, want 42s — the forge said how long to wait", se.RetryAfter)
+	}
+	if !se.RateLimited() {
+		t.Error("RateLimited() = false on a 429")
+	}
+}
+
+func TestDoTypedIsSilentOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"id":7}`))
+	}))
+	defer srv.Close()
+	var out struct {
+		ID int `json:"id"`
+	}
+	h := NewAdminHTTP(srv.Client(), srv.URL, "gitlab", nil)
+	if err := h.DoTyped(context.Background(), http.MethodGet, "/x", "get x", nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != 7 {
+		t.Fatalf("out = %+v, want the 2xx body decoded", out)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{"30", 30 * time.Second},
+		{"-5", 0},           // a past delta is no delay
+		{"not a number", 0}, // never a panic, never a guess
+	}
+	for _, tc := range cases {
+		if got := ParseRetryAfter(tc.in); got != tc.want {
+			t.Errorf("ParseRetryAfter(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+	// The HTTP-date form, which GitHub uses on a secondary rate limit.
+	future := time.Now().UTC().Add(90 * time.Second).Format(http.TimeFormat)
+	if got := ParseRetryAfter(future); got < 60*time.Second || got > 95*time.Second {
+		t.Errorf("ParseRetryAfter(<+90s date>) = %v, want ~90s", got)
+	}
+	past := time.Now().UTC().Add(-time.Hour).Format(http.TimeFormat)
+	if got := ParseRetryAfter(past); got != 0 {
+		t.Errorf("ParseRetryAfter(<past date>) = %v, want 0", got)
+	}
+}

--- a/pkg/forge/transport.go
+++ b/pkg/forge/transport.go
@@ -34,17 +34,26 @@ func DoJSON(ctx context.Context, client *http.Client, method, url, errPrefix str
 // refusal reason the operator needs verbatim (an avatar the forge rejects).
 // A 2xx body is still streamed into out and never returned.
 func DoJSONErrBody(ctx context.Context, client *http.Client, method, url, errPrefix string, setHeaders func(*http.Request), body, out any) (int, []byte, error) {
+	code, errBody, _, err := DoJSONFull(ctx, client, method, url, errPrefix, setHeaders, body, out)
+	return code, errBody, err
+}
+
+// DoJSONFull is DoJSONErrBody that also hands back a NON-2xx answer's
+// headers. They are where a rate limiter says how long to wait, and the
+// response is the only place that can be read — a caller holding just the
+// status can do nothing but guess.
+func DoJSONFull(ctx context.Context, client *http.Client, method, url, errPrefix string, setHeaders func(*http.Request), body, out any) (int, []byte, http.Header, error) {
 	var reqBody io.Reader
 	if body != nil {
 		raw, err := json.Marshal(body)
 		if err != nil {
-			return 0, nil, fmt.Errorf("%s: marshal body: %w", errPrefix, err)
+			return 0, nil, nil, fmt.Errorf("%s: marshal body: %w", errPrefix, err)
 		}
 		reqBody = bytes.NewReader(raw)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	if setHeaders != nil {
 		setHeaders(req)
@@ -57,30 +66,33 @@ func DoJSONErrBody(ctx context.Context, client *http.Client, method, url, errPre
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
-		return resp.StatusCode, errBody, nil
+		return resp.StatusCode, errBody, resp.Header, nil
 	}
 	if out != nil {
 		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-			return resp.StatusCode, nil, fmt.Errorf("%s: decode response: %w", errPrefix, err)
+			return resp.StatusCode, nil, resp.Header, fmt.Errorf("%s: decode response: %w", errPrefix, err)
 		}
 	} else {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
 	}
-	return resp.StatusCode, nil, nil
+	return resp.StatusCode, nil, resp.Header, nil
 }
 
 // StatusErr maps a non-2xx status to the appropriate forge sentinel,
-// falling back to a "<prefix>: <op>: HTTP <code>" error. Shared by every
-// AdminClient so the 401/403/404 mapping stays identical across providers.
+// falling back to a *StatusError carrying the status verbatim (its message is
+// still "<prefix>: <op>: HTTP <code>"). Shared by every AdminClient so the
+// mapping stays identical across providers.
 //
 // A 404 is typed by OPERATION (notFoundFor): only a hook operation yields
 // ErrHookNotFound, everything else a *NotFoundError naming its own call.
-// Every 404 still answers errors.Is(err, ErrNotFound).
+// Every 404 still answers errors.Is(err, ErrNotFound). Everything else is
+// typed by its STATUS, which is what lets a handler answer a rate limit as a
+// rate limit instead of as an iterion fault.
 func StatusErr(errPrefix, op string, code int) error {
 	return StatusErrNeeding(errPrefix, op, code, nil)
 }
@@ -98,7 +110,7 @@ func StatusErrNeeding(errPrefix, op string, code int, mayNeed []string) error {
 	case http.StatusNotFound:
 		return notFoundFor(errPrefix, op, mayNeed)
 	default:
-		return fmt.Errorf("%s: %s: HTTP %d", errPrefix, op, code)
+		return &StatusError{Provider: Provider(errPrefix), Op: op, Code: code}
 	}
 }
 

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -881,14 +881,11 @@ func (s *Server) pullClientForConn(w http.ResponseWriter, ctx context.Context, t
 // never approved. It is answered 404 with the operation and the grants it is
 // gated on, not the 502 a bare sentinel used to produce. Anything else is the
 // upstream failure it always was.
+// Both cases, and the rate limit and upstream 5xx behind them, come from the
+// one shared table (forgeUpstreamStatus); the 502 stays the answer for what
+// that table does not recognise as an answer from the forge.
 func writeForgePullError(w http.ResponseWriter, op string, err error) {
-	var pe *forge.PermissionError
-	if errors.As(err, &pe) {
-		httpError(w, http.StatusUnprocessableEntity, "%s: %v", op, err)
-		return
-	}
-	if errors.Is(err, forge.ErrNotFound) {
-		httpError(w, http.StatusNotFound, "%s: %v", op, err)
+	if writeForgeUpstreamError(w, err, "%s: %v", op, err) {
 		return
 	}
 	httpError(w, http.StatusBadGateway, "%s: %v", op, err)

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -285,6 +285,12 @@ func (s *Server) handleForgeConnectionAvatar(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err != nil {
+		// Deliberately NOT the shared forgeUpstreamStatus table: applyBotAvatar
+		// answers every actionable state as an *avatarRefusal above, and what
+		// reaches here wraps the forge's own sentinel inside a spent-budget
+		// failure — where the expiry outranks whatever the forge managed to
+		// send. Classifying by the wrapped sentinel would let a forge that
+		// answered 403 and then stalled turn a dead context into a 403.
 		httpError(w, http.StatusBadGateway, "%v", err)
 		return
 	}

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -125,7 +125,9 @@ func (s *Server) connectForgePAT(w http.ResponseWriter, r *http.Request, teamID,
 			httpError(w, http.StatusBadRequest, "the token was rejected by %s — check it has api scope", provider)
 			return
 		}
-		httpError(w, http.StatusBadGateway, "could not reach %s: %v", provider, err)
+		if !writeForgeUpstreamError(w, err, "could not reach %s: %v", provider, err) {
+			httpError(w, http.StatusBadGateway, "could not reach %s: %v", provider, err)
+		}
 		return
 	}
 	connID := uuid.NewString()

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -367,6 +367,7 @@ func (s *Server) handleCreateForgeRepo(w http.ResponseWriter, r *http.Request) {
 			httpError(w, http.StatusConflict, "%v", err)
 		case errors.Is(err, forge.ErrPermissionsNotGranted):
 			httpError(w, http.StatusUnprocessableEntity, "the GitHub App installation lacks the Administration permission — approve the App's pending permission update on GitHub, then retry: %v", err)
+		case writeForgeUpstreamError(w, err, "create repository: %v", err):
 		default:
 			httpError(w, http.StatusBadGateway, "create repository: %v", err)
 		}
@@ -477,7 +478,9 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 				httpError(w, http.StatusUnprocessableEntity, "%v", err)
 				return
 			}
-			httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
+			if !writeForgeUpstreamError(w, err, "security-read token mint: %v", err) {
+				httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
+			}
 			return
 		}
 		// Date the connection from the token we just minted — but ONLY on a
@@ -560,7 +563,9 @@ func (s *Server) handleListForgeRepos(w http.ResponseWriter, r *http.Request) {
 			httpError(w, http.StatusBadRequest, "connection credential rejected — reconnect")
 			return
 		}
-		httpError(w, http.StatusBadGateway, "list repos: %v", err)
+		if !writeForgeUpstreamError(w, err, "list repos: %v", err) {
+			httpError(w, http.StatusBadGateway, "list repos: %v", err)
+		}
 		return
 	}
 	if repos == nil {

--- a/pkg/server/forge_fork_guard_withheld_test.go
+++ b/pkg/server/forge_fork_guard_withheld_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// withheldHeadGateClient answers with a head repository the forge HAS and the
+// credential could not name — the shape a GitLab fork MR takes when the read
+// of its source project is refused, and a deleted fork's on every provider.
+type withheldHeadGateClient struct {
+	fakeGateClient
+	headErr error
+}
+
+func (c *withheldHeadGateClient) GetPullRequest(_ context.Context, _ string, _ int) (forge.PullRef, error) {
+	return forge.PullRef{
+		HeadSHA:          "deadbeef",
+		State:            "open",
+		HeadRepoDeclared: true, // declared, and deliberately unnamed
+		HeadRepoErr:      c.headErr,
+	}, nil
+}
+
+// The API-side fork guard must read the WITHHELD flag, not just the empty
+// name: the launch is refused either way, but a refusal that says "the
+// provider named no head repo" when the forge did name one and refused to
+// describe it sends the operator looking in the wrong place. The forge's own
+// typed refusal is quoted so the cause is actionable.
+func TestPRLaunchForkGuard_NamesAWithheldHeadAndItsCause(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.PublicURL = "https://iterion.test"
+	gc := &withheldHeadGateClient{
+		headErr: errors.New("gitlab: get source project 13: the credential may not read the merge request's source project"),
+	}
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+
+	_, err := s.applyPRLaunchContext(context.Background(), "team1", "conn1", "review-pr",
+		map[string]string{"pr_url": "https://github.com/o/r/pull/42"}, nil)
+	if err == nil {
+		t.Fatal("a head repository the forge would not name must never be launched on — the pair is <base>.CloneURL + a branch that may live elsewhere")
+	}
+	if !errors.Is(err, errPRLaunchForkGuard) {
+		t.Fatalf("err = %v, want the typed fork-guard refusal so the launch answers 422", err)
+	}
+	if !strings.Contains(err.Error(), "declared") {
+		t.Errorf("err = %v, want the refusal to say the head repo was DECLARED and not named", err)
+	}
+	if !strings.Contains(err.Error(), "source project") {
+		t.Errorf("err = %v, want the forge's own refusal quoted so the operator knows what to fix", err)
+	}
+}
+
+// A head the provider never declared keeps its own wording: nothing was
+// refused, so there is no cause to quote.
+func TestPRLaunchForkGuard_UndeclaredHeadIsRefusedWithoutInventingACause(t *testing.T) {
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.PublicURL = "https://iterion.test"
+	gc := &fakeGateClient{headSHA: "deadbeef", noHeadRepo: true}
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) { return gc, nil }
+
+	_, err := s.applyPRLaunchContext(context.Background(), "team1", "conn1", "review-pr",
+		map[string]string{"pr_url": "https://github.com/o/r/pull/42"}, nil)
+	if !errors.Is(err, errPRLaunchForkGuard) {
+		t.Fatalf("err = %v, want the typed fork-guard refusal", err)
+	}
+	if strings.Contains(err.Error(), "declared") {
+		t.Errorf("err = %v — an undeclared head must not be reported as withheld", err)
+	}
+}

--- a/pkg/server/forge_gate_autofix.go
+++ b/pkg/server/forge_gate_autofix.go
@@ -265,10 +265,12 @@ func (s *Server) autofixForRunID(ctx context.Context, runID, via string) error {
 	// BASE repo's CloneURL and RepoRef is the PR's SourceBranch), so a fork
 	// PR — or one whose head repo cannot be verified — would push LLM
 	// commits to a branch on the BASE repo. SameRepoAs returns false on
-	// empty HeadRepoFullName (deleted-fork payloads), so refuse both.
-	if !pr.SameRepoAs(repo) {
+	// empty HeadRepoFullName (deleted-fork payloads), so refuse both; the
+	// shared wording says WHICH of the three it met, and quotes the forge's
+	// refusal when the head repo took its own request.
+	if reason := forkGuardRefusalFor(pr, repo); reason != "" {
 		if s.logger != nil {
-			s.logger.Warn("gate auto-fix: refusing %s#%d — fork PR or unverifiable head repo (head=%q base=%q)", repo, number, pr.HeadRepoFullName, repo)
+			s.logger.Warn("gate auto-fix: refusing %s#%d — %s (head=%q base=%q)", repo, number, reason, pr.HeadRepoFullName, repo)
 		}
 		return nil
 	}

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -168,9 +168,9 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 	// the head repo, so the checkout misses (or hits a same-named branch on
 	// the base). SameRepoAs is false on empty HeadRepoFullName too, refusing
 	// deleted-fork payloads.
-	if !d.pr.SameRepoAs(d.repo) {
+	if reason := forkGuardRefusalFor(d.pr, d.repo); reason != "" {
 		if s.logger != nil {
-			s.logger.Warn("gate relaunch: refusing %s#%d — fork PR or unverifiable head repo (head=%q base=%q)", d.repo, d.number, d.pr.HeadRepoFullName, d.repo)
+			s.logger.Warn("gate relaunch: refusing %s#%d — %s (head=%q base=%q)", d.repo, d.number, reason, d.pr.HeadRepoFullName, d.repo)
 		}
 		return
 	}

--- a/pkg/server/forge_oauth_app_routes.go
+++ b/pkg/server/forge_oauth_app_routes.go
@@ -325,7 +325,10 @@ func (s *Server) createForgeOAuthApp(r *http.Request, teamID, userID string, pro
 }
 
 // writeForgeOAuthAppError maps store / provider errors to HTTP responses,
-// including the auto-create scope errors used in a later step.
+// including the auto-create scope errors used in a later step. The two
+// forge-shaped refusals keep their own wording (they name the remedy); the
+// rest goes through the shared upstream table, so a rate limit reads as one
+// and only an iterion fault reaches 500.
 func (s *Server) writeForgeOAuthAppError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, forge.ErrOAuthAppExists):
@@ -337,6 +340,7 @@ func (s *Server) writeForgeOAuthAppError(w http.ResponseWriter, err error) {
 		})
 	case errors.Is(err, forge.ErrUnauthorized):
 		httpError(w, http.StatusBadRequest, "the token was rejected by the forge")
+	case writeForgeUpstreamError(w, err, "%v", err):
 	default:
 		httpError(w, http.StatusInternalServerError, "%v", err)
 	}

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -373,6 +373,8 @@ func (s *Server) writeForgeProvisionError(w http.ResponseWriter, err error) {
 		})
 	case errors.Is(err, forge.ErrConnectionNotFound):
 		httpError(w, http.StatusNotFound, "connection not found")
+	case writeForgeUpstreamError(w, err, "provisioning failed: %v", err):
+		// A forge that throttled or fell over says so itself.
 	default:
 		httpError(w, http.StatusBadGateway, "provisioning failed: %v", err)
 	}

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -889,7 +889,7 @@ func (s *Server) prLaunchForkGuard(ctx context.Context, teamID, preferredConnID,
 	if err != nil {
 		return conn, false, fmt.Errorf("fork guard: %s: PR resolution: %w", prURL, err)
 	}
-	if reason := forkGuardRefusal(pr.SameRepoAs(repo), false, pr.HeadRepoFullName); reason != "" {
+	if reason := forkGuardRefusalFor(pr, repo); reason != "" {
 		return conn, false, fmt.Errorf("%w: %s: %s", errPRLaunchForkGuard, prURL, reason)
 	}
 	return conn, true, nil

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -853,6 +853,39 @@ var errForgePublishGrantTenant = errors.New("forge publish grant tenant mismatch
 // asked — so the HTTP lane answers 422 rather than 502.
 var errPRLaunchForkGuard = errors.New("fork guard")
 
+// errPRLaunchNoPullCapability marks a launch pinned to a connection whose
+// provider cannot read pull requests at all: same-repo can never be proven
+// through it, so no retry helps and the answer is not 502.
+var errPRLaunchNoPullCapability = errors.New("connection cannot read pull requests")
+
+// prLaunchContextStatus maps a refusal from applyPRLaunchContext onto the HTTP
+// status a launch surface answers with. The whole table lives here because the
+// FALL-THROUGH is the dangerous half: 502 tells the caller "the forge could not
+// be asked, try again", so a refusal a retry can never fix has to be named or
+// it reads as an outage the operator hammers.
+//
+//	errPRLaunchForkGuard             422  the pull request is not admissible
+//	errForgePublishGrantTenant       422  the launch pins ANOTHER team's grant
+//	errPRLaunchNoPullCapability      422  the connection cannot prove same-repo
+//	errForgePublishGrantUnavailable  503  the server's own grant capacity, retriable as-is
+//	anything else                    502  a forge that could not be asked
+//
+// The webhook lane already answers the tenant crossing 422
+// (insertAndLaunchWebhook); this is the same verdict on the surfaces that hold
+// no delivery.
+func prLaunchContextStatus(err error) int {
+	switch {
+	case errors.Is(err, errPRLaunchForkGuard),
+		errors.Is(err, errForgePublishGrantTenant),
+		errors.Is(err, errPRLaunchNoPullCapability):
+		return http.StatusUnprocessableEntity
+	case errors.Is(err, errForgePublishGrantUnavailable):
+		return http.StatusServiceUnavailable
+	default:
+		return http.StatusBadGateway
+	}
+}
+
 // prLaunchForkGuard is the fork guard of the launch surfaces that hold no
 // webhook payload — the studio/API launch and the cloud board coordinator —
 // over the same launch pair the webhook lanes guard: <base>.CloneURL + the
@@ -883,7 +916,8 @@ func (s *Server) prLaunchForkGuard(ctx context.Context, teamID, preferredConnID,
 		return conn, false, fmt.Errorf("fork guard: %s: cannot read the pull request through connection %s: %w", prURL, conn.ID, err)
 	}
 	if gc == nil {
-		return conn, false, fmt.Errorf("fork guard: %s: provider %s cannot read pull requests, so same-repo cannot be proven", prURL, conn.Provider)
+		return conn, false, fmt.Errorf("%w: fork guard: %s: provider %s cannot read pull requests, so same-repo cannot be proven",
+			errPRLaunchNoPullCapability, prURL, conn.Provider)
 	}
 	pr, err := gc.GetPullRequest(ctx, repo, number)
 	if err != nil {

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -97,8 +97,13 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 	pr, err := gc.GetPullRequest(r.Context(), repo, number)
 	if err != nil {
 		// Explicit, never a default answer: a tail told "open" because the
-		// forge was unreachable would push onto a branch nobody checked.
-		httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
+		// forge was unreachable would push onto a branch nobody checked. The
+		// shared table says WHICH refusal it was — a rate limit the caller
+		// may wait out, a grant it will never get — instead of one 502 for
+		// every cause.
+		if !writeForgeUpstreamError(w, err, "read pull request %s#%d: %v", repo, number, err) {
+			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
+		}
 		return
 	}
 	writeJSON(w, forgePullRequestResponse{

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// forgeUpstreamStatus is THE table every forge-facing handler consults before
+// falling back to its own fault status. It exists because the fall-through is
+// what lies: a rate limit answered 500 tells the operator, the logs, Sentry
+// and every alert that iterion broke, when the truth is that a third party is
+// throttling us — measured 34 times in 60 calls on the OAuth-app route.
+//
+//	*forge.PermissionError            422  a NAMED grant the operator can approve
+//	ErrPermissionsNotGranted          422  an installation approved too narrowly
+//	ErrUnauthorized                   422  the credential was rejected — reconnect, don't retry
+//	*forge.NotFoundError / ErrNotFound 404 the forge has no such thing under this credential
+//	ErrForbidden                      403  refused, with no permission named
+//	*forge.StatusError, 429           429  + Retry-After when the forge sent one
+//	*forge.StatusError, 5xx           502  the forge's own fault
+//	*forge.StatusError, other 4xx     4xx  mirrored: it answers the request we sent
+//	a transport failure (*url.Error)  502  no answer at all, still not ours
+//	anything else                       0  NOT an answer from the forge
+//
+// A 0 means "iterion's own" — a marshal error, a seal that will not open, a
+// store write — and the caller answers it with the fault status it already
+// used. Only that arm may be a 500.
+//
+// The second result is the Retry-After to echo, empty unless the forge named
+// one: a delay iterion invented would be worse than none.
+func forgeUpstreamStatus(err error) (int, string) {
+	if err == nil {
+		return 0, ""
+	}
+	var pe *forge.PermissionError
+	switch {
+	case errors.As(err, &pe), errors.Is(err, forge.ErrPermissionsNotGranted):
+		// The credential is valid and short of a grant the call needs: a
+		// configuration the operator closes, never an outage to retry.
+		return http.StatusUnprocessableEntity, ""
+	case errors.Is(err, forge.ErrNotFound):
+		return http.StatusNotFound, ""
+	case errors.Is(err, forge.ErrForbidden):
+		return http.StatusForbidden, ""
+	case errors.Is(err, forge.ErrUnauthorized):
+		// The token iterion holds was rejected. Reconnecting fixes it;
+		// retrying never does, which is exactly what a 5xx would invite.
+		return http.StatusUnprocessableEntity, ""
+	}
+	var se *forge.StatusError
+	if errors.As(err, &se) {
+		switch {
+		case se.RateLimited():
+			return http.StatusTooManyRequests, retryAfterHeader(se.RetryAfter)
+		case se.Upstream5xx():
+			return http.StatusBadGateway, ""
+		case se.Code >= 400:
+			// The forge is answering the request we sent — an operator can
+			// act on 400/409/422; mirroring is more useful than flattening.
+			return se.Code, ""
+		default:
+			return http.StatusBadGateway, ""
+		}
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		// No answer at all — an unreachable host, a TLS failure, a timeout.
+		return http.StatusBadGateway, ""
+	}
+	return 0, ""
+}
+
+// writeForgeUpstreamError answers err with the status forgeUpstreamStatus
+// gives it, echoing the forge's Retry-After. Reports false — writing
+// nothing — when the failure is not an answer from the forge, so the caller
+// keeps its own fault status for the errors that really are iterion's.
+func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, args ...any) bool {
+	code, retryAfter := forgeUpstreamStatus(err)
+	if code == 0 {
+		return false
+	}
+	if retryAfter != "" {
+		w.Header().Set("Retry-After", retryAfter)
+	}
+	httpError(w, code, format, args...)
+	return true
+}
+
+// retryAfterHeader renders a delay as delta-seconds, the form every client
+// reads. Zero (the forge said nothing) renders empty — never a guess.
+func retryAfterHeader(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return strconv.Itoa(int(math.Ceil(d.Seconds())))
+}

--- a/pkg/server/forge_upstream_status_test.go
+++ b/pkg/server/forge_upstream_status_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// A forge that answers 429 is not iterion breaking. Told 500, the operator,
+// the logs, Sentry and every alert read an iterion fault where the truth is
+// "the forge is rate-limiting us, retry later" — measured 34 times in 60
+// calls on the OAuth-app route.
+func TestForgeOAuthAppAutoCreate_UpstreamStatusTaxonomy(t *testing.T) {
+	cases := []struct {
+		name         string
+		upstream     int
+		retryAfter   string
+		want         int
+		wantRetryHdr string
+	}{
+		{"rate limit answers 429 with the forge's own delay", http.StatusTooManyRequests, "42", http.StatusTooManyRequests, "42"},
+		{"rate limit with no delay still answers 429", http.StatusTooManyRequests, "", http.StatusTooManyRequests, ""},
+		{"an upstream 5xx is a bad gateway", http.StatusServiceUnavailable, "", http.StatusBadGateway, ""},
+		{"an upstream 502 is a bad gateway", http.StatusBadGateway, "", http.StatusBadGateway, ""},
+		{"a refusal the operator can act on keeps its own 4xx", http.StatusConflict, "", http.StatusConflict, ""},
+		{"a scope refusal stays 403", http.StatusForbidden, "", http.StatusForbidden, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			forgeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tc.retryAfter != "" {
+					w.Header().Set("Retry-After", tc.retryAfter)
+				}
+				w.WriteHeader(tc.upstream)
+			}))
+			defer forgeSrv.Close()
+
+			s := newForgeOAuthAppTestServer(t)
+			w := httptest.NewRecorder()
+			body := `{"provider":"gitlab","mode":"auto","admin_token":"admintok","forge_base_url":"` + forgeSrv.URL + `"}`
+			s.handleRegisterForgeOAuthApp(w, oauthAppReq(superAdminCtx(), "POST", "/api/teams/t1/forge/oauth-apps", body, "t1", ""))
+
+			if w.Code != tc.want {
+				t.Fatalf("upstream %d → status %d, want %d; body=%s", tc.upstream, w.Code, tc.want, w.Body.String())
+			}
+			if got := w.Header().Get("Retry-After"); got != tc.wantRetryHdr {
+				t.Errorf("Retry-After = %q, want %q", got, tc.wantRetryHdr)
+			}
+		})
+	}
+}
+
+// Only an iterion fault answers 500 — the whole point of the taxonomy. A
+// failure that is not an answer from the forge keeps the fault status.
+func TestWriteForgeOAuthAppError_IterionFaultStays500(t *testing.T) {
+	w := httptest.NewRecorder()
+	(&Server{}).writeForgeOAuthAppError(w, errors.New("seal client secret: keyring unavailable"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 — this one really is iterion's", w.Code)
+	}
+}
+
+// forgeUpstreamStatus is the ONE table every forge-facing handler's default
+// arm consults; a 0 means "not an answer the forge gave", which each handler
+// answers with its own fault status.
+func TestForgeUpstreamStatus_Table(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"rate limit", &forge.StatusError{Provider: "gitlab", Op: "o", Code: http.StatusTooManyRequests}, http.StatusTooManyRequests},
+		{"upstream 500", &forge.StatusError{Code: http.StatusInternalServerError}, http.StatusBadGateway},
+		{"upstream 503", &forge.StatusError{Code: http.StatusServiceUnavailable}, http.StatusBadGateway},
+		{"upstream 409 reflects the request", &forge.StatusError{Code: http.StatusConflict}, http.StatusConflict},
+		{"a status below 400 is no answer to mirror", &forge.StatusError{Code: http.StatusFound}, http.StatusBadGateway},
+		{"named permission gap", &forge.PermissionError{Missing: []string{"checks:read"}, Cause: forge.ErrForbidden}, http.StatusUnprocessableEntity},
+		{"bare forbidden", forge.ErrForbidden, http.StatusForbidden},
+		{"typed 404", &forge.NotFoundError{Op: "GET pull"}, http.StatusNotFound},
+		{"rejected credential", forge.ErrUnauthorized, http.StatusUnprocessableEntity},
+		{"installation permissions", forge.ErrPermissionsNotGranted, http.StatusUnprocessableEntity},
+		{"an iterion fault is not an upstream answer", errors.New("marshal body: unsupported type"), 0},
+		{"no error", nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := forgeUpstreamStatus(tc.err)
+			if got != tc.want {
+				t.Errorf("forgeUpstreamStatus(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// A transport failure — no answer at all — is the forge's side, never a 500.
+func TestForgeUpstreamStatus_TransportFailureIs502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+	c := forge.NewAdminHTTP(nil, url, "gitlab", nil)
+	err := c.DoTyped(t.Context(), http.MethodGet, "/user", "GET /user", nil, nil)
+	if err == nil {
+		t.Fatal("expected a dial failure")
+	}
+	if got, _ := forgeUpstreamStatus(err); got != http.StatusBadGateway {
+		t.Fatalf("forgeUpstreamStatus(%v) = %d, want 502 — a forge that could not be reached is not iterion breaking", err, got)
+	}
+}

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -438,20 +438,12 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 	if launchID, _ := auth.FromContext(r.Context()); launchID.TeamID != "" {
 		vars, err := s.applyPRLaunchContext(r.Context(), launchID.TeamID, req.ConnectionID, req.BotID, req.Vars, r)
 		if err != nil {
-			// The fork guard refuses the operator's pull request (422); a
-			// publish grant the server could not mint is the server's own
-			// capacity, retriable as-is (503); a forge that could not be
-			// asked is an upstream failure (502). Either way nothing
-			// launches: the same door the webhook lanes keep closed is not
-			// left open for a hand-picked PR.
-			code := http.StatusBadGateway
-			switch {
-			case errors.Is(err, errPRLaunchForkGuard):
-				code = http.StatusUnprocessableEntity
-			case errors.Is(err, errForgePublishGrantUnavailable):
-				code = http.StatusServiceUnavailable
-			}
-			s.httpErrorFor(w, r, code, "%v", err)
+			// One table for the whole class (prLaunchContextStatus): an
+			// inadmissible request answers 422, the server's own grant
+			// capacity 503, and only a forge that could not be asked 502.
+			// Either way nothing launches: the same door the webhook lanes
+			// keep closed is not left open for a hand-picked PR.
+			s.httpErrorFor(w, r, prLaunchContextStatus(err), "%v", err)
 			span.SetStatus(codes.Error, "pr launch refused")
 			return
 		}

--- a/pkg/server/runs_launch_pr_context_status_test.go
+++ b/pkg/server/runs_launch_pr_context_status_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// launchPRContextServer is a launch surface with the forge stores the
+// PR-launch composition reads, and one connection covering github.com owned
+// by `connTeam`.
+func launchPRContextServer(t *testing.T, connTeam string) *Server {
+	t.Helper()
+	s := newQueueOutageHTTPTestServer(t)
+	s.cfg.PublicURL = "https://iterion.test"
+	s.forgeConnections = forge.NewMemoryConnectionStore()
+	s.forgePublishTokens = NewForgePublishTokenRegistry()
+	if err := s.forgeConnections.Create(context.Background(), forge.Connection{
+		ID: "conn1", TenantID: connTeam, Provider: forge.ProviderGitHub, Status: forge.StatusActive,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func launchAsTeam(t *testing.T, s *Server, teamID string, vars map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"file_path": "pr.bot",
+		"source":    "workflow pr:\n  entry: done\n",
+		"vars":      vars,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(auth.WithIdentity(req.Context(), auth.Identity{UserID: "u1", TeamID: teamID}))
+	rec := httptest.NewRecorder()
+	s.handleLaunchRun(rec, req)
+	return rec
+}
+
+// A launch that pins a forge publish grant minted for ANOTHER team is
+// inadmissible: it can only ever be refused, and no retry changes that. Told
+// 502, the studio shows a forge outage and the operator retries a request the
+// server will refuse again — and the tenant crossing, which is the whole
+// point of the check, never reaches them.
+func TestLaunchPinningAnotherTeamsGrantIs422(t *testing.T) {
+	s := launchPRContextServer(t, "team1")
+	registerPublishToken(t, s, "tok-team1", ForgePublishGrant{
+		TeamID: "team1", ConnectionID: "conn1", Repo: "o/r", Bot: "review-pr",
+	})
+
+	rec := launchAsTeam(t, s, "team-b", map[string]string{
+		"pr_url":             "https://github.com/o/r/pull/42",
+		forgePublishVarToken: "tok-team1",
+	})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 — a tenant-crossing pin is an inadmissible request, not an upstream forge failure; body=%s",
+			rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "team") {
+		t.Errorf("body = %s, want the refusal reason (which team the grant belongs to)", body)
+	}
+	if strings.Contains(rec.Body.String(), "tok-team1") {
+		t.Errorf("the refusal leaks the grant token: %s", rec.Body.String())
+	}
+}
+
+// forkGuardErrClient makes the fork guard's PR read fail the way an
+// unreachable forge does.
+type forkGuardErrClient struct{ fakeGateClient }
+
+func (c *forkGuardErrClient) GetPullRequest(_ context.Context, _ string, _ int) (forge.PullRef, error) {
+	return forge.PullRef{}, errors.New("dial tcp: connection refused")
+}
+
+// The 502 arm is not removed, only narrowed: a forge that could not be asked
+// is still an upstream failure.
+func TestLaunchWhoseForkGuardCannotReachTheForgeIs502(t *testing.T) {
+	s := launchPRContextServer(t, "team-b")
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return &forkGuardErrClient{}, nil
+	}
+	rec := launchAsTeam(t, s, "team-b", map[string]string{"pr_url": "https://github.com/o/r/pull/42"})
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 — the forge could not be asked; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A fork PR the guard PROVED is a fork stays 422, unchanged.
+func TestLaunchOnAForkPRIs422(t *testing.T) {
+	s := launchPRContextServer(t, "team-b")
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return &fakeGateClient{headSHA: "abc", headRepo: "mallory/r"}, nil
+	}
+	rec := launchAsTeam(t, s, "team-b", map[string]string{"pr_url": "https://github.com/o/r/pull/42"})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A publish grant the server could not mint is the server's OWN capacity —
+// the one row that stays 503 (retriable as-is).
+func TestLaunchWhoseGrantCannotBeMintedIs503(t *testing.T) {
+	s := launchPRContextServer(t, "team-b")
+	s.forgePublishTokens = &failingPublishTokenStore{
+		ForgePublishTokenStore: NewForgePublishTokenRegistry(),
+		err:                    errors.New("forge publish token registry full"),
+	}
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return &fakeGateClient{headSHA: "abc"}, nil // same-repo: the guard passes
+	}
+	rec := launchAsTeam(t, s, "team-b", map[string]string{"pr_url": "https://github.com/o/r/pull/42"})
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// A connection whose provider cannot read pull requests can never prove
+// same-repo: no retry helps, so it is not an upstream failure either.
+func TestLaunchOnAConnectionThatCannotReadPullRequestsIs422(t *testing.T) {
+	s := launchPRContextServer(t, "team-b")
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return nil, nil
+	}
+	rec := launchAsTeam(t, s, "team-b", map[string]string{"pr_url": "https://github.com/o/r/pull/42"})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -1268,17 +1268,34 @@ const prClosedRunReason = store.RunEndReasonPRClosed
 // /command lanes refuse the same states (same-repo only, silently), so no
 // refusal may advertise them as an escape hatch: fork work needs a branch in
 // the base repo before any bot runs on it.
+// Both sources reach it, so the wording names no source: `head.repo: null`
+// on a payload and a source project the credential may not read on an API
+// resolution are the same fact — a head repository that EXISTS and was not
+// named.
 func forkGuardRefusal(sameRepoProven, withheld bool, headRepo string) string {
 	switch {
 	case sameRepoProven:
 		return ""
 	case withheld:
-		return "head repo withheld by the payload (head.repo: null) — auto-launch blocked: a deleted or blocked fork has exactly this shape, and the launch pair would be <base>.CloneURL + a fork-chosen branch name; the /command lanes refuse it too (same-repo only)"
+		return "head repo withheld — the forge declared one and did not name it — auto-launch blocked: a deleted or blocked fork has exactly this shape, and the launch pair would be <base>.CloneURL + a fork-chosen branch name; the /command lanes refuse it too (same-repo only)"
 	case headRepo == "":
-		return "head repo not named by the payload — auto-launch blocked: same-repo is never assumed, only proven (the launch pair would be <base>.CloneURL + a branch that may live elsewhere); the /command lanes refuse it too (same-repo only)"
+		return "head repo not named — auto-launch blocked: same-repo is never assumed, only proven (the launch pair would be <base>.CloneURL + a branch that may live elsewhere); the /command lanes refuse it too (same-repo only)"
 	default:
 		return "fork PR — auto-launch blocked (untrusted; the /command lanes are same-repo only too, so the fork's work needs a branch in this repo before any bot runs on it)"
 	}
+}
+
+// forkGuardRefusalFor is forkGuardRefusal for a pull request resolved through
+// the forge API, where the head repository may have taken its own request:
+// it reads the withheld flag off the ref and quotes the forge's own typed
+// refusal, which the payload lanes never hold. A refusal that cannot name why
+// the head stayed unproven sends the operator looking in the wrong place.
+func forkGuardRefusalFor(pr forge.PullRef, baseRepo string) string {
+	reason := forkGuardRefusal(pr.SameRepoAs(baseRepo), pr.HeadRepoWithheld(), pr.HeadRepoFullName)
+	if reason != "" && pr.HeadRepoErr != nil {
+		reason += " (" + pr.HeadRepoErr.Error() + ")"
+	}
+	return reason
 }
 
 // prRequeuedRunReason names the auto-heal cancel for the same reason: a

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -460,7 +460,7 @@ func (s *Server) handleGitLabNote(ctx context.Context, w http.ResponseWriter, r 
 		return
 	}
 	if !head.SameRepoAs(p.ProjectPath) {
-		filtered(gitlabCommandForkRefusal("reply", head.HeadRepoFullName))
+		filtered(gitlabCommandForkRefusal("reply", head))
 		return
 	}
 	question := strings.TrimSpace(p.NoteBody)
@@ -585,7 +585,7 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 			return
 		}
 		if !resolved.SameRepoAs(p.ProjectPath) {
-			filtered(gitlabCommandForkRefusal(cmd, resolved.HeadRepoFullName))
+			filtered(gitlabCommandForkRefusal(cmd, resolved))
 			return
 		}
 		vars = applyWebhookVarLayers(buildCommandVars(p, route, cmdArgs, nil), cfg)
@@ -928,13 +928,21 @@ func gitlabForkRefusal(head string) string {
 }
 
 // gitlabCommandForkRefusal words the command lane's same-project refusal:
-// the fork's own project when the adapter resolved it, "unverifiable" when
-// the head could not be proven either way.
-func gitlabCommandForkRefusal(cmd, head string) string {
-	if head == "" {
-		return "fork MR or unverifiable head project — /" + cmd + " runs are same-project only"
+// the fork's own project when the adapter resolved it, else what the adapter
+// met — a source project the MR DECLARED and the credential could not read
+// (quoting the forge's own refusal), or no head project at all.
+func gitlabCommandForkRefusal(cmd string, head forge.PullRef) string {
+	if head.HeadRepoFullName != "" {
+		return "fork MR — the head lives in " + head.HeadRepoFullName + " — /" + cmd + " runs are same-project only"
 	}
-	return "fork MR — the head lives in " + head + " — /" + cmd + " runs are same-project only"
+	if head.HeadRepoWithheld() {
+		why := "the MR names a source project this credential could not read"
+		if head.HeadRepoErr != nil {
+			why += " (" + head.HeadRepoErr.Error() + ")"
+		}
+		return "fork MR — " + why + " — /" + cmd + " runs are same-project only"
+	}
+	return "fork MR or unverifiable head project — /" + cmd + " runs are same-project only"
 }
 
 // recordNoteDelivery inserts a terminal note-event audit row with a


### PR DESCRIPTION
Three commits, one per ticket (#887, #888, #893). Rebased onto current main.

## #887 — a permission answer arrived indistinguishable from "no source project"
**The ticket's premise was partly stale and is corrected here**: #846 already made the degrade return an EMPTY head, not the base's. The live defect stands and is worse in one place than the ticket says — `headProjectFor` (`pkg/forge/gitlab/ci.go`) mapped **both** 403 and 404 to `headProject{}, nil`, so "the project exists, you may not read it" reached every caller as the exact value a merge request naming no source project produces. The only thing between that and "therefore the base project" was `SameRepoAs` happening to fail closed on `""`. And `forge_publish.go` hardcoded `withheld=false`, so the API-side fork guard's refusal literally read *"head repo not named by the payload"* for a resolution that holds no payload.
`forge.PullRef` gains `HeadRepoDeclared` + a typed `HeadRepoErr` + `HeadRepoWithheld()`, mirroring `prforge.Parsed.HeadRepoWithheld` so the API and payload sides share one vocabulary. GitLab: 404 → declared + the per-operation `*NotFoundError`; **403 → declared + an `ErrForbidden`-wrapped error naming the op and the project id**. The MR read still answers — what could not be proven rides the ref instead of being dropped. **All three adapters set the flag** (GitHub/Forgejo record `head.repo` key-presence through one shared `forge.UnmarshalDeclaring`, so `repo: null` on a deleted fork is *withheld*, not *absent*) — a flag set on one adapter would have meant nothing.
Red: `declared = false withheld = false, want both: the MR names a source project id the read could not resolve`; `a declared source project that could not be read is withheld, not absent`; `TestGitHubPullHeadRepoDeclared/deleted_fork_sends_repo:_null`; `want the refusal to say the head repo was DECLARED and not named`.
Class table in the commit: four refusal sites fixed through one `forkGuardRefusalFor` helper, the GitLab converse and command lanes fixed, the base-clone-URL fallback documented in place (reached only after `SameRepoAs` proved same-project). Same degrade shape audited elsewhere in the adapters and found clean, with `github.OrgMembershipRole` named as fail-closed-by-value and documented.

## #888 — a tenant-crossing refusal answered 502
`runs_launch.go` mapped only the fork guard; `errForgePublishGrantTenant` fell through to 502, so an inadmissible request read as an upstream forge outage — while the webhook lane already answered **422** for that same refusal. The two surfaces disagreed on one verdict. Red: `status = 502, want 422`. The whole table is extracted to `prLaunchContextStatus` beside the sentinels it reads: fork guard 422, tenant mismatch **422**, a connection whose provider has no `PullClient` (same-repo unprovable forever) **422** via a new sentinel, registry-full **503** (deliberate, #886), `gateClientFor` / `GetPullRequest` failures **502**. Five HTTP-level tests including the two negative rows.

## #893 — an upstream 429 answered 500
`StatusErrNeeding`'s default arm produced a bare `fmt.Errorf("… HTTP %d")`, so the status survived only as text. Red, straight from the fake forge: `upstream 429 → status 500, want 429`, and the same for 503 → 502, 502 → 502, 409 → 409.
Two chokepoints. `pkg/forge`: `StatusErr` returns `*forge.StatusError{Provider, Op, Code, RetryAfter}` (message byte-identical, so no log or operator relearns anything) + `ParseRetryAfter`; `Retry-After` lives on the response, which nothing above the transport saw, so `DoJSONFull` hands a non-2xx answer's headers back and `AdminHTTP.DoTyped` types the refusal while they are in hand. `pkg/server`: **one** table, `forgeUpstreamStatus`, consumed through `writeForgeUpstreamError` — 429 → 429 with the forge's own `Retry-After` echoed (empty when it said nothing, never a guess), 5xx → 502, other 4xx mirrored, permission/unauthorized → 422, not-found → 404, a dial/TLS error → 502, and **only** a genuine iterion fault (marshal, seal, store) → 500. Seven handlers wired, each keeping its typed cases ahead of the table so no existing wording changed.
**One handler deliberately NOT wired, with its reason in the code**: the avatar route's fallback wraps the forge's sentinel inside a *spent-budget* failure, and classifying by the wrapped sentinel turned a dead context into the 403 a stalling forge had sent first — the existing test caught it, and reverting is the right answer.

## Run-facing degradations — checked, reported, not fixed (outside the "same helper" boundary)
`handleForgePublishReview` answers 502 with a structured response the bot reads, so it cannot go through the shared writer — a 429 is allowed there, but its **`Retry-After` is lost**, which matters for a bot that could park and retry. `postGateStatus` folds a failed `SetCommitStatus` into `errText` and still answers 200, so a 429 **degrades silently**. `gateStatusOn` and the reconciler's CI reads abstain silently on any error, so a rate-limited read makes the auto-fix lane stand down with nothing said.

## Proof
`go build`, `go vet`, `task lint` (0 issues), `go test ./pkg/... ./cmd/...`, `go test ./e2e/...` (455 s), `-race` on `pkg/forge/... pkg/server`, `task openapi:check` no drift. Re-verified after the rebase.

## Found on the way (not fixed)
A `pkg/forge` sentinel wrapped into a context-expiry error still classifies as the forge's answer — any `errors.Is`-based routing lets a forge that answered 403 and *then* stalled decide a status the code wants to be "the budget is spent". Filed separately.

Closes #887, #888, #893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
