### PR TITLE
fix(golden-master): report broken selftest fixtures before indexing verdicts

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3313,6 +3313,20 @@ tool oracle_run:
             if got != want:
                 failures.append("%s\n    attendu : %r\n    obtenu  : %r" % (name, want, got))
 
+        def fixture_git(repo, *args):
+            # A failed add/commit/reset used to be ignored: the verdict then read
+            # an old tree and acted[0] hid Git's diagnostic behind an IndexError
+            # (#876). Fixture setup must succeed before any rule can be judged.
+            # These disposable repos also must not spawn detached maintenance
+            # while the next scenario resets them (Git >= 2.48).
+            cmd = shlex.join(["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false",
+                              "-c", "user.email=t@t", "-c", "user.name=t"] + list(args))
+            code, out = run(cmd, repo, timeout=60)
+            if code != 0:
+                raise SystemExit("selftest fixture git failed in %s: %s (exit %s)\n%s"
+                                 % (repo, cmd, code, out))
+            return out.strip()
+
         g = globals()
         saved = {k: g[k] for k in ("apply_mutant", "revert_mutant", "tree_fingerprint",
                                    "data_fingerprint", "app_restart", "capture", "control_ids")}
@@ -3648,9 +3662,8 @@ tool oracle_run:
                   [True, False])
             repo2 = os.path.join(sroot, "committed")
             gmd2 = mk_holdout(repo2)
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, repo2, timeout=60)
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(repo2, *args)
             sealed2 = os.path.join(sroot, "sealed2")
             check("jeu committe -> laisse en place, rien de scelle",
                   [seal_holdout(gmd2, sealed2),
@@ -3690,9 +3703,8 @@ tool oracle_run:
             gmd3 = mk_holdout(repo3)
             with open(os.path.join(gmd3, "config.json"), "w", encoding="utf-8") as f:
                 f.write('{"seal_committed": true}')
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, repo3, timeout=60)
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(repo3, *args)
             check("opt-in par config.json -> le jeu committe se scelle",
                   [seal_holdout(gmd3, os.path.join(sroot, "sealed3")),
                    os.path.isdir(os.path.join(gmd3, "mutants", "holdout", "t01"))],
@@ -3748,10 +3760,9 @@ tool oracle_run:
                 json.dump({"entries": [base_entry]}, f)
             with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-1\n")
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, xroot, timeout=60)
-            xbase = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(xroot, *args)
+            xbase = fixture_git(xroot, "rev-parse", "HEAD")
 
             def xledger(*blks):
                 with open(os.path.join(xgm, "EXTENSIONS.md"), "w", encoding="utf-8") as f:
@@ -3759,9 +3770,8 @@ tool oracle_run:
                                       for b in blks))
 
             def xcommit():
