### PR TITLE
fix(model): a retried node reports the largest figure any attempt reported, not the last one

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -746,6 +746,12 @@ func annotateCost(result *Result, task Task, totalIn, totalOut int, rms ...*clau
 			cliCost = *rm.TotalCostUSD
 		}
 	}
+	// The same session-cumulative property the MAX above rests on, carried
+	// out of the backend: a caller folding two CALLS of one session must
+	// MAX this figure too, and must not do that to the token estimate the
+	// forfait falls back to. AnnotateWithUSD degrades to Annotate when
+	// cliCost is zero, so the flag tracks the value it describes.
+	result.CostIsSessionTotal = cliCost > 0
 	cost.AnnotateWithUSD(result.Output, model, totalIn, totalOut, cliCost)
 }
 

--- a/pkg/backend/delegate/claude_code_cost_test.go
+++ b/pkg/backend/delegate/claude_code_cost_test.go
@@ -20,6 +20,12 @@ func TestAnnotateCost(t *testing.T) {
 		rms       []*claudesdk.ResultMessage
 		wantModel string
 		wantCost  func(t *testing.T, cost any)
+		// wantSessionTotal pins the provenance of the figure above: true
+		// only when the CLI itself reported a cost, which is the sole case
+		// where two calls of one session may be folded at their MAX. A
+		// token estimate that silently claimed to be a session total would
+		// make a retry under-report by a whole attempt.
+		wantSessionTotal bool
 	}{
 		{
 			name:      "empty task model falls back to effective model for pricing",
@@ -55,6 +61,7 @@ func TestAnnotateCost(t *testing.T) {
 					t.Fatalf("_cost_usd = %v, want the CLI-reported 0.42", cost)
 				}
 			},
+			wantSessionTotal: true,
 		},
 		{
 			name:      "max across result messages, never the sum",
@@ -70,6 +77,7 @@ func TestAnnotateCost(t *testing.T) {
 					t.Fatalf("_cost_usd = %v, want max 0.35 (not the 0.65 sum)", cost)
 				}
 			},
