### PR TITLE
fix(recovery): a provider refusing the model parks the run instead of being redelivered

### DIFF
--- a/cmd/iterion/claw_runner.go
+++ b/cmd/iterion/claw_runner.go
@@ -175,9 +175,7 @@ func runClawRunner(ctx context.Context, stdin io.Reader, stdout, stderr io.Write
 	}
 
 	ioRes := delegate.ToIOResult(result)
-	if err != nil {
-		ioRes.Error = err.Error()
-	}
+	delegate.StampIOError(&ioRes, err)
 	resultEnv, marshalErr := delegate.NewResultEnvelope(ioRes)
 	if marshalErr != nil {
 		return emitFatal(dispatcher, stderr, marshalErr)

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -103,7 +103,7 @@ Being one of the engine's own codes does not make a verdict re-decidable.
 checkpoint that does not move), `CONTEXT_LENGTH_EXCEEDED` (the in-node
 recipe already compacted twice and gave up; a resume rehydrates the same
 conversation), `IR_UNLOADABLE`, `WORKSPACE_SAFETY`,
-`TOOL_FAILED_PERMANENT` and their peers reach the same verdict on every
+`TOOL_FAILED_PERMANENT`, `MODEL_UNAVAILABLE` and their peers reach the same verdict on every
 attempt. Which codes those are is **one table**,
 [`pkg/retrypolicy`'s classification](../pkg/retrypolicy/classify.go), read
 by every surface that decides "resume this failure automatically": the

--- a/pkg/backend/delegate/classify.go
+++ b/pkg/backend/delegate/classify.go
@@ -75,7 +75,14 @@ type ErrModelUnavailable struct {
 	// unavailability may clear. Reserved for ADR-087 stage 3; callers must
 	// fail open when it is zero.
 	ResetAt time.Time
+	// Cause is the upstream error the refusal was recognised in (the typed
+	// *api.APIError in-process, the runner exit across the sandbox IPC), kept
+	// reachable for errors.As / errors.Is consumers.
+	Cause error
 }
+
+// Unwrap exposes Cause to errors.Is / errors.As.
+func (e *ErrModelUnavailable) Unwrap() error { return e.Cause }
 
 func (e *ErrModelUnavailable) Error() string {
 	msg := "model unavailable"

--- a/pkg/backend/delegate/io.go
+++ b/pkg/backend/delegate/io.go
@@ -2,6 +2,7 @@ package delegate
 
 import (
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/plugin"
@@ -118,6 +119,43 @@ type IOResult struct {
 	PendingConversation json.RawMessage `json:"pending_conversation,omitempty"`
 	PendingToolUseID    string          `json:"pending_tool_use_id,omitempty"`
 	Error               string          `json:"error,omitempty"`
+	// ErrorKind names the typed class of Error when the runner recognised
+	// one (IOErrorKindModelUnavailable today). Error alone is flattened
+	// text; the launcher rebuilds the typed error from this field so the
+	// engine classifies the failure the way an in-process node would.
+	ErrorKind string `json:"error_kind,omitempty"`
+	// ErrorModel is the model id the provider refused (ErrorKind
+	// IOErrorKindModelUnavailable).
+	ErrorModel string `json:"error_model,omitempty"`
+}
+
+// IOErrorKindModelUnavailable is the ErrorKind of a provider refusing the
+// requested model to the run's credential.
+const IOErrorKindModelUnavailable = "model_unavailable"
+
+// StampIOError records err on r for the IPC: the flattened text always, and
+// the typed class when the runner can name one.
+func StampIOError(r *IOResult, err error) {
+	if err == nil {
+		return
+	}
+	r.Error = err.Error()
+	var unavailable *ErrModelUnavailable
+	if errors.As(err, &unavailable) {
+		r.ErrorKind = IOErrorKindModelUnavailable
+		r.ErrorModel = unavailable.Model
+	}
+}
+
+// TypedIOError rebuilds the typed error a runner stamped on r, wrapping
+// cause (typically the runner process exit) so it stays reachable. Nil
+// when the envelope carries no recognised kind.
+func TypedIOError(r IOResult, cause error) error {
+	switch r.ErrorKind {
+	case IOErrorKindModelUnavailable:
+		return &ErrModelUnavailable{Provider: BackendClaw, Model: r.ErrorModel, Detail: r.Error, Cause: cause}
+	}
+	return nil
 }
 
 // ToIOTask converts a [Task] to its wire form. The Sandbox handle and

--- a/pkg/backend/delegate/io_error_test.go
+++ b/pkg/backend/delegate/io_error_test.go
@@ -1,0 +1,54 @@
+package delegate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// The typed class a runner recognised must survive the IPC envelope as the
+// same typed error on the launcher side, with the process exit reachable.
+func TestStampIOError_TypedClassRoundTrips(t *testing.T) {
+	var r IOResult
+	StampIOError(&r, fmt.Errorf("claw backend: %w", &ErrModelUnavailable{Provider: "claw/openai", Model: "openai/gpt-6-astra", Detail: "requires a newer version of Codex"}))
+	if r.ErrorKind != IOErrorKindModelUnavailable || r.ErrorModel != "openai/gpt-6-astra" || r.Error == "" {
+		t.Fatalf("stamped envelope = %+v", r)
+	}
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back IOResult
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+	exit := errors.New("exit status 1")
+	typed := TypedIOError(back, exit)
+	var unavailable *ErrModelUnavailable
+	if !errors.As(typed, &unavailable) {
+		t.Fatalf("got %T (%v), want *ErrModelUnavailable", typed, typed)
+	}
+	if unavailable.Model != "openai/gpt-6-astra" || unavailable.Detail != r.Error || unavailable.Provider != BackendClaw {
+		t.Errorf("rebuilt error = %+v", unavailable)
+	}
+	if !errors.Is(typed, exit) {
+		t.Errorf("the runner exit must stay reachable: %v", typed)
+	}
+}
+
+func TestStampIOError_PlainErrorHasNoKind(t *testing.T) {
+	var r IOResult
+	StampIOError(&r, errors.New("boom"))
+	if r.Error != "boom" || r.ErrorKind != "" || r.ErrorModel != "" {
+		t.Errorf("plain error stamped as %+v", r)
+	}
+	if got := TypedIOError(r, nil); got != nil {
+		t.Errorf("no kind must rebuild nothing, got %v", got)
+	}
+	var untouched IOResult
+	StampIOError(&untouched, nil)
+	if untouched.Error != "" {
+		t.Errorf("nil error must leave the envelope untouched: %+v", untouched)
+	}
+}

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -199,6 +199,63 @@ func NewClawBackend(registry *Registry, hk EventHooks, retry RetryPolicy, opts .
 // [delegate.IOTask] and in docs/sandbox.md: no MCP servers, no
 // mid-tool-loop ask_user resume.
 func (b *ClawBackend) Execute(ctx context.Context, task delegate.Task) (delegate.Result, error) {
+	res, err := b.execute(ctx, task)
+	if err != nil {
+		err = withModelRefusal(err, task.Model)
+	}
+	return res, err
+}
+
+// withModelRefusal recognises a provider refusing the requested model in
+// the typed *api.APIError claw surfaces and returns it as the engine's
+// *delegate.ErrModelUnavailable (deterministic for this credential/model
+// pair), wrapping the original. Any other error is returned unchanged.
+func withModelRefusal(err error, model string) error {
+	var already *delegate.ErrModelUnavailable
+	if errors.As(err, &already) {
+		return err
+	}
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) || !isModelRefusal(apiErr) {
+		return err
+	}
+	return &delegate.ErrModelUnavailable{Provider: delegate.BackendClaw + "/" + apiErr.Provider, Model: model, Detail: apiErr.Message, Cause: err}
+}
+
+// modelRefusalNeedles are the wordings providers use when the requested
+// model cannot be served to the caller: OpenAI's model_not_found /
+// "does not exist", the ChatGPT-Codex "requires a newer version of Codex"
+// (measured 2026-09-07), Anthropic's not_found_error on a model id.
+var modelRefusalNeedles = []string{
+	"requires a newer version",
+	"model_not_found",
+	"model not found",
+	"no such model",
+	"unknown model",
+	"invalid model",
+	"not_found_error",
+	"does not exist",
+	"is not available",
+	"not supported",
+}
+
+// isModelRefusal reports whether a 400/404 carries one of the model
+// refusal wordings. Other statuses (401/403 auth, 429 windows, 5xx) keep
+// their own classification.
+func isModelRefusal(e *api.APIError) bool {
+	if e == nil || (e.StatusCode != 400 && e.StatusCode != 404) {
+		return false
+	}
+	msg := strings.ToLower(e.Message)
+	for _, needle := range modelRefusalNeedles {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *ClawBackend) execute(ctx context.Context, task delegate.Task) (delegate.Result, error) {
 	// Carry the resolved compression mode + rewriter chain into the tool loop
 	// so the bash builtin can compress command output (rewrite via context).
 	// Off is a no-op. For the sandboxed path the mode + chain specs ride the
@@ -1016,6 +1073,12 @@ func (b *ClawBackend) executeViaSandboxRunner(ctx context.Context, task delegate
 		return delegate.Result{}, fmt.Errorf("claw backend: runner exited with error: %w (stderr: %s)", waitErr, stderrBuf.String())
 	}
 	if ioRes.Error != "" {
+		// A typed class the runner stamped survives the IPC as the same
+		// typed error an in-process node would surface, so the engine
+		// parks a deterministic refusal instead of redelivering it.
+		if typed := delegate.TypedIOError(ioRes, waitErr); typed != nil {
+			return delegate.FromIOResult(ioRes), fmt.Errorf("claw backend: runner: %w", typed)
+		}
 		// Preserve waitErr for errors.Is / errors.As consumers when
 		// the runner emitted a structured error AND exited non-zero
 		// (the normal error path). Without %w on waitErr, downstream

--- a/pkg/backend/model/claw_model_refusal_test.go
+++ b/pkg/backend/model/claw_model_refusal_test.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+)
+
+// The ChatGPT-Codex backend refuses a model to a client it deems too old
+// with an HTTP 400 (measured 2026-09-07); Anthropic refuses an unknown model
+// id with a 404 not_found_error. Both are deterministic for the credential
+// and must surface as the engine's typed ErrModelUnavailable, with the
+// original APIError still reachable.
+func TestWithModelRefusal(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *api.APIError
+	}{
+		{"chatgpt-codex client too old", &api.APIError{Provider: "openai", StatusCode: 400, Message: `{"detail":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}`}},
+		{"openai model_not_found", &api.APIError{Provider: "openai", StatusCode: 404, Message: `{"error":{"message":"The model 'gpt-99' does not exist or you do not have access to it.","type":"invalid_request_error","code":"model_not_found"}}`}},
+		{"anthropic not_found_error", &api.APIError{Provider: "anthropic", StatusCode: 404, Message: `{"type":"error","error":{"type":"not_found_error","message":"model: claude-nope"}}`}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("claw backend: structured generation: %w", c.err)
+			got := withModelRefusal(wrapped, "some/model")
+			var unavailable *delegate.ErrModelUnavailable
+			if !errors.As(got, &unavailable) {
+				t.Fatalf("got %T (%v), want *delegate.ErrModelUnavailable", got, got)
+			}
+			if unavailable.Model != "some/model" || unavailable.Provider != "claw/"+c.err.Provider || unavailable.Detail != c.err.Message {
+				t.Errorf("typed error = %+v", unavailable)
+			}
+			var apiErr *api.APIError
+			if !errors.As(got, &apiErr) || apiErr != c.err {
+				t.Errorf("the original APIError must stay reachable through Cause: %v", got)
+			}
+		})
+	}
+}
+
+func TestWithModelRefusal_LeavesOtherErrorsAlone(t *testing.T) {
+	for _, e := range []*api.APIError{
+		{Provider: "openai", StatusCode: 429, Message: "rate limited"},
+		{Provider: "openai", StatusCode: 400, Message: `{"error":{"message":"messages must not be empty"}}`},
+		{Provider: "openai", StatusCode: 500, Message: "model not found"},
+		{Provider: "openai", StatusCode: 401, Message: "invalid model key"},
+	} {
+		err := fmt.Errorf("x: %w", e)
+		if got := withModelRefusal(err, "m"); got != err {
+			t.Errorf("%d %q: got %v, want the error unchanged", e.StatusCode, e.Message, got)
+		}
+	}
+	typed := &delegate.ErrModelUnavailable{Model: "m"}
+	if got := withModelRefusal(typed, "m"); got != typed {
+		t.Errorf("an already typed error must pass through, got %v", got)
+	}
+	plain := errors.New("boom")
+	if got := withModelRefusal(plain, "m"); got != plain {
+		t.Errorf("a non-API error must pass through, got %v", got)
+	}
+}

--- a/pkg/retrypolicy/classify.go
+++ b/pkg/retrypolicy/classify.go
@@ -102,6 +102,7 @@ var classification = map[store.FailureCode]Disposition{
 	// Deterministic — the same step against the same checkpoint, always the
 	// same verdict. Nothing here is decided by a model.
 	store.FailureExpressionFailed:    DispositionDeterministic, // a compute node: no LLM, no shell
+	store.FailureModelUnavailable:    DispositionDeterministic, // the provider refuses the same model to the same credential every time
 	store.FailureToolFailedPermanent: DispositionDeterministic, // a fixed exit code on unchanged inputs
 	store.FailureWorkspaceSafety:     DispositionDeterministic, // a static property of the graph
 	store.FailureNodeNotFound:        DispositionDeterministic, // the graph does not change between attempts

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -41,6 +41,7 @@ const (
 	ErrCodeToolFailedPermanent   = store.FailureToolFailedPermanent
 	ErrCodeNetworkTransient      = store.FailureNetworkTransient
 	ErrCodeAuthFailed            = store.FailureAuthFailed
+	ErrCodeModelUnavailable      = store.FailureModelUnavailable
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/recovery/recovery.go
+++ b/pkg/runtime/recovery/recovery.go
@@ -162,6 +162,19 @@ func AuthFailedRecipe() Recipe {
 	})
 }
 
+// ModelUnavailableRecipe: the provider refuses this model to this
+// credential; no retry can change that verdict, so fail terminal at once.
+// The run parks resumable under MODEL_UNAVAILABLE (deterministic), and an
+// operator resumes it with another model or credential.
+func ModelUnavailableRecipe() Recipe {
+	return RecipeFunc(func(_ context.Context, _ *runtime.RuntimeError, _ int) Action {
+		return Action{
+			Kind:   ActionFailTerminal,
+			Reason: "the provider refuses this model to this credential (unknown id, no entitlement, or a client too old to serve it); retrying cannot change it — pick another model or credential, then resume",
+		}
+	})
+}
+
 // TransientToolRecipe: retry with linear backoff up to maxRetries
 // (model gets the error in its next turn), then fail terminal.
 func TransientToolRecipe(maxRetries int) Recipe {
@@ -294,6 +307,7 @@ func DefaultRecipes() map[runtime.ErrorCode]Recipe {
 		runtime.ErrCodeExecutionFailed:       ExecutionFailedRecipe(1),
 		runtime.ErrCodeNetworkTransient:      NetworkTransientRecipe(6),
 		runtime.ErrCodeAuthFailed:            AuthFailedRecipe(),
+		runtime.ErrCodeModelUnavailable:      ModelUnavailableRecipe(),
 	}
 }
 
@@ -360,6 +374,13 @@ func Classify(err error) runtime.ErrorCode {
 	var authFailed *delegate.ErrAuthFailed
 	if errors.As(err, &authFailed) {
 		return runtime.ErrCodeAuthFailed
+	}
+	// A model the credential cannot reach, by TYPE: claw rebuilds it from
+	// the provider's 400/404 refusal on both sides of its sandbox IPC, so
+	// a flattened "API error 400" no longer lands in the retried catch-all.
+	var unavailable *delegate.ErrModelUnavailable
+	if errors.As(err, &unavailable) {
+		return runtime.ErrCodeModelUnavailable
 	}
 	var rateLimited *delegate.ErrRateLimited
 	if errors.As(err, &rateLimited) {

--- a/pkg/runtime/recovery/recovery_test.go
+++ b/pkg/runtime/recovery/recovery_test.go
@@ -335,3 +335,17 @@ func TestDefaultRecipes_HasAllClasses(t *testing.T) {
 		}
 	}
 }
+
+// A provider refusing the model to the credential is deterministic: the
+// typed error classifies to MODEL_UNAVAILABLE and the recipe fails terminal
+// at once, so the run parks instead of being retried and redelivered.
+func TestClassify_ModelUnavailableByType(t *testing.T) {
+	err := fmt.Errorf("claw backend: runner: %w", &delegate.ErrModelUnavailable{Provider: "claw", Model: "openai/gpt-6-astra", Detail: "requires a newer version of Codex"})
+	if got := Classify(err); got != runtime.ErrCodeModelUnavailable {
+		t.Fatalf("Classify = %q, want %q", got, runtime.ErrCodeModelUnavailable)
+	}
+	act := DefaultRecipes()[runtime.ErrCodeModelUnavailable].Apply(context.Background(), &runtime.RuntimeError{Code: runtime.ErrCodeModelUnavailable}, 0)
+	if act.Kind != ActionFailTerminal {
+		t.Errorf("recipe = %v, want FailTerminal", act.Kind)
+	}
+}

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -81,6 +81,15 @@ const (
 	// dispatcher pauses for human instead of burning the retry budget;
 	// the run is resumable once the credential is refreshed.
 	FailureAuthFailed FailureCode = "AUTH_FAILED"
+	// FailureModelUnavailable: the upstream provider refused the requested
+	// model to this credential — an unknown or withdrawn id, an account not
+	// entitled to it, or a client the backend deems too old to serve it.
+	// Deterministic: the same (credential, model) pair is refused again on
+	// every attempt, so a redelivery must park the run instead of resuming
+	// it (measured: ten resumes in eighty seconds, one sandbox pod each,
+	// before the run parked on its own). An operator changes the model or
+	// the credential (a launch override) and resumes.
+	FailureModelUnavailable FailureCode = "MODEL_UNAVAILABLE"
 
 	// FailureInterrupted: an INTERNAL stop (runner drain, dispatcher
 	// stall reap, server shutdown) parked the run failed_resumable.
@@ -178,6 +187,7 @@ var ReservedFailureCodes = []FailureCode{
 	FailureToolFailedPermanent,
 	FailureNetworkTransient,
 	FailureAuthFailed,
+	FailureModelUnavailable,
 	FailureInterrupted,
 	FailureFailNode,
 	FailureProcessOrphaned,


### PR DESCRIPTION
## Summary

A claw node whose provider refuses the requested model (an unknown or withdrawn id, no entitlement, or a client the ChatGPT-Codex backend deems too old) failed as the `EXECUTION_FAILED` catch-all: the in-executor retry re-issued it, the run parked `failed_resumable`, and every JetStream redelivery resumed it into the same refusal.

The refusal is now a typed failure end to end:

- **claw backend** recognises a 400/404 `*api.APIError` carrying a model-refusal wording (`requires a newer version`, `model_not_found`, `not_found_error`, `does not exist`, …) and surfaces `*delegate.ErrModelUnavailable`; the `APIError` stays reachable through `Cause`.
- **sandbox IPC**: the result envelope carries `error_kind` / `error_model`, stamped by the runner (`delegate.StampIOError`) and rebuilt by the launcher (`delegate.TypedIOError`), so the typed error survives the flattening the classifier's doc already named as the boundary where needles belong.
- **recovery**: the dispatcher classifies it to the new reserved `MODEL_UNAVAILABLE` code, deterministic for `retrypolicy`, with a recipe that fails terminal at once — the runner's redelivery precondition then drops the redelivery and the run stays parked for an operator to pick another model or credential.

## Measurement

Cloud run, 2026-09-07, claw node on `openai/gpt-6-astra` through the ChatGPT forfait (runner image shipping codex-cli 0.139.0):

```
openai: API error 400: {"detail":"The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}
```

`run_failed` → `run_resumed` → `sandbox_started` → same 400: **ten resumes in eighty seconds, one sandbox pod each**, before the run parked on its own. Code on the run: `EXECUTION_FAILED`.

## Test

- `TestWithModelRefusal` (ChatGPT-Codex 400, OpenAI `model_not_found` 404, Anthropic `not_found_error` 404 → typed, cause reachable) and `TestWithModelRefusal_LeavesOtherErrorsAlone` (429, unrelated 400, 500, 401, already typed, plain error).
- `TestStampIOError_TypedClassRoundTrips` / `TestStampIOError_PlainErrorHasNoKind` (envelope JSON round-trip, runner exit reachable).
- `TestClassify_ModelUnavailableByType` (code + FailTerminal recipe); `TestEveryReservedFailureCodeIsClassified` covers the new code.
- `go test ./pkg/store/... ./pkg/backend/... ./pkg/runtime/... ./pkg/runner/ ./cmd/iterion/ ./pkg/retrypolicy/`: 4445 tests green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
