### PR TITLE
fix(recovery,retrypolicy): a declared schema the backend cannot read is refused once, not on every pod

### DIFF
--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -1408,6 +1408,31 @@ func (e *ErrAuthFailed) Error() string {
 	return "authentication failed: " + e.Detail
 }
 
+// ErrSchemaUnusable marks a node whose DECLARED output schema the
+// serving backend cannot read — not output that failed to validate
+// against it (that is SCHEMA_VALIDATION, and the next sample may
+// conform), but the schema itself, which the request is built from. The
+// schema rides the IR: it is the same on every attempt, and the request
+// is never sent, so no sample and no wait exist to help.
+//
+// Measured on run 01a07db7 (2026-09-07): a `json` field emits a JSON
+// Schema type UNION (`["object","array",…]`, the shape that keeps a
+// type key without narrowing the value), which the claw API types read
+// into a single string. The node failed five times, four pods, on
+// `parse ExplicitSchema: json: cannot unmarshal array into Go struct
+// field InputSchema.properties.verdicts.type of type string`.
+type ErrSchemaUnusable struct {
+	Schema string // the schema block's name, when known
+	Detail string // the parse failure, for diagnostics
+}
+
+func (e *ErrSchemaUnusable) Error() string {
+	if e.Schema != "" {
+		return "output schema " + e.Schema + " is unusable by this backend: " + e.Detail
+	}
+	return "the declared output schema is unusable by this backend: " + e.Detail
+}
+
 // ErrTransient marks a backend failure the dispatcher should retry
 // (subprocess killed by OOM, peer reset, network blip, …). CLI
 // backends wrap stderr-matched indicators in this type so the executor's

