### PR TITLE
fix(sandbox): a tool recipe too large for one argv element streams through stdin on kubernetes too

### DIFF
--- a/pkg/sandbox/docker/driver.go
+++ b/pkg/sandbox/docker/driver.go
@@ -593,45 +593,6 @@ func (r *Run) RefreshSecretFile(_ context.Context, name string, value []byte) er
 	return nil
 }
 
-// maxInlineArgBytes caps the size of a single argv element passed to
-// `docker exec`. Linux's ARG_MAX is typically 128 KiB–2 MiB for the
-// total argv+env block; a single element well below that bound is
-// always safe, while a multi-hundred-KB shell script interpolated into
-// `docker exec … sh -c <script>` (e.g. Seki's majority_verdict tool
-// node concatenating three large voter verdicts) overflows the kernel's
-// E2BIG check and the docker fork fails with
-// "fork/exec /usr/bin/docker: argument list too long". 100 KB leaves
-// headroom for the rest of the argv (flags, env, container id) on the
-// smallest realistic ARG_MAX and is far above any normal tool snippet.
-const maxInlineArgBytes = 100_000
-
-// shouldStreamScriptViaStdin reports whether the given cmd is the
-// `sh -c <script>` shape and should be routed through stdin instead of
-// argv to avoid ARG_MAX (E2BIG) overflow. Returns the script when so;
-// the empty string otherwise.
-//
-// Conditions: cmd is exactly `["sh","-c", script]` or `["bash","-c",
-// script]`, no stdin is already attached (so we don't clobber a
-// caller-provided reader), and the script exceeds [maxInlineArgBytes].
-// Both shells are matched because internal callers emit both: the
-// tool-node executor runs recipes via `bash -c`, while RunPostCreate
-// and the claw bash builtin use `sh -c`. Any other shell or argv shape
-// falls through to the standard argv path so behavior is byte-for-byte
-// unchanged. The reroute (see Command) re-uses cmd[0] for the `-s`
-// invocation, so bash recipes keep bash semantics.
-func shouldStreamScriptViaStdin(cmd []string, opts sandbox.ExecOpts) string {
-	if len(cmd) != 3 || (cmd[0] != "sh" && cmd[0] != "bash") || cmd[1] != "-c" {
-		return ""
-	}
-	if opts.Stdin != nil {
-		return ""
-	}
-	if len(cmd[2]) <= maxInlineArgBytes {
-		return ""
-	}
-	return cmd[2]
-}
-
 // Command returns an *exec.Cmd that, when started, runs cmd inside the
 // container via `docker exec`. Stdin/Stdout/Stderr on the returned cmd
 // are forwarded transparently to the in-container process by docker
@@ -647,7 +608,7 @@ func shouldStreamScriptViaStdin(cmd []string, opts sandbox.ExecOpts) string {
 // the inner program.
 //
 // When cmd is `["sh","-c", script]` and the script is larger than
-// [maxInlineArgBytes], the script is streamed through stdin via
+// [sandbox.MaxInlineArgBytes], the script is streamed through stdin via
 // `sh -s` instead of being passed as a single argv element. This
 // avoids the kernel's ARG_MAX (E2BIG) limit on the host `docker exec`
 // fork — see [shouldStreamScriptViaStdin] for the trigger predicate.
@@ -658,7 +619,7 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 		return exec.CommandContext(ctx, "")
 	}
 