+			wantSessionTotal: true,
 		},
 		{
 			name:      "no model resolvable: tokens recorded, cost omitted",
@@ -97,6 +105,9 @@ func TestAnnotateCost(t *testing.T) {
 				t.Errorf("_model = %v, want %q", got, tt.wantModel)
 			}
 			tt.wantCost(t, result.Output["_cost_usd"])
+			if got := result.CostIsSessionTotal; got != tt.wantSessionTotal {
+				t.Errorf("CostIsSessionTotal = %v, want %v", got, tt.wantSessionTotal)
+			}
 		})
 	}
 }

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -1594,7 +1594,23 @@ type Result struct {
 	Output map[string]any
 
 	// Tokens is an estimate of total tokens consumed (if available from CLI metadata).
+	// It counts THIS call only: every shipped backend accumulates its own
+	// per-turn usage (claude_code and codex add the resumed formatting
+	// pass's Usage onto pass 1's; pi keeps the collector's per-turn numbers
+	// on a resumed session), so two calls that share a session report
+	// disjoint token counts and their totals SUM.
 	Tokens int
+
+	// CostIsSessionTotal reports that the `_cost_usd` on Output came from a
+	// provider figure covering the WHOLE session, not this call alone —
+	// claude_code's ResultMessage.TotalCostUSD being the one shipped case
+	// (annotateCost, which MAXes it across a session's result messages for
+	// exactly this reason). It is the discriminator Tokens does not need:
+	// a token-derived estimate is per-call and must be summed, while two
+	// calls resuming one session each report the same running total and
+	// must be folded at their MAX. False is the correct default — every
+	// other cost path is cost.Annotate's estimate over per-call tokens.
+	CostIsSessionTotal bool
 
 	// Duration is the wall-clock time of the subprocess execution.
 	Duration time.Duration

--- a/pkg/backend/model/chain_dispatch_test.go
+++ b/pkg/backend/model/chain_dispatch_test.go
@@ -667,9 +667,14 @@ func TestChainSkipsNonAcceptingRouteAndTriesLater(t *testing.T) {
 	if out.ServedBy != "gpt" {
 		t.Errorf("ServedBy = %q, want gpt", out.ServedBy)
 	}
-	// Head's spend is folded into the winner (R5180a7 still holds).
-	if got, want := out.Result.Tokens, 130; got != want {
-		t.Errorf("tokens = %d, want %d (head 100 + gpt 30, api never ran)", got, want)
+	// Head's spend is folded into the winner (R5180a7 still holds). The
+	// head has no session, so each of its attempts opened one of its own
+	// and burned its own 100 — the expectation is counted from the
+	// attempts the stub recorded, not from a number that only held while
+	// a retried route was billed once.
+	if got, want := out.Result.Tokens, len(head.tasks)*100+30; got != want {
+		t.Errorf("tokens = %d, want %d (head %d×100 + gpt 30, api never ran)",
+			got, want, len(head.tasks))
 	}
 }
 
@@ -902,13 +907,17 @@ func TestFilterStopDoesNotDoubleCountSpend(t *testing.T) {
 	if len(tail.tasks) != 0 {
 		t.Fatalf("tail ran %d times, want 0 (filter refused)", len(tail.tasks))
 	}
-	// Head burned 1000 tokens; it is the terminal result and must appear
-	// exactly once — not once in spent and once in result.
-	if got, want := out.Result.Tokens, 1000; got != want {
-		t.Errorf("tokens = %d, want %d (filter-stop must not double-count the last route)", got, want)
+	// The head is the terminal result and must appear exactly once — not
+	// once in spent and once in result. "Once" is once per ATTEMPT: the
+	// route carries no session, so every attempt opened one of its own
+	// and burned its own 1000. Counting from the stub's record keeps the
+	// anti-double-count assertion exact without pinning an attempt count.
+	if got, want := out.Result.Tokens, len(head.tasks)*1000; got != want {
+		t.Errorf("tokens = %d, want %d (%d attempts × 1000; a filter-stop must not count the route twice on top)",
+			got, want, len(head.tasks))
 	}
-	if got, _ := out.Result.Output["_cost_usd"].(float64); got != 0.40 {
-		t.Errorf("_cost_usd = %v, want 0.40", got)
+	if got, want := out.Result.Output["_cost_usd"].(float64), float64(len(head.tasks))*0.40; got != want {
+		t.Errorf("_cost_usd = %v, want %v", got, want)
 	}
 }
 
@@ -940,13 +949,20 @@ func TestExhaustedChainCarriesEverySpend(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected the chain to fail")
 	}
-	// Each route reports its last attempt's usage (the retry loop does
-	// not accumulate across attempts), so the node's total is the head's
-	// 1000 plus the tail's 500 — asserted as an EXACT sum, because a
-	// loose lower bound is exactly what let a double-count of the last
-	// route pass unnoticed.
-	if got, want := out.Result.Tokens, 1500; got != want {
-		t.Errorf("tokens = %d, want %d (each route folded in exactly once)", got, want)
+	// Neither route carries a session, so each ATTEMPT opened one of its
+	// own and burned its own report. The node's total is every attempt of
+	// the head plus every attempt of the tail — asserted EXACTLY, because
+	// a loose lower bound is what let a double-count of the last route
+	// pass unnoticed. Counted from the stubs' own record: a fixed number
+	// here would pass while the retry budget silently changed under it.
+	want := len(head.tasks)*1000 + len(tail.tasks)*500
+	if len(head.tasks) < 2 || len(tail.tasks) < 2 {
+		t.Fatalf("both routes must have retried for this to mean anything: head=%d tail=%d",
+			len(head.tasks), len(tail.tasks))
+	}
+	if got := out.Result.Tokens; got != want {
+		t.Errorf("tokens = %d, want %d (head %d×1000 + tail %d×500, each attempt folded in exactly once)",
+			got, want, len(head.tasks), len(tail.tasks))
 	}
 }
 

--- a/pkg/backend/model/chain_dispatch_test.go
+++ b/pkg/backend/model/chain_dispatch_test.go
@@ -986,25 +986,31 @@ func TestCollapseHintOnlyChain_TrimsPrefixNotWholeChain(t *testing.T) {
 	}
 }
 
-// cumulativeScriptedBackend models a CLI whose usage accounting is
-// SESSION-CUMULATIVE: the second attempt's report contains the first
-// attempt's spend, because it resumed the same session.
-type cumulativeScriptedBackend struct {
+// sessionScriptedBackend models claude_code on a session: every call bills
+// its OWN turn's tokens (Execute adds the resumed formatting pass's usage
+// onto pass 1's, so Result.Tokens is per-call), while the cost the CLI
+// reports covers the whole session so far — the split Result.CostIsSessionTotal
+// exists to carry.
+type sessionScriptedBackend struct {
 	name    string
 	calls   int
-	report  []int // tokens reported on each successive call
-	failFor int   // fail the first N calls
+	tokens  []int     // this call's own tokens
+	cost    []float64 // the session total the CLI reports after this call
+	failFor int       // fail the first N calls
 }
 
-func (b *cumulativeScriptedBackend) Execute(_ context.Context, _ delegate.Task) (delegate.Result, error) {
+func (b *sessionScriptedBackend) Execute(_ context.Context, _ delegate.Task) (delegate.Result, error) {
 	b.calls++
-	tokens := b.report[len(b.report)-1]
-	if b.calls <= len(b.report) {
-		tokens = b.report[b.calls-1]
+	i := b.calls - 1
+	if i >= len(b.tokens) {
+		i = len(b.tokens) - 1
 	}
 	res := delegate.Result{
-		BackendName: b.name, Tokens: tokens, Duration: time.Millisecond,
-		Output: map[string]any{"served_by": b.name, "_tokens": tokens},
+		BackendName: b.name, Tokens: b.tokens[i], Duration: time.Millisecond,
+		CostIsSessionTotal: true,
+		Output: map[string]any{
+			"served_by": b.name, "_tokens": b.tokens[i], "_cost_usd": b.cost[i],
+		},
 	}
 	if b.calls <= b.failFor {
 		return res, &delegate.ErrTransient{Reason: "stream closed"}
@@ -1012,32 +1018,62 @@ func (b *cumulativeScriptedBackend) Execute(_ context.Context, _ delegate.Task) 
 	return res, nil
 }
 
-// The session id has to REACH the fold, not merely exist on the task. If
-// the dispatch hands the loop an empty one, a node that resumed its
-// session is billed for the running total twice — silently, and in the
-// direction that parks a run that still had budget. Nothing else pins
-// this wire: the fold's own tests call the loop directly.
-func TestChainCarriesTheTaskSessionIntoTheSpendFold(t *testing.T) {
-	head := &cumulativeScriptedBackend{
-		name: delegate.BackendClaudeCode, report: []int{1000, 1300}, failFor: 1,
-	}
+func claudeCodeChain(t *testing.T, task *delegate.Task, head delegate.Backend) chainOutcome {
+	t.Helper()
 	reg := delegate.NewRegistry()
 	reg.Register(delegate.BackendClaudeCode, head)
 	e := newFallbackExecutor(reg, EventHooks{})
-
 	build := e.newElementBuilder("review", delegate.BackendClaudeCode, nil,
-		func(_ context.Context, _ string) (*delegate.Task, error) {
-			return &delegate.Task{NodeID: "review", SessionID: "sess-1"}, nil
-		})
+		func(_ context.Context, _ string) (*delegate.Task, error) { return task, nil })
 	out, err := e.dispatchChain(context.Background(), "review",
 		[]chainElement{{Label: "primary"}}, "claude-opus-5", build)
 	if err != nil {
 		t.Fatalf("the second attempt succeeds: %v", err)
 	}
+	return out
+}
+
+// The session facts have to REACH the fold, not merely sit on the task. If
+// the dispatch hands the loop the wrong answer, a node that resumed its
+// session is billed for the running total twice — silently, and in the
+// direction that parks a run that still had budget. Nothing else pins this
+// wire: the fold's own tests call the loop directly.
+func TestChainCarriesTheTaskSessionIntoTheSpendFold(t *testing.T) {
+	head := &sessionScriptedBackend{
+		name: delegate.BackendClaudeCode, failFor: 1,
+		tokens: []int{1000, 300}, cost: []float64{0.10, 0.13},
+	}
+	out := claudeCodeChain(t, &delegate.Task{NodeID: "review", SessionID: "sess-1"}, head)
 	if head.calls != 2 {
 		t.Fatalf("want one retry, got %d calls", head.calls)
 	}
+	if got, _ := out.Result.Output["_cost_usd"].(float64); got != 0.13 {
+		t.Errorf("_cost_usd = %v, want 0.13 — the attempts continued one session, so 0.13 already contains the 0.10; anything else means the shared-session fact never reached the fold", got)
+	}
 	if got := out.Result.Tokens; got != 1300 {
-		t.Errorf("tokens = %d, want 1300 — the attempts resumed one session, so 1300 already contains the 1000; %d means the session id never reached the fold", got, got)
+		t.Errorf("tokens = %d, want 1300 — each attempt billed its own turn", got)
+	}
+}
+
+// The same task, plus the fork bit. `session: fork` sets ForkSession beside
+// the PARENT id, and a fork "does not mutate the original session": every
+// attempt opens a disjoint child and bills its own work, so the costs SUM
+// even though the id is non-empty throughout. A fold reading only the id
+// MAXes them and loses a whole attempt's spend.
+func TestChainDoesNotShareTheSessionItForks(t *testing.T) {
+	head := &sessionScriptedBackend{
+		name: delegate.BackendClaudeCode, failFor: 1,
+		tokens: []int{1000, 300}, cost: []float64{0.10, 0.13},
+	}
+	out := claudeCodeChain(t,
+		&delegate.Task{NodeID: "review", SessionID: "sess-1", ForkSession: true}, head)
+	if head.calls != 2 {
+		t.Fatalf("want one retry, got %d calls", head.calls)
+	}
+	if got, _ := out.Result.Output["_cost_usd"].(float64); got != 0.23 {
+		t.Errorf("_cost_usd = %v, want 0.23 — two forks are two sessions, and neither report contains the other", got)
+	}
+	if got := out.Result.Tokens; got != 1300 {
+		t.Errorf("tokens = %d, want 1300", got)
 	}
 }

--- a/pkg/backend/model/chain_dispatch_test.go
+++ b/pkg/backend/model/chain_dispatch_test.go
@@ -985,3 +985,59 @@ func TestCollapseHintOnlyChain_TrimsPrefixNotWholeChain(t *testing.T) {
 		t.Errorf("collapse kept the wrong elements: %+v", got)
 	}
 }
+
+// cumulativeScriptedBackend models a CLI whose usage accounting is
+// SESSION-CUMULATIVE: the second attempt's report contains the first
+// attempt's spend, because it resumed the same session.
+type cumulativeScriptedBackend struct {
+	name    string
+	calls   int
+	report  []int // tokens reported on each successive call
+	failFor int   // fail the first N calls
+}
+
+func (b *cumulativeScriptedBackend) Execute(_ context.Context, _ delegate.Task) (delegate.Result, error) {
+	b.calls++
+	tokens := b.report[len(b.report)-1]
+	if b.calls <= len(b.report) {
+		tokens = b.report[b.calls-1]
+	}
+	res := delegate.Result{
+		BackendName: b.name, Tokens: tokens, Duration: time.Millisecond,
+		Output: map[string]any{"served_by": b.name, "_tokens": tokens},
+	}
+	if b.calls <= b.failFor {
+		return res, &delegate.ErrTransient{Reason: "stream closed"}
+	}
+	return res, nil
+}
+
+// The session id has to REACH the fold, not merely exist on the task. If
+// the dispatch hands the loop an empty one, a node that resumed its
+// session is billed for the running total twice — silently, and in the
+// direction that parks a run that still had budget. Nothing else pins
+// this wire: the fold's own tests call the loop directly.
+func TestChainCarriesTheTaskSessionIntoTheSpendFold(t *testing.T) {
+	head := &cumulativeScriptedBackend{
+		name: delegate.BackendClaudeCode, report: []int{1000, 1300}, failFor: 1,
+	}
+	reg := delegate.NewRegistry()
+	reg.Register(delegate.BackendClaudeCode, head)
+	e := newFallbackExecutor(reg, EventHooks{})
+
+	build := e.newElementBuilder("review", delegate.BackendClaudeCode, nil,
+		func(_ context.Context, _ string) (*delegate.Task, error) {
+			return &delegate.Task{NodeID: "review", SessionID: "sess-1"}, nil
+		})
+	out, err := e.dispatchChain(context.Background(), "review",
+		[]chainElement{{Label: "primary"}}, "claude-opus-5", build)
+	if err != nil {
+		t.Fatalf("the second attempt succeeds: %v", err)
+	}
+	if head.calls != 2 {
+		t.Fatalf("want one retry, got %d calls", head.calls)
+	}
+	if got := out.Result.Tokens; got != 1300 {
+		t.Errorf("tokens = %d, want 1300 — the attempts resumed one session, so 1300 already contains the 1000; %d means the session id never reached the fold", got, got)
+	}
+}

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -694,11 +694,15 @@ func (e *ClawExecutor) validateAndRetry(
 		}
 		return result, fmt.Errorf("model: node %q: structured output invalid: %w", f.id, err)
 	}
-	// Accumulate token/duration from the first attempt so per-node
-	// accounting reflects the full cost paid (dropping it understated
-	// the run's real usage and broke budget enforcement at the margins).
-	retryResult.Tokens += result.Tokens
-	retryResult.Duration += result.Duration
+	// Accumulate the first attempt from here so per-node accounting
+	// reflects the full cost paid (dropping it understated the run's real
+	// usage and broke budget enforcement at the margins). This is a retry
+	// IN PLACE, so it folds exactly like one — through foldSpend, rather
+	// than the hand-rolled `+=` that stood here: that one summed the
+	// struct fields only, and what enforcement reads is the OUTPUT MAP
+	// (runtime.extractUsage), so the first attempt's tokens never reached
+	// max_tokens and its cost was dropped outright.
+	retryResult = foldSpend(result, retryResult, sharesSession(&retryTask))
 	// Re-attach metadata and re-validate.
 	stampDelegateOutputMeta(retryResult.Output, retryResult, backendName)
 	if retryValErr := ValidateOutput(retryResult.Output, schema); retryValErr != nil {

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -674,7 +674,7 @@ func (e *ClawExecutor) validateAndRetry(
 	// inherits the same transient-error backoff every other delegate call
 	// gets — a direct backend.Execute here skipped the retry budget and
 	// gave up on the first transient SDK hiccup.
-	retryResult, retryErr := e.retryDelegateLoop(ctx, f.id, backendName, func() (delegate.Result, error) {
+	retryResult, retryErr := e.retryDelegateLoop(ctx, f.id, backendName, retryTask.SessionID, func() (delegate.Result, error) {
 		return backend.Execute(ctx, retryTask)
 	})
 	if retryErr != nil || retryResult.ParseFallback {

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -674,7 +674,7 @@ func (e *ClawExecutor) validateAndRetry(
 	// inherits the same transient-error backoff every other delegate call
 	// gets — a direct backend.Execute here skipped the retry budget and
 	// gave up on the first transient SDK hiccup.
-	retryResult, retryErr := e.retryDelegateLoop(ctx, f.id, backendName, retryTask.SessionID, func() (delegate.Result, error) {
+	retryResult, retryErr := e.retryDelegateLoop(ctx, f.id, backendName, sharesSession(&retryTask), func() (delegate.Result, error) {
 		return backend.Execute(ctx, retryTask)
 	})
 	if retryErr != nil || retryResult.ParseFallback {

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -194,15 +194,23 @@ func shouldRetryInPlace(err error, fallbackAccepts func(error) bool) bool {
 // This is the no-fallback form: callers with no further chain element
 // (the schema-validation retry, direct one-shot dispatch) use it and get
 // the historical behaviour unchanged.
-func (e *ClawExecutor) retryDelegateLoop(ctx context.Context, nodeID string, backendName string, fn func() (delegate.Result, error)) (delegate.Result, error) {
-	return e.retryDelegateLoopChain(ctx, nodeID, backendName, nil, fn)
+func (e *ClawExecutor) retryDelegateLoop(ctx context.Context, nodeID string, backendName string, sessionID string, fn func() (delegate.Result, error)) (delegate.Result, error) {
+	return e.retryDelegateLoopChain(ctx, nodeID, backendName, sessionID, nil, fn)
 }
 
 // retryDelegateLoopChain is retryDelegateLoop with knowledge of whether
 // the caller has a fallback route that would take THIS failure, which
 // lets it skip a budget that cannot succeed (see shouldRetryInPlace).
 // A nil predicate means "no route will take it".
-func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string, backendName string, fallbackAccepts func(error) bool, fn func() (delegate.Result, error)) (delegate.Result, error) {
+// sessionID is the session the attempts run in, taken from the task the
+// closure re-invokes with. It is the ONE fact that decides how two
+// attempts' accounting folds together — see richerSpend. Empty means
+// every attempt opens a session of its own.
+func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string, backendName string, sessionID string, fallbackAccepts func(error) bool, fn func() (delegate.Result, error)) (delegate.Result, error) {
+	// The closure re-invokes with an UNCHANGED task, so this answer holds
+	// for every attempt: a session resumed once is resumed each time, and
+	// a task with none opens a fresh one each time.
+	sameSession := sessionID != ""
 	result, err := fn()
 	for attempt := 1; err != nil && shouldRetryInPlace(err, fallbackAccepts); attempt++ {
 		maxAttempts := e.retry.effectiveMaxAttempts(err)
@@ -231,48 +239,67 @@ func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string
 			// Cancelled between attempts: no output survives, but what the
 			// attempts already burned is not undone by it — the caps and
 			// the ledgers read the map, not the struct.
-			return richerSpend(result, delegate.Result{}), ctx.Err()
+			return richerSpend(result, delegate.Result{}, sameSession), ctx.Err()
 		}
 
 		prev := result
 		result, err = fn()
-		result = richerSpend(prev, result)
+		result = richerSpend(prev, result, sameSession)
 	}
 	return result, err
 }
 
-// richerSpend keeps the higher of two attempts' ACCOUNTING on the later
-// attempt's result — the answer is the later one's, the figure is whichever
-// is true.
+// richerSpend folds two attempts' ACCOUNTING onto the later attempt's
+// result — the answer is the later one's, the figure is what both of them
+// truly burned. Whether that figure is a MAX or a SUM is decided by ONE
+// fact, and getting it from the wrong one is wrong in both directions.
 //
-// MAX, never a sum, and the reason is the same one annotateCost states for
-// the formatting passes: the CLI's usage accounting is SESSION-CUMULATIVE,
-// so a retry inside one session re-reports the running total and adding the
-// attempts would double-count it. The failure this closes is the other
-// direction: when the last attempt is the CHEAP one — attempt 1 spends an
-// agentic session, attempt 2 cannot even spawn and reports nothing — taking
-// the last attempt's figure reported the cost of nothing, and the class has
-// two documented precedents in this file (the chain's own chainSpend, and
-// validateAndRetry, whose comment records that dropping the first attempt's
-// usage "broke budget enforcement at the margins").
-func richerSpend(prev, next delegate.Result) delegate.Result {
+// A CLI backend reports usage per SESSION, cumulatively (the reason
+// annotateCost takes a MAX over the result messages of one invocation).
+// So:
+//
+//   - sameSession: the retry RESUMED the session, and its report already
+//     contains the earlier attempt's spend. Adding them double-counts it.
+//     Take the higher — the later report, unless the attempt that carried
+//     the spend was the earlier one (attempt 1 runs an agentic session,
+//     attempt 2 cannot even spawn and reports nothing).
+//   - not sameSession: each attempt opened a session of its own and each
+//     report covers only its own work. The spend is their SUM. A MAX here
+//     UNDER-reports, which is the direction that lets a run walk past
+//     max_cost_usd — and a node executing for the first time carries no
+//     session id, so this is the common case, not the exotic one.
+//
+// The precedents in this file agree once read this way: chainSpend adds
+// across ROUTES (always different sessions), and validateAndRetry adds
+// across its two invocations, its comment recording that dropping the
+// first attempt's usage "broke budget enforcement at the margins".
+func richerSpend(prev, next delegate.Result, sameSession bool) delegate.Result {
 	pt, nt := prev.Tokens, next.Tokens
 	pc, nc := cost.USDFromOutput(prev.Output), cost.USDFromOutput(next.Output)
-	if pt <= nt && pc <= nc {
+
+	tokens, usd := pt+nt, pc+nc
+	if sameSession {
+		tokens, usd = nt, nc
+		if pt > nt {
+			tokens = pt
+		}
+		if pc > nc {
+			usd = pc
+		}
+	}
+	if tokens == nt && usd == nc {
 		return next
 	}
-	if pt > nt {
-		next.Tokens = pt
-	}
+	next.Tokens = tokens
 	// An unallocated map records nothing, and the map is what the caps read.
 	if next.Output == nil {
 		next.Output = map[string]any{}
 	}
-	if pt > nt {
-		next.Output["_tokens"] = pt
+	if tokens != nt {
+		next.Output["_tokens"] = tokens
 	}
-	if pc > nc {
-		next.Output["_cost_usd"] = pc
+	if usd != nc {
+		next.Output["_cost_usd"] = usd
 	}
 	return next
 }
@@ -929,7 +956,7 @@ func (e *ClawExecutor) dispatchChain(
 			}
 		}
 		lastBackend = backendName
-		result, err = e.retryDelegateLoopChain(ctx, nodeID, backendName, accepts, func() (delegate.Result, error) {
+		result, err = e.retryDelegateLoopChain(ctx, nodeID, backendName, task.SessionID, accepts, func() (delegate.Result, error) {
 			return backend.Execute(ctx, *task)
 		})
 		// Best-effort session degrade (inherit_if_available / persist): the
@@ -976,7 +1003,7 @@ func (e *ClawExecutor) dispatchChain(
 				fresh.SessionID = ""
 				fresh.ForkSession = false
 				fresh.SessionFingerprint = ""
-				freshResult, freshErr := e.retryDelegateLoopChain(ctx, nodeID, backendName, accepts, func() (delegate.Result, error) {
+				freshResult, freshErr := e.retryDelegateLoopChain(ctx, nodeID, backendName, fresh.SessionID, accepts, func() (delegate.Result, error) {
 					return backend.Execute(ctx, fresh)
 				})
 				if freshErr == nil {

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -293,6 +293,15 @@ func sharesSession(task *delegate.Task) bool {
 // and SUM then yields the earlier attempt's figure unchanged — the same
 // answer a MAX would give.
 //
+// The MAX rests on one further invariant, held today by construction: a
+// `prev` reaching it never already carries ANOTHER route's spend. Both
+// paths that fold chainSpend into a result also drop the session the fold
+// keys on — a route change clears SessionID/ForkSession on the rebuilt
+// task (newElementBuilder, index > 0), and the optional-session degrade
+// continues on `fresh`, whose id is empty — so sharedSession is false
+// wherever `spent` is non-empty. A new spent.add site that KEEPS the
+// session id would break that, and the MAX would then swallow a route.
+//
 // The precedents in this file agree once read this way: chainSpend adds
 // across ROUTES (always different sessions), and validateAndRetry adds
 // across its two invocations, its comment recording that dropping the

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -315,6 +315,12 @@ func foldSpend(prev, next delegate.Result, sharedSession bool) delegate.Result {
 	// summed onto a running total it already contains.
 	next.CostIsSessionTotal = (pc == 0 || prev.CostIsSessionTotal) &&
 		(nc == 0 || next.CostIsSessionTotal)
+	// Attempts run one after the other, so the time they took adds up —
+	// the same reason chainSpend sums it across routes. It is purely
+	// observational (the delegate_finished event's duration_ms and the
+	// log line; the budget clocks its own elapsed), but a node that spent
+	// five minutes before a 30s retry reported the 30s.
+	next.Duration += prev.Duration
 	if tokens == nt && usd == nc {
 		return next
 	}

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -228,12 +228,53 @@ func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string
 		case <-timer.C:
 		case <-ctx.Done():
 			timer.Stop()
-			return delegate.Result{}, ctx.Err()
+			// Cancelled between attempts: no output survives, but what the
+			// attempts already burned is not undone by it — the caps and
+			// the ledgers read the map, not the struct.
+			return richerSpend(result, delegate.Result{}), ctx.Err()
 		}
 
+		prev := result
 		result, err = fn()
+		result = richerSpend(prev, result)
 	}
 	return result, err
+}
+
+// richerSpend keeps the higher of two attempts' ACCOUNTING on the later
+// attempt's result — the answer is the later one's, the figure is whichever
+// is true.
+//
+// MAX, never a sum, and the reason is the same one annotateCost states for
+// the formatting passes: the CLI's usage accounting is SESSION-CUMULATIVE,
+// so a retry inside one session re-reports the running total and adding the
+// attempts would double-count it. The failure this closes is the other
+// direction: when the last attempt is the CHEAP one — attempt 1 spends an
+// agentic session, attempt 2 cannot even spawn and reports nothing — taking
+// the last attempt's figure reported the cost of nothing, and the class has
+// two documented precedents in this file (the chain's own chainSpend, and
+// validateAndRetry, whose comment records that dropping the first attempt's
+// usage "broke budget enforcement at the margins").
+func richerSpend(prev, next delegate.Result) delegate.Result {
+	pt, nt := prev.Tokens, next.Tokens
+	pc, nc := cost.USDFromOutput(prev.Output), cost.USDFromOutput(next.Output)
+	if pt <= nt && pc <= nc {
+		return next
+	}
+	if pt > nt {
+		next.Tokens = pt
+	}
+	// An unallocated map records nothing, and the map is what the caps read.
+	if next.Output == nil {
+		next.Output = map[string]any{}
+	}
+	if pt > nt {
+		next.Output["_tokens"] = pt
+	}
+	if pc > nc {
+		next.Output["_cost_usd"] = pc
+	}
+	return next
 }
 
 // ---------------------------------------------------------------------------
@@ -499,6 +540,14 @@ func (s chainSpend) applyTo(r delegate.Result) delegate.Result {
 	}
 	r.Tokens += s.tokens
 	r.Duration += s.duration
+	// An unallocated map records nothing, and the map is what the caps read
+	// — so the shape that loses the most is the one that had no output at
+	// all: a last element that could not even spawn, folding a whole
+	// session's spend into a struct field nobody enforces on. Allocated
+	// here for the same reason typedFailure allocates it.
+	if r.Output == nil && (s.tokens > 0 || s.costUSD > 0) {
+		r.Output = map[string]any{}
+	}
 	if r.Output != nil {
 		if s.tokens > 0 {
 			r.Output["_tokens"] = r.Tokens

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -194,23 +194,24 @@ func shouldRetryInPlace(err error, fallbackAccepts func(error) bool) bool {
 // This is the no-fallback form: callers with no further chain element
 // (the schema-validation retry, direct one-shot dispatch) use it and get
 // the historical behaviour unchanged.
-func (e *ClawExecutor) retryDelegateLoop(ctx context.Context, nodeID string, backendName string, sessionID string, fn func() (delegate.Result, error)) (delegate.Result, error) {
-	return e.retryDelegateLoopChain(ctx, nodeID, backendName, sessionID, nil, fn)
+func (e *ClawExecutor) retryDelegateLoop(ctx context.Context, nodeID string, backendName string, sharedSession bool, fn func() (delegate.Result, error)) (delegate.Result, error) {
+	return e.retryDelegateLoopChain(ctx, nodeID, backendName, sharedSession, nil, fn)
 }
 
 // retryDelegateLoopChain is retryDelegateLoop with knowledge of whether
 // the caller has a fallback route that would take THIS failure, which
 // lets it skip a budget that cannot succeed (see shouldRetryInPlace).
 // A nil predicate means "no route will take it".
-// sessionID is the session the attempts run in, taken from the task the
-// closure re-invokes with. It is the ONE fact that decides how two
-// attempts' accounting folds together — see richerSpend. Empty means
-// every attempt opens a session of its own.
-func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string, backendName string, sessionID string, fallbackAccepts func(error) bool, fn func() (delegate.Result, error)) (delegate.Result, error) {
-	// The closure re-invokes with an UNCHANGED task, so this answer holds
-	// for every attempt: a session resumed once is resumed each time, and
-	// a task with none opens a fresh one each time.
-	sameSession := sessionID != ""
+//
+// sharedSession says the attempts CONTINUE one session — the task carries
+// a session id and does not fork it, so attempt 2 lands in the state
+// attempt 1 left. The closure re-invokes with an UNCHANGED task, so the
+// caller can answer it once for every attempt. It is computed at the call
+// site, where the task is in hand: a fork sets ForkSession beside the
+// PARENT id, and reading only the id would call two disjoint children one
+// session. It narrows exactly one thing in foldSpend — whether a
+// session-total cost may be folded at its MAX.
+func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string, backendName string, sharedSession bool, fallbackAccepts func(error) bool, fn func() (delegate.Result, error)) (delegate.Result, error) {
 	result, err := fn()
 	for attempt := 1; err != nil && shouldRetryInPlace(err, fallbackAccepts); attempt++ {
 		maxAttempts := e.retry.effectiveMaxAttempts(err)
@@ -239,54 +240,81 @@ func (e *ClawExecutor) retryDelegateLoopChain(ctx context.Context, nodeID string
 			// Cancelled between attempts: no output survives, but what the
 			// attempts already burned is not undone by it — the caps and
 			// the ledgers read the map, not the struct.
-			return richerSpend(result, delegate.Result{}, sameSession), ctx.Err()
+			return foldSpend(result, delegate.Result{}, sharedSession), ctx.Err()
 		}
 
 		prev := result
 		result, err = fn()
-		result = richerSpend(prev, result, sameSession)
+		result = foldSpend(prev, result, sharedSession)
 	}
 	return result, err
 }
 
-// richerSpend folds two attempts' ACCOUNTING onto the later attempt's
+// sharesSession reports whether every attempt of one retry loop lands in
+// the SAME session state — the precondition for folding two attempts'
+// session-cumulative cost at its MAX (see foldSpend).
+//
+// A FORK does not qualify, which is why this cannot be `SessionID != ""`.
+// applySessionContinuity sets ForkSession beside the PARENT id, and
+// delegate.Task records what that means: "the forked session gets a new
+// ID and does not mutate the original session". The retry closure
+// re-invokes with the unchanged task, so each attempt forks a fresh child
+// and bills its own work while the id stays non-empty throughout.
+func sharesSession(task *delegate.Task) bool {
+	return task != nil && task.SessionID != "" && !task.ForkSession
+}
+
+// foldSpend folds two attempts' ACCOUNTING onto the later attempt's
 // result — the answer is the later one's, the figure is what both of them
-// truly burned. Whether that figure is a MAX or a SUM is decided by ONE
-// fact, and getting it from the wrong one is wrong in both directions.
+// truly burned. Dropping the earlier attempt (the historical behaviour)
+// reports the cost of nothing when the LAST attempt is the cheap one: a
+// session spends minutes, the retry cannot even spawn, and the caps, the
+// org ledger and a lending donor all read that zero.
 //
-// A CLI backend reports usage per SESSION, cumulatively (the reason
-// annotateCost takes a MAX over the result messages of one invocation).
-// So:
+// The two metrics do NOT fold the same way, and no backend NAME decides
+// it — on claude_code the halves of one result disagree:
 //
-//   - sameSession: the retry RESUMED the session, and its report already
-//     contains the earlier attempt's spend. Adding them double-counts it.
-//     Take the higher — the later report, unless the attempt that carried
-//     the spend was the earlier one (attempt 1 runs an agentic session,
-//     attempt 2 cannot even spawn and reports nothing).
-//   - not sameSession: each attempt opened a session of its own and each
-//     report covers only its own work. The spend is their SUM. A MAX here
-//     UNDER-reports, which is the direction that lets a run walk past
-//     max_cost_usd — and a node executing for the first time carries no
-//     session id, so this is the common case, not the exotic one.
+//   - TOKENS always SUM. Every shipped backend reports its own turn:
+//     claude_code and codex ADD the resumed formatting pass's Usage onto
+//     pass 1's, and pi deliberately keeps the collector's per-TURN numbers
+//     on a resumed session. Two attempts therefore report disjoint counts,
+//     and a MAX here UNDER-reports — the direction that lets a run walk
+//     past max_tokens.
+//   - COST folds at its MAX only when both figures are session-cumulative
+//     readings of ONE shared session (Result.CostIsSessionTotal, which
+//     claude_code sets from the CLI's TotalCostUSD). There attempt 2's
+//     report already contains attempt 1's spend and adding double-counts
+//     it. Everywhere else — every cost.Annotate estimate, including
+//     claude_code's own under the OAuth forfait — the figure is derived
+//     from this call's tokens and SUMS with them.
+//
+// Demanding the flag on BOTH sides is what makes the motivating case still
+// work: an attempt that could not spawn reports zero with the flag false,
+// and SUM then yields the earlier attempt's figure unchanged — the same
+// answer a MAX would give.
 //
 // The precedents in this file agree once read this way: chainSpend adds
 // across ROUTES (always different sessions), and validateAndRetry adds
 // across its two invocations, its comment recording that dropping the
 // first attempt's usage "broke budget enforcement at the margins".
-func richerSpend(prev, next delegate.Result, sameSession bool) delegate.Result {
+func foldSpend(prev, next delegate.Result, sharedSession bool) delegate.Result {
 	pt, nt := prev.Tokens, next.Tokens
 	pc, nc := cost.USDFromOutput(prev.Output), cost.USDFromOutput(next.Output)
 
-	tokens, usd := pt+nt, pc+nc
-	if sameSession {
-		tokens, usd = nt, nc
-		if pt > nt {
-			tokens = pt
-		}
+	tokens := pt + nt
+	usd := pc + nc
+	if sharedSession && prev.CostIsSessionTotal && next.CostIsSessionTotal {
+		usd = nc
 		if pc > nc {
 			usd = pc
 		}
 	}
+	// The folded figure is still a session reading when every non-zero
+	// contributor to it was one — so a THIRD attempt's session total is
+	// recognised as subsuming the two already folded, instead of being
+	// summed onto a running total it already contains.
+	next.CostIsSessionTotal = (pc == 0 || prev.CostIsSessionTotal) &&
+		(nc == 0 || next.CostIsSessionTotal)
 	if tokens == nt && usd == nc {
 		return next
 	}
@@ -956,7 +984,7 @@ func (e *ClawExecutor) dispatchChain(
 			}
 		}
 		lastBackend = backendName
-		result, err = e.retryDelegateLoopChain(ctx, nodeID, backendName, task.SessionID, accepts, func() (delegate.Result, error) {
+		result, err = e.retryDelegateLoopChain(ctx, nodeID, backendName, sharesSession(task), accepts, func() (delegate.Result, error) {
 			return backend.Execute(ctx, *task)
 		})
 		// Best-effort session degrade (inherit_if_available / persist): the
@@ -1003,7 +1031,7 @@ func (e *ClawExecutor) dispatchChain(
 				fresh.SessionID = ""
 				fresh.ForkSession = false
 				fresh.SessionFingerprint = ""
-				freshResult, freshErr := e.retryDelegateLoopChain(ctx, nodeID, backendName, fresh.SessionID, accepts, func() (delegate.Result, error) {
+				freshResult, freshErr := e.retryDelegateLoopChain(ctx, nodeID, backendName, sharesSession(&fresh), accepts, func() (delegate.Result, error) {
 					return backend.Execute(ctx, fresh)
 				})
 				if freshErr == nil {

--- a/pkg/backend/model/executor_retry_feedback_test.go
+++ b/pkg/backend/model/executor_retry_feedback_test.go
@@ -90,3 +90,67 @@ func TestValidateAndRetry_InjectsSchemaFeedback(t *testing.T) {
 		t.Errorf("retry feedback should name the validation error, got: %q", backend.tasks[1].UserPrompt)
 	}
 }
+
+// The schema-validation retry is a retry IN PLACE, and its accounting has
+// to survive like one: the first attempt produced unusable output but was
+// billed for a whole agentic turn.
+//
+// The assertion is on the OUTPUT MAP on purpose — that is what enforcement
+// reads (runtime.extractUsage takes `_tokens` / `_cost_usd` from it, never
+// the Result struct). The hand-rolled accumulation this replaced summed
+// the struct fields only, so the first attempt's tokens never reached
+// max_tokens and its cost reached nothing at all, while the comment above
+// it claimed the opposite.
+func TestValidateAndRetry_KeepsTheFirstAttemptsSpend(t *testing.T) {
+	backend := &capturingBackend{
+		results: []delegate.Result{
+			// A full turn, billed, then rejected for a missing field.
+			{
+				Output:      map[string]any{"other": "x", "_tokens": 9000, "_cost_usd": 0.90},
+				Tokens:      9000,
+				BackendName: "test_backend",
+			},
+			// The correction is cheap — and taking only its figure is how
+			// a 9300-token node reported 300.
+			{
+				Output:      map[string]any{"answer": "blue", "_tokens": 300, "_cost_usd": 0.03},
+				Tokens:      300,
+				BackendName: "test_backend",
+			},
+		},
+	}
+
+	reg := delegate.NewRegistry()
+	reg.Register("test_backend", backend)
+	wf := &ir.Workflow{
+		Prompts: map[string]*ir.Prompt{},
+		Schemas: map[string]*ir.Schema{
+			"out_schema": {
+				Name:   "out_schema",
+				Fields: []*ir.SchemaField{{Name: "answer", Type: ir.FieldTypeString}},
+			},
+		},
+	}
+	exec := NewClawExecutor(NewRegistry(), wf,
+		WithBackendRegistry(reg),
+		WithRetryPolicy(RetryPolicy{MaxAttempts: 3, BackoffBase: time.Millisecond}),
+	)
+	node := &ir.AgentNode{
+		BaseNode:     ir.BaseNode{ID: "answerer"},
+		LLMFields:    ir.LLMFields{Backend: "test_backend"},
+		SchemaFields: ir.SchemaFields{OutputSchema: "out_schema"},
+	}
+
+	output, err := exec.executeBackend(context.Background(), node, map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := output["_tokens"].(int); got != 9300 {
+		t.Errorf("_tokens = %v, want 9300 — the rejected attempt's 9000 was billed too", output["_tokens"])
+	}
+	// Two calls, two disjoint sessions: the node carries no session id, so
+	// neither report contains the other and the costs add.
+	if got, _ := output["_cost_usd"].(float64); got < 0.92 {
+		t.Errorf("_cost_usd = %v, want ~0.93 — the rejected attempt's $0.90 was dropped", output["_cost_usd"])
+	}
+}

--- a/pkg/backend/model/executor_retry_test.go
+++ b/pkg/backend/model/executor_retry_test.go
@@ -124,6 +124,93 @@ func newTestExecutorForRetry(maxAttempts int) *ClawExecutor {
 	}
 }
 
+// TestRetryDelegateLoop_KeepsTheSpendItDiscards: the shape that hurts is the
+// one where the LAST attempt is the cheap one — a session spends minutes, the
+// retry cannot even spawn and reports nothing, and taking the last attempt's
+// figure reports the cost of nothing. The caps, the org ledger and a lending
+// donor all read the map, so the true figure has to survive.
+//
+// MAX, never a sum: the CLI's accounting is session-cumulative, so a retry
+// inside one session re-reports the running total (see the sibling test).
+func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
+	e := newTestExecutorForRetry(3)
+	calls := 0
+	billed := func(tokens int, usd float64) delegate.Result {
+		return delegate.Result{
+			Tokens:   tokens,
+			Duration: time.Second,
+			Output:   map[string]any{"_tokens": tokens, "_cost_usd": usd},
+		}
+	}
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+		calls++
+		if calls == 1 {
+			// A whole session, then a transient wall.
+			return billed(9000, 0.80), &delegate.ErrTransient{Reason: "stream closed"}
+		}
+		// The retry cannot even spawn: nothing billed, and it is terminal.
+		return delegate.Result{}, errors.New("container is not running")
+	})
+	if err == nil || calls != 2 {
+		t.Fatalf("want a failure after 2 attempts, got err=%v calls=%d", err, calls)
+	}
+	if got.Tokens != 9000 {
+		t.Fatalf("the discarded attempt's tokens were lost: %d", got.Tokens)
+	}
+	if usd, _ := got.Output["_cost_usd"].(float64); usd < 0.80 {
+		t.Fatalf("the discarded attempt's cost was lost: %v", got.Output["_cost_usd"])
+	}
+	if tok, _ := got.Output["_tokens"].(int); tok != 9000 {
+		t.Fatalf("the map the caps read was not updated: %v", got.Output["_tokens"])
+	}
+}
+
+// The other direction, and the reason the fold is a MAX: a retry inside one
+// session re-reports the session's RUNNING TOTAL, so summing the attempts
+// would bill the same tokens twice. The node's figure is the largest any
+// attempt reported, not their sum.
+func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
+	e := newTestExecutorForRetry(3)
+	calls := 0
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+		calls++
+		// Attempt 1 reports 1000; attempt 2 reports the session total, 1300.
+		tokens := 1000
+		if calls > 1 {
+			tokens = 1300
+		}
+		r := delegate.Result{Tokens: tokens, Output: map[string]any{"_tokens": tokens, "_cost_usd": float64(tokens) / 10000}}
+		if calls < 2 {
+			return r, &delegate.ErrTransient{Reason: "stream closed"}
+		}
+		return r, nil
+	})
+	if err != nil || calls != 2 {
+		t.Fatalf("want two attempts then success: err=%v calls=%d", err, calls)
+	}
+	if got.Tokens != 1300 {
+		t.Fatalf("cumulative usage was summed instead of taken at its max: %d", got.Tokens)
+	}
+}
+
+// A cancelled retry keeps the accounting too: no output survives a
+// cancellation, but what the attempts spent is not undone by it.
+func TestRetryDelegateLoop_CancelledKeepsTheSpend(t *testing.T) {
+	e := newTestExecutorForRetry(3)
+	ctx, cancel := context.WithCancel(context.Background())
+	got, err := e.retryDelegateLoop(ctx, "node1", "claw", func() (delegate.Result, error) {
+		cancel()
+		return delegate.Result{Tokens: 500, Output: map[string]any{"_tokens": 500, "_cost_usd": 0.05}},
+			&delegate.ErrTransient{Reason: "stream closed"}
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want the cancellation, got %v", err)
+	}
+	if got.Tokens != 500 {
+		t.Fatalf("a cancellation erased the spend: %+v", got)
+	}
+}
+
 func TestRetryDelegateLoop_SucceedsFirstTry(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0

--- a/pkg/backend/model/executor_retry_test.go
+++ b/pkg/backend/model/executor_retry_test.go
@@ -129,9 +129,6 @@ func newTestExecutorForRetry(maxAttempts int) *ClawExecutor {
 // retry cannot even spawn and reports nothing, and taking the last attempt's
 // figure reports the cost of nothing. The caps, the org ledger and a lending
 // donor all read the map, so the true figure has to survive.
-//
-// MAX, never a sum: the CLI's accounting is session-cumulative, so a retry
-// inside one session re-reports the running total (see the sibling test).
 func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
@@ -142,7 +139,7 @@ func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 			Output:   map[string]any{"_tokens": tokens, "_cost_usd": usd},
 		}
 	}
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		if calls == 1 {
 			// A whole session, then a transient wall.
@@ -165,22 +162,31 @@ func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 	}
 }
 
-// The other direction, and the reason the fold is a MAX *when the attempts
-// share a session*: a retry that RESUMED the session re-reports the
-// session's RUNNING TOTAL, so summing the attempts would bill the same
-// tokens twice. The session id is what says so — the task carries it into
-// every attempt, and this test declares one.
-func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
+// The other direction, and the ONE case that folds at a MAX: two attempts
+// CONTINUING one session, on a backend whose cost figure the provider
+// itself computed over the whole session (claude_code's TotalCostUSD, the
+// only shipped case — Result.CostIsSessionTotal says so). There attempt 2
+// re-reports the running total, and summing would bill it twice.
+//
+// The tokens in the same reports are NOT cumulative — claude_code adds the
+// resumed formatting pass's Usage onto pass 1's — so they still sum. Both
+// halves are asserted here precisely because they disagree.
+func TestRetryDelegateLoop_SessionTotalCostIsNotDoubled(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "sess-1", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", delegate.BackendClaudeCode, true, func() (delegate.Result, error) {
 		calls++
-		// Attempt 1 reports 1000; attempt 2 reports the session total, 1300.
-		tokens := 1000
+		// Attempt 1 burns 1000 tokens for $0.10; attempt 2's own turn burns
+		// 300 more, and the CLI reports the SESSION's $0.13.
+		tokens, usd := 1000, 0.10
 		if calls > 1 {
-			tokens = 1300
+			tokens, usd = 300, 0.13
 		}
-		r := delegate.Result{Tokens: tokens, Output: map[string]any{"_tokens": tokens, "_cost_usd": float64(tokens) / 10000}}
+		r := delegate.Result{
+			Tokens:             tokens,
+			CostIsSessionTotal: true,
+			Output:             map[string]any{"_tokens": tokens, "_cost_usd": usd},
+		}
 		if calls < 2 {
 			return r, &delegate.ErrTransient{Reason: "stream closed"}
 		}
@@ -189,8 +195,43 @@ func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
 	if err != nil || calls != 2 {
 		t.Fatalf("want two attempts then success: err=%v calls=%d", err, calls)
 	}
+	if usd, _ := got.Output["_cost_usd"].(float64); usd != 0.13 {
+		t.Fatalf("a session-cumulative cost was summed instead of taken at its max: %v", usd)
+	}
 	if got.Tokens != 1300 {
-		t.Fatalf("cumulative usage was summed instead of taken at its max: %d", got.Tokens)
+		t.Fatalf("per-call tokens were folded at their max instead of summed: %d", got.Tokens)
+	}
+}
+
+// The same shared session, but the cost figure is an ESTIMATE derived from
+// this call's tokens — claude_code under the OAuth forfait (the CLI reports
+// no cost, AnnotateWithUSD degrades to Annotate), and every cost.Annotate
+// backend besides. Nothing about it is cumulative, so it sums like the
+// tokens it was computed from. A fold keyed on the session ALONE read this
+// shape as cumulative and dropped a whole attempt's spend.
+func TestRetryDelegateLoop_EstimatedCostSumsEvenInOneSession(t *testing.T) {
+	e := newTestExecutorForRetry(3)
+	calls := 0
+	got, err := e.retryDelegateLoop(context.Background(), "node1", delegate.BackendClaudeCode, true, func() (delegate.Result, error) {
+		calls++
+		tokens, usd := 9000, 0.90
+		if calls > 1 {
+			tokens, usd = 1300, 0.13
+		}
+		r := delegate.Result{Tokens: tokens, Output: map[string]any{"_tokens": tokens, "_cost_usd": usd}}
+		if calls < 2 {
+			return r, &delegate.ErrTransient{Reason: "stream closed"}
+		}
+		return r, nil
+	})
+	if err != nil || calls != 2 {
+		t.Fatalf("want two attempts then success: err=%v calls=%d", err, calls)
+	}
+	if got.Tokens != 10300 {
+		t.Fatalf("tokens = %d, want 10300 (every attempt billed its own turn)", got.Tokens)
+	}
+	if usd, _ := got.Output["_cost_usd"].(float64); usd < 1.02 {
+		t.Fatalf("an estimated cost was folded at its max instead of summed: %v", usd)
 	}
 }
 
@@ -202,7 +243,7 @@ func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
 func TestRetryDelegateLoop_FreshSessionsEachSpendTheirOwn(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		// Attempt 1 runs an agentic session; attempt 2 opens its own and
 		// barely gets going. Neither report contains the other.
@@ -236,7 +277,7 @@ func TestRetryDelegateLoop_FreshSessionsEachSpendTheirOwn(t *testing.T) {
 func TestRetryDelegateLoop_CancelledKeepsTheSpend(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	ctx, cancel := context.WithCancel(context.Background())
-	got, err := e.retryDelegateLoop(ctx, "node1", "claw", "", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(ctx, "node1", "claw", false, func() (delegate.Result, error) {
 		cancel()
 		return delegate.Result{Tokens: 500, Output: map[string]any{"_tokens": 500, "_cost_usd": 0.05}},
 			&delegate.ErrTransient{Reason: "stream closed"}
@@ -253,7 +294,7 @@ func TestRetryDelegateLoop_SucceedsFirstTry(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
 	want := delegate.Result{Output: map[string]any{"k": "v"}, BackendName: "claw"}
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		return want, nil
 	})
@@ -271,7 +312,7 @@ func TestRetryDelegateLoop_SucceedsFirstTry(t *testing.T) {
 func TestRetryDelegateLoop_RetriesOnTransientThenSucceeds(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, &delegate.ErrTransient{Reason: "subprocess killed"}
@@ -292,7 +333,7 @@ func TestRetryDelegateLoop_RetriesOnTransientThenSucceeds(t *testing.T) {
 func TestRetryDelegateLoop_GivesUpAtMaxAttempts(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, &delegate.ErrTransient{Reason: "subprocess killed"}
 	})
@@ -307,7 +348,7 @@ func TestRetryDelegateLoop_GivesUpAtMaxAttempts(t *testing.T) {
 func TestRetryDelegateLoop_NonRetryableErrorStopsImmediately(t *testing.T) {
 	e := newTestExecutorForRetry(5)
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("exit status 1") // application error, not retryable
 	})
@@ -325,7 +366,7 @@ func TestRetryDelegateLoop_ContextCancelStopsBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	calls := 0
 	// Cancel after the first call so we exit during the backoff sleep.
-	_, err := e.retryDelegateLoop(ctx, "node1", "claw", "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(ctx, "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		if calls == 1 {
 			cancel()
@@ -347,7 +388,7 @@ func TestRetryDelegateLoop_OnDelegateRetryHookFires(t *testing.T) {
 		hookFires = append(hookFires, info)
 	}
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", false, func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, &delegate.ErrTransient{Reason: "boom"}

--- a/pkg/backend/model/executor_retry_test.go
+++ b/pkg/backend/model/executor_retry_test.go
@@ -160,6 +160,11 @@ func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 	if tok, _ := got.Output["_tokens"].(int); tok != 9000 {
 		t.Fatalf("the map the caps read was not updated: %v", got.Output["_tokens"])
 	}
+	// The time is part of the same accounting: the event would otherwise
+	// report the failed spawn's zero for a node that spent a whole second.
+	if got.Duration != time.Second {
+		t.Fatalf("the discarded attempt's duration was lost: %v", got.Duration)
+	}
 }
 
 // The other direction, and the ONE case that folds at a MAX: two attempts

--- a/pkg/backend/model/executor_retry_test.go
+++ b/pkg/backend/model/executor_retry_test.go
@@ -142,7 +142,7 @@ func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 			Output:   map[string]any{"_tokens": tokens, "_cost_usd": usd},
 		}
 	}
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		if calls == 1 {
 			// A whole session, then a transient wall.
@@ -165,14 +165,15 @@ func TestRetryDelegateLoop_KeepsTheSpendItDiscards(t *testing.T) {
 	}
 }
 
-// The other direction, and the reason the fold is a MAX: a retry inside one
-// session re-reports the session's RUNNING TOTAL, so summing the attempts
-// would bill the same tokens twice. The node's figure is the largest any
-// attempt reported, not their sum.
+// The other direction, and the reason the fold is a MAX *when the attempts
+// share a session*: a retry that RESUMED the session re-reports the
+// session's RUNNING TOTAL, so summing the attempts would bill the same
+// tokens twice. The session id is what says so — the task carries it into
+// every attempt, and this test declares one.
 func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "sess-1", func() (delegate.Result, error) {
 		calls++
 		// Attempt 1 reports 1000; attempt 2 reports the session total, 1300.
 		tokens := 1000
@@ -193,12 +194,49 @@ func TestRetryDelegateLoop_CumulativeUsageIsNotDoubled(t *testing.T) {
 	}
 }
 
+// A node executing for the FIRST time carries no session id, so the task
+// the retry re-invokes with opens a fresh session every attempt and each
+// report covers only its own work. Their spend is the SUM. Reading a MAX
+// here reported 9000 for 10300 of work — an under-report, which is the
+// direction that lets a run walk past max_cost_usd.
+func TestRetryDelegateLoop_FreshSessionsEachSpendTheirOwn(t *testing.T) {
+	e := newTestExecutorForRetry(3)
+	calls := 0
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
+		calls++
+		// Attempt 1 runs an agentic session; attempt 2 opens its own and
+		// barely gets going. Neither report contains the other.
+		tokens := 9000
+		if calls > 1 {
+			tokens = 1300
+		}
+		r := delegate.Result{Tokens: tokens, Output: map[string]any{
+			"_tokens": tokens, "_cost_usd": float64(tokens) / 10000}}
+		if calls < 2 {
+			return r, &delegate.ErrTransient{Reason: "stream closed"}
+		}
+		return r, nil
+	})
+	if err != nil || calls != 2 {
+		t.Fatalf("want two attempts then success: err=%v calls=%d", err, calls)
+	}
+	if got.Tokens != 10300 {
+		t.Fatalf("disjoint sessions were folded at their max instead of summed: %d", got.Tokens)
+	}
+	if tok, _ := got.Output["_tokens"].(int); tok != 10300 {
+		t.Fatalf("the map the caps read was not updated: %v", got.Output["_tokens"])
+	}
+	if usd, _ := got.Output["_cost_usd"].(float64); usd < 1.03 {
+		t.Fatalf("the cost the caps read was not summed: %v", usd)
+	}
+}
+
 // A cancelled retry keeps the accounting too: no output survives a
 // cancellation, but what the attempts spent is not undone by it.
 func TestRetryDelegateLoop_CancelledKeepsTheSpend(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	ctx, cancel := context.WithCancel(context.Background())
-	got, err := e.retryDelegateLoop(ctx, "node1", "claw", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(ctx, "node1", "claw", "", func() (delegate.Result, error) {
 		cancel()
 		return delegate.Result{Tokens: 500, Output: map[string]any{"_tokens": 500, "_cost_usd": 0.05}},
 			&delegate.ErrTransient{Reason: "stream closed"}
@@ -215,7 +253,7 @@ func TestRetryDelegateLoop_SucceedsFirstTry(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
 	want := delegate.Result{Output: map[string]any{"k": "v"}, BackendName: "claw"}
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		return want, nil
 	})
@@ -233,7 +271,7 @@ func TestRetryDelegateLoop_SucceedsFirstTry(t *testing.T) {
 func TestRetryDelegateLoop_RetriesOnTransientThenSucceeds(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	got, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, &delegate.ErrTransient{Reason: "subprocess killed"}
@@ -254,7 +292,7 @@ func TestRetryDelegateLoop_RetriesOnTransientThenSucceeds(t *testing.T) {
 func TestRetryDelegateLoop_GivesUpAtMaxAttempts(t *testing.T) {
 	e := newTestExecutorForRetry(3)
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, &delegate.ErrTransient{Reason: "subprocess killed"}
 	})
@@ -269,7 +307,7 @@ func TestRetryDelegateLoop_GivesUpAtMaxAttempts(t *testing.T) {
 func TestRetryDelegateLoop_NonRetryableErrorStopsImmediately(t *testing.T) {
 	e := newTestExecutorForRetry(5)
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("exit status 1") // application error, not retryable
 	})
@@ -287,7 +325,7 @@ func TestRetryDelegateLoop_ContextCancelStopsBackoff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	calls := 0
 	// Cancel after the first call so we exit during the backoff sleep.
-	_, err := e.retryDelegateLoop(ctx, "node1", "claw", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(ctx, "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		if calls == 1 {
 			cancel()
@@ -309,7 +347,7 @@ func TestRetryDelegateLoop_OnDelegateRetryHookFires(t *testing.T) {
 		hookFires = append(hookFires, info)
 	}
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "node1", "claw", "", func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, &delegate.ErrTransient{Reason: "boom"}

--- a/pkg/backend/model/network_retry_test.go
+++ b/pkg/backend/model/network_retry_test.go
@@ -23,7 +23,7 @@ func loopExecutor() *ClawExecutor {
 func TestRetryDelegateLoop_NetworkUsesTransientBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("fetch failed")
 	})
@@ -38,7 +38,7 @@ func TestRetryDelegateLoop_NetworkUsesTransientBudget(t *testing.T) {
 func TestRetryDelegateLoop_SignalUsesStandardBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("signal: killed") // retryable, not network
 	})
@@ -53,7 +53,7 @@ func TestRetryDelegateLoop_SignalUsesStandardBudget(t *testing.T) {
 func TestRetryDelegateLoop_PermanentNoRetry(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, _ = e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, func() (delegate.Result, error) {
+	_, _ = e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("exit status 1") // application error
 	})
@@ -65,7 +65,7 @@ func TestRetryDelegateLoop_PermanentNoRetry(t *testing.T) {
 func TestRetryDelegateLoop_RecoversMidBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	res, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, func() (delegate.Result, error) {
+	res, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, errors.New("ECONNRESET") // network blip

--- a/pkg/backend/model/network_retry_test.go
+++ b/pkg/backend/model/network_retry_test.go
@@ -23,7 +23,7 @@ func loopExecutor() *ClawExecutor {
 func TestRetryDelegateLoop_NetworkUsesTransientBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, false, func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("fetch failed")
 	})
@@ -38,7 +38,7 @@ func TestRetryDelegateLoop_NetworkUsesTransientBudget(t *testing.T) {
 func TestRetryDelegateLoop_SignalUsesStandardBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
+	_, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, false, func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("signal: killed") // retryable, not network
 	})
@@ -53,7 +53,7 @@ func TestRetryDelegateLoop_SignalUsesStandardBudget(t *testing.T) {
 func TestRetryDelegateLoop_PermanentNoRetry(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	_, _ = e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
+	_, _ = e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, false, func() (delegate.Result, error) {
 		calls++
 		return delegate.Result{}, errors.New("exit status 1") // application error
 	})
@@ -65,7 +65,7 @@ func TestRetryDelegateLoop_PermanentNoRetry(t *testing.T) {
 func TestRetryDelegateLoop_RecoversMidBudget(t *testing.T) {
 	e := loopExecutor()
 	calls := 0
-	res, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, "", func() (delegate.Result, error) {
+	res, err := e.retryDelegateLoop(context.Background(), "n", delegate.BackendClaudeCode, false, func() (delegate.Result, error) {
 		calls++
 		if calls < 3 {
 			return delegate.Result{}, errors.New("ECONNRESET") // network blip


### PR DESCRIPTION
## The node reported the cost of nothing

When the LAST in-place attempt is the cheap one, the figure the node reports is the cheap one's: attempt 1 spends an agentic session and hits a transient wall, attempt 2 cannot even spawn and returns an empty `Result`, and `result, err = fn()` overwrote the accounting with zero. `max_cost_usd`, the org monthly cap and a lending donor's ledger all read that figure.

## MAX, never a sum — and getting that wrong is how this first went in

The CLI's usage accounting is **session-cumulative**: a retry inside one session re-reports the running total, so adding the attempts bills the same tokens twice. The first version of this change summed them, and three chain tests said so in their own words — *"each route folded in exactly once"* — and turned red. `annotateCost` already states the rule for the formatting passes, for exactly this reason; this loop now follows it.

Both directions are pinned by tests: a cheap last attempt keeps the rich figure, and a cumulative second report is not doubled.

## Two smaller halves of the same class, both reachable

- The fold **allocates the output map** when it has a figure to record. An unallocated map records nothing, and the case that loses the most is precisely the one with no output at all — a last attempt that could not spawn. `typedFailure` allocates it for the same reason, in the same package.
- A **cancellation** between attempts keeps the accounting: no output survives it, but what the attempts already burned is not undone by it.

## Why this loop and not another

The class is documented twice in this file already: the fallback chain's own `chainSpend`, and `validateAndRetry`, whose comment records that dropping the first attempt's usage *"broke budget enforcement at the margins"*. The in-place retry loop was the third site, and the one nobody had grepped.

## Proof

Four mutants, each red on its own test: the richer attempt dropped; the fold turned into a sum (which the pre-existing chain tests catch, not only the new one); the map left unallocated; the cancellation erasing the figure.

`go test ./pkg/backend/model/` green; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
