### PR TITLE
fix(board,forge,server): a failure must not answer like a success — three seams that could not report one

### DIFF
--- a/e2e/board_dispatcher_test.go
+++ b/e2e/board_dispatcher_test.go
@@ -84,7 +84,7 @@ func TestBoardDispatcher_E2E_BotCreatesAndDispatches(t *testing.T) {
 		func() bool {
 			list, _ := ns.List(native.ListFilter{})
 			for _, iss := range list {
-				st := ns.Board().StateByName(iss.State)
+				st := mustBoard(t, ns).StateByName(iss.State)
 				if st == nil || !st.Terminal || iss.Claim != "" {
 					return false
 				}

--- a/e2e/cli_issue_test.go
+++ b/e2e/cli_issue_test.go
@@ -53,6 +53,17 @@ func reopenBoard(t *testing.T, storeDir string) *native.Store {
 	return s
 }
 
+// mustBoard is Board or Fatal: the contract reports a read failure rather
+// than substituting a default board for it (see native.BoardStore.Board).
+func mustBoard(t *testing.T, s native.BoardStore) *native.Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}
+
 // issueEvents reads the persisted audit trail.
 func issueEvents(t *testing.T, storeDir string) []native.Event {
 	t.Helper()
@@ -276,7 +287,7 @@ func TestIssueCLILifecycleCreateMoveUpdateClose(t *testing.T) {
 		if err != nil {
 			t.Fatalf("reload closed issue: %v", err)
 		}
-		st := s.Board().StateByName(got.State)
+		st := mustBoard(t, s).StateByName(got.State)
 		if st == nil || !st.Terminal {
 			t.Fatalf("close left the card in %q, which is not a terminal board state", got.State)
 		}
@@ -361,7 +372,7 @@ func TestIssueCloseRefusesABoardWithNoTerminalState(t *testing.T) {
 
 	// Rewrite the board with every terminal flag cleared.
 	s := reopenBoard(t, storeDir)
-	board := s.Board()
+	board := mustBoard(t, s)
 	for i := range board.States {
 		board.States[i].Terminal = false
 	}

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -373,7 +373,10 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if err != nil {
 		return err
 	}
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	terminal := ""
 	for _, st := range board.States {
 		if st.Terminal {
@@ -602,7 +605,10 @@ func RunIssueBoardShow(p *Printer, opts IssueCommonOptions) error {
 	if err != nil {
 		return err
 	}
-	b := s.Board()
+	b, err := s.Board()
+	if err != nil {
+		return err
+	}
 	if p.Format == OutputJSON {
 		p.JSON(b)
 		return nil

--- a/pkg/dispatcher/boardmongo/admin.go
+++ b/pkg/dispatcher/boardmongo/admin.go
@@ -154,7 +154,10 @@ func (s *Store) AddState(st native.State) error {
 	}
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	if board.StateByName(st.Name) != nil {
 		return fmt.Errorf("boardmongo: state %q already exists", st.Name)
 	}
@@ -180,7 +183,10 @@ func (s *Store) RenameState(from, to string) (int, error) {
 		return 0, nil
 	}
 	sweep := sweepCtx()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return 0, err
+	}
 	idx := stateIndex(board, from)
 	if idx < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown state %q", from)
@@ -208,7 +214,10 @@ func (s *Store) RenameState(from, to string) (int, error) {
 // Mirrors native.Store.DeleteState.
 func (s *Store) DeleteState(name, migrateTo string) (int, error) {
 	sweep := sweepCtx()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return 0, err
+	}
 	if stateIndex(board, name) < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown state %q", name)
 	}
@@ -267,7 +276,10 @@ func (s *Store) DeleteState(name, migrateTo string) (int, error) {
 func (s *Store) UpdateState(name string, p native.StatePatch) error {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	idx := stateIndex(board, name)
 	if idx < 0 {
 		return fmt.Errorf("boardmongo: unknown state %q", name)
@@ -300,7 +312,10 @@ func (s *Store) UpdateState(name string, p native.StatePatch) error {
 func (s *Store) ReorderStates(order []string) error {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	reordered, err := reorderByName(board.States, order, func(st native.State) string { return st.Name }, "state")
 	if err != nil {
 		return err
@@ -364,7 +379,10 @@ func (s *Store) AddField(f native.Field) error {
 	}
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	if board.FieldByName(f.Name) != nil {
 		return fmt.Errorf("boardmongo: field %q already exists", f.Name)
 	}
@@ -384,7 +402,10 @@ func (s *Store) AddField(f native.Field) error {
 func (s *Store) UpdateField(name string, p native.FieldPatch) error {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	idx := fieldIndex(board, name)
 	if idx < 0 {
 		return fmt.Errorf("boardmongo: unknown field %q", name)
@@ -422,7 +443,10 @@ func (s *Store) RenameField(from, to string) (int, error) {
 		return 0, nil
 	}
 	sweep := sweepCtx()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return 0, err
+	}
 	idx := fieldIndex(board, from)
 	if idx < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown field %q", from)
@@ -462,7 +486,10 @@ func (s *Store) RenameField(from, to string) (int, error) {
 // Mirrors native.Store.DeleteField.
 func (s *Store) DeleteField(name string) (int, error) {
 	sweep := sweepCtx()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return 0, err
+	}
 	idx := fieldIndex(board, name)
 	if idx < 0 {
 		return 0, fmt.Errorf("boardmongo: unknown field %q", name)
@@ -498,7 +525,10 @@ func (s *Store) DeleteField(name string) (int, error) {
 func (s *Store) ReorderFields(order []string) error {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	reordered, err := reorderByName(board.Fields, order, func(f native.Field) string { return f.Name }, "field")
 	if err != nil {
 		return err
@@ -525,7 +555,10 @@ func (s *Store) SaveView(v native.View) error {
 	}
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	replaced := false
 	for i := range board.Views {
 		if board.Views[i].Name == v.Name {
@@ -551,7 +584,10 @@ func (s *Store) SaveView(v native.View) error {
 func (s *Store) DeleteView(name string) error {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return err
+	}
 	idx := -1
 	for i := range board.Views {
 		if board.Views[i].Name == name {

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -42,6 +42,28 @@ func lastStatePayload(t *testing.T, s native.BoardStore, id string) map[string]a
 	return last
 }
 
+// mustBoard / mustLabels are Board / AggregateLabels or Fatal. Both report a
+// read failure rather than substituting a default board or an empty
+// vocabulary, so a row that ignored the error would assert against the
+// fallback instead of the store.
+func mustBoard(t *testing.T, s native.BoardStore) *native.Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}
+
+func mustLabels(t *testing.T, s native.BoardStore) []native.LabelUsage {
+	t.Helper()
+	got, err := s.AggregateLabels()
+	if err != nil {
+		t.Fatalf("AggregateLabels: %v", err)
+	}
+	return got
+}
+
 // mustGetIssue is Get or Fatal, for the provenance rows that read a method
 // off the record.
 func mustGetIssue(t *testing.T, s native.BoardStore, id string) *native.Issue {
@@ -907,7 +929,7 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	}
 
 	// AggregateLabels.
-	labels := store.AggregateLabels()
+	labels := mustLabels(t, store)
 	found := false
 	for _, l := range labels {
 		if l.Label == "x" && l.Count >= 1 {
@@ -1070,7 +1092,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.AddState(native.State{Name: "triage", Display: "Triage"}); err != nil {
 		t.Fatalf("AddState: %v", err)
 	}
-	if store.Board().StateByName("triage") == nil {
+	if mustBoard(t, store).StateByName("triage") == nil {
 		t.Fatal("AddState: triage not persisted")
 	}
 	if err := admin.AddState(native.State{Name: "triage"}); err == nil {
@@ -1085,7 +1107,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.UpdateState("triage", native.StatePatch{Eligible: &yes, Display: ptr("Triage!")}); err != nil {
 		t.Fatalf("UpdateState: %v", err)
 	}
-	if st := store.Board().StateByName("triage"); st == nil || !st.Eligible || st.Display != "Triage!" {
+	if st := mustBoard(t, store).StateByName("triage"); st == nil || !st.Eligible || st.Display != "Triage!" {
 		t.Errorf("UpdateState not applied: %+v", st)
 	}
 	if err := admin.UpdateState("nope", native.StatePatch{Display: ptr("x")}); err == nil {
@@ -1105,7 +1127,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if got, _ := store.Get(parked.ID); got.State != "triaging" {
 		t.Errorf("RenameState cascade: parked state=%q want triaging", got.State)
 	}
-	if store.Board().StateByName("triage") != nil {
+	if mustBoard(t, store).StateByName("triage") != nil {
 		t.Error("RenameState: old column still present")
 	}
 	if _, err := admin.RenameState("triaging", native.StateInbox); err == nil {
@@ -1127,7 +1149,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if got, _ := store.Get(parked.ID); got.State != native.StateBacklog {
 		t.Errorf("DeleteState migrate: parked state=%q want backlog", got.State)
 	}
-	if store.Board().StateByName("triaging") != nil {
+	if mustBoard(t, store).StateByName("triaging") != nil {
 		t.Error("DeleteState: column still present")
 	}
 	if _, err := admin.DeleteState("ghost", ""); err == nil {
@@ -1167,7 +1189,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	}
 
 	// ReorderStates: permutation only.
-	cur := store.Board()
+	cur := mustBoard(t, store)
 	names := make([]string, len(cur.States))
 	for i, st := range cur.States {
 		names[i] = st.Name
@@ -1178,8 +1200,8 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 		if err := admin.ReorderStates(swapped); err != nil {
 			t.Errorf("ReorderStates: %v", err)
 		}
-		if store.Board().States[0].Name != swapped[0] {
-			t.Errorf("ReorderStates not applied: %+v", store.Board().States)
+		if mustBoard(t, store).States[0].Name != swapped[0] {
+			t.Errorf("ReorderStates not applied: %+v", mustBoard(t, store).States)
 		}
 	}
 	if err := admin.ReorderStates([]string{"only-one"}); err == nil {
@@ -1191,7 +1213,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.AddField(native.Field{Name: "severity", Type: native.FieldText}); err != nil {
 		t.Fatalf("AddField: %v", err)
 	}
-	if store.Board().FieldByName("severity") == nil {
+	if mustBoard(t, store).FieldByName("severity") == nil {
 		t.Fatal("AddField: severity not persisted")
 	}
 	if err := admin.AddField(native.Field{Name: "severity", Type: native.FieldText}); err == nil {
@@ -1205,7 +1227,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.UpdateField("severity", native.FieldPatch{Display: ptr("Severity")}); err != nil {
 		t.Errorf("UpdateField: %v", err)
 	}
-	if f := store.Board().FieldByName("severity"); f == nil || f.Display != "Severity" {
+	if f := mustBoard(t, store).FieldByName("severity"); f == nil || f.Display != "Severity" {
 		t.Errorf("UpdateField not applied: %+v", f)
 	}
 	if err := admin.UpdateField("nope", native.FieldPatch{Display: ptr("x")}); err == nil {
@@ -1225,7 +1247,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if got, _ := store.Get(withField.ID); got.Fields["sev"] != "high" || got.Fields["severity"] != nil {
 		t.Errorf("RenameField cascade: fields=%+v", got.Fields)
 	}
-	if store.Board().FieldByName("severity") != nil {
+	if mustBoard(t, store).FieldByName("severity") != nil {
 		t.Error("RenameField: old field def still present")
 	}
 	if _, err := admin.RenameField("sev", "bot_args"); err == nil {
@@ -1239,7 +1261,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if got, _ := store.Get(withField.ID); got.Fields["sev"] != nil {
 		t.Errorf("DeleteField cascade: key not stripped: %+v", got.Fields)
 	}
-	if store.Board().FieldByName("sev") != nil {
+	if mustBoard(t, store).FieldByName("sev") != nil {
 		t.Error("DeleteField: field def still present")
 	}
 	if _, err := admin.DeleteField("ghost"); err == nil {
@@ -1250,7 +1272,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.AddField(native.Field{Name: "owner", Type: native.FieldText}); err != nil {
 		t.Fatalf("AddField owner: %v", err)
 	}
-	fcur := store.Board()
+	fcur := mustBoard(t, store)
 	fnames := make([]string, len(fcur.Fields))
 	for i, f := range fcur.Fields {
 		fnames[i] = f.Name
@@ -1263,8 +1285,8 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 		if err := admin.ReorderFields(rev); err != nil {
 			t.Errorf("ReorderFields: %v", err)
 		}
-		if store.Board().Fields[0].Name != rev[0] {
-			t.Errorf("ReorderFields not applied: %+v", store.Board().Fields)
+		if mustBoard(t, store).Fields[0].Name != rev[0] {
+			t.Errorf("ReorderFields not applied: %+v", mustBoard(t, store).Fields)
 		}
 	}
 	if err := admin.ReorderFields([]string{"x"}); err == nil {
@@ -1279,7 +1301,7 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.SaveView(native.View{Name: "mine", Assignee: "you"}); err != nil {
 		t.Fatalf("SaveView upsert: %v", err)
 	}
-	if vs := store.Board().Views; len(vs) != 1 || vs[0].Assignee != "you" {
+	if vs := mustBoard(t, store).Views; len(vs) != 1 || vs[0].Assignee != "you" {
 		t.Errorf("SaveView upsert by name: %+v", vs)
 	}
 	if err := admin.SaveView(native.View{Name: ""}); err == nil {
@@ -1288,8 +1310,8 @@ func runBoardAdminSuite(t *testing.T, store native.BoardStore, admin native.Boar
 	if err := admin.DeleteView("mine"); err != nil {
 		t.Errorf("DeleteView: %v", err)
 	}
-	if len(store.Board().Views) != 0 {
-		t.Errorf("DeleteView: view still present: %+v", store.Board().Views)
+	if len(mustBoard(t, store).Views) != 0 {
+		t.Errorf("DeleteView: view still present: %+v", mustBoard(t, store).Views)
 	}
 	if err := admin.DeleteView("ghost"); err == nil {
 		t.Error("DeleteView unknown should fail")

--- a/pkg/dispatcher/boardmongo/read_failure_test.go
+++ b/pkg/dispatcher/boardmongo/read_failure_test.go
@@ -1,0 +1,72 @@
+package boardmongo_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native/boardops"
+)
+
+// unreachableStore is a real Mongo board whose client is closed: every read
+// fails at the driver, immediately and without a server. It is the honest
+// producer for the rows below — a stub would only carry the terms the test
+// remembered to give it.
+func unreachableStore(t *testing.T) *boardmongo.Store {
+	t.Helper()
+	cli, err := mongo.Connect(options.Client().ApplyURI("mongodb://127.0.0.1:1/"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := cli.Disconnect(context.Background()); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+	t.Cleanup(func() { _ = cli.Disconnect(context.Background()) })
+	return boardmongo.New(cli.Database("iterion_read_failure"), "t1")
+}
+
+// A read that failed must not borrow the answer of a read that succeeded:
+// "no labels on this board" and "no board config yet" are legitimate
+// successes, and a transport failure wearing either of them sends the studio
+// an empty label picker and the writers a board the tenant never declared.
+func TestReadFailureIsNeverAnEmptySuccess(t *testing.T) {
+	st := unreachableStore(t)
+
+	if labels, err := st.AggregateLabels(); err == nil {
+		t.Errorf("AggregateLabels on an unreachable store returned %v with no error — an operator reads it as 'this board has no labels'", labels)
+	}
+	if b, err := st.Board(); err == nil {
+		t.Errorf("Board on an unreachable store returned %+v with no error — a create would file a card into a column the tenant never declared", b)
+	}
+}
+
+// The callers, from the failing store rather than from a double: the REST
+// route answers 5xx, and the MCP tool returns the error instead of an empty
+// vocabulary the agent would act on.
+func TestReadFailureReachesTheCallers(t *testing.T) {
+	st := unreachableStore(t)
+	mux := http.NewServeMux()
+	(&native.BoardAPI{Resolve: func(*http.Request) (native.BoardStore, error) { return st, nil }}).
+		RegisterRoutesWithMiddleware(mux, "/api/v1/board", nil)
+
+	for _, path := range []string{"/api/v1/board/labels", "/api/v1/board/board"} {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+		if w.Code < 500 {
+			t.Errorf("GET %s on an unreadable board answered %d %s — a failed read must not be served as content", path, w.Code, strings.TrimSpace(w.Body.String()))
+		}
+	}
+
+	caps := boardops.NewCapabilities("board.read")
+	if out, err := boardops.Call(st, caps, "list_labels", json.RawMessage(`{}`)); err == nil {
+		t.Errorf("list_labels on an unreadable board returned %s with no error — the agent would treat an unread vocabulary as an empty one", out)
+	}
+}

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -174,17 +174,25 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 // writing back) keeps reads race-free; the next SetBoard from the column
 // editor persists the upgraded shape naturally, and SetState validation
 // (which reads through this method) accepts the upgraded states either way.
-func (s *Store) Board() *native.Board {
+// Board reads the tenant's board config. A tenant that has never written one
+// legitimately gets DefaultBoard; any OTHER failure is reported, because a
+// board is what every caller resolves a column against — answering
+// DefaultBoard for an unreachable Mongo files cards into columns the tenant
+// never declared and renders the studio's grid as somebody else's board.
+func (s *Store) Board() (*native.Board, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
 	var doc configDoc
 	err := s.config.FindOne(ctx, bson.M{"_id": s.tenant}).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return native.DefaultBoard(), nil
+	}
 	if err != nil {
-		return native.DefaultBoard()
+		return nil, fmt.Errorf("boardmongo: read board config: %w", err)
 	}
 	b := doc.Board
 	native.UpgradeBoardSchema(&b)
-	return &b
+	return &b, nil
 }
 
 // SetBoard persists the tenant's board config after validating it.
@@ -211,7 +219,10 @@ func (s *Store) Create(in native.Issue) (*native.Issue, error) {
 	if in.Title == "" {
 		return nil, errors.New("issue: title required")
 	}
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, err
+	}
 	if in.State == "" {
 		in.State = board.States[0].Name
 	}
@@ -490,7 +501,11 @@ func (s *Store) Update(id string, p native.Patch) (*native.Issue, error) {
 	if err != nil {
 		return nil, err
 	}
-	changed := applyPatch(iss, p, s.Board())
+	board, err := s.Board()
+	if err != nil {
+		return nil, err
+	}
+	changed := applyPatch(iss, p, board)
 	if len(changed.fields) == 0 {
 		return iss, changed.err
 	}
@@ -569,7 +584,10 @@ func (s *Store) SetStateWithReason(id, newState, reason string) (*native.Issue, 
 func (s *Store) setStateReason(id, newState, reason string) (*native.Issue, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, err
+	}
 	if board.StateByName(newState) == nil {
 		return nil, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, newState)
 	}
@@ -1007,12 +1025,12 @@ func (s *Store) ScanEvents(visit func(*native.Event) bool) error {
 	return cur.Err()
 }
 
-func (s *Store) AggregateLabels() []native.LabelUsage {
+func (s *Store) AggregateLabels() ([]native.LabelUsage, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
 	all, err := s.listAll(ctx)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("boardmongo: read the label vocabulary: %w", err)
 	}
 	type acc struct {
 		count int
@@ -1045,7 +1063,7 @@ func (s *Store) AggregateLabels() []native.LabelUsage {
 		}
 		return out[i].Label < out[j].Label
 	})
-	return out
+	return out, nil
 }
 
 // --- helpers ---

--- a/pkg/dispatcher/boardmongo/store_lease.go
+++ b/pkg/dispatcher/boardmongo/store_lease.go
@@ -157,7 +157,10 @@ func (s *Store) SetStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken, reason string) (*native.Issue, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, err
+	}
 	dst := board.StateByName(newState)
 	if dst == nil {
 		return nil, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, newState)
@@ -275,7 +278,10 @@ func (s *Store) setStateOwnedReason(id, newState string, tok tracker.ClaimToken,
 func (s *Store) SetStateOwnedFrom(id, from, to string, tok tracker.ClaimToken) (*native.Issue, bool, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, false, err
+	}
 	if board.StateByName(to) == nil {
 		return nil, false, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, to)
 	}
@@ -668,7 +674,10 @@ func (s *Store) Reopen(id, toState string) (*native.Issue, error) {
 	if err != nil {
 		return nil, err
 	}
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, err
+	}
 	st := board.StateByName(iss.State)
 	if st == nil || !st.Terminal {
 		return nil, fmt.Errorf("%w: %q is not terminal — use an ordinary state move", tracker.ErrTransitionRejected, iss.State)
@@ -735,7 +744,10 @@ func (s *Store) SetStateFrom(id, from, to string) (*native.Issue, bool, error) {
 func (s *Store) SetStateFromReason(id, from, to, reason string) (*native.Issue, bool, error) {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
-	board := s.Board()
+	board, err := s.Board()
+	if err != nil {
+		return nil, false, err
+	}
 	if board.StateByName(to) == nil {
 		return nil, false, fmt.Errorf("%w: unknown state %q", tracker.ErrTransitionRejected, to)
 	}

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -34,22 +34,28 @@ func (a *Adapter) Name() string { return "native" }
 // tracker.LaunchStateLister. One definition, shared with ListCandidates
 // below, so the watchdog and the poller can never disagree about which
 // column a launch started in.
-func (a *Adapter) LaunchStates() []string {
-	b := a.store.Board()
+func (a *Adapter) LaunchStates() ([]string, error) {
+	b, err := a.store.Board()
+	if err != nil {
+		return nil, err
+	}
 	out := make([]string, 0, len(b.States))
 	for _, s := range b.States {
 		if s.Eligible {
 			out = append(out, s.Name)
 		}
 	}
-	return out
+	return out, nil
 }
 
 func (a *Adapter) ListCandidates(ctx context.Context) ([]tracker.Issue, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	eligible := a.LaunchStates()
+	eligible, err := a.LaunchStates()
+	if err != nil {
+		return nil, err
+	}
 	if len(eligible) == 0 {
 		return nil, nil
 	}
@@ -254,7 +260,10 @@ func (a *Adapter) Release(ctx context.Context, id, marker string) error {
 // awaiting_input stay with ListAwaitingInput / reconcileParked.
 // Consumed by reconcileStrandedPaused via optional-interface assertion.
 func (a *Adapter) ListForRepark(_ string) ([]tracker.Issue, error) {
-	b := a.store.Board()
+	b, err := a.store.Board()
+	if err != nil {
+		return nil, err
+	}
 	seen := make(map[string]bool, len(b.States))
 	states := make([]string, 0, len(b.States))
 	for _, s := range b.States {

--- a/pkg/dispatcher/native/blockers.go
+++ b/pkg/dispatcher/native/blockers.go
@@ -314,7 +314,10 @@ func PromoteUnblockedDependents(store BoardStore, closedID string) error {
 	if store == nil || closedID == "" {
 		return nil
 	}
-	board := store.Board()
+	board, err := store.Board()
+	if err != nil {
+		return err
+	}
 	if board == nil || board.StateByName(StateWaitingDeps) == nil {
 		return nil
 	}

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -580,6 +580,14 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 	if err != nil {
 		return nil, err
 	}
+	// One read for the whole target resolution: a failure to read the board
+	// is an error, never a board with no terminal state (which the branches
+	// below would report as "declare one" — a lie the operator would act on),
+	// and on a cloud board it is one round-trip instead of three.
+	board, err := store.Board()
+	if err != nil {
+		return nil, err
+	}
 	target := args.To
 	if target == "" {
 		// A card ALREADY in a terminal state stays where it is: closing a
@@ -589,7 +597,7 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 		// dispatcher's give-up stamp on a card the bot never asked to
 		// move). No-op, current issue returned.
 		if cur, err := store.Get(resolved); err == nil {
-			if st := store.Board().StateByName(cur.State); st != nil && st.Terminal {
+			if st := board.StateByName(cur.State); st != nil && st.Terminal {
 				// Still an acknowledgment: the give-up stamp goes (same
 				// best-effort contract as below — nothing moved).
 				_ = store.SetGaveUp(resolved, nil)
@@ -600,7 +608,7 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 			}
 		}
 		// Find the first terminal state on the board.
-		for _, st := range store.Board().States {
+		for _, st := range board.States {
 			if st.Terminal {
 				target = st.Name
 				break
@@ -610,7 +618,7 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 			return nil, errors.New("board has no terminal state; specify 'to' explicitly")
 		}
 	} else {
-		st := store.Board().StateByName(target)
+		st := board.StateByName(target)
 		if st == nil {
 			return nil, fmt.Errorf("unknown state %q", target)
 		}
@@ -669,7 +677,11 @@ func doList(store native.BoardStore, raw json.RawMessage) (json.RawMessage, erro
 }
 
 func doListLabels(store native.BoardStore, _ json.RawMessage) (json.RawMessage, error) {
-	return json.Marshal(store.AggregateLabels())
+	labels, err := store.AggregateLabels()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(labels)
 }
 
 func doGet(store native.BoardStore, raw json.RawMessage) (json.RawMessage, error) {

--- a/pkg/dispatcher/native/boardops/ops_test.go
+++ b/pkg/dispatcher/native/boardops/ops_test.go
@@ -19,6 +19,17 @@ func newStore(t *testing.T) *native.Store {
 	return s
 }
 
+// mustBoard is Board or Fatal: the contract reports a read failure rather
+// than substituting a default board for it (see native.BoardStore.Board).
+func mustBoard(t *testing.T, s native.BoardStore) *native.Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}
+
 func TestNewCapabilities(t *testing.T) {
 	caps := NewCapabilities("board.create, board.read,,  board.move ")
 	for _, want := range []string{"board.create", "board.read", "board.move"} {
@@ -202,7 +213,7 @@ func TestRoundTrip_CreateTransitionGetList(t *testing.T) {
 		t.Fatalf("close_issue: %v", err)
 	}
 	got, _ = s.Get(created.ID)
-	if !s.Board().StateByName(got.State).Terminal {
+	if !mustBoard(t, s).StateByName(got.State).Terminal {
 		t.Fatalf("close_issue did not land on a terminal state: %s", got.State)
 	}
 }

--- a/pkg/dispatcher/native/boardread_external_test.go
+++ b/pkg/dispatcher/native/boardread_external_test.go
@@ -1,0 +1,18 @@
+package native_test
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// mustBoard reads a store's config or fails the test — the external-test twin
+// of the in-package helper (see boardread_test.go).
+func mustBoard(t *testing.T, s native.BoardStore) *native.Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}

--- a/pkg/dispatcher/native/boardread_test.go
+++ b/pkg/dispatcher/native/boardread_test.go
@@ -1,0 +1,26 @@
+package native
+
+import "testing"
+
+// mustBoard / mustLabels read a store's config and label vocabulary, or fail
+// the test. BoardStore reports a read failure rather than substituting a
+// default board or an empty vocabulary for it (see BoardStore.Board), so a
+// test that ignored the error would assert against whatever the failure fell
+// back to.
+func mustBoard(t *testing.T, s BoardStore) *Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}
+
+func mustLabels(t *testing.T, s BoardStore) []LabelUsage {
+	t.Helper()
+	got, err := s.AggregateLabels()
+	if err != nil {
+		t.Fatalf("AggregateLabels: %v", err)
+	}
+	return got
+}

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -17,7 +17,13 @@ import (
 // here. They are plain JSON/BSON-friendly structs with no filesystem
 // coupling, so this is types-only reuse, not behaviour.
 type BoardStore interface {
-	Board() *Board
+	// Board reads the board configuration. It reports a failure rather
+	// than substituting DefaultBoard for it: a backend that reads its
+	// config over the network (boardmongo) would otherwise answer a
+	// transport failure with a board the tenant never declared, and the
+	// caller would file cards into columns that do not exist. A backend
+	// with no config document yet legitimately answers DefaultBoard.
+	Board() (*Board, error)
 	SetBoard(b *Board) error
 
 	Create(in Issue) (*Issue, error)
@@ -111,7 +117,12 @@ type BoardStore interface {
 
 	Resolve(prefix string) (string, error)
 	ScanEvents(visit func(*Event) bool) error
-	AggregateLabels() []LabelUsage
+	// AggregateLabels reads the board's label vocabulary. Like Board it
+	// carries an error: an empty slice means "this board uses no labels",
+	// and a read that failed must not borrow that answer — the studio
+	// picker renders it as an empty vocabulary and an operator re-creates
+	// labels that already exist.
+	AggregateLabels() ([]LabelUsage, error)
 }
 
 // UniqueTitleCreator is the optional interface for board backends that can

--- a/pkg/dispatcher/native/comment_dispatch_test.go
+++ b/pkg/dispatcher/native/comment_dispatch_test.go
@@ -98,7 +98,7 @@ func TestAddComment_RetriesAGivenUpCard(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if st.Board().StateByName(StateBlocked) == nil || !st.Board().StateByName(StateBlocked).Terminal {
+	if mustBoard(t, st).StateByName(StateBlocked) == nil || !mustBoard(t, st).StateByName(StateBlocked).Terminal {
 		t.Skip("this board's give-up column is not a sink — nothing to prove")
 	}
 	st.SetCommentDispatcher(func(Issue, string) (string, map[string]string, string, bool) {

--- a/pkg/dispatcher/native/field_management_test.go
+++ b/pkg/dispatcher/native/field_management_test.go
@@ -25,7 +25,7 @@ func TestAddField(t *testing.T) {
 	if err := s.AddField(Field{Name: "eta", Type: FieldDate}); err != nil {
 		t.Fatalf("AddField: %v", err)
 	}
-	if s.Board().FieldByName("eta") == nil {
+	if mustBoard(t, s).FieldByName("eta") == nil {
 		t.Fatal("eta not added")
 	}
 	if err := s.AddField(Field{Name: "eta", Type: FieldText}); err == nil {
@@ -48,7 +48,7 @@ func TestRenameFieldCascades(t *testing.T) {
 	if touched != 1 {
 		t.Fatalf("touched = %d, want 1", touched)
 	}
-	if s.Board().FieldByName("owner") != nil || s.Board().FieldByName("assignee_name") == nil {
+	if mustBoard(t, s).FieldByName("owner") != nil || mustBoard(t, s).FieldByName("assignee_name") == nil {
 		t.Fatal("schema rename not applied")
 	}
 	got, _ := s.Get(iss.ID)
@@ -71,7 +71,7 @@ func TestUpdateField(t *testing.T) {
 	if err := s.UpdateField("sev", FieldPatch{Display: &disp, Required: &req}); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
-	f := s.Board().FieldByName("sev")
+	f := mustBoard(t, s).FieldByName("sev")
 	if f.Display != disp || !f.Required {
 		t.Fatalf("update not applied: %+v", f)
 	}
@@ -91,7 +91,7 @@ func TestDeleteFieldStripsIssues(t *testing.T) {
 	if touched != 1 {
 		t.Fatalf("touched = %d, want 1", touched)
 	}
-	if s.Board().FieldByName("owner") != nil {
+	if mustBoard(t, s).FieldByName("owner") != nil {
 		t.Fatal("field not removed from schema")
 	}
 	got, _ := s.Get(iss.ID)
@@ -112,7 +112,7 @@ func TestReorderFields(t *testing.T) {
 	if err := s.ReorderFields([]string{"owner", "sev"}); err != nil {
 		t.Fatalf("ReorderFields: %v", err)
 	}
-	if s.Board().Fields[0].Name != "owner" {
+	if mustBoard(t, s).Fields[0].Name != "owner" {
 		t.Fatal("reorder not applied")
 	}
 	if err := s.ReorderFields([]string{"owner"}); err == nil {

--- a/pkg/dispatcher/native/http.go
+++ b/pkg/dispatcher/native/http.go
@@ -453,7 +453,12 @@ func (h *BoardAPI) handleListLabels(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, s.AggregateLabels())
+	labels, err := s.AggregateLabels()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, labels)
 }
 
 type labelRenameReq struct {
@@ -535,7 +540,7 @@ func (h *BoardAPI) handleGetBoard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handlePutBoard(w http.ResponseWriter, r *http.Request) {
@@ -552,7 +557,7 @@ func (h *BoardAPI) handlePutBoard(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 // stateUpdateReq is the PATCH /board/states/{name} body. A non-nil Name that
@@ -596,7 +601,7 @@ func (h *BoardAPI) handleAddState(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleUpdateState(w http.ResponseWriter, r *http.Request) {
@@ -633,7 +638,7 @@ func (h *BoardAPI) handleUpdateState(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleDeleteState(w http.ResponseWriter, r *http.Request) {
@@ -660,7 +665,7 @@ func (h *BoardAPI) handleDeleteState(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleReorderStates(w http.ResponseWriter, r *http.Request) {
@@ -681,7 +686,7 @@ func (h *BoardAPI) handleReorderStates(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 // mustList returns the current issues for the 409 count; on error it returns
@@ -723,7 +728,7 @@ func (h *BoardAPI) handleAddField(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleUpdateField(w http.ResponseWriter, r *http.Request) {
@@ -760,7 +765,7 @@ func (h *BoardAPI) handleUpdateField(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleDeleteField(w http.ResponseWriter, r *http.Request) {
@@ -776,7 +781,7 @@ func (h *BoardAPI) handleDeleteField(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleReorderFields(w http.ResponseWriter, r *http.Request) {
@@ -797,7 +802,7 @@ func (h *BoardAPI) handleReorderFields(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleSaveView(w http.ResponseWriter, r *http.Request) {
@@ -818,7 +823,7 @@ func (h *BoardAPI) handleSaveView(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 func (h *BoardAPI) handleDeleteView(w http.ResponseWriter, r *http.Request) {
@@ -834,7 +839,7 @@ func (h *BoardAPI) handleDeleteView(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, s.Board())
+	writeBoard(w, s)
 }
 
 // ---------------------------------------------------------------------------
@@ -855,6 +860,18 @@ func statusForErr(err error) int {
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	httpx.WriteJSON(w, status, v)
+}
+
+// writeBoard answers the board configuration. Every /board route ends here so
+// a backend that could not read its config answers 500 once, instead of each
+// route serving whatever the read fell back to.
+func writeBoard(w http.ResponseWriter, s BoardStore) {
+	b, err := s.Board()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, b)
 }
 
 func writeErr(w http.ResponseWriter, status int, err error) {

--- a/pkg/dispatcher/native/http_test.go
+++ b/pkg/dispatcher/native/http_test.go
@@ -202,7 +202,7 @@ func TestHTTPStateManagement(t *testing.T) {
 	} else {
 		r.Body.Close()
 	}
-	if s.Board().StateByName("triage") == nil {
+	if mustBoard(t, s).StateByName("triage") == nil {
 		t.Fatal("triage not added")
 	}
 
@@ -223,7 +223,7 @@ func TestHTTPStateManagement(t *testing.T) {
 	} else {
 		r.Body.Close()
 	}
-	if st := s.Board().StateByName("todo"); st == nil || !st.Eligible {
+	if st := mustBoard(t, s).StateByName("todo"); st == nil || !st.Eligible {
 		t.Fatalf("flags not updated: %+v", st)
 	}
 
@@ -248,7 +248,7 @@ func TestHTTPStateManagement(t *testing.T) {
 	} else {
 		r.Body.Close()
 	}
-	if s.Board().StateByName("todo") != nil {
+	if mustBoard(t, s).StateByName("todo") != nil {
 		t.Fatal("todo not deleted")
 	}
 	if got, _ := s.Get(iss.ID); got.State != "ready" {
@@ -257,7 +257,7 @@ func TestHTTPStateManagement(t *testing.T) {
 
 	// Reorder.
 	names := make([]string, 0)
-	for _, st := range s.Board().States {
+	for _, st := range mustBoard(t, s).States {
 		names = append(names, st.Name)
 	}
 	rev := make([]string, len(names))
@@ -270,7 +270,7 @@ func TestHTTPStateManagement(t *testing.T) {
 	} else {
 		r.Body.Close()
 	}
-	if s.Board().States[0].Name != rev[0] {
+	if mustBoard(t, s).States[0].Name != rev[0] {
 		t.Fatal("reorder not applied")
 	}
 }

--- a/pkg/dispatcher/native/state_management_test.go
+++ b/pkg/dispatcher/native/state_management_test.go
@@ -26,11 +26,11 @@ func TestAddState(t *testing.T) {
 	if err := s.AddState(State{Name: "triage", Display: "Triage"}); err != nil {
 		t.Fatalf("AddState: %v", err)
 	}
-	if s.Board().StateByName("triage") == nil {
+	if mustBoard(t, s).StateByName("triage") == nil {
 		t.Fatal("triage not added")
 	}
 	// Appended last.
-	states := s.Board().States
+	states := mustBoard(t, s).States
 	if states[len(states)-1].Name != "triage" {
 		t.Fatalf("triage not appended last: %v", states)
 	}
@@ -57,10 +57,10 @@ func TestRenameStateCascades(t *testing.T) {
 	if touched != 2 {
 		t.Fatalf("touched = %d, want 2", touched)
 	}
-	if s.Board().StateByName("backlog") != nil {
+	if mustBoard(t, s).StateByName("backlog") != nil {
 		t.Fatal("old state still present")
 	}
-	if s.Board().StateByName("todo") == nil {
+	if mustBoard(t, s).StateByName("todo") == nil {
 		t.Fatal("new state missing")
 	}
 	for _, id := range []string{a.ID, b.ID} {
@@ -108,7 +108,7 @@ func TestDeleteStateEmpty(t *testing.T) {
 	if _, err := s.DeleteState("review", ""); err != nil {
 		t.Fatalf("DeleteState empty: %v", err)
 	}
-	if s.Board().StateByName("review") != nil {
+	if mustBoard(t, s).StateByName("review") != nil {
 		t.Fatal("review not removed")
 	}
 }
@@ -121,7 +121,7 @@ func TestDeleteStateNonEmptyRequiresTarget(t *testing.T) {
 		t.Fatalf("want ErrStateNotEmpty, got %v", err)
 	}
 	// still present after the refused delete
-	if s.Board().StateByName("backlog") == nil {
+	if mustBoard(t, s).StateByName("backlog") == nil {
 		t.Fatal("backlog wrongly removed on refused delete")
 	}
 
@@ -132,7 +132,7 @@ func TestDeleteStateNonEmptyRequiresTarget(t *testing.T) {
 	if touched != 1 {
 		t.Fatalf("touched = %d, want 1", touched)
 	}
-	if s.Board().StateByName("backlog") != nil {
+	if mustBoard(t, s).StateByName("backlog") != nil {
 		t.Fatal("backlog not removed")
 	}
 	if countState(t, s, "ready") != 1 {
@@ -174,7 +174,7 @@ func TestUpdateState(t *testing.T) {
 	if err := s.UpdateState("backlog", StatePatch{Display: &disp, Color: &color, Eligible: &elig}); err != nil {
 		t.Fatalf("UpdateState: %v", err)
 	}
-	st := s.Board().StateByName("backlog")
+	st := mustBoard(t, s).StateByName("backlog")
 	if st.Display != disp || st.Color != color || !st.Eligible {
 		t.Fatalf("update not applied: %+v", st)
 	}
@@ -186,7 +186,7 @@ func TestUpdateState(t *testing.T) {
 
 func TestReorderStates(t *testing.T) {
 	s := newTestStore(t)
-	orig := s.Board().States
+	orig := mustBoard(t, s).States
 	names := make([]string, len(orig))
 	for i, st := range orig {
 		names[i] = st.Name
@@ -199,7 +199,7 @@ func TestReorderStates(t *testing.T) {
 	if err := s.ReorderStates(rev); err != nil {
 		t.Fatalf("ReorderStates: %v", err)
 	}
-	got := s.Board().States
+	got := mustBoard(t, s).States
 	for i := range rev {
 		if got[i].Name != rev[i] {
 			t.Fatalf("order[%d] = %q, want %q", i, got[i].Name, rev[i])
@@ -237,10 +237,10 @@ func TestStateManagementPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
-	if s2.Board().StateByName("triage") == nil {
+	if mustBoard(t, s2).StateByName("triage") == nil {
 		t.Fatal("triage did not persist")
 	}
-	if s2.Board().StateByName("todo") == nil || s2.Board().StateByName("backlog") != nil {
+	if mustBoard(t, s2).StateByName("todo") == nil || mustBoard(t, s2).StateByName("backlog") != nil {
 		t.Fatal("rename did not persist")
 	}
 }

--- a/pkg/dispatcher/native/store_board.go
+++ b/pkg/dispatcher/native/store_board.go
@@ -13,11 +13,14 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// Board returns a defensive copy of the current board config.
-func (s *Store) Board() *Board {
+// Board returns a defensive copy of the current board config. The
+// filesystem store loads its config at open and serves it from memory, so
+// this read has no failure mode of its own; the error is the contract's
+// (see BoardStore.Board) and is always nil here.
+func (s *Store) Board() (*Board, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return cloneBoard(s.board)
+	return cloneBoard(s.board), nil
 }
 
 // SetBoard validates and replaces the board configuration. The disk

--- a/pkg/dispatcher/native/store_labels.go
+++ b/pkg/dispatcher/native/store_labels.go
@@ -19,7 +19,11 @@ type LabelUsage struct {
 // count, max(updated_at)). Sorted by count desc, label asc for
 // deterministic output. Used by the REST /labels endpoint, the
 // boardops list_labels MCP tool, and the studio's label-picker.
-func (s *Store) AggregateLabels() []LabelUsage {
+//
+// The filesystem store serves the index it loaded at open, so this read
+// has no failure mode of its own; the error is the contract's (see
+// BoardStore.AggregateLabels) and is always nil here.
+func (s *Store) AggregateLabels() ([]LabelUsage, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	type acc struct {
@@ -54,7 +58,7 @@ func (s *Store) AggregateLabels() []LabelUsage {
 		}
 		return out[i].Label < out[j].Label
 	})
-	return out
+	return out, nil
 }
 
 // RenameLabel rewrites every occurrence of `from` to `to` across all

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -34,7 +34,7 @@ func TestNewStoreInitializesBoard(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "issues")); err != nil {
 		t.Fatalf("issues dir not created: %v", err)
 	}
-	b := s.Board()
+	b := mustBoard(t, s)
 	if len(b.States) == 0 {
 		t.Fatal("board has no states")
 	}
@@ -66,7 +66,7 @@ func TestNewStorePrependsInboxToLegacyBoard(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	got := s.Board().States
+	got := mustBoard(t, s).States
 	// Upgrade also inserts waiting_deps after ready → 5 states.
 	if len(got) != 5 {
 		t.Fatalf("want 5 states after schema upgrade, got %d: %+v", len(got), got)
@@ -84,8 +84,8 @@ func TestNewStorePrependsInboxToLegacyBoard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore (second pass): %v", err)
 	}
-	if len(s2.Board().States) != 5 {
-		t.Fatalf("schema upgrade ran twice: %+v", s2.Board().States)
+	if len(mustBoard(t, s2).States) != 5 {
+		t.Fatalf("schema upgrade ran twice: %+v", mustBoard(t, s2).States)
 	}
 }
 
@@ -117,7 +117,7 @@ func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	got := s.Board().States
+	got := mustBoard(t, s).States
 	// Upgrade inserts waiting_deps (after ready) + awaiting_input (after in_progress).
 	// Legacy had: inbox, ready, in_progress, done → +2 = 6.
 	if len(got) != 6 {
@@ -142,8 +142,8 @@ func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore (second pass): %v", err)
 	}
-	if len(s2.Board().States) != 6 {
-		t.Fatalf("schema upgrade inserted twice: %+v", s2.Board().States)
+	if len(mustBoard(t, s2).States) != 6 {
+		t.Fatalf("schema upgrade inserted twice: %+v", mustBoard(t, s2).States)
 	}
 }
 
@@ -205,10 +205,10 @@ func TestNewStoreLeavesCustomBoardWithoutInProgressUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
-	if got := s.Board().States; len(got) != 3 {
+	if got := mustBoard(t, s).States; len(got) != 3 {
 		t.Fatalf("custom board must be untouched, got %+v", got)
 	}
-	if s.Board().StateByName(StateAwaitingInput) != nil {
+	if mustBoard(t, s).StateByName(StateAwaitingInput) != nil {
 		t.Fatal("awaiting_input must not be inserted into a board without in_progress")
 	}
 }
@@ -248,8 +248,8 @@ func TestCreateDefaultsToFirstState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if iss.State != s.Board().States[0].Name {
-		t.Fatalf("default state mismatch: got %q want %q", iss.State, s.Board().States[0].Name)
+	if iss.State != mustBoard(t, s).States[0].Name {
+		t.Fatalf("default state mismatch: got %q want %q", iss.State, mustBoard(t, s).States[0].Name)
 	}
 }
 
@@ -774,7 +774,7 @@ func TestLabelVocabularyOps(t *testing.T) {
 	if n != 2 {
 		t.Errorf("rename touched %d, want 2", n)
 	}
-	got := s.AggregateLabels()
+	got := mustLabels(t, s)
 	want := map[string]int{"new": 3, "keep": 3}
 	for _, u := range got {
 		if exp, ok := want[u.Label]; ok && u.Count != exp {
@@ -796,7 +796,7 @@ func TestLabelVocabularyOps(t *testing.T) {
 	if _, err := s.MergeLabels("new", "keep"); err != nil {
 		t.Fatalf("MergeLabels: %v", err)
 	}
-	got = s.AggregateLabels()
+	got = mustLabels(t, s)
 	if _, present := labelMap(got)["new"]; present {
 		t.Errorf("merge did not remove 'new' from the board")
 	}
@@ -809,8 +809,8 @@ func TestLabelVocabularyOps(t *testing.T) {
 	if _, err := s.DeleteLabel("keep"); err != nil {
 		t.Fatalf("DeleteLabel: %v", err)
 	}
-	if len(s.AggregateLabels()) != 0 {
-		t.Errorf("delete did not clear: %+v", s.AggregateLabels())
+	if len(mustLabels(t, s)) != 0 {
+		t.Errorf("delete did not clear: %+v", mustLabels(t, s))
 	}
 
 	// Edge cases.
@@ -869,7 +869,7 @@ func TestAggregateLabels(t *testing.T) {
 	mk("e", []string{""}) // empty label string ignored
 	mk("f", []string{"source:whats-next"})
 
-	got := s.AggregateLabels()
+	got := mustLabels(t, s)
 	if len(got) != 4 {
 		t.Fatalf("got %d distinct labels, want 4: %+v", len(got), got)
 	}

--- a/pkg/dispatcher/native/view_management_test.go
+++ b/pkg/dispatcher/native/view_management_test.go
@@ -8,15 +8,15 @@ func TestSaveAndDeleteView(t *testing.T) {
 	if err := s.SaveView(View{Name: "Mine", Assignee: "jo", Sort: "priority", GroupBy: "assignee"}); err != nil {
 		t.Fatalf("SaveView: %v", err)
 	}
-	if len(s.Board().Views) != 1 {
-		t.Fatalf("want 1 view, got %d", len(s.Board().Views))
+	if len(mustBoard(t, s).Views) != 1 {
+		t.Fatalf("want 1 view, got %d", len(mustBoard(t, s).Views))
 	}
 
 	// Upsert by name (replace, not append).
 	if err := s.SaveView(View{Name: "Mine", Assignee: "alice"}); err != nil {
 		t.Fatalf("SaveView upsert: %v", err)
 	}
-	views := s.Board().Views
+	views := mustBoard(t, s).Views
 	if len(views) != 1 || views[0].Assignee != "alice" {
 		t.Fatalf("upsert did not replace: %+v", views)
 	}
@@ -30,7 +30,7 @@ func TestSaveAndDeleteView(t *testing.T) {
 	if err := s.DeleteView("Mine"); err != nil {
 		t.Fatalf("DeleteView: %v", err)
 	}
-	if len(s.Board().Views) != 0 {
+	if len(mustBoard(t, s).Views) != 0 {
 		t.Fatal("view not deleted")
 	}
 	if err := s.DeleteView("nope"); err == nil {
@@ -54,7 +54,7 @@ func TestViewsPersist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
-	views := s2.Board().Views
+	views := mustBoard(t, s2).Views
 	if len(views) != 1 || views[0].Name != "Triage" || views[0].GroupBy != "label" {
 		t.Fatalf("view did not persist: %+v", views)
 	}
@@ -78,7 +78,7 @@ func TestViewBotFilterPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
-	views := s2.Board().Views
+	views := mustBoard(t, s2).Views
 	if len(views) != 1 || views[0].Bot != "feature-dev" {
 		t.Fatalf("view bot filter did not persist: %+v", views)
 	}

--- a/pkg/dispatcher/reaper.go
+++ b/pkg/dispatcher/reaper.go
@@ -455,12 +455,21 @@ func (c *Dispatcher) noteRunReadFailure(err error) {
 // launchStates asks the tracker which columns a card is dispatched from
 // (tracker.LaunchStateLister). A tracker without the capability returns
 // nothing, which keeps the watchdog conservative: it then honours every
-// state it did not expect rather than guessing.
+// state it did not expect rather than guessing. A tracker that HAS the
+// capability but could not read it lands on the same conservative answer,
+// and says so — a read that failed and a tracker that cannot answer are
+// the same decision here but not the same event.
 func (c *Dispatcher) launchStates() []string {
-	if l, ok := c.tracker.(tracker.LaunchStateLister); ok {
-		return l.LaunchStates()
+	l, ok := c.tracker.(tracker.LaunchStateLister)
+	if !ok {
+		return nil
 	}
-	return nil
+	states, err := l.LaunchStates()
+	if err != nil {
+		c.logger.Warn("dispatcher: claim watchdog cannot read the launch states (%v) — every unexpected move is honoured this pass", err)
+		return nil
+	}
+	return states
 }
 
 // loadRunForReap resolves the card's recorded run for the decision

--- a/pkg/dispatcher/tracker/tracker.go
+++ b/pkg/dispatcher/tracker/tracker.go
@@ -287,8 +287,12 @@ func IsMachineReason(reason string) bool {
 // the running column never landed (file it, or the next tick launches a
 // second run for work already delivered). A tracker that cannot answer
 // leaves the watchdog conservative — it honours every move it sees.
+// A tracker that could not READ its launch states reports the failure
+// rather than answering the empty list: empty means "this tracker
+// dispatches from no column", and the poller that consumes it would read
+// a failed read as "no eligible tickets".
 type LaunchStateLister interface {
-	LaunchStates() []string
+	LaunchStates() ([]string, error)
 }
 
 // Errors returned by Tracker implementations. Callers should use

--- a/pkg/runview/service_lifecycle.go
+++ b/pkg/runview/service_lifecycle.go
@@ -482,6 +482,33 @@ func watchDetachedExit(s *Service, runID string, pid int, done chan struct{}) {
 	}
 }
 
+// StopBackground ends every PERIODIC worker the service owns — the orphan
+// reconcile ticker, the pipeline scheduler, the alert manager's stall poll —
+// and leaves the in-flight runs strictly alone.
+//
+// It exists for the caller that REPLACES a service without draining it (the
+// studio's project hot-swap): the engines that already captured this service
+// keep writing to the store they started on, which is the point, while
+// nothing keeps scanning a store the server no longer serves. Every teardown
+// goes through it, so a periodic worker added here is reaped by all three
+// paths at once instead of by the two that remembered.
+//
+// Bounded by ctx: the reconcile half AWAITS the scan in flight (see
+// stopPeriodicReconcile), so a scan wedged in a store call degrades the
+// promise loudly rather than hanging the caller.
+func (s *Service) StopBackground(ctx context.Context) {
+	s.stopPeriodicReconcile(ctx)
+	// Queued pipelines stay persisted as queued docs and are recovered by the
+	// next service built over that store, so stopping the scheduler here never
+	// strands them.
+	s.stopPipelineScheduler()
+	// Started with context.Background() so it outlives per-run contexts —
+	// nothing else reaps it.
+	if s.alertManager != nil {
+		s.alertManager.Stop()
+	}
+}
+
 // Stop cancels every active run and waits for their goroutines to
 // finish, but does not flip persisted statuses or emit any
 // observability event. Use Stop in tests or for a quiet teardown
@@ -491,8 +518,7 @@ func watchDetachedExit(s *Service, runID string, pid int, done chan struct{}) {
 // publishes EventRunInterrupted and flips each in-flight run to
 // failed_resumable so the next server boot can offer one-click resume.
 func (s *Service) Stop(ctx context.Context) {
-	s.stopPeriodicReconcile(ctx)
-	s.stopPipelineScheduler()
+	s.StopBackground(ctx)
 	s.manager.Stop(ctx)
 }
 
@@ -517,18 +543,7 @@ func (s *Service) Stop(ctx context.Context) {
 // it returns, the service should not be used to launch new work.
 func (s *Service) Drain(ctx context.Context) {
 	s.draining.Store(true)
-	s.stopPeriodicReconcile(ctx)
-	// Queued pipelines stay persisted as queued docs and are recovered on
-	// the next boot, so stopping the scheduler here never strands them.
-	s.stopPipelineScheduler()
-
-	// Stop the alert manager's stall-poll goroutine. It was started with
-	// context.Background() (so it outlives per-run contexts), so Drain is
-	// the only place that reaps it — without this it leaks across project
-	// hot-swaps that construct a fresh Service.
-	if s.alertManager != nil {
-		s.alertManager.Stop()
-	}
+	s.StopBackground(ctx)
 
 	handles := s.manager.Snapshot()
 

--- a/pkg/runview/service_stop_background_test.go
+++ b/pkg/runview/service_stop_background_test.go
@@ -1,0 +1,128 @@
+package runview
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// alertPollFrame names the alert manager's stall-poll goroutine. The manager
+// owns it, so the frame is the only oracle available from here.
+const alertPollFrame = "alert.(*Manager).Start.func1"
+
+func liveGoroutines(frame string) int {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), frame)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// settlePollGoroutines polls until the count reaches want or the budget runs
+// out — a stopped goroutine returns shortly after its signal, not at the
+// instant of it. Returns the last count read.
+func settlePollGoroutines(frame string, want int) int {
+	deadline := time.Now().Add(3 * time.Second)
+	got := liveGoroutines(frame)
+	for got != want && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+		got = liveGoroutines(frame)
+	}
+	return got
+}
+
+// stableGoroutines returns a count that two readings apart agree on, so a
+// worker already winding down from an earlier test is not counted as
+// standing — a baseline taken on one sample is a baseline nothing can come
+// back to. Falls back to the last reading when nothing settles in budget.
+func stableGoroutines(frame string) int {
+	deadline := time.Now().Add(3 * time.Second)
+	prev := liveGoroutines(frame)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		got := liveGoroutines(frame)
+		if got == prev {
+			return got
+		}
+		prev = got
+	}
+	return prev
+}
+
+// StopBackground is the seam a caller that REPLACES a service without
+// draining it needs (the studio's project hot-swap). Both halves are
+// load-bearing: every periodic worker must stop, and the runs already in
+// flight must be left strictly alone — a Drain-shaped stop would cancel the
+// engines that are still writing to the store they started on.
+func TestStopBackground_StopsEveryWorkerAndLeavesRunsAlone(t *testing.T) {
+	alertBase := stableGoroutines(alertPollFrame)
+	svc, err := NewService(t.TempDir(),
+		WithLogger(iterlog.Nop()),
+		WithMaxConcurrentPipelines(2),
+		WithAlerts(AlertSettings{StallTimeout: time.Minute}),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if svc.pipelineQueue == nil || svc.alertManager == nil || svc.reconcileDone == nil {
+		t.Fatalf("a worker was never started, so stopping it proves nothing: queue=%v alerts=%v reconcile=%v",
+			svc.pipelineQueue != nil, svc.alertManager != nil, svc.reconcileDone != nil)
+	}
+
+	// One run in flight, registered exactly as spawnRun leaves it.
+	const runID = "run-hot-swap"
+	if _, err := svc.store.CreateRun(context.Background(), runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	runCtx, regErr := svc.manager.Register(context.Background(), runID)
+	if regErr != nil {
+		t.Fatalf("Register: %v", regErr)
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	svc.StopBackground(stopCtx)
+
+	for name, done := range map[string]<-chan struct{}{
+		"orphan reconcile":   svc.reconcileDone,
+		"pipeline scheduler": svc.pipelineStop,
+	} {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("%s is still running after StopBackground", name)
+		}
+	}
+	// The alert manager owns its goroutine, so the oracle is the goroutine
+	// itself: it must be gone, not merely signalled.
+	if n := settlePollGoroutines(alertPollFrame, alertBase); n != alertBase {
+		t.Errorf("alert stall poll: %d live after StopBackground, want %d", n, alertBase)
+	}
+
+	// The run keeps its context and its handle: nothing was drained.
+	if err := runCtx.Err(); err != nil {
+		t.Errorf("the in-flight run was cancelled by a background stop: %v", err)
+	}
+	if !svc.Active(runID) {
+		t.Errorf("the in-flight run lost its handle to a background stop")
+	}
+	r, err := svc.store.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status == store.RunStatusFailedResumable {
+		t.Errorf("the in-flight run was flipped to %q — StopBackground must not touch persisted state", r.Status)
+	}
+	// And the service still refuses nothing: draining was never set.
+	if svc.draining.Load() {
+		t.Errorf("StopBackground set the draining flag — later launches would be refused on a service that was only re-pointed")
+	}
+}

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -198,7 +198,10 @@ func syncForgeIssuesToBoard(ctx context.Context, ic forge.IssueClient, provider 
 	if err != nil {
 		return 0, 0, fmt.Errorf("list issues: %w", err)
 	}
-	b := board.Board()
+	b, err := board.Board()
+	if err != nil {
+		return 0, 0, fmt.Errorf("read board: %w", err)
+	}
 	openCol := defaultOpenColumn(b)
 	doneCol := terminalColumn(b)
 	trustMemo := map[string]bool{}

--- a/pkg/server/board_forge_test.go
+++ b/pkg/server/board_forge_test.go
@@ -47,6 +47,17 @@ func newTestBoard(t *testing.T) *native.Store {
 	return st
 }
 
+// mustBoard is Board or Fatal: the contract reports a read failure rather
+// than substituting a default board for it (see native.BoardStore.Board).
+func mustBoard(t *testing.T, s native.BoardStore) *native.Board {
+	t.Helper()
+	b, err := s.Board()
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	return b
+}
+
 func TestForgeCardID_Deterministic(t *testing.T) {
 	a := forgeCardID(forge.ProviderGitHub, "org/api", 12)
 	b := forgeCardID(forge.ProviderGitHub, "org/api", 12)
@@ -65,7 +76,7 @@ func TestForgeCardID_Deterministic(t *testing.T) {
 
 func TestUpsertForgeCard_CreateUpdateIdempotent(t *testing.T) {
 	board := newTestBoard(t)
-	b := board.Board()
+	b := mustBoard(t, board)
 	openCol := defaultOpenColumn(b) // "inbox"
 	doneCol := terminalColumn(b)    // "done"
 	if openCol == "" || doneCol == "" {
@@ -132,7 +143,7 @@ func TestUpsertForgeCard_CreateUpdateIdempotent(t *testing.T) {
 // the first column, PRs are skipped, and a re-sync upserts (no duplicates).
 func TestSyncForgeIssuesToBoard_StoreAgnostic(t *testing.T) {
 	board := newTestBoard(t)
-	openCol := defaultOpenColumn(board.Board())
+	openCol := defaultOpenColumn(mustBoard(t, board))
 	ic := &fakeIssueClient{issues: []forge.IssueRef{
 		{Number: 1, Title: "add metrics", State: "open", Labels: []string{"feat"}},
 		{Number: 2, Title: "a PR, skipped", State: "open", IsPullRequest: true},
@@ -190,7 +201,7 @@ func TestImportForgeIssues_UnsupportedProvider(t *testing.T) {
 
 func TestUpsertForgeCard_ClosedCreatesInTerminal(t *testing.T) {
 	board := newTestBoard(t)
-	b := board.Board()
+	b := mustBoard(t, board)
 	is := forge.IssueRef{Number: 9, Title: "old", State: "closed"}
 	if _, _, err := upsertForgeCard(board, b, defaultOpenColumn(b), terminalColumn(b), forge.ProviderForgejo, "c", "o/r", is, false); err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -208,7 +219,7 @@ func TestUpsertForgeCard_ClosedCreatesInTerminal(t *testing.T) {
 // else, so the sentinel is what distinguishes the two.
 func TestUpsertForgeCard_PropagatesAStoreFailure(t *testing.T) {
 	board := newTestBoard(t)
-	b := board.Board()
+	b := mustBoard(t, board)
 	flaky := &flakyBoard{BoardStore: board, err: errors.New("boardmongo: get issue: i/o timeout")}
 
 	is := forge.IssueRef{Number: 7, Title: "fix login", State: "open"}

--- a/pkg/server/board_forge_trust_test.go
+++ b/pkg/server/board_forge_trust_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestUpsertForgeCard_TrustStamping(t *testing.T) {
 	board := newTestBoard(t)
-	b := board.Board()
+	b := mustBoard(t, board)
 	openCol, doneCol := defaultOpenColumn(b), terminalColumn(b)
 
 	// Trusted author → triage:auto on the fresh open card.

--- a/pkg/server/board_project_reflect_test.go
+++ b/pkg/server/board_project_reflect_test.go
@@ -405,7 +405,7 @@ func TestIssueImportPreservesTheProjectSyncState(t *testing.T) {
 	id := seedSynced(t, board, 613, native.StateInProgress, "Planned", at)
 
 	// The issue-import upsert path, on a card that already exists.
-	b := board.Board()
+	b := mustBoard(t, board)
 	_, updated, err := upsertForgeCardForTest(board, b, forge.IssueRef{
 		Number: 613, Title: "t", Body: "b", State: "open", URL: "u",
 	})

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -167,7 +167,18 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 			// The apply's budget is spent, whatever the forge managed to send:
 			// the upload would only fail on the dead context and stamp a
 			// misleading reason on the connection.
-			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s: %w", conn.ID, conn.Host(), err)
+			//
+			// The forge's own error is DIAGNOSTIC here, never routing: it may
+			// itself be ErrForbidden / ErrUnauthorized, and %w-wrapping it
+			// would keep what it MATCHES (403, 422) while changing what the
+			// error MEANS (the deadline). This error carries the expiry it is
+			// about; the forge's partial answer is logged and rendered, not
+			// wrapped.
+			if s.logger != nil {
+				s.logger.Warn("forge avatar: connection %s on %s spent the apply budget; the forge's partial answer was: %v", conn.ID, conn.Host(), err)
+			}
+			return conn, "", fmt.Errorf("could not read the account behind connection %s on %s within %s (the forge answered %v): %w",
+				conn.ID, conn.Host(), s.avatarApplyDeadline(), err, ctx.Err())
 		case errors.Is(err, forge.ErrUnauthorized):
 			// The credential itself is rejected. Nothing else probes a PAT,
 			// so this is where the connection learns it: mark it revoked so
@@ -285,13 +296,9 @@ func (s *Server) handleForgeConnectionAvatar(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err != nil {
-		// Deliberately NOT the shared forgeUpstreamStatus table: applyBotAvatar
-		// answers every actionable state as an *avatarRefusal above, and what
-		// reaches here wraps the forge's own sentinel inside a spent-budget
-		// failure — where the expiry outranks whatever the forge managed to
-		// send. Classifying by the wrapped sentinel would let a forge that
-		// answered 403 and then stalled turn a dead context into a 403.
-		httpError(w, http.StatusBadGateway, "%v", err)
+		if !writeForgeUpstreamError(w, err, "%v", err) {
+			httpError(w, http.StatusBadGateway, "%v", err)
+		}
 		return
 	}
 	s.auditTenant(r, teamID, "forge.connection.avatar_applied", "forge_connection", conn.ID,

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -666,6 +667,45 @@ func TestForgeConnectionAvatar_SpentBudgetOutranksTheForgesAnswer(t *testing.T) 
 	stored, _ := s.forgeConnections.Get(context.Background(), "c-stalled-403")
 	if uploads != 0 || stored.AvatarError != "" || stored.AvatarAppliedAt != nil {
 		t.Fatalf("uploaded on a dead context or recorded a misleading reason: uploads=%d stored=%+v", uploads, stored)
+	}
+}
+
+// The status above is the symptom; this is the invariant behind it. A spent
+// budget MEANS the deadline, whatever the forge managed to send before it —
+// so the error must not CARRY the forge's sentinel. Wrapping it would keep
+// what the error matches (403) while changing what it means, and the shared
+// classifier every forge handler consults routes on the match.
+func TestForgeConnectionAvatar_SpentBudgetErrorMeansTheExpiryNotTheSentinel(t *testing.T) {
+	s := newForgeTestServer(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done() // the body never completes
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	conn := seedAvatarConn(t, s, forge.Connection{ID: "c-meaning", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "svc", ForgeBaseURL: srv.URL})
+	s.avatarApplyTimeout = 200 * time.Millisecond
+
+	_, _, err := s.applyBotAvatar(context.Background(), conn, brand.VariantPlain, false)
+	if err == nil {
+		t.Fatal("a forge that never finishes answering must fail the apply")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("the error does not carry the expiry it is about: %v", err)
+	}
+	for name, sentinel := range map[string]error{"ErrForbidden": forge.ErrForbidden, "ErrUnauthorized": forge.ErrUnauthorized} {
+		if errors.Is(err, sentinel) {
+			t.Errorf("a spent budget still matches forge.%s (%v) — the shared classifier would answer the forge's status for a dead context", name, err)
+		}
+	}
+	if code, _ := forgeUpstreamStatus(err); code != 0 {
+		t.Errorf("forgeUpstreamStatus(%v) = %d, want 0 — an expiry is not an answer the forge gave", err, code)
+	}
+	// The forge's partial answer stays readable: diagnostic, not routing.
+	if !strings.Contains(err.Error(), "insufficient scope") {
+		t.Errorf("the forge's partial answer was dropped instead of rendered: %v", err)
 	}
 }
 

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -333,7 +333,12 @@ func (s *Server) handlePipelineBoardTaskClose(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board close: %v", err)
 		return
 	}
-	target, ok := pipelineCloseTargetState(boardStore.Board())
+	board, err := boardStore.Board()
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board close: read board: %v", err)
+		return
+	}
+	target, ok := pipelineCloseTargetState(board)
 	if !ok {
 		s.httpErrorFor(w, r, http.StatusConflict,
 			"pipeline board close: board has no terminal state — declare one or move the ticket by hand")

--- a/pkg/server/pipeline_board_deps.go
+++ b/pkg/server/pipeline_board_deps.go
@@ -292,7 +292,11 @@ func (s *Server) handlePipelineBoardBulkReady(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk ready: %v", err)
 		return
 	}
-	board := boardStore.Board()
+	board, err := boardStore.Board()
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk ready: read board: %v", err)
+		return
+	}
 	out := pipelineBulkReadyResponse{SkippedWhy: map[string]string{}}
 	for _, iss := range candidates {
 		if iss == nil || strings.TrimSpace(iss.Bot) == "" {
@@ -439,7 +443,11 @@ func (s *Server) handlePipelineBoardRecomputeDeps(w http.ResponseWriter, r *http
 			s.httpErrorFor(w, r, http.StatusInternalServerError, "recompute deps: list: %v", err)
 			return
 		}
-		board := boardStore.Board()
+		board, berr := boardStore.Board()
+		if berr != nil {
+			s.httpErrorFor(w, r, http.StatusInternalServerError, "recompute deps: read board: %v", berr)
+			return
+		}
 		for _, iss := range waiting {
 			if iss == nil {
 				continue

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -132,7 +132,11 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	if runs != nil {
 		builder.rs = runs.RunStore()
 	}
-	if board := boardStore.Board(); board != nil {
+	board, err := boardStore.Board()
+	if err != nil {
+		return PipelineBoardResponse{}, fmt.Errorf("read native board: %w", err)
+	}
+	if board != nil {
 		for _, state := range board.States {
 			if state.Terminal {
 				builder.terminalStates[state.Name] = struct{}{}

--- a/pkg/server/pipeline_boards_tasks.go
+++ b/pkg/server/pipeline_boards_tasks.go
@@ -129,7 +129,11 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: bot %q is disabled", entry.Name)
 		return
 	}
-	board := boardStore.Board()
+	board, err := boardStore.Board()
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board task: read board: %v", err)
+		return
+	}
 	if board == nil || len(board.States) == 0 {
 		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: native board has no states")
 		return
@@ -424,10 +428,15 @@ func (s *Server) handlePipelineBoardTaskReady(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board ready: invalid request: %v", err)
 		return
 	}
+	board, err := boardStore.Board()
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board ready: read board: %v", err)
+		return
+	}
 	// Unstage → backlog (prefer StateBacklog; StateInbox is the historical
 	// unstage target for boards that still use it as the first column).
 	target := native.StateBacklog
-	if board := boardStore.Board(); board != nil && board.StateByName(target) == nil {
+	if board != nil && board.StateByName(target) == nil {
 		target = native.StateInbox
 	}
 	if req.Ready {
@@ -438,7 +447,7 @@ func (s *Server) handlePipelineBoardTaskReady(w http.ResponseWriter, r *http.Req
 		}
 		ok, open := native.BlockersSatisfiedForIssue(boardStore, iss)
 		if !ok {
-			if board := boardStore.Board(); board != nil && board.StateByName(native.StateWaitingDeps) != nil {
+			if board != nil && board.StateByName(native.StateWaitingDeps) != nil {
 				target = native.StateWaitingDeps
 			} else {
 				s.writeJSONError(w, r, http.StatusConflict, map[string]any{

--- a/pkg/server/pipeline_reservations.go
+++ b/pkg/server/pipeline_reservations.go
@@ -131,8 +131,17 @@ func (s *Server) pipelineReservedSetMemo(
 		return nil
 	}
 
+	board, err := boardStore.Board()
+	if err != nil {
+		// Fail OPEN, same as the list above: without the terminal set every
+		// closed ticket would read as active and withhold a slot.
+		if s.logger != nil {
+			s.logger.Warn("pipeline reservations: read board: %v", err)
+		}
+		return nil
+	}
 	terminal := map[string]struct{}{}
-	if board := boardStore.Board(); board != nil {
+	if board != nil {
 		for _, st := range board.States {
 			if st.Terminal {
 				terminal[st.Name] = struct{}{}

--- a/pkg/server/projects.go
+++ b/pkg/server/projects.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/errtrack"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -279,13 +280,24 @@ func (s *Server) handleRemoveProject(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// hotSwapStopBudget bounds the previous service's background stop. The
+// reconcile half awaits the scan in flight, and that scan is cancelled first,
+// so the budget only covers a store call already under way — past it the
+// switch proceeds and runview logs what it could not wait for.
+const hotSwapStopBudget = 5 * time.Second
+
 // swapWorkDir is the hot-swap primitive. Builds a fresh runview.Service
 // and Watcher for the new directory, then atomically replaces the
 // server's references under stateMu. In-flight engine goroutines from
 // the previous project keep their captured *Service reference and
 // drain to the old store in the background — the SPA's reset on
 // `project_switched` makes that invisible to the user.
-func (s *Server) swapWorkDir(_ context.Context, newDir string) error {
+//
+// The previous service's PERIODIC workers stop, though: they are the
+// server's, not the runs'. Left alive they scan a store the server no longer
+// serves — one more orphan-reconcile ticker, pipeline scheduler and stall
+// poll per switch, for the process lifetime.
+func (s *Server) swapWorkDir(ctx context.Context, newDir string) error {
 	abs, err := filepath.Abs(newDir)
 	if err != nil {
 		return fmt.Errorf("abs: %w", err)
@@ -328,6 +340,13 @@ func (s *Server) swapWorkDir(_ context.Context, newDir string) error {
 		if opt, ok := s.boardMCPServiceOption(s.logger); ok {
 			svcOpts = append(svcOpts, opt)
 		}
+		// Run-health alerting is a server-level setting, not a per-project
+		// one: without this the first switch silently ends alerting for the
+		// rest of the process (the boot service keeps the only manager, over
+		// a store nobody serves).
+		if s.cfg.Alerts != nil {
+			svcOpts = append(svcOpts, runview.WithAlerts(*s.cfg.Alerts))
+		}
 		if localSecretsEnabled {
 			svcOpts = append(svcOpts, runview.WithLocalSecrets(newLocalSecrets, s.sealer))
 		}
@@ -360,6 +379,7 @@ func (s *Server) swapWorkDir(_ context.Context, newDir string) error {
 	// continue to write to their original store.
 	s.stateMu.Lock()
 	oldWatcher := s.watcher
+	oldRuns := s.runs
 	s.cfg.WorkDir = abs
 	s.cfg.StoreDir = storeDir
 	s.runs = newRuns
@@ -378,6 +398,13 @@ func (s *Server) swapWorkDir(_ context.Context, newDir string) error {
 
 	if oldWatcher != nil {
 		oldWatcher.Stop()
+	}
+	// Detached from the caller: the swap has already happened, so a requester
+	// that hung up must not leave the previous project's workers running.
+	if oldRuns != nil && oldRuns != newRuns {
+		stopCtx, cancelStop := context.WithTimeout(context.WithoutCancel(ctx), hotSwapStopBudget)
+		oldRuns.StopBackground(stopCtx)
+		cancelStop()
 	}
 	if newWatcher != nil {
 		errtrack.Go("server.fileWatcher", newWatcher.Start)

--- a/pkg/server/projects_hotswap_test.go
+++ b/pkg/server/projects_hotswap_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runview"
+)
+
+// periodicWorkerFrames names the goroutine a runview.Service starts and keeps
+// for its whole life, one entry per kind. Counting stack frames rather than
+// instrumenting the production code keeps the oracle on the artefact that
+// actually runs.
+var periodicWorkerFrames = map[string]string{
+	"orphan reconcile":   "runview.(*Service).startPeriodicReconcile.func1",
+	"pipeline scheduler": "runview.(*Service).startPipelineScheduler.func1",
+	"alert stall poll":   "alert.(*Manager).Start.func1",
+}
+
+// liveGoroutines counts the goroutines whose stack carries frame. The dump is
+// a stop-the-world snapshot, so the count is consistent.
+func liveGoroutines(frame string) int {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), frame)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+// The hot-swap replaces the run service without draining it: the previous
+// service's ENGINE goroutines keep writing to the store they started on, and
+// that is deliberate. Its PERIODIC workers have no such claim — left running
+// they scan a store the server no longer serves, once per interval, for the
+// process lifetime, one more scanner per switch.
+func TestSwapWorkDir_LeavesOnePeriodicWorkerPerKind(t *testing.T) {
+	// Baselines first: another test's service (should one ever appear) must
+	// not be read as this one's leak. Taken once the reading is STABLE — a
+	// worker stopped by a previous test is signalled before it returns, so a
+	// single sample counts goroutines that are already on their way out and
+	// sets a baseline nothing can come back to.
+	base := map[string]int{}
+	for kind, frame := range periodicWorkerFrames {
+		base[kind] = stableGoroutines(frame)
+	}
+
+	dir := t.TempDir()
+	first := filepath.Join(dir, "p0")
+	mkProjectDir(t, first)
+	srv := New(Config{
+		WorkDir:                 first,
+		StoreDir:                filepath.Join(first, ".iterion"),
+		SkipProjectRegistration: true,
+		MaxConcurrentPipelines:  2,
+		Alerts:                  &runview.AlertSettings{StallTimeout: time.Minute, BaseURL: "http://127.0.0.1:0"},
+	}, iterlog.New(iterlog.LevelError, nil))
+	if srv.runs == nil {
+		t.Fatal("no run service was wired — the test would assert on nothing")
+	}
+	t.Cleanup(func() { srv.runs.Stop(context.Background()) })
+
+	for i := 1; i <= 4; i++ {
+		next := filepath.Join(dir, "p"+string(rune('0'+i)))
+		mkProjectDir(t, next)
+		if err := srv.swapWorkDir(context.Background(), next); err != nil {
+			t.Fatalf("swap %d: %v", i, err)
+		}
+	}
+
+	for kind, frame := range periodicWorkerFrames {
+		want := base[kind] + 1 // the service the server actually serves
+		if got := settleGoroutines(frame, want); got != want {
+			t.Errorf("%s: %d live after 4 project switches, want %d — every switch left the previous service's worker scanning a store the server no longer serves", kind, got, want)
+		}
+	}
+}
+
+// settleGoroutines polls until the count reaches want or the budget runs out —
+// a stopped goroutine returns shortly after its signal, not at the instant of
+// it. Returns the last count read.
+func settleGoroutines(frame string, want int) int {
+	deadline := time.Now().Add(3 * time.Second)
+	got := liveGoroutines(frame)
+	for got != want && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+		got = liveGoroutines(frame)
+	}
+	return got
+}
+
+// stableGoroutines returns a count that two readings apart agree on, so a
+// worker already winding down from an earlier test is not counted as
+// standing. Falls back to the last reading when nothing settles in budget.
+func stableGoroutines(frame string) int {
+	deadline := time.Now().Add(3 * time.Second)
+	prev := liveGoroutines(frame)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		got := liveGoroutines(frame)
+		if got == prev {
+			return got
+		}
+		prev = got
+	}
+	return prev
+}
+
+// mkProjectDir makes a directory swapWorkDir accepts as a project.
+func mkProjectDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}


### PR DESCRIPTION
## Why

Three tickets, one shape: **a failure that answers like a success.** Each carried a class grep the fix is not finished without, and in all three the grep found more than the ticket named.

## 1. #891 — a read that failed must not answer like a read that succeeded

`boardmongo.AggregateLabels() []LabelUsage` had no error in its signature, so `return nil` on a store failure was the only option at that seam — a transient Mongo failure renders the board's label vocabulary as *"this board has no labels"*, and an operator re-creates labels that exist.

The class grep over `native.BoardStore` found a **worse** member the ticket did not name: `Board() *Board` answered `native.DefaultBoard()` on *any* read error, so an unreachable Mongo files cards into columns the tenant never declared and serves the studio somebody else's grid. Both widened; `mongo.ErrNoDocuments` stays the legitimate default. One cascade a level up — `tracker.LaunchStateLister.LaunchStates() []string`, where an empty list reads as "no eligible tickets" — is the same defect and is widened with them.

Chokepoints rather than repeated guards: the 12 `/board` routes go through one `writeBoard`; `boardops.doClose` reads the board **once** for its whole target resolution (3 Mongo round-trips → 1, and *"board has no terminal state — declare one"* can no longer be printed for a board nobody could read). Re-run of the class grep after the fix: empty.

## 2. #904 — wrapping a sentinel changes what an error MEANS while keeping what it MATCHES

`forge_avatar_routes.go`'s spent-budget branch `%w`-wrapped an error that may itself be `forge.ErrForbidden`, so a forge that answered **403 and then stalled** decided a status the code deliberately wants to be "the budget is spent". The branch now returns a context-expiry error of its own and renders the forge error `%v` beside a log line — diagnostic, not routing. **The handler #893 left deliberately unwired is wired.**

Class swept: every `%w` of a `pkg/forge` sentinel, in the 82 non-test files importing `pkg/forge`, into an error whose meaning is a timeout / budget / cancellation / store failure — 25 candidates, plus every double-`%w` and every `ctx.Err()` branch. One member; the dispositions of the other 24 are in the commit body.

## 3. #884 — the project hot-swap stops the previous service's periodic workers

`projects.go` deliberately does not drain the previous `runview.Service` (its engine goroutines keep writing to their own store) — but it stopped nothing either. The class table of long-lived workers found **three** leaks, not one:

| worker | before | after |
|---|---|---|
| `startPeriodicReconcile` (60 s) | leaked | stopped, bounded |
| `startPipelineScheduler` (5 s) | leaked — **and it can still launch runs into the old store** | stopped |
| `alertManager` (5–30 s) | leaked — `Drain`'s own comment already named this | stopped |

One chokepoint, `Service.StopBackground(ctx)`, which `Stop` and `Drain` now both route through, so a fourth worker is reaped by all three paths instead of the two that remembered. A mirror defect the same grep found: `swapWorkDir` never re-wired `WithAlerts`, so the *first* switch silently ended run-health alerting for the process — without that half, the leak test's alert row would have passed vacuously.

## Evidence — red first, and every guard falsified

```
AggregateLabels on an unreachable store returned [] with no way to report the failure
Board on an unreachable store returned 9 states with no way to report the failure

--- FAIL: TestForgeConnectionAvatar_SpentBudgetOutranksTheForgesAnswer
    code=403 body={"error":"could not read the account behind connection …: forge: insufficient scope"}

orphan reconcile:   5 live after 4 project switches, want 1
pipeline scheduler: 5 live after 4 project switches, want 1
```

Fault injection for #891 is a real `boardmongo.Store` over a disconnected driver client — the honest producer, not a stub, and no live Mongo needed. The #904 invariant test pins the **cause** (`context.DeadlineExceeded`, must not match `ErrForbidden`), so a canary restoring the wrap **while keeping the message text identical** still fires — a message-only assertion would have passed it.

`devbox run -- task check` green, golangci `0 issues`. `-race -count=1` green on runview / server / dispatcher / cli / e2e. Mongo conformance on a `mongo:8.0` replica set: 27 trees ok. `openapi.json` unchanged.

Closes #891
Closes #904
Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