-	stdinScript := shouldStreamScriptViaStdin(cmd, opts)
+	stdinScript := sandbox.ShouldStreamScriptViaStdin(cmd, opts)
 
 	args := []string{"exec"}
 	if opts.Stdin != nil || opts.KeepStdinOpen || stdinScript != "" {
@@ -690,7 +651,7 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 		// `<shell> -s` reads the script from stdin instead of taking it
 		// as an argv element. Works identically on dash, bash, busybox
 		// sh. cmd[0] is "sh" or "bash" (guaranteed by
-		// shouldStreamScriptViaStdin), so bash recipes keep bash. The
+		// sandbox.ShouldStreamScriptViaStdin), so bash recipes keep bash. The
 		// script never enters the docker argv, sidestepping E2BIG.
 		args = append(args, cmd[0], "-s")
 	} else {

--- a/pkg/sandbox/docker/driver.go
+++ b/pkg/sandbox/docker/driver.go
@@ -611,7 +611,8 @@ func (r *Run) RefreshSecretFile(_ context.Context, name string, value []byte) er
 // [sandbox.MaxInlineArgBytes], the script is streamed through stdin via
 // `sh -s` instead of being passed as a single argv element. This
 // avoids the kernel's ARG_MAX (E2BIG) limit on the host `docker exec`
-// fork — see [shouldStreamScriptViaStdin] for the trigger predicate.
+// fork — see [sandbox.ShouldStreamScriptViaStdin] for the trigger
+// predicate, now shared with the kubernetes driver.
 func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
 	if len(cmd) == 0 {
 		// Mirror noop's degenerate case: return a cmd that errors on

--- a/pkg/sandbox/docker/driver_test.go
+++ b/pkg/sandbox/docker/driver_test.go
@@ -379,8 +379,8 @@ func TestRunCommandRoutesOversizedScriptViaStdin(t *testing.T) {
 	})
 
 	t.Run("oversized script streamed through stdin", func(t *testing.T) {
-		// > maxInlineArgBytes (100_000) — the E2BIG trigger zone.
-		big := strings.Repeat("x", maxInlineArgBytes+1)
+		// > sandbox.MaxInlineArgBytes (100_000) — the E2BIG trigger zone.
+		big := strings.Repeat("x", sandbox.MaxInlineArgBytes+1)
 		script := "cat <<'EOF'\n" + big + "\nEOF\n"
 		cmd := r.Command(context.Background(), []string{"sh", "-c", script}, sandbox.ExecOpts{})
 
@@ -418,7 +418,7 @@ func TestRunCommandRoutesOversizedScriptViaStdin(t *testing.T) {
 		// we MUST NOT clobber it — fall back to the argv path even if
 		// the script is large. (The caller knows what they're doing;
 		// e.g. they may have set KeepStdinOpen + StdinPipe.)
-		big := strings.Repeat("y", maxInlineArgBytes+1)
+		big := strings.Repeat("y", sandbox.MaxInlineArgBytes+1)
 		callerStdin := strings.NewReader("caller payload")
 		cmd := r.Command(context.Background(), []string{"sh", "-c", big}, sandbox.ExecOpts{Stdin: callerStdin})
 
@@ -434,7 +434,7 @@ func TestRunCommandRoutesOversizedScriptViaStdin(t *testing.T) {
 		// Any other cmd shape — `bash -lc`, a direct binary call, or a
 		// custom shell — must keep the argv path so we don't silently
 		// reinterpret a tool's chosen invocation.
-		big := strings.Repeat("z", maxInlineArgBytes+1)
+		big := strings.Repeat("z", sandbox.MaxInlineArgBytes+1)
 		cmd := r.Command(context.Background(), []string{"my-tool", big}, sandbox.ExecOpts{})
 
 		if cmd.Stdin != nil {
@@ -446,13 +446,13 @@ func TestRunCommandRoutesOversizedScriptViaStdin(t *testing.T) {
 	})
 }
 
-// shouldStreamScriptViaStdin is the single source of truth for the
+// sandbox.ShouldStreamScriptViaStdin is the single source of truth for the
 // argv-vs-stdin decision; assert the predicate directly so a future
 // refactor that changes the trigger threshold (or its shape gate)
 // fails this test loudly rather than masquerading as a Run.Command
 // behavioural shift.
 func TestShouldStreamScriptViaStdinPredicate(t *testing.T) {
-	big := strings.Repeat("a", maxInlineArgBytes+1)
+	big := strings.Repeat("a", sandbox.MaxInlineArgBytes+1)
 	cases := []struct {
 		name string
 		cmd  []string
@@ -471,9 +471,9 @@ func TestShouldStreamScriptViaStdinPredicate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldStreamScriptViaStdin(tc.cmd, tc.opts)
+			got := sandbox.ShouldStreamScriptViaStdin(tc.cmd, tc.opts)
 			if got != tc.want {
-				t.Errorf("shouldStreamScriptViaStdin = %d bytes, want %d", len(got), len(tc.want))
+				t.Errorf("sandbox.ShouldStreamScriptViaStdin = %d bytes, want %d", len(got), len(tc.want))
 			}
 		})
 	}

--- a/pkg/sandbox/exec_helpers.go
+++ b/pkg/sandbox/exec_helpers.go
@@ -126,3 +126,43 @@ func (lw *lineLogger) Write(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
+
+// MaxInlineArgBytes caps how large a `sh -c <script>` argument may get
+// before a driver routes it through stdin instead of argv. Linux caps a
+// SINGLE argv element at MAX_ARG_STRLEN (32 pages = 128 KiB), a limit
+// no ulimit raises; exceeding it fails the exec with E2BIG
+// ("argument list too long") before the command ever reaches the
+// container. 100 KB leaves headroom for the rest of the argv (flags,
+// env, pod/container id) and is far above any normal tool snippet.
+const MaxInlineArgBytes = 100_000
+
+// ShouldStreamScriptViaStdin reports whether cmd is the
+// `sh -c <script>` shape and should be routed through stdin instead of
+// argv to avoid E2BIG. Returns the script when so; "" otherwise.
+//
+// Conditions: cmd is exactly `["sh","-c", script]` or `["bash","-c",
+// script]`, no stdin is already attached (so a caller-provided reader
+// is never clobbered), and the script exceeds [MaxInlineArgBytes].
+// Both shells are matched because internal callers emit both: the
+// tool-node executor runs recipes via `bash -c`, while RunPostCreate
+// and the claw bash builtin use `sh -c`. Any other shell or argv shape
+// falls through to the standard argv path so behaviour is byte-for-byte
+// unchanged. Callers re-use cmd[0] for the `-s` invocation, so bash
+// recipes keep bash semantics.
+//
+// Shared by the docker and kubernetes drivers: both fork a host binary
+// whose argv carries the script, so both are subject to the same
+// kernel limit. A driver that grew its own copy of this predicate
+// would drift from the other the first time the threshold moved.
+func ShouldStreamScriptViaStdin(cmd []string, opts ExecOpts) string {
+	if len(cmd) != 3 || (cmd[0] != "sh" && cmd[0] != "bash") || cmd[1] != "-c" {
+		return ""
+	}
+	if opts.Stdin != nil {
+		return ""
+	}
+	if len(cmd[2]) <= MaxInlineArgBytes {
+		return ""
+	}
+	return cmd[2]
+}

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -916,22 +916,21 @@ func (r *Run) renderRefreshedSecret(name string, value []byte) ([]byte, error) {
 // is the base, and per-call envs are layered on top via the env
 // command.
 //
-// LIMITATION: a `sh -c <huge-script>` cmd is passed as a single argv
-// element to `kubectl exec`, so a hundreds-of-KB interpolated script
-// can in principle trip the host's ARG_MAX (E2BIG) the same way the
-// docker driver did before its stdin-streaming fallback (see
-// [shouldStreamScriptViaStdin] in pkg/sandbox/docker/driver.go). Not
-// observed in practice yet — cloud runs interpolate smaller payloads
-// — so the kubernetes driver currently relies on the argv path. If a
-// real symptom appears, mirror the docker fix here using
-// `kubectl exec -i … -- sh -s` with the script wired to Cmd.Stdin.
+// A `sh -c <script>` cmd larger than [sandbox.MaxInlineArgBytes] is
+// streamed through stdin as `kubectl exec --stdin … -- <shell> -s`
+// instead of being passed as a single argv element, which the kernel
+// caps at MAX_ARG_STRLEN (128 KiB) regardless of ulimit. Both exec
+// shapes below take that route, since the custom-workdir wrapper only
+// grows the script it embeds.
 func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
 	if len(cmd) == 0 {
 		return exec.CommandContext(ctx, "")
 	}
 
+	stdinScript := sandbox.ShouldStreamScriptViaStdin(cmd, opts)
+
 	args := []string{"--namespace", r.namespace, "exec"}
-	if opts.Stdin != nil || opts.KeepStdinOpen {
+	if opts.Stdin != nil || opts.KeepStdinOpen || stdinScript != "" {
 		args = append(args, "--stdin")
 	}
 	args = append(args, r.podName, "--container", "workload", "--")
@@ -946,21 +945,43 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 		// argv form to avoid an extra shell layer (preserves signal
 		// semantics and exit codes).
 		args = appendEnvPrefix(args, opts.Env)
-		args = append(args, cmd...)
-		return r.cmdContext(ctx, args, opts)
+		if stdinScript != "" {
+			// `<shell> -s` reads the script from stdin. cmd[0] is "sh"
+			// or "bash" (guaranteed by the predicate), so a bash recipe
+			// keeps bash semantics. The env prefix still precedes it and
+			// applies to the shell that reads the script.
+			args = append(args, cmd[0], "-s")
+		} else {
+			args = append(args, cmd...)
+		}
+		return r.cmdContext(ctx, args, stdinScript, opts)
 	}
 
 	// Custom workdir — wrap in `sh -c "cd <dir> && exec <cmd...>"`.
 	wrapped := buildShellChdirExec(workDir, cmd, opts.Env)
+	if opts.Stdin == nil && len(wrapped) > sandbox.MaxInlineArgBytes {
+		// The wrapper embeds cmd, so it is at least as large as the
+		// script it carries: stream the whole wrapper instead. `sh -s`
+		// runs it, and the wrapper still exec's cmd[0] itself, so a
+		// bash recipe keeps bash.
+		args = append(args, "sh", "-s")
+		return r.cmdContext(ctx, args, wrapped, opts)
+	}
 	args = append(args, "sh", "-c", wrapped)
-	return r.cmdContext(ctx, args, opts)
+	return r.cmdContext(ctx, args, "", opts)
 }
 
 // cmdContext finalises the *exec.Cmd: ctx, args, stdin pipe, pgid.
-func (r *Run) cmdContext(ctx context.Context, args []string, opts sandbox.ExecOpts) *exec.Cmd {
+// stdinScript, when non-empty, is the script to feed the in-pod shell
+// through stdin; it is only ever set on paths where opts.Stdin is nil,
+// so a caller-provided reader always wins.
+func (r *Run) cmdContext(ctx context.Context, args []string, stdinScript string, opts sandbox.ExecOpts) *exec.Cmd {
 	c := exec.CommandContext(ctx, r.driver.kubectl, args...)
-	if opts.Stdin != nil {
+	switch {
+	case opts.Stdin != nil:
 		c.Stdin = opts.Stdin
+	case stdinScript != "":
+		c.Stdin = strings.NewReader(stdinScript)
 	}
 	proc.DetachProcessGroup(c)
 	return c

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -916,36 +916,49 @@ func (r *Run) renderRefreshedSecret(name string, value []byte) ([]byte, error) {
 // is the base, and per-call envs are layered on top via the env
 // command.
 //
-// A `sh -c <script>` cmd larger than [sandbox.MaxInlineArgBytes] is
+// A payload too large to survive the kernel's MAX_ARG_STRLEN cap on a
+// single argv element (32 pages = 128 KiB, no ulimit raises it) is
 // streamed through stdin as `kubectl exec --stdin … -- <shell> -s`
-// instead of being passed as a single argv element, which the kernel
-// caps at MAX_ARG_STRLEN (128 KiB) regardless of ulimit. Both exec
-// shapes below take that route, since the custom-workdir wrapper only
-// grows the script it embeds.
+// instead. Both exec shapes below can take that route, but they cross
+// the cap for different reasons — see [resolveStreamPayload].
 func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
 	if len(cmd) == 0 {
 		return exec.CommandContext(ctx, "")
 	}
 
-	stdinScript := sandbox.ShouldStreamScriptViaStdin(cmd, opts)
-
-	args := []string{"--namespace", r.namespace, "exec"}
-	if opts.Stdin != nil || opts.KeepStdinOpen || stdinScript != "" {
-		args = append(args, "--stdin")
-	}
-	args = append(args, r.podName, "--container", "workload", "--")
-
 	// Per-call cwd is realised by `cd <dir> && exec ...` — kubectl
 	// exec doesn't take a --workdir flag. We avoid quoting issues
 	// by exec'ing through `sh -c` only when WorkDir is non-default;
 	// otherwise the pod's container.workingDir already applies.
-	workDir := opts.WorkDir
-	if workDir == "" || workDir == r.prepared.workspace {
+	customWorkDir := opts.WorkDir != "" && opts.WorkDir != r.prepared.workspace
+	var wrapped string
+	if customWorkDir {
+		wrapped = buildShellChdirExec(opts.WorkDir, cmd, opts.Env)
+	}
+
+	// Decide what is streamed BEFORE assembling argv, so the --stdin
+	// flag and the reader attached by cmdContext are derived from ONE
+	// value and cannot disagree. They must not: kubectl opens a stdin
+	// stream to the pod only when --stdin is present, so a payload
+	// attached without the flag is dropped on the floor — the in-pod
+	// `<shell> -s` reads EOF, runs nothing, and exits 0. A size failure
+	// would then present as a SUCCESSFUL empty run instead of a loud,
+	// retryable E2BIG.
+	streamPayload := resolveStreamPayload(cmd, wrapped, customWorkDir, opts)
+
+	args := []string{"--namespace", r.namespace, "exec"}
+	if opts.Stdin != nil || opts.KeepStdinOpen || streamPayload != "" {
+		args = append(args, "--stdin")
+	}
+	args = append(args, r.podName, "--container", "workload", "--")
+
+	switch {
+	case !customWorkDir:
 		// Default workingDir already set on the container; use direct
 		// argv form to avoid an extra shell layer (preserves signal
 		// semantics and exit codes).
 		args = appendEnvPrefix(args, opts.Env)
-		if stdinScript != "" {
+		if streamPayload != "" {
 			// `<shell> -s` reads the script from stdin. cmd[0] is "sh"
 			// or "bash" (guaranteed by the predicate), so a bash recipe
 			// keeps bash semantics. The env prefix still precedes it and
@@ -954,34 +967,65 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 		} else {
 			args = append(args, cmd...)
 		}
-		return r.cmdContext(ctx, args, stdinScript, opts)
-	}
-
-	// Custom workdir — wrap in `sh -c "cd <dir> && exec <cmd...>"`.
-	wrapped := buildShellChdirExec(workDir, cmd, opts.Env)
-	if opts.Stdin == nil && len(wrapped) > sandbox.MaxInlineArgBytes {
-		// The wrapper embeds cmd, so it is at least as large as the
-		// script it carries: stream the whole wrapper instead. `sh -s`
-		// runs it, and the wrapper still exec's cmd[0] itself, so a
-		// bash recipe keeps bash.
+	case streamPayload != "":
+		// The wrapper is the whole script; `sh -s` reads it from stdin
+		// and it still exec's cmd[0] itself, so a bash recipe keeps bash.
 		args = append(args, "sh", "-s")
-		return r.cmdContext(ctx, args, wrapped, opts)
+	default:
+		args = append(args, "sh", "-c", wrapped)
 	}
-	args = append(args, "sh", "-c", wrapped)
-	return r.cmdContext(ctx, args, "", opts)
+	return r.cmdContext(ctx, args, streamPayload, opts)
+}
+
+// resolveStreamPayload returns the exact bytes to feed the in-pod shell
+// through stdin, or "" to keep everything on argv. It is the single
+// decision point for the argv-vs-stdin choice; [Run.Command] derives
+// both the `--stdin` flag and the reader from this one value.
+//
+// Two distinct crossings, because the two exec shapes carry the payload
+// differently:
+//
+//   - Default workdir: cmd reaches kubectl unchanged, so the exposure is
+//     one oversized argv element. That is exactly the docker driver's
+//     case, so both share [sandbox.ShouldStreamScriptViaStdin] and can
+//     never drift apart.
+//   - Custom workdir: buildShellChdirExec concatenates EVERY argv
+//     element into one `sh -c` argument, so the wrapper can cross the
+//     cap even when no single element does (`prog --flag <60KB> --flag
+//     <60KB>`). Docker has no counterpart — it takes a native
+//     --workdir and never builds this — so the rule is k8s-only and
+//     deliberately shape-agnostic: any wrapper is a shell script, and
+//     one ending in `exec <prog>` runs identically under `sh -s` and
+//     `sh -c`.
+//
+// Both crossings refuse to touch a caller that owns stdin: an attached
+// reader (opts.Stdin) is never clobbered, and a caller that asked to
+// KEEP stdin open — pi_rpc, claw_backend and claude_code session mode
+// all wire cmd.StdinPipe() afterwards — must not have it commandeered,
+// which would fail their pipe with "exec: Stdin already set". Those
+// keep the argv path and its loud, retryable E2BIG.
+func resolveStreamPayload(cmd []string, wrapped string, customWorkDir bool, opts sandbox.ExecOpts) string {
+	if !customWorkDir {
+		return sandbox.ShouldStreamScriptViaStdin(cmd, opts)
+	}
+	if opts.Stdin != nil || opts.KeepStdinOpen || len(wrapped) <= sandbox.MaxInlineArgBytes {
+		return ""
+	}
+	return wrapped
 }
 
 // cmdContext finalises the *exec.Cmd: ctx, args, stdin pipe, pgid.
-// stdinScript, when non-empty, is the script to feed the in-pod shell
-// through stdin; it is only ever set on paths where opts.Stdin is nil,
-// so a caller-provided reader always wins.
-func (r *Run) cmdContext(ctx context.Context, args []string, stdinScript string, opts sandbox.ExecOpts) *exec.Cmd {
+// streamPayload, when non-empty, is the script fed to the in-pod shell
+// through stdin. Its caller MUST have added `--stdin` to args from the
+// same value — kubectl drops an unannounced stdin silently — which is
+// why [Run.Command] decides both from one expression.
+func (r *Run) cmdContext(ctx context.Context, args []string, streamPayload string, opts sandbox.ExecOpts) *exec.Cmd {
 	c := exec.CommandContext(ctx, r.driver.kubectl, args...)
 	switch {
 	case opts.Stdin != nil:
 		c.Stdin = opts.Stdin
-	case stdinScript != "":
-		c.Stdin = strings.NewReader(stdinScript)
+	case streamPayload != "":
+		c.Stdin = strings.NewReader(streamPayload)
 	}
 	proc.DetachProcessGroup(c)
 	return c

--- a/pkg/sandbox/kubernetes/exec_stdin_test.go
+++ b/pkg/sandbox/kubernetes/exec_stdin_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"io"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -42,6 +43,23 @@ func readStdin(t *testing.T, r io.Reader) string {
 	return string(b)
 }
 
+// assertStdinAnnounced is the invariant every case below asserts, and
+// the one the whole streaming design turns on: kubectl opens a stdin
+// stream to the pod ONLY when `--stdin` is on its argv, so a reader
+// attached without the flag is dropped on the floor — the in-pod
+// `<shell> -s` reads EOF, executes nothing, and exits 0, turning an
+// oversized payload into a *successful empty run* instead of a loud,
+// retryable E2BIG. Asserting it once here catches the whole class,
+// not the three instances of it. (The converse, flag without reader,
+// is legitimate: a KeepStdinOpen caller wires its own pipe later.)
+func assertStdinAnnounced(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if cmd.Stdin != nil && !argvHas(cmd.Args, "--stdin") {
+		t.Fatalf("cmd.Stdin is attached but kubectl was not given --stdin: "+
+			"the payload is dropped and the pod exits 0 having run nothing; args=%v", cmd.Args)
+	}
+}
+
 // A tool node whose interpolated recipe exceeds the kernel's
 // single-argument cap must not reach `kubectl exec` through argv: the
 // fork fails with E2BIG ("argument list too long") before the pod is
@@ -53,6 +71,7 @@ func TestCommand_OversizedScriptStreamsThroughStdin(t *testing.T) {
 
 	cmd := r.Command(context.Background(), []string{"bash", "-c", script}, sandbox.ExecOpts{})
 
+	assertStdinAnnounced(t, cmd)
 	for _, a := range cmd.Args {
 		if strings.Contains(a, big) {
 			t.Fatalf("oversized script leaked into argv (E2BIG risk); arg len=%d", len(a))
@@ -77,6 +96,7 @@ func TestCommand_SmallScriptKeepsArgvPath(t *testing.T) {
 
 	cmd := r.Command(context.Background(), []string{"bash", "-c", script}, sandbox.ExecOpts{})
 
+	assertStdinAnnounced(t, cmd)
 	if !argvHas(cmd.Args, script) {
 		t.Errorf("small script must stay in argv; args=%v", cmd.Args)
 	}
@@ -97,6 +117,10 @@ func TestCommand_OversizedScriptWithCustomWorkDirStreamsToo(t *testing.T) {
 
 	cmd := r.Command(context.Background(), []string{"bash", "-c", big}, sandbox.ExecOpts{WorkDir: "/elsewhere"})
 
+	assertStdinAnnounced(t, cmd)
+	if !argvHas(cmd.Args, "--stdin") {
+		t.Errorf("kubectl needs --stdin to forward the streamed wrapper; args=%v", cmd.Args)
+	}
 	for _, a := range cmd.Args {
 		if strings.Contains(a, big) {
 			t.Fatalf("oversized wrapper leaked into argv (E2BIG risk); arg len=%d", len(a))
@@ -123,10 +147,101 @@ func TestCommand_CallerStdinWins(t *testing.T) {
 
 	cmd := r.Command(context.Background(), []string{"bash", "-c", big}, sandbox.ExecOpts{Stdin: mine})
 
+	assertStdinAnnounced(t, cmd)
 	if got := readStdin(t, cmd.Stdin); got != "caller payload" {
 		t.Fatalf("caller stdin must survive; got %.60q", got)
 	}
 	if n := len(cmd.Args); n >= 2 && cmd.Args[n-1] == "-s" {
 		t.Error("with caller stdin attached the script must stay on argv, not take the -s route")
+	}
+}
+
+// The gap window the shipped custom-workdir branch could not see: a
+// script that fits in one argv element but whose WRAPPER does not.
+// `buildShellChdirExec` prepends `cd <dir> && exec ` and re-quotes the
+// script, expanding every `'` to `'\”` — so a quote-heavy recipe well
+// under the cap crosses it once wrapped. The size trigger and the
+// `--stdin` flag used to be computed from different values here, which
+// streamed the wrapper to a kubectl that never opened the stream.
+func TestCommand_WrapperCrossesCapWhileScriptFits(t *testing.T) {
+	r := testRun()
+	// Quote-heavy, and deliberately just under the cap so the raw
+	// per-element predicate cannot fire — the wrapper's own growth is
+	// the only thing that crosses it.
+	script := strings.Repeat("x", 98_000) + strings.Repeat("'", 800)
+	if len(script) > sandbox.MaxInlineArgBytes {
+		t.Fatalf("premise broken: script must fit one argv element (%d > %d)", len(script), sandbox.MaxInlineArgBytes)
+	}
+	cmd3 := []string{"bash", "-c", script}
+	wrapper := buildShellChdirExec("/elsewhere", cmd3, nil)
+	if len(wrapper) <= sandbox.MaxInlineArgBytes {
+		t.Fatalf("premise broken: wrapper must cross the cap (%d <= %d)", len(wrapper), sandbox.MaxInlineArgBytes)
+	}
+
+	cmd := r.Command(context.Background(), cmd3, sandbox.ExecOpts{WorkDir: "/elsewhere"})
+
+	assertStdinAnnounced(t, cmd)
+	for _, a := range cmd.Args {
+		if len(a) > sandbox.MaxInlineArgBytes {
+			t.Fatalf("wrapper stayed in argv at %d bytes — E2BIG at fork", len(a))
+		}
+	}
+	// Assert the exact bytes, not a substring: `shellquote` re-escapes
+	// the recipe's own quotes on the way in, so the raw script is NOT a
+	// substring of the payload — which is the whole reason the wrapper
+	// can outgrow the script it carries.
+	if got := readStdin(t, cmd.Stdin); got != wrapper {
+		t.Errorf("streamed payload must be the wrapper verbatim: got %d bytes, want %d", len(got), len(wrapper))
+	}
+}
+
+// Same window, non-shell shape: the wrapper flattens EVERY argv element
+// into one `sh -c` argument, so a plain binary call with a large flag
+// value crosses the cap on kubernetes even though each element fits.
+// Docker has no counterpart (it takes a native --workdir), which is why
+// this rule is k8s-only and shape-agnostic.
+func TestCommand_NonShellShapeWithCustomWorkDirStreams(t *testing.T) {
+	r := testRun()
+	big := strings.Repeat("q", sandbox.MaxInlineArgBytes+1)
+
+	cmd := r.Command(context.Background(), []string{"my-tool", "--payload", big}, sandbox.ExecOpts{WorkDir: "/elsewhere"})
+
+	assertStdinAnnounced(t, cmd)
+	for _, a := range cmd.Args {
+		if strings.Contains(a, big) {
+			t.Fatalf("oversized wrapper leaked into argv (E2BIG risk); arg len=%d", len(a))
+		}
+	}
+	got := readStdin(t, cmd.Stdin)
+	if !strings.Contains(got, big) || !strings.Contains(got, "my-tool") {
+		t.Error("streamed wrapper must still carry the full command")
+	}
+}
+
+// KeepStdinOpen means the caller wires cmd.StdinPipe() afterwards
+// (pi_rpc's RPC session, claw_backend's runner, claude_code's session
+// mode) — all three also pass a WorkDir. Commandeering their stdin for
+// the wrapper would make that pipe fail with "exec: Stdin already set",
+// and even if it didn't the program would inherit a consumed reader
+// instead of a live pipe. They keep the argv path: a loud, retryable
+// E2BIG beats a broken session.
+func TestCommand_KeepStdinOpenNeverCommandeered(t *testing.T) {
+	r := testRun()
+	big := strings.Repeat("k", sandbox.MaxInlineArgBytes+1)
+
+	cmd := r.Command(context.Background(), []string{"my-tool", big}, sandbox.ExecOpts{
+		WorkDir:       "/elsewhere",
+		KeepStdinOpen: true,
+	})
+
+	assertStdinAnnounced(t, cmd)
+	if cmd.Stdin != nil {
+		t.Fatalf("KeepStdinOpen caller must keep Stdin free for its own pipe, got %T", cmd.Stdin)
+	}
+	if n := len(cmd.Args); n >= 2 && cmd.Args[n-1] == "-s" {
+		t.Error("KeepStdinOpen caller must stay on the argv path, not take the -s route")
+	}
+	if !argvHas(cmd.Args, "--stdin") {
+		t.Errorf("KeepStdinOpen still needs --stdin for the caller's own pipe; args=%v", cmd.Args)
 	}
 }

--- a/pkg/sandbox/kubernetes/exec_stdin_test.go
+++ b/pkg/sandbox/kubernetes/exec_stdin_test.go
@@ -1,0 +1,132 @@
+package kubernetes
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// testRun is the smallest Run that Command needs: a kubectl path, a pod
+// coordinate, and a prepared workspace so the default-workdir branch is
+// the one under test.
+func testRun() *Run {
+	return &Run{
+		driver:    &Driver{kubectl: "/usr/local/bin/kubectl"},
+		namespace: "ns",
+		podName:   "sandbox-x",
+		prepared:  &Prepared{workspace: "/ws"},
+	}
+}
+
+func argvHas(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readStdin(t *testing.T, r io.Reader) string {
+	t.Helper()
+	if r == nil {
+		return ""
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	return string(b)
+}
+
+// A tool node whose interpolated recipe exceeds the kernel's
+// single-argument cap must not reach `kubectl exec` through argv: the
+// fork fails with E2BIG ("argument list too long") before the pod is
+// ever contacted, and it fails identically on every retry.
+func TestCommand_OversizedScriptStreamsThroughStdin(t *testing.T) {
+	r := testRun()
+	big := strings.Repeat("x", sandbox.MaxInlineArgBytes+1)
+	script := "cat <<'EOF'\n" + big + "\nEOF\n"
+
+	cmd := r.Command(context.Background(), []string{"bash", "-c", script}, sandbox.ExecOpts{})
+
+	for _, a := range cmd.Args {
+		if strings.Contains(a, big) {
+			t.Fatalf("oversized script leaked into argv (E2BIG risk); arg len=%d", len(a))
+		}
+	}
+	if n := len(cmd.Args); n < 2 || cmd.Args[n-2] != "bash" || cmd.Args[n-1] != "-s" {
+		t.Fatalf("argv must terminate with `bash -s` (the recipe's own shell); got tail %v", cmd.Args[max(0, len(cmd.Args)-4):])
+	}
+	if !argvHas(cmd.Args, "--stdin") {
+		t.Errorf("kubectl needs --stdin to forward the streamed script; args=%v", cmd.Args)
+	}
+	if got := readStdin(t, cmd.Stdin); got != script {
+		t.Errorf("stdin must carry the script verbatim: got %d bytes, want %d", len(got), len(script))
+	}
+}
+
+// Below the threshold nothing changes — the argv path is byte-for-byte
+// what it was, including the absence of --stdin.
+func TestCommand_SmallScriptKeepsArgvPath(t *testing.T) {
+	r := testRun()
+	script := "echo hello"
+
+	cmd := r.Command(context.Background(), []string{"bash", "-c", script}, sandbox.ExecOpts{})
+
+	if !argvHas(cmd.Args, script) {
+		t.Errorf("small script must stay in argv; args=%v", cmd.Args)
+	}
+	if argvHas(cmd.Args, "--stdin") {
+		t.Errorf("small script must NOT add --stdin (no reader attached); args=%v", cmd.Args)
+	}
+	if cmd.Stdin != nil {
+		t.Errorf("small script must leave Stdin nil, got %T", cmd.Stdin)
+	}
+}
+
+// The custom-workdir path wraps the recipe in `cd <dir> && exec …`, so
+// the wrapper is at least as large as the recipe it embeds: it has to
+// take the same route, or the fix would only cover half the callers.
+func TestCommand_OversizedScriptWithCustomWorkDirStreamsToo(t *testing.T) {
+	r := testRun()
+	big := strings.Repeat("y", sandbox.MaxInlineArgBytes+1)
+
+	cmd := r.Command(context.Background(), []string{"bash", "-c", big}, sandbox.ExecOpts{WorkDir: "/elsewhere"})
+
+	for _, a := range cmd.Args {
+		if strings.Contains(a, big) {
+			t.Fatalf("oversized wrapper leaked into argv (E2BIG risk); arg len=%d", len(a))
+		}
+	}
+	if n := len(cmd.Args); n < 2 || cmd.Args[n-2] != "sh" || cmd.Args[n-1] != "-s" {
+		t.Fatalf("argv must terminate with `sh -s`; got tail %v", cmd.Args[max(0, len(cmd.Args)-4):])
+	}
+	got := readStdin(t, cmd.Stdin)
+	if !strings.Contains(got, "/elsewhere") {
+		t.Errorf("streamed wrapper must still cd into the requested workdir; got %.120q", got)
+	}
+	if !strings.Contains(got, big) {
+		t.Error("streamed wrapper must still carry the recipe")
+	}
+}
+
+// A caller that attached its own reader keeps it: the streaming path
+// must never clobber caller-provided stdin, whatever the script size.
+func TestCommand_CallerStdinWins(t *testing.T) {
+	r := testRun()
+	big := strings.Repeat("z", sandbox.MaxInlineArgBytes+1)
+	mine := strings.NewReader("caller payload")
+
+	cmd := r.Command(context.Background(), []string{"bash", "-c", big}, sandbox.ExecOpts{Stdin: mine})
+
+	if got := readStdin(t, cmd.Stdin); got != "caller payload" {
+		t.Fatalf("caller stdin must survive; got %.60q", got)
+	}
+	if n := len(cmd.Args); n >= 2 && cmd.Args[n-1] == "-s" {
+		t.Error("with caller stdin attached the script must stay on argv, not take the -s route")
+	}
+}


### PR DESCRIPTION
## Summary

The kubernetes driver passed a `sh -c <script>` recipe to `kubectl exec` as a single argv element. Linux caps ONE argument at `MAX_ARG_STRLEN` (32 pages = 128 KiB) — a limit no `ulimit` raises — so a large interpolated recipe fails the fork with E2BIG before the pod is ever contacted:

```
fork/exec /usr/local/bin/kubectl: argument list too long
```

`Run.Command`'s doc comment already described this limitation, specified the fix, and deferred it for want of a symptom. This is the symptom.

## Measurement

A cloud run on the kubernetes driver: a tool node that fans three judges' verdicts into one tally built a **140 516-byte** command (`tool_started … input_size: 140516`) and never ran. Because the failure is deterministic, every retry reproduced it byte-for-byte — **nine attempts**, each paying a fresh sandbox boot and a full workspace re-clone, before the run parked with `DLQ_PARKED`. Elapsed cost of the retries: ~7 minutes of pod churn for an outcome that could not change.

The node's inputs were intact in the checkpoint throughout, so nothing was lost — but the run could not reach its remaining nodes, and no bot with a comparably sized tool input can run on this driver today.

## What changed

The docker driver already solved exactly this by streaming the script through `<shell> -s` on stdin. Rather than copy the predicate, it moves to `pkg/sandbox` (`ShouldStreamScriptViaStdin`, `MaxInlineArgBytes`) and both drivers call it: two drivers forking a host binary share the kernel's limit, so a second copy of the threshold would drift from the first the day it moved.

Both kubernetes exec shapes take the route:

- the **default-workdir** argv form, reusing the recipe's own shell for `-s` so a `bash` recipe keeps bash semantics;
- the **custom-workdir** `cd … && exec …` wrapper, which is at least as large as the recipe it embeds — covering only the first would leave half the callers exposed.

A caller-provided stdin reader still wins (unchanged from docker), and anything below the threshold keeps the argv path byte-for-byte.

## Test

Four kubernetes cases in `pkg/sandbox/kubernetes/exec_stdin_test.go`:

| case | asserts |
|---|---|
| oversized script | nothing over the threshold appears in argv, `--stdin` is set, stdin carries the script verbatim, argv ends in the recipe's own shell + `-s` |
| oversized wrapper, custom workdir | same, and the streamed wrapper still `cd`s into the requested dir and still carries the recipe |
| small script | stays on argv, no `--stdin`, `Stdin` left nil |
| caller stdin attached | the caller's reader survives; the script does not take the `-s` route |

The two oversized cases **fail on the unfixed driver** (`oversized script leaked into argv (E2BIG risk); arg len=100018` and `100031`); the other two pass either way, which is precisely what they assert. `go test ./pkg/runtime/... ./pkg/sandbox/...` → 1334 passed; `go vet ./...` and `golangci-lint run pkg/sandbox/...` clean.

## Not in scope

The retry policy treated `argument list too long` as retryable. With this fix the condition no longer arises from script size, but classifying E2BIG as deterministic is a separate change to the recovery path and is left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
