### PR TITLE
fix(dispatcher): a run parked on a paused subbot descendant is waiting, not stalled

### DIFF
--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -213,6 +213,16 @@ func (c *Dispatcher) reconcileStalled(ctx context.Context, cfg *Config) {
 		}
 		rows = append(rows, stalledRow{id, r})
 	}
+	if len(rows) == 0 {
+		return
+	}
+	// One store handle for the whole sweep, opened only now that something
+	// has actually aged out: store.New does MkdirAll + gitignore housekeeping,
+	// too expensive to run on the actor goroutine every tick. A store that
+	// cannot be opened leaves rs nil, and the exemption below then fails
+	// closed exactly as an unreadable record does.
+	rs, _ := c.openRunStore()
+
 	for _, row := range rows {
 		id, r := row.id, row.r
 		// A run still in its claimed→running setup hasn't started — don't
@@ -223,6 +233,15 @@ func (c *Dispatcher) reconcileStalled(ctx context.Context, cfg *Config) {
 			continue
 		}
 		if r.CancelIssuedAt.IsZero() {
+			// Silence is not a stall when a subbot descendant is parked on a
+			// human gate: the parent sits in runview.AwaitSubbotTerminal
+			// polling the child, emitting nothing. Checked only before the
+			// FIRST cancel — once the ladder has started the run is being torn
+			// down, and letting a late park block the force-reap would pin the
+			// concurrency slot for good.
+			if rs != nil && c.exemptParkedFromStall(ctx, rs, r) {
+				continue
+			}
 			atomicLag := now.Sub(r.lastEventTime())
 			actorLag := now.Sub(r.LastEventAt)
 			c.logger.Warn("dispatcher: %s stalled (atomic_lag=%s actor_lag=%s timeout=%s) — cancelling", r.Identifier, atomicLag, actorLag, timeout)

--- a/pkg/dispatcher/stall_parked.go
+++ b/pkg/dispatcher/stall_parked.go
@@ -1,0 +1,114 @@
+package dispatcher
+
+import (
+	"context"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// maxParkedProbeRuns bounds how many run records one parked-descendant probe
+// reads. The answer a parked run needs is found at depth 1 (its own children),
+// so the budget only bites on a deep or wide tree in which NOTHING is paused —
+// exactly the tree that should be reaped. Exceeding it therefore returns "not
+// parked", the fail-closed answer.
+const maxParkedProbeRuns = 256
+
+// parkedOnPausedDescendant reports whether a silent run is silent BECAUSE a
+// run below it is parked on a pause only an operator can lift.
+//
+// It is the stall watchdog's exemption oracle, and it is a PULL from persisted
+// truth rather than a heartbeat the parked code pushes: a parent blocked in
+// runview.AwaitSubbotTerminal emits no event and books no work, so any signal
+// it produced itself would either be invisible to the dispatcher or would have
+// to fake node progress on the run's timeline. What it does leave behind is
+// exact — the child id under SubbotChildren (written before the child engine
+// runs) and the child's own paused status — so the watchdog reads that instead.
+//
+// The exemption is self-limiting by construction: the moment the operator
+// answers, the descendant leaves its paused status and the next tick judges the
+// run on its silence alone. A run that is merely wedged, at any depth, is never
+// exempt.
+//
+// Fails CLOSED. An unreadable record, a pruned child, a cycle in a corrupt
+// SubbotChildren map, or a probe past its budget all read as "not parked": no
+// information is not a licence to disarm the watchdog.
+func parkedOnPausedDescendant(ctx context.Context, rs store.RunStore, runID string) bool {
+	if rs == nil || runID == "" {
+		return false
+	}
+	// Breadth-first over SubbotChildren, one store read per run. `seen` is what
+	// guarantees termination on a corrupt map that points back at an ancestor;
+	// the budget only bounds cost.
+	seen := map[string]bool{runID: true}
+	frontier := []string{runID}
+	budget := maxParkedProbeRuns
+	// The ROOT's own pause is deliberately NOT an exemption: a run that pauses
+	// itself returns from the engine, and finishRun's pause arm parks the card
+	// and frees the slot. Only a descendant keeps a parent silent while the
+	// parent is still `running`.
+	root := true
+
+	for len(frontier) > 0 && budget > 0 {
+		var next []string
+		for _, id := range frontier {
+			if budget <= 0 {
+				break
+			}
+			run, err := rs.LoadRun(ctx, id)
+			budget--
+			if err != nil || run == nil {
+				continue
+			}
+			if !root {
+				// IsPaused is the same predicate finishRun's pause arm reads,
+				// so "what parks a card" and "what exempts a parent" cannot
+				// drift apart.
+				if run.Status.IsPaused() {
+					return true
+				}
+				// IsTerminal matches runview.AwaitSubbotTerminal's own terminal
+				// set: a child in one of those states is something the parent
+				// stops waiting on, so its subtree is not worth walking.
+				if run.Status.IsTerminal() {
+					continue
+				}
+			}
+			for _, childID := range run.SubbotChildren {
+				if childID == "" || seen[childID] {
+					continue
+				}
+				seen[childID] = true
+				next = append(next, childID)
+			}
+		}
+		frontier = next
+		root = false
+	}
+	return false
+}
+
+// exemptParkedFromStall answers reconcileStalled's question for one entry:
+// should this aged-out run be spared? It also owns the operator-visible log
+// line, bracketed per park episode so a multi-day review costs two lines and
+// not one per tick — an exemption nobody can see reads as a hung watchdog.
+//
+// Actor-goroutine only: it mutates the entry's episode flag and reads the
+// store, both under the same ADR-028 Step 3 boundary as the parked sweeps.
+func (c *Dispatcher) exemptParkedFromStall(ctx context.Context, rs store.RunStore, r *runningEntry) bool {
+	parked := parkedOnPausedDescendant(ctx, rs, r.RunID)
+	switch {
+	case parked && !r.parkedNoticed:
+		r.parkedNoticed = true
+		c.logger.Info(
+			"dispatcher: %s is silent because a subbot descendant of run %s awaits human input — exempt from the stall watchdog until it is answered",
+			r.Identifier, r.RunID,
+		)
+	case !parked && r.parkedNoticed:
+		r.parkedNoticed = false
+		c.logger.Info(
+			"dispatcher: %s no longer waits on a paused descendant (run=%s) — the stall watchdog applies again",
+			r.Identifier, r.RunID,
+		)
+	}
+	return parked
+}

--- a/pkg/dispatcher/stall_parked_test.go
+++ b/pkg/dispatcher/stall_parked_test.go
@@ -1,0 +1,436 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// gateChildBot parks on a human gate the test deliberately never answers —
+// the legitimate weekend-long review the stall watchdog must not mistake for
+// a wedged engine. Tool-only otherwise, so the fixture needs no credential.
+const gateChildBot = `
+schema gate_out:
+  approved: bool
+  notes: string
+
+schema child_out:
+  verdict: string
+
+human review:
+  output: gate_out
+
+compute wrap:
+  output: child_out
+  expr:
+    verdict: "outputs.review.notes"
+
+workflow gate_child:
+  entry: review
+  review -> wrap
+  wrap -> done
+`
+
+const gateParentBot = `
+schema pout:
+  ready: bool
+
+schema child_out:
+  verdict: string
+
+tool prep:
+  command: ` + "`printf '{\"ready\":true}'`" + `
+  output: pout
+
+subbot run_child:
+  source: "gate_child.bot"
+  output: child_out
+
+compute summarize:
+  output: child_out
+  expr:
+    verdict: "outputs.run_child.verdict"
+
+workflow gate_parent:
+  entry: prep
+  prep      -> run_child
+  run_child -> summarize
+  summarize -> done
+`
+
+// newStallTestDispatcher builds a dispatcher bound to storeDir, so
+// reconcileStalled can consult the run records the engine wrote.
+func newStallTestDispatcher(t *testing.T, storeDir string) *Dispatcher {
+	t.Helper()
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "ws")
+	cfg := &Config{
+		Name:      "test",
+		Workflow:  filepath.Join(dir, "fake.bot"),
+		Tracker:   TrackerConfig{Kind: "fake"},
+		Polling:   PollingConfig{IntervalMS: 50},
+		Agent:     AgentConfig{MaxConcurrent: 4, MaxRetryBackoffMS: 1000},
+		Workspace: WorkspaceConfig{Root: wsDir},
+		// A deliberately short stall window: the whole point is that a park
+		// outlives it without being reaped.
+		Stall: StallConfig{TimeoutMS: 50},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(wsDir)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config:     cfg,
+		Tracker:    newFakeTracker(),
+		Runner:     &StubRunner{},
+		Workspaces: ws,
+		Logger:     iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test",
+		StoreDir:   storeDir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// seedStalledEntry registers runID as an in-flight dispatch whose event
+// watermark is already older than the stall timeout, and returns a pointer
+// that reports whether reconcileStalled cancelled it.
+func seedStalledEntry(c *Dispatcher, issueID, runID string) *bool {
+	cancelled := false
+	c.state.running[issueID] = &runningEntry{
+		IssueID:    issueID,
+		Identifier: issueID,
+		RunID:      runID,
+		StartedAt:  time.Now().Add(-time.Hour),
+		// Silent for an hour under a 50ms stall timeout.
+		LastEventAt: time.Now().Add(-time.Hour),
+		Cancel:      func(error) { cancelled = true },
+	}
+	return &cancelled
+}
+
+// writeRunDoc plants a run record with the given status and subbot children.
+// The doc shape mirrors what the engine and runview.RecordSubbotChild write.
+func writeRunDoc(t *testing.T, storeDir, runID string, status store.RunStatus, children map[string]string) {
+	t.Helper()
+	s, err := store.New(storeDir, store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := s.CreateRun(context.Background(), runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun(%s): %v", runID, err)
+	}
+	r, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun(%s): %v", runID, err)
+	}
+	r.Status = status
+	if err := s.SaveRun(context.Background(), r); err != nil {
+		t.Fatalf("SaveRun(%s): %v", runID, err)
+	}
+	for key, child := range children {
+		if err := s.SetSubbotChild(context.Background(), runID, key, child); err != nil {
+			t.Fatalf("SetSubbotChild(%s→%s): %v", runID, child, err)
+		}
+	}
+}
+
+// TestReconcileStalled_ExemptsParentParkedOnPausedSubbotChild is the #558
+// regression, driven end to end: the REAL dispatcher engine runs a parent
+// whose subbot child parks on a human gate nobody answers, and the REAL stall
+// watchdog then judges the parent. A parent blocked in AwaitSubbotTerminal
+// emits no event, so its watermark ages past any stall timeout while nothing
+// is wrong — and cancelling it burns a dispatcher attempt on a review the
+// operator has simply not come back to yet.
+func TestReconcileStalled_ExemptsParentParkedOnPausedSubbotChild(t *testing.T) {
+	botDir := t.TempDir()
+	parentPath := filepath.Join(botDir, "gate_parent.bot")
+	if err := os.WriteFile(parentPath, []byte(gateParentBot), 0o644); err != nil {
+		t.Fatalf("write parent bot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(botDir, "gate_child.bot"), []byte(gateChildBot), 0o644); err != nil {
+		t.Fatalf("write child bot: %v", err)
+	}
+
+	storeDir := t.TempDir()
+	workspace := t.TempDir()
+	runner, err := NewEngineRunner(parentPath, iterlog.Nop())
+	if err != nil {
+		t.Fatalf("NewEngineRunner: %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+
+	parentID, err := store.GenerateRunID()
+	if err != nil {
+		t.Fatalf("GenerateRunID: %v", err)
+	}
+
+	// The dispatch parks forever (nobody answers the child's gate); cancelling
+	// its context at cleanup is what drains the goroutine.
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	dispatchDone := make(chan error, 1)
+	go func() {
+		dispatchDone <- runner.Dispatch(runCtx, DispatchSpec{
+			RunID:         parentID,
+			WorkspacePath: workspace,
+			StoreDir:      storeDir,
+			Issue:         &IssueRef{ID: "native:" + parentID, Identifier: parentID, Title: "parked on a subbot gate"},
+		})
+	}()
+	t.Cleanup(func() {
+		cancelRun()
+		select {
+		case <-dispatchDone:
+		case <-time.After(30 * time.Second):
+			t.Error("dispatch goroutine did not drain after cancel")
+		}
+	})
+
+	probe, err := store.New(storeDir, store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	childID := waitForPausedSubbotChild(t, probe, parentID, dispatchDone)
+
+	// The parent is genuinely parked: still `running`, and its child sits on
+	// the human gate. This is the exact production shape of the ticket.
+	parent, err := probe.LoadRun(context.Background(), parentID)
+	if err != nil {
+		t.Fatalf("LoadRun(parent): %v", err)
+	}
+	if parent.Status != store.RunStatusRunning {
+		t.Fatalf("parent status = %q, want running (a parked parent stays running)", parent.Status)
+	}
+
+	c := newStallTestDispatcher(t, storeDir)
+	cancelled := seedStalledEntry(c, "fake:parked", parentID)
+	c.reconcileStalled(context.Background(), c.cfg.Load())
+
+	if *cancelled {
+		t.Fatalf("parent run %s was stall-reaped while its subbot child %s legitimately awaits human input", parentID, childID)
+	}
+	if entry := c.state.running["fake:parked"]; entry == nil || !entry.CancelIssuedAt.IsZero() {
+		t.Fatalf("stall watchdog issued a cancel against a parked parent (entry=%+v)", entry)
+	}
+
+	// The parent kept executing (it is still parked, not torn down) and the
+	// park produced no sibling child — the "no second child is created" half
+	// of the acceptance list. A reap here would have failed the parent, its
+	// retry would have re-run the subbot node, and the operator's pending
+	// review would have been orphaned on a child nothing consumes.
+	after, err := probe.LoadRun(context.Background(), parentID)
+	if err != nil {
+		t.Fatalf("LoadRun(parent) after the sweep: %v", err)
+	}
+	if after.Status != store.RunStatusRunning {
+		t.Fatalf("parent status after the stall sweep = %q, want running", after.Status)
+	}
+	children := childRunsOf(t, probe, parentID)
+	if len(children) != 1 || children[0] != childID {
+		t.Fatalf("children of %s = %v, want exactly [%s] — a second child was spawned", parentID, children, childID)
+	}
+}
+
+// childRunsOf lists every run in the store whose ParentRunID is parentID.
+func childRunsOf(t *testing.T, probe *store.FilesystemRunStore, parentID string) []string {
+	t.Helper()
+	ids, err := probe.ListRuns(context.Background())
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	var children []string
+	for _, id := range ids {
+		if id == parentID {
+			continue
+		}
+		r, lerr := probe.LoadRun(context.Background(), id)
+		if lerr == nil && r.ParentRunID == parentID {
+			children = append(children, id)
+		}
+	}
+	return children
+}
+
+// waitForPausedSubbotChild blocks until the parent has recorded a subbot child
+// that is paused on its human gate, and returns that child's run id.
+func waitForPausedSubbotChild(t *testing.T, probe *store.FilesystemRunStore, parentID string, dispatchDone <-chan error) string {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-dispatchDone:
+			t.Fatalf("dispatch returned before the child parked on its gate: %v", err)
+		default:
+		}
+		parent, err := probe.LoadRun(context.Background(), parentID)
+		if err == nil {
+			for _, childID := range parent.SubbotChildren {
+				child, cerr := probe.LoadRun(context.Background(), childID)
+				if cerr == nil && child.Status == store.RunStatusPausedWaitingHuman {
+					return childID
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("no subbot child of %s reached paused_waiting_human", parentID)
+	return ""
+}
+
+// TestReconcileStalled_ReapsGenuinelySilentRun is the guard that keeps the
+// exemption from disarming the watchdog: a run with no paused descendant is
+// still cancelled the moment its watermark ages out. Without this assertion a
+// green suite would prove nothing — an exemption that always fires is not a
+// fix, it is the removal of stall detection.
+func TestReconcileStalled_ReapsGenuinelySilentRun(t *testing.T) {
+	cases := []struct {
+		name     string
+		children map[string]string
+		// childStatus is the status given to every child in children.
+		childStatus store.RunStatus
+	}{
+		{name: "no subbot children at all", children: nil},
+		{
+			name:        "child running — a wedged descendant is not a parked one",
+			children:    map[string]string{"run_child#0": "child-running"},
+			childStatus: store.RunStatusRunning,
+		},
+		{
+			name:        "child finished — the park is over, silence is now a wedge",
+			children:    map[string]string{"run_child#0": "child-finished"},
+			childStatus: store.RunStatusFinished,
+		},
+		{
+			name:        "child failed — the parent should surface the failure, not sit",
+			children:    map[string]string{"run_child#0": "child-failed"},
+			childStatus: store.RunStatusFailed,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storeDir := t.TempDir()
+			writeRunDoc(t, storeDir, "parent-silent", store.RunStatusRunning, tc.children)
+			for _, childID := range tc.children {
+				writeRunDoc(t, storeDir, childID, tc.childStatus, nil)
+			}
+
+			c := newStallTestDispatcher(t, storeDir)
+			cancelled := seedStalledEntry(c, "fake:silent", "parent-silent")
+			c.reconcileStalled(context.Background(), c.cfg.Load())
+
+			if !*cancelled {
+				t.Fatal("a genuinely silent run was NOT stall-reaped — the watchdog is disarmed")
+			}
+		})
+	}
+}
+
+// TestReconcileStalled_ExemptsParentParkedOnPausedGrandchild covers the nested
+// case: the parent parks on a child that is itself parked on ITS child's gate.
+// Only the deepest run carries the paused status, so an oracle that looks one
+// level down would reap the whole chain.
+func TestReconcileStalled_ExemptsParentParkedOnPausedGrandchild(t *testing.T) {
+	storeDir := t.TempDir()
+	writeRunDoc(t, storeDir, "gp", store.RunStatusRunning, map[string]string{"a#0": "parent"})
+	writeRunDoc(t, storeDir, "parent", store.RunStatusRunning, map[string]string{"b#0": "child"})
+	writeRunDoc(t, storeDir, "child", store.RunStatusPausedWaitingHuman, nil)
+
+	c := newStallTestDispatcher(t, storeDir)
+	cancelled := seedStalledEntry(c, "fake:nested", "gp")
+	c.reconcileStalled(context.Background(), c.cfg.Load())
+
+	if *cancelled {
+		t.Fatal("a root parked two levels above a paused grandchild was stall-reaped")
+	}
+}
+
+// TestReconcileStalled_ExemptsParentParkedOnOperatorPausedChild pins the other
+// pause status a child can carry: an operator pause from the run console is
+// just as legitimate a park as a human gate.
+func TestReconcileStalled_ExemptsParentParkedOnOperatorPausedChild(t *testing.T) {
+	storeDir := t.TempDir()
+	writeRunDoc(t, storeDir, "parent-op", store.RunStatusRunning, map[string]string{"c#0": "child-op"})
+	writeRunDoc(t, storeDir, "child-op", store.RunStatusPausedOperator, nil)
+
+	c := newStallTestDispatcher(t, storeDir)
+	cancelled := seedStalledEntry(c, "fake:oppaused", "parent-op")
+	c.reconcileStalled(context.Background(), c.cfg.Load())
+
+	if *cancelled {
+		t.Fatal("a parent parked on an operator-paused child was stall-reaped")
+	}
+}
+
+// TestReconcileStalled_ReapsWhenDescendantCycles proves the descendant walk
+// terminates on a corrupt store rather than spinning: a child recorded as its
+// own parent must not hang the actor goroutine, and must not exempt the run.
+func TestReconcileStalled_ReapsWhenDescendantCycles(t *testing.T) {
+	storeDir := t.TempDir()
+	writeRunDoc(t, storeDir, "cyc-a", store.RunStatusRunning, map[string]string{"x#0": "cyc-b"})
+	writeRunDoc(t, storeDir, "cyc-b", store.RunStatusRunning, map[string]string{"y#0": "cyc-a"})
+
+	c := newStallTestDispatcher(t, storeDir)
+	cancelled := seedStalledEntry(c, "fake:cycle", "cyc-a")
+
+	done := make(chan struct{})
+	go func() {
+		c.reconcileStalled(context.Background(), c.cfg.Load())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reconcileStalled did not terminate on a cyclic subbot-children graph")
+	}
+	if !*cancelled {
+		t.Fatal("a cycle with no paused run anywhere must not exempt the run")
+	}
+}
+
+// TestReconcileStalled_ReapsWhenRunRecordUnreadable fails CLOSED: a store the
+// dispatcher cannot read must not silently become a blanket exemption. "No
+// information" is not "legitimately parked".
+func TestReconcileStalled_ReapsWhenRunRecordUnreadable(t *testing.T) {
+	storeDir := t.TempDir()
+	c := newStallTestDispatcher(t, storeDir)
+	// No run record at all for this id — the pruned/never-written case.
+	cancelled := seedStalledEntry(c, "fake:missing", "no-such-run")
+	c.reconcileStalled(context.Background(), c.cfg.Load())
+
+	if !*cancelled {
+		t.Fatal("an unreadable/absent run record must not exempt a silent run from the stall watchdog")
+	}
+}
+
+// TestReconcileStalled_StillReapsParkedRunAfterGrace pins the second half of
+// the watchdog on the exempt path: a parked run is never cancelled at all, so
+// it never enters the force-reap ladder either. Guards against a fix that
+// merely delays the cancel.
+func TestReconcileStalled_StillReapsParkedRunAfterGrace(t *testing.T) {
+	t.Setenv("ITERION_DISPATCHER_STALL_REAP_GRACE", "1ms")
+	storeDir := t.TempDir()
+	writeRunDoc(t, storeDir, "parent-parked", store.RunStatusRunning, map[string]string{"d#0": "child-parked"})
+	writeRunDoc(t, storeDir, "child-parked", store.RunStatusPausedWaitingHuman, nil)
+
+	c := newStallTestDispatcher(t, storeDir)
+	cancelled := seedStalledEntry(c, "fake:stillparked", "parent-parked")
+	// Several ticks: a parked run must survive all of them.
+	for i := 0; i < 5; i++ {
+		c.reconcileStalled(context.Background(), c.cfg.Load())
+	}
+	if *cancelled {
+		t.Fatal("a parked parent was reaped on a later tick")
+	}
+	if _, still := c.state.running["fake:stillparked"]; !still {
+		t.Fatal("a parked parent lost its running entry — the slot was force-reaped")
+	}
+}

--- a/pkg/dispatcher/state.go
+++ b/pkg/dispatcher/state.go
@@ -145,6 +145,13 @@ type runningEntry struct {
 	// single writer so no mutex is needed.
 	CancelIssuedAt time.Time
 
+	// parkedNoticed brackets the log episode for a run the stall watchdog
+	// is exempting because a subbot descendant awaits human input (see
+	// exemptParkedFromStall). Without it a weekend-long review would emit
+	// one line per tick; without any line at all, the exemption would be
+	// indistinguishable from a hung watchdog. Actor-owned; no mutex.
+	parkedNoticed bool
+
 	// setupPending is true between claim-time allocation (dispatch, on the
 	// actor) and the off-actor setup worker reporting the in-progress
 	// transition + workspace back via cmdDispatchSetupDone. It marks the


### PR DESCRIPTION
## Why

A dispatcher-owned parent parked inside `AwaitSubbotTerminal` polls the child's store record once a second and emits **nothing** — no engine event, no liveness signal. The dispatcher's stall freshness is fed by `DispatchSpec.OnEvent`, so the parent's watermark ages past the stall timeout while nothing is wrong: it is cancelled, retried, and eventually burns `max_attempts`. A human review left open over a weekend is enough. A production deployment is working around it today with `stall.timeout_ms: 86400000` — 24 hours — which is the real cost of the defect.

**Sharpened diagnosis** (`pkg/dispatcher/heartbeat_store.go:33`): `onEvent` receives only the event *type*, not the run id, and the child shares the parent's heartbeat store. The watermark is therefore fed by the whole subtree and ages out only when the entire subtree goes silent — which is exactly the park window, and nothing else.

## What, and what was rejected

The ticket offers two designs. **Option (1) — release the concurrency slot — is not carryable here**, and the reasons are worth recording so nobody re-derives them:

- nothing would ever resume the parent: `reconcileParked` only moves cards whose run is **terminal**, and a parent paused with no interaction of its own has no waker;
- a subbot inside a `fan_out_all` branch would require checkpointing the whole parent mid-fan-out, which the engine deliberately does not do (`slot.release()` on park keeps siblings running);
- `AwaitSubbotTerminal` is shared by three runners (studio, dispatcher, CLI), so all three would need the new resume trigger.

That is a runtime redesign, not a fix for #558.

**Option (2) is taken, but pulled instead of pushed.** The ticket's own constraint — *no fabricated paid work or node progress* — is the argument against a heartbeat: the signal would have to be invented by the goroutine that is, correctly, doing nothing, and anything event-shaped corrupts the run's timeline and the budget's meaning. So the watchdog **reads persisted truth** instead: the park already leaves an exact record (`SubbotChildren`, written before the child engine runs, plus the child's own `paused_*` status), and `reconcileStalled` consults it. One site covers all three runners, adds nothing to `pkg/runtime` or `pkg/runview`, and **cannot be faked by the parked code** — which a heartbeat, by construction, can.

## The class

Class A, *"parked awaiting a human, with a persisted status to read"* — every row verified:

| site | disposition |
|---|---|
| `AwaitSubbotTerminal` (studio / dispatcher / CLI) | **fixed** |
| `ReattachSubbotChild` (post-restart re-park) | **fixed** by the same site — `SubbotChildren` survives a restart |
| human gate on the parent itself | already correct — the pause arm parks the card and frees the slot |
| `await_answers` | **member, deliberately not fixed**: pending async questions also exist while an `interaction: async` agent keeps working, so this oracle would exempt a genuinely wedged agent. Needs a different signal; mandatory `timeout:` bounds it meanwhile |
| `wait` node · usage-window park | not members (compiler-enforced timeout; run already ended) |
| `pkg/alert` stall observer | **member, not fixed**: same blind spot, but it raises a false *alert*, not a reap |

Class B — *silent but genuinely working* (a tool node's shell is unbounded; k8s pod-Ready 10 min, workspace copy 15 min, `post_create` 30 min; `acquireResources` unbounded) — is the same symptom with a different cause: real work is happening, no paused status exists, so a liveness signal is the legitimate answer there and this oracle cannot serve. Swept and listed in the commit body rather than folded in.

## Evidence

Red first, driven by the **real engine** parking a **real child** on a **real human gate**, judged by the **real watchdog** — not a stubbed status:

```
--- FAIL: TestReconcileStalled_ExemptsParentParkedOnPausedSubbotChild
    parent run 01a07f72-da7b-… was stall-reaped while its subbot child
    01a07f72-daea-… legitimately awaits human input
--- FAIL: TestReconcileStalled_ExemptsParentParkedOnPausedGrandchild
--- FAIL: TestReconcileStalled_ExemptsParentParkedOnOperatorPausedChild
--- FAIL: TestReconcileStalled_StillReapsParkedRunAfterGrace
```

Three canaries, each falsifying a different half (all reverted; no residue):

- oracle always **false** → the 4 exemption tests go red, the anti-disarm tests stay green;
- oracle always **true** → **all 6 anti-disarm assertions go red** (`ReapsGenuinelySilentRun` ×4, `ReapsWhenDescendantCycles`, `ReapsWhenRunRecordUnreadable`). This is the one that matters: it proves the ticket's acceptance item 6 — *a genuinely silent non-parked run is still reaped* — is not vacuous;
- recursion removed → only the grandchild test goes red.

`task check` exit 0. `-race` on `pkg/dispatcher` green, including the two pre-existing stall tests. Acceptance items 4 and 5 are covered upstream and re-run green (`TestServiceLaunch_SubbotChildHumanGate_ParkAndResume`, `TestServiceLaunch_SubbotReattachAfterRestart`). `openapi.json` unchanged — no persisted or API-exposed struct moved.

Follow-up left out deliberately, not overlooked: projecting the exemption on the dashboard (`RunningView` gaining an *awaiting input (subbot)* flag) would deliver the visible half of option (1) cheaply, but it changes an API-exposed struct and would collide with concurrent work; today the exemption is visible as a log line.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