-                run("git add -A", xroot, timeout=60)
-                run("git -c user.email=t@t -c user.name=t commit -qm x",
-                    xroot, timeout=60)
+                fixture_git(xroot, "add", "-A")
+                fixture_git(xroot, "commit", "-qm", "x")
 
             def xrequest(req):
                 """The lot files its request and commits. A fixture that stages a
@@ -3772,8 +3782,16 @@ tool oracle_run:
                 xcommit()
 
             def xreset():
-                run("git reset -q --hard %s" % xbase, xroot, timeout=60)
-                run("git clean -qfd", xroot, timeout=60)
+                fixture_git(xroot, "reset", "-q", "--hard", xbase)
+                fixture_git(xroot, "clean", "-qfd")
+
+            def xverdict(base):
+                verdict = extension_verdict(xroot, ".golden-master", base)
+                if len(verdict.get("acted", [])) != 1:
+                    raise SystemExit("selftest extension fixture expected one acted entry "
+                                     "in %s at base %s; got %s"
+                                     % (xroot, base, json.dumps(verdict, sort_keys=True)))
+                return verdict
 
             req2 = ('{"id": "E-1", "lot": "L", "type": "add-file",'
                     ' "paths": [".golden-master/refs/2.txt"]}')
@@ -3798,7 +3816,7 @@ tool oracle_run:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase)
+            v = xverdict(xbase)
             check("add-file legitime -> ok, chemin exempte",
                   [v["acted"][0]["ok"], v["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
@@ -3806,11 +3824,11 @@ tool oracle_run:
             # Un acte deja present A LA BASE n'est pas re-juge : ses ajouts sont
             # les references de cette base, et les relire comme des reecritures
             # refuserait tout lot parti d'une base qui contient un acte certifie.
-            xbase_acted = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            xbase_acted = fixture_git(xroot, "rev-parse", "HEAD")
             with open(os.path.join(xroot, "later.txt"), "w", encoding="utf-8") as f:
                 f.write("a lot landed after the act\n")
             xcommit()
-            v_after = extension_verdict(xroot, ".golden-master", xbase_acted)
+            v_after = xverdict(xbase_acted)
             check("acte present a la base -> ok, acted_at_base, aucun probleme",
                   [v_after["acted"][0]["ok"], v_after["acted"][0].get("acted_at_base"),
                    v_after["acted"][0]["problems"], v_after["problems"]],
@@ -3820,7 +3838,7 @@ tool oracle_run:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2-reecrite-par-un-lot\n")
             xcommit()
-            v_touch = extension_verdict(xroot, ".golden-master", xbase_acted)
+            v_touch = xverdict(xbase_acted)
             check("acte a la base + ref reecrite -> le certificat n'exempte rien",
                   [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
 
@@ -3832,7 +3850,7 @@ tool oracle_run:
                 f.write("ref-1-reecrite\n")
             xcommit()
             check("reecriture deguisee en ajout -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Suppression enregistree : le chemin manque a HEAD (le cote delete
             # d'un renommage perd exactement ici).
@@ -3840,7 +3858,7 @@ tool oracle_run:
             xledger(("request", req2), ("act", act2))
             xcommit()
             check("chemin enregistre absent a HEAD (delete/rename) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Entree de corpus legitime, revendiquee par la demande.
             xreset()
@@ -3855,7 +3873,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, new_entry]}, f)
             xcommit()
             check("add-entry legitime et revendiquee -> ok",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+                  xverdict(xbase)["acted"][0]["ok"], True)
 
             # La meme demande dans l'orthographe du registre de re-baseline
             # (`expected_paths` + `entries` en identifiants) : lue au meme point,
@@ -3875,7 +3893,7 @@ tool oracle_run:
                 f.write("ref-2\n")
             xcommit()
             check("demande ecrite comme le registre de re-baseline l'enseigne -> ok",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+                  xverdict(xbase)["acted"][0]["ok"], True)
 
             # Retouche d'une entree existante sous couvert d'ajout.
             xreset()
@@ -3887,7 +3905,7 @@ tool oracle_run:
                 json.dump({"entries": [touched, new_entry]}, f)
             xcommit()
             check("entree existante retouchee -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Collision : la « nouvelle » entree observe le meme tuple qu'une
             # existante — deux references pour une observation.
@@ -3900,7 +3918,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, collider]}, f)
             xcommit()
             check("collision de tuple d'observation -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Entree passee en fraude : ajoutee au corpus, revendiquee par
             # personne.
@@ -3913,7 +3931,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, new_entry, smuggled]}, f)
             xcommit()
             check("entree non revendiquee a cote d'une actee -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Chemin hors surface : le canon est le territoire du juge.
             xreset()
@@ -3925,7 +3943,7 @@ tool oracle_run:
                 f.write("# neuf\n")
             xcommit()
             check("chemin hors refs/+corpus (canon) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Registre reecrit : un registre COMMITTE a la base n'est plus un
             # prefixe de HEAD. (Un registre ne EXISTANT PAS a la base rend ce
@@ -3934,12 +3952,12 @@ tool oracle_run:
             xreset()
             xledger(("request", req2))
             xcommit()
-            xbase2 = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            xbase2 = fixture_git(xroot, "rev-parse", "HEAD")
             xledger(("act", act2))  # la demande a disparu : trail edite
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase2)
+            v = xverdict(xbase2)
             check("registre committe puis reecrit -> append_only faux et acte refuse",
                   [v["ledger_append_only"], v["acted"][0]["ok"]],
                   [False, False])
@@ -3957,7 +3975,7 @@ tool oracle_run:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v_self = extension_verdict(xroot, ".golden-master", xbase)
+            v_self = xverdict(xbase)
             check("demande et acte dans UN commit (le lot s'auto-sert) -> refuse",
                   [v_self["acted"][0]["ok"], v_self["ok_paths"]], [False, []])
 
@@ -3972,7 +3990,7 @@ tool oracle_run:
             check("acte n'enregistrant QUE le registre -> la demande RESTE pendante",
                   [p["id"] for p in pending_extensions(xgm)], ["E-1"])
             check("acte n'enregistrant QUE le registre -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"],
+                  xverdict(xbase)["acted"][0]["ok"],
                   False)
 
             # Un scalaire la ou le juge itere : le bloc devient refusable, il ne
@@ -3984,7 +4002,7 @@ tool oracle_run:
             xcommit()
             check("recorded_paths scalaire -> la demande RESTE pendante, pas de crash",
                   [p["id"] for p in pending_extensions(xgm)], ["E-1"])
-            v_scalar = extension_verdict(xroot, ".golden-master", xbase)
+            v_scalar = xverdict(xbase)
             check("recorded_paths scalaire -> verdict rendu et acte refuse",
                   ["error" not in v_scalar, v_scalar["acted"][0]["ok"]], [True, False])
 
@@ -3998,7 +4016,7 @@ tool oracle_run:
                   _entry_observation_key(a1) == _entry_observation_key(a2), False)
 
             check("acte sans demande -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # 8f. Les refus arraches par la revue adversariale — chaque
             #     deguisement executee contre le verdict doit rester rouge.
@@ -4020,7 +4038,7 @@ tool oracle_run:
             os.symlink("1.txt", os.path.join(xgm, "refs", "2.txt"))
             xcommit()
             check("symlink sous refs/ -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Un chemin refs/ enregistre mais non declare par la demande.
             xreset()
@@ -4031,7 +4049,7 @@ tool oracle_run:
                 f.write("ref-3\n")
             xcommit()
             check("ref ajoutee non declaree par la demande -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
@@ -4043,7 +4061,7 @@ tool oracle_run:
                 json.dump({"entries": [twin, base_entry]}, f)
             xcommit()
             check("id duplique dans le corpus -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Une cle cosmetique ne neutralise pas la collision d'observation.
             xreset()
@@ -4055,7 +4073,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, cosmetic]}, f)
             xcommit()
             check("collision masquee par une cle cosmetique -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Une base irresoluble ne tamponne rien : elle refuse.
             check("GM_BASE irresoluble -> erreur, pas un laissez-passer",
@@ -4070,7 +4088,7 @@ tool oracle_run:
                 f.write('{"entries": {"E1": {}}}')
             xcommit()
             check("corpus malforme -> refuse, pas une traceback",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # 8g. Les refus du tour de CONSOLIDATION — la classe id-derive-un-
             #     chemin et la cle sensible a la presence, plus le flux add-entry
@@ -4087,7 +4105,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, traversal]}, f)
             xcommit()
             check("id en traversee (../refs/1) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # La PRESENCE d'un champ allowliste vide ne scinde pas la cle.
             xreset()
@@ -4099,7 +4117,7 @@ tool oracle_run:
                 json.dump({"entries": [base_entry, present_twin]}, f)
             xcommit()
             check("collision masquee par un champ allowliste VIDE -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Le flux add-entry LEGITIME : l'entree revendiquee revendique sa
             # reference derivee — corpus.json ET refs/2.txt exemptes, sans
@@ -4116,7 +4134,7 @@ tool oracle_run:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase)
+            v = xverdict(xbase)
             check("add-entry avec sa ref derivee, sans `paths` -> ok, les deux exemptes",
                   [v["acted"][0]["ok"], v["ok_paths"]],
                   [True, [".golden-master/corpus.json", ".golden-master/refs/2.txt"]])

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3094,6 +3094,20 @@ def _selftest():
         if got != want:
             failures.append("%s\n    attendu : %r\n    obtenu  : %r" % (name, want, got))
 
+    def fixture_git(repo, *args):
+        # A failed add/commit/reset used to be ignored: the verdict then read
+        # an old tree and acted[0] hid Git's diagnostic behind an IndexError
+        # (#876). Fixture setup must succeed before any rule can be judged.
+        # These disposable repos also must not spawn detached maintenance
+        # while the next scenario resets them (Git >= 2.48).
+        cmd = shlex.join(["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false",
+                          "-c", "user.email=t@t", "-c", "user.name=t"] + list(args))
+        code, out = run(cmd, repo, timeout=60)
+        if code != 0:
+            raise SystemExit("selftest fixture git failed in %s: %s (exit %s)\n%s"
+                             % (repo, cmd, code, out))
+        return out.strip()
+
     g = globals()
     saved = {k: g[k] for k in ("apply_mutant", "revert_mutant", "tree_fingerprint",
                                "data_fingerprint", "app_restart", "capture", "control_ids")}
@@ -3429,9 +3443,8 @@ def _selftest():
               [True, False])
         repo2 = os.path.join(sroot, "committed")
         gmd2 = mk_holdout(repo2)
-        for cmd in ("git init -q", "git add -A",
-                    "git -c user.email=t@t -c user.name=t commit -qm seed"):
-            run(cmd, repo2, timeout=60)
+        for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+            fixture_git(repo2, *args)
         sealed2 = os.path.join(sroot, "sealed2")
         check("jeu committe -> laisse en place, rien de scelle",
               [seal_holdout(gmd2, sealed2),
@@ -3471,9 +3484,8 @@ def _selftest():
         gmd3 = mk_holdout(repo3)
         with open(os.path.join(gmd3, "config.json"), "w", encoding="utf-8") as f:
             f.write('{"seal_committed": true}')
-        for cmd in ("git init -q", "git add -A",
-                    "git -c user.email=t@t -c user.name=t commit -qm seed"):
-            run(cmd, repo3, timeout=60)
+        for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+            fixture_git(repo3, *args)
         check("opt-in par config.json -> le jeu committe se scelle",
               [seal_holdout(gmd3, os.path.join(sroot, "sealed3")),
                os.path.isdir(os.path.join(gmd3, "mutants", "holdout", "t01"))],
@@ -3529,10 +3541,9 @@ def _selftest():
             json.dump({"entries": [base_entry]}, f)
         with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
             f.write("ref-1\n")
-        for cmd in ("git init -q", "git add -A",
-                    "git -c user.email=t@t -c user.name=t commit -qm seed"):
-            run(cmd, xroot, timeout=60)
-        xbase = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+            fixture_git(xroot, *args)
+        xbase = fixture_git(xroot, "rev-parse", "HEAD")
 
         def xledger(*blks):
             with open(os.path.join(xgm, "EXTENSIONS.md"), "w", encoding="utf-8") as f:
@@ -3540,9 +3551,8 @@ def _selftest():
                                   for b in blks))
 
         def xcommit():
-            run("git add -A", xroot, timeout=60)
-            run("git -c user.email=t@t -c user.name=t commit -qm x",
-                xroot, timeout=60)
+            fixture_git(xroot, "add", "-A")
+            fixture_git(xroot, "commit", "-qm", "x")
 
         def xrequest(req):
             """The lot files its request and commits. A fixture that stages a
