### PR TITLE
fix(sandbox): export the seeded forfait config dirs on the container env

### DIFF
--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -485,6 +485,12 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 	if err != nil {
 		return nil, fmt.Errorf("runtime: sandbox: chatgpt forfait delivery: %w", err)
 	}
+	// The forfait config dirs are seeded AFTER the container starts (below),
+	// but their paths are constants: advertise them on the container env now
+	// so every exec — a tool node, a devbox script, a scanner that shells out
+	// to `claude` or `codex` — authenticates as the run, not only the
+	// claude_code/claw delegate spawns that set the variables themselves.
+	exportForfaitConfigDirs(spec, claudeOAuthMounted, codexOAuthMounted)
 
 	// Optionally start the network proxy. When the workflow has no
 	// explicit network policy, default to the iterion-default

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -490,7 +490,16 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 	// so every exec — a tool node, a devbox script, a scanner that shells out
 	// to `claude` or `codex` — authenticates as the run, not only the
 	// claude_code/claw delegate spawns that set the variables themselves.
-	exportForfaitConfigDirs(spec, claudeOAuthMounted, codexOAuthMounted)
+	//
+	// One window follows from that order and is stated rather than hidden:
+	// a devcontainer `postCreateCommand` runs inside driver.Start, i.e.
+	// BEFORE the seeding, so a post_create that itself shells out to
+	// `claude`/`codex` sees the variable pointing at a dir that is not
+	// populated yet. No bot in the catalogue does (the only post_create
+	// enables corepack and makes cache dirs); a TARGET repo's devcontainer
+	// could. Closing it means delivering the config at container CREATION,
+	// not after start — a change to the secret-file path, not to this line.
+	exportForfaitConfigDirs(spec, p.Logger, claudeOAuthMounted, codexOAuthMounted)
 
 	// Optionally start the network proxy. When the workflow has no
 	// explicit network policy, default to the iterion-default

--- a/pkg/runtime/sandbox_forfait_env_test.go
+++ b/pkg/runtime/sandbox_forfait_env_test.go
@@ -1,0 +1,48 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+func TestExportForfaitConfigDirs(t *testing.T) {
+	t.Run("nothing mounted leaves the env untouched", func(t *testing.T) {
+		var spec sandbox.Spec
+		exportForfaitConfigDirs(&spec, false, false)
+		if spec.Env != nil {
+			t.Fatalf("env = %v, want nil", spec.Env)
+		}
+	})
+
+	t.Run("claude forfait alone exports only CLAUDE_CONFIG_DIR", func(t *testing.T) {
+		var spec sandbox.Spec
+		exportForfaitConfigDirs(&spec, true, false)
+		if got := spec.Env["CLAUDE_CONFIG_DIR"]; got != secrets.ClaudeCodeSandboxConfigDir {
+			t.Fatalf("CLAUDE_CONFIG_DIR = %q, want %q", got, secrets.ClaudeCodeSandboxConfigDir)
+		}
+		if _, set := spec.Env["CODEX_HOME"]; set {
+			t.Fatalf("CODEX_HOME must not be set without a codex forfait: %v", spec.Env)
+		}
+	})
+
+	t.Run("both forfaits export both dirs", func(t *testing.T) {
+		var spec sandbox.Spec
+		exportForfaitConfigDirs(&spec, true, true)
+		if spec.Env["CLAUDE_CONFIG_DIR"] != secrets.ClaudeCodeSandboxConfigDir || spec.Env["CODEX_HOME"] != secrets.CodexSandboxConfigDir {
+			t.Fatalf("env = %v", spec.Env)
+		}
+	})
+
+	t.Run("an operator-declared value wins", func(t *testing.T) {
+		spec := sandbox.Spec{Env: map[string]string{"CLAUDE_CONFIG_DIR": "/operator/claude", "PATH": "/bin"}}
+		exportForfaitConfigDirs(&spec, true, true)
+		if spec.Env["CLAUDE_CONFIG_DIR"] != "/operator/claude" {
+			t.Fatalf("operator value overwritten: %v", spec.Env)
+		}
+		if spec.Env["CODEX_HOME"] != secrets.CodexSandboxConfigDir || spec.Env["PATH"] != "/bin" {
+			t.Fatalf("env = %v", spec.Env)
+		}
+	})
+}

