### PR TITLE
fix(claw): a stale codex-cli never downgrades the ChatGPT identity, and a JSON Schema type array parses (claw b6e34a39)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260905191936-28eefe727f57
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260905191936-28eefe727f57 h1:yysO9v2QkJ3HdchOyVTrAmQk7e8J1yKi7kMwBxn0Txk=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260905191936-28eefe727f57/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad h1:5vokAXjPSzPuV3lcu5GeKK2CnPTVTmVz4+dtoBMxNpo=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1139,15 +1139,15 @@ func forwardableProviderEnv(ctx context.Context, model string) (map[string]strin
 		}
 	}
 	// No ITERION_CODEX_VERSION override set: forward the HOST-resolved
-	// codex-cli version instead. The in-container runner cannot probe
-	// `codex --version` itself (the sandbox image ships no codex binary),
-	// so without a value crossing the boundary it falls back to claw's
-	// baked-in version string — which the ChatGPT-forfait backend refuses
-	// for newer models ("gpt-5.6-sol requires a newer version of Codex")
-	// even though the host's codex install is current.
+	// codex-cli version as a PROBE (ITERION_CODEX_HOST_VERSION), not as the
+	// decision. The in-container runner cannot probe `codex --version`
+	// itself (the sandbox image ships no codex binary); it keeps the newer
+	// of this probe and its own baked release, so neither a stale host
+	// binary nor a stale image can pin the ChatGPT-forfait identity below
+	// what either side would present alone.
 	if env["ITERION_CODEX_VERSION"] == "" {
 		if v := hostCodexVersion(); v != "" {
-			env["ITERION_CODEX_VERSION"] = v
+			env[codexHostVersionEnv] = v
 		}
 	}
 	creds, ok := secrets.CredentialsFromContext(ctx)

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -97,15 +97,15 @@ func TestForwardableProviderEnv_forwardsHostProbedCodexVersion(t *testing.T) {
 
 	hostCodexVersion = func() string { return "0.144.6" }
 	env := envFor(t, context.Background())
-	if env["ITERION_CODEX_VERSION"] != "0.144.6" {
-		t.Errorf("ITERION_CODEX_VERSION = %q, want the host-probed version forwarded when no override is set", env["ITERION_CODEX_VERSION"])
+	if env["ITERION_CODEX_HOST_VERSION"] != "0.144.6" {
+		t.Errorf("ITERION_CODEX_HOST_VERSION = %q, want the host-probed version forwarded as a probe when no override is set", env["ITERION_CODEX_HOST_VERSION"])
 	}
 
 	// No codex on the host either: forward nothing, never an empty pair.
 	hostCodexVersion = func() string { return "" }
 	env = envFor(t, context.Background())
-	if v, ok := env["ITERION_CODEX_VERSION"]; ok {
-		t.Errorf("ITERION_CODEX_VERSION = %q set with nothing to forward — an empty value must not cross", v)
+	if v, ok := env["ITERION_CODEX_HOST_VERSION"]; ok {
+		t.Errorf("ITERION_CODEX_HOST_VERSION = %q set with nothing to forward — an empty value must not cross", v)
 	}
 }
 

--- a/pkg/backend/model/codex_client_version_test.go
+++ b/pkg/backend/model/codex_client_version_test.go
@@ -1,0 +1,52 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+)
+
+func TestNewerCodexVersion(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"0.139.0", "0.144.6", "0.144.6"},
+		{"0.153.4", "0.144.6", "0.153.4"},
+		{"", "0.144.6", "0.144.6"},
+		{"garbage", "0.144.6", "0.144.6"},
+		{"0.144.6", "", "0.144.6"},
+		{"0.144", "0.144.0", "0.144"},
+		{"v0.145.0-beta.1", "0.144.6", "v0.145.0-beta.1"},
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		if got := newerCodexVersion(c.a, c.b); got != c.want {
+			t.Errorf("newerCodexVersion(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// A stale codex binary on the host must never drag the identity below the
+// release claw itself presents; an operator override still passes as-is.
+func TestCodexCLIVersion_HostNeverBelowBaked(t *testing.T) {
+	codexVersionOnce.Do(func() {})
+	orig := codexVersionCached
+	t.Cleanup(func() { codexVersionCached = orig })
+
+	t.Setenv("ITERION_CODEX_VERSION", "")
+	codexVersionCached = "0.139.0"
+	if got := codexCLIVersion(); got != api.ChatGPTClientVersion {
+		t.Errorf("stale host binary: got %q, want the baked %q", got, api.ChatGPTClientVersion)
+	}
+	codexVersionCached = "0.199.0"
+	if got := codexCLIVersion(); got != "0.199.0" {
+		t.Errorf("newer host binary: got %q, want it forwarded", got)
+	}
+	codexVersionCached = ""
+	if got := codexCLIVersion(); got != api.ChatGPTClientVersion {
+		t.Errorf("no host binary: got %q, want the baked %q", got, api.ChatGPTClientVersion)
+	}
+
+	t.Setenv("ITERION_CODEX_VERSION", "0.100.0")
+	if got := codexCLIVersion(); got != "0.100.0" {
+		t.Errorf("operator override: got %q, want it sent as-is", got)
+	}
+}

--- a/pkg/backend/model/codex_client_version_test.go
+++ b/pkg/backend/model/codex_client_version_test.go
@@ -15,6 +15,9 @@ func TestNewerCodexVersion(t *testing.T) {
 		{"0.144.6", "", "0.144.6"},
 		{"0.144", "0.144.0", "0.144"},
 		{"v0.145.0-beta.1", "0.144.6", "v0.145.0-beta.1"},
+		{"0.145.0-beta.1", "0.145.0", "0.145.0"},
+		{"0.145.0", "0.145.0-rc.2", "0.145.0"},
+		{"0.145.0-beta.1", "0.145.0-beta.2", "0.145.0-beta.1"},
 		{"", "", ""},
 	}
 	for _, c := range cases {
@@ -48,5 +51,25 @@ func TestCodexCLIVersion_HostNeverBelowBaked(t *testing.T) {
 	t.Setenv("ITERION_CODEX_VERSION", "0.100.0")
 	if got := codexCLIVersion(); got != "0.100.0" {
 		t.Errorf("operator override: got %q, want it sent as-is", got)
+	}
+}
+
+// Inside a sandbox the launcher forwards its own probe as
+// ITERION_CODEX_HOST_VERSION; the runner keeps the newest of that probe, its
+// own (absent) binary and its baked release — never below the baked one.
+func TestCodexCLIVersion_HostProbeIsAProbeNotADecision(t *testing.T) {
+	codexVersionOnce.Do(func() {})
+	orig := codexVersionCached
+	t.Cleanup(func() { codexVersionCached = orig })
+	t.Setenv("ITERION_CODEX_VERSION", "")
+	codexVersionCached = ""
+
+	t.Setenv(codexHostVersionEnv, "0.139.0")
+	if got := codexCLIVersion(); got != api.ChatGPTClientVersion {
+		t.Errorf("stale host probe: got %q, want the baked %q", got, api.ChatGPTClientVersion)
+	}
+	t.Setenv(codexHostVersionEnv, "0.199.0")
+	if got := codexCLIVersion(); got != "0.199.0" {
+		t.Errorf("newer host probe: got %q, want it used", got)
 	}
 }

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -316,12 +316,15 @@ func withClientIdentity(cfg api.ProviderConfig) api.ProviderConfig {
 // backend gates model availability on this value (e.g. gpt-5.5 requires
 // codex-cli >= 0.130, gpt-6-astra >= 0.144). Resolution precedence:
 //  1. ITERION_CODEX_VERSION env var (operator override, sent as-is; lets a
-//     fresh-but-binary-stale environment claim newer model access)
-//  2. the newer of `codex --version` (parsed at most once per process) and
-//     claw's baked api.ChatGPTClientVersion — a stale codex binary on the
-//     host must not downgrade the identity below what claw alone would
-//     present (measured: a runner image shipping 0.139.0 was refused a
-//     model the 0.144.6 baseline is served)
+//     fresh-but-binary-stale environment claim newer model access, or pin
+//     an older release deliberately)
+//  2. the newest of `codex --version` (parsed at most once per process),
+//     the host-side probe a sandbox launcher forwarded as
+//     ITERION_CODEX_HOST_VERSION, and claw's baked api.ChatGPTClientVersion
+//     — a stale codex binary on either side of the sandbox boundary must
+//     not downgrade the identity below what claw alone would present
+//     (measured: a runner image shipping 0.139.0 was refused a model the
+//     0.144.6 baseline is served)
 var (
 	codexVersionOnce   sync.Once
 	codexVersionCached string
@@ -347,15 +350,22 @@ func codexCLIVersion() string {
 		}
 		codexVersionCached = fields[len(fields)-1]
 	})
-	return newerCodexVersion(codexVersionCached, api.ChatGPTClientVersion)
+	return newerCodexVersion(newerCodexVersion(codexVersionCached, os.Getenv(codexHostVersionEnv)), api.ChatGPTClientVersion)
 }
+
+// codexHostVersionEnv carries the launcher's own `codex --version` probe into
+// a sandboxed runner, which cannot probe a binary the image does not ship.
+// Unlike ITERION_CODEX_VERSION it is a PROBE, not a decision: the runner
+// still keeps the newer of it and its own baked release.
+const codexHostVersionEnv = "ITERION_CODEX_HOST_VERSION"
 
 // newerCodexVersion returns the higher of two dotted numeric versions. A
 // side that does not parse loses; when neither parses, b (the baked value)
-// is returned.
+// is returned. A pre-release ("0.145.0-beta.1") ranks below its release
+// ("0.145.0") and above the previous one, as semver orders them.
 func newerCodexVersion(a, b string) string {
-	av, aok := parseDottedVersion(a)
-	bv, bok := parseDottedVersion(b)
+	av, apre, aok := parseDottedVersion(a)
+	bv, bpre, bok := parseDottedVersion(b)
 	switch {
 	case !aok:
 		return b
@@ -377,30 +387,35 @@ func newerCodexVersion(a, b string) string {
 			return b
 		}
 	}
+	if apre && !bpre {
+		return b
+	}
 	return a
 }
 
 // parseDottedVersion reads "0.144.6" / "v0.145.0-beta.1" into its numeric
-// components (a pre-release suffix is dropped from the component carrying
-// it). ok is false when any component is not a number.
-func parseDottedVersion(s string) ([]int, bool) {
+// components; pre reports a pre-release suffix, whose own parts are not
+// compared. ok is false when a numeric component is not a number.
+func parseDottedVersion(s string) (parts []int, pre bool, ok bool) {
 	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
 	if s == "" {
-		return nil, false
+		return nil, false, false
 	}
-	parts := strings.Split(s, ".")
-	out := make([]int, 0, len(parts))
-	for _, p := range parts {
+	for _, p := range strings.Split(s, ".") {
 		if i := strings.IndexAny(p, "-+"); i >= 0 {
 			p = p[:i]
+			pre = true
 		}
 		n, err := strconv.Atoi(p)
 		if err != nil {
-			return nil, false
+			return nil, false, false
 		}
-		out = append(out, n)
+		parts = append(parts, n)
+		if pre {
+			break
+		}
 	}
-	return out, true
+	return parts, pre, true
 }
 
 // Register adds a provider factory under the given name.

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -313,11 +314,14 @@ func withClientIdentity(cfg api.ProviderConfig) api.ProviderConfig {
 // codexCLIVersion resolves the Codex CLI version string to send in the
 // `version:` HTTP header when claw operates in ChatGPT-OAuth mode. OpenAI's
 // backend gates model availability on this value (e.g. gpt-5.5 requires
-// codex-cli >= 0.130). Resolution precedence:
-//  1. ITERION_CODEX_VERSION env var (operator override; lets a fresh-but-
-//     binary-stale environment claim newer model access)
-//  2. `codex --version` parsed at most once per process (cached)
-//  3. "" — claw-code-go falls back to its baked-in version string
+// codex-cli >= 0.130, gpt-6-astra >= 0.144). Resolution precedence:
+//  1. ITERION_CODEX_VERSION env var (operator override, sent as-is; lets a
+//     fresh-but-binary-stale environment claim newer model access)
+//  2. the newer of `codex --version` (parsed at most once per process) and
+//     claw's baked api.ChatGPTClientVersion — a stale codex binary on the
+//     host must not downgrade the identity below what claw alone would
+//     present (measured: a runner image shipping 0.139.0 was refused a
+//     model the 0.144.6 baseline is served)
 var (
 	codexVersionOnce   sync.Once
 	codexVersionCached string
@@ -343,7 +347,60 @@ func codexCLIVersion() string {
 		}
 		codexVersionCached = fields[len(fields)-1]
 	})
-	return codexVersionCached
+	return newerCodexVersion(codexVersionCached, api.ChatGPTClientVersion)
+}
+
+// newerCodexVersion returns the higher of two dotted numeric versions. A
+// side that does not parse loses; when neither parses, b (the baked value)
+// is returned.
+func newerCodexVersion(a, b string) string {
+	av, aok := parseDottedVersion(a)
+	bv, bok := parseDottedVersion(b)
+	switch {
+	case !aok:
+		return b
+	case !bok:
+		return a
+	}
+	for i := 0; i < len(av) || i < len(bv); i++ {
+		var x, y int
+		if i < len(av) {
+			x = av[i]
+		}
+		if i < len(bv) {
+			y = bv[i]
+		}
+		if x != y {
+			if x > y {
+				return a
+			}
+			return b
+		}
+	}
+	return a
+}
+
+// parseDottedVersion reads "0.144.6" / "v0.145.0-beta.1" into its numeric
+// components (a pre-release suffix is dropped from the component carrying
+// it). ok is false when any component is not a number.
+func parseDottedVersion(s string) ([]int, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	if s == "" {
+		return nil, false
+	}
+	parts := strings.Split(s, ".")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		if i := strings.IndexAny(p, "-+"); i >= 0 {
+			p = p[:i]
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
 }
 
 // Register adds a provider factory under the given name.

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/provider.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/provider.go
@@ -13,6 +13,14 @@ const (
 	AuthMethodAzureIdentity AuthMethod = "azure_identity" // Azure Managed Identity (Foundry)
 )
 
+// ChatGPTClientVersion is the codex-cli release claw presents on the
+// ChatGPT-Codex wire (`version:` header + User-Agent) when the caller passes
+// no OpenAIClientVersion. The backend gates model availability on it: a model
+// newer than the release claw claims is refused with "requires a newer
+// version of Codex" (measured 2026-09-07: gpt-6-astra refused at 0.139.0,
+// served at 0.144.6). Bump it when a new model line ships.
+const ChatGPTClientVersion = "0.144.6"
+
 // ProviderConfig holds the credentials and settings needed to create a provider client.
 type ProviderConfig struct {
 	APIKey     string // API key (Anthropic direct, Azure Foundry)
@@ -31,9 +39,9 @@ type ProviderConfig struct {
 	// OpenAIClientVersion is the version string sent in both the `version:`
 	// HTTP header and the User-Agent when the OpenAI provider operates in
 	// ChatGPT-OAuth mode. OpenAI's backend gates model availability on this
-	// value (e.g. gpt-5.5 requires codex-cli >= 0.130). Callers should pass
-	// the locally installed Codex CLI version. Empty defaults to a baseline
-	// version embedded in the provider.
+	// value (e.g. gpt-5.5 requires codex-cli >= 0.130). Callers that can
+	// probe a real Codex CLI should pass the newer of its version and
+	// ChatGPTClientVersion. Empty defaults to ChatGPTClientVersion.
 	OpenAIClientVersion string
 
 	// UserAgent overrides the User-Agent header sent on every request.

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/provider.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/provider.go
@@ -21,7 +21,7 @@ const (
 	defaultBaseURL         = "https://api.openai.com"
 	chatgptCodexBaseURL    = "https://chatgpt.com/backend-api/codex"
 	chatgptOriginator      = "codex_cli_rs"
-	chatgptFallbackVersion = "0.130.0"
+	chatgptFallbackVersion = api.ChatGPTClientVersion
 	DefaultOpenAIModel     = "gpt-5.5"
 )
 

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/types.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/types.go
@@ -1,6 +1,10 @@
 package api
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 // CacheControlMarker is the Anthropic prompt caching marker.
 // Set Type to "ephemeral" to enable caching up to this content block.
@@ -187,12 +191,83 @@ type InputSchema struct {
 // under any of the given schemas`. Anthropic's validator accepted the
 // malformed shape, which is why this only surfaced on OpenAI calls.
 type Property struct {
-	Type        string              `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
+	// Types keeps a JSON Schema `type` given as an array of alternatives
+	// (`["array","null"]`, or the six-kind union a schema generator emits for
+	// an untyped field). Type then holds the first non-null alternative so
+	// single-type consumers keep working, and the array round-trips on
+	// marshal. Empty for the common single-type property.
+	Types       []string            `json:"-"`
 	Description string              `json:"description,omitempty"`
 	Items       *Property           `json:"items,omitempty"`
 	Enum        []any               `json:"enum,omitempty"`
 	Properties  map[string]Property `json:"properties,omitempty"`
 	Required    []string            `json:"required,omitempty"`
+}
+
+// UnmarshalJSON accepts `type` as a string or as an array of strings. Both
+// are valid JSON Schema; a generator that spells "any value" as the union of
+// every kind must not be refused with an unmarshal error at request time.
+func (p *Property) UnmarshalJSON(data []byte) error {
+	type plain Property
+	var aux struct {
+		plain
+		Type json.RawMessage `json:"type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	typ, types, err := parseSchemaType(aux.Type)
+	if err != nil {
+		return err
+	}
+	*p = Property(aux.plain)
+	p.Type, p.Types = typ, types
+	return nil
+}
+
+// MarshalJSON writes the array form back when the property carried one.
+func (p Property) MarshalJSON() ([]byte, error) {
+	type plain Property
+	if len(p.Types) == 0 {
+		return json.Marshal(plain(p))
+	}
+	return json.Marshal(struct {
+		plain
+		Type []string `json:"type"`
+	}{plain(p), p.Types})
+}
+
+// parseSchemaType reads a JSON Schema `type` value: absent/null → empty; a
+// string → itself; an array of strings → the first non-null kind as the
+// scalar view plus the full list. Anything else is a schema error.
+func parseSchemaType(raw json.RawMessage) (string, []string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return "", nil, nil
+	}
+	switch trimmed[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return "", nil, err
+		}
+		return s, nil, nil
+	case '[':
+		var list []string
+		if err := json.Unmarshal(trimmed, &list); err != nil {
+			return "", nil, fmt.Errorf("json schema: type array must hold strings: %w", err)
+		}
+		first := ""
+		for _, t := range list {
+			if t != "null" {
+				first = t
+				break
+			}
+		}
+		return first, list, nil
+	}
+	return "", nil, fmt.Errorf("json schema: type must be a string or an array of strings, got %s", trimmed)
 }
 
 // ToolChoice controls which tool the model must use.

--- a/vendor/github.com/SocialGouv/claw-code-go/pkg/api/provider.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/pkg/api/provider.go
@@ -7,6 +7,11 @@ import (
 // ProviderConfig holds the credentials and settings needed to create a provider client.
 type ProviderConfig = api.ProviderConfig
 
+// ChatGPTClientVersion is the codex-cli release claw presents on the
+// ChatGPT-Codex wire when ProviderConfig.OpenAIClientVersion is empty; a
+// caller probing a real Codex CLI should send the newer of the two.
+const ChatGPTClientVersion = api.ChatGPTClientVersion
+
 // APIClient is the interface all provider clients must implement.
 type APIClient = api.APIClient
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
 # github.com/SherClockHolmes/webpush-go v1.4.0
 ## explicit; go 1.13
 github.com/SherClockHolmes/webpush-go
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260905191936-28eefe727f57
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
## Summary

Two claw-code-go fixes measured on a cloud campaign on 2026-09-07, vendored together (claw `332e0946` → `b6e34a39`):

1. **ChatGPT-Codex identity.** The backend gates model availability on the `version:` header. iterion resolved it from a host `codex --version` probe and let the probe win over claw's baked release, so a stale binary in an image downgraded every OAuth call. claw now exports the release it presents (`api.ChatGPTClientVersion`, 0.144.6); `codexCLIVersion()` returns the newer of the host probe and that release; `ITERION_CODEX_VERSION` stays an operator override sent as-is.
2. **JSON Schema `type` arrays.** iterion spells an untyped (`json`) output field as the union of every kind (`schema.go`), which is valid JSON Schema; claw's `Property.Type` was a plain string and refused it before any request. claw now reads a string or an array (scalar view = first non-null kind; the array round-trips).

## Measurement

- claw node on `openai/gpt-6-astra` through the ChatGPT forfait, runner image shipping codex-cli 0.139.0:
  `openai: API error 400: {"detail":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}` — the same model is served to a 0.144.6 header. `openai/gpt-5.6-sol` was unaffected.
- claw judge whose output schema carries a `json` field (the same schema every voter of `sec-audit-source` uses), any provider:
  `structured generation: parse ExplicitSchema: json: cannot unmarshal array into Go struct field InputSchema.properties.verdicts.type of type string` — the run parked at the judge; a judge has no run-level fallback to die into.

Side observation for a separate change: the first failure was redelivered and resumed 10 times in 80 s (one sandbox pod each) before the run parked — a deterministic provider 400 is not on the `retrypolicy` deterministic list.

## Test

- `TestNewerCodexVersion` (8 cases) and `TestCodexCLIVersion_HostNeverBelowBaked`; claw: `TestNewClient_ChatGPTOAuthDefaultsToBakedVersion`, `TestProperty_*` (5 tests: round-trip, null-first, nested, invalid, `{}` stays `{}`); claw full suite 2620 tests green.
- `go build ./...`, `go vet`, `go test ./pkg/backend/model/` green.

Note: #785 also bumps claw (to `28eefe7`, an ancestor of `b6e34a39`); whichever lands second re-runs `go mod vendor` — one-line go.mod conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