@@ -3553,8 +3563,16 @@ def _selftest():
             xcommit()
 
         def xreset():
-            run("git reset -q --hard %s" % xbase, xroot, timeout=60)
-            run("git clean -qfd", xroot, timeout=60)
+            fixture_git(xroot, "reset", "-q", "--hard", xbase)
+            fixture_git(xroot, "clean", "-qfd")
+
+        def xverdict(base):
+            verdict = extension_verdict(xroot, ".golden-master", base)
+            if len(verdict.get("acted", [])) != 1:
+                raise SystemExit("selftest extension fixture expected one acted entry "
+                                 "in %s at base %s; got %s"
+                                 % (xroot, base, json.dumps(verdict, sort_keys=True)))
+            return verdict
 
         req2 = ('{"id": "E-1", "lot": "L", "type": "add-file",'
                 ' "paths": [".golden-master/refs/2.txt"]}')
@@ -3579,7 +3597,7 @@ def _selftest():
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
         xcommit()
-        v = extension_verdict(xroot, ".golden-master", xbase)
+        v = xverdict(xbase)
         check("add-file legitime -> ok, chemin exempte",
               [v["acted"][0]["ok"], v["ok_paths"]],
               [True, [".golden-master/refs/2.txt"]])
@@ -3587,11 +3605,11 @@ def _selftest():
         # Un acte deja present A LA BASE n'est pas re-juge : ses ajouts sont
         # les references de cette base, et les relire comme des reecritures
         # refuserait tout lot parti d'une base qui contient un acte certifie.
