### PR TITLE
fix(delegate): the two terminal returns that walked past the spend stamp

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -516,7 +516,7 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	result.Tokens = totalIn + totalOut
 
 	if rm.IsError && rm.Subtype != claudesdk.ResultSuccess {
-		if errResult, errOut, fatal := b.handleCLIErrorSubtype(rm, task, result); fatal {
+		if errResult, errOut, fatal := b.handleCLIErrorSubtype(rm, task, result, totalIn, totalOut); fatal {
 			return errResult, errOut
 		}
 	}
@@ -811,7 +811,27 @@ func (b *ClaudeCodeBackend) buildStreamErrorResult(rm *claudesdk.ResultMessage, 
 	// lands on stderr. Re-type it as ErrTransient so the executor's
 	// retry loop rides the blip out instead of failing the whole node.
 	streamErr = b.retypeNetworkError(streamErr, stderr, task)
-	return errResult, fmt.Errorf("delegate: claude-code failed: %w", streamErr)
+	// The session was billed for whatever it streamed before the drop, and
+	// this return is TERMINAL for the delegation. The caps, the fallback
+	// chain's carried spend and a donor's ledger all read the cost from the
+	// output map, so a return that skips the stamp records nothing — the
+	// spend is real either way, only the accounting disappears. Same choke
+	// point as every other typed failure.
+	in, out := usageOf(rm)
+	errResult.Tokens = in + out
+	return errResult, typedFailure(&errResult, task, in, out,
+		fmt.Errorf("delegate: claude-code failed: %w", streamErr), rm)
+}
+
+// usageOf reads a result message's token usage, tolerating the nils a
+// broken stream leaves behind: the message may never have arrived, or have
+// arrived without usage, and neither is a reason to bill zero silently
+// when the other half is there.
+func usageOf(rm *claudesdk.ResultMessage) (int, int) {
+	if rm == nil || rm.Usage == nil {
+		return 0, 0
+	}
+	return rm.Usage.InputTokens, rm.Usage.OutputTokens
 }
 
 // handleCLIErrorSubtype branches on the CLI's error subtype after a stream
@@ -824,7 +844,7 @@ func (b *ClaudeCodeBackend) buildStreamErrorResult(rm *claudesdk.ResultMessage, 
 // error subtypes (error_during_execution, error_max_budget_usd) remain
 // hard failures. Returns `fatal=true` when the caller must return the
 // (result, err) pair immediately; `fatal=false` lets Execute fall through.
-func (b *ClaudeCodeBackend) handleCLIErrorSubtype(rm *claudesdk.ResultMessage, task Task, result Result) (Result, error, bool) {
+func (b *ClaudeCodeBackend) handleCLIErrorSubtype(rm *claudesdk.ResultMessage, task Task, result Result, totalIn, totalOut int) (Result, error, bool) {
 	// error_max_turns is a SOFT stop, not a failure: the agent hit its
 	// tool_max_steps cap (claude --max-turns). For an implementer
 	// (act/fix, no output schema) the work it did is already in the
@@ -838,7 +858,12 @@ func (b *ClaudeCodeBackend) handleCLIErrorSubtype(rm *claudesdk.ResultMessage, t
 		b.Logger.Warn("[%s#%d/claude-code] hit max turns (tool_max_steps) — returning partial result; downstream review/fix completes any gaps", task.NodeID, task.Iteration)
 		return result, nil, false
 	}
-	return result, fmt.Errorf("delegate: claude-code error: subtype=%s", rm.Subtype), true
+	// The stamp lives HERE, with the decision, not at the call site: a
+	// session that reached a hard subtype was billed exactly like one that
+	// rendered a refusal — which stamps — and a caller is free to forget.
+	typed := typedFailure(&result, task, totalIn, totalOut,
+		fmt.Errorf("delegate: claude-code error: subtype=%s", rm.Subtype), rm)
+	return result, typed, true
 }
 
 // runTwoPassFormatting runs the Pass-2 structured-output extraction loop

--- a/pkg/backend/delegate/claude_code_terminal_spend_test.go
+++ b/pkg/backend/delegate/claude_code_terminal_spend_test.go
@@ -1,0 +1,87 @@
+package delegate
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// A delegation that ends badly still SPENT. The caps, the fallback chain's
+// carried spend and a donor's ledger all read the cost from the output map,
+// so a terminal return that skips the stamp records nothing — the money is
+// gone either way, only the accounting disappears. `typedFailure` is the
+// choke point that stamps it, and two terminal returns used to walk past it.
+func TestTerminalReturnsCarryTheirSpend(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	task := Task{NodeID: "n", Iteration: 1, Model: "claude-fable-5"}
+	billed := &claudesdk.ResultMessage{
+		SessionID:    "s1",
+		Usage:        &claudesdk.Usage{InputTokens: 900, OutputTokens: 120},
+		TotalCostUSD: f(0.42),
+	}
+	backend := func() *ClaudeCodeBackend {
+		return &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+	}
+
+	t.Run("a stream that broke after being billed", func(t *testing.T) {
+		res, err := backend().buildStreamErrorResult(billed, sessionMeta{}, errors.New("session ended without result"),
+			"fetch failed", 3*time.Second, task)
+		if err == nil {
+			t.Fatal("a broken stream must still return an error")
+		}
+		if res.Output == nil || res.Output["_cost_usd"] == nil || res.Output["_tokens"] == nil {
+			t.Fatalf("the session was billed and the spend went unrecorded: %v", res.Output)
+		}
+		if got, _ := res.Output["_cost_usd"].(float64); got < 0.42 {
+			t.Fatalf("the CLI's own figure was lost: _cost_usd=%v (want >= 0.42)", res.Output["_cost_usd"])
+		}
+		if res.Tokens != 1020 {
+			t.Fatalf("tokens: got %d, want 1020", res.Tokens)
+		}
+	})
+
+	t.Run("a stream that broke before any message", func(t *testing.T) {
+		// No result message at all: nothing to bill, and nothing to crash on.
+		res, err := backend().buildStreamErrorResult(nil, sessionMeta{}, errors.New("spawn failed"),
+			"", time.Second, task)
+		if err == nil {
+			t.Fatal("want an error")
+		}
+		if res.Output == nil {
+			t.Fatal("the output map must exist even at zero, or the caps read nothing")
+		}
+		if res.Tokens != 0 {
+			t.Fatalf("tokens invented from nothing: %d", res.Tokens)
+		}
+	})
+
+	t.Run("a hard CLI subtype is billed like a rendered refusal", func(t *testing.T) {
+		// The path Execute takes: the result carries the pass's usage, and
+		// the subtype is fatal.
+		rm := &claudesdk.ResultMessage{IsError: true, Subtype: claudesdk.ResultErrorExecution,
+			Usage: billed.Usage, TotalCostUSD: billed.TotalCostUSD}
+		result := Result{ExitCode: 0, Tokens: 1020}
+		errResult, errOut, fatal := backend().handleCLIErrorSubtype(rm, task, result, 900, 120)
+		if !fatal || errOut == nil {
+			t.Fatalf("error_during_execution must stay fatal: fatal=%v err=%v", fatal, errOut)
+		}
+		if errResult.Output == nil || errResult.Output["_cost_usd"] == nil || errResult.Output["_tokens"] == nil {
+			t.Fatalf("a fatal subtype without its spend: %v", errResult.Output)
+		}
+		if got, _ := errResult.Output["_cost_usd"].(float64); got < 0.42 {
+			t.Fatalf("the CLI's own figure was lost: %v", errResult.Output["_cost_usd"])
+		}
+	})
+
+	t.Run("max turns stays a soft stop", func(t *testing.T) {
+		rm := &claudesdk.ResultMessage{IsError: true, Subtype: claudesdk.ResultErrorMaxTurns}
+		_, errOut, fatal := backend().handleCLIErrorSubtype(rm, task, Result{}, 0, 0)
+		if fatal || errOut != nil {
+			t.Fatalf("max_turns must stay a partial result, not a failure: fatal=%v err=%v", fatal, errOut)
+		}
+	})
+}


### PR DESCRIPTION
## A delegation that ends badly still spent

The caps, the fallback chain's carried spend and a donor's ledger all read the cost from the delegation's output map. `typedFailure` exists to stamp it on every typed failure — its docstring says exactly that, down to the warning about Go's evaluation order. Two terminal returns walked past it.

- **A stream that broke mid-session** (`buildStreamErrorResult`) returned a Result with no cost and no tokens, even when the CLI had already reported both. A connectivity drop is the common failure of a long agent node, so the spend most likely to vanish was the spend of the longest sessions.
- **A hard CLI subtype** (`error_during_execution`, `error_max_budget_usd`) returned tokens but no cost — three lines above a rendered refusal that stamps both. `error_max_budget_usd` is the one that stings: a session that died **because** it spent its budget reported no cost at all.

## What changed

The stamp for the subtype now lives with the **decision** rather than at the call site. A caller is free to forget, and this one did; `handleCLIErrorSubtype` takes the pass's usage and returns an already-stamped result, so no future caller can reintroduce the gap.

The broken-stream path reads the usage from the result message through a small helper that tolerates the nils a broken stream leaves behind: the message may never have arrived, or have arrived without usage, and neither is a reason to bill zero silently when the other half is there.

The soft stop is untouched: `error_max_turns` still returns the partial result and lets the workflow continue — the work an implementer did is already in the worktree, and a node with an output schema fails on schema validation, which is the correct outcome.

## Proof

Four mutants, each red on its own test:

- either terminal return dropping the stamp;
- the usage of a billed stream read as zero;
- `max_turns` turned into a hard failure.

`go test ./pkg/backend/delegate/` green; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
