### PR TITLE
fix(runview): list a run's artifacts from its artifact_index when the directory is not on this host

### DIFF
--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -2,6 +2,7 @@ package runview
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -114,13 +115,18 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 
 // listAllArtifactsFromIndex serves the listing from run.ArtifactIndex
 // (node id → latest version), which every store maintains on WriteArtifact.
-// Reached when no artifact directory exists on this host; an unknown run
-// is an empty list, like the directory walk.
+// Reached when no artifact directory exists on this host. An unknown run is
+// an empty list, like the directory walk; any other store failure is an
+// error, not an empty listing — on the cloud pod this fallback exists for,
+// a transient outage must not read as "this run published nothing".
 func (s *Service) listAllArtifactsFromIndex(runID string) ([]RunArtifactSummary, error) {
 	ctx := context.Background()
 	run, err := s.store.LoadRun(ctx, runID)
 	if err != nil {
-		return nil, nil
+		if errors.Is(err, store.ErrRunNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("runview: list artifacts: load run: %w", err)
 	}
 	out := make([]RunArtifactSummary, 0, len(run.ArtifactIndex))
 	for nodeID, version := range run.ArtifactIndex {

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -194,6 +194,14 @@ func (s *Service) listAllArtifactsFromIndex(ctx context.Context, runID string) (
 		entry := RunArtifactSummary{NodeID: nodeID, Version: version}
 		art, lerr := s.store.LoadArtifact(ctx, runID, nodeID, version)
 		if lerr != nil || art == nil {
+			// A cancelled or expired context is not a broken body: every
+			// remaining node would degrade for a reason that has nothing
+			// to do with what this run published, and a wholly degraded
+			// listing is the same lie about the store's state that the
+			// silent drop was. Surface it as the outage it is.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, fmt.Errorf("runview: list artifacts: %w", ctxErr)
+			}
 			s.logger.Warn("runview: run %s node %s v%d is in the artifact index but its body did not load, listing it degraded: %v",
 				runID, nodeID, version, lerr)
 		} else {

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -167,6 +167,19 @@ func (s *Service) ListAllArtifactsCtx(ctx context.Context, runID string) ([]RunA
 // listing — on the cloud pod this fallback exists for, a transient outage
 // must not read as "this run published nothing".
 //
+// The same reasoning one level down: an index entry is only ever written
+// AFTER the body was successfully persisted, so a body that will not load
+// is an outage or a lifecycle deletion, never a node that published
+// nothing. Dropping it would serve a partial listing as an authoritative
+// one — worse than the empty listing this fallback replaced, because it
+// looks complete. The entry is emitted DEGRADED instead (node id + the
+// indexed version, no labels or title) and logged: the studio already
+// falls back to the node id for a missing title, so the card renders and
+// still opens on the per-node endpoint, which reads the body itself.
+// Returning the error is not an option here — the mongo store answers an
+// untyped error for a body that is genuinely gone, so one lifecycle-
+// deleted blob would take down the whole Artifacts view for that run.
+//
 // ctx is the caller's, so the mongo tenant filter scopes the LoadRun.
 func (s *Service) listAllArtifactsFromIndex(ctx context.Context, runID string) ([]RunArtifactSummary, error) {
 	run, err := s.store.LoadRun(ctx, runID)
@@ -178,17 +191,18 @@ func (s *Service) listAllArtifactsFromIndex(ctx context.Context, runID string) (
 	}
 	out := make([]RunArtifactSummary, 0, len(run.ArtifactIndex))
 	for nodeID, version := range run.ArtifactIndex {
+		entry := RunArtifactSummary{NodeID: nodeID, Version: version}
 		art, lerr := s.store.LoadArtifact(ctx, runID, nodeID, version)
 		if lerr != nil || art == nil {
+			s.logger.Warn("runview: run %s node %s v%d is in the artifact index but its body did not load, listing it degraded: %v",
+				runID, nodeID, version, lerr)
+			out = append(out, entry)
 			continue
 		}
-		out = append(out, RunArtifactSummary{
-			NodeID:    nodeID,
-			Version:   version,
-			Labels:    art.Labels,
-			Title:     artifactTitle(art.Data),
-			WrittenAt: art.WrittenAt,
-		})
+		entry.Labels = art.Labels
+		entry.Title = artifactTitle(art.Data)
+		entry.WrittenAt = art.WrittenAt
+		out = append(out, entry)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })
 	return out, nil

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -67,10 +67,12 @@ type RunArtifactSummary struct {
 
 // ListAllArtifacts enumerates the latest published artifact per node for a
 // run — the data behind the centralized Artifacts view. It walks
-// runs/<id>/artifacts/*/ (filesystem store only; cloud mode returns an
-// empty list, mirroring ListArtifacts) and loads each node's latest
-// version to surface its labels + title. Sorted by node id for stable
-// rendering. Few artifacts per run, so the per-node body read is cheap.
+// runs/<id>/artifacts/*/ when the run's artifact directory is on this
+// host, and otherwise serves the run document's artifact_index (the case
+// of a cloud server pod: the directory lives on the runner that wrote it).
+// Each node's latest version is loaded to surface its labels + title.
+// Sorted by node id for stable rendering. Few artifacts per run, so the
+// per-node body read is cheap.
 func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 	if err := validatePathComponent("run ID", runID); err != nil {
 		return nil, err
@@ -79,7 +81,7 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 	nodes, err := os.ReadDir(root)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return s.listAllArtifactsFromIndex(runID)
 		}
 		return nil, fmt.Errorf("runview: list artifacts: %w", err)
 	}
@@ -104,6 +106,34 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 			Labels:    art.Labels,
 			Title:     artifactTitle(art.Data),
 			WrittenAt: latest.WrittenAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })
+	return out, nil
+}
+
+// listAllArtifactsFromIndex serves the listing from run.ArtifactIndex
+// (node id → latest version), which every store maintains on WriteArtifact.
+// Reached when no artifact directory exists on this host; an unknown run
+// is an empty list, like the directory walk.
+func (s *Service) listAllArtifactsFromIndex(runID string) ([]RunArtifactSummary, error) {
+	ctx := context.Background()
+	run, err := s.store.LoadRun(ctx, runID)
+	if err != nil {
+		return nil, nil
+	}
+	out := make([]RunArtifactSummary, 0, len(run.ArtifactIndex))
+	for nodeID, version := range run.ArtifactIndex {
+		art, lerr := s.store.LoadArtifact(ctx, runID, nodeID, version)
+		if lerr != nil || art == nil {
+			continue
+		}
+		out = append(out, RunArtifactSummary{
+			NodeID:    nodeID,
+			Version:   version,
+			Labels:    art.Labels,
+			Title:     artifactTitle(art.Data),
+			WrittenAt: art.WrittenAt,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -2,7 +2,6 @@ package runview
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -67,14 +66,26 @@ type RunArtifactSummary struct {
 }
 
 // ListAllArtifacts enumerates the latest published artifact per node for a
-// run — the data behind the centralized Artifacts view. It walks
-// runs/<id>/artifacts/*/ when the run's artifact directory is on this
+// run — the data behind the centralized Artifacts view.
+//
+// Uses context.Background with the mongo tenant filter explicitly
+// bypassed — it does NOT carry caller identity. The bypass is load-bearing,
+// not decoration: the index fallback below goes through LoadRun, whose
+// mongo implementation PANICS on a context carrying neither a tenant nor
+// this marker. Use ListAllArtifactsCtx from cloud HTTP handlers so the
+// tenant_id filter applies instead.
+func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
+	return s.ListAllArtifactsCtx(store.WithoutTenantFilter(context.Background()), runID)
+}
+
+// ListAllArtifactsCtx is the tenant-aware variant of ListAllArtifacts. It
+// walks runs/<id>/artifacts/*/ when the run's artifact directory is on this
 // host, and otherwise serves the run document's artifact_index (the case
 // of a cloud server pod: the directory lives on the runner that wrote it).
 // Each node's latest version is loaded to surface its labels + title.
 // Sorted by node id for stable rendering. Few artifacts per run, so the
 // per-node body read is cheap.
-func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
+func (s *Service) ListAllArtifactsCtx(ctx context.Context, runID string) ([]RunArtifactSummary, error) {
 	if err := validatePathComponent("run ID", runID); err != nil {
 		return nil, err
 	}
@@ -82,7 +93,7 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 	nodes, err := os.ReadDir(root)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return s.listAllArtifactsFromIndex(runID)
+			return s.listAllArtifactsFromIndex(ctx, runID)
 		}
 		return nil, fmt.Errorf("runview: list artifacts: %w", err)
 	}
@@ -97,7 +108,7 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 			continue
 		}
 		latest := versions[len(versions)-1]
-		art, lerr := s.LoadArtifact(runID, nodeID, latest.Version)
+		art, lerr := s.LoadArtifactCtx(ctx, runID, nodeID, latest.Version)
 		if lerr != nil || art == nil {
 			continue
 		}
@@ -115,15 +126,17 @@ func (s *Service) ListAllArtifacts(runID string) ([]RunArtifactSummary, error) {
 
 // listAllArtifactsFromIndex serves the listing from run.ArtifactIndex
 // (node id → latest version), which every store maintains on WriteArtifact.
-// Reached when no artifact directory exists on this host. An unknown run is
-// an empty list, like the directory walk; any other store failure is an
-// error, not an empty listing — on the cloud pod this fallback exists for,
-// a transient outage must not read as "this run published nothing".
-func (s *Service) listAllArtifactsFromIndex(runID string) ([]RunArtifactSummary, error) {
-	ctx := context.Background()
+// Reached when no artifact directory exists on this host. A run that is
+// absent — never existed, or tombstoned — is an empty list, like the
+// directory walk; any other store failure is an error, not an empty
+// listing — on the cloud pod this fallback exists for, a transient outage
+// must not read as "this run published nothing".
+//
+// ctx is the caller's, so the mongo tenant filter scopes the LoadRun.
+func (s *Service) listAllArtifactsFromIndex(ctx context.Context, runID string) ([]RunArtifactSummary, error) {
 	run, err := s.store.LoadRun(ctx, runID)
 	if err != nil {
-		if errors.Is(err, store.ErrRunNotFound) {
+		if store.RunAbsent(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("runview: list artifacts: load run: %w", err)

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -196,16 +196,47 @@ func (s *Service) listAllArtifactsFromIndex(ctx context.Context, runID string) (
 		if lerr != nil || art == nil {
 			s.logger.Warn("runview: run %s node %s v%d is in the artifact index but its body did not load, listing it degraded: %v",
 				runID, nodeID, version, lerr)
-			out = append(out, entry)
-			continue
+		} else {
+			entry.Labels = art.Labels
+			entry.Title = artifactTitle(art.Data)
+			entry.WrittenAt = art.WrittenAt
 		}
-		entry.Labels = art.Labels
-		entry.Title = artifactTitle(art.Data)
-		entry.WrittenAt = art.WrittenAt
+		if entry.WrittenAt.IsZero() {
+			entry.WrittenAt = s.artifactWrittenAt(ctx, runID, nodeID, version)
+		}
 		out = append(out, entry)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })
 	return out, nil
+}
+
+// artifactWrittenAt recovers a published artifact's timestamp when its own
+// body does not carry one.
+//
+// Only the FILESYSTEM store stamps Artifact.WrittenAt, and it does so on
+// write; the mongo store marshals the artifact exactly as handed to it, and
+// no engine writer sets the field. So on a cloud pod every entry of this
+// listing would otherwise serve `"written_at":"0001-01-01T00:00:00Z"` — an
+// epoch date for API clients, and a meaningless key for any date sort.
+//
+// The store's ListArtifactVersions is the store-agnostic answer: mongo
+// folds the artifact_written events, whose ts is real, so this also repairs
+// artifacts already written rather than only future ones. Best-effort — a
+// lookup failure leaves the zero time rather than failing a listing that is
+// otherwise complete. Guarded by the IsZero check at the call site, so the
+// filesystem path never pays for it.
+func (s *Service) artifactWrittenAt(ctx context.Context, runID, nodeID string, version int) time.Time {
+	versions, err := s.store.ListArtifactVersions(ctx, runID, nodeID)
+	if err != nil {
+		s.logger.Warn("runview: run %s node %s v%d: version lookup for a missing timestamp failed: %v", runID, nodeID, version, err)
+		return time.Time{}
+	}
+	for _, v := range versions {
+		if v.Version == version {
+			return v.WrittenAt
+		}
+	}
+	return time.Time{}
 }
 
 // artifactTitle picks a short human title from artifact data, or "".

--- a/pkg/runview/service_artifacts.go
+++ b/pkg/runview/service_artifacts.go
@@ -14,11 +14,22 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// ListArtifacts enumerates the persisted artifacts for one node by
-// reading the artifact directory directly — avoids the O(versions)
-// JSON-decode of the full bodies that LoadArtifact would do just to
-// extract the version number. Returns the versions in ascending order.
+// ListArtifacts enumerates the persisted artifacts for one node.
+//
+// Uses context.Background with the mongo tenant filter bypassed — it does
+// NOT carry caller identity. Use ListArtifactsCtx from cloud HTTP handlers
+// so the tenant_id filter applies.
 func (s *Service) ListArtifacts(runID, nodeID string) ([]ArtifactSummary, error) {
+	return s.ListArtifactsCtx(store.WithoutTenantFilter(context.Background()), runID, nodeID)
+}
+
+// ListArtifactsCtx is the tenant-aware variant of ListArtifacts. It reads
+// the node's artifact directory directly when it is on this host — which
+// avoids the O(versions) JSON-decode of the full bodies that LoadArtifact
+// would do just to extract the version number — and otherwise asks the
+// store, the case of a cloud server pod (the directory lives on the runner
+// that wrote it). Returns the versions in ascending order.
+func (s *Service) ListArtifactsCtx(ctx context.Context, runID, nodeID string) ([]ArtifactSummary, error) {
 	if err := validatePathComponent("run ID", runID); err != nil {
 		return nil, err
 	}
@@ -29,7 +40,7 @@ func (s *Service) ListArtifacts(runID, nodeID string) ([]ArtifactSummary, error)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return s.listArtifactVersionsFromStore(ctx, runID, nodeID)
 		}
 		return nil, fmt.Errorf("runview: list artifacts: %w", err)
 	}
@@ -48,6 +59,30 @@ func (s *Service) ListArtifacts(runID, nodeID string) ([]ArtifactSummary, error)
 			continue
 		}
 		out = append(out, ArtifactSummary{Version: v, WrittenAt: info.ModTime().UTC()})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
+	return out, nil
+}
+
+// listArtifactVersionsFromStore asks the store for a node's persisted
+// versions when the artifact directory is not on this host — the same
+// condition that sends the aggregate listing to the artifact index.
+//
+// Without it the per-node drill-in behind every card of that listing came
+// back empty, and the studio's version picker falls back to v1 for both
+// selectors (ArtifactDiff.tsx: `sorted[0]?.version ?? 1`). The engine's
+// first version is v0, so the common case answered 404 on expand and a
+// node whose latest is v3 rendered a stale v1. An empty version list here
+// means the node published nothing; a store failure is an error, never an
+// empty listing.
+func (s *Service) listArtifactVersionsFromStore(ctx context.Context, runID, nodeID string) ([]ArtifactSummary, error) {
+	versions, err := s.store.ListArtifactVersions(ctx, runID, nodeID)
+	if err != nil {
+		return nil, fmt.Errorf("runview: list artifacts: store versions: %w", err)
+	}
+	out := make([]ArtifactSummary, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, ArtifactSummary{Version: v.Version, WrittenAt: v.WrittenAt})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Version < out[j].Version })
 	return out, nil
@@ -103,7 +138,7 @@ func (s *Service) ListAllArtifactsCtx(ctx context.Context, runID string) ([]RunA
 			continue
 		}
 		nodeID := n.Name()
-		versions, verr := s.ListArtifacts(runID, nodeID)
+		versions, verr := s.ListArtifactsCtx(ctx, runID, nodeID)
 		if verr != nil || len(versions) == 0 {
 			continue
 		}

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -3,6 +3,7 @@ package runview
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -145,4 +146,105 @@ type failingRunStore struct{ store.RunStore }
 
 func (failingRunStore) LoadRun(context.Context, string) (*store.Run, error) {
 	return nil, errors.New("mongo: connection reset")
+}
+
+// tenantGuardedRunStore reproduces the mongo store's fail-closed tenant
+// guard (withTenantFilter, pkg/store/mongo/tenant.go): a LoadRun whose ctx
+// carries neither a tenant nor the explicit bypass marker PANICS. That is
+// the only faithful stand-in for the cloud server pod the index fallback
+// exists for — the fs-backed tests above cannot see the defect, because
+// the filesystem store ignores the context entirely.
+type tenantGuardedRunStore struct {
+	store.RunStore
+	wantTenant string
+}
+
+func (t tenantGuardedRunStore) LoadRun(ctx context.Context, id string) (*store.Run, error) {
+	if tenant, ok := store.TenantFromContext(ctx); ok && tenant != "" {
+		if tenant != t.wantTenant {
+			// What mongo answers a cross-tenant read: not-found, never a leak.
+			return nil, fmt.Errorf("run %s not found: %w", id, store.ErrRunNotFound)
+		}
+	} else if !store.IsWithoutTenantFilter(ctx) {
+		panic("store: tenant-scoped query without tenant in ctx (use store.WithoutTenantFilter to bypass)")
+	}
+	return t.RunStore.LoadRun(ctx, id)
+}
+
+// TestListAllArtifacts_FromIndexCarriesTenantContext pins the two halves of
+// the context contract on the index path: the exported context-free
+// ListAllArtifacts must reach LoadRun with the bypass marker (a bare
+// context.Background panics the mongo store — a 500 on the very host this
+// fallback targets), and ListAllArtifactsCtx must forward the caller's
+// tenant so a cross-tenant read gets nothing.
+func TestListAllArtifacts_FromIndexCarriesTenantContext(t *testing.T) {
+	logger := iterlog.Nop()
+	seed, err := store.New(t.TempDir(), store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := seed.CreateRun(ctx, "run3", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run3", NodeID: "report", Version: 0, Data: map[string]any{"title": "R"}}); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	// storeDir holds no artifact directory for the run → the index path.
+	svc, err := NewService(t.TempDir(), WithLogger(logger),
+		WithStore(tenantGuardedRunStore{RunStore: seed, wantTenant: "team-a"}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	// The context-free wrapper: must not panic, and must serve the listing.
+	got, err := svc.ListAllArtifacts("run3")
+	if err != nil {
+		t.Fatalf("ListAllArtifacts: %v", err)
+	}
+	if len(got) != 1 || got[0].NodeID != "report" {
+		t.Errorf("context-free listing = %+v, want the report node", got)
+	}
+
+	// The tenant-aware variant with the owning tenant: same listing.
+	got, err = svc.ListAllArtifactsCtx(store.WithTenant(ctx, "team-a"), "run3")
+	if err != nil {
+		t.Fatalf("ListAllArtifactsCtx(team-a): %v", err)
+	}
+	if len(got) != 1 || got[0].NodeID != "report" {
+		t.Errorf("tenant listing = %+v, want the report node", got)
+	}
+
+	// Another tenant: the store answers not-found, which is an empty
+	// listing, not an error.
+	other, err := svc.ListAllArtifactsCtx(store.WithTenant(ctx, "team-b"), "run3")
+	if err != nil || len(other) != 0 {
+		t.Errorf("cross-tenant listing = %+v, %v; want empty, nil", other, err)
+	}
+}
+
+// deletedRunStore returns the tombstone error mongo answers for a run that
+// was deleted — distinct from ErrRunNotFound, and just as much an absence.
+type deletedRunStore struct{ store.RunStore }
+
+func (deletedRunStore) LoadRun(_ context.Context, id string) (*store.Run, error) {
+	return nil, fmt.Errorf("run %s: %w", id, store.ErrRunDeleted)
+}
+
+// A tombstoned run is absent, not an outage: it must list empty rather
+// than 500. errors.Is(err, ErrRunNotFound) alone misses this — hence
+// store.RunAbsent.
+func TestListAllArtifacts_FromIndexDeletedRunIsEmpty(t *testing.T) {
+	real, err := store.New(t.TempDir(), store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	svc, err := NewService(t.TempDir(), WithLogger(iterlog.Nop()), WithStore(deletedRunStore{RunStore: real}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	got, err := svc.ListAllArtifacts("gone")
+	if err != nil || len(got) != 0 {
+		t.Errorf("deleted run: got %+v, %v; want empty, nil", got, err)
+	}
 }

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -2,6 +2,7 @@ package runview
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -119,4 +120,29 @@ func TestListAllArtifacts_FromIndexWhenNoDirectory(t *testing.T) {
 	if err != nil || len(empty) != 0 {
 		t.Errorf("unknown run: got %v, %v; want empty, nil", empty, err)
 	}
+}
+
+// A store failure that is not "unknown run" must surface as an error: an
+// empty listing would read as "nothing published" on exactly the host the
+// index fallback exists for.
+func TestListAllArtifacts_FromIndexStoreFailureIsAnError(t *testing.T) {
+	real, err := store.New(t.TempDir(), store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	svc, err := NewService(t.TempDir(), WithLogger(iterlog.Nop()), WithStore(failingRunStore{RunStore: real}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if _, err := svc.ListAllArtifacts("run-any"); err == nil {
+		t.Fatal("a store outage must not be reported as an empty listing")
+	}
+}
+
+// failingRunStore is a real store whose LoadRun fails with a non-not-found
+// error (an outage), the shape the index fallback must not swallow.
+type failingRunStore struct{ store.RunStore }
+
+func (failingRunStore) LoadRun(context.Context, string) (*store.Run, error) {
+	return nil, errors.New("mongo: connection reset")
 }

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -217,6 +218,63 @@ type failingRunStore struct{ store.RunStore }
 
 func (failingRunStore) LoadRun(context.Context, string) (*store.Run, error) {
 	return nil, errors.New("mongo: connection reset")
+}
+
+// zeroWrittenAtStore is a real store whose artifact bodies carry no
+// timestamp — the mongo shape. Only the filesystem store stamps
+// Artifact.WrittenAt (on write); mongo marshals the artifact as handed to
+// it, and no engine writer sets the field.
+type zeroWrittenAtStore struct{ store.RunStore }
+
+func (z zeroWrittenAtStore) LoadArtifact(ctx context.Context, runID, nodeID string, version int) (*store.Artifact, error) {
+	art, err := z.RunStore.LoadArtifact(ctx, runID, nodeID, version)
+	if err != nil || art == nil {
+		return art, err
+	}
+	art.WrittenAt = time.Time{}
+	return art, nil
+}
+
+// TestListAllArtifacts_FromIndexRecoversWrittenAt: the directory walk takes
+// WrittenAt from the file mtime, which is always real. The index path takes
+// it from the body, which on every non-filesystem store is the zero time —
+// so the listing would serve an epoch date for every entry. It must be
+// recovered from the store's version enumeration instead.
+func TestListAllArtifacts_FromIndexRecoversWrittenAt(t *testing.T) {
+	logger := iterlog.Nop()
+	seed, err := store.New(t.TempDir(), store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := seed.CreateRun(ctx, "run6", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run6", NodeID: "report", Version: 1, Data: map[string]any{"title": "R"}}); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	want, err := seed.ListArtifactVersions(ctx, "run6", "report")
+	if err != nil || len(want) != 1 {
+		t.Fatalf("seed versions: %+v, %v", want, err)
+	}
+
+	svc, err := NewService(t.TempDir(), WithLogger(logger), WithStore(zeroWrittenAtStore{RunStore: seed}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	got, err := svc.ListAllArtifacts("run6")
+	if err != nil {
+		t.Fatalf("ListAllArtifacts: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d entries, want 1: %+v", len(got), got)
+	}
+	if got[0].WrittenAt.IsZero() {
+		t.Fatal("written_at is the zero time — the listing serves an epoch date for every cloud artifact")
+	}
+	if !got[0].WrittenAt.Equal(want[0].WrittenAt) {
+		t.Errorf("written_at = %v, want the store's %v", got[0].WrittenAt, want[0].WrittenAt)
+	}
 }
 
 // unreadableBodyStore is a real store whose artifact BODIES will not load,

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -70,3 +70,53 @@ func TestListAllArtifacts(t *testing.T) {
 		t.Errorf("unknown run returned %d artifacts, want 0", len(empty))
 	}
 }
+
+// TestListAllArtifacts_FromIndexWhenNoDirectory is the cloud shape: the
+// server pod has no runs/<id>/artifacts directory (the runner that wrote
+// the artifacts has it), but the run document carries artifact_index and
+// the store can load every version. The listing must come from there
+// instead of reading as an empty run.
+func TestListAllArtifacts_FromIndexWhenNoDirectory(t *testing.T) {
+	storeRoot := t.TempDir()
+	logger := iterlog.Nop()
+	seed, err := store.New(storeRoot, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := seed.CreateRun(ctx, "run2", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	for _, v := range []int{0, 1} {
+		if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run2", NodeID: "report", Version: v, Labels: []string{"report"}, Data: map[string]any{"title": "Report v" + string(rune('0'+v))}}); err != nil {
+			t.Fatalf("write artifact v%d: %v", v, err)
+		}
+	}
+	if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run2", NodeID: "verdict", Version: 0, Data: map[string]any{"ok": true}}); err != nil {
+		t.Fatalf("write verdict: %v", err)
+	}
+
+	// A service whose storeDir holds NO artifact directory for the run,
+	// backed by the store that does know the run.
+	svc, err := NewService(t.TempDir(), WithLogger(logger), WithStore(seed))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	got, err := svc.ListAllArtifacts("run2")
+	if err != nil {
+		t.Fatalf("ListAllArtifacts: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d artifacts, want 2 (from artifact_index): %+v", len(got), got)
+	}
+	if got[0].NodeID != "report" || got[0].Version != 1 || got[0].Title != "Report v1" || len(got[0].Labels) != 1 {
+		t.Errorf("report: %+v, want the latest version with its label and title", got[0])
+	}
+	if got[1].NodeID != "verdict" || got[1].Version != 0 {
+		t.Errorf("verdict: %+v", got[1])
+	}
+	empty, err := svc.ListAllArtifacts("unknown")
+	if err != nil || len(empty) != 0 {
+		t.Errorf("unknown run: got %v, %v; want empty, nil", empty, err)
+	}
+}

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -327,6 +327,36 @@ func TestListAllArtifacts_FromIndexDegradesUnreadableBody(t *testing.T) {
 	}
 }
 
+// A cancelled context is an outage, not a run whose every artifact body is
+// broken: degrading the whole listing would tell the caller the same lie
+// the silent drop did, only louder.
+func TestListAllArtifacts_FromIndexCancelledContextIsAnError(t *testing.T) {
+	logger := iterlog.Nop()
+	seed, err := store.New(t.TempDir(), store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	if _, err := seed.CreateRun(context.Background(), "run7", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	if err := seed.WriteArtifact(context.Background(), &store.Artifact{RunID: "run7", NodeID: "report", Version: 0, Data: map[string]any{"title": "R"}}); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+	svc, err := NewService(t.TempDir(), WithLogger(logger), WithStore(unreadableBodyStore{RunStore: seed}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	ctx, cancel := context.WithCancel(store.WithoutTenantFilter(context.Background()))
+	cancel()
+	got, err := svc.ListAllArtifactsCtx(ctx, "run7")
+	if err == nil {
+		t.Fatalf("cancelled context served %+v; want an error, not a wholly degraded listing", got)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want it to wrap context.Canceled", err)
+	}
+}
+
 // tenantGuardedRunStore reproduces the mongo store's fail-closed tenant
 // guard (withTenantFilter, pkg/store/mongo/tenant.go): a LoadRun whose ctx
 // carries neither a tenant nor the explicit bypass marker PANICS. That is

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -219,6 +219,56 @@ func (failingRunStore) LoadRun(context.Context, string) (*store.Run, error) {
 	return nil, errors.New("mongo: connection reset")
 }
 
+// unreadableBodyStore is a real store whose artifact BODIES will not load,
+// while the run document (and so its artifact_index) still does — a
+// transient blob outage, or a body a lifecycle rule deleted out from under
+// a live index entry.
+type unreadableBodyStore struct{ store.RunStore }
+
+func (unreadableBodyStore) LoadArtifact(context.Context, string, string, int) (*store.Artifact, error) {
+	return nil, errors.New("s3: connection reset")
+}
+
+// TestListAllArtifacts_FromIndexDegradesUnreadableBody: an index entry is
+// only ever written after its body was persisted, so a body that will not
+// load is an outage — never "this node published nothing". Dropping the
+// node would serve a PARTIAL listing as an authoritative one, which is
+// worse than the empty listing this fallback replaced because it looks
+// complete. The node must still be listed, at its indexed version.
+func TestListAllArtifacts_FromIndexDegradesUnreadableBody(t *testing.T) {
+	logger := iterlog.Nop()
+	seed, err := store.New(t.TempDir(), store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := seed.CreateRun(ctx, "run5", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	for _, n := range []string{"planner", "reviewer"} {
+		if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run5", NodeID: n, Version: 2, Data: map[string]any{"title": n}}); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	svc, err := NewService(t.TempDir(), WithLogger(logger), WithStore(unreadableBodyStore{RunStore: seed}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	got, err := svc.ListAllArtifacts("run5")
+	if err != nil {
+		t.Fatalf("ListAllArtifacts: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want both nodes listed degraded: %+v", len(got), got)
+	}
+	if got[0].NodeID != "planner" || got[0].Version != 2 || got[1].NodeID != "reviewer" || got[1].Version != 2 {
+		t.Errorf("degraded entries = %+v, want planner v2 and reviewer v2 from the index", got)
+	}
+	if got[0].Title != "" || len(got[0].Labels) != 0 {
+		t.Errorf("degraded entry invented body-derived fields: %+v", got[0])
+	}
+}
+
 // tenantGuardedRunStore reproduces the mongo store's fail-closed tenant
 // guard (withTenantFilter, pkg/store/mongo/tenant.go): a LoadRun whose ctx
 // carries neither a tenant nor the explicit bypass marker PANICS. That is

--- a/pkg/runview/service_artifacts_test.go
+++ b/pkg/runview/service_artifacts_test.go
@@ -140,6 +140,77 @@ func TestListAllArtifacts_FromIndexStoreFailureIsAnError(t *testing.T) {
 	}
 }
 
+// TestListArtifacts_FromStoreWhenNoDirectory is the drill-in half of the
+// cloud shape: each card of the aggregate listing expands into a per-node
+// version list, which the studio uses to pick which versions to fetch. On a
+// server pod the node's artifact directory is on the runner, so reading it
+// locally yields nothing — and an empty list pins BOTH of the studio's
+// version selectors to v1 (ArtifactDiff.tsx `sorted[0]?.version ?? 1`),
+// which 404s for the engine's first version (v0) and silently renders a
+// stale v1 for a node whose latest is v3. The store must answer instead.
+func TestListArtifacts_FromStoreWhenNoDirectory(t *testing.T) {
+	logger := iterlog.Nop()
+	seed, err := store.New(t.TempDir(), store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := seed.CreateRun(ctx, "run4", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	for _, v := range []int{0, 3} {
+		if err := seed.WriteArtifact(ctx, &store.Artifact{RunID: "run4", NodeID: "report", Version: v, Data: map[string]any{"v": v}}); err != nil {
+			t.Fatalf("write artifact v%d: %v", v, err)
+		}
+	}
+	// storeDir holds no artifact directory for the run — the cloud pod.
+	svc, err := NewService(t.TempDir(), WithLogger(logger), WithStore(seed))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	got, err := svc.ListArtifacts("run4", "report")
+	if err != nil {
+		t.Fatalf("ListArtifacts: %v", err)
+	}
+	if len(got) != 2 || got[0].Version != 0 || got[1].Version != 3 {
+		t.Fatalf("versions = %+v, want v0 and v3 ascending (an empty list pins the studio to v1)", got)
+	}
+	if got[0].WrittenAt.IsZero() || got[1].WrittenAt.IsZero() {
+		t.Errorf("versions carry no timestamp: %+v", got)
+	}
+
+	// A node that genuinely published nothing is still an empty list, not
+	// an error — the studio renders an empty state for it.
+	none, err := svc.ListArtifacts("run4", "never-ran")
+	if err != nil || len(none) != 0 {
+		t.Errorf("unpublished node: got %+v, %v; want empty, nil", none, err)
+	}
+}
+
+// failingVersionsStore is a real store whose ListArtifactVersions fails —
+// the outage shape the drill-in must surface rather than render as "this
+// node published nothing".
+type failingVersionsStore struct{ store.RunStore }
+
+func (failingVersionsStore) ListArtifactVersions(context.Context, string, string) ([]store.ArtifactVersionInfo, error) {
+	return nil, errors.New("s3: connection reset")
+}
+
+func TestListArtifacts_FromStoreFailureIsAnError(t *testing.T) {
+	real, err := store.New(t.TempDir(), store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	svc, err := NewService(t.TempDir(), WithLogger(iterlog.Nop()), WithStore(failingVersionsStore{RunStore: real}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if _, err := svc.ListArtifacts("run-any", "report"); err == nil {
+		t.Fatal("a store outage must not be reported as an empty version list")
+	}
+}
+
 // failingRunStore is a real store whose LoadRun fails with a non-not-found
 // error (an outage), the shape the index fallback must not swallow.
 type failingRunStore struct{ store.RunStore }

--- a/pkg/server/runs_artifacts.go
+++ b/pkg/server/runs_artifacts.go
@@ -27,7 +27,7 @@ func (s *Server) handleListAllArtifacts(w http.ResponseWriter, r *http.Request) 
 		s.httpErrorFor(w, r, http.StatusNotFound, "run not found: %v", err)
 		return
 	}
-	out, err := s.runs.ListAllArtifacts(id)
+	out, err := s.runs.ListAllArtifactsCtx(r.Context(), id)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "list artifacts: %v", err)
 		return

--- a/pkg/server/runs_artifacts.go
+++ b/pkg/server/runs_artifacts.go
@@ -53,7 +53,7 @@ func (s *Server) handleListArtifacts(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusNotFound, "run not found: %v", err)
 		return
 	}
-	out, err := s.runs.ListArtifacts(id, node)
+	out, err := s.runs.ListArtifactsCtx(r.Context(), id, node)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "list artifacts: %v", err)
 		return

--- a/pkg/server/runs_artifacts_test.go
+++ b/pkg/server/runs_artifacts_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestArtifactEndpointsWithoutLocalDirectory is the cloud server pod at the
+// HTTP surface: the run and its artifacts live in the shared store, but the
+// pod's own store directory has no runs/<id>/artifacts tree (the runner that
+// wrote them has it). Both artifact endpoints must serve from the store —
+// the aggregate listing from the run's artifact_index, and the per-node
+// version list the studio drills into from the store's version enumeration.
+// Serving either as empty is what made the Artifacts view read as "this run
+// published nothing", or its cards fail to open.
+func TestArtifactEndpointsWithoutLocalDirectory(t *testing.T) {
+	srv, hs := newTestServer(t)
+
+	// The shared store the run actually lives in — a different root from
+	// the service's own store directory, which is what makes the local
+	// artifact directory absent.
+	shared, err := store.New(t.TempDir(), store.WithLogger(iterlog.New(iterlog.LevelError, os.Stderr)))
+	if err != nil {
+		t.Fatalf("shared store: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := shared.CreateRun(ctx, "cloudrun", "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for _, v := range []int{0, 3} {
+		if err := shared.WriteArtifact(ctx, &store.Artifact{
+			RunID: "cloudrun", NodeID: "report", Version: v,
+			Labels: []string{"plan"}, Data: map[string]any{"title": "Migration plan"},
+		}); err != nil {
+			t.Fatalf("WriteArtifact v%d: %v", v, err)
+		}
+	}
+
+	// The service's own store directory is a fresh, empty tree — so every
+	// artifact read must go through the injected shared store, exactly as
+	// on a pod that never wrote these files.
+	stopRunviewOnCleanup(t, srv.runs) // the one newTestServer built, now replaced
+	srv.runs = newTestRunviewService(t, t.TempDir(),
+		runview.WithLogger(iterlog.New(iterlog.LevelError, os.Stderr)),
+		runview.WithStore(shared))
+
+	// The aggregate listing: one card for the report node, at its latest
+	// version — not an empty list.
+	var all struct {
+		Artifacts []runview.RunArtifactSummary `json:"artifacts"`
+	}
+	getJSON(t, hs.URL+"/api/runs/cloudrun/artifacts", &all)
+	if len(all.Artifacts) != 1 {
+		t.Fatalf("aggregate listing = %+v, want 1 entry", all.Artifacts)
+	}
+	if all.Artifacts[0].NodeID != "report" || all.Artifacts[0].Version != 3 {
+		t.Errorf("aggregate entry = %+v, want report v3", all.Artifacts[0])
+	}
+
+	// The per-node drill-in behind that card: both versions, so the studio
+	// picker cannot fall back to a v1 that does not exist.
+	var versions struct {
+		Artifacts []runview.ArtifactSummary `json:"artifacts"`
+	}
+	getJSON(t, hs.URL+"/api/runs/cloudrun/artifacts/report", &versions)
+	if len(versions.Artifacts) != 2 || versions.Artifacts[0].Version != 0 || versions.Artifacts[1].Version != 3 {
+		t.Fatalf("version list = %+v, want v0 and v3", versions.Artifacts)
+	}
+}
+
+// getJSON performs a GET, asserts 200, and decodes the body into out.
+func getJSON(t *testing.T, url string, out any) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, want 200", url, resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		t.Fatalf("decode %s: %v", url, err)
+	}
+}


### PR DESCRIPTION
## Summary

`ListAllArtifacts` walked `runs/<id>/artifacts` on the local filesystem and returned an empty list when the directory was absent — which is every run on a cloud server pod, since the directory lives on the runner that wrote it. The studio's centralized Artifacts view and `GET /api/runs/{id}/artifacts` were therefore empty in cloud while the per-node routes served the bodies.

Every store maintains `run.artifact_index` (node id → latest version) on `WriteArtifact`; when no directory exists on this host, the listing is served from it and each latest version is loaded for its labels and title. An unknown run stays an empty list.

## Measurement

Cloud run, 2026-09-07: events carried two `artifact_written` entries (one with `publish: toolchain_report`); `GET /api/runs/{id}/artifacts` → `{"artifacts": []}`; `GET /api/runs/{id}/artifacts/toolchain/0` → the body.

## Test

`TestListAllArtifacts_FromIndexWhenNoDirectory`: a service whose storeDir holds no artifact directory, backed by a store that wrote two nodes (one with two versions) — the listing returns both latest versions with labels and title; an unknown run returns empty. Existing `TestListAllArtifacts` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