-        xbase_acted = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        xbase_acted = fixture_git(xroot, "rev-parse", "HEAD")
         with open(os.path.join(xroot, "later.txt"), "w", encoding="utf-8") as f:
             f.write("a lot landed after the act\n")
         xcommit()
-        v_after = extension_verdict(xroot, ".golden-master", xbase_acted)
+        v_after = xverdict(xbase_acted)
         check("acte present a la base -> ok, acted_at_base, aucun probleme",
               [v_after["acted"][0]["ok"], v_after["acted"][0].get("acted_at_base"),
                v_after["acted"][0]["problems"], v_after["problems"]],
@@ -3601,7 +3619,7 @@ def _selftest():
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2-reecrite-par-un-lot\n")
         xcommit()
-        v_touch = extension_verdict(xroot, ".golden-master", xbase_acted)
+        v_touch = xverdict(xbase_acted)
         check("acte a la base + ref reecrite -> le certificat n'exempte rien",
               [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
 
@@ -3613,7 +3631,7 @@ def _selftest():
             f.write("ref-1-reecrite\n")
         xcommit()
         check("reecriture deguisee en ajout -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Suppression enregistree : le chemin manque a HEAD (le cote delete
         # d'un renommage perd exactement ici).
@@ -3621,7 +3639,7 @@ def _selftest():
         xledger(("request", req2), ("act", act2))
         xcommit()
         check("chemin enregistre absent a HEAD (delete/rename) -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Entree de corpus legitime, revendiquee par la demande.
         xreset()
@@ -3636,7 +3654,7 @@ def _selftest():
             json.dump({"entries": [base_entry, new_entry]}, f)
         xcommit()
         check("add-entry legitime et revendiquee -> ok",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+              xverdict(xbase)["acted"][0]["ok"], True)
 
         # La meme demande dans l'orthographe du registre de re-baseline
         # (`expected_paths` + `entries` en identifiants) : lue au meme point,
@@ -3656,7 +3674,7 @@ def _selftest():
             f.write("ref-2\n")
         xcommit()
         check("demande ecrite comme le registre de re-baseline l'enseigne -> ok",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+              xverdict(xbase)["acted"][0]["ok"], True)
 
         # Retouche d'une entree existante sous couvert d'ajout.
         xreset()
@@ -3668,7 +3686,7 @@ def _selftest():
             json.dump({"entries": [touched, new_entry]}, f)
         xcommit()
         check("entree existante retouchee -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Collision : la « nouvelle » entree observe le meme tuple qu'une
         # existante — deux references pour une observation.
@@ -3681,7 +3699,7 @@ def _selftest():
             json.dump({"entries": [base_entry, collider]}, f)
         xcommit()
         check("collision de tuple d'observation -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Entree passee en fraude : ajoutee au corpus, revendiquee par
         # personne.
@@ -3694,7 +3712,7 @@ def _selftest():
             json.dump({"entries": [base_entry, new_entry, smuggled]}, f)
         xcommit()
         check("entree non revendiquee a cote d'une actee -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Chemin hors surface : le canon est le territoire du juge.
         xreset()
@@ -3706,7 +3724,7 @@ def _selftest():
             f.write("# neuf\n")
         xcommit()
         check("chemin hors refs/+corpus (canon) -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Registre reecrit : un registre COMMITTE a la base n'est plus un
         # prefixe de HEAD. (Un registre ne EXISTANT PAS a la base rend ce
@@ -3715,12 +3733,12 @@ def _selftest():
         xreset()
         xledger(("request", req2))
         xcommit()
-        xbase2 = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        xbase2 = fixture_git(xroot, "rev-parse", "HEAD")
         xledger(("act", act2))  # la demande a disparu : trail edite
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
         xcommit()
-        v = extension_verdict(xroot, ".golden-master", xbase2)
+        v = xverdict(xbase2)
         check("registre committe puis reecrit -> append_only faux et acte refuse",
               [v["ledger_append_only"], v["acted"][0]["ok"]],
               [False, False])
@@ -3738,7 +3756,7 @@ def _selftest():
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
         xcommit()
-        v_self = extension_verdict(xroot, ".golden-master", xbase)
+        v_self = xverdict(xbase)
         check("demande et acte dans UN commit (le lot s'auto-sert) -> refuse",
               [v_self["acted"][0]["ok"], v_self["ok_paths"]], [False, []])
 
@@ -3753,7 +3771,7 @@ def _selftest():
         check("acte n'enregistrant QUE le registre -> la demande RESTE pendante",
               [p["id"] for p in pending_extensions(xgm)], ["E-1"])
         check("acte n'enregistrant QUE le registre -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"],
+              xverdict(xbase)["acted"][0]["ok"],
               False)
 
         # Un scalaire la ou le juge itere : le bloc devient refusable, il ne
@@ -3765,7 +3783,7 @@ def _selftest():
         xcommit()
         check("recorded_paths scalaire -> la demande RESTE pendante, pas de crash",
               [p["id"] for p in pending_extensions(xgm)], ["E-1"])
-        v_scalar = extension_verdict(xroot, ".golden-master", xbase)
+        v_scalar = xverdict(xbase)
         check("recorded_paths scalaire -> verdict rendu et acte refuse",
               ["error" not in v_scalar, v_scalar["acted"][0]["ok"]], [True, False])
 
@@ -3779,7 +3797,7 @@ def _selftest():
               _entry_observation_key(a1) == _entry_observation_key(a2), False)
 
         check("acte sans demande -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # 8f. Les refus arraches par la revue adversariale — chaque
         #     deguisement executee contre le verdict doit rester rouge.
@@ -3801,7 +3819,7 @@ def _selftest():
         os.symlink("1.txt", os.path.join(xgm, "refs", "2.txt"))
         xcommit()
         check("symlink sous refs/ -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Un chemin refs/ enregistre mais non declare par la demande.
         xreset()
@@ -3812,7 +3830,7 @@ def _selftest():
             f.write("ref-3\n")
         xcommit()
         check("ref ajoutee non declaree par la demande -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
         xreset()
@@ -3824,7 +3842,7 @@ def _selftest():
             json.dump({"entries": [twin, base_entry]}, f)
         xcommit()
         check("id duplique dans le corpus -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Une cle cosmetique ne neutralise pas la collision d'observation.
         xreset()
@@ -3836,7 +3854,7 @@ def _selftest():
             json.dump({"entries": [base_entry, cosmetic]}, f)
         xcommit()
         check("collision masquee par une cle cosmetique -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Une base irresoluble ne tamponne rien : elle refuse.
         check("GM_BASE irresoluble -> erreur, pas un laissez-passer",
@@ -3851,7 +3869,7 @@ def _selftest():
             f.write('{"entries": {"E1": {}}}')
         xcommit()
         check("corpus malforme -> refuse, pas une traceback",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # 8g. Les refus du tour de CONSOLIDATION — la classe id-derive-un-
         #     chemin et la cle sensible a la presence, plus le flux add-entry
@@ -3868,7 +3886,7 @@ def _selftest():
             json.dump({"entries": [base_entry, traversal]}, f)
         xcommit()
         check("id en traversee (../refs/1) -> refuse",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # La PRESENCE d'un champ allowliste vide ne scinde pas la cle.
         xreset()
@@ -3880,7 +3898,7 @@ def _selftest():
             json.dump({"entries": [base_entry, present_twin]}, f)
         xcommit()
         check("collision masquee par un champ allowliste VIDE -> refusee",
-              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+              xverdict(xbase)["acted"][0]["ok"], False)
 
         # Le flux add-entry LEGITIME : l'entree revendiquee revendique sa
         # reference derivee — corpus.json ET refs/2.txt exemptes, sans
@@ -3897,7 +3915,7 @@ def _selftest():
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
         xcommit()
-        v = extension_verdict(xroot, ".golden-master", xbase)
+        v = xverdict(xbase)
         check("add-entry avec sa ref derivee, sans `paths` -> ok, les deux exemptes",
               [v["acted"][0]["ok"], v["ok_paths"]],
               [True, [".golden-master/corpus.json", ".golden-master/refs/2.txt"]])

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3261,6 +3261,20 @@ tool sync_harness:
             if got != want:
                 failures.append("%s\n    attendu : %r\n    obtenu  : %r" % (name, want, got))
 
+        def fixture_git(repo, *args):
+            # A failed add/commit/reset used to be ignored: the verdict then read
+            # an old tree and acted[0] hid Git's diagnostic behind an IndexError
+            # (#876). Fixture setup must succeed before any rule can be judged.
+            # These disposable repos also must not spawn detached maintenance
+            # while the next scenario resets them (Git >= 2.48).
+            cmd = shlex.join(["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false",
+                              "-c", "user.email=t@t", "-c", "user.name=t"] + list(args))
+            code, out = run(cmd, repo, timeout=60)
+            if code != 0:
+                raise SystemExit("selftest fixture git failed in %s: %s (exit %s)\n%s"
+                                 % (repo, cmd, code, out))
+            return out.strip()
+
         g = globals()
         saved = {k: g[k] for k in ("apply_mutant", "revert_mutant", "tree_fingerprint",
                                    "data_fingerprint", "app_restart", "capture", "control_ids")}
@@ -3596,9 +3610,8 @@ tool sync_harness:
                   [True, False])
             repo2 = os.path.join(sroot, "committed")
             gmd2 = mk_holdout(repo2)
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, repo2, timeout=60)
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(repo2, *args)
             sealed2 = os.path.join(sroot, "sealed2")
             check("jeu committe -> laisse en place, rien de scelle",
                   [seal_holdout(gmd2, sealed2),
@@ -3638,9 +3651,8 @@ tool sync_harness:
             gmd3 = mk_holdout(repo3)
             with open(os.path.join(gmd3, "config.json"), "w", encoding="utf-8") as f:
                 f.write('{"seal_committed": true}')
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, repo3, timeout=60)
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(repo3, *args)
             check("opt-in par config.json -> le jeu committe se scelle",
                   [seal_holdout(gmd3, os.path.join(sroot, "sealed3")),
                    os.path.isdir(os.path.join(gmd3, "mutants", "holdout", "t01"))],
@@ -3696,10 +3708,9 @@ tool sync_harness:
                 json.dump({"entries": [base_entry]}, f)
             with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-1\n")
-            for cmd in ("git init -q", "git add -A",
-                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
-                run(cmd, xroot, timeout=60)
-            xbase = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "seed")):
+                fixture_git(xroot, *args)
+            xbase = fixture_git(xroot, "rev-parse", "HEAD")
 
             def xledger(*blks):
                 with open(os.path.join(xgm, "EXTENSIONS.md"), "w", encoding="utf-8") as f:
@@ -3707,9 +3718,8 @@ tool sync_harness:
                                       for b in blks))
 
             def xcommit():
-                run("git add -A", xroot, timeout=60)
-                run("git -c user.email=t@t -c user.name=t commit -qm x",
-                    xroot, timeout=60)
+                fixture_git(xroot, "add", "-A")
+                fixture_git(xroot, "commit", "-qm", "x")
 
             def xrequest(req):
                 """The lot files its request and commits. A fixture that stages a
@@ -3720,8 +3730,16 @@ tool sync_harness:
                 xcommit()
 
             def xreset():
-                run("git reset -q --hard %s" % xbase, xroot, timeout=60)
-                run("git clean -qfd", xroot, timeout=60)
+                fixture_git(xroot, "reset", "-q", "--hard", xbase)
+                fixture_git(xroot, "clean", "-qfd")
+
+            def xverdict(base):
+                verdict = extension_verdict(xroot, ".golden-master", base)
+                if len(verdict.get("acted", [])) != 1:
+                    raise SystemExit("selftest extension fixture expected one acted entry "
+                                     "in %s at base %s; got %s"
+                                     % (xroot, base, json.dumps(verdict, sort_keys=True)))
+                return verdict
 
             req2 = ('{"id": "E-1", "lot": "L", "type": "add-file",'
                     ' "paths": [".golden-master/refs/2.txt"]}')
@@ -3746,7 +3764,7 @@ tool sync_harness:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase)
+            v = xverdict(xbase)
             check("add-file legitime -> ok, chemin exempte",
                   [v["acted"][0]["ok"], v["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
@@ -3754,11 +3772,11 @@ tool sync_harness:
             # Un acte deja present A LA BASE n'est pas re-juge : ses ajouts sont
             # les references de cette base, et les relire comme des reecritures
             # refuserait tout lot parti d'une base qui contient un acte certifie.
-            xbase_acted = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            xbase_acted = fixture_git(xroot, "rev-parse", "HEAD")
             with open(os.path.join(xroot, "later.txt"), "w", encoding="utf-8") as f:
                 f.write("a lot landed after the act\n")
             xcommit()
-            v_after = extension_verdict(xroot, ".golden-master", xbase_acted)
+            v_after = xverdict(xbase_acted)
             check("acte present a la base -> ok, acted_at_base, aucun probleme",
                   [v_after["acted"][0]["ok"], v_after["acted"][0].get("acted_at_base"),
                    v_after["acted"][0]["problems"], v_after["problems"]],
@@ -3768,7 +3786,7 @@ tool sync_harness:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2-reecrite-par-un-lot\n")
             xcommit()
-            v_touch = extension_verdict(xroot, ".golden-master", xbase_acted)
+            v_touch = xverdict(xbase_acted)
             check("acte a la base + ref reecrite -> le certificat n'exempte rien",
                   [v_touch["acted"][0]["ok"], v_touch["ok_paths"]], [True, []])
 
@@ -3780,7 +3798,7 @@ tool sync_harness:
                 f.write("ref-1-reecrite\n")
             xcommit()
             check("reecriture deguisee en ajout -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Suppression enregistree : le chemin manque a HEAD (le cote delete
             # d'un renommage perd exactement ici).
@@ -3788,7 +3806,7 @@ tool sync_harness:
             xledger(("request", req2), ("act", act2))
             xcommit()
             check("chemin enregistre absent a HEAD (delete/rename) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Entree de corpus legitime, revendiquee par la demande.
             xreset()
@@ -3803,7 +3821,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, new_entry]}, f)
             xcommit()
             check("add-entry legitime et revendiquee -> ok",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+                  xverdict(xbase)["acted"][0]["ok"], True)
 
             # La meme demande dans l'orthographe du registre de re-baseline
             # (`expected_paths` + `entries` en identifiants) : lue au meme point,
@@ -3823,7 +3841,7 @@ tool sync_harness:
                 f.write("ref-2\n")
             xcommit()
             check("demande ecrite comme le registre de re-baseline l'enseigne -> ok",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+                  xverdict(xbase)["acted"][0]["ok"], True)
 
             # Retouche d'une entree existante sous couvert d'ajout.
             xreset()
@@ -3835,7 +3853,7 @@ tool sync_harness:
                 json.dump({"entries": [touched, new_entry]}, f)
             xcommit()
             check("entree existante retouchee -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Collision : la « nouvelle » entree observe le meme tuple qu'une
             # existante — deux references pour une observation.
@@ -3848,7 +3866,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, collider]}, f)
             xcommit()
             check("collision de tuple d'observation -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Entree passee en fraude : ajoutee au corpus, revendiquee par
             # personne.
@@ -3861,7 +3879,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, new_entry, smuggled]}, f)
             xcommit()
             check("entree non revendiquee a cote d'une actee -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Chemin hors surface : le canon est le territoire du juge.
             xreset()
@@ -3873,7 +3891,7 @@ tool sync_harness:
                 f.write("# neuf\n")
             xcommit()
             check("chemin hors refs/+corpus (canon) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Registre reecrit : un registre COMMITTE a la base n'est plus un
             # prefixe de HEAD. (Un registre ne EXISTANT PAS a la base rend ce
@@ -3882,12 +3900,12 @@ tool sync_harness:
             xreset()
             xledger(("request", req2))
             xcommit()
-            xbase2 = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            xbase2 = fixture_git(xroot, "rev-parse", "HEAD")
             xledger(("act", act2))  # la demande a disparu : trail edite
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase2)
+            v = xverdict(xbase2)
             check("registre committe puis reecrit -> append_only faux et acte refuse",
                   [v["ledger_append_only"], v["acted"][0]["ok"]],
                   [False, False])
@@ -3905,7 +3923,7 @@ tool sync_harness:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v_self = extension_verdict(xroot, ".golden-master", xbase)
+            v_self = xverdict(xbase)
             check("demande et acte dans UN commit (le lot s'auto-sert) -> refuse",
                   [v_self["acted"][0]["ok"], v_self["ok_paths"]], [False, []])
 
@@ -3920,7 +3938,7 @@ tool sync_harness:
             check("acte n'enregistrant QUE le registre -> la demande RESTE pendante",
                   [p["id"] for p in pending_extensions(xgm)], ["E-1"])
             check("acte n'enregistrant QUE le registre -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"],
+                  xverdict(xbase)["acted"][0]["ok"],
                   False)
 
             # Un scalaire la ou le juge itere : le bloc devient refusable, il ne
@@ -3932,7 +3950,7 @@ tool sync_harness:
             xcommit()
             check("recorded_paths scalaire -> la demande RESTE pendante, pas de crash",
                   [p["id"] for p in pending_extensions(xgm)], ["E-1"])
-            v_scalar = extension_verdict(xroot, ".golden-master", xbase)
+            v_scalar = xverdict(xbase)
             check("recorded_paths scalaire -> verdict rendu et acte refuse",
                   ["error" not in v_scalar, v_scalar["acted"][0]["ok"]], [True, False])
 
@@ -3946,7 +3964,7 @@ tool sync_harness:
                   _entry_observation_key(a1) == _entry_observation_key(a2), False)
 
             check("acte sans demande -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # 8f. Les refus arraches par la revue adversariale — chaque
             #     deguisement executee contre le verdict doit rester rouge.
@@ -3968,7 +3986,7 @@ tool sync_harness:
             os.symlink("1.txt", os.path.join(xgm, "refs", "2.txt"))
             xcommit()
             check("symlink sous refs/ -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Un chemin refs/ enregistre mais non declare par la demande.
             xreset()
@@ -3979,7 +3997,7 @@ tool sync_harness:
                 f.write("ref-3\n")
             xcommit()
             check("ref ajoutee non declaree par la demande -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
@@ -3991,7 +4009,7 @@ tool sync_harness:
                 json.dump({"entries": [twin, base_entry]}, f)
             xcommit()
             check("id duplique dans le corpus -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Une cle cosmetique ne neutralise pas la collision d'observation.
             xreset()
@@ -4003,7 +4021,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, cosmetic]}, f)
             xcommit()
             check("collision masquee par une cle cosmetique -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Une base irresoluble ne tamponne rien : elle refuse.
             check("GM_BASE irresoluble -> erreur, pas un laissez-passer",
@@ -4018,7 +4036,7 @@ tool sync_harness:
                 f.write('{"entries": {"E1": {}}}')
             xcommit()
             check("corpus malforme -> refuse, pas une traceback",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # 8g. Les refus du tour de CONSOLIDATION — la classe id-derive-un-
             #     chemin et la cle sensible a la presence, plus le flux add-entry
@@ -4035,7 +4053,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, traversal]}, f)
             xcommit()
             check("id en traversee (../refs/1) -> refuse",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # La PRESENCE d'un champ allowliste vide ne scinde pas la cle.
             xreset()
@@ -4047,7 +4065,7 @@ tool sync_harness:
                 json.dump({"entries": [base_entry, present_twin]}, f)
             xcommit()
             check("collision masquee par un champ allowliste VIDE -> refusee",
-                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+                  xverdict(xbase)["acted"][0]["ok"], False)
 
             # Le flux add-entry LEGITIME : l'entree revendiquee revendique sa
             # reference derivee — corpus.json ET refs/2.txt exemptes, sans
@@ -4064,7 +4082,7 @@ tool sync_harness:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
-            v = extension_verdict(xroot, ".golden-master", xbase)
+            v = xverdict(xbase)
             check("add-entry avec sa ref derivee, sans `paths` -> ok, les deux exemptes",
                   [v["acted"][0]["ok"], v["ok_paths"]],
                   [True, [".golden-master/corpus.json", ".golden-master/refs/2.txt"]])

--- a/bots/golden_master_selftest_fixture_test.go
+++ b/bots/golden_master_selftest_fixture_test.go
@@ -1,0 +1,64 @@
+package bots
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A fixture that failed to commit is not evidence about the extension rule.
+// Exercise the real selftest, interrupting the sixth extension commit: this
+// used to discard Git's failure, then panic at acted[0] on an empty ledger.
+func TestGoldenMasterSelftestReportsBrokenGitFixture(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	harness, err := filepath.Abs("golden-master/oracle-harness.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const program = `
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("oracle", sys.argv[1])
+oracle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(oracle)
+real_run, commits = oracle.run, [0]
+def broken_git(cmd, cwd, timeout=oracle.CMD_TIMEOUT_S):
+    if "commit -qm x" in cmd:
+        commits[0] += 1
+        if commits[0] == 6:
+            return 128, "fatal: injected fixture commit failure"
+    return real_run(cmd, cwd, timeout)
+oracle.run = broken_git
+if sys.argv[2] == "missing-act":
+    oracle.extension_verdict = lambda *args: {"acted": [], "problems": ["injected empty verdict"]}
+raise SystemExit(oracle._selftest())
+`
+	for _, tc := range []struct {
+		name string
+		want []string
+	}{
+		{"failed-commit", []string{"selftest fixture", "commit -qm x", "exit 128", "injected fixture commit failure"}},
+		{"missing-act", []string{"selftest extension fixture expected one acted entry", `"acted": []`, "injected empty verdict"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("python3", "-c", program, harness, tc.name)
+			cmd.Dir = t.TempDir()
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("a broken fixture must stop the selftest: %s", out)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(string(out), want) {
+					t.Errorf("missing %q in fixture failure: %s", want, out)
+				}
+			}
+			if strings.Contains(string(out), "Traceback") || strings.Contains(string(out), "IndexError") {
+				t.Errorf("fixture failure was masked by a Python exception: %s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The golden-master selftest discarded failed fixture Git commands, then indexed `acted[0]` as if the commit had succeeded. A failed sixth extension commit reproduces the exact `IndexError` reported in #876 and loses the original diagnostic.

Fixture setup now checks every previously unchecked Git operation and stops with its command, repository, exit code and output. Disposable fixture writes disable detached auto-maintenance. Extension scenarios require one acted entry before indexing and print the complete unexpected verdict otherwise. Both executable harness copies are regenerated from the canonical source; the production extension rules are unchanged.

Validation:
- New failed-commit regression reproduced `IndexError` before the fix, then passed; a second regression verifies the empty-verdict diagnostic.
- Harness synchronization, sync workflow, refusal, commit/gate and configuration scenarios pass, including all 218 selftest checks and the race detector.
- The original failing subtest passed 30 repetitions under `-race` before this change. The historical CI log contains no Git diagnostic, so the original environmental trigger cannot be established retrospectively; this addresses the ticket's explicit diagnostic fallback and removes unchecked setup rather than claiming an unobserved timing fix.

Closes #876.
