### PR TITLE
test: a test's git command has one place that builds it, and a run's source repo is one the test owns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1696,6 +1696,27 @@ log + `0 tokens` billed confirms the OAuth-forfait path (not a metered API key).
 - `tmpStore()` — creates temp directory-backed RunStore for test isolation
 - `compileFixture()` — loads and compiles .bot files from `examples/` directory
 - **Scenario executor** (`e2e/e2e_test.go`) — configurable stub with `.on(nodeID, handler)` for per-node behavior
+- **Every git subprocess a test spawns goes through [`internal/gittest`](internal/gittest/gittest.go)**
+  (`Run` / `Try` / `Cmd`, `SourceRepo`, `RemoveWorktree`) — not a style
+  preference, two defects: (1) since git 2.48 a writing command detaches
+  `git maintenance run --auto`, which keeps writing under `.git/objects`
+  after `CombinedOutput` returned and races `t.TempDir()`'s removal (that
+  ejected PRs from the merge queue, #821/#828), and (2) the operator's
+  `~/.gitconfig` otherwise decides whether a test passes (a global
+  `commit.gpgsign` hangs every fixture commit on a pinentry with no TTY).
+  The helper bakes both in; `pkg/git.TestEveryTestGitCallerDisablesAutoMaintenance`
+  sweeps `_test.go` and fails a new site that assembles its own argv.
+- **A run's workspace must be a repository the TEST owns.** An engine built
+  without `WithWorkDir` defaults to `os.Getwd()` — the package directory,
+  inside the developer's checkout — so `worktree: auto` (the IR default)
+  registers the run's worktree in the REAL repository and the registration
+  outlives the `t.TempDir()` that held the checkout (#870: 1 773 dead
+  entries / 2.5 GB measured). Pass `gittest.SourceRepo(t)` (e2e goes through
+  `newEngine`), or `t.Chdir` into one where the CLI takes its workspace from
+  the cwd. `gittest.NoWorktreeLeaks(m)` in `TestMain` (e2e, `pkg/runview`,
+  `pkg/cli`) fails the suite naming the test behind any entry left behind,
+  and reclaims it **by recorded path** — never `git worktree prune`, which
+  would also drop an operator's checkout on an unmounted volume.
 - Table-driven subtests with standard `testing` package
 - `task test:live` — runs E2E with real Claude/Codex CLIs (requires API keys)
 - **Mongo conformance locally** — the `mongo-conformance` CI job is reproducible with one `mongo:8.0` replica-set container on port 27018 (`--ulimit nofile=131072:131072`, member advertised as `localhost:27018`); recipe + the two traps in [docs/development.md](docs/development.md#running-the-mongo-conformance-harness-locally). A store-twin or conformance-row change is unverified until it ran there

--- a/bots/dep_update_guard_prepare_test.go
+++ b/bots/dep_update_guard_prepare_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestDepUpdateGuardPrepareClassifies guards the deterministic bump detector
@@ -58,10 +60,7 @@ func TestDepUpdateGuardPrepareClassifies(t *testing.T) {
 
 	git := func(t *testing.T, ws string, args ...string) {
 		t.Helper()
-		full := append([]string{"-C", ws}, args...)
-		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
+		gittest.Run(t, ws, args...)
 	}
 
 	// bumpRepo builds a repo with a `main` baseline and a PR commit on top

--- a/bots/docs_refresh_hints_test.go
+++ b/bots/docs_refresh_hints_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestDocsRefreshHintsProducer executes docs-refresh v3's scan_hints
@@ -234,14 +236,8 @@ and the [dead anchor](docs/guide.md#not-there).
 		// 43% noise on live run 019f8ba3 without this rule.
 		ws := t.TempDir()
 		git := func(args ...string) {
-			cmd := exec.Command("git", args...)
-			cmd.Dir = ws
-			cmd.Env = append(os.Environ(),
-				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("git %v: %v\n%s", args, err, out)
-			}
+			t.Helper()
+			gittest.Run(t, ws, args...)
 		}
 		git("init", "-q")
 		write(t, ws, "bots/real/tracked.go", "package real\n")
@@ -359,16 +355,8 @@ Scaffold your own with `+"`bots/my-bot/main.bot`"+` as a starting name.
 		// the code changed SINCE it. A periodic run re-aligns only the delta.
 		ws := t.TempDir()
 		git := func(args ...string) string {
-			cmd := exec.Command("git", args...)
-			cmd.Dir = ws
-			cmd.Env = append(os.Environ(),
-				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Fatalf("git %v: %v\n%s", args, err, out)
-			}
-			return strings.TrimSpace(string(out))
+			t.Helper()
+			return gittest.Run(t, ws, args...)
 		}
 		git("init", "-q")
 		write(t, ws, "README.md", "# fixture\n")
@@ -415,14 +403,8 @@ Scaffold your own with `+"`bots/my-bot/main.bot`"+` as a starting name.
 		// corpus. A clean degrade to full, never an error.
 		ws := t.TempDir()
 		git := func(args ...string) {
-			cmd := exec.Command("git", args...)
-			cmd.Dir = ws
-			cmd.Env = append(os.Environ(),
-				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("git %v: %v\n%s", args, err, out)
-			}
+			t.Helper()
+			gittest.Run(t, ws, args...)
 		}
 		git("init", "-q")
 		write(t, ws, "README.md", "# fixture\n")
@@ -445,16 +427,8 @@ Scaffold your own with `+"`bots/my-bot/main.bot`"+` as a starting name.
 		// base_ref) even though the mode var is the "full" default.
 		ws := t.TempDir()
 		git := func(args ...string) string {
-			cmd := exec.Command("git", args...)
-			cmd.Dir = ws
-			cmd.Env = append(os.Environ(),
-				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				t.Fatalf("git %v: %v\n%s", args, err, out)
-			}
-			return strings.TrimSpace(string(out))
+			t.Helper()
+			return gittest.Run(t, ws, args...)
 		}
 		git("init", "-q")
 		write(t, ws, "README.md", "# fixture\n")
@@ -494,14 +468,8 @@ Scaffold your own with `+"`bots/my-bot/main.bot`"+` as a starting name.
 		// remote-tracking ref in the run's clone. scan_hints must still resolve
 		// the delta against origin/main.
 		gitIn := func(dir string, args ...string) {
-			cmd := exec.Command("git", args...)
-			cmd.Dir = dir
-			cmd.Env = append(os.Environ(),
-				"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-				"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Fatalf("git -C %s %v: %v\n%s", dir, args, err, out)
-			}
+			t.Helper()
+			gittest.Run(t, dir, args...)
 		}
 		origin := t.TempDir()
 		gitIn(origin, "init", "-q", "-b", "main")

--- a/bots/docs_refresh_scope_test.go
+++ b/bots/docs_refresh_scope_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestDocsRefreshScopeCheckBase executes docs-refresh's scope_check command
@@ -40,18 +42,7 @@ func TestDocsRefreshScopeCheckBase(t *testing.T) {
 
 	git := func(t *testing.T, dir string, args ...string) string {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-		)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
-		}
-		return string(out)
+		return gittest.Run(t, dir, args...)
 	}
 	write := func(t *testing.T, dir, rel, content string) {
 		t.Helper()

--- a/bots/e2e_coverage_matrix_gate_test.go
+++ b/bots/e2e_coverage_matrix_gate_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestE2ECoverageMatrixGate guards the deterministic MATRIX CONTRACT half of
@@ -81,9 +83,7 @@ func TestE2ECoverageMatrixGate(t *testing.T) {
 	gitWorkspace := func(t *testing.T) string {
 		t.Helper()
 		ws := t.TempDir()
-		if out, err := exec.Command("git", "-C", ws, "init", "-q").CombinedOutput(); err != nil {
-			t.Fatalf("git init: %v (%s)", err, out)
-		}
+		gittest.Run(t, ws, "init", "-q")
 		return ws
 	}
 

--- a/bots/golden_master_extend_verify_test.go
+++ b/bots/golden_master_extend_verify_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 type extendVerifyOut struct {
@@ -34,14 +36,7 @@ func extendVerifyRepo(t *testing.T, verdict, pending string) (string, string) {
 	ws := t.TempDir()
 	git := func(args ...string) string {
 		t.Helper()
-		full := append([]string{"-C", ws}, args...)
-		cmd := exec.Command("git", full...)
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, args...)
 	}
 	git("init", "-q", "-b", "main")
 	git("config", "user.email", "t@example.com")

--- a/bots/golden_master_sync_harness_bot_test.go
+++ b/bots/golden_master_sync_harness_bot_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 )
@@ -212,14 +213,7 @@ func syncHarnessGitRepo(t *testing.T) (string, func(args ...string) string) {
 	ws := t.TempDir()
 	git := func(args ...string) string {
 		t.Helper()
-		full := append([]string{"-C", ws}, args...)
-		cmd := exec.Command("git", full...)
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, args...)
 	}
 	git("init", "-q", "-b", "main")
 	git("config", "user.email", "t@example.com")

--- a/bots/modernize_mark_done_test.go
+++ b/bots/modernize_mark_done_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // modernizeMarkDoneOut is the subset of mark_done's output the tests read.
@@ -26,17 +28,7 @@ func modernizeRepo(t *testing.T, planYAML string) (string, string, func(args ...
 	ws := t.TempDir()
 	git := func(args ...string) string {
 		t.Helper()
-		full := append([]string{"-C", ws}, args...)
-		cmd := exec.Command("git", full...)
-		cmd.Env = append(os.Environ(),
-			"GIT_CONFIG_GLOBAL=/dev/null",
-			"GIT_CONFIG_SYSTEM=/dev/null",
-		)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, args...)
 	}
 	git("init", "-q", "-b", "main")
 	git("config", "user.email", "t@example.com")

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestModernizePlanReadExitGateForms pins the contract surface of the
@@ -133,18 +135,7 @@ func modernizePlanRead(t *testing.T, script, planYAML, onlyLot string, wantExit 
 	ws := t.TempDir()
 	git := func(args ...string) {
 		t.Helper()
-		full := append([]string{"-C", ws}, args...)
-		cmd := exec.Command("git", full...)
-		// The throwaway repo must not inherit the operator's global or
-		// system config: a core.hooksPath or commit.gpgsign there fails
-		// `git commit` for reasons unrelated to what this test pins.
-		cmd.Env = append(os.Environ(),
-			"GIT_CONFIG_GLOBAL=/dev/null",
-			"GIT_CONFIG_SYSTEM=/dev/null",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
+		gittest.Run(t, ws, args...)
 	}
 	git("init", "-q", "-b", "main")
 	git("config", "user.email", "t@example.com")

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // product-docs (Prody) ships four deterministic nodes that decide the run:
@@ -88,18 +90,7 @@ func runExpectingFailure(t *testing.T, command, wantSubstr string) {
 
 func gitIn(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
-		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
-	}
-	return string(out)
+	return gittest.Run(t, dir, args...)
 }
 
 func writeFile(t *testing.T, dir, rel, content string) {
@@ -1101,11 +1092,7 @@ func TestProductDocsScopeCheck(t *testing.T) {
 	// at the moment the run starts.
 	headOf := func(t *testing.T, ws string) string {
 		t.Helper()
-		out, err := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
-		if err != nil {
-			t.Fatalf("git rev-parse HEAD: %v", err)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, "rev-parse", "HEAD")
 	}
 	prodyCommit := func(t *testing.T, ws, msg string) {
 		gitIn(t, ws, "add", "-A")
@@ -1338,11 +1325,7 @@ func TestProductDocsScopeCheckAcceptsAccentedPages(t *testing.T) {
 	writeFile(t, ws, "documentation_produits/demo/README.md", "# Demo\n")
 	gitIn(t, ws, "add", "-A")
 	gitIn(t, ws, "commit", "-q", "-m", "seed")
-	baseOut, err := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
-	if err != nil {
-		t.Fatalf("git rev-parse: %v", err)
-	}
-	base := strings.TrimSpace(string(baseOut))
+	base := gittest.Run(t, ws, "rev-parse", "HEAD")
 
 	// One accented page committed (the diff path), one still untracked
 	// (the status -uall path) — both must stay in scope.
@@ -1437,8 +1420,7 @@ func TestProductDocsScanHintsIncrementalScopedToProduct(t *testing.T) {
 	writeFile(t, ws, "docs/demo/page.md", "# Page\n")
 	gitIn(t, ws, "add", "-A")
 	gitIn(t, ws, "commit", "-q", "-m", "docs(demo): align\n\nBot: product-docs")
-	demoOut, _ := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
-	demoSHA := strings.TrimSpace(string(demoOut))
+	demoSHA := gittest.Run(t, ws, "rev-parse", "HEAD")
 	// …then a SIBLING product's newer one, then drift on this product.
 	writeFile(t, ws, "docs/autre/page.md", "# Autre page\n")
 	gitIn(t, ws, "add", "-A")

--- a/bots/review_pr_finding_id_test.go
+++ b/bots/review_pr_finding_id_test.go
@@ -11,6 +11,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestFindingIDMatchesTheEngineDerivation pins the one thing that makes a
@@ -55,13 +57,7 @@ func TestFindingIDMatchesTheEngineDerivation(t *testing.T) {
 	ws := t.TempDir()
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = ws
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v: %s", args, err, out)
-		}
+		gittest.Run(t, ws, args...)
 	}
 	git("init", "--quiet", "-b", "main")
 	if err := os.WriteFile(ws+"/a.txt", []byte("one\n"), 0o644); err != nil {

--- a/bots/review_pr_stale_anchor_test.go
+++ b/bots/review_pr_stale_anchor_test.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestReviewPRStaleAnchorStillPublishes pins what a review owes the PR it is
@@ -37,15 +39,7 @@ func TestReviewPRStaleAnchorStillPublishes(t *testing.T) {
 	ws := t.TempDir()
 	git := func(args ...string) string {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = ws
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v: %s", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, args...)
 	}
 	git("init", "--quiet", "-b", "main")
 	if err := os.WriteFile(ws+"/a.txt", []byte("one\n"), 0o644); err != nil {

--- a/bots/verify_run_drift_test.go
+++ b/bots/verify_run_drift_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 )
@@ -63,9 +64,7 @@ func TestVerifyRunDriftTail(t *testing.T) {
 	gitWorkspace := func(t *testing.T) string {
 		t.Helper()
 		ws := t.TempDir()
-		if out, err := exec.Command("git", "-C", ws, "init", "-q").CombinedOutput(); err != nil {
-			t.Fatalf("git init: %v (%s)", err, out)
-		}
+		gittest.Run(t, ws, "init", "-q")
 		return ws
 	}
 
@@ -317,9 +316,7 @@ func TestVerifyRunMaskedPipeline(t *testing.T) {
 	setup := func(t *testing.T, body string) (string, string) {
 		t.Helper()
 		ws, scratch := t.TempDir(), t.TempDir()
-		if out, err := exec.Command("git", "-C", ws, "init", "-q").CombinedOutput(); err != nil {
-			t.Fatalf("git init: %v (%s)", err, out)
-		}
+		gittest.Run(t, ws, "init", "-q")
 		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(body), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -456,9 +453,7 @@ func TestAppDevVerifyRunEnforcesTheSameTail(t *testing.T) {
 	workspace := func(t *testing.T, ci bool) (string, string) {
 		t.Helper()
 		ws, scratch := t.TempDir(), t.TempDir()
-		if out, err := exec.Command("git", "-C", ws, "init", "-q").CombinedOutput(); err != nil {
-			t.Fatalf("git init: %v (%s)", err, out)
-		}
+		gittest.Run(t, ws, "init", "-q")
 		if ci {
 			dir := filepath.Join(ws, ".github", "workflows")
 			if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/bots/workspace_probe_test.go
+++ b/bots/workspace_probe_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // shellQuote wraps a value so `sh -c` passes it through verbatim, the way
@@ -35,7 +37,7 @@ func hermeticGitEnv(t *testing.T) []string {
 // the test on a non-zero exit.
 func gitHermetic(t *testing.T, env []string, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd := gittest.Cmd(dir, args...)
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -92,7 +94,7 @@ func runnerStyleClone(t *testing.T, env []string) string {
 	gitHermetic(t, env, ws, "checkout", "-q", "-B", "feature", "FETCH_HEAD")
 
 	// The fixture must have the runner's shape, or the case proves nothing.
-	if out, err := exec.Command("git", "-C", ws, "rev-parse", "--verify", "-q", "develop^{commit}").CombinedOutput(); err == nil {
+	if out, err := gittest.Try(ws, "rev-parse", "--verify", "-q", "develop^{commit}"); err == nil {
 		t.Fatalf("fixture drift: `develop` resolves as a LOCAL ref in the runner-style clone (%s)", out)
 	}
 	gitHermetic(t, env, ws, "rev-parse", "--verify", "-q", "refs/remotes/origin/develop^{commit}")

--- a/e2e/async_interaction_test.go
+++ b/e2e/async_interaction_test.go
@@ -48,7 +48,7 @@ func TestAwaitAnswersAlreadyAnswered(t *testing.T) {
 		t.Fatalf("answer interaction: %v", err)
 	}
 
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 	if err := eng.Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestAwaitAnswersReleasedByAnswer(t *testing.T) {
 
 	seedAsyncInteraction(t, s, runID, "asker", iid, "ship it?")
 
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(context.Background(), runID, nil) }()
@@ -164,7 +164,7 @@ func TestAwaitAnswersDoorbellNeverMissed(t *testing.T) {
 		iid := runID + "_asker_async_1"
 		seedAsyncInteraction(t, s, runID, "asker", iid, "ship it?")
 
-		eng := runtime.New(wf, s, newScenarioExecutor())
+		eng := newEngine(t, wf, s, newScenarioExecutor())
 		done := make(chan error, 1)
 		go func() { done <- eng.Run(context.Background(), runID, nil) }()
 
@@ -225,7 +225,7 @@ func TestAwaitAnswersTimeout(t *testing.T) {
 
 	seedAsyncInteraction(t, s, runID, "asker", iid, "never answered")
 
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 	err := eng.Run(context.Background(), runID, nil)
 	if err == nil {
 		t.Fatal("run succeeded, want timeout failure")
@@ -253,7 +253,7 @@ func TestAwaitAnswersNoQuestions(t *testing.T) {
 	s := tmpStore(t)
 	runID := "e2e-async-noq"
 
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 	if err := eng.Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}

--- a/e2e/bot_golden_master_extend_test.go
+++ b/e2e/bot_golden_master_extend_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -43,7 +42,7 @@ func runExtend(t *testing.T, exec *scenarioExecutor, runID string) *store.Run {
 	t.Helper()
 	wf := compileFixtureStubSafe(t, "golden-master/extend.bot")
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/bot_modernize_test.go
+++ b/e2e/bot_modernize_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -49,7 +48,7 @@ func runModernize(t *testing.T, exec *scenarioExecutor, runID string) *store.Run
 	t.Helper()
 	wf := compileFixtureStubSafe(t, "modernize/main.bot")
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	_ = eng.Run(context.Background(), runID, nil) // the status is the verdict, read below
 	run, err := s.LoadRun(context.Background(), runID)
 	if err != nil {

--- a/e2e/branch_ctx_identity_test.go
+++ b/e2e/branch_ctx_identity_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 )
 
 // ctxProbeExecutor records, per node id, the run identity and the template
@@ -76,7 +75,7 @@ func TestFanOutBranchesCarryTheSnapshotNotTheIdentity(t *testing.T) {
 	const runID = "e2e-branch-ctx-identity"
 
 	exec := &ctxProbeExecutor{seen: map[string][]ctxProbe{}}
-	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, nil); err != nil {
+	if err := newEngine(t, wf, s, exec).Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 

--- a/e2e/branch_improve_decline_test.go
+++ b/e2e/branch_improve_decline_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -51,7 +50,7 @@ func TestBranchImproveLoop_DeclineEndsTypedWithoutShipping(t *testing.T) {
 	stubDeclineTail(exec, true, reason)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	err := eng.Run(context.Background(), "run-bil-declined", map[string]any{
 		"plan_phase": "off", "push_branch": "feature", "pr_url": "https://forge/x/y/pull/1",
 	})
@@ -97,7 +96,7 @@ func TestBranchImproveLoop_RefusedDeclineShipsAnyway(t *testing.T) {
 	stubDeclineTail(exec, false, "declined but HEAD moved from abc123456789 to def987654321: the pass committed work")
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-decline-refused", map[string]any{"plan_phase": "off"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/branch_improve_delivery_reserve_test.go
+++ b/e2e/branch_improve_delivery_reserve_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -61,7 +60,7 @@ func runReserveScenario(t *testing.T, id string, tweak func(*ir.Workflow)) *stor
 	stubBranchPlanRelay(exec)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), id, map[string]any{"plan_phase": "off"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -232,7 +231,7 @@ func TestBranchImproveLoop_WindowStoppedPassLeavesTheLoop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-window-stop", map[string]any{"plan_phase": "off"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/branch_improve_loop_test.go
+++ b/e2e/branch_improve_loop_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -116,7 +115,7 @@ func TestBranchImproveLoop_ContinuesUntilClean(t *testing.T) {
 	stubBranchCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-continue", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -156,7 +155,7 @@ func TestBranchImproveLoop_ConvergesFirstPass(t *testing.T) {
 	stubBranchCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-first", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -201,7 +200,7 @@ func TestBranchImproveLoop_RedVerifyRoutesBackToCampaign(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-red", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -230,7 +229,7 @@ func TestBranchImproveLoop_MRPathOnConverge(t *testing.T) {
 	stubBranchCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	inputs := map[string]any{"open_mr": true}
 	if err := eng.Run(context.Background(), "run-bil-mr", inputs); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -420,7 +419,7 @@ func TestBranchImproveLoop_PlanBudgetExhaustedFailsBeforeCampaign(t *testing.T) 
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	err := eng.Run(context.Background(), "run-bil-plan-budget-fail", map[string]any{"plan_review": "on"})
 	if err == nil {
 		t.Fatal("Run: want an error (the plan budget guard routes to plan_exhausted), got nil")
@@ -483,7 +482,7 @@ func TestBranchImproveLoop_PlanBudgetWithinShareRunsCampaign(t *testing.T) {
 	stubConvergingCampaignTail(exec, &campaignIns)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-plan-budget-ok", map[string]any{"plan_review": "on"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -535,7 +534,7 @@ func TestBranchImproveLoop_PlanBudgetFollowsTheCapInForce(t *testing.T) {
 	stubConvergingCampaignTail(exec, &campaignIns)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-plan-budget-recap", map[string]any{"plan_review": "on"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -575,7 +574,7 @@ func TestBranchImproveLoop_PlanBudgetUnboundedNeverTrips(t *testing.T) {
 	stubConvergingCampaignTail(exec, &campaignIns)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-bil-plan-budget-uncapped", map[string]any{"plan_review": "on"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -613,7 +612,7 @@ func TestBranchImproveLoop_PlanBudgetResumeRunsTheCampaign(t *testing.T) {
 
 	exec := newScenarioExecutor()
 	planBudgetGateStubs(exec, planOverShareUSD)
-	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, map[string]any{"plan_review": "on"}); err == nil {
+	if err := newEngine(t, wf, s, exec).Run(context.Background(), runID, map[string]any{"plan_review": "on"}); err == nil {
 		t.Fatal("first pass succeeded; $37.50 must cross the $22.50 share")
 	}
 	run, err := s.LoadRun(context.Background(), runID)
@@ -632,7 +631,7 @@ func TestBranchImproveLoop_PlanBudgetResumeRunsTheCampaign(t *testing.T) {
 	planBudgetGateStubs(resumeExec, planOverShareUSD)
 	var campaignIns []map[string]any
 	stubConvergingCampaignTail(resumeExec, &campaignIns)
-	if err := runtime.New(wf, s, resumeExec).Resume(context.Background(), runID, nil); err != nil {
+	if err := newEngine(t, wf, s, resumeExec).Resume(context.Background(), runID, nil); err != nil {
 		t.Fatalf("resume failed: %v", err)
 	}
 

--- a/e2e/branch_template_context_test.go
+++ b/e2e/branch_template_context_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -89,7 +88,7 @@ func TestTemplateContextReachesFanOutBranches(t *testing.T) {
 		model.WithWorkDir(t.TempDir()),
 	)
 
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}
@@ -222,7 +221,7 @@ workflow run_ref_missing_member:
 	const runID = "e2e-run-ref-missing-member"
 	exec := model.NewClawExecutor(model.NewRegistry(), wf, model.WithWorkDir(t.TempDir()))
 
-	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, nil); err != nil {
+	if err := newEngine(t, wf, s, exec).Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	events, err := s.LoadEvents(context.Background(), runID)

--- a/e2e/campaign_plan_phase_test.go
+++ b/e2e/campaign_plan_phase_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -103,7 +102,7 @@ func TestCampaignPlanPhase_ReviewOffStillAuthorsThePlan(t *testing.T) {
 			captureCampaignInputs(exec, &ins)
 
 			s := tmpStore(t)
-			eng := runtime.New(wf, s, exec)
+			eng := newEngine(t, wf, s, exec)
 			runID := "run-plan-review-off-" + tc.name
 			if err := eng.Run(context.Background(), runID, map[string]any{"plan_review": "off"}); err != nil {
 				t.Fatalf("Run: %v", err)
@@ -156,7 +155,7 @@ func TestCampaignPlanPhase_OffSkipsPlanningExplicitly(t *testing.T) {
 			captureCampaignInputs(exec, &ins)
 
 			s := tmpStore(t)
-			eng := runtime.New(wf, s, exec)
+			eng := newEngine(t, wf, s, exec)
 			runID := "run-plan-phase-off-" + tc.name
 			if err := eng.Run(context.Background(), runID, map[string]any{"plan_phase": "off"}); err != nil {
 				t.Fatalf("Run: %v", err)
@@ -219,7 +218,7 @@ func runProbeRefusal(t *testing.T, tc campaignBotCase, reason string) {
 	}
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	runID := "run-probe-refusal-" + tc.name + "-" + strings.Fields(reason)[0]
 	if err := eng.Run(context.Background(), runID, nil); err == nil {
 		t.Fatal("Run: want an error (workspace_probe -> fail), got nil")

--- a/e2e/cli_async_questions_test.go
+++ b/e2e/cli_async_questions_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -69,7 +68,7 @@ func TestRunsQuestionsThenAnswerReleasesAwaitGate(t *testing.T) {
 	iid := runID + "_asker_async_1"
 	seedAsyncInteraction(t, s, runID, "asker", iid, "ship it?")
 
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 	done := make(chan error, 1)
 	go func() { done <- eng.Run(context.Background(), runID, nil) }()
 	waitForRun(t, s, runID)

--- a/e2e/dispatcher_test.go
+++ b/e2e/dispatcher_test.go
@@ -156,9 +156,14 @@ func TestDispatcherE2E_CancelInFlight(t *testing.T) {
 	defer cleanup()
 
 	started := make(chan struct{}, 1)
+	// Whether the worker came back is what splits the two failures this row
+	// can have. Without it the timeout says only that the entry is still
+	// there, which is the symptom both halves share.
+	var handlerReturned atomic.Bool
 	runner.Handler = func(ctx context.Context, _ dispatcher.DispatchSpec) error {
 		started <- struct{}{}
 		<-ctx.Done()
+		handlerReturned.Store(true)
 		return ctx.Err()
 	}
 
@@ -180,7 +185,19 @@ func TestDispatcherE2E_CancelInFlight(t *testing.T) {
 	// been widened once for flakiness, and the passing runs said nothing about
 	// whether the margin was shrinking.
 	waitUntil(t, 10*time.Second, "cancel to flush the running entry",
-		func() bool { return len(c.Snapshot().Running) == 0 })
+		func() bool { return len(c.Snapshot().Running) == 0 },
+		func() string {
+			// The measured shape of this wait is ~25ms or never (60 runs under
+			// -race on a starved box: 0.020-0.035s, no slow tail), so a
+			// timeout here is a park, not a slow machine — and no budget
+			// widens into it. It has been widened twice already (2s -> 10s,
+			// a354dc0a0 and 5368500f5 "flaky race job") and still reaches the
+			// ceiling on the race job. What the next occurrence needs is which
+			// half parked, not another number.
+			return fmt.Sprintf("handler returned=%v (false: the cancel never reached the worker's ctx; "+
+				"true: the worker came back and the actor never drained cmdRunFinished), snapshot=%+v",
+				handlerReturned.Load(), c.Snapshot())
+		})
 }
 
 func TestDispatcherE2E_RespectsTerminalStateChange(t *testing.T) {

--- a/e2e/docs_refresh_test.go
+++ b/e2e/docs_refresh_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -73,7 +72,7 @@ func runDocsRefresh(t *testing.T, exec *scenarioExecutor, runID string) *store.R
 	t.Helper()
 	wf := compileFixtureStubSafe(t, "docs-refresh/main.bot")
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/e2e_coverage_bot_test.go
+++ b/e2e/e2e_coverage_bot_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -104,7 +103,7 @@ func TestE2ECoverage_ContinuesUntilComplete(t *testing.T) {
 	stubEndyCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-endy-continue", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -148,7 +147,7 @@ func TestE2ECoverage_WholeAppRunBlocksOnUncoveredRows(t *testing.T) {
 	stubEndyCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-endy-block", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -180,7 +179,7 @@ func TestE2ECoverage_ScopedRunConvergesWithUncoveredRows(t *testing.T) {
 	stubEndyCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	inputs := map[string]any{"target": "persistence & resume lifecycle"}
 	if err := eng.Run(context.Background(), "run-endy-scoped", inputs); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -219,7 +218,7 @@ func TestE2ECoverage_BlankTargetIsNotAScope(t *testing.T) {
 	stubEndyCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	inputs := map[string]any{"target": "   "}
 	if err := eng.Run(context.Background(), "run-endy-blank", inputs); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -260,7 +259,7 @@ func TestE2ECoverage_MatrixProblemsRouteBackToCampaign(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-endy-orphan", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -306,7 +305,7 @@ func TestE2ECoverage_RedSuiteRoutesBackWithFailLog(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-endy-red", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -335,7 +334,7 @@ func TestE2ECoverage_EventTrace(t *testing.T) {
 	stubEndyCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-endy-events", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -244,7 +244,7 @@ func TestSingleModel_HappyPath(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-single-happy", nil)
 	if err != nil {
@@ -391,7 +391,7 @@ func TestSingleModel_RefineLoop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-single-refine", nil)
 	if err != nil {
@@ -484,7 +484,7 @@ func TestSingleModel_GlobalReloop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-single-reloop", nil)
 	if err != nil {
@@ -606,7 +606,7 @@ func TestDualParallel_HappyPath(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-dual-happy", nil)
 	if err != nil {
@@ -754,7 +754,7 @@ func TestDualParallel_GlobalReloop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-dual-reloop", nil)
 	if err != nil {
@@ -859,7 +859,7 @@ func TestCompliance_HappyPath_NoHumanGate(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-comp-nohuman", nil)
 	if err != nil {
@@ -974,7 +974,7 @@ func TestCompliance_HumanGate(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	// Phase 1: Run should pause at human checkpoint.
 	err := eng.Run(context.Background(), "e2e-comp-human", nil)
@@ -1141,7 +1141,7 @@ func TestCompliance_RefineLoop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-comp-refine", nil)
 	if err != nil {
@@ -1220,7 +1220,7 @@ func TestCIFix_HappyPath(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-ci-happy", nil)
 	if err != nil {
@@ -1334,7 +1334,7 @@ func TestCIFix_FixLoop(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-ci-loop", nil)
 	if err != nil {
@@ -1424,7 +1424,7 @@ func TestCIFix_LoopExhaustion(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-ci-exhaust", nil)
 	if err == nil {
@@ -1564,7 +1564,7 @@ func TestEventSequenceCoherence(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	if err := eng.Run(context.Background(), "e2e-events", nil); err != nil {
 		t.Fatalf("run error: %v", err)

--- a/e2e/engine_test.go
+++ b/e2e/engine_test.go
@@ -1,0 +1,48 @@
+package e2e
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// newEngine is how this suite builds an engine: on a git repository the TEST
+// owns, never on the checkout the tests happen to run in.
+//
+// runtime.New with no WithWorkDir defaults to os.Getwd() at Run() time — the
+// e2e package directory, inside the developer's clone — so `worktree: auto`
+// (the IR default, which every fixture here inherits) makes `git worktree add`
+// register the run's worktree in the REAL repository. The checkout itself
+// lives under the store's t.TempDir() and is deleted when the test returns;
+// the registration is not, and nothing ever comes back for it (#870: 1 773
+// dead entries / 2.5 GB measured after two days of agent work, 27 more per
+// `go test ./e2e/`).
+//
+// A caller that genuinely needs a particular workspace still passes
+// runtime.WithWorkDir: options apply in order, so an explicit one wins over
+// the scratch repository below.
+func newEngine(t *testing.T, wf *ir.Workflow, s store.RunStore, exec runtime.NodeExecutor, opts ...runtime.EngineOption) *runtime.Engine {
+	t.Helper()
+	full := append([]runtime.EngineOption{runtime.WithWorkDir(scratchRepo(t))}, opts...)
+	return runtime.New(wf, s, exec, full...)
+}
+
+// scratchRepos memoises one repository per test. A test that runs then
+// RESUMES builds two engines over the same run, and a second repository would
+// re-anchor it on a tree it never executed against.
+var scratchRepos sync.Map // *testing.T -> string
+
+func scratchRepo(t *testing.T) string {
+	t.Helper()
+	if dir, ok := scratchRepos.Load(t); ok {
+		return dir.(string)
+	}
+	dir := gittest.SourceRepo(t)
+	scratchRepos.Store(t, dir)
+	t.Cleanup(func() { scratchRepos.Delete(t) })
+	return dir
+}

--- a/e2e/events_emit_wait_test.go
+++ b/e2e/events_emit_wait_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -21,7 +20,7 @@ func TestEventsEmitWait(t *testing.T) {
 	s := tmpStore(t)
 	// No LLM/tool nodes — emit/wait/compute are engine-handled; the stub
 	// executor is never invoked.
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 
 	if err := eng.Run(context.Background(), "e2e-events-pingpong", nil); err != nil {
 		t.Fatalf("run pingpong: %v", err)

--- a/e2e/feature_dev_test.go
+++ b/e2e/feature_dev_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -104,7 +103,7 @@ func TestVibeFeatureDev_ConvergesFirstPass(t *testing.T) {
 	stubFeatureDevCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-fd-first", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -145,7 +144,7 @@ func TestVibeFeatureDev_ReviewBlocksThenConverges(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-fd-review", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -176,7 +175,7 @@ func TestVibeFeatureDev_ContinuesUntilComplete(t *testing.T) {
 	stubFeatureDevCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-fd-continue", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -227,7 +226,7 @@ func TestVibeFeatureDev_RedVerifyRoutesBackToCampaign(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-fd-red", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -257,7 +256,7 @@ func TestVibeFeatureDev_MRPathOnConverge(t *testing.T) {
 	stubFeatureDevCampaign(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	inputs := map[string]any{"open_mr": true}
 	if err := eng.Run(context.Background(), "run-fd-mr", inputs); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -369,7 +368,7 @@ func TestVibeFeatureDev_ProbeSeesLoopIteration(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-fd-iter", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/feed_watch_test.go
+++ b/e2e/feed_watch_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"time"
 )
@@ -438,7 +437,7 @@ func TestFeedWatch_GraphRouting(t *testing.T) {
 			return map[string]any{"new_count": 0, "duplicate_count": 0, "pending_totals": map[string]any{}, "committed": false, "summary": "s", "_tokens": 1}, nil
 		})
 		s := tmpStore(t)
-		if err := runtime.New(wf, s, exec).Run(context.Background(), "fw-collect", nil); err != nil {
+		if err := newEngine(t, wf, s, exec).Run(context.Background(), "fw-collect", nil); err != nil {
 			t.Fatalf("run: %v", err)
 		}
 		r, _ := s.LoadRun(context.Background(), "fw-collect")
@@ -462,7 +461,7 @@ func TestFeedWatch_GraphRouting(t *testing.T) {
 			}, nil
 		})
 		s := tmpStore(t)
-		if err := runtime.New(wf, s, exec).Run(context.Background(), "fw-empty", nil); err != nil {
+		if err := newEngine(t, wf, s, exec).Run(context.Background(), "fw-empty", nil); err != nil {
 			t.Fatalf("run: %v", err)
 		}
 		r, _ := s.LoadRun(context.Background(), "fw-empty")
@@ -497,7 +496,7 @@ func TestFeedWatch_GraphRouting(t *testing.T) {
 			return map[string]any{"posted": false, "dry_run": true, "delivered": 0, "targets": []any{}, "summary": "dry", "_tokens": 1}, nil
 		})
 		s := tmpStore(t)
-		if err := runtime.New(wf, s, exec).Run(context.Background(), "fw-dry", nil); err != nil {
+		if err := newEngine(t, wf, s, exec).Run(context.Background(), "fw-dry", nil); err != nil {
 			t.Fatalf("run: %v", err)
 		}
 		r, _ := s.LoadRun(context.Background(), "fw-dry")
@@ -535,7 +534,7 @@ func TestFeedWatch_GraphRouting(t *testing.T) {
 			return map[string]any{"cleared": 1, "archived": true, "committed": false, "summary": "s", "_tokens": 1}, nil
 		})
 		s := tmpStore(t)
-		if err := runtime.New(wf, s, exec).Run(context.Background(), "fw-full", nil); err != nil {
+		if err := newEngine(t, wf, s, exec).Run(context.Background(), "fw-full", nil); err != nil {
 			t.Fatalf("run: %v", err)
 		}
 		r, _ := s.LoadRun(context.Background(), "fw-full")

--- a/e2e/handoff_publish_test.go
+++ b/e2e/handoff_publish_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -40,7 +39,7 @@ func TestOnlyAPublishedNodeLeavesAnArtifact(t *testing.T) {
 
 	s := tmpStore(t)
 	const runID = "e2e-handoff-publish"
-	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, nil); err != nil {
+	if err := newEngine(t, wf, s, exec).Run(context.Background(), runID, nil); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 	ctx := context.Background()

--- a/e2e/live_bot_feature_dev_test.go
+++ b/e2e/live_bot_feature_dev_test.go
@@ -5,12 +5,11 @@ package e2e
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -105,11 +104,9 @@ func TestLive_FeatureDev(t *testing.T) {
 	}
 
 	// The acceptance criterion: at least one new commit beyond the seed.
-	cmd := exec.Command("git", "-C", workspaceDir, "rev-list", "--count", "HEAD")
-	out, err := cmd.CombinedOutput()
-	commitCount := strings.TrimSpace(string(out))
+	commitCount, err := gittest.Try(workspaceDir, "rev-list", "--count", "HEAD")
 	if err != nil {
-		t.Errorf("git rev-list failed: %v\n%s", err, out)
+		t.Errorf("git rev-list failed: %v\n%s", err, commitCount)
 	} else if commitCount == "1" {
 		t.Errorf("expected at least 2 commits (seed + one feature commit), got %s — commit_changes likely never landed", commitCount)
 	} else {
@@ -204,9 +201,8 @@ func TestLive_FeatureDev_Real(t *testing.T) {
 		t.Fatalf("LoadEvents: %v", err)
 	}
 	requireWorkspaceCommitGrowth(t, workspaceDir, commitsBefore)
-	cmd := exec.Command("git", "-C", workspaceDir, "log", "--oneline", "-10")
-	out, _ := cmd.CombinedOutput()
-	t.Logf("Recent commits:\n%s", string(out))
+	out, _ := gittest.Try(workspaceDir, "log", "--oneline", "-10")
+	t.Logf("Recent commits:\n%s", out)
 
 	writeLiveTestReport(t, runID, workspaceDir, storeDir, s, events)
 	assessQualityRaw(t, "feature-dev", "Featurly", "Add POST users/id/posts endpoint with validation, idempotency, and table-driven tests", runID, workspaceDir, storeDir, s, events, time.Since(start), reason, gitArtifactEvidence(t, workspaceDir))

--- a/e2e/live_bot_secured_renovacy_test.go
+++ b/e2e/live_bot_secured_renovacy_test.go
@@ -5,12 +5,12 @@ package e2e
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -132,11 +132,9 @@ func TestLive_SecuredRenovacy(t *testing.T) {
 	}
 
 	// Probe whether ANY upgrade landed: count commits beyond the seed.
-	cmd := exec.Command("git", "-C", workspaceDir, "rev-list", "--count", "HEAD")
-	out, err := cmd.CombinedOutput()
-	commitCount := strings.TrimSpace(string(out))
+	commitCount, err := gittest.Try(workspaceDir, "rev-list", "--count", "HEAD")
 	if err != nil {
-		t.Errorf("git rev-list failed: %v\n%s", err, out)
+		t.Errorf("git rev-list failed: %v\n%s", err, commitCount)
 	} else {
 		t.Logf("Commits in workspace: %s (≥3 expected: seed + npm-fixture + ≥1 upgrade)", commitCount)
 	}
@@ -247,9 +245,8 @@ func TestLive_SecuredRenovacy_Real(t *testing.T) {
 		t.Fatalf("LoadEvents: %v", err)
 	}
 	requireWorkspaceCommitGrowth(t, workspaceDir, commitsBefore)
-	cmd := exec.Command("git", "-C", workspaceDir, "log", "--oneline", "-30")
-	out, _ := cmd.CombinedOutput()
-	t.Logf("Commits in workspace:\n%s", string(out))
+	out, _ := gittest.Try(workspaceDir, "log", "--oneline", "-30")
+	t.Logf("Commits in workspace:\n%s", out)
 
 	writeLiveTestReport(t, runID, workspaceDir, storeDir, s, events)
 	assessQualityRaw(t, "secured-renovacy", "Renovacy", "Upgrade polyglot CVE-flagged dependencies incl. node-ipc malware screen", runID, workspaceDir, storeDir, s, events, time.Since(start), reason, gitArtifactEvidence(t, workspaceDir))

--- a/e2e/live_bot_whole_improve_loop_test.go
+++ b/e2e/live_bot_whole_improve_loop_test.go
@@ -5,12 +5,11 @@ package e2e
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -219,10 +218,9 @@ func TestLive_VibeReviewAlternating_Real(t *testing.T) {
 		t.Fatalf("LoadEvents: %v", err)
 	}
 	requireWorkspaceCommitGrowth(t, workspaceDir, commitsBefore)
-	cmd := exec.Command("git", "-C", workspaceDir, "diff", "--stat", "HEAD")
-	out, _ := cmd.CombinedOutput()
-	if len(strings.TrimSpace(string(out))) > 0 {
-		t.Logf("Uncommitted fixer changes (working tree):\n%s", string(out))
+	out, _ := gittest.Try(workspaceDir, "diff", "--stat", "HEAD")
+	if out != "" {
+		t.Logf("Uncommitted fixer changes (working tree):\n%s", out)
 	}
 
 	writeLiveTestReport(t, runID, workspaceDir, storeDir, s, events)

--- a/e2e/live_quality_test.go
+++ b/e2e/live_quality_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
@@ -301,19 +302,18 @@ func worktreeArtifactEvidence(t *testing.T, ws string) string {
 
 // gitOut runs a git command in dir and returns combined output (best-effort).
 func gitOut(dir string, args ...string) string {
-	full := append([]string{"-C", dir}, args...)
-	out, _ := exec.Command("git", full...).CombinedOutput()
-	return string(out)
+	out, _ := gittest.Try(dir, args...)
+	return out
 }
 
 // iterionSHA returns the short HEAD sha of the iterion repo (for snapshot
 // provenance). Repo root is the e2e parent directory.
 func iterionSHA() string {
-	out, err := exec.Command("git", "-C", "..", "rev-parse", "--short", "HEAD").CombinedOutput()
+	out, err := gittest.Try("..", "rev-parse", "--short", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(out))
+	return out
 }
 
 // liveJudgeInvoker composes the cross-family judge panel's backends:

--- a/e2e/live_test.go
+++ b/e2e/live_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	clawtools "github.com/SocialGouv/claw-code-go/pkg/api/tools"
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
@@ -284,10 +285,7 @@ func TestLive_Lite_DualModel_PlanImplementReview(t *testing.T) {
 	t.Logf("Workspace directory (persists after test): %s", workspaceDir)
 
 	// Initialize a git repo so claude_code can read git context (status/diff).
-	gitInit := exec.Command("git", "init", workspaceDir)
-	if out, gitErr := gitInit.CombinedOutput(); gitErr != nil {
-		t.Fatalf("git init failed: %v\n%s", gitErr, out)
-	}
+	gittest.Run(t, workspaceDir, "init")
 
 	installValidateSyntax(t, workspaceDir)
 
@@ -637,10 +635,7 @@ func TestLive_Lite_SessionContinuity_ReviewFix(t *testing.T) {
 	}
 	t.Logf("Workspace directory (persists after test): %s", workspaceDir)
 
-	gitInit := exec.Command("git", "init", workspaceDir)
-	if out, gitErr := gitInit.CombinedOutput(); gitErr != nil {
-		t.Fatalf("git init failed: %v\n%s", gitErr, out)
-	}
+	gittest.Run(t, workspaceDir, "init")
 
 	installValidateSyntax(t, workspaceDir)
 
@@ -910,10 +905,7 @@ func TestLive_Full_ExhaustiveDSLCoverage(t *testing.T) {
 	}
 	t.Logf("Workspace directory (persists after test): %s", workspaceDir)
 
-	gitInit := exec.Command("git", "init", workspaceDir)
-	if out, gitErr := gitInit.CombinedOutput(); gitErr != nil {
-		t.Fatalf("git init failed: %v\n%s", gitErr, out)
-	}
+	gittest.Run(t, workspaceDir, "init")
 
 	installValidateSyntax(t, workspaceDir)
 
@@ -1246,10 +1238,7 @@ func TestLive_Lite_SessionInheritValidation(t *testing.T) {
 	}
 	t.Logf("Workspace directory (persists after test): %s", workspaceDir)
 
-	gitInit := exec.Command("git", "init", workspaceDir)
-	if out, gitErr := gitInit.CombinedOutput(); gitErr != nil {
-		t.Fatalf("git init failed: %v\n%s", gitErr, out)
-	}
+	gittest.Run(t, workspaceDir, "init")
 
 	storeDir := resolveLiveStoreDir(t, workspaceDir)
 	s, storeErr := store.New(storeDir)
@@ -3087,14 +3076,14 @@ func liveRunResultAcceptableReal(err error) (bool, string) {
 // both shapes.
 func workspaceCommitCount(t *testing.T, dir string) int {
 	t.Helper()
-	out, err := exec.Command("git", "-C", dir, "rev-list", "--count", "--all").Output()
+	out, err := gittest.Try(dir, "rev-list", "--count", "--all")
 	if err != nil {
 		t.Logf("git rev-list failed in %s: %v", dir, err)
 		return 0
 	}
-	n, parseErr := strconv.Atoi(strings.TrimSpace(string(out)))
+	n, parseErr := strconv.Atoi(out)
 	if parseErr != nil {
-		t.Logf("could not parse commit count %q: %v", string(out), parseErr)
+		t.Logf("could not parse commit count %q: %v", out, parseErr)
 		return 0
 	}
 	return n
@@ -3110,8 +3099,8 @@ func requireWorkspaceCommitGrowth(t *testing.T, workspaceDir string, before int)
 	if after <= before {
 		// Dump recent commits across every ref so failure diagnostics
 		// surface storage-branch work too.
-		recent, _ := exec.Command("git", "-C", workspaceDir, "log", "--all", "--oneline", "-10").CombinedOutput()
-		t.Fatalf("expected ≥1 new commit on any ref, got before=%d after=%d (no work landed).\nRecent log (all refs):\n%s", before, after, string(recent))
+		recent, _ := gittest.Try(workspaceDir, "log", "--all", "--oneline", "-10")
+		t.Fatalf("expected ≥1 new commit on any ref, got before=%d after=%d (no work landed).\nRecent log (all refs):\n%s", before, after, recent)
 	}
 	t.Logf("Workspace commits across all refs: %d → %d (Δ=%d)", before, after, after-before)
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // e2eParallelCap bounds how many of this package's tests run at once.
@@ -30,9 +32,16 @@ const e2eParallelCap = 8
 // holds its GOMAXPROCS default, i.e. nobody chose).
 const e2eParallelEnv = "ITERION_E2E_PARALLEL"
 
+// The suite runs out of the developer's own checkout, so an engine built
+// without WithWorkDir hands `worktree: auto` (the IR default) that repository
+// as its source: `git worktree add` registers the run's worktree THERE while
+// the checkout lives under t.TempDir() and is deleted on return. Measured at
+// 1 773 dead entries / 2.5 GB after two days of parallel agent work (#870),
+// and 66 more per full `go test ./...`. gittest.NoWorktreeLeaks fails the
+// package when that count moves, and names the test that moved it.
 func TestMain(m *testing.M) {
 	capParallelism()
-	os.Exit(m.Run())
+	os.Exit(gittest.NoWorktreeLeaks(m))
 }
 
 // capParallelism lowers `-parallel` to e2eParallelCap when the operator left

--- a/e2e/modernize_test.go
+++ b/e2e/modernize_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -45,7 +44,7 @@ func TestModernize_OnlyLotBlockedFailsTyped(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	runErr := eng.Run(context.Background(), "run-modernize-blocked", map[string]any{"only_lot": "lot-2"})
 	if runErr == nil {
 		t.Fatal("Run: want an error (work_gate routes a non-actionable only_lot to fail), got nil")
@@ -102,7 +101,7 @@ func TestModernize_UnfilteredNothingToDoStaysGreen(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-modernize-done", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/plan_review_test.go
+++ b/e2e/plan_review_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -68,7 +67,7 @@ func runPlanReview(t *testing.T, runID string, inputs map[string]any, reviewSkip
 	planReviewStubs(exec, reviewSkipped, &campaignIns)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, inputs); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/e2e/privacy_test.go
+++ b/e2e/privacy_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -56,7 +55,7 @@ func TestE2E_PrivacyPipeline(t *testing.T) {
 	const rawToken = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
 	rawText := "Contact " + rawEmail + " or use token " + rawToken
 
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, map[string]any{
 		"text": rawText,
 	}); err != nil {

--- a/e2e/product_docs_test.go
+++ b/e2e/product_docs_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -129,7 +128,7 @@ func runProductDocs(t *testing.T, exec *scenarioExecutor, runID string, inputs m
 	t.Helper()
 	wf := compileFixtureStubSafe(t, "product-docs/main.bot")
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, inputs); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/review_pr_convergence_test.go
+++ b/e2e/review_pr_convergence_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -24,7 +23,7 @@ func TestReviewPRDual_CollectorChainFiresOnce(t *testing.T) {
 
 	s := tmpStore(t)
 	runID := "e2e-dual-converges-once"
-	if err := runtime.New(wf, s, exec).Run(context.Background(), runID, map[string]any{
+	if err := newEngine(t, wf, s, exec).Run(context.Background(), runID, map[string]any{
 		"review_tier": "audit", "mono_family": "claude",
 	}); err != nil {
 		t.Fatalf("run error: %v", err)

--- a/e2e/review_pr_tiers_test.go
+++ b/e2e/review_pr_tiers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -63,7 +62,7 @@ func runReviewPRTier(t *testing.T, runID string, inputs map[string]any) *scenari
 	wireReviewPRStubs(exec)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, inputs); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/e2e/review_topology_test.go
+++ b/e2e/review_topology_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -44,7 +43,7 @@ func runTopology(t *testing.T, runID string, inputs map[string]any) *scenarioExe
 	approvingReviewers(exec)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), runID, inputs); err != nil {
 		t.Fatalf("run error: %v", err)
 	}

--- a/e2e/rewind_resume_test.go
+++ b/e2e/rewind_resume_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -40,7 +39,7 @@ func TestRewindThenResume_SkipsUpstreamNodes(t *testing.T) {
 	})
 
 	const runID = "e2e-rewind-mini"
-	eng := runtime.New(wf, st, exec)
+	eng := newEngine(t, wf, st, exec)
 	if err := eng.Run(context.Background(), runID, nil); err == nil {
 		t.Fatal("expected the run to fail (verify -> fail), got success")
 	}
@@ -81,7 +80,7 @@ func TestRewindThenResume_SkipsUpstreamNodes(t *testing.T) {
 	exec.on("verify", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"value": "approved", "ok": true}, nil
 	})
-	eng2 := runtime.New(wf, st, exec)
+	eng2 := newEngine(t, wf, st, exec)
 	if err := eng2.Resume(context.Background(), runID, nil); err != nil {
 		t.Fatalf("resume after rewind: %v", err)
 	}

--- a/e2e/rewind_workspace_test.go
+++ b/e2e/rewind_workspace_test.go
@@ -59,7 +59,7 @@ func TestRewindRestoresWorkspaceEndToEnd(t *testing.T) {
 	})
 
 	const runID = "e2e-rewind-workspace"
-	eng := runtime.New(wf, st, exec,
+	eng := newEngine(t, wf, st, exec,
 		runtime.WithLogger(iterlog.Nop()),
 		runtime.WithWorkDir(ws),
 		runtime.WithWorkspaceTracker(tracker),
@@ -169,7 +169,7 @@ func TestRewindAfterResumeKeepsTriageEdits(t *testing.T) {
 
 	const runID = "e2e-rewind-after-resume"
 	newEngine := func() *runtime.Engine {
-		return runtime.New(wf, st, exec,
+		return newEngine(t, wf, st, exec,
 			runtime.WithLogger(iterlog.Nop()),
 			runtime.WithWorkDir(ws),
 			runtime.WithWorkspaceTracker(tracker),
@@ -266,7 +266,7 @@ func TestRewindScopeAfterHumanGatePause(t *testing.T) {
 
 	const runID = "e2e-rewind-human-gate"
 	newEngine := func() *runtime.Engine {
-		return runtime.New(wf, st, exec,
+		return newEngine(t, wf, st, exec,
 			runtime.WithLogger(iterlog.Nop()),
 			runtime.WithWorkDir(ws),
 			runtime.WithWorkspaceTracker(tracker),
@@ -358,7 +358,7 @@ func TestRewindScopeAfterDelegatePause(t *testing.T) {
 
 	const runID = "e2e-rewind-delegate-pause"
 	newEngine := func() *runtime.Engine {
-		return runtime.New(wf, st, exec,
+		return newEngine(t, wf, st, exec,
 			runtime.WithLogger(iterlog.Nop()),
 			runtime.WithWorkDir(ws),
 			runtime.WithWorkspaceTracker(tracker),
@@ -445,7 +445,7 @@ func TestRewindScopeCoversAFailedNodesDebris(t *testing.T) {
 	})
 
 	const runID = "e2e-rewind-failed-node"
-	eng := runtime.New(wf, st, exec,
+	eng := newEngine(t, wf, st, exec,
 		runtime.WithLogger(iterlog.Nop()),
 		runtime.WithWorkDir(ws),
 		runtime.WithWorkspaceTracker(tracker),

--- a/e2e/secured_renovacy_test.go
+++ b/e2e/secured_renovacy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -186,7 +185,7 @@ func TestSecuredRenovacy_PatchFastTrack(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-sr-patch", securedRenovacyStubInputs); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -396,7 +395,7 @@ func TestSecuredRenovacy_PerPackageMinor(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-sr-minor", securedRenovacyStubInputs); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -573,7 +572,7 @@ func TestSecuredRenovacy_FixLoopThenCommit(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-sr-fix", securedRenovacyStubInputs); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/turing_countdown_test.go
+++ b/e2e/turing_countdown_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -27,7 +26,7 @@ func TestTuringCountdown(t *testing.T) {
 	s := tmpStore(t)
 	// The bot has no LLM/tool nodes, so the executor is never invoked; a bare
 	// stub satisfies the engine constructor.
-	eng := runtime.New(wf, s, newScenarioExecutor())
+	eng := newEngine(t, wf, s, newScenarioExecutor())
 
 	if err := eng.Run(context.Background(), "e2e-turing-countdown", nil); err != nil {
 		t.Fatalf("run countdown: %v", err)

--- a/e2e/verified_action_test.go
+++ b/e2e/verified_action_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -59,7 +58,7 @@ workflow w:
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "e2e-va", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
@@ -1253,13 +1254,7 @@ func TestVulnWatch_PushConflictKeepsOperatorWork(t *testing.T) {
 	bare := filepath.Join(dir, "origin.git")
 	run := func(wd string, args ...string) {
 		t.Helper()
-		c := exec.Command("git", args...)
-		c.Dir = wd
-		c.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@e",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@e")
-		if out, err := c.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, wd, args...)
 	}
 	run(dir, "init", "--bare", "-b", "main", bare)
 	run(dir, "clone", bare, ws)
@@ -1325,10 +1320,8 @@ func TestVulnWatch_PushConflictKeepsOperatorWork(t *testing.T) {
 	if b, rerr := os.ReadFile(precious); rerr != nil || string(b) != "hours of work\n" {
 		t.Fatalf("the operator's uncommitted file was destroyed (err %v, content %q)", rerr, string(b))
 	}
-	log := exec.Command("git", "log", "--oneline")
-	log.Dir = ws
-	out, _ := log.CombinedOutput()
-	if !strings.Contains(string(out), "operator's own commit") {
+	out, _ := gittest.Try(ws, "log", "--oneline")
+	if !strings.Contains(out, "operator's own commit") {
 		t.Fatalf("the operator's unpushed commit was destroyed:\n%s", out)
 	}
 }

--- a/e2e/whats_next_loop_test.go
+++ b/e2e/whats_next_loop_test.go
@@ -143,7 +143,7 @@ func TestWhatsNextV2_ChatLoop_PauseResumeClose(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-nexie-chat", nil)
 	if !errors.Is(err, runtime.ErrRunPaused) {
@@ -228,7 +228,7 @@ func TestWhatsNextV2_AskUserOptions_PauseResume(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 
 	err := eng.Run(context.Background(), "e2e-nexie-askuser", nil)
 	if !errors.Is(err, runtime.ErrRunPaused) {

--- a/e2e/whole_improve_loop_test.go
+++ b/e2e/whole_improve_loop_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
-	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -112,7 +111,7 @@ func TestWholeImproveLoop_ContinuesUntilComplete(t *testing.T) {
 	stubCampaignSweep(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-wil-continue", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -152,7 +151,7 @@ func TestWholeImproveLoop_ConvergesFirstPass(t *testing.T) {
 	stubCampaignSweep(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-wil-first", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -197,7 +196,7 @@ func TestWholeImproveLoop_RedVerifyRoutesBackToCampaign(t *testing.T) {
 	})
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-wil-red", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -226,7 +225,7 @@ func TestWholeImproveLoop_MRPathOnConverge(t *testing.T) {
 	stubCampaignSweep(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	inputs := map[string]any{"open_mr": true}
 	if err := eng.Run(context.Background(), "run-wil-mr", inputs); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -254,7 +253,7 @@ func TestWholeImproveLoop_EventTrace(t *testing.T) {
 	stubCampaignSweep(exec, st)
 
 	s := tmpStore(t)
-	eng := runtime.New(wf, s, exec)
+	eng := newEngine(t, wf, s, exec)
 	if err := eng.Run(context.Background(), "run-wil-events", nil); err != nil {
 		t.Fatalf("Run: %v", err)
 	}

--- a/internal/gittest/gittest.go
+++ b/internal/gittest/gittest.go
@@ -1,0 +1,98 @@
+// Package gittest is the one place iterion's tests build a `git`
+// subprocess, a throwaway repository, or unregister a worktree.
+//
+// It exists because the two properties a test's git command must have are
+// invisible at the call site, and a guard copied per helper drifts:
+//
+//   - Auto-maintenance must be OFF. Since git 2.48 every writing command
+//     (fetch, commit, merge, rebase, am) ends by detaching
+//     `git maintenance run --auto`; that child calls setsid() and closes its
+//     descriptors, which is exactly what os/exec waits for, so
+//     CombinedOutput returns while it still holds
+//     `.git/objects/maintenance.lock` and writes under `.git/objects`. A
+//     test builds its repository under t.TempDir(), which Go removes the
+//     moment the test returns — so the removal races a writer nothing can
+//     wait for. On CI's git that has ejected pull requests from the merge
+//     queue (issues #821, #828); the host's git 2.43 shows nothing.
+//
+//   - The environment must be scrubbed and pinned. An inherited GIT_DIR or
+//     GIT_COMMON_DIR makes the command answer about another repository —
+//     `worktree add` then writes into somebody else's admin dir — and an
+//     absent identity makes `git commit` fail on a machine with no global
+//     gitconfig, which is every CI runner.
+//
+// Both are baked into Cmd, so a caller cannot forget either. The guard that
+// keeps new call sites coming here is
+// pkg/git.TestEveryTestGitCallerDisablesAutoMaintenance.
+package gittest
+
+import (
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
+)
+
+// testConfig is applied to every command on top of NoAutoMaintenance.
+//
+// init.defaultBranch is here because Env cuts the global config off: without
+// it `git init` (with no -b) lands on git's built-in default and warns, which
+// is a fixture's branch name deciding to change under it.
+var testConfig = []string{"-c", "init.defaultBranch=main"}
+
+// Cmd builds `git args...` to run in dir, with auto-maintenance refused and
+// Env applied. Use it when the caller needs the *exec.Cmd itself (stdin, a
+// context, an exit code it asserts on); Run and Try cover the rest.
+func Cmd(dir string, args ...string) *exec.Cmd {
+	full := gitlib.NoAutoMaintenance(append(slices.Clone(testConfig), args...)...)
+	cmd := exec.Command("git", full...) // #nosec G204 -- test-only helper, args come from the test
+	cmd.Dir = dir
+	cmd.Env = Env()
+	return cmd
+}
+
+// Env is the environment every git command a test runs gets. It is the scrub
+// Cmd applies just above: gitlib.SanitizeEnv drops the redirection variables
+// (GIT_DIR, GIT_COMMON_DIR, GIT_INDEX_FILE…) that would make the command
+// answer about another repository.
+//
+// The operator's own config is cut off too (GIT_CONFIG_SYSTEM/GLOBAL →
+// os.DevNull) so a `commit.gpgsign = true`, a `core.hooksPath` or an alias in
+// ~/.gitconfig cannot decide whether a test passes; the identity variables
+// stand in for the config that is then no longer there, which is also the
+// state of every CI runner. LC_ALL/LANG pin git's own diagnostics to English
+// so a caller may branch on them. Cmd's testConfig restores
+// init.defaultBranch, the one setting that cut genuinely removes.
+func Env() []string {
+	return append(gitlib.SanitizeEnv(os.Environ()),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_SYSTEM="+os.DevNull,
+		"GIT_AUTHOR_NAME=iterion test",
+		"GIT_AUTHOR_EMAIL=test@iterion.invalid",
+		"GIT_COMMITTER_NAME=iterion test",
+		"GIT_COMMITTER_EMAIL=test@iterion.invalid",
+		"LC_ALL=C",
+		"LANG=C",
+	)
+}
+
+// Run runs `git args...` in dir and returns its trimmed combined output,
+// failing the test when git exits non-zero.
+func Run(t testing.TB, dir string, args ...string) string {
+	t.Helper()
+	out, err := Try(dir, args...)
+	if err != nil {
+		t.Fatalf("git %s in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return out
+}
+
+// Try is Run for a command the caller expects may fail: it returns git's
+// trimmed combined output alongside the error instead of ending the test.
+func Try(dir string, args ...string) (string, error) {
+	out, err := Cmd(dir, args...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}

--- a/internal/gittest/gittest_test.go
+++ b/internal/gittest/gittest_test.go
@@ -1,0 +1,217 @@
+package gittest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The oracle is git's OWN configuration resolution, not the argv the helper
+// assembled: `git config --get` answers with the value git actually parsed
+// and applied for that invocation. An argv shim would only prove the flag
+// reached the command line — the lesson this repo paid a production
+// regression for — and on the host's git 2.43 no maintenance process detaches
+// either way, so a timing observation proves nothing here.
+//
+// Falsified by construction: without `-c maintenance.auto=…`, both keys are
+// unset and `git config --get` exits 1 (checked below on the same repo).
+func TestCmd_GitItselfReportsAutoMaintenanceOff(t *testing.T) {
+	repo := SourceRepo(t)
+
+	for _, tc := range []struct{ key, want string }{
+		{"maintenance.auto", "false"},
+		{"gc.auto", "0"},
+	} {
+		if got := Run(t, repo, "config", "--get", tc.key); got != tc.want {
+			t.Errorf("git resolved %s = %q, want %q — a writing command may detach `git maintenance run --auto` into a directory the test is about to delete", tc.key, got, tc.want)
+		}
+	}
+
+	// The same question asked WITHOUT the helper: unset, so the assertion
+	// above is not vouching for a value git would report anyway.
+	bare := exec.Command("git", "config", "--get", "maintenance.auto") // #nosec G204 -- fixed argv
+	bare.Dir = repo
+	bare.Env = Env()
+	if out, err := bare.CombinedOutput(); err == nil {
+		t.Fatalf("maintenance.auto is set in the repository itself (%q) — this test cannot tell the helper's config apart from it", strings.TrimSpace(string(out)))
+	}
+}
+
+// A commit must go through, on a machine with no global git identity — which
+// is every CI runner. Env carries the identity; the repo config carries it
+// for the commands iterion itself spawns during a test.
+func TestSourceRepo_CommitsWithoutAGlobalIdentity(t *testing.T) {
+	repo := SourceRepo(t)
+
+	if err := os.WriteFile(filepath.Join(repo, "f.txt"), []byte("a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	Run(t, repo, "add", "f.txt")
+	Run(t, repo, "commit", "-q", "-m", "work")
+
+	if branch := Run(t, repo, "rev-parse", "--abbrev-ref", "HEAD"); branch != "main" {
+		t.Errorf("branch = %q, want main (a fixture that builds on `main` must not depend on the host's init.defaultBranch)", branch)
+	}
+	if n := len(strings.Split(Run(t, repo, "log", "--format=%H"), "\n")); n != 2 {
+		t.Errorf("commit count = %d, want 2 (the seed plus this one)", n)
+	}
+	// The repository's own config must carry the identity too: a git command
+	// iterion spawns during the run does not inherit Env.
+	if got := Run(t, repo, "config", "--get", "user.email"); got != "test@iterion.invalid" {
+		t.Errorf("repo user.email = %q, want the pinned test identity", got)
+	}
+}
+
+// The operator's ~/.gitconfig must not be able to decide whether a test
+// passes. commit.gpgsign is the setting that actually does it: with a real
+// global config in reach, every commit a fixture makes would try to sign and
+// fail on a machine with no key.
+func TestEnv_TheOperatorsGlobalConfigCannotReachTheCommand(t *testing.T) {
+	hostile := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(hostile, []byte("[commit]\n\tgpgsign = true\n[core]\n\thooksPath = /nonexistent\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", hostile)
+
+	repo := SourceRepo(t)
+	if got := Run(t, repo, "config", "--get", "commit.gpgsign"); got != "false" {
+		t.Errorf("commit.gpgsign = %q, want the repository's own false — the operator's global config reached the command", got)
+	}
+
+	// And `git init` with no -b still lands on main: cutting the global config
+	// off also removes init.defaultBranch, which Cmd puts back.
+	bare := t.TempDir()
+	Run(t, bare, "init", "-q")
+	if got := Run(t, bare, "symbolic-ref", "--short", "HEAD"); got != "main" {
+		t.Errorf("default branch = %q, want main — a fixture's branch name must not depend on the host", got)
+	}
+}
+
+func TestTry_ReturnsGitsDiagnosticInsteadOfEndingTheTest(t *testing.T) {
+	repo := SourceRepo(t)
+	out, err := Try(repo, "rev-parse", "--verify", "refs/heads/nope")
+	if err == nil {
+		t.Fatalf("resolving a missing ref succeeded: %q", out)
+	}
+	if out == "" {
+		t.Error("Try returned an empty diagnostic — the caller has nothing to report")
+	}
+}
+
+// The observable effect: after RemoveWorktree the repository holds exactly
+// the administrative entries it held before, and the OTHER worktree's entry
+// is untouched — the property `git worktree prune` cannot promise.
+func TestRemoveWorktree_DropsOnlyItsOwnRegistration(t *testing.T) {
+	repo := SourceRepo(t)
+	before := countAdmin(t, repo)
+
+	mine := filepath.Join(t.TempDir(), "mine")
+	other := filepath.Join(t.TempDir(), "other")
+	Run(t, repo, "worktree", "add", "--detach", mine, "HEAD")
+	Run(t, repo, "worktree", "add", "--detach", other, "HEAD")
+	if n := countAdmin(t, repo); n != before+2 {
+		t.Fatalf("admin entries after two adds = %d, want %d", n, before+2)
+	}
+
+	// The directory vanishes first — exactly what t.TempDir() does at the end
+	// of a test, and the state in which the registration is orphaned.
+	if err := os.RemoveAll(mine); err != nil {
+		t.Fatal(err)
+	}
+	RemoveWorktree(t, repo, mine)
+
+	if n := countAdmin(t, repo); n != before+1 {
+		t.Errorf("admin entries after RemoveWorktree = %d, want %d (its own entry gone, the other kept)", n, before+1)
+	}
+	if _, err := os.Stat(filepath.Join(other, ".git")); err != nil {
+		t.Errorf("the sibling worktree lost its pointer: %v", err)
+	}
+	if out, err := Try(repo, "rev-parse", "--verify", "HEAD"); err != nil {
+		t.Errorf("the repository is no longer readable after the prune: %v\n%s", err, out)
+	}
+}
+
+func countAdmin(t *testing.T, repo string) int {
+	t.Helper()
+	common, err := commonDir(repo)
+	if err != nil {
+		t.Fatalf("common dir: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(common, "worktrees"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read admin dir: %v", err)
+	}
+	return len(entries)
+}
+
+// reclaimLeaked is what the TestMain guard runs. It must claim a dead
+// temp-rooted entry, and refuse the two shapes that make `git worktree prune`
+// unusable: a LIVE entry (a sibling package's worktree, mid-run) and an entry
+// outside the test temp root (an operator's checkout on an unmounted volume,
+// which is absent for reasons that are none of this guard's business).
+func TestReclaimLeaked_ClaimsDeadTempEntriesOnly(t *testing.T) {
+	repo := SourceRepo(t)
+	common, err := commonDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(common, "worktrees")
+
+	// The temp root the guard compares against, resolved the same way.
+	tmp, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		tmp = os.TempDir()
+	}
+
+	live := filepath.Join(t.TempDir(), "live")
+	dead := filepath.Join(tmp, "TestSomethingLeaky1234", "001", "worktrees", "run-x")
+	outside := filepath.Join(t.TempDir(), "elsewhere")
+	Run(t, repo, "worktree", "add", "--detach", live, "HEAD")
+	Run(t, repo, "worktree", "add", "--detach", outside, "HEAD")
+	// `dead` never existed as a directory; only its registration does. That
+	// is the end state of a leaked run worktree.
+	writeAdmin(t, root, "dead-entry", filepath.Join(dead, ".git"))
+	// An entry outside the temp root whose directory is also gone: the
+	// unmounted-volume shape.
+	unmounted := filepath.Join(string(filepath.Separator)+"mnt", "detached-volume", "checkout")
+	writeAdmin(t, root, "unmounted-entry", filepath.Join(unmounted, ".git"))
+
+	leaked := reclaimLeaked(root, map[string]bool{})
+
+	if len(leaked) != 1 || !strings.Contains(leaked[0], "TestSomethingLeaky") {
+		t.Fatalf("reclaimLeaked = %v, want exactly the dead temp entry named after its test", leaked)
+	}
+	if _, err := os.Stat(filepath.Join(root, "dead-entry")); !os.IsNotExist(err) {
+		t.Errorf("the dead entry survived: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "unmounted-entry")); err != nil {
+		t.Errorf("an entry outside the test temp root was reclaimed — that is the operator's checkout on an unmounted volume: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(live, ".git")); err != nil {
+		t.Errorf("a LIVE worktree lost its registration — a sibling package's run would die: %v", err)
+	}
+}
+
+func writeAdmin(t *testing.T, root, name, gitdir string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "gitdir"), []byte(gitdir+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOwnerTest_NamesTheTestBehindALeakedPath(t *testing.T) {
+	tmp := string(filepath.Separator) + filepath.Join("tmp") + string(filepath.Separator)
+	got := ownerTest(filepath.Join(tmp, "TestRewindThenResume_SkipsUpstreamNodes3725362394", "001", "worktrees", "e2e-rewind-mini"), tmp)
+	if got != "TestRewindThenResume_SkipsUpstreamNodes" {
+		t.Errorf("ownerTest = %q, want the test name without t.TempDir()'s random suffix", got)
+	}
+}

--- a/internal/gittest/leakguard.go
+++ b/internal/gittest/leakguard.go
@@ -38,6 +38,13 @@ import (
 // live worktree still exists, and an operator's checkout on an unmounted
 // volume — the case that makes `git worktree prune` unusable — is never
 // under os.TempDir().
+//
+// That leaves one honest imprecision, observed on this repository: the
+// registry is shared by every checkout of it (a linked worktree's .git points
+// at the main repository's), so a leak from a sibling package — or from an
+// agent's own worktree running the suite at the same time — appears inside
+// this window and is reported here. The report names the test behind each
+// path, which is what makes it actionable regardless of who ran it.
 func NoWorktreeLeaks(m *testing.M) int {
 	root, ok := worktreeAdminRoot()
 	if !ok {
@@ -54,7 +61,7 @@ func NoWorktreeLeaks(m *testing.M) int {
 		return code
 	}
 	fmt.Fprintf(os.Stderr, `
-FAIL: this package left %d dead worktree registration(s) in %s.
+FAIL: %d dead worktree registration(s) appeared in %s while this package ran.
 
 A run with `+"`worktree: auto`"+` (the IR default) used the checkout the tests
 run in as its source repository, so git registered the run's worktree HERE
@@ -65,6 +72,11 @@ genuinely the point, unregister it with gittest.RemoveWorktree(t, repo, path).
 
 The entries have been reclaimed by recorded path, so the repository is clean
 again; the failure is the leak, not its residue.
+
+Each line names the test that owns the path. That test is not necessarily in
+THIS package: a sibling package (or a second worktree of the same repository)
+running concurrently shares this registry, and the window is all of m.Run().
+Fix the test the path names.
 
 Leaked (recorded path -> the test that owns it):
   %s

--- a/internal/gittest/leakguard.go
+++ b/internal/gittest/leakguard.go
@@ -1,0 +1,164 @@
+package gittest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// NoWorktreeLeaks runs m and returns the exit code the suite should use,
+// turning a leaked worktree registration into a failure.
+//
+// Wire it from TestMain:
+//
+//	func TestMain(m *testing.M) { os.Exit(gittest.NoWorktreeLeaks(m)) }
+//
+// What it catches. A `worktree: auto` run takes its source repository from
+// the workspace it is launched in, and an engine constructed without an
+// explicit workDir defaults to the process cwd — the package directory,
+// inside the developer's own checkout. `git worktree add` then registers the
+// run's worktree in the REAL repository, while the checkout itself lives
+// under t.TempDir() and is deleted the moment the test returns. Nothing ever
+// comes back for the registration: it keeps an index, a HEAD and a logs/
+// tree (~1.3 MB each), and every git command that enumerates worktrees walks
+// all of them. Measured on one developer machine after two days of parallel
+// agent work: 1 773 dead entries, 2.5 GB (issue #870).
+//
+// The verdict is the observable effect — the entry count of the repository
+// the tests run in — not an argv reading, so it stays true however the run
+// reached `git worktree add`.
+//
+// Concurrency. `go test ./...` runs sibling packages against this same
+// repository, so an entry that appeared during m.Run() may be another
+// package's LIVE worktree. Only entries whose recorded directory is GONE are
+// claimed, and only when that directory sits under the test temp root: a
+// live worktree still exists, and an operator's checkout on an unmounted
+// volume — the case that makes `git worktree prune` unusable — is never
+// under os.TempDir().
+func NoWorktreeLeaks(m *testing.M) int {
+	root, ok := worktreeAdminRoot()
+	if !ok {
+		// Not inside a git repository (or git is unavailable): there is no
+		// registry to leak into.
+		return m.Run()
+	}
+	before := adminEntries(root)
+
+	code := m.Run()
+
+	leaked := reclaimLeaked(root, before)
+	if len(leaked) == 0 {
+		return code
+	}
+	fmt.Fprintf(os.Stderr, `
+FAIL: this package left %d dead worktree registration(s) in %s.
+
+A run with `+"`worktree: auto`"+` (the IR default) used the checkout the tests
+run in as its source repository, so git registered the run's worktree HERE
+while the checkout itself lived under t.TempDir() and is now gone. Give the
+run a workspace the test owns — internal/gittest.SourceRepo(t) passed as
+runtime.WithWorkDir / runview.WithWorkDir — or, when the real checkout is
+genuinely the point, unregister it with gittest.RemoveWorktree(t, repo, path).
+
+The entries have been reclaimed by recorded path, so the repository is clean
+again; the failure is the leak, not its residue.
+
+Leaked (recorded path -> the test that owns it):
+  %s
+`, len(leaked), root, strings.Join(leaked, "\n  "))
+	if code == 0 {
+		return 1
+	}
+	return code
+}
+
+// worktreeAdminRoot returns <git-common-dir>/worktrees for the repository
+// containing the process working directory.
+func worktreeAdminRoot() (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	common, err := commonDir(cwd)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(common, "worktrees"), true
+}
+
+// adminEntries is the set of administrative entry names present now. A
+// missing worktrees/ directory is an empty set, not an error: git creates it
+// with the first linked worktree.
+func adminEntries(root string) map[string]bool {
+	set := map[string]bool{}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return set
+	}
+	for _, e := range entries {
+		set[e.Name()] = true
+	}
+	return set
+}
+
+// reclaimLeaked removes the administrative entries that appeared since
+// `before`, point at a directory under the test temp root, and whose
+// directory no longer exists. Returns one human line per reclaimed entry.
+func reclaimLeaked(root string, before map[string]bool) []string {
+	tmp, err := filepath.EvalSymlinks(os.TempDir())
+	if err != nil {
+		tmp = os.TempDir()
+	}
+	tmp = filepath.Clean(tmp) + string(filepath.Separator)
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var leaked []string
+	for _, e := range entries {
+		if before[e.Name()] {
+			continue
+		}
+		admin := filepath.Join(root, e.Name())
+		raw, err := os.ReadFile(filepath.Join(admin, "gitdir")) // #nosec G304 -- under git's own admin dir
+		if err != nil {
+			continue
+		}
+		wt := filepath.Clean(filepath.Dir(strings.TrimSpace(string(raw))))
+		if !strings.HasPrefix(wt+string(filepath.Separator), tmp) {
+			// Outside the test temp root: not ours to judge, let alone remove.
+			continue
+		}
+		if _, err := os.Stat(wt); err == nil {
+			// Still on disk — a sibling package's live worktree, or one this
+			// package is about to remove itself. Absence is what makes an
+			// entry dead.
+			continue
+		}
+		if err := os.RemoveAll(admin); err != nil {
+			leaked = append(leaked, fmt.Sprintf("%s -> %s (reclaim failed: %v)", wt, ownerTest(wt, tmp), err))
+			continue
+		}
+		leaked = append(leaked, fmt.Sprintf("%s -> %s", wt, ownerTest(wt, tmp)))
+	}
+	sort.Strings(leaked)
+	return leaked
+}
+
+// ownerTest names the test that owns a leaked path. t.TempDir() roots at
+// <tmp>/<TestName><random>/<n>, so the first element under the temp root
+// carries the test's name — the only breadcrumb left once the directory is
+// gone.
+func ownerTest(wt, tmpPrefix string) string {
+	rest := strings.TrimPrefix(wt, tmpPrefix)
+	first, _, _ := strings.Cut(filepath.ToSlash(rest), "/")
+	name := strings.TrimRight(first, "0123456789")
+	if name == "" {
+		return "unknown test"
+	}
+	return name
+}

--- a/internal/gittest/repo.go
+++ b/internal/gittest/repo.go
@@ -1,0 +1,125 @@
+package gittest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// InitRepo turns dir into a git repository with one commit on `main` and
+// returns that commit's SHA.
+//
+// The identity and the signing opt-out are written into the repository's own
+// config, not only into Env: a command iterion itself spawns during the test
+// (finalizeWorktree's squash, the runner's bank) does not inherit this
+// package's environment, and CI has no global identity to fall back on.
+func InitRepo(t testing.TB, dir string) string {
+	t.Helper()
+	Run(t, dir, "init", "-q", "-b", "main")
+	Run(t, dir, "config", "user.name", "iterion test")
+	Run(t, dir, "config", "user.email", "test@iterion.invalid")
+	Run(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0o600); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+	Run(t, dir, "add", "README.md")
+	Run(t, dir, "commit", "-q", "-m", "init")
+	return Run(t, dir, "rev-parse", "HEAD")
+}
+
+// SourceRepo returns a throwaway repository under t.TempDir(), ready to be
+// the workspace of a `worktree: auto` run.
+//
+// This is the answer to the other half of the class: a run whose workspace is
+// the checkout the tests THEMSELVES run in registers its per-run worktree in
+// the developer's own repository, and the registration outlives the checkout
+// t.TempDir() deletes (issue #870 — 1 773 dead entries, 2.5 GB, measured).
+// A repository the test owns is deleted whole, admin dir included.
+func SourceRepo(t testing.TB) string {
+	t.Helper()
+	dir := t.TempDir()
+	InitRepo(t, dir)
+	return dir
+}
+
+// RemoveWorktree deletes the linked worktree at path and drops the one
+// administrative entry that names it, for a test that genuinely had to run
+// against a repository it does not own.
+//
+// It never calls `git worktree prune`: that sweeps the whole repository and
+// removes the registration of ANY worktree missing at that instant — an
+// operator's checkout on an unmounted volume among them, whose index (and
+// staged work) lives in that entry. Matching on the recorded path is the
+// same discipline as pkg/worktreepool's pruneWorktreeRegistration, and for
+// the same reason: git disambiguates colliding basenames with a numeric
+// suffix, so the entry named after a run id may well be somebody else's.
+func RemoveWorktree(t testing.TB, repo, path string) {
+	t.Helper()
+	// Captured before the removal: EvalSymlinks cannot resolve a path that
+	// no longer exists, and a store reached through a symlink would then
+	// never match the recorded pointer.
+	resolved := path
+	if r, err := filepath.EvalSymlinks(path); err == nil {
+		resolved = r
+	}
+	resolved = filepath.Clean(resolved)
+
+	// Best effort: the directory may already be gone, which is precisely the
+	// case the registration sweep below exists for.
+	_, _ = Try(repo, "worktree", "remove", "--force", path)
+
+	common, err := commonDir(repo)
+	if err != nil {
+		t.Fatalf("locate git common dir of %s: %v", repo, err)
+	}
+	if pruned, err := pruneRegistration(common, resolved); err != nil {
+		t.Fatalf("prune worktree registration for %s: %v", resolved, err)
+	} else if !pruned {
+		// Nothing named it: `worktree remove` above already took the entry,
+		// or the worktree was never registered here. Both are fine.
+		return
+	}
+}
+
+// commonDir returns the absolute path of the repository-wide git directory
+// of the repository containing dir — the one that holds `worktrees/`. For a
+// linked worktree that is the MAIN repository's .git, which is exactly where
+// a per-run worktree gets registered.
+func commonDir(dir string) (string, error) {
+	out, err := Try(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(strings.TrimSpace(out)), nil
+}
+
+// pruneRegistration removes the administrative entry under
+// <common>/worktrees whose `gitdir` pointer names resolvedPath, and only
+// that one. Reports whether an entry was removed.
+func pruneRegistration(common, resolvedPath string) (bool, error) {
+	root := filepath.Join(common, "worktrees")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, e := range entries {
+		admin := filepath.Join(root, e.Name())
+		raw, err := os.ReadFile(filepath.Join(admin, "gitdir")) // #nosec G304 -- under git's own admin dir
+		if err != nil {
+			continue
+		}
+		// The pointer names <worktree>/.git; compare the worktree itself.
+		if filepath.Clean(filepath.Dir(strings.TrimSpace(string(raw)))) != resolvedPath {
+			continue
+		}
+		if err := os.RemoveAll(admin); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}

--- a/internal/gittest/repo.go
+++ b/internal/gittest/repo.go
@@ -73,12 +73,10 @@ func RemoveWorktree(t testing.TB, repo, path string) {
 	if err != nil {
 		t.Fatalf("locate git common dir of %s: %v", repo, err)
 	}
-	if pruned, err := pruneRegistration(common, resolved); err != nil {
+	// A false return is not a failure: `worktree remove` above may already
+	// have taken the entry, or the worktree was never registered here.
+	if _, err := pruneRegistration(common, resolved); err != nil {
 		t.Fatalf("prune worktree registration for %s: %v", resolved, err)
-	} else if !pruned {
-		// Nothing named it: `worktree remove` above already took the entry,
-		// or the worktree was never registered here. Both are fine.
-		return
 	}
 }
 

--- a/pkg/cli/clean_test.go
+++ b/pkg/cli/clean_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	gitlib "github.com/SocialGouv/iterion/pkg/git"
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/worktreepool"
 )
@@ -94,18 +94,11 @@ func (f *cleanFixture) git(dir string, args ...string) string {
 }
 
 func (f *cleanFixture) gitErr(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	// Same scrub as production (clean.go / pkg/git): an inherited GIT_DIR
-	// would make worktree add write into another repository's admin dir
-	// and fail with "could not open '.git/worktrees/<name>/locked'".
-	cmd.Env = append(gitlib.SanitizeEnv(os.Environ()),
-		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
-		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
-		"LC_ALL=C", "LANG=C")
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	// gittest scrubs the environment the way production does (clean.go /
+	// pkg/git): an inherited GIT_DIR would make worktree add write into another
+	// repository's admin dir and fail with "could not open
+	// '.git/worktrees/<name>/locked'".
+	return gittest.Try(dir, args...)
 }
 
 // addWorktree creates <store>/worktrees/<runID> the way iterion does:

--- a/pkg/cli/cli_docs_examples_test.go
+++ b/pkg/cli/cli_docs_examples_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestNoIterExtensionAnywhere is the zero-trace guard for the deprecated
@@ -37,10 +39,9 @@ import (
 func TestNoIterExtensionAnywhere(t *testing.T) {
 	root := repoRootForDocsTest(t)
 
-	cmd := exec.Command("git", "grep", "-nIE", `\.iter([^a-zA-Z0-9._]|$)`,
+	cmd := gittest.Cmd(root, "grep", "-nIE", `\.iter([^a-zA-Z0-9._]|$)`,
 		"--", ".", ":(exclude)vendor/",
 		":(exclude)CHANGELOG.md", ":(exclude)docs/changelog/")
-	cmd.Dir = root
 	out, err := cmd.Output()
 	// git grep exits 1 with no output when there are no matches — the
 	// success case. A real match exits 0 with the offending lines.

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -377,6 +378,11 @@ func (e *rejectExecutor) Execute(_ context.Context, node ir.Node, input map[stri
 }
 
 func TestRun_HumanPause(t *testing.T) {
+	// `iterion run` executes in the operator's cwd, and `worktree: auto` (the
+	// IR default) takes its source repository from there — so without this the
+	// run registers its worktree in the DEVELOPER's checkout and the
+	// registration outlives the t.TempDir() store that held it (#870).
+	t.Chdir(gittest.SourceRepo(t))
 	dir := t.TempDir()
 	path := writeFixture(t, dir, "test.bot", humanWorkflow)
 	storeDir := filepath.Join(dir, "store")
@@ -1428,6 +1434,11 @@ func TestInspect_LegacyPathUnchanged(t *testing.T) {
 
 func TestResume_Success(t *testing.T) {
 	hermeticSandbox(t)
+	// `iterion run` executes in the operator's cwd, and `worktree: auto` (the
+	// IR default) takes its source repository from there — so without this the
+	// run registers its worktree in the DEVELOPER's checkout and the
+	// registration outlives the t.TempDir() store that held it (#870).
+	t.Chdir(gittest.SourceRepo(t))
 	dir := t.TempDir()
 	botPath := writeFixture(t, dir, "test.bot", humanWorkflow)
 	storeDir := filepath.Join(dir, "store")

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -1,0 +1,20 @@
+package cli_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
+)
+
+// `iterion run` takes its workspace from the process cwd — this package's own
+// directory when a test does not say otherwise — so a run with
+// `worktree: auto` (the IR default) registers its per-run worktree in the
+// developer's checkout, while the checkout itself lives under the test's
+// t.TempDir() store and is deleted on return.
+//
+// The guard fails the package when the registry the tests run in gained such
+// an entry, and names the test that left it.
+func TestMain(m *testing.M) {
+	os.Exit(gittest.NoWorktreeLeaks(m))
+}

--- a/pkg/dispatcher/cleanup_workspace_test.go
+++ b/pkg/dispatcher/cleanup_workspace_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -427,11 +428,7 @@ func TestCleanupWorkspace_KeepsDirtyGitWorkspace(t *testing.T) {
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "Test"},
 	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = wsPath
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, wsPath, args...)
 	}
 	if err := os.WriteFile(filepath.Join(wsPath, "uncommitted.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("write uncommitted file: %v", err)
@@ -459,11 +456,5 @@ func TestCleanupWorkspace_KeepsDirtyGitWorkspace(t *testing.T) {
 
 func runCleanupGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-	}
-	return string(out)
+	return gittest.Run(t, dir, args...)
 }

--- a/pkg/dispatcher/engine_runner_subbot_test.go
+++ b/pkg/dispatcher/engine_runner_subbot_test.go
@@ -3,7 +3,6 @@ package dispatcher
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime/pprof"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -446,18 +446,10 @@ func TestEngineRunner_SubbotChildNeverAdoptsParentWorktree(t *testing.T) {
 		{"config", "user.name", "T"},
 		{"commit", "-q", "--allow-empty", "-m", "seed"},
 	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = mainRepo
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
+		gittest.Run(t, mainRepo, args...)
 	}
 	workspace := filepath.Join(t.TempDir(), "issue-ws")
-	cmd := exec.Command("git", "worktree", "add", "--detach", workspace, "HEAD")
-	cmd.Dir = mainRepo
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git worktree add: %v (%s)", err, out)
-	}
+	gittest.Run(t, mainRepo, "worktree", "add", "--detach", workspace, "HEAD")
 	marker := `{"validated":true,"echoed":"from-workspace"}`
 	if err := os.WriteFile(filepath.Join(workspace, "marker.json"), []byte(marker), 0o644); err != nil {
 		t.Fatalf("write marker: %v", err)

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -79,7 +79,8 @@ func gitTestEnv() []string {
 
 func mustRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	// NoAutoMaintenance, not internal/gittest: that package imports this one.
+	cmd := exec.Command("git", NoAutoMaintenance(args...)...)
 	cmd.Dir = dir
 	cmd.Env = gitTestEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/git/sanitize_env_test.go
+++ b/pkg/git/sanitize_env_test.go
@@ -65,7 +65,7 @@ func TestSanitizeEnvIsWhatMakesDirAuthoritative(t *testing.T) {
 	}
 
 	run := func(env []string) string {
-		cmd := exec.Command("git", "status", "--porcelain")
+		cmd := exec.Command("git", NoAutoMaintenance("status", "--porcelain")...)
 		cmd.Dir = target
 		cmd.Env = env
 		out, err := cmd.CombinedOutput()

--- a/pkg/git/test_callers_test.go
+++ b/pkg/git/test_callers_test.go
@@ -1,0 +1,86 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestEveryTestGitCallerDisablesAutoMaintenance is the _test.go half of
+// TestEveryGitCallerSanitizesEnv, which deliberately skips test files.
+//
+// It has to exist for the same reason that one does: reviewing it by hand does
+// not work. The sweep behind issue #828 found 33 test files building a git
+// subprocess, four of them with a helper used dozens of times, and every one of
+// those helpers is the identical merge-queue ejector on CI's git — a test
+// builds its repository under t.TempDir(), runs a writing command
+// (commit/merge/rebase/am/fetch), and Go removes the directory the moment the
+// test returns, while `git maintenance run --auto` is still detached inside it
+// writing under .git/objects.
+//
+// The chokepoint is internal/gittest: gittest.Run / gittest.Try / gittest.Cmd
+// bake the config in, so the next helper cannot forget it. A caller that
+// genuinely has to assemble its own argv — pkg/git's own tests, which cannot
+// import internal/gittest without an import cycle — satisfies the property by
+// passing through NoAutoMaintenance directly.
+func TestEveryTestGitCallerDisablesAutoMaintenance(t *testing.T) {
+	root := filepath.Join("..", "..")
+	skipNames := map[string]bool{"vendor": true, "studio": true, "node_modules": true, "testdata": true}
+
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Same exclusions as the production sweep: hidden directories hold
+			// scratch clones of other people's code (.local, .works, .repos).
+			name := info.Name()
+			// internal/gittest is the chokepoint itself: its Cmd applies the
+			// config, and its own test builds one bare command on purpose, to
+			// show the assertion is not vouching for a value git would report
+			// anyway.
+			if skipNames[name] || (strings.HasPrefix(name, ".") && path != root) ||
+				path == filepath.Join("..", "..", "internal", "gittest") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path) // #nosec G304 -- walking this repository's own tree
+		if rerr != nil {
+			return rerr
+		}
+		body := string(src)
+		for _, loc := range gitExec.FindAllStringIndex(body, -1) {
+			// A call quoted inside a comment is prose, not a call site.
+			lineStart := strings.LastIndex(body[:loc[0]], "\n") + 1
+			if strings.Contains(body[lineStart:loc[0]], "//") {
+				continue
+			}
+			// Bounded by the NEXT call site so one site's config cannot vouch
+			// for its neighbour's — the failure mode the production sweep
+			// measured with a fixed window.
+			end := min(loc[0]+1600, len(body))
+			if next := gitExec.FindStringIndex(body[loc[1]:]); next != nil {
+				end = min(end, loc[1]+next[0])
+			}
+			if strings.Contains(body[loc[0]:end], "NoAutoMaintenance(") {
+				continue
+			}
+			line := 1 + strings.Count(body[:loc[0]], "\n")
+			offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(line)+"  "+strings.TrimSpace(body[loc[0]:min(loc[1]+40, len(body))]))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("git subprocess(es) built in a test without refusing auto-maintenance — since git 2.48 a writing command detaches `git maintenance run --auto`, which keeps writing under .git/objects after the command returned and races t.TempDir()'s removal.\nRoute them through internal/gittest (gittest.Run / gittest.Try / gittest.Cmd), or pass git.NoAutoMaintenance(args...) when the package cannot import it:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -25,13 +25,7 @@ import (
 
 func gitOut(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v: %v\n%s", args, err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return gittest.Run(t, dir, args...)
 }
 
 func bankFixture(t *testing.T) (r *Runner, msg *queue.RunMessage, work, origin string, base string) {
@@ -92,7 +86,7 @@ func TestBankRepoWorkspaceNoWorkIsNoop(t *testing.T) {
 
 	r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
 
-	if out, err := exec.Command("git", "-C", origin, "rev-parse", "refs/heads/iterion/run-"+msg.RunID).CombinedOutput(); err == nil {
+	if out, err := gittest.Try(origin, "rev-parse", "refs/heads/iterion/run-"+msg.RunID); err == nil {
 		t.Errorf("a workless run banked a branch anyway: %s", out)
 	}
 	if run := loadRun(t, r, msg.RunID); run.FinalBranch != "" || run.FinalCommit != "" {
@@ -131,8 +125,8 @@ func bankedBranch(t *testing.T, origin, runID string) (string, bool) {
 
 func refAt(t *testing.T, origin, ref string) (string, bool) {
 	t.Helper()
-	out, err := exec.Command("git", "-C", origin, "rev-parse", ref).CombinedOutput()
-	return strings.TrimSpace(string(out)), err == nil
+	out, err := gittest.Try(origin, "rev-parse", ref)
+	return out, err == nil
 }
 
 func TestBankRepoWorkspaceExportMismatchRefusesStaleTree(t *testing.T) {
@@ -721,8 +715,7 @@ func TestBankPushLeaseRejectsAStaleExpectation(t *testing.T) {
 	gitOut(t, work, "checkout", "-q", first)
 	gitOut(t, work, "commit", "--allow-empty", "-m", "our divergent head")
 	ours := gitOut(t, work, "rev-parse", "HEAD")
-	args := append([]string{"-C", work}, bankPushArgs(branch, ours, first)...)
-	if out, err := exec.Command("git", args...).CombinedOutput(); err == nil {
+	if out, err := gittest.Try(work, bankPushArgs(branch, ours, first)...); err == nil {
 		t.Fatalf("the stale-lease push succeeded and clobbered the sibling: %s", out)
 	}
 	if got, _ := bankedBranch(t, origin, msg.RunID); got != sibling {
@@ -1022,7 +1015,7 @@ func TestBankAttemptRefVerifiedNoopStaysSilent(t *testing.T) {
 	r.bankIfBankable(context.Background(), msg, work, base,
 		runtime.WorkspaceIntegrity{Applicable: true, PodHead: base}, runtime.ErrRunPaused)
 
-	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+	if out, err := gittest.Try(origin, "for-each-ref", "refs/heads/iterion/"); err != nil || out != "" {
 		t.Fatalf("a workless pause parked something anyway: %q (%v)", out, err)
 	}
 	if ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt); ev != nil {
@@ -1042,7 +1035,7 @@ func TestBankAttemptRefIntegrityRefusalIsLoudOnTheTimeline(t *testing.T) {
 	r.bankIfBankable(context.Background(), msg, work, base,
 		runtime.WorkspaceIntegrity{Applicable: true, PodHead: podHead}, runtime.ErrRunInterrupted)
 
-	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+	if out, err := gittest.Try(origin, "for-each-ref", "refs/heads/iterion/"); err != nil || out != "" {
 		t.Fatalf("an unverifiable export parked a ref anyway: %q (%v)", out, err)
 	}
 	run := loadRun(t, r, msg.RunID)
@@ -1092,7 +1085,7 @@ func TestBankAttemptRefUnreadableHeadIsLoud(t *testing.T) {
 
 	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunInterrupted)
 
-	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+	if out, err := gittest.Try(origin, "for-each-ref", "refs/heads/iterion/"); err != nil || out != "" {
 		t.Fatalf("an unreadable HEAD parked something: %q (%v)", out, err)
 	}
 	ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)

--- a/pkg/runner/base_ref_test.go
+++ b/pkg/runner/base_ref_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 )
@@ -146,10 +147,8 @@ func newStackedPRFixture(t *testing.T) *stackedPRFixture {
 // gitErr runs git and returns only whether it failed — for asserting that a
 // revision does (or does not) resolve.
 func gitErr(dir string, args ...string) error {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return &gitFailure{args: strings.Join(args, " "), out: strings.TrimSpace(string(out))}
+	if out, err := gittest.Try(dir, args...); err != nil {
+		return &gitFailure{args: strings.Join(args, " "), out: out}
 	}
 	return nil
 }

--- a/pkg/runner/loop_checkpoint_test.go
+++ b/pkg/runner/loop_checkpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -209,13 +210,7 @@ func TestCheckpointScriptPreservesTheTreeAndTouchesNothing(t *testing.T) {
 	ws := t.TempDir()
 	git := func(args ...string) string {
 		t.Helper()
-		cmd := exec.Command("git", append([]string{"-C", ws}, args...)...)
-		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v (%s)", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
+		return gittest.Run(t, ws, args...)
 	}
 	git("init", "-q", "-b", "main")
 	git("config", "user.email", "lot@run")

--- a/pkg/runtime/conflict_test.go
+++ b/pkg/runtime/conflict_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 func TestParseConflictHunks_TwoWay(t *testing.T) {
@@ -136,17 +138,7 @@ func TestParseConflicts_EndToEnd(t *testing.T) {
 	dir := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"LC_ALL=C",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
-		}
+		gittest.Run(t, dir, args...)
 	}
 	write := func(name, content string) {
 		t.Helper()
@@ -172,10 +164,8 @@ func TestParseConflicts_EndToEnd(t *testing.T) {
 	run("commit", "-qam", "main-change")
 
 	// Squash into main; conflict expected.
-	cmd := exec.Command("git", "merge", "--squash", "feature")
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "LC_ALL=C")
-	_, _ = cmd.CombinedOutput() // intentionally ignore the non-zero exit
+	// The conflict is the point, so the non-zero exit is expected.
+	_, _ = gittest.Try(dir, "merge", "--squash", "feature")
 
 	det, err := ParseConflicts(dir)
 	if err != nil {

--- a/pkg/runtime/review_gate_internal_test.go
+++ b/pkg/runtime/review_gate_internal_test.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -21,17 +21,7 @@ import (
 
 func gitRun(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=iterion", "GIT_AUTHOR_EMAIL=iterion@example.test",
-		"GIT_COMMITTER_NAME=iterion", "GIT_COMMITTER_EMAIL=iterion@example.test",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return gittest.Run(t, dir, args...)
 }
 
 // gateRepo is a git worktree with one commit, ready to be anchored.
@@ -54,9 +44,8 @@ func gateRepo(t *testing.T) string {
 
 func refExists(t *testing.T, dir, ref string) bool {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
-	cmd.Dir = dir
-	return cmd.Run() == nil
+	_, err := gittest.Try(dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	return err == nil
 }
 
 func TestMarkReviewGate_WritesTheRefAndIsIdempotent(t *testing.T) {

--- a/pkg/runtime/review_test.go
+++ b/pkg/runtime/review_test.go
@@ -2,11 +2,10 @@ package runtime
 
 import (
 	"context"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -37,8 +36,8 @@ func setupReviewRun(t *testing.T, withCommit bool) (*Engine, store.RunStore, *ru
 	t.Helper()
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := originalTip
 	if withCommit {
@@ -82,12 +81,12 @@ func TestReviewGate_PerformGateMerge_Squash(t *testing.T) {
 	// (the change landed). We don't assert the squash SHA differs from finalSHA:
 	// for a single commit with identical metadata + same-second timestamp the
 	// squash commit can hash-equal the original — the merge still happened.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip == originalTip {
 		t.Fatalf("main did not advance from base %s", originalTip)
 	}
-	mainTree := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main^{tree}")))
-	wtTree := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", finalSHA+"^{tree}")))
+	mainTree := gittest.Run(t, repo, "rev-parse", "main^{tree}")
+	wtTree := gittest.Run(t, repo, "rev-parse", finalSHA+"^{tree}")
 	if mainTree != wtTree {
 		t.Errorf("main tree %s != worktree tree %s (change did not land)", mainTree, wtTree)
 	}
@@ -108,11 +107,11 @@ func TestReviewGate_PerformGateMerge_Squash(t *testing.T) {
 
 	// Idempotency: run-end finalize must skip (final_branch set) — no second
 	// (suffixed) storage branch and no re-merge.
-	before := strings.TrimSpace(string(mustOutput(t, repo, "git", "branch", "--list", "iterion/run/*")))
-	mainBefore := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	before := gittest.Run(t, repo, "branch", "--list", "iterion/run/*")
+	mainBefore := gittest.Run(t, repo, "rev-parse", "main")
 	eng.finalizeOnExit(ctx, "run-rg", eng.reconstructWorktreeContext(r2), nil, nil)
-	after := strings.TrimSpace(string(mustOutput(t, repo, "git", "branch", "--list", "iterion/run/*")))
-	mainAfter := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	after := gittest.Run(t, repo, "branch", "--list", "iterion/run/*")
+	mainAfter := gittest.Run(t, repo, "rev-parse", "main")
 	if before != after {
 		t.Errorf("finalizeOnExit created a duplicate branch: before=%q after=%q", before, after)
 	}
@@ -135,7 +134,7 @@ func TestReviewGate_PerformGateMerge_NoCommits(t *testing.T) {
 	if r2.MergeStatus != store.MergeStatusSkipped {
 		t.Errorf("MergeStatus = %q, want skipped", r2.MergeStatus)
 	}
-	out := strings.TrimSpace(string(mustOutput(t, repo, "git", "branch", "--list", "iterion/run/*")))
+	out := gittest.Run(t, repo, "branch", "--list", "iterion/run/*")
 	if out != "" {
 		t.Errorf("no branch should be created for a no-commit gate, got %q", out)
 	}
@@ -151,8 +150,8 @@ func TestReviewGate_PerformGateMerge_IntoNone(t *testing.T) {
 	if err := eng.performGateMerge(ctx, rs, hn, "gate", nil); err != nil {
 		t.Fatalf("performGateMerge: %v", err)
 	}
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
-	base := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "HEAD")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
+	base := gittest.Run(t, repo, "rev-parse", "HEAD")
 	if mainTip != base {
 		t.Errorf("main should not move for merge_into: none")
 	}
@@ -194,8 +193,8 @@ workflow wf:
 
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 	addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
 	s := tmpStore(t)
@@ -235,7 +234,7 @@ workflow wf:
 	if r2.MergeStatus != store.MergeStatusMerged {
 		t.Errorf("MergeStatus = %q, want merged", r2.MergeStatus)
 	}
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip == originalTip {
 		t.Errorf("main did not advance — merge did not land")
 	}
@@ -273,8 +272,8 @@ workflow wf:
 
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	s := tmpStore(t)
 	r, _ := s.CreateRun(ctx, "run-rc", "wf", nil)
@@ -299,7 +298,7 @@ workflow wf:
 	if r2.MergeStatus == store.MergeStatusMerged {
 		t.Errorf("request_changes must not merge, got merge_status=merged")
 	}
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Errorf("main moved on request_changes — should not merge")
 	}
@@ -387,7 +386,7 @@ func TestReviewGate_PerformGateMerge_MessageOverride(t *testing.T) {
 	if err := eng.performGateMerge(ctx, rs, hn, "gate", answers); err != nil {
 		t.Fatalf("performGateMerge: %v", err)
 	}
-	subject := strings.TrimSpace(string(mustOutput(t, repo, "git", "log", "-1", "--format=%s", "main")))
+	subject := gittest.Run(t, repo, "log", "-1", "--format=%s", "main")
 	if subject != "custom squash subject" {
 		t.Errorf("squash subject = %q, want custom override", subject)
 	}

--- a/pkg/runtime/sandbox_shared_test.go
+++ b/pkg/runtime/sandbox_shared_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/sandbox/docker"
@@ -495,20 +496,7 @@ workflow child:
 // parent's sandbox would never mount.
 func TestSharedChildRunsInPlace(t *testing.T) {
 	workDir := t.TempDir()
-	for _, args := range [][]string{{"init", "-q", "-b", "main"}, {"config", "user.email", "t@x"}, {"config", "user.name", "t"}} {
-		if out, err := exec.Command("git", append([]string{"-C", workDir}, args...)...).CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v %s", args, err, out)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("x\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if out, err := exec.Command("git", "-C", workDir, "add", "-A").CombinedOutput(); err != nil {
-		t.Fatalf("git add: %v %s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", workDir, "commit", "-qm", "seed").CombinedOutput(); err != nil {
-		t.Fatalf("git commit: %v %s", err, out)
-	}
+	gittest.InitRepo(t, workDir)
 	wf := compileBot(t, `
 schema out:
   ok: bool

--- a/pkg/runtime/squash_message_range_test.go
+++ b/pkg/runtime/squash_message_range_test.go
@@ -1,10 +1,11 @@
 package runtime
 
 import (
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // A run's squash message must describe the RUN, and the range that bounds it
@@ -24,8 +25,8 @@ func TestBuildSquashMessageForMerge_NeverEnumeratesFromTheRoot(t *testing.T) {
 	addCommit(t, repo, "history2.md", "two\n", "chore: second commit on main")
 
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "a.go", "package main\n// a\n", "feat(lot-1): the run's first unit")
 	finalSHA := addCommit(t, wt, "b.go", "package main\n// b\n", "feat(lot-1): the run's second unit")
@@ -58,11 +59,11 @@ func TestBuildSquashMessageForMerge_KeepsAResolvableBase(t *testing.T) {
 	base := addCommit(t, repo, "history.md", "one\n", "chore: main moved on")
 
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "a.go", "package main\n", "feat: only unit")
-	finalSHA := strings.TrimSpace(string(mustOutput(t, wt, "git", "rev-parse", "HEAD")))
+	finalSHA := gittest.Run(t, wt, "rev-parse", "HEAD")
 
 	got := BuildSquashMessageForMerge(repo, base, "main", finalSHA, "run")
 	if !strings.HasPrefix(got, "feat: only unit") {
@@ -80,8 +81,8 @@ func TestBuildSquashMessageForMerge_UnreachableBaseFallsToMergeBase(t *testing.T
 	addCommit(t, repo, "history.md", "one\n", "Add new directory")
 
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "a.go", "package main\n", "feat: the run's unit")
 
@@ -99,10 +100,10 @@ func TestBuildSquashMessageForMerge_UnreachableBaseFallsToMergeBase(t *testing.T
 // so the full walk is the right answer there and must be preserved.
 func TestBuildSquashMessageForMerge_GreenfieldKeepsTheWholeHistory(t *testing.T) {
 	dir := t.TempDir()
-	mustRun(t, dir, "git", "init", "-b", "main")
-	mustRun(t, dir, "git", "config", "user.email", "test@example.com")
-	mustRun(t, dir, "git", "config", "user.name", "Test")
-	mustRun(t, dir, "git", "config", "commit.gpgsign", "false")
+	gittest.Run(t, dir, "init", "-b", "main")
+	gittest.Run(t, dir, "config", "user.email", "test@example.com")
+	gittest.Run(t, dir, "config", "user.name", "Test")
+	gittest.Run(t, dir, "config", "commit.gpgsign", "false")
 	addCommit(t, dir, "a.go", "package main\n", "feat: scaffold the app")
 	finalSHA := addCommit(t, dir, "b.go", "package main\n// b\n", "feat: first endpoint")
 

--- a/pkg/runtime/workspace_authority_test.go
+++ b/pkg/runtime/workspace_authority_test.go
@@ -2,10 +2,10 @@ package runtime
 
 import (
 	"context"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -13,17 +13,7 @@ import (
 // gitOut runs a git command in dir, failing the test on error.
 func gitOut(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(cmd.Environ(),
-		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
-	}
-	return string(out)
+	return gittest.Run(t, dir, args...)
 }
 
 // TestRunPersistWorkspace_WorkspaceAuthority pins the managed-worktree

--- a/pkg/runtime/worktree_cloud_test.go
+++ b/pkg/runtime/worktree_cloud_test.go
@@ -22,11 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -53,12 +53,11 @@ func (w *workDirProbeExecutor) SetWorkDir(dir string) { w.workDir = dir }
 // resolved repo top or the full git error (which carries the
 // "not a git repository: <gitdir>" detail on a severed worktree).
 func gitToplevel(dir string) (string, error) {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
-	out, err := cmd.CombinedOutput()
+	out, err := gittest.Try(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse --show-toplevel in %s: %v: %s", dir, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("git rev-parse --show-toplevel in %s: %v: %s", dir, err, out)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return out, nil
 }
 
 // TestCloudRun_WorktreeAuto_GitWorksAcrossDeliveries reproduces the
@@ -89,7 +88,7 @@ func TestCloudRun_WorktreeAuto_GitWorksAcrossDeliveries(t *testing.T) {
 		if err := os.RemoveAll(clone); err != nil {
 			t.Fatalf("remove clone: %v", err)
 		}
-		mustRun(t, pod, "git", "clone", "--quiet", seed, clone)
+		gittest.Run(t, pod, "clone", "--quiet", seed, clone)
 	}
 	cloneFresh()
 
@@ -279,8 +278,8 @@ func TestResume_RefusesSeveredWorktreeLinkage(t *testing.T) {
 func TestCheckWorktreeLinkage(t *testing.T) {
 	repo, _ := initBareishRepo(t)
 	linked := filepath.Join(t.TempDir(), "linked")
-	mustRun(t, repo, "git", "worktree", "add", "--detach", linked, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", linked).Run() })
+	gittest.Run(t, repo, "worktree", "add", "--detach", linked, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", linked) })
 
 	severed := t.TempDir()
 	writeFile(t, filepath.Join(severed, ".git"), "gitdir: "+filepath.Join(t.TempDir(), "nope", ".git", "worktrees", "x"))

--- a/pkg/runtime/worktree_default_test.go
+++ b/pkg/runtime/worktree_default_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -193,8 +194,8 @@ func TestEngineRun_UnmanagedLinkedWorktreeRecordsBaseline(t *testing.T) {
 	s := tmpStore(t)
 	repo, originalTip := initBareishRepo(t)
 	linked := filepath.Join(t.TempDir(), "linked-wt")
-	mustRun(t, repo, "git", "worktree", "add", "--detach", linked, "HEAD")
-	t.Cleanup(func() { mustRun(t, repo, "git", "worktree", "remove", "--force", linked) })
+	gittest.Run(t, repo, "worktree", "add", "--detach", linked, "HEAD")
+	t.Cleanup(func() { gittest.Run(t, repo, "worktree", "remove", "--force", linked) })
 
 	eng := New(wf, s, newStubExecutor(),
 		WithWorkDir(linked),

--- a/pkg/runtime/worktree_empty_repo_test.go
+++ b/pkg/runtime/worktree_empty_repo_test.go
@@ -1,8 +1,9 @@
 package runtime
 
 import (
-	"os/exec"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
 )
 
 // TestWorkspaceHasCommits distinguishes an unborn-HEAD repo (freshly
@@ -13,11 +14,7 @@ func TestWorkspaceHasCommits(t *testing.T) {
 	dir := t.TempDir()
 	run := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	run("init", "-b", "main")
 	if workspaceHasCommits(dir) {

--- a/pkg/runtime/worktree_pool_test.go
+++ b/pkg/runtime/worktree_pool_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -36,7 +37,7 @@ func poolWorkflow() *ir.Workflow {
 func parkWorktree(t *testing.T, s store.RunStore, repo, runID string) string {
 	t.Helper()
 	path := filepath.Join(s.Root(), "worktrees", runID)
-	mustRun(t, repo, "git", "worktree", "add", "--detach", path, "HEAD")
+	gittest.Run(t, repo, "worktree", "add", "--detach", path, "HEAD")
 	if _, err := s.CreateRun(context.Background(), runID, "wt-pool", nil); err != nil {
 		t.Fatalf("CreateRun(%s): %v", runID, err)
 	}

--- a/pkg/runtime/worktree_test.go
+++ b/pkg/runtime/worktree_test.go
@@ -5,35 +5,15 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
-
-func mustRun(t *testing.T, dir string, name string, args ...string) {
-	t.Helper()
-	cmd := exec.Command(name, args...)
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("%s %v failed in %s: %v\noutput: %s", name, args, dir, err, string(out))
-	}
-}
-
-func mustOutput(t *testing.T, dir string, name string, args ...string) []byte {
-	t.Helper()
-	cmd := exec.Command(name, args...)
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("%s %v failed in %s: %v", name, args, dir, err)
-	}
-	return out
-}
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
@@ -48,15 +28,7 @@ func writeFile(t *testing.T, path, content string) {
 func initBareishRepo(t *testing.T) (string, string) {
 	t.Helper()
 	dir := t.TempDir()
-	mustRun(t, dir, "git", "init", "-b", "main")
-	mustRun(t, dir, "git", "config", "user.email", "test@example.com")
-	mustRun(t, dir, "git", "config", "user.name", "Test")
-	mustRun(t, dir, "git", "config", "commit.gpgsign", "false")
-	writeFile(t, filepath.Join(dir, "README.md"), "init\n")
-	mustRun(t, dir, "git", "add", "README.md")
-	mustRun(t, dir, "git", "commit", "-m", "init")
-	sha := strings.TrimSpace(string(mustOutput(t, dir, "git", "rev-parse", "HEAD")))
-	return dir, sha
+	return dir, gittest.InitRepo(t, dir)
 }
 
 // addCommit makes a single commit in the worktree at wtPath. Returns the
@@ -64,9 +36,9 @@ func initBareishRepo(t *testing.T) (string, string) {
 func addCommit(t *testing.T, wtPath, file, content, msg string) string {
 	t.Helper()
 	writeFile(t, filepath.Join(wtPath, file), content)
-	mustRun(t, wtPath, "git", "add", file)
-	mustRun(t, wtPath, "git", "commit", "-m", msg)
-	return strings.TrimSpace(string(mustOutput(t, wtPath, "git", "rev-parse", "HEAD")))
+	gittest.Run(t, wtPath, "add", file)
+	gittest.Run(t, wtPath, "commit", "-m", msg)
+	return gittest.Run(t, wtPath, "rev-parse", "HEAD")
 }
 
 // TestFinalizeWorktree_NoCommits — a run that produced no commits in
@@ -74,8 +46,8 @@ func addCommit(t *testing.T, wtPath, file, content, msg string) string {
 func TestFinalizeWorktree_NoCommits(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	res := finalizeWorktree(worktreeContext{
 		repoRoot:       repo,
@@ -88,9 +60,8 @@ func TestFinalizeWorktree_NoCommits(t *testing.T) {
 		t.Fatalf("expected zero finalization for unchanged HEAD, got %+v", res)
 	}
 	// And no branch was created.
-	out, _ := exec.Command("git", "-C", repo, "branch", "--list", "iterion/run/*").Output()
-	if strings.TrimSpace(string(out)) != "" {
-		t.Fatalf("no branch should be created when no commits, got: %q", string(out))
+	if out, _ := gittest.Try(repo, "branch", "--list", "iterion/run/*"); out != "" {
+		t.Fatalf("no branch should be created when no commits, got: %q", out)
 	}
 }
 
@@ -121,16 +92,16 @@ func TestFinalizeWorktree_RefusesRepoRootAsWorktree(t *testing.T) {
 		t.Errorf("PreserveWorktree = false, want true (must not clean the live checkout)")
 	}
 	// The operator's branch must be UNTOUCHED — no wip commit created.
-	if headNow := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "HEAD"))); headNow != originalTip {
+	if headNow := gittest.Run(t, repo, "rev-parse", "HEAD"); headNow != originalTip {
 		t.Errorf("repo HEAD moved to %s (want %s) — finalize committed on the operator's branch", headNow, originalTip)
 	}
 	// The uncommitted change must still be uncommitted (not banked away).
-	if st := strings.TrimSpace(string(mustOutput(t, repo, "git", "status", "--porcelain"))); st == "" {
+	if st := gittest.Run(t, repo, "status", "--porcelain"); st == "" {
 		t.Errorf("working tree is clean — finalize banked the uncommitted change instead of leaving it")
 	}
 	// No storage branch either.
-	if br, _ := exec.Command("git", "-C", repo, "branch", "--list", "iterion/run/*").Output(); strings.TrimSpace(string(br)) != "" {
-		t.Errorf("storage branch created: %q — expected none", string(br))
+	if br, _ := gittest.Try(repo, "branch", "--list", "iterion/run/*"); br != "" {
+		t.Errorf("storage branch created: %q — expected none", br)
 	}
 }
 
@@ -156,7 +127,7 @@ func TestRecoverFinalize_SkipsPhantomWorktree(t *testing.T) {
 	if r.FinalCommit != "" || r.FinalBranch != "" {
 		t.Errorf("RecoverFinalize stamped finalization (%q/%q) — expected skip", r.FinalCommit, r.FinalBranch)
 	}
-	if headNow := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "HEAD"))); headNow != originalTip {
+	if headNow := gittest.Run(t, repo, "rev-parse", "HEAD"); headNow != originalTip {
 		t.Errorf("repo HEAD moved to %s (want %s) — recovery committed on the operator's branch", headNow, originalTip)
 	}
 }
@@ -166,8 +137,8 @@ func TestRecoverFinalize_SkipsPhantomWorktree(t *testing.T) {
 func TestFinalizeWorktree_HappyPath_FFCurrent(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -191,7 +162,7 @@ func TestFinalizeWorktree_HappyPath_FFCurrent(t *testing.T) {
 		t.Errorf("MergeStatus = %q, want merged", res.MergeStatus)
 	}
 	// And main really moved.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != finalSHA {
 		t.Errorf("main tip = %s, want %s", mainTip, finalSHA)
 	}
@@ -203,8 +174,8 @@ func TestFinalizeWorktree_HappyPath_FFCurrent(t *testing.T) {
 func TestFinalizeWorktree_DirtyMain_SkipsFF(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	// Dirty the main worktree before finalize.
 	writeFile(t, filepath.Join(repo, "wip.txt"), "uncommitted\n")
@@ -231,7 +202,7 @@ func TestFinalizeWorktree_DirtyMain_SkipsFF(t *testing.T) {
 		t.Errorf("MergeStatus = %q, want failed", res.MergeStatus)
 	}
 	// Main should still point at the original tip.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Errorf("main tip moved to %s, want still at %s", mainTip, originalTip)
 	}
@@ -242,14 +213,14 @@ func TestFinalizeWorktree_DirtyMain_SkipsFF(t *testing.T) {
 func TestFinalizeWorktree_NonFF_SkipsFF(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	// Main advances independently (e.g. user committed in another tab).
 	writeFile(t, filepath.Join(repo, "side.txt"), "side\n")
-	mustRun(t, repo, "git", "add", "side.txt")
-	mustRun(t, repo, "git", "commit", "-m", "side commit")
-	mainTipAfter := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	gittest.Run(t, repo, "add", "side.txt")
+	gittest.Run(t, repo, "commit", "-m", "side commit")
+	mainTipAfter := gittest.Run(t, repo, "rev-parse", "main")
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -273,7 +244,7 @@ func TestFinalizeWorktree_NonFF_SkipsFF(t *testing.T) {
 		t.Errorf("MergeStatus = %q, want failed", res.MergeStatus)
 	}
 	// Main should still point at the side commit, not at the run's commit.
-	cur := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	cur := gittest.Run(t, repo, "rev-parse", "main")
 	if cur != mainTipAfter {
 		t.Errorf("main tip = %s, want %s (unchanged)", cur, mainTipAfter)
 	}
@@ -284,8 +255,8 @@ func TestFinalizeWorktree_NonFF_SkipsFF(t *testing.T) {
 func TestFinalizeWorktree_OptOutNone(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -306,7 +277,7 @@ func TestFinalizeWorktree_OptOutNone(t *testing.T) {
 		t.Errorf("MergeStatus = %q, want skipped", res.MergeStatus)
 	}
 	// Main untouched.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Errorf("main tip moved despite none, %s != %s", mainTip, originalTip)
 	}
@@ -317,8 +288,8 @@ func TestFinalizeWorktree_OptOutNone(t *testing.T) {
 func TestFinalizeWorktree_BranchNameOverride(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -332,9 +303,9 @@ func TestFinalizeWorktree_BranchNameOverride(t *testing.T) {
 	if res.FinalBranch != "feat/auto-fixes" {
 		t.Errorf("FinalBranch = %q, want feat/auto-fixes", res.FinalBranch)
 	}
-	out, _ := exec.Command("git", "-C", repo, "branch", "--list", "feat/auto-fixes").Output()
-	if !strings.Contains(string(out), "feat/auto-fixes") {
-		t.Errorf("override branch not created: %q", string(out))
+	out, _ := gittest.Try(repo, "branch", "--list", "feat/auto-fixes")
+	if !strings.Contains(out, "feat/auto-fixes") {
+		t.Errorf("override branch not created: %q", out)
 	}
 }
 
@@ -344,11 +315,11 @@ func TestFinalizeWorktree_BranchNameOverride(t *testing.T) {
 func TestFinalizeWorktree_BranchNameCollision(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	// Pre-create the would-be default branch on some earlier commit.
-	mustRun(t, repo, "git", "branch", "iterion/run/swift-cedar-a3f2", originalTip)
+	gittest.Run(t, repo, "branch", "iterion/run/swift-cedar-a3f2", originalTip)
 
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -366,7 +337,7 @@ func TestFinalizeWorktree_BranchNameCollision(t *testing.T) {
 		t.Errorf("expected suffixed fallback, got %q", res.FinalBranch)
 	}
 	// And the fallback branch points at the run's commit.
-	tip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", res.FinalBranch)))
+	tip := gittest.Run(t, repo, "rev-parse", res.FinalBranch)
 	if tip != finalSHA {
 		t.Errorf("fallback branch tip = %s, want %s", tip, finalSHA)
 	}
@@ -377,11 +348,11 @@ func TestFinalizeWorktree_BranchNameCollision(t *testing.T) {
 // skipped — there's no branch to advance.
 func TestFinalizeWorktree_DetachedAtStart(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
-	mustRun(t, repo, "git", "checkout", "--detach", "HEAD")
+	gittest.Run(t, repo, "checkout", "--detach", "HEAD")
 
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -407,8 +378,8 @@ func TestFinalizeWorktree_DetachedAtStart(t *testing.T) {
 func TestFinalizeWorktree_DeferredMerge_AutoMergeOff(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -432,7 +403,7 @@ func TestFinalizeWorktree_DeferredMerge_AutoMergeOff(t *testing.T) {
 		t.Errorf("MergeStatus = %q, want pending", res.MergeStatus)
 	}
 	// Main untouched.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Errorf("main tip moved despite deferred merge, %s != %s", mainTip, originalTip)
 	}
@@ -443,8 +414,8 @@ func TestFinalizeWorktree_DeferredMerge_AutoMergeOff(t *testing.T) {
 func TestFinalizeWorktree_SquashStrategy(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "a.go", "package main\n// a\n", "feat: add a")
 	addCommit(t, wt, "b.go", "package main\n// b\n", "feat: add b")
@@ -470,7 +441,7 @@ func TestFinalizeWorktree_SquashStrategy(t *testing.T) {
 		t.Errorf("MergedCommit should be a fresh squash SHA distinct from FinalCommit; got %q (final %q)", res.MergedCommit, finalSHA)
 	}
 	// Main should be one commit ahead of originalTip — not three.
-	count := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-list", "--count", originalTip+"..main")))
+	count := gittest.Run(t, repo, "rev-list", "--count", originalTip+"..main")
 	if count != "1" {
 		t.Errorf("main has %s commits past base, want 1 squash commit", count)
 	}
@@ -484,14 +455,14 @@ func TestFinalizeWorktree_SquashStrategy(t *testing.T) {
 func TestBuildSquashMessage_SingleCommit(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	fullMessage := "feat(privacy): add pure-Go privacy_filter tools\n\nDetect and redact 5 PII categories.\nNo Python, no ONNX."
 	writeFile(t, filepath.Join(wt, "a.go"), "package main\n// a\n")
-	mustRun(t, wt, "git", "add", "a.go")
-	mustRun(t, wt, "git", "commit", "-m", fullMessage)
-	finalSHA := strings.TrimSpace(string(mustOutput(t, wt, "git", "rev-parse", "HEAD")))
+	gittest.Run(t, wt, "add", "a.go")
+	gittest.Run(t, wt, "commit", "-m", fullMessage)
+	finalSHA := gittest.Run(t, wt, "rev-parse", "HEAD")
 
 	got := buildSquashMessage(repo, originalTip, finalSHA, "plain-basalt-0d49")
 	want := fullMessage + "\n"
@@ -507,8 +478,8 @@ func TestBuildSquashMessage_SingleCommit(t *testing.T) {
 func TestBuildSquashMessage_MultipleCommitsListsAll(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	addCommit(t, wt, "a.go", "package main\n// a\n", "feat(api): add v2 endpoint")
 	addCommit(t, wt, "b.go", "package main\n// b\n", "test(api): cover v2 happy path")
@@ -592,8 +563,8 @@ func TestResolveMergeTarget(t *testing.T) {
 func TestRecoverFinalize_HappyPath(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: add feature")
 
@@ -635,8 +606,7 @@ func TestRecoverFinalize_HappyPath(t *testing.T) {
 		t.Errorf("persisted final_* mismatch: %+v", r2)
 	}
 	// And the branch actually exists in the repo.
-	out, _ := exec.Command("git", "-C", repo, "rev-parse", "iterion/run/swift-cedar-a3f2").Output()
-	if got := strings.TrimSpace(string(out)); got != finalSHA {
+	if got, _ := gittest.Try(repo, "rev-parse", "iterion/run/swift-cedar-a3f2"); got != finalSHA {
 		t.Errorf("branch tip = %q, want %q", got, finalSHA)
 	}
 }
@@ -748,8 +718,8 @@ func TestRecoverFinalize_SkipsNonFinished(t *testing.T) {
 func TestRecoverFinalize_CancelledRun(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	finalSHA := addCommit(t, wt, "partial.go", "package main\n", "feat: partial work")
 
@@ -790,8 +760,8 @@ func TestRecoverFinalize_CancelledRun(t *testing.T) {
 func TestFinalizeWorktree_WipBanksDirtyWorktree(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	// Uncommitted work: one new file + one modified tracked file.
 	writeFile(t, filepath.Join(wt, "new_feature.go"), "package main\n")
@@ -820,12 +790,12 @@ func TestFinalizeWorktree_WipBanksDirtyWorktree(t *testing.T) {
 		t.Fatalf("a wip-banked HEAD must never merge (want skipped), got %+v", res)
 	}
 	// The operator's branch must NOT have moved.
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Fatalf("main moved to %s — a wip bank must never touch the operator's branch", mainTip)
 	}
 	// The banked commit really contains the uncommitted work.
-	show := string(mustOutput(t, repo, "git", "show", "--stat", "--format=%s", res.FinalCommit))
+	show := gittest.Run(t, repo, "show", "--stat", "--format=%s", res.FinalCommit)
 	if !strings.Contains(show, "wip(iterion)") || !strings.Contains(show, "new_feature.go") || !strings.Contains(show, "README.md") {
 		t.Fatalf("banked commit missing expected content:\n%s", show)
 	}
@@ -839,8 +809,8 @@ func TestFinalizeWorktree_WipBanksDirtyWorktree(t *testing.T) {
 func TestFinalizeWorktree_WipBankResidueOnTopOfCommits(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	agentSHA := addCommit(t, wt, "feature.go", "package main\n", "feat: real work")
 	writeFile(t, filepath.Join(wt, "residue.go"), "package main\n")
@@ -859,14 +829,14 @@ func TestFinalizeWorktree_WipBankResidueOnTopOfCommits(t *testing.T) {
 		t.Fatalf("expected banked tip above the agent commit, got %+v", res)
 	}
 	// The banked tip's parent is the agent's real commit.
-	parent := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", res.FinalCommit+"^")))
+	parent := gittest.Run(t, repo, "rev-parse", res.FinalCommit+"^")
 	if parent != agentSHA {
 		t.Fatalf("banked commit parent = %s, want agent commit %s", parent, agentSHA)
 	}
 	if res.MergeStatus != "skipped" || res.MergedInto != "" {
 		t.Fatalf("wip-banked tip must skip the merge, got %+v", res)
 	}
-	mainTip := strings.TrimSpace(string(mustOutput(t, repo, "git", "rev-parse", "main")))
+	mainTip := gittest.Run(t, repo, "rev-parse", "main")
 	if mainTip != originalTip {
 		t.Fatalf("main moved to %s — must stay at %s", mainTip, originalTip)
 	}
@@ -886,7 +856,7 @@ func TestSetupWorktree_AnchorsOnTheLaunchCheckout(t *testing.T) {
 
 	// A linked worktree pinned to the FIRST commit, on its own branch.
 	linked := filepath.Join(t.TempDir(), "linked")
-	mustRun(t, main, "git", "worktree", "add", "-b", "side", linked, firstSHA)
+	gittest.Run(t, main, "worktree", "add", "-b", "side", linked, firstSHA)
 
 	// main moves on. The two checkouts now disagree, which is the whole point.
 	secondSHA := addCommit(t, main, "moved.txt", "on main only\n", "second")
@@ -900,7 +870,7 @@ func TestSetupWorktree_AnchorsOnTheLaunchCheckout(t *testing.T) {
 	}
 	defer cleanup()
 
-	got := strings.TrimSpace(string(mustOutput(t, wc.wtPath, "git", "rev-parse", "HEAD")))
+	got := gittest.Run(t, wc.wtPath, "rev-parse", "HEAD")
 	if got != firstSHA {
 		t.Errorf("run worktree anchored at %s, want the launch checkout's %s (main is at %s)",
 			shortSHA(got), shortSHA(firstSHA), shortSHA(secondSHA))
@@ -936,7 +906,7 @@ func TestSetupWorktree_SingleCheckoutUnchanged(t *testing.T) {
 	if !samePath(wc.anchor(), wc.repoRoot) {
 		t.Errorf("anchor() = %q, repoRoot = %q — they must coincide for a single checkout", wc.anchor(), wc.repoRoot)
 	}
-	got := strings.TrimSpace(string(mustOutput(t, wc.wtPath, "git", "rev-parse", "HEAD")))
+	got := gittest.Run(t, wc.wtPath, "rev-parse", "HEAD")
 	if got != firstSHA {
 		t.Errorf("run worktree at %s, want %s", shortSHA(got), shortSHA(firstSHA))
 	}
@@ -1007,8 +977,8 @@ func TestRunOutputPaths_IgnoresIterionsOwnScaffolding(t *testing.T) {
 func TestTrySquashMerge_LargeMessageCommits(t *testing.T) {
 	repo, _ := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", "-b", "iterion/run/big", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", "-b", "iterion/run/big", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 	addCommit(t, wt, "a.go", "package main\n// a\n", "feat: add a")
 
 	message := "feat: a converged campaign\n\n" + strings.Repeat("- report line that a campaign wrote into its message\n", 6000)
@@ -1019,7 +989,7 @@ func TestTrySquashMerge_LargeMessageCommits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("squash with a %d-byte message: %v", len(message), err)
 	}
-	got := string(mustOutput(t, repo, "git", "log", "-1", "--pretty=format:%B", sha))
+	got := gittest.Run(t, repo, "log", "-1", "--pretty=format:%B", sha)
 	if strings.TrimRight(got, "\n") != strings.TrimRight(message, "\n") {
 		t.Fatalf("committed message differs from the one supplied (%d vs %d bytes)", len(got), len(message))
 	}
@@ -1053,16 +1023,16 @@ func TestAssembleSquashMessage_ElidesALongCommitList(t *testing.T) {
 func TestBuildSquashMessage_BoundsASingleOversizedBody(t *testing.T) {
 	repo, originalTip := initBareishRepo(t)
 	wt := filepath.Join(t.TempDir(), "wt")
-	mustRun(t, repo, "git", "worktree", "add", wt, "HEAD")
-	t.Cleanup(func() { _ = exec.Command("git", "-C", repo, "worktree", "remove", "--force", wt).Run() })
+	gittest.Run(t, repo, "worktree", "add", wt, "HEAD")
+	t.Cleanup(func() { _, _ = gittest.Try(repo, "worktree", "remove", "--force", wt) })
 
 	body := strings.Repeat("a line of the campaign's report that nobody needs on main\n", 6000)
 	msgFile := filepath.Join(t.TempDir(), "msg")
 	writeFile(t, msgFile, "feat(report): converge\n\n"+body)
 	writeFile(t, filepath.Join(wt, "a.go"), "package main\n")
-	mustRun(t, wt, "git", "add", "a.go")
-	mustRun(t, wt, "git", "commit", "-F", msgFile)
-	finalSHA := strings.TrimSpace(string(mustOutput(t, wt, "git", "rev-parse", "HEAD")))
+	gittest.Run(t, wt, "add", "a.go")
+	gittest.Run(t, wt, "commit", "-F", msgFile)
+	finalSHA := gittest.Run(t, wt, "rev-parse", "HEAD")
 
 	got := buildSquashMessage(repo, originalTip, finalSHA, "run")
 	if len(got) > maxSquashMessageBytes+256 {

--- a/pkg/runview/conflict_test.go
+++ b/pkg/runview/conflict_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -45,17 +46,7 @@ func TestPerformMerge_ConflictPath(t *testing.T) {
 	}
 	runGit := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = repoDir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"LC_ALL=C",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
-		}
+		gittest.Run(t, repoDir, args...)
 	}
 	writeRepo := func(name, content string) {
 		t.Helper()
@@ -230,17 +221,7 @@ func TestAbortMergeConflict_RestoresWorktree(t *testing.T) {
 	}
 	runGit := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = repoDir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"LC_ALL=C",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
-		}
+		gittest.Run(t, repoDir, args...)
 	}
 	writeRepo := func(name, content string) {
 		t.Helper()
@@ -321,12 +302,5 @@ func TestAbortMergeConflict_RestoresWorktree(t *testing.T) {
 
 func captureGitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "LC_ALL=C")
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git %v: %v", args, err)
-	}
-	return string(out)
+	return gittest.Run(t, dir, args...)
 }

--- a/pkg/runview/main_test.go
+++ b/pkg/runview/main_test.go
@@ -1,0 +1,20 @@
+package runview
+
+import (
+	"os"
+	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
+)
+
+// A Service launched without WithWorkDir hands the engine os.Getwd() — this
+// package's own directory, inside the developer's checkout — so a run with
+// `worktree: auto` (the IR default) registers its per-run worktree in the REAL
+// repository while the checkout itself lives under t.TempDir() and is deleted
+// on return. Nothing ever comes back for the registration.
+//
+// The guard makes that visible: it fails the package when the repository the
+// tests run in gained a dead worktree entry, and names the test that left it.
+func TestMain(m *testing.M) {
+	os.Exit(gittest.NoWorktreeLeaks(m))
+}

--- a/pkg/runview/merge_claim_test.go
+++ b/pkg/runview/merge_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -36,17 +37,7 @@ func seedMergeableRun(t *testing.T) (*store.FilesystemRunStore, *Service, string
 	}
 	runGit := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = repoDir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"LC_ALL=C",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
-		}
+		gittest.Run(t, repoDir, args...)
 	}
 	write := func(name, content string) {
 		t.Helper()

--- a/pkg/runview/merge_remote_test.go
+++ b/pkg/runview/merge_remote_test.go
@@ -3,11 +3,11 @@ package runview
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -15,16 +15,7 @@ import (
 // tgit runs one git command in dir and fails the test on error.
 func tgit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@test.invalid",
-		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@test.invalid")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v: %v\n%s", args, err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return gittest.Run(t, dir, args...)
 }
 
 // seedForge builds a bare "forge" repo with a trunk branch (one base

--- a/pkg/runview/rewind_files_test.go
+++ b/pkg/runview/rewind_files_test.go
@@ -9,23 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 func git(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=iterion", "GIT_AUTHOR_EMAIL=iterion@example.test",
-		"GIT_COMMITTER_NAME=iterion", "GIT_COMMITTER_EMAIL=iterion@example.test",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return gittest.Run(t, dir, args...)
 }
 
 func writeFile(t *testing.T, dir, name, body string) {

--- a/pkg/runview/service_launch_pause_test.go
+++ b/pkg/runview/service_launch_pause_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -43,7 +44,10 @@ func TestLaunch_PersistsRunBeforeReturn_AndPauseKeepsSubscribers(t *testing.T) {
 		t.Fatalf("write bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -88,7 +92,10 @@ func TestLaunch_PersistsParentRunIDBeforeReturn(t *testing.T) {
 		t.Fatalf("write bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/pkg/runview/service_resume_hash_test.go
+++ b/pkg/runview/service_resume_hash_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -208,7 +209,10 @@ func TestResume_RejectsWorkflowHashMismatchSynchronouslyBeforeSpawn(t *testing.T
 		t.Fatalf("write bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/pkg/runview/subbot_child_control_test.go
+++ b/pkg/runview/subbot_child_control_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -100,7 +101,10 @@ func TestServiceLaunch_SubbotChild_CancelMidFlight(t *testing.T) {
 		t.Fatalf("write parent bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
@@ -160,7 +164,10 @@ func TestServiceLaunch_SubbotChild_PauseMidFlight(t *testing.T) {
 		t.Fatalf("write parent bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/pkg/runview/subbot_child_control_test.go
+++ b/pkg/runview/subbot_child_control_test.go
@@ -69,7 +69,7 @@ workflow control_parent:
 // non-terminal state, returning its id. Fails the test on timeout.
 func waitForActiveChild(t *testing.T, svc *Service, parentID string) string {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(waitBudget(t, 30*time.Second))
 	for {
 		if time.Now().After(deadline) {
 			t.Fatal("child run never appeared active")
@@ -113,6 +113,17 @@ func TestServiceLaunch_SubbotChild_CancelMidFlight(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Launch: %v", err)
 	}
+	// A run goroutine that outlives the test writes into the store while
+	// t.TempDir() is removing it — "directory not empty" on cleanup, a second
+	// failure that hides the first.
+	t.Cleanup(func() {
+		_ = svc.Cancel(res.RunID)
+		select {
+		case <-res.Done:
+		case <-time.After(waitBudget(t, 30*time.Second)):
+			t.Error("the run goroutine outlived the test; its writes race t.TempDir() removal")
+		}
+	})
 
 	childID := waitForActiveChild(t, svc, res.RunID)
 
@@ -128,9 +139,23 @@ func TestServiceLaunch_SubbotChild_CancelMidFlight(t *testing.T) {
 
 	// The child ends cancelled, and the parent branch fails (its subbot node
 	// returns the child's error) — not a hang.
+	//
+	// The ceiling is a HANG detector, and it must not be the child's own
+	// blocking duration: the child sits in `sleep 30`, so a bare 30s here
+	// reads "the tool node ran to completion" as "the parent hung", with a
+	// margin equal to the launch→cancel gap alone. Measured post-cancel on a
+	// starved box (GOMAXPROCS=1, 30 busy processes, n=30): 0.15-0.18s once the
+	// run's source repository is one the test owns, 5.7-20.3s when it was the
+	// developer's checkout — a spread that reached this ceiling on CI (#927).
+	// waitBudget is the package's own allowance for a contended runner, which
+	// every budget in the sibling subbot_restart_test.go already takes.
+	//
+	// Raising it does not make the row vacuous: the status assertion below
+	// still refuses a child that merely ran its sleep out instead of being
+	// cancelled.
 	select {
 	case <-res.Done:
-	case <-time.After(30 * time.Second):
+	case <-time.After(waitBudget(t, 30*time.Second)):
 		t.Fatal("parent did not terminate after the child was cancelled")
 	}
 
@@ -189,7 +214,7 @@ func TestServiceLaunch_SubbotChild_PauseMidFlight(t *testing.T) {
 	}
 
 	// Within a few loop boundaries the child checkpoints as paused_operator.
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(waitBudget(t, 30*time.Second))
 	for {
 		if time.Now().After(deadline) {
 			child, _ := svc.store.LoadRun(context.Background(), childID)

--- a/pkg/runview/subbot_human_gate_test.go
+++ b/pkg/runview/subbot_human_gate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -84,7 +85,10 @@ func TestServiceLaunch_SubbotChildHumanGate_ParkAndResume(t *testing.T) {
 		t.Fatalf("write parent bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/pkg/runview/subbot_restart_test.go
+++ b/pkg/runview/subbot_restart_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -32,7 +33,10 @@ func TestServiceLaunch_SubbotReattachAfterRestart(t *testing.T) {
 		t.Fatalf("write parent bot: %v", err)
 	}
 
-	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	// The run gets a repository the test OWNS: without one, `worktree: auto`
+	// (the IR default) takes os.Getwd() — this package inside the developer's
+	// checkout — and registers the run's worktree there for good (#870).
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithWorkDir(gittest.SourceRepo(t)))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}

--- a/pkg/sandbox/kubernetes/workspace_test.go
+++ b/pkg/sandbox/kubernetes/workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/internal/gittest"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 )
 
@@ -126,18 +127,49 @@ func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// podEnv builds the environment for EVERY git command below — the probe,
+	// the two script runs and the read-back. They vouch for one another, and a
+	// command that resolves git's configuration differently vouches for
+	// something else.
+	//
+	// The global and system config are cut off on purpose: `safe.directory` is
+	// read ONLY from those two files, and its ABSENCE is the pod condition
+	// being reproduced. Leaving them ambient made the outcome a property of
+	// the HOST — on a CI image carrying a covering `safe.directory` the
+	// hermetic probe refused while the ambient subject succeeded, and the test
+	// failed claiming the fixup should have died (git 2.55, PR #927).
+	//
+	// This is also why these commands do not go through internal/gittest:
+	// that helper makes the same cut as hygiene, and here it is the SUBJECT.
+	// The auto-maintenance config it also carries is orthogonal, so it is
+	// applied directly.
+	podEnv := func(extra ...string) []string {
+		env := append(os.Environ(),
+			"GIT_CONFIG_GLOBAL="+os.DevNull,
+			"GIT_CONFIG_SYSTEM="+os.DevNull,
+			"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
+		)
+		return append(env, extra...)
+	}
+	safeDirEnv := []string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0=" + dir,
+	}
+
 	// Sanity: the knob must actually break repository discovery on this
 	// host's git (≥2.35.2). If it doesn't (ancient git), the regression
 	// can't be exercised here.
-	probe := gittest.Cmd(dir, "rev-parse", "--git-dir")
-	probe.Env = append(probe.Env, "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
+	probe := exec.Command("git", gitlib.NoAutoMaintenance("rev-parse", "--git-dir")...)
+	probe.Dir = dir
+	probe.Env = podEnv()
 	if err := probe.Run(); err == nil {
 		t.Skip("this git does not honour GIT_TEST_ASSUME_DIFFERENT_OWNER; cannot simulate the root-owned pod workspace")
 	}
 
 	// WITHOUT the pod env: the exact live failure — exit 128.
 	cmd := exec.Command("sh", "-c", fixupWorkspaceGitScript, "sh", dir)
-	cmd.Env = append(os.Environ(), "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
+	cmd.Env = podEnv()
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("expected the fixup to fail under dubious ownership (the live 128), got success:\n%s", out)
@@ -150,22 +182,13 @@ func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
 	// workspace, protected command scope): the same script succeeds and
 	// re-points the credential helper.
 	cmd = exec.Command("sh", "-c", fixupWorkspaceGitScript, "sh", dir)
-	cmd.Env = append(os.Environ(),
-		"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0=safe.directory",
-		"GIT_CONFIG_VALUE_0="+dir,
-	)
+	cmd.Env = podEnv(safeDirEnv...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("fixup with safe.directory env: %v\n%s", err, out)
 	}
-	read := gittest.Cmd(dir, "config", "credential.helper")
-	read.Env = append(read.Env,
-		"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0=safe.directory",
-		"GIT_CONFIG_VALUE_0="+dir,
-	)
+	read := exec.Command("git", gitlib.NoAutoMaintenance("config", "credential.helper")...)
+	read.Dir = dir
+	read.Env = podEnv(safeDirEnv...)
 	got, err := read.Output()
 	if err != nil {
 		t.Fatalf("read credential.helper: %v", err)

--- a/pkg/sandbox/kubernetes/workspace_test.go
+++ b/pkg/sandbox/kubernetes/workspace_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 )
 
@@ -24,13 +25,7 @@ func TestResolveCloneRoot(t *testing.T) {
 	repo := filepath.Join(dir, "clone")
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	git("init", "-q", repo)
 	git("-C", repo, "commit", "-q", "--allow-empty", "-m", "init")
@@ -74,13 +69,7 @@ func TestFixupWorkspaceGitScript(t *testing.T) {
 	dir := t.TempDir()
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	git("init", "-q", dir)
 	// The runner's credential store, recorded with a HOST path that does
@@ -100,12 +89,8 @@ func TestFixupWorkspaceGitScript(t *testing.T) {
 		t.Fatalf("fixup script: %v\n%s", err, out)
 	}
 
-	out, err := exec.Command("git", "-C", dir, "config", "credential.helper").Output()
-	if err != nil {
-		t.Fatalf("read credential.helper: %v", err)
-	}
 	want := "store --file=" + credPath
-	if got := strings.TrimSpace(string(out)); got != want {
+	if got := gittest.Run(t, dir, "config", "credential.helper"); got != want {
 		t.Errorf("credential.helper = %q, want %q", got, want)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".git", "worktrees")); !os.IsNotExist(err) {
@@ -135,9 +120,7 @@ func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
 		t.Skip("git not available")
 	}
 	dir := t.TempDir()
-	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
-		t.Fatalf("git init: %v\n%s", err, out)
-	}
+	gittest.Run(t, dir, "init", "-q")
 	credPath := filepath.Join(dir, ".git", "iterion-credentials")
 	if err := os.WriteFile(credPath, []byte("https://oauth2:tok@example.com\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -146,8 +129,8 @@ func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
 	// Sanity: the knob must actually break repository discovery on this
 	// host's git (≥2.35.2). If it doesn't (ancient git), the regression
 	// can't be exercised here.
-	probe := exec.Command("git", "-C", dir, "rev-parse", "--git-dir")
-	probe.Env = append(os.Environ(), "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
+	probe := gittest.Cmd(dir, "rev-parse", "--git-dir")
+	probe.Env = append(probe.Env, "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
 	if err := probe.Run(); err == nil {
 		t.Skip("this git does not honour GIT_TEST_ASSUME_DIFFERENT_OWNER; cannot simulate the root-owned pod workspace")
 	}
@@ -176,8 +159,8 @@ func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("fixup with safe.directory env: %v\n%s", err, out)
 	}
-	read := exec.Command("git", "-C", dir, "config", "credential.helper")
-	read.Env = append(os.Environ(),
+	read := gittest.Cmd(dir, "config", "credential.helper")
+	read.Env = append(read.Env,
 		"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
 		"GIT_CONFIG_COUNT=1",
 		"GIT_CONFIG_KEY_0=safe.directory",

--- a/pkg/server/outcome_router_test.go
+++ b/pkg/server/outcome_router_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/alert"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -239,15 +240,7 @@ func TestOutcomeRouter_MergesAndCountsEpisodes(t *testing.T) {
 	repo := t.TempDir()
 	git := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = repo
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, repo, args...)
 	}
 	git("init", "-q", "-b", "main")
 	// Repo-local identity: PerformMergeCtx's squash commit runs without
@@ -265,13 +258,7 @@ func TestOutcomeRouter_MergesAndCountsEpisodes(t *testing.T) {
 		t.Fatal(err)
 	}
 	git("commit", "-qam", "work")
-	sha := func() string {
-		out, err := exec.Command("git", "-C", repo, "rev-parse", "HEAD").Output()
-		if err != nil {
-			t.Fatal(err)
-		}
-		return strings.TrimSpace(string(out))
-	}()
+	sha := gittest.Run(t, repo, "rev-parse", "HEAD")
 	git("checkout", "-q", "main")
 
 	r := h.seedRun(t, "i1-converged", func(r *store.Run) {

--- a/pkg/server/runs_commits_test.go
+++ b/pkg/server/runs_commits_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -20,11 +20,7 @@ func commitInRunWorktree(t *testing.T, dir, relPath, content, msg string) string
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", relPath}, {"commit", "-q", "-m", msg}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	return revParse(t, dir, "HEAD")
 }
@@ -148,11 +144,7 @@ func TestRunCommitFileDiff_HappyPath(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "a.txt"}, {"commit", "-q", "-m", "v2"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	target := revParse(t, dir, "HEAD")
 	seedRunWithBaseline(t, srv, "cdiff-ok", dir, baseSHA)

--- a/pkg/server/runs_files_test.go
+++ b/pkg/server/runs_files_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -46,21 +47,13 @@ func initRepo(t *testing.T) string {
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "test"},
 	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "a.txt"}, {"commit", "-q", "-m", "init"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	return dir
 }
@@ -212,32 +205,20 @@ func TestRunFiles_Historical_RepoRootStaleFallsBackToCWD(t *testing.T) {
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "test"},
 	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "a.txt"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "a.txt"}, {"commit", "-q", "-m", "base"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	baseSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
 	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "b.txt"), []byte("new\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "b.txt"}, {"commit", "-q", "-m", "add b"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	finalSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
 
@@ -285,13 +266,7 @@ func TestRunFiles_Historical_RepoRootStaleFallsBackToCWD(t *testing.T) {
 
 func revParse(t *testing.T, dir, ref string) string {
 	t.Helper()
-	cmd := exec.Command("git", "rev-parse", ref)
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git rev-parse %s: %v", ref, err)
-	}
-	return string(out[:len(out)-1]) // strip trailing newline
+	return gittest.Run(t, dir, "rev-parse", ref)
 }
 
 // TestRunFiles_ModeBranch verifies that mode=branch on a live worktree
@@ -309,11 +284,7 @@ func TestRunFiles_ModeBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "b.txt"}, {"commit", "-q", "-m", "add b"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, dir, args...)
 	}
 	// One uncommitted change that must be excluded in branch mode.
 	if err := os.WriteFile(filepath.Join(dir, "c.txt"), []byte("uncommitted\n"), 0o644); err != nil {
@@ -731,32 +702,20 @@ func TestRunFiles_ModeProduced_WorktreeGone(t *testing.T) {
 		{"config", "user.email", "test@example.com"},
 		{"config", "user.name", "test"},
 	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "a.txt"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "a.txt"}, {"commit", "-q", "-m", "base"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	baseSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
 	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "b.txt"), []byte("new\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	for _, args := range [][]string{{"add", "b.txt"}, {"commit", "-q", "-m", "add b"}} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = srv.cfg.WorkDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
+		gittest.Run(t, srv.cfg.WorkDir, args...)
 	}
 	finalSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
 

--- a/pkg/server/runs_merge_conflict_test.go
+++ b/pkg/server/runs_merge_conflict_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -190,17 +191,7 @@ func setupConflictingRepo(t *testing.T) string {
 	dir := t.TempDir()
 	runGit := func(args ...string) {
 		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
-			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-			"LC_ALL=C",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
-		}
+		gittest.Run(t, dir, args...)
 	}
 	write := func(name, content string) {
 		t.Helper()
@@ -245,16 +236,8 @@ func seedConflictRun(t *testing.T, srv *Server, repoDir, runID string) {
 	r.Status = store.RunStatusFinished
 	r.FinalBranch = "iterion/run/test"
 	// FinalCommit is the storage branch tip; resolve via git.
-	out, err := exec.Command("git", "-C", repoDir, "rev-parse", "iterion/run/test").Output()
-	if err != nil {
-		t.Fatalf("rev-parse storage: %v", err)
-	}
-	r.FinalCommit = strings.TrimSpace(string(out))
-	baseOut, err := exec.Command("git", "-C", repoDir, "merge-base", "main", "iterion/run/test").Output()
-	if err != nil {
-		t.Fatalf("merge-base: %v", err)
-	}
-	r.BaseCommit = strings.TrimSpace(string(baseOut))
+	r.FinalCommit = gittest.Run(t, repoDir, "rev-parse", "iterion/run/test")
+	r.BaseCommit = gittest.Run(t, repoDir, "merge-base", "main", "iterion/run/test")
 	if err := st.SaveRun(context.Background(), r); err != nil {
 		t.Fatalf("SaveRun seed: %v", err)
 	}

--- a/pkg/server/runs_review_scope_test.go
+++ b/pkg/server/runs_review_scope_test.go
@@ -8,23 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/workspacetrack"
 )
 
 func gitIn(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=iterion", "GIT_AUTHOR_EMAIL=iterion@example.test",
-		"GIT_COMMITTER_NAME=iterion", "GIT_COMMITTER_EMAIL=iterion@example.test",
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return gittest.Run(t, dir, args...)
 }
 
 func writeIn(t *testing.T, dir, name, body string) {

--- a/pkg/store/gitdiff_test.go
+++ b/pkg/store/gitdiff_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 )
 
@@ -27,11 +28,7 @@ func setupDiffRepo(t *testing.T) (string, string) {
 	}
 	gitRun(t, dir, "add", "a.txt")
 	gitRun(t, dir, "commit", "-q", "-m", "base")
-	baseOut, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
-	if err != nil {
-		t.Fatalf("rev-parse: %v", err)
-	}
-	base := strings.TrimSpace(string(baseOut))
+	base := gittest.Run(t, dir, "rev-parse", "HEAD")
 
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("two\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/pkg/store/gitmeta_test.go
+++ b/pkg/store/gitmeta_test.go
@@ -8,17 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/internal/gittest"
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 )
 
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_AUTHOR_DATE=2024-01-01T00:00:00Z", "GIT_COMMITTER_DATE=2024-01-01T00:00:00Z")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %v: %v\n%s", args, err, out)
-	}
+	gittest.Run(t, dir, args...)
 }
 
 func TestBuildRunGitMeta(t *testing.T) {
@@ -35,13 +31,7 @@ func TestBuildRunGitMeta(t *testing.T) {
 	gitRun(t, dir, "add", "a.txt")
 	gitRun(t, dir, "commit", "-q", "-m", "base")
 
-	baseCmd := exec.Command("git", "rev-parse", "HEAD")
-	baseCmd.Dir = dir
-	baseOut, err := baseCmd.Output()
-	if err != nil {
-		t.Fatalf("rev-parse: %v", err)
-	}
-	base := string(baseOut[:len(baseOut)-1])
+	base := gittest.Run(t, dir, "rev-parse", "HEAD")
 
 	// No commits yet beyond base → empty snapshot.
 	meta, err := BuildRunGitMeta(dir, base)

--- a/pkg/worktreepool/bound_test.go
+++ b/pkg/worktreepool/bound_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	gitlib "github.com/SocialGouv/iterion/pkg/git"
+	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -51,15 +51,7 @@ func (f *poolFixture) git(dir string, args ...string) string {
 }
 
 func (f *poolFixture) gitErr(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = append(gitlib.SanitizeEnv(os.Environ()),
-		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
-		"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
-		"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
-		"LC_ALL=C", "LANG=C")
-	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	return gittest.Try(dir, args...)
 }
 
 // idle is the shape the incident produced and the one the bound exists


### PR DESCRIPTION
## Why

Two tickets of one family: a test's git subprocess, and the repository a test's run takes as its source. Both leak into the developer's own checkout and both have already cost the merge queue.

**#828 item 2.** Since git 2.48 every writing command detaches `git maintenance run --auto`, which keeps writing under `.git/objects` after the command returned and races `t.TempDir()`'s removal — the ejector behind #821. Item 1 (the runner's own `git fetch`) landed in #829; the 28 test helpers the ticket names did not.

**#870.** An engine built without `WithWorkDir` defaults to `os.Getwd()` — the package directory, inside the developer's checkout — so `worktree: auto` (the IR default) registers the run's worktree in the REAL repository, and the registration outlives the `t.TempDir()` that held the checkout. Measured on this machine: **1 773 dead registrations, 2.5 GB**, and every git command that enumerates worktrees walks all of them.

## What

**One chokepoint each**, not a guard copied per site — the ticket asked for exactly that, and the sweep is what proves it held.

- `internal/gittest` (`Run` / `Try` / `Cmd`, `SourceRepo`, `RemoveWorktree`, `NoWorktreeLeaks`). Top-level, not `pkg/internal/`, because `e2e/` and `bots/` — 19 of the 51 offending files — cannot import the latter. Precedent: `internal/httpx`.
- The sweep is **wider than the ticket's own command** on purpose: every `exec.Command*("git"` in a `_test.go`, not only the maintenance verbs. Enumerating verbs is the drift the ticket warns about. **129 sites across 51 files.**
- `pkg/git.TestEveryTestGitCallerDisablesAutoMaintenance` — the `_test.go` half of the existing `TestEveryGitCallerSanitizesEnv` sweep, which deliberately skips test files — fails any new site that assembles its own argv.
- `gittest.NoWorktreeLeaks(m)` in the `TestMain` of e2e, `pkg/runview`, `pkg/cli`: names the test behind any entry left behind, and reclaims **by recorded path** — never `git worktree prune`, which would also drop an operator's checkout on an unmounted volume.

**The oracle is not an argv shim.** That distinction is why this repo shipped a production regression in #877: the test proved the flag reached the command line, never that the command still worked. Here `git config --get maintenance.auto` answers with the value **git itself** parsed and applied for that invocation, with a bare control command on the same repo proving the key is otherwise unset. Falsified by deleting the chokepoint from `Cmd`.

Closed by the same chokepoint: the operator's `~/.gitconfig` no longer decides whether a test passes (a global `commit.gpgsign` hangs every fixture commit on a pinentry with no TTY — the `bots` package already carried a workaround).

## Evidence

Red first, both guards:

```
--- FAIL: TestEveryTestGitCallerDisablesAutoMaintenance
    129 sites …
FAIL: this package left 10 dead worktree registration(s) in /home/jo/lab/ai/iterion/.git/worktrees   (pkg/runview)
FAIL: this package left 27 dead worktree registration(s) …                                           (e2e)
```

One test, one entry, before the fix: `TestRewindThenResume_SkipsUpstreamNodes` → 1340 → 1341. Whole suite: **66 new registrations per `go test ./...`**. After: **1498 → 1498, zero new.**

Side effect worth having — those runs were checking out the whole iterion tree per test: **e2e 139 s → 42 s, `pkg/runview` 51 s → 31 s.**

`devbox run -- task check` green (138 packages, golangci clean, studio vitest 1335/1335); `-race` green on e2e / runview / runtime / cli / runner / gittest / git / bots.

95 of the 99 files are `_test.go`; the other four are `CLAUDE.md` and the new `internal/gittest/`. **No production code touched.**

Closes #828
Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