--- a/pkg/backend/model/generation.go
+++ b/pkg/backend/model/generation.go
@@ -414,7 +414,13 @@ func GenerateObjectDirect[T any](ctx context.Context, client api.APIClient, opts
 
 	var inputSchema api.InputSchema
 	if err := json.Unmarshal(opts.ExplicitSchema, &inputSchema); err != nil {
-		return nil, fmt.Errorf("parse ExplicitSchema: %w", err)
+		// Typed AND worded: this call is made in-process by the executor
+		// and out-of-process by the claw runner, whose subprocess
+		// boundary flattens the type to text before it reaches the
+		// classifier.
+		return nil, fmt.Errorf("parse ExplicitSchema: %w", &delegate.ErrSchemaUnusable{
+			Schema: schemaName, Detail: err.Error(),
+		})
 	}
 
 	syntheticTool := api.Tool{

--- a/pkg/backend/model/generation_schema_unusable_test.go
+++ b/pkg/backend/model/generation_schema_unusable_test.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+)
+
+// The declared schema is read BEFORE any request is built, so a schema the
+// API types cannot represent costs a run every attempt and never a token.
+// It must leave here wearing a type the classifier can read, not a
+// sentence — measured on run 01a07db7, where the sentence was classified
+// EXECUTION_FAILED and redelivered onto four pods.
+func TestGenerateObjectDirect_AnUnreadableSchemaIsTyped(t *testing.T) {
+	// Unreadable under ANY definition of the schema types — deliberately
+	// not the `type` union that produced the measured failure, because
+	// that one becomes readable the day the backend's types accept it,
+	// and this test would then prove nothing while still passing.
+	schema := json.RawMessage(`{"type":"object","properties":"not-an-object"}`)
+
+	_, err := GenerateObjectDirect[map[string]any](context.Background(), nil, GenerationOptions{
+		ExplicitSchema: schema,
+		Messages:       []api.Message{{Role: "user", Content: []api.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err == nil {
+		t.Fatal("a schema whose `properties` is a string was accepted — the guard this test pins is gone")
+	}
+	var unusable *delegate.ErrSchemaUnusable
+	if !errors.As(err, &unusable) {
+		t.Fatalf("error is not *delegate.ErrSchemaUnusable, so the classifier reads a sentence: %v", err)
+	}
+	if unusable.Detail == "" {
+		t.Error("Detail empty — the diagnosis that names the offending field is lost")
+	}
+}

--- a/pkg/retrypolicy/classify.go
+++ b/pkg/retrypolicy/classify.go
@@ -128,6 +128,13 @@ var classification = map[store.FailureCode]Disposition{
 	// — eight pods, eight sandboxes — because the 400 wore
 	// EXECUTION_FAILED, whose disposition promises that waiting helps.
 	store.FailureModelUnavailable: DispositionDeterministic,
+	// The DECLARED schema, not the output measured against it: it rides
+	// the IR, the request is never built, and no sample exists to differ.
+	// Measured on 2026-09-07 (run 01a07db7): a `json` field's type union
+	// the serving backend read as a single string — five attempts, four
+	// pods, one verdict. SchemaValidation stays re-executable: there, a
+	// request WAS served and the next sample may conform.
+	store.FailureSchemaUnusable: DispositionDeterministic,
 }
 
 // Classify reports what an automatic resume can achieve for this code.

--- a/pkg/retrypolicy/classify.go
+++ b/pkg/retrypolicy/classify.go
@@ -119,6 +119,15 @@ var classification = map[store.FailureCode]Disposition{
 	store.FailureLaunchFailed:          DispositionDeterministic, // the run never left the launch path — no checkpoint exists
 	store.FailureDLQParked:             DispositionDeterministic, // the deliveries are already spent
 	store.FailureCancelled:             DispositionDeterministic, // an operator's decision, not a fault
+	// The provider will not serve this model to this caller. Nothing in
+	// the request's content is at fault, so a different sample cannot
+	// help either — this is the one provider rejection that does not
+	// belong with the LLM-decided codes above. Measured on 2026-09-07
+	// (run 01a07da6): a claw node on a model the ChatGPT backend gates
+	// on the client release failed identically NINE times in 77 seconds
+	// — eight pods, eight sandboxes — because the 400 wore
+	// EXECUTION_FAILED, whose disposition promises that waiting helps.
+	store.FailureModelUnavailable: DispositionDeterministic,
 }
 
 // Classify reports what an automatic resume can achieve for this code.

--- a/pkg/retrypolicy/classify_test.go
+++ b/pkg/retrypolicy/classify_test.go
@@ -69,6 +69,10 @@ func TestDispositionsAreDistinct(t *testing.T) {
 		// the effective token on the next attempt can differ from the one
 		// that was refused, even though the sealed blob does not.
 		{store.FailureAuthFailed, false, false},
+		// The provider answered about the MODEL, not about the request:
+		// no sample differs, no wait helps. The one provider rejection
+		// that clears the deterministic bar.
+		{store.FailureModelUnavailable, true, false},
 	}
 	for _, c := range cases {
 		if got := IsDeterministic(c.code); got != c.deterministic {

--- a/pkg/retrypolicy/classify_test.go
+++ b/pkg/retrypolicy/classify_test.go
@@ -73,6 +73,10 @@ func TestDispositionsAreDistinct(t *testing.T) {
 		// no sample differs, no wait helps. The one provider rejection
 		// that clears the deterministic bar.
 		{store.FailureModelUnavailable, true, false},
+		// The DECLARED schema, refused before any request was built —
+		// unlike FailureSchemaValidation two rows above, where a request
+		// was served and the next sample may conform.
+		{store.FailureSchemaUnusable, true, false},
 	}
 	for _, c := range cases {
 		if got := IsDeterministic(c.code); got != c.deterministic {

--- a/pkg/runner/deterministic_failure_test.go
+++ b/pkg/runner/deterministic_failure_test.go
@@ -41,6 +41,12 @@ func TestClassifyExecResult_DeterministicNodeFailureAcks(t *testing.T) {
 		{"wrapped expression failure", fmt.Errorf("engine: %w", &runtime.RuntimeError{
 			Code: store.FailureExpressionFailed, Message: "boom",
 		})},
+		// Measured 2026-09-07 on run 01a07da6: eight pods in 77 seconds
+		// for a model the ChatGPT backend does not serve to this image.
+		{"a model the provider will not serve", &runtime.RuntimeError{
+			Code: store.FailureModelUnavailable, NodeID: "m_astra",
+			Message: `backend "claw" failed: openai: API error 400: {"detail":"The 'gpt-6-astra' model requires a newer version of Codex."}`,
+		}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/runner/deterministic_failure_test.go
+++ b/pkg/runner/deterministic_failure_test.go
@@ -41,6 +41,12 @@ func TestClassifyExecResult_DeterministicNodeFailureAcks(t *testing.T) {
 		{"wrapped expression failure", fmt.Errorf("engine: %w", &runtime.RuntimeError{
 			Code: store.FailureExpressionFailed, Message: "boom",
 		})},
+		// Measured 2026-09-07 on run 01a07db7: four pods for a schema the
+		// serving backend could not read. The declaration rides the IR.
+		{"a declared schema the backend cannot read", &runtime.RuntimeError{
+			Code: store.FailureSchemaUnusable, NodeID: "voter_v2",
+			Message: "parse ExplicitSchema: json: cannot unmarshal array into Go struct field InputSchema.properties.verdicts.type of type string",
+		}},
 		// Measured 2026-09-07 on run 01a07da6: eight pods in 77 seconds
 		// for a model the ChatGPT backend does not serve to this image.
 		{"a model the provider will not serve", &runtime.RuntimeError{

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -42,6 +42,7 @@ const (
 	ErrCodeNetworkTransient      = store.FailureNetworkTransient
 	ErrCodeAuthFailed            = store.FailureAuthFailed
 	ErrCodeModelUnavailable      = store.FailureModelUnavailable
+	ErrCodeSchemaUnusable        = store.FailureSchemaUnusable
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -41,6 +41,7 @@ const (
 	ErrCodeToolFailedPermanent   = store.FailureToolFailedPermanent
 	ErrCodeNetworkTransient      = store.FailureNetworkTransient
 	ErrCodeAuthFailed            = store.FailureAuthFailed
+	ErrCodeModelUnavailable      = store.FailureModelUnavailable
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/recovery/recovery.go
+++ b/pkg/runtime/recovery/recovery.go
@@ -162,6 +162,18 @@ func AuthFailedRecipe() Recipe {
 	})
 }
 
+// SchemaUnusableRecipe: no retry. The declaration rides the IR, so a
+// second attempt builds the same request from the same schema and is
+// refused by the same parser.
+func SchemaUnusableRecipe() Recipe {
+	return RecipeFunc(func(_ context.Context, _ *runtime.RuntimeError, _ int) Action {
+		return Action{
+			Kind:   ActionFailTerminal,
+			Reason: "the node's declared output schema is unusable by the serving backend — fix the schema (or the backend that cannot read it), then resume",
+		}
+	})
+}
+
 // ModelUnavailableRecipe: no retry at all. The provider answered about
 // the MODEL, not about this request, so a second call from the same
 // image asks the same question and is told the same thing — and the
@@ -308,6 +320,7 @@ func DefaultRecipes() map[runtime.ErrorCode]Recipe {
 		runtime.ErrCodeNetworkTransient:      NetworkTransientRecipe(6),
 		runtime.ErrCodeAuthFailed:            AuthFailedRecipe(),
 		runtime.ErrCodeModelUnavailable:      ModelUnavailableRecipe(),
+		runtime.ErrCodeSchemaUnusable:        SchemaUnusableRecipe(),
 	}
 }
 
@@ -374,6 +387,13 @@ func Classify(err error) runtime.ErrorCode {
 	var authFailed *delegate.ErrAuthFailed
 	if errors.As(err, &authFailed) {
 		return runtime.ErrCodeAuthFailed
+	}
+	// The node's own declaration is what the backend refused. Checked by
+	// TYPE first, like the credential above: the needle below only
+	// catches today's wording.
+	var schemaUnusable *delegate.ErrSchemaUnusable
+	if errors.As(err, &schemaUnusable) {
+		return runtime.ErrCodeSchemaUnusable
 	}
 	var rateLimited *delegate.ErrRateLimited
 	if errors.As(err, &rateLimited) {
@@ -443,6 +463,12 @@ func Classify(err error) runtime.ErrorCode {
 		if strings.Contains(msg, needle) {
 			return runtime.ErrCodeAuthFailed
 		}
+	}
+	// The out-of-process host (the claw runner) flattens the typed error
+	// above into text before it reaches here, so the wording is read too
+	// — this is the shape that was actually measured in the cloud.
+	if strings.Contains(msg, "parse explicitschema") {
+		return runtime.ErrCodeSchemaUnusable
 	}
 	// Checked through the SAME list the typed branch reads, and after
 	// the credential needles: a rejection that names both a credential

--- a/pkg/runtime/recovery/recovery.go
+++ b/pkg/runtime/recovery/recovery.go
@@ -462,10 +462,13 @@ func Classify(err error) runtime.ErrorCode {
 // provider will not serve the MODEL, whatever the request contains. ALL
 // entries MUST be lowercase — both callers lowercase first.
 var modelUnavailableNeedles = []string{
-	"requires a newer version", // ChatGPT backend gating a model on the client release claw announces
-	"api error 404",            // claw/openai verbatim: the model id reached no endpoint
-	"model_not_found",          // OpenAI error code field
-	"unknown model",            // gateway wording for an id no backend claims
+	// Scoped to the MODEL on purpose: a bare "requires a newer version"
+	// is any tool announcing a version floor, and a false positive here
+	// PARKS a run — the disposition is deterministic.
+	"model requires a newer version",
+	"api error 404",   // claw/openai verbatim: the model id reached no endpoint
+	"model_not_found", // OpenAI error code field
+	"unknown model",   // gateway wording for an id no backend claims
 }
 
 // matchesModelUnavailable is the ONE reading of that list. Both the

--- a/pkg/runtime/recovery/recovery.go
+++ b/pkg/runtime/recovery/recovery.go
@@ -162,6 +162,19 @@ func AuthFailedRecipe() Recipe {
 	})
 }
 
+// ModelUnavailableRecipe: no retry at all. The provider answered about
+// the MODEL, not about this request, so a second call from the same
+// image asks the same question and is told the same thing — and the
+// automatic resume above it would spend a pod per attempt to hear it.
+func ModelUnavailableRecipe() Recipe {
+	return RecipeFunc(func(_ context.Context, _ *runtime.RuntimeError, _ int) Action {
+		return Action{
+			Kind:   ActionFailTerminal,
+			Reason: "the provider does not serve this model to this client (unknown id, no access, or a client release it gates on) — change the model or the image, then resume",
+		}
+	})
+}
+
 // TransientToolRecipe: retry with linear backoff up to maxRetries
 // (model gets the error in its next turn), then fail terminal.
 func TransientToolRecipe(maxRetries int) Recipe {
@@ -294,6 +307,7 @@ func DefaultRecipes() map[runtime.ErrorCode]Recipe {
 		runtime.ErrCodeExecutionFailed:       ExecutionFailedRecipe(1),
 		runtime.ErrCodeNetworkTransient:      NetworkTransientRecipe(6),
 		runtime.ErrCodeAuthFailed:            AuthFailedRecipe(),
+		runtime.ErrCodeModelUnavailable:      ModelUnavailableRecipe(),
 	}
 }
 
@@ -394,6 +408,14 @@ func Classify(err error) runtime.ErrorCode {
 		if apiErr.StatusCode == 401 || apiErr.StatusCode == 403 {
 			return runtime.ErrCodeAuthFailed
 		}
+		// A model this caller may not have. 404 says it by status; the
+		// wordings say it under a 400, which the backends use for a
+		// model gated on a minimum client release. A bare 400 is NOT
+		// included: one raised mid-turn can be the model's own tool
+		// arguments, and those differ on the next sample.
+		if apiErr.StatusCode == 404 || matchesModelUnavailable(body) {
+			return runtime.ErrCodeModelUnavailable
+		}
 		return runtime.ErrCodeExecutionFailed
 	}
 	// String-pattern fallback for unstructured errors that bubble up
@@ -422,12 +444,42 @@ func Classify(err error) runtime.ErrorCode {
 			return runtime.ErrCodeAuthFailed
 		}
 	}
+	// Checked through the SAME list the typed branch reads, and after
+	// the credential needles: a rejection that names both a credential
+	// and a model is a credential to re-authenticate first.
+	if matchesModelUnavailable(msg) {
+		return runtime.ErrCodeModelUnavailable
+	}
 	for _, needle := range networkTransientNeedles {
 		if strings.Contains(msg, needle) {
 			return runtime.ErrCodeNetworkTransient
 		}
 	}
 	return runtime.ErrCodeExecutionFailed
+}
+
+// modelUnavailableNeedles enumerates lowercase substrings that say the
+// provider will not serve the MODEL, whatever the request contains. ALL
+// entries MUST be lowercase — both callers lowercase first.
+var modelUnavailableNeedles = []string{
+	"requires a newer version", // ChatGPT backend gating a model on the client release claw announces
+	"api error 404",            // claw/openai verbatim: the model id reached no endpoint
+	"model_not_found",          // OpenAI error code field
+	"unknown model",            // gateway wording for an id no backend claims
+}
+
+// matchesModelUnavailable is the ONE reading of that list. Both the
+// typed *api.APIError branch and the flattened-string fallback call it,
+// because an out-of-process backend (the claw runner) stringifies its
+// typed error before it reaches here — the same reason the credential
+// needles exist twice over.
+func matchesModelUnavailable(msg string) bool {
+	for _, needle := range modelUnavailableNeedles {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // authFailedNeedles enumerates lowercase substrings that indicate the

--- a/pkg/runtime/recovery/recovery_test.go
+++ b/pkg/runtime/recovery/recovery_test.go
@@ -238,6 +238,77 @@ func TestClassify_APIError409_StaysExecutionFailed(t *testing.T) {
 	}
 }
 
+// Measured 2026-09-07 on run 01a07da6: a claw node asked for a model the
+// ChatGPT backend gates on the client release claw announces. The 400 wore
+// EXECUTION_FAILED, whose disposition promises that a later attempt can
+// outlast the fault — so the node failed, the delivery naked, the
+// redelivery synthesised a resume, and the identical verdict came back
+// NINE times in 77 seconds: eight pods, eight clones, eight sandboxes.
+// Nothing in the request was at fault, so no sample and no wait could have
+// helped; only an operator changing the model or the image.
+func TestClassify_ModelTheProviderWillNotServe(t *testing.T) {
+	// The flattened string is the shape that actually reached the
+	// classifier: the claw runner is out of process, so its typed error is
+	// text by the time it bubbles up — verbatim from the run.
+	measured := errors.New(`model: node "m_astra": backend "claw" failed: claw backend: runner: ` +
+		`claw backend: structured generation: openai: API error 400: {"detail":"The 'gpt-6-astra' ` +
+		`model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."}`)
+
+	cases := []struct {
+		name string
+		err  error
+		want runtime.ErrorCode
+	}{
+		{"the flattened string from run 01a07da6", measured, runtime.ErrCodeModelUnavailable},
+		{"typed, gated on a client release", &api.APIError{
+			StatusCode: 400, Message: "The 'gpt-6-astra' model requires a newer version of Codex.",
+		}, runtime.ErrCodeModelUnavailable},
+		{"typed 404: the id reached no endpoint", &api.APIError{
+			StatusCode: 404, Message: "The model `gpt-9` does not exist or you do not have access to it.",
+		}, runtime.ErrCodeModelUnavailable},
+		{"flattened 404", errors.New("claw backend: openai: API error 404: model_not_found"),
+			runtime.ErrCodeModelUnavailable},
+
+		// The other half of the rule. A bare 400 can be raised mid-turn on
+		// the model's OWN tool arguments, and those differ on the next
+		// sample — reading it as a model verdict would park a run that
+		// recovers on its own.
+		{"a bare 400 is not a model verdict", &api.APIError{StatusCode: 400, Message: "bad request"},
+			runtime.ErrCodeExecutionFailed},
+		// The credential is read first: a rejection naming both is one to
+		// re-authenticate, not one to re-model.
+		{"401 naming a model is still a credential", &api.APIError{
+			StatusCode: 401, Message: "unknown model gpt-9: authentication token is expired",
+		}, runtime.ErrCodeAuthFailed},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Classify(c.err); got != c.want {
+				t.Errorf("Classify() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// No retry at all: the provider answered about the model, so a second call
+// from the same image is told the same thing — and every attempt above
+// this recipe costs a pod.
+func TestModelUnavailableRecipe_FailsTerminalWithoutRetrying(t *testing.T) {
+	r := ModelUnavailableRecipe()
+	for _, attempts := range []int{0, 1, 5} {
+		act := r.Apply(context.Background(), &runtime.RuntimeError{Code: runtime.ErrCodeModelUnavailable}, attempts)
+		if act.Kind != ActionFailTerminal {
+			t.Fatalf("attempts=%d: Kind = %v, want ActionFailTerminal", attempts, act.Kind)
+		}
+		if act.AttemptsLeft != 0 {
+			t.Errorf("attempts=%d: AttemptsLeft = %d, want 0", attempts, act.AttemptsLeft)
+		}
+	}
+	if _, ok := DefaultRecipes()[runtime.ErrCodeModelUnavailable]; !ok {
+		t.Error("no recipe registered for MODEL_UNAVAILABLE — Dispatch would fail terminal with a reason that names the gap instead of the cure")
+	}
+}
+
 func TestClassify_PlainError(t *testing.T) {
 	if got := Classify(errors.New("something")); got != runtime.ErrCodeExecutionFailed {
 		t.Errorf("expected EXECUTION_FAILED for plain error, got %v", got)

--- a/pkg/runtime/recovery/recovery_test.go
+++ b/pkg/runtime/recovery/recovery_test.go
@@ -275,6 +275,11 @@ func TestClassify_ModelTheProviderWillNotServe(t *testing.T) {
 		// recovers on its own.
 		{"a bare 400 is not a model verdict", &api.APIError{StatusCode: 400, Message: "bad request"},
 			runtime.ErrCodeExecutionFailed},
+		// A version floor that is NOT about a model: any tool can announce
+		// one, and reading it as a model verdict would park a run over a
+		// devbox package.
+		{"a version floor that names no model", errors.New("devbox: package pinned: requires a newer version of nix"),
+			runtime.ErrCodeExecutionFailed},
 		// The credential is read first: a rejection naming both is one to
 		// re-authenticate, not one to re-model.
 		{"401 naming a model is still a credential", &api.APIError{

--- a/pkg/runtime/recovery/recovery_test.go
+++ b/pkg/runtime/recovery/recovery_test.go
@@ -238,6 +238,60 @@ func TestClassify_APIError409_StaysExecutionFailed(t *testing.T) {
 	}
 }
 
+// Measured 2026-09-07 on run 01a07db7: a node whose `json` field emits a
+// JSON Schema type UNION, which the serving backend read into a single
+// string. The schema rides the IR and the request is never built, so no
+// sample and no wait existed to help — and yet the parse failure wore
+// EXECUTION_FAILED and was redelivered five times for four pods.
+func TestClassify_ADeclaredSchemaTheBackendCannotRead(t *testing.T) {
+	// Verbatim from the run: the claw runner is out of process, so the
+	// typed error below is text by the time it reaches the classifier.
+	measured := errors.New(`model: node "voter_v2": backend "claw" failed: claw backend: runner: ` +
+		`claw backend: structured generation: parse ExplicitSchema: json: cannot unmarshal array ` +
+		`into Go struct field InputSchema.properties.verdicts.type of type string (exit: exit status 1)`)
+
+	cases := []struct {
+		name string
+		err  error
+		want runtime.ErrorCode
+	}{
+		{"the flattened string from run 01a07db7", measured, runtime.ErrCodeSchemaUnusable},
+		{"typed, in process", &delegate.ErrSchemaUnusable{Schema: "voter_output", Detail: "cannot unmarshal array"},
+			runtime.ErrCodeSchemaUnusable},
+		{"typed, wrapped by its caller", fmt.Errorf("parse ExplicitSchema: %w",
+			&delegate.ErrSchemaUnusable{Schema: "voter_output"}), runtime.ErrCodeSchemaUnusable},
+
+		// The other half, and the distinction the whole code rests on: a
+		// request WAS served and the model's OUTPUT missed the schema.
+		// The next sample may conform, so this must stay re-executable.
+		{"output that missed its schema is not an unusable schema", &runtime.RuntimeError{
+			Code: runtime.ErrCodeSchemaValidation, Message: `field "verdicts" is required`,
+		}, runtime.ErrCodeSchemaValidation},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Classify(c.err); got != c.want {
+				t.Errorf("Classify() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// No retry: the declaration rides the IR, so a second attempt builds the
+// same request from the same schema for the same parser to refuse.
+func TestSchemaUnusableRecipe_FailsTerminalWithoutRetrying(t *testing.T) {
+	r := SchemaUnusableRecipe()
+	for _, attempts := range []int{0, 1, 5} {
+		act := r.Apply(context.Background(), &runtime.RuntimeError{Code: runtime.ErrCodeSchemaUnusable}, attempts)
+		if act.Kind != ActionFailTerminal {
+			t.Fatalf("attempts=%d: Kind = %v, want ActionFailTerminal", attempts, act.Kind)
+		}
+	}
+	if _, ok := DefaultRecipes()[runtime.ErrCodeSchemaUnusable]; !ok {
+		t.Error("no recipe registered for SCHEMA_UNUSABLE")
+	}
+}
+
 // Measured 2026-09-07 on run 01a07da6: a claw node asked for a model the
 // ChatGPT backend gates on the client release claw announces. The 400 wore
 // EXECUTION_FAILED, whose disposition promises that a later attempt can

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -82,6 +82,19 @@ const (
 	// the run is resumable once the credential is refreshed.
 	FailureAuthFailed FailureCode = "AUTH_FAILED"
 
+	// FailureModelUnavailable: the provider refused the request because
+	// the MODEL it names is not served to this caller — an id the
+	// backend does not know, a model the account may not use, a model
+	// whose minimum client release this image is behind ("requires a
+	// newer version of Codex"). Distinct from FailureAuthFailed, where
+	// the credential is what was rejected, and from
+	// FailureExecutionFailed, whose automatic resume claims that a later
+	// attempt can outlast the fault: this verdict is a property of the
+	// model and the caller, not of the request's content, so every
+	// attempt from the same image is told the same thing. The cure is an
+	// operator changing the model or the image, then resuming.
+	FailureModelUnavailable FailureCode = "MODEL_UNAVAILABLE"
+
 	// FailureInterrupted: an INTERNAL stop (runner drain, dispatcher
 	// stall reap, server shutdown) parked the run failed_resumable.
 	// Previously only visible as the run_failed event's
@@ -178,6 +191,7 @@ var ReservedFailureCodes = []FailureCode{
 	FailureToolFailedPermanent,
 	FailureNetworkTransient,
 	FailureAuthFailed,
+	FailureModelUnavailable,
 	FailureInterrupted,
 	FailureFailNode,
 	FailureProcessOrphaned,

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -95,6 +95,16 @@ const (
 	// operator changing the model or the image, then resuming.
 	FailureModelUnavailable FailureCode = "MODEL_UNAVAILABLE"
 
+	// FailureSchemaUnusable: the node's DECLARED output schema could not
+	// be read by the backend serving it, so no request was ever built.
+	// Distinct from FailureSchemaValidation, where a request WAS served
+	// and the model's output missed the schema — that one is decided by
+	// a sample and the next may conform. This one rides the IR: the same
+	// declaration reaches the same parser on every attempt. The cure is
+	// fixing the schema (or the backend that cannot read it), then
+	// resuming.
+	FailureSchemaUnusable FailureCode = "SCHEMA_UNUSABLE"
+
 	// FailureInterrupted: an INTERNAL stop (runner drain, dispatcher
 	// stall reap, server shutdown) parked the run failed_resumable.
 	// Previously only visible as the run_failed event's
@@ -192,6 +202,7 @@ var ReservedFailureCodes = []FailureCode{
 	FailureNetworkTransient,
 	FailureAuthFailed,
 	FailureModelUnavailable,
+	FailureSchemaUnusable,
 	FailureInterrupted,
 	FailureFailNode,
 	FailureProcessOrphaned,


### PR DESCRIPTION
## A declared schema the backend cannot read is refused once, not on every pod

A node's output schema rides the IR. When the backend serving it cannot read that schema, **no request is ever built** — there is no sample to differ and no wait to outlast. The parse failure nonetheless left as a sentence, fell to the `EXECUTION_FAILED` catch-all, and `DispositionTransient` promises exactly one thing: *a later attempt can genuinely outlast this fault.* So the delivery naked, the redelivery synthesised a resume, and a pod was spent per attempt to be refused by the same parser.

This is the class `pkg/retrypolicy` was written to close — its own comment measures the first twin (a `compute` node's unsatisfiable expression, seven pods in ten minutes). The lever is single and already there: `retrypolicy.IsDeterministic`, which makes the runner ack the delivery instead of naking it. What was missing was a row.

## Measurement

Run `01a07db7`, 2026-09-07. A `json` field emits a JSON Schema type **union** — `["object","array","string","number","boolean","null"]`, the shape that keeps a `type` key without narrowing the value — and the serving backend's types read `type` into a single string:

```
model: node "voter_v2": backend "claw" failed: claw backend: runner: claw backend:
structured generation: parse ExplicitSchema: json: cannot unmarshal array into Go
struct field InputSchema.properties.verdicts.type of type string
```

Five attempts, four `sandbox_started`, one verdict — and not one token spent, because the request was never sent.

## The change

- **`delegate.ErrSchemaUnusable` types the refusal at the parse site**, carrying the schema's name and the parse detail, and **`SCHEMA_UNUSABLE`** joins the engine vocabulary classified `DispositionDeterministic`. The run parks resumable for an operator who fixed the schema — one pod, not four.
- **`recovery.Classify` reads the TYPE first, and the wording too.** The claw runner is out of process, so the typed error is text by the time it reaches the classifier — that is the shape actually measured in the cloud, the same reason the credential needles already exist on both paths. The needle is a **bridge, and it says so**: once the sandbox IPC's typed error channel lands (#920), this error rides it and the needle goes.
- **`SchemaUnusableRecipe`** fails terminal with no in-node retry.

## The distinction the whole code rests on, pinned in both directions

`SCHEMA_VALIDATION` stays **re-executable**. There, a request *was* served and the model's output missed the schema — the next sample may conform, and parking it would strand runs that recover on their own. Here the schema itself is unreadable and no sample exists. A mutant that collapses the two turns `TestDispositionsAreDistinct` red.

## Scope, stated rather than implied

- **The root cause is elsewhere and already fixed.** The union is valid JSON Schema and the backend's types should hold it: that is `b6e34a3` on claw's master, vendored by #917. This PR does not touch it. What it adds is that the *next* schema a backend cannot read costs one pod instead of four.
- **The model-refusal half of this class is #920's**, which types the refusal end to end across the sandbox IPC — a better channel than a wording. An earlier revision of this branch carried a duplicate of it; that revision is withdrawn, and only the schema failure remains here.
- **What is still missing, and belongs with #917:** nothing pins the emitter (`SchemaToJSON`) to the reader (`api.InputSchema`). They live in two repositories and have just diverged in silence. A conformance test over every `ir.FieldType` would have been red in CI before a single pod started.

## Proof

`TestClassify_ADeclaredSchemaTheBackendCannotRead` runs the run's **verbatim** flattened string, the typed error, a typed error wrapped by its caller, and — as the other half — a `SCHEMA_VALIDATION` that must stay re-executable. `TestGenerateObjectDirect_AnUnreadableSchemaIsTyped` pins the typing at the source, on a schema no definition of the API types could ever read: deliberately **not** the union that produced the failure, because that one becomes readable the day the backend accepts it, and the test would then prove nothing while still passing. `TestSchemaUnusableRecipe_FailsTerminalWithoutRetrying` pins zero retries and the registration; `TestClassifyExecResult_DeterministicNodeFailureAcks` pins the payload — the runner acks.

Seven mutants, each red on its own test, each asserted to have actually changed the tree before running (a mutant that silently fails to apply produces a green that means nothing):

| mutant | red on |
|---|---|
| the parse site stops typing the error | `TestGenerateObjectDirect_AnUnreadableSchemaIsTyped` |
| the classifier stops reading the type | `TestClassify_ADeclaredSchemaTheBackendCannotRead` |
| …stops reading the flattened wording | same, on the run's verbatim trace |
| the recipe retries | `TestSchemaUnusableRecipe_…` |
| the disposition becomes `Reexecutable` | `TestDispositionsAreDistinct` |
| …and the runner naks again | `TestClassifyExecResult_DeterministicNodeFailureAcks` |
| `SCHEMA_VALIDATION` is swept in with it | `TestDispositionsAreDistinct` |

`go test ./pkg/...` green, `golangci-lint` 0 issues, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