--- a/pkg/runtime/sandbox_forfait_env_test.go
+++ b/pkg/runtime/sandbox_forfait_env_test.go
@@ -1,7 +1,11 @@
 package runtime
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -10,7 +14,7 @@ import (
 func TestExportForfaitConfigDirs(t *testing.T) {
 	t.Run("nothing mounted leaves the env untouched", func(t *testing.T) {
 		var spec sandbox.Spec
-		exportForfaitConfigDirs(&spec, false, false)
+		exportForfaitConfigDirs(&spec, nil, false, false)
 		if spec.Env != nil {
 			t.Fatalf("env = %v, want nil", spec.Env)
 		}
@@ -18,7 +22,7 @@ func TestExportForfaitConfigDirs(t *testing.T) {
 
 	t.Run("claude forfait alone exports only CLAUDE_CONFIG_DIR", func(t *testing.T) {
 		var spec sandbox.Spec
-		exportForfaitConfigDirs(&spec, true, false)
+		exportForfaitConfigDirs(&spec, nil, true, false)
 		if got := spec.Env["CLAUDE_CONFIG_DIR"]; got != secrets.ClaudeCodeSandboxConfigDir {
 			t.Fatalf("CLAUDE_CONFIG_DIR = %q, want %q", got, secrets.ClaudeCodeSandboxConfigDir)
 		}
@@ -29,15 +33,52 @@ func TestExportForfaitConfigDirs(t *testing.T) {
 
 	t.Run("both forfaits export both dirs", func(t *testing.T) {
 		var spec sandbox.Spec
-		exportForfaitConfigDirs(&spec, true, true)
+		exportForfaitConfigDirs(&spec, nil, true, true)
 		if spec.Env["CLAUDE_CONFIG_DIR"] != secrets.ClaudeCodeSandboxConfigDir || spec.Env["CODEX_HOME"] != secrets.CodexSandboxConfigDir {
 			t.Fatalf("env = %v", spec.Env)
 		}
 	})
 
+	// A config dir is the WEAKEST channel the CLI reads: a key on the
+	// container env outranks it, and a forfait that silently does not
+	// authenticate the work is the failure this path exists to end.
+	t.Run("a credential that outranks the dir is said out loud", func(t *testing.T) {
+		for _, c := range []struct {
+			name, key, want string
+			claude, codex   bool
+		}{
+			{name: "anthropic key beats the claude dir", key: "ANTHROPIC_API_KEY", want: "ANTHROPIC_API_KEY", claude: true},
+			{name: "anthropic token beats it too", key: "ANTHROPIC_AUTH_TOKEN", want: "ANTHROPIC_AUTH_TOKEN", claude: true},
+			{name: "openai key beats CODEX_HOME", key: "OPENAI_API_KEY", want: "OPENAI_API_KEY", codex: true},
+		} {
+			t.Run(c.name, func(t *testing.T) {
+				var buf bytes.Buffer
+				spec := sandbox.Spec{Env: map[string]string{c.key: "secret-by-reference"}}
+				exportForfaitConfigDirs(&spec, iterlog.New(iterlog.LevelDebug, &buf), c.claude, c.codex)
+				if !strings.Contains(buf.String(), c.want) {
+					t.Errorf("the run's forfait is not what authenticates and nothing said so:\n%s", buf.String())
+				}
+				if strings.Contains(buf.String(), "secret-by-reference") {
+					t.Errorf("the credential VALUE reached the log:\n%s", buf.String())
+				}
+			})
+		}
+	})
+
+	// The other half: no credential on the env, nothing to warn about. A
+	// warning that always fires teaches operators to ignore it.
+	t.Run("no competing credential, no warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		spec := sandbox.Spec{Env: map[string]string{"PATH": "/bin"}}
+		exportForfaitConfigDirs(&spec, iterlog.New(iterlog.LevelDebug, &buf), true, true)
+		if strings.Contains(buf.String(), "authenticate") {
+			t.Errorf("warned with nothing to warn about:\n%s", buf.String())
+		}
+	})
+
 	t.Run("an operator-declared value wins", func(t *testing.T) {
 		spec := sandbox.Spec{Env: map[string]string{"CLAUDE_CONFIG_DIR": "/operator/claude", "PATH": "/bin"}}
-		exportForfaitConfigDirs(&spec, true, true)
+		exportForfaitConfigDirs(&spec, nil, true, true)
 		if spec.Env["CLAUDE_CONFIG_DIR"] != "/operator/claude" {
 			t.Fatalf("operator value overwritten: %v", spec.Env)
 		}

--- a/pkg/runtime/sandbox_secret_files.go
+++ b/pkg/runtime/sandbox_secret_files.go
@@ -186,6 +186,33 @@ mkdir -p "$1"
 cp "$2" "$1/$3"
 chmod 600 "$1/$3"`
 
+// exportForfaitConfigDirs advertises the seeded forfait config dirs on the
+// container env. seedClaudeConfigDir / seedCodexConfigDir populate those
+// dirs once the sandbox is up, and the claude_code and claw delegates point
+// their own spawns at them — but any OTHER process in the sandbox (a tool
+// node running `claude -p`, a scanner driving the claude-agent-sdk) inherits
+// only the container env, and without these variables it runs
+// unauthenticated ("Not logged in") while the credentials sit next to it.
+// A value the operator declared on the spec wins.
+func exportForfaitConfigDirs(spec *sandbox.Spec, claudeMounted, codexMounted bool) {
+	if !claudeMounted && !codexMounted {
+		return
+	}
+	if spec.Env == nil {
+		spec.Env = map[string]string{}
+	}
+	if claudeMounted {
+		if _, set := spec.Env["CLAUDE_CONFIG_DIR"]; !set {
+			spec.Env["CLAUDE_CONFIG_DIR"] = secrets.ClaudeCodeSandboxConfigDir
+		}
+	}
+	if codexMounted {
+		if _, set := spec.Env["CODEX_HOME"]; !set {
+			spec.Env["CODEX_HOME"] = secrets.CodexSandboxConfigDir
+		}
+	}
+}
+
 // seedClaudeConfigDir runs [seedClaudeConfigScript] inside the freshly
 // started sandbox. Hard error on failure: the run resolved a forfait
 // credential, so a half-delivered config dir must fail the boot loudly

--- a/pkg/runtime/sandbox_secret_files.go
+++ b/pkg/runtime/sandbox_secret_files.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 )
@@ -194,7 +195,20 @@ chmod 600 "$1/$3"`
 // only the container env, and without these variables it runs
 // unauthenticated ("Not logged in") while the credentials sit next to it.
 // A value the operator declared on the spec wins.
-func exportForfaitConfigDirs(spec *sandbox.Spec, claudeMounted, codexMounted bool) {
+//
+// A config DIR is the weakest of the CLI's credential channels: the claude
+// CLI prefers ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN over it, and codex
+// prefers OPENAI_API_KEY over CODEX_HOME. So when the container env
+// already carries one of those — a workflow file secret declared with
+// `env:`, a bot's `sandbox.env:`, a devcontainer `${localEnv:…}`
+// expansion — a generic process authenticates with THAT, not with the
+// run's forfait, and this export changes nothing for it. That is the
+// operator's declaration winning, which is the intended precedence; it is
+// said out loud because a forfait that silently does not authenticate the
+// work is the failure this whole path exists to end. The delegate spawns
+// are unaffected either way: claudeForfaitEnv actively clears those
+// variables for its own subprocess.
+func exportForfaitConfigDirs(spec *sandbox.Spec, logger *iterlog.Logger, claudeMounted, codexMounted bool) {
 	if !claudeMounted && !codexMounted {
 		return
 	}
@@ -205,11 +219,33 @@ func exportForfaitConfigDirs(spec *sandbox.Spec, claudeMounted, codexMounted boo
 		if _, set := spec.Env["CLAUDE_CONFIG_DIR"]; !set {
 			spec.Env["CLAUDE_CONFIG_DIR"] = secrets.ClaudeCodeSandboxConfigDir
 		}
+		warnCredentialOutranksForfait(logger, spec.Env, "claude", "CLAUDE_CONFIG_DIR",
+			"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
 	}
 	if codexMounted {
 		if _, set := spec.Env["CODEX_HOME"]; !set {
 			spec.Env["CODEX_HOME"] = secrets.CodexSandboxConfigDir
 		}
+		warnCredentialOutranksForfait(logger, spec.Env, "codex", "CODEX_HOME",
+			"OPENAI_API_KEY")
+	}
+}
+
+// warnCredentialOutranksForfait says, once per CLI, that a credential
+// declared on the container env is what a generic process will use — the
+// run resolved a forfait and the config dir is exported, but the CLI reads
+// the key first, so the work is not billed or attributed to the run.
+func warnCredentialOutranksForfait(logger *iterlog.Logger, env map[string]string, cli, dirVar string, keyVars ...string) {
+	if logger == nil {
+		return
+	}
+	for _, k := range keyVars {
+		if env[k] == "" {
+			continue
+		}
+		logger.Warn("runtime: sandbox: %s is set on the container env and the %s CLI reads it before %s — "+
+			"processes in the sandbox authenticate with that credential, NOT with the run's forfait", k, cli, dirVar)
+		return
 	}
 }
 


### PR DESCRIPTION
## Summary

The run's Claude Code / Codex forfait is delivered into the sandbox and seeded into `CLAUDE_CONFIG_DIR` / `CODEX_HOME` after start, but only the `claude_code` and `claw` delegates pointed their own spawns at those dirs. Every other process in the container — a tool node, a devbox script, a scanner driving the claude-agent-sdk — inherited the bare container env and ran unauthenticated while the credentials sat next to it.

This advertises the two constant paths on `spec.Env` before the driver prepares the container (an operator-declared value still wins), so a process in the sandbox finds the run's credential instead of none.

Scope, stated precisely: this reaches every process that inherits the container env. It does **not** reach a child whose parent rebuilds its environment from an allowlist — a scanner that curates the env of the CLI it spawns (as a prompt-injection defence) will drop `CLAUDE_CONFIG_DIR` unless that name is on its list. Such callers need the credential by a channel they preserve; that is their fix to make, not this one's. The claim here is the narrow one the probe below supports.

## Measurement

Cloud probe on the kubernetes driver with the scanner image (2026-09-07):

- `/tmp/iterion-claude-config/.credentials.json` present (forfait seeded);
- no `CLAUDE_*` / `ANTHROPIC_*` / `CODEX_*` variable in a tool node's env;
- `claude -p "reply with the single word OK"` from that tool node → `Not logged in · Please run /login`.

The LLM scanner that `sec-audit-source` drives from a tool node therefore lost its whole contribution behind a coverage banner (`deepsec unavailable` / `step failed: process`), which reads as a degraded scan rather than as an auth failure.

A second probe (2026-09-08) closes the other half — that the exported variable is *sufficient*, not merely plausible. Same tool node, same image, four spawns of the same `claude -p` differing only by the env handed to it:

| env given to the spawn | result |
|---|---|
| none — today's behaviour | `Not logged in · Please run /login` |
| `CLAUDE_CONFIG_DIR` (this PR) | **OK** |
| `CLAUDE_CODE_OAUTH_TOKEN` read from the seeded file | **OK** |
| both, or a copy of the seeded file into `$HOME/.claude` | **OK** |

The seeded file was present, `0600`, and its token unexpired throughout, so the failure was never a stale or half-delivered credential: the container simply never named the directory. That also settles the shape of the fix — one export at the sandbox boundary reaches every process, where a per-caller workaround (each tool node adopting `/tmp/iterion-claude-config` itself) would have to be repeated in every bot and would drift.

## Test

- `exportForfaitConfigDirs`: 4 cases (nothing mounted → env untouched; claude only; both; operator value wins).
- `go test ./pkg/runtime/` green, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


