### PR TITLE
fix(server): a team's forked bot serves every launch surface, not only the manual one

### DIFF
--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -45,7 +45,12 @@ is CLI-first.
   it launches for (the card's, the subscription's, the schedule's, the
   webhook token's). A team that forks a bot runs its fork on its own
   automation, and every launch records which tier served it
-  (`bot_source_tier`), so a fork is never a silent substitution. Enforced
+  (`bot_source_tier`) **and shows it** — the run API returns it on the run
+  header, the studio badges a `team bot` / `platform override` run beside
+  its bot chip, and *Launched with* names the tier in full. A run that
+  recorded no tier shows nothing rather than defaulting to `baked`: an
+  unresolved tier reading as a working one is the failure mode this whole
+  section exists for. Enforced
   by the central resolver in `pkg/server/bot_resolver.go` and its static
   sweep tests — one of which fails a launch site that hardcodes an empty
   team.

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -39,11 +39,25 @@ is CLI-first.
   compile check as team-authored bots (the pattern platform LLM
   credentials established). Hard limits: 6 MiB / 512 files per bundle.
 - **Resolution precedence** (most specific wins): *team botsource →
-  platform botsource → baked catalog FS*. The team tier applies only on
-  the studio launch surface (a team's experimental fork must not silently
-  hijack its schedules/webhooks); the platform tier applies everywhere a
-  bot id resolves, enforced by the central resolver in
-  `pkg/server/bot_resolver.go` and its static sweep test.
+  platform botsource → baked catalog FS*, on **every launch surface** —
+  the studio button, the board dispatcher, the trigger spine, a cloud
+  schedule and an inbound webhook — because each launcher knows the team
+  it launches for (the card's, the subscription's, the schedule's, the
+  webhook token's). A team that forks a bot runs its fork on its own
+  automation, and every launch records which tier served it
+  (`bot_source_tier`), so a fork is never a silent substitution. Enforced
+  by the central resolver in `pkg/server/bot_resolver.go` and its static
+  sweep tests — one of which fails a launch site that hardcodes an empty
+  team.
+- **The team tier is a LAUNCH tier, not a metadata tier.** Listings,
+  webhook command discovery, hand-off `produces:`/`consumes:` matching,
+  gate-var defaults and the retry-policy manifest read the platform
+  overlay over the baked catalog, with no tenant context — on every
+  surface, including the studio's. So a fork whose `manifest.yaml`
+  differs from its origin's runs as the fork but is *described* by the
+  origin's manifest. The exception is a caller holding the tier a run
+  actually resolved through (`bot_source_tenant`), which reads the team
+  row first (`teamBotManifest`).
 - **Launch**: the server resolves the override ONCE, materializes it to a
   temp dir, and compiles against it (prompts/ participate in IR and the
   workflow hash). The queue message (schema v9) carries a
@@ -60,8 +74,10 @@ is CLI-first.
   resume is REFUSED until you force it (and the auto-retry sweeper, which
   never forces, re-arms then abandons). Same for a deleted row.
 - **Resume re-resolves by ORIGIN, not by path**: the launch persists which
-  tier served the run (`bot_source_tenant` on the run doc — the team, the
-  `platform:` sentinel, or empty for baked). A resume/auto-retry reloads
+  tier served the run — `bot_source_tier` (`team` | `platform` | `baked`)
+  and, for the two stored tiers, the row's owner in `bot_source_tenant`
+  (the team id or the `platform:` sentinel; empty for baked, which is why
+  the tier is its own field). A resume/auto-retry reloads
   the SAME row at its current version; a row deleted mid-run fails the
   resume explicitly (relaunch, or resume with inline source). A run
   launched from the BAKED catalog picks up an override pushed since — the

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -54,15 +54,21 @@ is CLI-first.
   by the central resolver in `pkg/server/bot_resolver.go` and its static
   sweep tests — one of which fails a launch site that hardcodes an empty
   team.
-- **The team tier is a LAUNCH tier, not a metadata tier.** Listings,
-  webhook command discovery, hand-off `produces:`/`consumes:` matching,
-  gate-var defaults and the retry-policy manifest read the platform
-  overlay over the baked catalog, with no tenant context — on every
-  surface, including the studio's. So a fork whose `manifest.yaml`
-  differs from its origin's runs as the fork but is *described* by the
-  origin's manifest. The exception is a caller holding the tier a run
-  actually resolved through (`bot_source_tenant`), which reads the team
-  row first (`teamBotManifest`).
+- **Spelling.** All three tiers tolerate the same variants
+  (`feature_dev` / `Feature-Dev` / `"feature dev"` → `feature-dev`),
+  because a board card, an agent's `set_bot` and a hand-written
+  subscription all carry operator-typed names. A slug may legitimately be
+  stored with `_` too, so the team tier compares both sides normalized.
+- **A metadata read must match the tier that will SERVE the launch**, or
+  the two disagree in silence — a fork that renames a `consumes:` var
+  gets an empty seed, not an error. Wired: the webhook hand-off seeds,
+  the gate-var defaults and the retry-policy manifest all read the team
+  row first (`effectiveFindByNameForTeam` / `botManifestFor`, both over
+  the same row resolution the launch uses). Still tenant-free, and
+  therefore still able to describe a bundle it will not run: the /bots
+  listing, the command-routing discovery, the config-share surface, and
+  the hand-off PRODUCER set (a deployment-wide question a per-team read
+  cannot answer). Tracked as **#946**.
 - **Launch**: the server resolves the override ONCE, materializes it to a
   temp dir, and compiles against it (prompts/ participate in IR and the
   workflow hash). The queue message (schema v9) carries a

--- a/openapi.json
+++ b/openapi.json
@@ -1829,6 +1829,12 @@
             },
             "type": "array"
           },
+          "bot_source_tenant": {
+            "type": "string"
+          },
+          "bot_source_tier": {
+            "type": "string"
+          },
           "budget": {
             "$ref": "#/components/schemas/RunBudget"
           },

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -190,6 +190,12 @@ type LaunchSpec struct {
 	// BotBundle carries the immutable collection and its origin to the cloud
 	// publisher. Nil for loose/inline launches that bypass bundle resolution.
 	BotBundle *BotBundleRef
+	// BotSourceTier names which tier served this launch (store.BotSourceTier*):
+	// team, platform or baked. Persisted on the run so a launch says which
+	// bundle it ran — BotBundle answers it only for the two STORED tiers, and
+	// a baked resolution is otherwise indistinguishable from no resolution at
+	// all. Empty for loose/inline launches.
+	BotSourceTier string
 	// KeyOverrides pins a specific BYOK key per LLM provider for this run
 	// (provider name → api_key id), overriding the org/user default in
 	// secrets.Resolve. Set by webhook launches that carry per-webhook key

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -133,6 +133,20 @@ type RunHeader struct {
 	// targets — the cloud run's repo identity (WorkDir is a runner-pod
 	// path there). Empty for local and repo-less runs.
 	ProjectPath string `json:"project_path,omitempty"`
+	// BotSourceTier is which tier resolved this run's bundle at launch:
+	// store.BotSourceTierTeam (the launching team's own row), …Platform (a
+	// deployment override) or …Baked (the catalog in the image). It answers
+	// "did my fork actually serve this run?" — the question that went
+	// unanswerable while the team tier was inert on four launch surfaces.
+	//
+	// ABSENT, never defaulted: a local run and a run predating the stamp
+	// record no tier, and an unresolved tier must not read as a positive
+	// `baked` claim. Consumers render nothing when it is empty.
+	BotSourceTier string `json:"bot_source_tier,omitempty"`
+	// BotSourceTenant is the owner of the stored row BotSourceTier names —
+	// the team id, or the platform sentinel. Empty on the baked tier (there
+	// is no row) and on an unstamped run.
+	BotSourceTenant string `json:"bot_source_tenant,omitempty"`
 	// Worktree is true when WorkDir was created by `worktree: auto`.
 	Worktree bool `json:"worktree,omitempty"`
 	// WorktreeAvailable is true when WorkDir still exists on THIS server's
@@ -1454,6 +1468,8 @@ func headerFromRun(r *store.Run) RunHeader {
 		Checkpoint:           r.Checkpoint,
 		WorkDir:              r.WorkDir,
 		ProjectPath:          r.ProjectPath,
+		BotSourceTier:        r.BotSourceTier,
+		BotSourceTenant:      r.BotSourceTenant,
 		Worktree:             r.Worktree,
 		WorktreeAvailable:    worktreeAvailable(r.WorkDir),
 		FinalCommit:          r.FinalCommit,

--- a/pkg/runview/snapshot_bot_source_test.go
+++ b/pkg/runview/snapshot_bot_source_test.go
@@ -1,0 +1,71 @@
+package runview
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #871 — the run says which bot-source tier served it, on the wire. The
+// tier being persisted but unreadable is what let an inert tier read as a
+// working one for four launch surfaces; an operator has to be able to see
+// the answer without opening the database.
+//
+// The three cases are asserted on the MARSHALLED header, not the struct,
+// because the contract that matters to a reader is the JSON one: an
+// unrecorded tier must be ABSENT, never rendered as a claim.
+func TestHeaderFromRun_ExposesTheBotSourceTier(t *testing.T) {
+	cases := []struct {
+		name       string
+		run        store.Run
+		wantTier   string // "" = the key must be absent
+		wantTenant string
+	}{
+		{
+			name:       "a team fork names the team that owns the row",
+			run:        store.Run{ID: "r-team", BotSourceTier: store.BotSourceTierTeam, BotSourceTenant: "t1"},
+			wantTier:   "team",
+			wantTenant: "t1",
+		},
+		{
+			name:     "the baked catalog says so positively",
+			run:      store.Run{ID: "r-baked", BotSourceTier: store.BotSourceTierBaked},
+			wantTier: "baked",
+		},
+		{
+			name:     "a run that recorded no tier claims none",
+			run:      store.Run{ID: "r-local"},
+			wantTier: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := headerFromRun(&tc.run)
+			if h.BotSourceTier != tc.wantTier {
+				t.Errorf("header.BotSourceTier = %q, want %q", h.BotSourceTier, tc.wantTier)
+			}
+			if h.BotSourceTenant != tc.wantTenant {
+				t.Errorf("header.BotSourceTenant = %q, want %q", h.BotSourceTenant, tc.wantTenant)
+			}
+			b, err := json.Marshal(h)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wire map[string]any
+			if err := json.Unmarshal(b, &wire); err != nil {
+				t.Fatal(err)
+			}
+			got, present := wire["bot_source_tier"]
+			switch {
+			case tc.wantTier == "" && present:
+				t.Errorf("bot_source_tier = %v on a run that recorded none — absence must stay absence, or an unresolved tier reads as a deliberate one", got)
+			case tc.wantTier != "" && got != tc.wantTier:
+				t.Errorf("wire bot_source_tier = %v, want %q", got, tc.wantTier)
+			}
+			if _, present := wire["bot_source_tenant"]; present != (tc.wantTenant != "") {
+				t.Errorf("bot_source_tenant present=%v, want %v", present, tc.wantTenant != "")
+			}
+		})
+	}
+}

--- a/pkg/server/admin_bots_routes_test.go
+++ b/pkg/server/admin_bots_routes_test.go
@@ -84,8 +84,8 @@ func TestAdminBots_PlatformOverrideLifecycle(t *testing.T) {
 		t.Fatal("no platform.bot.created audit row carrying the bundle digest")
 	}
 
-	// ---- every tenant-context-free launch surface resolves the override ----
-	lb, err := s.resolveBotSource(adminCtx, "reviewer")
+	// ---- a launch with no team of its own resolves the override ----
+	lb, err := s.resolveBotSource(adminCtx, "", "reviewer")
 	if err != nil {
 		t.Fatalf("resolveBotSource: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestAdminBots_PlatformOverrideLifecycle(t *testing.T) {
 	if dw.Code != http.StatusOK {
 		t.Fatalf("delete = %d: %s", dw.Code, dw.Body.String())
 	}
-	if _, err := s.resolveBotSource(context.Background(), "reviewer"); err == nil {
+	if _, err := s.resolveBotSource(context.Background(), "", "reviewer"); err == nil {
 		t.Fatal("override must be gone after delete (fallback to baked = not-found here)")
 	}
 }

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -1805,7 +1805,9 @@ func (s *Server) boardLaunchPreconditions(ctx context.Context, tenant string, is
 		return nil, boardLaunchContext{}, fmt.Errorf("card %s has no bot: %w", iss.ID, errCardUnlaunchable)
 	}
 	ctx = store.WithIdentity(ctx, tenant, boardDispatcherActor)
-	lb, err := s.resolveBotSource(ctx, iss.Bot)
+	// The card's own team owns the resolution: a team that forked this bot
+	// runs its fork here exactly as on the studio button.
+	lb, err := s.resolveBotSource(ctx, tenant, iss.Bot)
 	if err != nil {
 		return nil, boardLaunchContext{}, fmt.Errorf("card %s names bot %q: %w: %w", iss.ID, iss.Bot, err, errCardUnlaunchable)
 	}

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -25,19 +25,21 @@ import (
 // (bot_resolver_sweep_test.go) forbids new direct botregistry reads in this
 // package.
 //
-// The team tier is deliberately consulted ONLY where an active-team context
-// exists (the studio launch surface): a team's experimental fork must not
-// silently hijack that team's schedules/webhooks. The platform tier applies
-// everywhere — overriding the deployment's catalog is its purpose.
+// The team tier applies on EVERY launch surface, because every launcher
+// knows the team it launches for: the card's, the subscription's, the
+// schedule's, the webhook token's. A team that forks a bot gets its fork on
+// its board cards and its webhook reviews as much as on the studio button —
+// and each launch RECORDS the tier that served it (launchBot.Tier →
+// LaunchSpec.BotSourceTier → Run.BotSourceTier), so a fork is never a silent
+// substitution. A surface with no team id has none to invent: it resolves
+// platform-over-baked and says so by passing an empty team.
 //
-// That exclusion is a CONTRACT, not an oversight, and it binds the metadata
-// reads below as much as the launch: effectiveEntries* / effectiveFindByName
-// are the tenant-context-FREE view (platform over baked), which is exactly the
-// resolution resolveBotSource performs on the lanes that read them — the
-// webhook hand-off matcher (produces:/consumes:), the command discovery, the
-// gate-var defaults. A team-authored bot is therefore invisible to those
-// lanes, on purpose: describing a fork the launch will never run would seed a
-// run from the wrong manifest. A caller that holds the tier a bot ACTUALLY
+// The METADATA reads below are a separate, narrower view:
+// effectiveEntries* / effectiveFindByName / botExists / platformBotManifest
+// are tenant-context-FREE (platform over baked) on every surface, including
+// the manual one. So a team fork's manifest is not what the hand-off matcher
+// (produces:/consumes:), the command discovery, the gate-var defaults or the
+// retry-policy resolution read. A caller that holds the tier a bot ACTUALLY
 // resolved through — a run's BotSourceTenant, stamped at launch — asks
 // teamBotManifest first instead.
 
@@ -56,6 +58,20 @@ type launchBot struct {
 	cleanupSnapshot func()
 }
 
+// Tier maps the resolution's origin onto the persisted tier vocabulary
+// (store.BotSourceTier*). One conversion site: Origin is the resolver's
+// internal word, BotSourceTier the operator-facing one.
+func (lb *launchBot) Tier() string {
+	switch lb.Origin {
+	case "team":
+		return store.BotSourceTierTeam
+	case "platform":
+		return store.BotSourceTierPlatform
+	default:
+		return store.BotSourceTierBaked
+	}
+}
+
 // Stamp applies the resolution onto a LaunchSpec.
 func (lb *launchBot) Stamp(spec *runview.LaunchSpec) {
 	spec.FilePath = lb.Path
@@ -64,14 +80,16 @@ func (lb *launchBot) Stamp(spec *runview.LaunchSpec) {
 	lb.StampBundle(spec)
 }
 
-// StampBundle stamps the compile dir and runner ref for callers that resolved
-// path/source separately (the studio derives an absolute path first). Nil-safe.
+// StampBundle stamps the compile dir, the runner ref and the tier that served
+// the launch, for callers that resolved path/source separately (the studio
+// derives an absolute path first). Nil-safe.
 func (lb *launchBot) StampBundle(spec *runview.LaunchSpec) {
 	if lb == nil {
 		return
 	}
 	spec.BundleDir = lb.BundleDir
 	spec.BotBundle = lb.Ref
+	spec.BotSourceTier = lb.Tier()
 }
 
 // Cleanup removes the materialized bundle dir, if any. Safe on nil.
@@ -194,11 +212,21 @@ func (s *Server) storedLaunchBot(bs botsource.BotSource, origin string) (*launch
 	}, nil
 }
 
-// resolveBotSource resolves a bot id for the tenant-context-free launch
-// surfaces (webhooks, schedules, board dispatch, triggers): platform store
-// first, then the baked catalog. Errors when the id resolves nowhere.
-func (s *Server) resolveBotSource(ctx context.Context, botID string) (*launchBot, error) {
-	lb, err := s.resolveBotTiered(ctx, "", botID, "")
+// resolveBotSource resolves a bot id for the AUTOMATED launch surfaces
+// (webhooks, schedules, board dispatch, triggers) through the full tier
+// order: teamID's own botsource row, then the platform store, then the baked
+// catalog. Errors when the id resolves nowhere.
+//
+// teamID is the tenant the launch is FOR — the card's, the subscription's,
+// the schedule's, the webhook token's. It is the one thing this chokepoint
+// cannot derive for itself, so it is a parameter and not a ctx read: nearby
+// code re-scopes the ctx for forge and secret lookups, and a tier resolved
+// off whichever tenant happened to be on the ctx would be a different
+// question from "who is this launch for". Empty is legitimate only for a
+// surface that genuinely has no tenant; the resolver sweep test keeps that
+// set closed.
+func (s *Server) resolveBotSource(ctx context.Context, teamID, botID string) (*launchBot, error) {
+	lb, err := s.resolveBotTiered(ctx, teamID, botID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -36,12 +36,18 @@ import (
 //
 // The METADATA reads below are a separate, narrower view:
 // effectiveEntries* / effectiveFindByName / botExists / platformBotManifest
-// are tenant-context-FREE (platform over baked) on every surface, including
-// the manual one. So a team fork's manifest is not what the hand-off matcher
-// (produces:/consumes:), the command discovery, the gate-var defaults or the
-// retry-policy resolution read. A caller that holds the tier a bot ACTUALLY
-// resolved through — a run's BotSourceTenant, stamped at launch — asks
-// teamBotManifest first instead.
+// are tenant-context-FREE (platform over baked). A metadata read must match
+// the tier the LAUNCH it describes will resolve, or the two disagree in
+// silence — so a lane whose launch is tenant-aware reads through
+// effectiveFindByNameForTeam, and a lane whose launch is tenant-free keeps
+// the tenant-free view. Wired so far: the webhook hand-off `consumes:` seeds
+// and the gate-var defaults, the two that describe a delivery this file's
+// launch resolution now serves from the team tier. Still tenant-free, and
+// therefore still able to disagree with a team fork: the retry-policy
+// manifest read (botManifest), the command discovery, the /bots listing, and
+// the hand-off PRODUCER set — pre-existing on the manual surface, tracked as
+// #946. A caller that holds the tier a bot ACTUALLY resolved through — a
+// run's BotSourceTenant, stamped at launch — asks teamBotManifest instead.
 
 // launchBot is a resolved, launch-ready bot. Cloud resolution freezes its
 // collection before compile and carries the same snapshot to the runner.
@@ -130,11 +136,12 @@ func (s *Server) resolveBotTieredRaw(ctx context.Context, teamID, botID, filePat
 	// The catalog tier tolerates spelling variants (feature_dev /
 	// Feature-Dev / "feature dev" → feature-dev; ResolveBotPath normalizes
 	// internally), and board cards / trigger subscriptions rely on it. The
-	// PLATFORM tier must tolerate the same set, or an override is silently
-	// bypassed for every non-canonical spelling. Resolved into its OWN
-	// variable: rewriting `slug` itself let a platform entry's canonical
-	// name miss the team row and hijack the team tier — team > platform
-	// must hold even across spellings.
+	// PLATFORM tier (here) and the TEAM tier (teamBotRow) must tolerate the
+	// same set, or a stored bot is silently bypassed for every non-canonical
+	// spelling. Each resolves into its OWN variable and never rewrites
+	// `slug`: rewriting it let a platform entry's canonical name miss the
+	// team row and hijack the team tier — team > platform must hold even
+	// across spellings.
 	platformSlug := slug
 	if s.botSources != nil {
 		if norm := botregistry.NormalizeName(slug); norm != slug {
@@ -152,12 +159,12 @@ func (s *Server) resolveBotTieredRaw(ctx context.Context, teamID, botID, filePat
 		// STALE BAKED bot — the exact façade the runner-side version check
 		// refuses (erreurs-explicites, both halves of the same contract).
 		if teamID != "" {
-			bs, err := s.botSources.GetBySlug(store.WithTenant(ctx, teamID), teamID, slug)
+			bs, found, err := s.teamBotRow(ctx, teamID, slug)
 			switch {
-			case err == nil:
-				return s.storedLaunchBot(bs, "team")
-			case !errors.Is(err, botsource.ErrNotFound):
+			case err != nil:
 				return nil, fmt.Errorf("resolve bot %q (team tier): %w", slug, err)
+			case found:
+				return s.storedLaunchBot(bs, "team")
 			}
 		}
 		pctx := store.WithTenant(ctx, botsource.PlatformTenantID)
@@ -180,6 +187,40 @@ func (s *Server) resolveBotTieredRaw(ctx context.Context, teamID, botID, filePat
 		return nil, fmt.Errorf("read bot %q: %w", slug, err)
 	}
 	return &launchBot{BotID: slug, Origin: "catalog", Path: path, Source: string(b)}, nil
+}
+
+// teamBotRow finds teamID's OWN botsource row for a bot id, tolerating the
+// spelling variants the catalog and platform tiers tolerate. It reports
+// (row, found, err); only a genuine absence is (_, false, nil), so a store
+// failure can never be read as "this team authored no such bot" and fall
+// through to a bundle nobody chose.
+//
+// Two passes. The indexed read answers the exact spelling — the common
+// case, and the only one a `(tenant, slug)` index can serve. The scan is
+// what makes the tolerance SYMMETRIC: `botsource.ValidSlug` admits `_`, so
+// BOTH the query and the stored slug may be non-canonical, and matching
+// those needs both sides normalized, which no index can answer. It runs
+// only after the exact read missed, and reads one tenant's own rows.
+func (s *Server) teamBotRow(ctx context.Context, teamID, slug string) (botsource.BotSource, bool, error) {
+	tctx := store.WithTenant(ctx, teamID)
+	bs, err := s.botSources.GetBySlug(tctx, teamID, slug)
+	switch {
+	case err == nil:
+		return bs, true, nil
+	case !errors.Is(err, botsource.ErrNotFound):
+		return botsource.BotSource{}, false, err
+	}
+	norm := botregistry.NormalizeName(slug)
+	list, err := s.botSources.ListByTenant(tctx, teamID)
+	if err != nil {
+		return botsource.BotSource{}, false, err
+	}
+	for i := range list {
+		if botregistry.NormalizeName(list[i].Slug) == norm {
+			return list[i], true, nil
+		}
+	}
+	return botsource.BotSource{}, false, nil
 }
 
 // storedLaunchBot materializes one stored row into a launch-ready bot.
@@ -392,24 +433,60 @@ func (s *Server) botExists(botID string) bool {
 // or no such slug), leaving the caller on the platform + baked tiers.
 //
 // Deliberately NOT folded into effectiveFindByName: see the contract at the
-// top of this file — the tenant-context-free lanes must stay blind to a team
-// fork, because their launch is blind to it too.
+// top of this file — a lane whose LAUNCH is tenant-free must stay blind to a
+// team fork, or it would describe a bundle it will not run.
+//
+// It resolves the row through teamBotRow, so one row resolution serves the
+// launch, the entry metadata and the manifest: a card's spelling cannot
+// reach one and miss another.
 func (s *Server) teamBotManifest(ctx context.Context, tenantID, slug string) *bundle.Manifest {
 	slug = strings.TrimSpace(slug)
 	tenantID = strings.TrimSpace(tenantID)
 	if s.botSources == nil || slug == "" || tenantID == "" || tenantID == botsource.PlatformTenantID {
 		return nil
 	}
-	bs, err := s.botSources.GetBySlug(store.WithTenant(ctx, tenantID), tenantID, slug)
+	bs, found, err := s.teamBotRow(ctx, tenantID, slug)
 	if err != nil {
-		if !errors.Is(err, botsource.ErrNotFound) {
-			// A store blip is not "this team authored no such bot": say so,
-			// then fall through to the tiers that can still answer.
-			s.logger.Warn("bot source %s/%s: %v — reading the manifest fell through to the platform tier", tenantID, slug, err)
-		}
+		// A store blip is not "this team authored no such bot": say so,
+		// then fall through to the tiers that can still answer.
+		s.logger.Warn("bot source %s/%s: %v — reading the manifest fell through to the platform tier", tenantID, slug, err)
+		return nil
+	}
+	if !found {
 		return nil
 	}
 	return bs.Manifest()
+}
+
+// effectiveFindByNameForTeam is effectiveFindByName with the launching
+// team's own row consulted first — the metadata counterpart of the launch
+// resolution, for the lanes where the two describe the SAME delivery.
+//
+// It exists because a lane that launches a team's fork and then reads the
+// origin's manifest disagrees with itself in silence: a fork that renames a
+// `consumes:` var gets an empty seed, not an error. It resolves the row
+// through teamBotRow, so the spelling a card carries reaches the same row on
+// both reads.
+//
+// Deliberately NOT the default: effectiveFindByName stays tenant-free for
+// the lanes whose launch is tenant-free too (see the contract at the top of
+// this file). Widening it is #946, not this seam.
+func (s *Server) effectiveFindByNameForTeam(ctx context.Context, teamID, name string) (botregistry.EntryWithSchema, bool, error) {
+	if teamID != "" && s.botSources != nil && strings.TrimSpace(name) != "" {
+		bs, found, err := s.teamBotRow(ctx, teamID, name)
+		switch {
+		case err != nil:
+			// A store blip is not "this team authored no such bot": say so,
+			// then fall through to the tiers that can still answer.
+			s.logger.Warn("bot source %s/%s: %v — reading the metadata fell through to the platform tier", teamID, name, err)
+		case found:
+			if entries := s.materializeBotEntries([]botsource.BotSource{bs}); len(entries) == 1 {
+				return entries[0], true, nil
+			}
+			s.logger.Warn("bot source %s/%s: metadata could not be materialized — falling through to the platform tier", teamID, bs.Slug)
+		}
+	}
+	return s.effectiveFindByName(name)
 }
 
 // effectiveFindByName returns the effective (platform-overlaid) entry for a

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -47,6 +47,32 @@ func TestBotResolutionSweep_NoRawRegistryReads(t *testing.T) {
 	})
 }
 
+// teamlessResolveAllowed lists the files that may resolve a bot with a
+// LITERAL empty team, with the reason. Every launch surface knows the team it
+// launches for; a hardcoded "" there drops the team tier for that surface
+// alone — the #871 defect, which survived because four launchers were assumed
+// to behave like the fifth.
+var teamlessResolveAllowed = map[string]string{
+	"resume_source.go": "the no-persisted-origin branch: a run whose BotSourceTenant is empty did NOT launch from a team row (the team branch above re-resolves that row by its own tenant)",
+}
+
+func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
+	// The bare `resolveBot(` arm catches the trigger spine, which calls the
+	// authority through an injected closure field rather than by name.
+	// Only a LITERAL "" is decidable statically; a variable that happens to
+	// be empty at run time is the caller's own contract to keep.
+	teamless := regexp.MustCompile(`resolveBot(?:Source|Tiered(?:Raw)?)?\([^,]+,\s*""`)
+	sweepServerFiles(t, func(name, body string) {
+		if !teamless.MatchString(body) {
+			return
+		}
+		if _, ok := teamlessResolveAllowed[name]; ok {
+			return
+		}
+		t.Errorf("%s resolves a bot with a hardcoded empty team — pass the team the launch is FOR (the card's, the subscription's, the schedule's, the webhook's) or add an allowlist entry saying why this surface has none", name)
+	})
+}
+
 // The webhook role constants are config now (platformcfg bot_roles): a site
 // that reads a constant directly re-hardcodes the role and silently ignores
 // the operator's override.

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -57,11 +57,15 @@ var teamlessResolveAllowed = map[string]string{
 }
 
 func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
+	// Both halves of the class: the launch resolution AND the metadata reads
+	// that describe the same launch (a lane that launches a team's fork and
+	// then reads the origin's manifest disagrees with itself in silence).
 	// The bare `resolveBot(` arm catches the trigger spine, which calls the
 	// authority through an injected closure field rather than by name.
 	// Only a LITERAL "" is decidable statically; a variable that happens to
 	// be empty at run time is the caller's own contract to keep.
-	teamless := regexp.MustCompile(`resolveBot(?:Source|Tiered(?:Raw)?)?\([^,]+,\s*""`)
+	teamless := regexp.MustCompile(
+		`(?:resolveBot(?:Source|Tiered(?:Raw)?)?|resolveRunRetryPolicy|handoffConsumersFor|botVarDefault|botManifestFor|effectiveFindByNameForTeam)\([^,]+,\s*""`)
 	sweepServerFiles(t, func(name, body string) {
 		if !teamless.MatchString(body) {
 			return

--- a/pkg/server/bot_snapshot_test.go
+++ b/pkg/server/bot_snapshot_test.go
@@ -40,7 +40,7 @@ func TestSnapshotCapturesTransitiveChildren(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "child/main.bot"), []byte(snapshotParent("newchild")), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	lb, err := s.resolveBotSource(context.Background(), "parent")
+	lb, err := s.resolveBotSource(context.Background(), "", "parent")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func snapshotFixture(t *testing.T) (*Server, string) {
 
 func TestSnapshotCatalogLaunchAndResume(t *testing.T) {
 	s, root := snapshotFixture(t)
-	lb, err := s.resolveBotSource(context.Background(), "parent")
+	lb, err := s.resolveBotSource(context.Background(), "", "parent")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestSnapshotChildUsesServerAuthorityAndRefusesMissingChild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lb, err := s.resolveBotSource(context.Background(), "parent")
+	lb, err := s.resolveBotSource(context.Background(), "", "parent")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestSnapshotChildUsesServerAuthorityAndRefusesMissingChild(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "parent/main.bot"), []byte(snapshotParent("missing")), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.resolveBotSource(context.Background(), "parent"); err == nil || !strings.Contains(err.Error(), "missing") {
+	if _, err := s.resolveBotSource(context.Background(), "", "parent"); err == nil || !strings.Contains(err.Error(), "missing") {
 		t.Fatalf("missing child = %v", err)
 	}
 }

--- a/pkg/server/bot_team_tier_launch_test.go
+++ b/pkg/server/bot_team_tier_launch_test.go
@@ -77,16 +77,24 @@ func (p *tierPublisher) only(t *testing.T) runview.LaunchSpec {
 // shape (pkg/botsource) the ticket is about.
 func newTeamForkServer(t *testing.T, pub *tierPublisher) (*Server, *store.FilesystemRunStore) {
 	t.Helper()
+	return newTeamForkServerSlug(t, pub, "probe")
+}
+
+// newTeamForkServerSlug is newTeamForkServer with the bot's slug chosen by
+// the caller — the spelling tests need a name that HAS a separator, since
+// `probe` has no non-canonical variant to mis-spell.
+func newTeamForkServerSlug(t *testing.T, pub *tierPublisher, slug string) (*Server, *store.FilesystemRunStore) {
+	t.Helper()
 	s := newOrgTestServer(t)
 	seedGate(t, s, gateSpec{id: "t1"})
 	botsDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(tierBakedBot), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(botsDir, slug+".bot"), []byte(tierBakedBot), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	s.cfg.Bots.Paths = []string{botsDir}
 	s.botSources = botsource.NewMemoryStore()
 	if _, err := s.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
-		TenantID: "t1", Slug: "probe",
+		TenantID: "t1", Slug: slug,
 		Files: map[string]string{botsource.MainBotFile: tierForkBot},
 	}); err != nil {
 		t.Fatalf("seed the team's fork: %v", err)
@@ -171,6 +179,115 @@ func TestTeamForkServesTheInboundWebhook(t *testing.T) {
 		t.Fatalf("launchWebhookBot = %v, want nil", err)
 	}
 	assertServedByTheFork(t, "inbound webhook", pub.only(t))
+}
+
+// Rf19ce0 — the team tier must tolerate the same spelling variants the
+// catalog and platform tiers already do. Board cards, an agent's `set_bot`
+// and hand-written subscriptions are documented to carry non-canonical
+// names (`feature_dev` for a `feature-dev` bundle), so a spelling-exact
+// team lookup leaves #871 open for exactly the surfaces this change routes
+// through the team tier — and stamps a truthful `baked` on the wrong
+// resolution.
+func TestTeamTierToleratesSpellingVariants(t *testing.T) {
+	// The team's fork is slugged canonically (a fork takes the catalog id);
+	// the CARD is what varies.
+	for _, spelling := range []string{"probe_bot", "PROBE-BOT", "probe bot"} {
+		t.Run("card says "+spelling, func(t *testing.T) {
+			pub := &tierPublisher{}
+			s, rs := newTeamForkServerSlug(t, pub, "probe-bot")
+			pub.onLaunch = func(runID string) { finishRunAs(t, rs, runID, store.RunStatusFinished) }
+
+			if err := s.processBoardCard(boundedCtx(t), "t1", native.Issue{
+				ID: "native:1", Bot: spelling, State: native.StateReady,
+			}); err != nil {
+				t.Fatalf("processBoardCard = %v, want nil", err)
+			}
+			assertServedByTheFork(t, "board dispatch ("+spelling+")", pub.only(t))
+		})
+	}
+
+	// The SYMMETRIC direction, which the two indexed reads cannot answer:
+	// botsource.ValidSlug admits `_`, so a hand-authored team row may itself
+	// be spelled non-canonically while the card carries the canonical name.
+	// Only the normalized scan closes this one.
+	t.Run("a non-canonical team row is reached by the canonical name", func(t *testing.T) {
+		pub := &tierPublisher{}
+		s := newOrgTestServer(t)
+		seedGate(t, s, gateSpec{id: "t1"})
+		botsDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(botsDir, "probe-bot.bot"), []byte(tierBakedBot), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.Bots.Paths = []string{botsDir}
+		s.botSources = botsource.NewMemoryStore()
+		if _, err := s.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
+			TenantID: "t1", Slug: "probe_bot", // the OPERATOR typed the underscore
+			Files: map[string]string{botsource.MainBotFile: tierForkBot},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		rs, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.Store = rs
+		s.runs = newTestRunviewService(t, "", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+
+		lb, err := s.resolveBotSource(boundedCtx(t), "t1", "probe-bot")
+		if err != nil || lb == nil {
+			t.Fatalf("resolve = %+v, %v", lb, err)
+		}
+		defer lb.Cleanup()
+		if lb.Origin != "team" || !strings.Contains(lb.Source, "TEAMFORK") {
+			t.Fatalf("origin=%q — a team row slugged `probe_bot` must answer to `probe-bot`", lb.Origin)
+		}
+	})
+
+	// team > platform must keep holding ACROSS spellings: the normalized
+	// lookup may not hand a platform row a tier it must never win.
+	t.Run("team still outranks platform across spellings", func(t *testing.T) {
+		pub := &tierPublisher{}
+		s, _ := newTeamForkServerSlug(t, pub, "probe-bot")
+		if _, err := s.botSources.Create(store.WithTenant(context.Background(), botsource.PlatformTenantID), botsource.BotSource{
+			TenantID: botsource.PlatformTenantID, Slug: "probe-bot",
+			Files: map[string]string{botsource.MainBotFile: strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1)},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.invalidatePlatformBots()
+
+		lb, err := s.resolveBotSource(boundedCtx(t), "t1", "probe_bot")
+		if err != nil || lb == nil {
+			t.Fatalf("resolve = %+v, %v", lb, err)
+		}
+		defer lb.Cleanup()
+		if lb.Origin != "team" || !strings.Contains(lb.Source, "TEAMFORK") {
+			t.Fatalf("HIJACK across spellings: origin=%q — the platform row won a tier it must never win", lb.Origin)
+		}
+	})
+
+	// And a team with NO row of its own still reaches the platform override
+	// through the same tolerated spelling — the team pass must not shadow it.
+	t.Run("no team row still reaches the platform override", func(t *testing.T) {
+		pub := &tierPublisher{}
+		s, _ := newTeamForkServerSlug(t, pub, "probe-bot")
+		if _, err := s.botSources.Create(store.WithTenant(context.Background(), botsource.PlatformTenantID), botsource.BotSource{
+			TenantID: botsource.PlatformTenantID, Slug: "probe-bot",
+			Files: map[string]string{botsource.MainBotFile: strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1)},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.invalidatePlatformBots()
+
+		lb, err := s.resolveBotSource(boundedCtx(t), "t2", "probe_bot")
+		if err != nil || lb == nil {
+			t.Fatalf("resolve = %+v, %v", lb, err)
+		}
+		defer lb.Cleanup()
+		if lb.Origin != "platform" || !strings.Contains(lb.Source, "PLATFORM") {
+			t.Fatalf("origin=%q source=%q, want the platform override", lb.Origin, lb.Source)
+		}
+	})
 }
 
 // The stamp answers for the OTHER two tiers as well — otherwise

--- a/pkg/server/bot_team_tier_launch_test.go
+++ b/pkg/server/bot_team_tier_launch_test.go
@@ -1,0 +1,236 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/cloudsched"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// A team's own bot row serves EVERY launch surface of that team, not only
+// the manual studio launch: the board dispatcher, the trigger spine, the
+// cloud scheduler and the inbound webhooks resolve through the same
+// team → platform → baked order (#871, docs/platform-bots.md). Four
+// surfaces, four proofs: the defect existed because four launchers were
+// assumed to behave like the fifth.
+
+const (
+	tierBakedBot = "schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"BAKED\"}'`\n  output: probe_out\n\nworkflow tier_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n"
+	tierForkBot  = "schema probe_out:\n  ok: string\n\ntool noop:\n  command: `printf '{\"ok\":\"TEAMFORK\"}'`\n  output: probe_out\n\nworkflow tier_probe:\n  worktree: none\n  entry: noop\n  noop -> done\n"
+)
+
+// tierPublisher records every LaunchSpec a surface publishes — the spec is
+// what carries the resolved bundle, so it is the oracle for "which tier
+// served this launch". onLaunch plays the runner pod for surfaces that wait
+// on the run's outcome.
+type tierPublisher struct {
+	mu       sync.Mutex
+	specs    []runview.LaunchSpec
+	onLaunch func(runID string)
+}
+
+func (p *tierPublisher) SubmitLaunch(_ context.Context, runID string, spec runview.LaunchSpec, _ *ir.Workflow, _ string) (int, error) {
+	p.mu.Lock()
+	p.specs = append(p.specs, spec)
+	p.mu.Unlock()
+	if p.onLaunch != nil {
+		p.onLaunch(runID)
+	}
+	return 0, nil
+}
+
+func (*tierPublisher) CancelRun(context.Context, string) error { return nil }
+func (*tierPublisher) CancelRunWithReason(context.Context, string, store.RunEndReason) error {
+	return nil
+}
+func (*tierPublisher) SubmitResume(context.Context, runview.ResumeSpec, *ir.Workflow, string) error {
+	return nil
+}
+
+// only returns the single spec published, failing when a surface published
+// none (or more than one).
+func (p *tierPublisher) only(t *testing.T) runview.LaunchSpec {
+	t.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.specs) != 1 {
+		t.Fatalf("the surface published %d launches, want exactly 1", len(p.specs))
+	}
+	return p.specs[0]
+}
+
+// newTeamForkServer is a cloud-shaped server whose BAKED catalog holds
+// `probe`, and whose team `t1` has forked that very slug — the studio-editor
+// shape (pkg/botsource) the ticket is about.
+func newTeamForkServer(t *testing.T, pub *tierPublisher) (*Server, *store.FilesystemRunStore) {
+	t.Helper()
+	s := newOrgTestServer(t)
+	seedGate(t, s, gateSpec{id: "t1"})
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(tierBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	s.botSources = botsource.NewMemoryStore()
+	if _, err := s.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
+		TenantID: "t1", Slug: "probe",
+		Files: map[string]string{botsource.MainBotFile: tierForkBot},
+	}); err != nil {
+		t.Fatalf("seed the team's fork: %v", err)
+	}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = rs
+	s.runs = newTestRunviewService(t, "", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+	return s, rs
+}
+
+// assertServedByTheFork is the shared verdict: the launch carries the team's
+// own bundle, and says so.
+func assertServedByTheFork(t *testing.T, surface string, spec runview.LaunchSpec) {
+	t.Helper()
+	if !strings.Contains(spec.Source, "TEAMFORK") {
+		t.Errorf("%s launched a bundle that is not the team's fork of `probe` (source: %q)", surface, spec.Source)
+	}
+	if spec.BotBundle == nil || spec.BotBundle.TenantID != "t1" {
+		t.Errorf("%s: bundle ref = %+v, want the team's row (tenant t1) so the runner rebuilds the fork, not the baked twin", surface, spec.BotBundle)
+	}
+	if spec.BotSourceTier != store.BotSourceTierTeam {
+		t.Errorf("%s: bot_source_tier = %q, want %q — a launch must say which tier served it", surface, spec.BotSourceTier, store.BotSourceTierTeam)
+	}
+}
+
+// Surface 1/4 — the board dispatcher (processBoardCard).
+func TestTeamForkServesTheBoardDispatcher(t *testing.T) {
+	pub := &tierPublisher{}
+	s, rs := newTeamForkServer(t, pub)
+	pub.onLaunch = func(runID string) { finishRunAs(t, rs, runID, store.RunStatusFinished) }
+
+	if err := s.processBoardCard(boundedCtx(t), "t1", native.Issue{
+		ID: "native:1", Bot: "probe", State: native.StateReady,
+	}); err != nil {
+		t.Fatalf("processBoardCard = %v, want nil", err)
+	}
+	assertServedByTheFork(t, "board dispatch", pub.only(t))
+}
+
+// Surface 2/4 — the trigger spine's direct launch (serviceLauncher.Launch).
+func TestTeamForkServesTheTriggerSpine(t *testing.T) {
+	pub := &tierPublisher{}
+	s, _ := newTeamForkServer(t, pub)
+
+	if _, err := s.triggerLauncher().Launch(boundedCtx(t), trigger.LaunchPlan{
+		BotID:    "probe",
+		TenantID: "t1",
+		Mode:     bundle.ExecutionDirect,
+		Event: trigger.Event{
+			ID: "custom:probe:1", Source: trigger.SourceCustom, Kind: "probe",
+			TenantID: "t1", OccurredAt: time.Now().UTC(),
+		},
+	}); err != nil {
+		t.Fatalf("trigger Launch = %v, want nil", err)
+	}
+	assertServedByTheFork(t, "trigger spine", pub.only(t))
+}
+
+// Surface 3/4 — the cloud scheduler's tick (launchScheduledBot).
+func TestTeamForkServesTheCloudSchedule(t *testing.T) {
+	pub := &tierPublisher{}
+	s, _ := newTeamForkServer(t, pub)
+
+	if err := s.launchScheduledBot(boundedCtx(t), cloudsched.ScheduledBot{
+		ID: "sched-1", TenantID: "t1", BotID: "probe", Cron: "0 2 * * 1",
+	}); err != nil {
+		t.Fatalf("launchScheduledBot = %v, want nil", err)
+	}
+	assertServedByTheFork(t, "cloud schedule", pub.only(t))
+}
+
+// Surface 4/4 — an inbound webhook delivery (launchWebhookBot).
+func TestTeamForkServesTheInboundWebhook(t *testing.T) {
+	pub := &tierPublisher{}
+	s, _ := newTeamForkServer(t, pub)
+
+	if _, err := s.launchWebhookBot(boundedCtx(t), webhooks.Config{ID: "wh-1", TenantID: "t1"},
+		"probe", map[string]string{}, "", "", "acme/repo", nil, nil); err != nil {
+		t.Fatalf("launchWebhookBot = %v, want nil", err)
+	}
+	assertServedByTheFork(t, "inbound webhook", pub.only(t))
+}
+
+// The stamp answers for the OTHER two tiers as well — otherwise
+// `bot_source_tier` would only ever be written when it happens to say
+// "team", and the field that exists to make the tier visible would itself
+// be a partial answer.
+func TestBotSourceTierNamesEveryTier(t *testing.T) {
+	tiers := []struct {
+		name  string
+		rows  map[string]string // tenant → main.bot marker
+		want  string
+		tenID string
+	}{
+		{"a team row is `team`", map[string]string{"t1": tierForkBot}, store.BotSourceTierTeam, "t1"},
+		{"a platform override is `platform`", map[string]string{botsource.PlatformTenantID: tierForkBot}, store.BotSourceTierPlatform, botsource.PlatformTenantID},
+		{"the baked catalog is `baked`", nil, store.BotSourceTierBaked, ""},
+	}
+	for _, tc := range tiers {
+		t.Run(tc.name, func(t *testing.T) {
+			pub := &tierPublisher{}
+			s := newOrgTestServer(t)
+			seedGate(t, s, gateSpec{id: "t1"})
+			botsDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(tierBakedBot), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			s.cfg.Bots.Paths = []string{botsDir}
+			s.botSources = botsource.NewMemoryStore()
+			for tenant, body := range tc.rows {
+				if _, err := s.botSources.Create(store.WithTenant(context.Background(), tenant), botsource.BotSource{
+					TenantID: tenant, Slug: "probe",
+					Files: map[string]string{botsource.MainBotFile: body},
+				}); err != nil {
+					t.Fatalf("seed %s row: %v", tenant, err)
+				}
+			}
+			s.invalidatePlatformBots()
+			rs, err := store.New(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.cfg.Store = rs
+			s.runs = newTestRunviewService(t, "", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+
+			if err := s.launchScheduledBot(boundedCtx(t), cloudsched.ScheduledBot{
+				ID: "sched-1", TenantID: "t1", BotID: "probe", Cron: "0 2 * * 1",
+			}); err != nil {
+				t.Fatalf("launchScheduledBot = %v, want nil", err)
+			}
+			spec := pub.only(t)
+			if spec.BotSourceTier != tc.want {
+				t.Errorf("bot_source_tier = %q, want %q", spec.BotSourceTier, tc.want)
+			}
+			gotTenant := ""
+			if spec.BotBundle != nil {
+				gotTenant = spec.BotBundle.TenantID
+			}
+			if gotTenant != tc.tenID {
+				t.Errorf("bundle ref tenant = %q, want %q", gotTenant, tc.tenID)
+			}
+		})
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1725,6 +1725,10 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		ProjectPath:     spec.ProjectPath,
 		BotID:           spec.BotID,
 		BotSourceTenant: botSourceTenantOf(spec.BotBundle),
+		// The tier the launch resolver actually served, in its own field:
+		// BotSourceTenant is empty for a baked bundle AND for a run that
+		// resolved no bot, so it cannot say which of the two happened.
+		BotSourceTier:   spec.BotSourceTier,
 		KeyOverrides:    spec.KeyOverrides,
 		SecretOverrides: spec.SecretOverrides,
 		// Cap. 3 sharding fields — propagate to the persisted Run so

--- a/pkg/server/config_shares_routes.go
+++ b/pkg/server/config_shares_routes.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"path/filepath"
@@ -79,13 +80,17 @@ func (s *Server) shareURL(id, token string) string {
 	return base + "/config/" + id + "#" + token
 }
 
-// botConfigShareSpec resolves a bot_id to its declared config-share surface
-// (manifest config_share: block), or nil when the bot declares none or is not
-// resolvable on this server (a loose .bot, or a bot absent from the effective
-// paths). Best-effort by design: the operator is trusted (canManageTeam), so a
-// bot without a discoverable surface mints with explicit operator-supplied
-// paths — the block is a guard-rail + convenience for the common case, not the
-// trust boundary against the operator.
+// botManifestFor is botManifest with the launching team's own row consulted
+// first — the manifest counterpart of effectiveFindByNameForTeam, for a lane
+// whose LAUNCH resolves the team tier. Reading a different tier than the
+// launch means describing a bundle that is not the one running.
+func (s *Server) botManifestFor(ctx context.Context, teamID, botID string) *bundle.Manifest {
+	if m := s.teamBotManifest(ctx, teamID, botID); m != nil {
+		return m
+	}
+	return s.botManifest(botID)
+}
+
 // botManifest loads a bot's manifest.yaml (persona display_name, config_share
 // surface, …) resolving the bot id against the effective bot paths. Returns nil
 // when the bot isn't resolvable on this server (e.g. a loose .bot).
@@ -106,6 +111,13 @@ func (s *Server) botManifest(botID string) *bundle.Manifest {
 	return m
 }
 
+// botConfigShareSpec resolves a bot_id to its declared config-share surface
+// (manifest config_share: block), or nil when the bot declares none or is not
+// resolvable on this server (a loose .bot, or a bot absent from the effective
+// paths). Best-effort by design: the operator is trusted (canManageTeam), so a
+// bot without a discoverable surface mints with explicit operator-supplied
+// paths — the block is a guard-rail + convenience for the common case, not the
+// trust boundary against the operator.
 func (s *Server) botConfigShareSpec(botID string) *bundle.ConfigShareSpec {
 	if m := s.botManifest(botID); m != nil {
 		return m.ConfigShare

--- a/pkg/server/forge_gate_autofix.go
+++ b/pkg/server/forge_gate_autofix.go
@@ -292,7 +292,7 @@ func (s *Server) autofixForRunID(ctx context.Context, runID, via string) error {
 		return nil
 	}
 
-	fixer := s.reviewFixerFor(integration)
+	fixer := s.reviewFixerFor(ctx, integration)
 	if fixer == "" {
 		s.logWarn("gate auto-fix: %s opted in but no enabled bot on it consumes a review — nothing to launch", repo)
 		return nil
@@ -460,9 +460,9 @@ func autofixIdemKey(teamID, repo string, number int, sha string) string {
 // review. That declaration already means "I start from a review and act on it",
 // which is exactly the bot a red gate needs — so the lane names no bot, and a
 // repo that enables a different fixer gets that one.
-func (s *Server) reviewFixerFor(integration forge.RepoIntegration) string {
+func (s *Server) reviewFixerFor(ctx context.Context, integration forge.RepoIntegration) string {
 	for _, want := range integration.BotIDs {
-		for _, c := range s.handoffConsumersFor(want) {
+		for _, c := range s.handoffConsumersFor(ctx, integration.TenantID, want) {
 			if c.Kind == bundle.HandoffKindReview {
 				return want
 			}

--- a/pkg/server/forge_gate_autofix_test.go
+++ b/pkg/server/forge_gate_autofix_test.go
@@ -794,14 +794,14 @@ func TestReviewFixerIsDerivedNotNamed(t *testing.T) {
 	s := newWebhookTestServer(t)
 	s.cfg.WorkDir = writeConsumerBotFixture(t, "some-other-fixer", "prior_review")
 
-	if got := s.reviewFixerFor(forge.RepoIntegration{BotIDs: []string{"some-other-fixer"}}); got != "some-other-fixer" {
+	if got := s.reviewFixerFor(context.Background(), forge.RepoIntegration{BotIDs: []string{"some-other-fixer"}}); got != "some-other-fixer" {
 		t.Errorf("reviewFixerFor = %q, want the bot that declares it consumes a review", got)
 	}
 	// A bot the repo has not enabled is not a candidate, however it is declared.
-	if got := s.reviewFixerFor(forge.RepoIntegration{BotIDs: []string{"unrelated"}}); got != "" {
+	if got := s.reviewFixerFor(context.Background(), forge.RepoIntegration{BotIDs: []string{"unrelated"}}); got != "" {
 		t.Errorf("reviewFixerFor = %q, want none — that bot is not enabled on the repo", got)
 	}
-	if got := s.reviewFixerFor(forge.RepoIntegration{}); got != "" {
+	if got := s.reviewFixerFor(context.Background(), forge.RepoIntegration{}); got != "" {
 		t.Errorf("reviewFixerFor = %q, want none", got)
 	}
 }

--- a/pkg/server/invocation_dispatch.go
+++ b/pkg/server/invocation_dispatch.go
@@ -232,7 +232,7 @@ func (s *Server) ensureBoardCard(ctx context.Context, cfg webhooks.Config, route
 	// same PR. Derived rather than listed: a fixed list would mean a bot that
 	// declares a new hand-off gets it on the direct lane and silently loses it
 	// on the board lane — the failure this whole carry-list exists to prevent.
-	for _, c := range s.handoffConsumersFor(route.BotID) {
+	for _, c := range s.handoffConsumersFor(ctx, cfg.TenantID, route.BotID) {
 		carry = append(carry, c.Var)
 	}
 	for _, k := range carry {

--- a/pkg/server/retry_resolve.go
+++ b/pkg/server/retry_resolve.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -27,10 +29,14 @@ import (
 // machine default and the platform ceiling are appended here so no launch
 // site has to remember them, and so a site that passes nothing still gets a
 // correct policy rather than an empty one.
-func (s *Server) resolveRunRetryPolicy(botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy {
+// teamID is the tenant the launch is FOR: the bot layer is read from the
+// tier that will SERVE it (that team's own row first, then platform over
+// baked). A fork declaring `retry: usage_window: off` must not be retried on
+// its origin's policy — the run being retried is the fork's.
+func (s *Server) resolveRunRetryPolicy(ctx context.Context, teamID, botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy {
 	layers := make([]retrypolicy.Layer, 0, len(higher)+2)
 	layers = append(layers, higher...)
-	if m := s.botManifest(botID); m != nil {
+	if m := s.botManifestFor(ctx, teamID, botID); m != nil {
 		layers = append(layers, retrypolicy.Layer{Source: retrypolicy.SourceBot, Policy: m.RetryPolicy()})
 	}
 	layers = append(layers, retrypolicy.Layer{Source: retrypolicy.SourceEnv, Policy: retrypolicy.FromEnv()})

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -464,6 +464,10 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 			return err
 		}
 	}
+	// The tenant the bot resolution above ran under, so the retry chain reads
+	// the bot layer from the tier that will actually serve this launch.
+	retryID, _ := auth.FromContext(r.Context())
+	retryTeamID := retryID.TeamID
 
 	spec := runview.LaunchSpec{
 		FilePath:          absPath,
@@ -490,7 +494,7 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 		// `retry: usage_window: off` be auto-retried anyway whenever a
 		// human pressed Launch — a declared directive silently violated on
 		// the one path where the author is watching.
-		RetryPolicy:        s.resolveRunRetryPolicy(botID),
+		RetryPolicy:        s.resolveRunRetryPolicy(r.Context(), retryTeamID, botID),
 		ModelOverrides:     req.ModelOverrides,
 		RoutingPolicy:      req.RoutingPolicy,
 		Fallback:           req.Fallback,

--- a/pkg/server/trigger_launcher.go
+++ b/pkg/server/trigger_launcher.go
@@ -27,7 +27,7 @@ type serviceLauncher struct {
 	// with the bot manifest, the machine default and the platform ceiling.
 	// Injected rather than reached for, because the launcher deliberately
 	// holds no *Server.
-	resolveRetry func(botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy
+	resolveRetry func(ctx context.Context, teamID, botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy
 	// resolveBot is the server's tiered bot resolution (the subscription's
 	// team → platform override → baked catalog), injected for the same
 	// no-*Server reason. REQUIRED: a second, override-blind resolution path
@@ -71,7 +71,7 @@ func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (
 		KeyOverrides:    plan.KeyOverrides,
 		SecretOverrides: plan.SecretOverrides,
 		SourceRef:       plan.SourceRef,
-		RetryPolicy:     l.retryPolicyFor(plan),
+		RetryPolicy:     l.retryPolicyFor(ctx, plan),
 	}
 	if l.resolveBot == nil {
 		return "", errors.New("trigger: no bot resolver wired for direct launch")
@@ -110,11 +110,11 @@ func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (
 // retryPolicyFor resolves the run's retry contract, tolerating a launcher
 // built without a resolver (tests) by leaving the field nil — the consumer
 // then applies the package defaults.
-func (l *serviceLauncher) retryPolicyFor(plan trigger.LaunchPlan) *store.RunRetryPolicy {
+func (l *serviceLauncher) retryPolicyFor(ctx context.Context, plan trigger.LaunchPlan) *store.RunRetryPolicy {
 	if l.resolveRetry == nil {
 		return nil
 	}
-	return l.resolveRetry(plan.BotID, retrypolicy.Layer{
+	return l.resolveRetry(ctx, plan.TenantID, plan.BotID, retrypolicy.Layer{
 		Source: retrypolicy.SourceTrigger,
 		Policy: plan.Retry,
 	})

--- a/pkg/server/trigger_launcher.go
+++ b/pkg/server/trigger_launcher.go
@@ -28,11 +28,11 @@ type serviceLauncher struct {
 	// Injected rather than reached for, because the launcher deliberately
 	// holds no *Server.
 	resolveRetry func(botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy
-	// resolveBot is the server's tiered bot resolution (platform override →
-	// baked catalog), injected for the same no-*Server reason. REQUIRED: a
-	// second, override-blind resolution path here is exactly what the
-	// resolver sweep forbids.
-	resolveBot func(ctx context.Context, botID string) (*launchBot, error)
+	// resolveBot is the server's tiered bot resolution (the subscription's
+	// team → platform override → baked catalog), injected for the same
+	// no-*Server reason. REQUIRED: a second, override-blind resolution path
+	// here is exactly what the resolver sweep forbids.
+	resolveBot func(ctx context.Context, teamID, botID string) (*launchBot, error)
 	// gate is the server's shared launch admission (suspend → concurrency →
 	// launch rate → monthly caps), injected for the same no-*Server reason.
 	// REQUIRED: a direct launch that skipped it would be the one cloud
@@ -83,7 +83,7 @@ func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (
 	// store identity scopes the run and seals its credentials, and the auth
 	// identity is what the gate reads to find the caps to apply.
 	ctx = store.WithIdentity(ctx, plan.TenantID, triggerSpineActor)
-	lb, err := l.resolveBot(ctx, plan.BotID)
+	lb, err := l.resolveBot(ctx, plan.TenantID, plan.BotID)
 	if err != nil {
 		return "", fmt.Errorf("trigger: resolve bot %q: %w", plan.BotID, err)
 	}

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -1196,7 +1196,7 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 		return err
 	}
 	defer lb.Cleanup()
-	retry := s.resolveRunRetryPolicy(sb.BotID, retrypolicy.Layer{
+	retry := s.resolveRunRetryPolicy(ctx, sb.TenantID, sb.BotID, retrypolicy.Layer{
 		Source: retrypolicy.SourceSchedule,
 		Policy: sb.RetryPolicy(),
 	})
@@ -1317,7 +1317,7 @@ func (s *Server) launchWebhookBot(ctx context.Context, cfg webhooks.Config, botI
 		// A webhook-launched run is often the one an author is waiting on,
 		// so the config's own horizon usually wants to be shorter than a
 		// nightly's — hence the layer.
-		RetryPolicy: s.resolveRunRetryPolicy(botID, retrypolicy.Layer{
+		RetryPolicy: s.resolveRunRetryPolicy(ctx, cfg.TenantID, botID, retrypolicy.Layer{
 			Source: retrypolicy.SourceWebhook,
 			Policy: cfg.RetryPolicy(),
 		}),
@@ -1498,7 +1498,7 @@ func (s *Server) handleGitLabReviewApprove(ctx context.Context, w http.ResponseW
 		s.gitlabApproveFilteredWithReply(ctx, w, cfg, meta, p, path.conn, path.connOK, sameRefusal("the forge returned no head sha for this MR"), payloadHash, srcIP)
 		return
 	}
-	gateCtx := s.resolveGateContext(cfg, reviewer)
+	gateCtx := s.resolveGateContext(ctx, cfg, reviewer)
 	if gateCtx == "" {
 		s.gitlabApproveFilteredWithReply(ctx, w, cfg, meta, p, path.conn, path.connOK, sameRefusal("no merge-gate context is pinned on this repo (pin gate_context on the integration — see docs/merge-gate.md)"), payloadHash, srcIP)
 		return

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -1191,7 +1191,7 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 		return errors.New("run service unavailable")
 	}
 	ctx = store.WithIdentity(ctx, sb.TenantID, "scheduler:"+sb.BotID)
-	lb, err := s.resolveBotSource(ctx, sb.BotID)
+	lb, err := s.resolveBotSource(ctx, sb.TenantID, sb.BotID)
 	if err != nil {
 		return err
 	}
@@ -1302,7 +1302,7 @@ func (s *Server) launchWebhookBot(ctx context.Context, cfg webhooks.Config, botI
 	if s.runs == nil {
 		return "", errors.New("run service unavailable")
 	}
-	lb, err := s.resolveBotSource(ctx, botID)
+	lb, err := s.resolveBotSource(ctx, cfg.TenantID, botID)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/server/webhooks_handoff.go
+++ b/pkg/server/webhooks_handoff.go
@@ -74,7 +74,7 @@ func (s *Server) stampHandoffs(ctx context.Context, cfg webhooks.Config, botID s
 	if vars == nil || strings.TrimSpace(q.PRURL) == "" {
 		return
 	}
-	for _, want := range s.handoffConsumersFor(botID) {
+	for _, want := range s.handoffConsumersFor(ctx, cfg.TenantID, botID) {
 		if _, pinned := vars[want.Var]; pinned {
 			continue
 		}
@@ -86,12 +86,15 @@ func (s *Server) stampHandoffs(ctx context.Context, cfg webhooks.Config, botID s
 	}
 }
 
-// handoffConsumersFor returns the bot's declared PR-scoped consumption entries.
-func (s *Server) handoffConsumersFor(botID string) []bundle.ConsumedArtifact {
+// handoffConsumersFor returns the bot's declared PR-scoped consumption
+// entries, read from the tier that will SERVE the launch — teamID's own row
+// when it has one, else platform over baked. Reading a different tier than
+// the launch stamps the seed under a var the running bundle never declared.
+func (s *Server) handoffConsumersFor(ctx context.Context, teamID, botID string) []bundle.ConsumedArtifact {
 	if strings.TrimSpace(botID) == "" {
 		return nil
 	}
-	entry, ok, err := s.effectiveFindByName(botID)
+	entry, ok, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
 	if err != nil {
 		s.logWarn("handoff: cannot read the bot catalog, %s will be launched without its declared seeds: %v", botID, err)
 		return nil
@@ -161,11 +164,13 @@ func (s *Server) realWebhookHandoff(ctx context.Context, cfg webhooks.Config, ki
 // handoffProducers maps each discovered bot that declares it produces this kind
 // to the node layout to read it from.
 //
-// Resolved against the BAKED CATALOG only, not the tenant-merged set: a webhook
-// delivery carries no active-team context to read team-authored bundles with.
-// A team that forks a reviewer in the cloud editor therefore does not
-// participate in the hand-off — a real boundary, stated here because a miss is
-// silent and would otherwise read as "nothing reviewed this PR".
+// The PRODUCER side is resolved against the platform+baked set only, unlike
+// the consumer side above: this asks "who, anywhere on this deployment,
+// produces this kind", which a per-team read cannot answer without listing
+// every team's rows. So a team that forks a reviewer AND renames the node its
+// `produces:` block points at drops out of the hand-off — a real boundary,
+// stated here because a miss is silent and would otherwise read as "nothing
+// reviewed this PR". Closing it is #946.
 func (s *Server) handoffProducers(kind bundle.HandoffKind) map[string]bundle.ProducedArtifact {
 	entries, err := s.effectiveEntries()
 	if err != nil {

--- a/pkg/server/webhooks_handoff_team_test.go
+++ b/pkg/server/webhooks_handoff_team_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// R33cf5e — the webhook lane launches a team's fork (#871), so the METADATA
+// it reads on the same delivery has to come from the same row. Before the
+// team tier reached this lane, launch and metadata both resolved
+// platform-over-baked and could not disagree; making the launch tenant-aware
+// is what opened the gap, so it closes here rather than in the general
+// metadata sweep (#946).
+//
+// The failure is silent by construction: a fork that renames its `consumes:`
+// var gets its seed stamped under the ORIGIN's name — an empty hand-off, not
+// an error — and a fork that moves its gate context greens a status nothing
+// requires.
+
+const handoffBakedBot = "schema out:\n  ok: bool\n\nvars:\n  gate_context: string = \"iterion/baked\"\n\ntool work:\n  command: `printf '{\"ok\":true}'`\n  output: out\n\nworkflow reviewer_bot:\n  worktree: none\n  entry: work\n  work -> done\n"
+
+const handoffForkBot = "schema out:\n  ok: bool\n\nvars:\n  gate_context: string = \"iterion/fork\"\n\ntool work:\n  command: `printf '{\"ok\":true}'`\n  output: out\n\nworkflow reviewer_bot:\n  worktree: none\n  entry: work\n  work -> done\n"
+
+const handoffBakedManifest = "name: reviewer-bot\nversion: 1.0.0\nretry:\n  usage_window: resume\n  max_attempts: 9\nconsumes:\n  - kind: review\n    var: prior_review\n    scope: pr\n"
+
+const handoffForkManifest = "name: reviewer-bot\nversion: 1.0.0\nretry:\n  usage_window: off\n  max_attempts: 2\nconsumes:\n  - kind: review\n    var: prior_review_fork\n    scope: pr\n"
+
+// newHandoffTeamServer bakes `reviewer-bot` into the catalog and gives team
+// t1 a fork of it whose manifest and vars BOTH differ from the origin's.
+func newHandoffTeamServer(t *testing.T) *Server {
+	t.Helper()
+	s := newOrgTestServer(t)
+	seedGate(t, s, gateSpec{id: "t1"})
+	botsDir := t.TempDir()
+	bundleDir := filepath.Join(botsDir, "reviewer-bot")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "main.bot"), []byte(handoffBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "manifest.yaml"), []byte(handoffBakedManifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	s.botSources = botsource.NewMemoryStore()
+	if _, err := s.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
+		TenantID: "t1", Slug: "reviewer-bot",
+		Files: map[string]string{
+			botsource.MainBotFile: handoffForkBot,
+			"manifest.yaml":       handoffForkManifest,
+		},
+	}); err != nil {
+		t.Fatalf("seed the team's fork: %v", err)
+	}
+	return s
+}
+
+func TestWebhookMetadataReadsTheTeamsFork(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("hand-off seeds come from the fork's manifest", func(t *testing.T) {
+		s := newHandoffTeamServer(t)
+		got := s.handoffConsumersFor(ctx, "t1", "reviewer-bot")
+		if len(got) != 1 || got[0].Var != "prior_review_fork" || got[0].Kind != bundle.HandoffKindReview {
+			t.Fatalf("consumes = %+v, want the FORK's `prior_review_fork` — the launch runs the fork, so the seed must be stamped under the var the fork actually declares", got)
+		}
+	})
+
+	t.Run("gate context comes from the fork's var default", func(t *testing.T) {
+		s := newHandoffTeamServer(t)
+		got := s.resolveGateContext(ctx, webhooks.Config{ID: "wh-1", TenantID: "t1"}, "reviewer-bot")
+		if got != "iterion/fork" {
+			t.Fatalf("gate context = %q, want %q — a fork that moves its gate context must not green the origin's status", got, "iterion/fork")
+		}
+	})
+
+	// A team with no row of its own still reads the baked bot: the team pass
+	// must not shadow the tiers below it.
+	t.Run("a team with no fork still reads the baked bot", func(t *testing.T) {
+		s := newHandoffTeamServer(t)
+		if got := s.handoffConsumersFor(ctx, "t2", "reviewer-bot"); len(got) != 1 || got[0].Var != "prior_review" {
+			t.Fatalf("consumes = %+v, want the baked `prior_review`", got)
+		}
+		if got := s.resolveGateContext(ctx, webhooks.Config{ID: "wh-1", TenantID: "t2"}, "reviewer-bot"); got != "iterion/baked" {
+			t.Fatalf("gate context = %q, want %q", got, "iterion/baked")
+		}
+	})
+
+	// The third read on the same delivery, same class as the two Revi named:
+	// a fork's manifest is what decides whether ITS run is auto-retried.
+	t.Run("retry policy comes from the fork's manifest", func(t *testing.T) {
+		s := newHandoffTeamServer(t)
+		if got := s.resolveRunRetryPolicy(ctx, "t1", "reviewer-bot"); got == nil || got.MaxAttempts != 2 {
+			t.Fatalf("retry = %+v, want the FORK's max_attempts 2 — the fork's run is the one being retried", got)
+		}
+		if got := s.resolveRunRetryPolicy(ctx, "t2", "reviewer-bot"); got == nil || got.MaxAttempts != 9 {
+			t.Fatalf("retry = %+v, want the baked max_attempts 9 for a team with no fork", got)
+		}
+	})
+
+	// An explicit operator/webhook launch var still outranks BOTH — the fork
+	// is a default source, never an override of what the operator pinned.
+	t.Run("an operator launch var still wins over the fork", func(t *testing.T) {
+		s := newHandoffTeamServer(t)
+		cfg := webhooks.Config{ID: "wh-1", TenantID: "t1", OperatorLaunchVars: map[string]string{gateContextVar: "iterion/pinned"}}
+		if got := s.resolveGateContext(ctx, cfg, "reviewer-bot"); got != "iterion/pinned" {
+			t.Fatalf("gate context = %q, want the operator's pin", got)
+		}
+	})
+}

--- a/pkg/server/webhooks_handoff_test.go
+++ b/pkg/server/webhooks_handoff_test.go
@@ -338,13 +338,13 @@ func TestRenderReviewLedger(t *testing.T) {
 func TestHandoffConsumersComeFromTheManifest(t *testing.T) {
 	s := newWebhookTestServer(t)
 	s.cfg.WorkDir = writeConsumerBotFixture(t, "fixer-bot", "prior_review")
-	if got := s.handoffConsumersFor("fixer-bot"); len(got) != 1 || got[0].Var != "prior_review" {
+	if got := s.handoffConsumersFor(context.Background(), "", "fixer-bot"); len(got) != 1 || got[0].Var != "prior_review" {
 		t.Fatalf("the fixture bot's declaration did not load: %+v", got)
 	}
 
 	s2 := newWebhookTestServer(t)
 	s2.cfg.WorkDir = writeConsumerBotFixture(t, "other-fixer", "upstream_notes")
-	got := s2.handoffConsumersFor("other-fixer")
+	got := s2.handoffConsumersFor(context.Background(), "", "other-fixer")
 	if len(got) != 1 || got[0].Var != "upstream_notes" {
 		t.Fatalf("a bot consuming into its own var name must be honoured, got %+v", got)
 	}

--- a/pkg/server/webhooks_review_approve.go
+++ b/pkg/server/webhooks_review_approve.go
@@ -54,30 +54,29 @@ const gateContextVar = "gate_context"
 // (the documented setup, and the only one where a required check can span two
 // bots) was getting a green `revi/review` instead: a status nothing required,
 // leaving the real gate untouched while reporting success.
-func (s *Server) resolveGateContext(cfg webhooks.Config, botID string) string {
+func (s *Server) resolveGateContext(ctx context.Context, cfg webhooks.Config, botID string) string {
 	if v := strings.TrimSpace(cfg.OperatorLaunchVars[gateContextVar]); v != "" {
 		return v
 	}
 	if v := strings.TrimSpace(cfg.LaunchVars[gateContextVar]); v != "" {
 		return v
 	}
-	return strings.TrimSpace(s.botVarDefault(botID, gateContextVar))
+	return strings.TrimSpace(s.botVarDefault(ctx, cfg.TenantID, botID, gateContextVar))
 }
 
-// botVarDefault reads a bot's declared default for one workflow var.
-func (s *Server) botVarDefault(botID, name string) string {
-	entries, err := s.effectiveEntriesWithSchema()
-	if err != nil {
+// botVarDefault reads a bot's declared default for one workflow var, from the
+// tier that will SERVE the launch — teamID's own row when it has one, else
+// platform over baked. A fork that moves its gate context would otherwise
+// green a status nothing requires, which is the exact failure the function
+// above exists to prevent.
+func (s *Server) botVarDefault(ctx context.Context, teamID, botID, name string) string {
+	entry, ok, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
+	if err != nil || !ok || entry.Vars == nil {
 		return ""
 	}
-	for _, e := range entries {
-		if e.Name != botID || e.Vars == nil {
-			continue
-		}
-		for _, f := range e.Vars.Fields {
-			if f.Name == name && f.Default != nil {
-				return f.Default.StrVal
-			}
+	for _, f := range entry.Vars.Fields {
+		if f.Name == name && f.Default != nil {
+			return f.Default.StrVal
 		}
 	}
 	return ""
@@ -268,7 +267,7 @@ func (s *Server) handlePRForgeReviewApprove(ctx context.Context, w http.Response
 		s.approveFilteredWithReply(ctx, w, cfg, meta, provider, p, sameRefusal("the forge returned no head sha for this PR"), payloadHash, srcIP)
 		return
 	}
-	gateCtx := s.resolveGateContext(cfg, reviewer)
+	gateCtx := s.resolveGateContext(ctx, cfg, reviewer)
 	if gateCtx == "" {
 		s.approveFilteredWithReply(ctx, w, cfg, meta, provider, p, sameRefusal("no merge-gate context is pinned on this repo (pin gate_context on the integration — see docs/merge-gate.md)"), payloadHash, srcIP)
 		return

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -506,7 +506,7 @@ func TestResolveGateContextFollowsTheRepoPin(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := s.resolveGateContext(c.cfg, "any-review-bot"); got != c.want {
+			if got := s.resolveGateContext(context.Background(), c.cfg, "any-review-bot"); got != c.want {
 				t.Errorf("resolveGateContext = %q, want %q", got, c.want)
 			}
 		})

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -203,6 +203,20 @@ func EndedBecausePRClosed(r *Run) bool {
 // Bump this when making breaking changes to the Run struct.
 const RunFormatVersion = 1
 
+// The bot-resolution tiers a launch can be served by, persisted on
+// Run.BotSourceTier. The vocabulary lives here, next to the field, so the
+// resolver that produces it and the publisher that stores it cannot drift.
+const (
+	// BotSourceTierTeam — the launching team's own botsource row (a fork
+	// authored in the studio editor, or a bot only that team has).
+	BotSourceTierTeam = "team"
+	// BotSourceTierPlatform — a deployment-wide override under the
+	// reserved platform sentinel tenant.
+	BotSourceTierPlatform = "platform"
+	// BotSourceTierBaked — the catalog baked into the image.
+	BotSourceTierBaked = "baked"
+)
+
 // Run is the top-level metadata for a single workflow invocation.
 //
 // bson tags mirror the json tags exactly (same snake_case names) so a
@@ -786,6 +800,13 @@ type Run struct {
 	// (or the baked bundle), and a unique-slug team bot could not resume
 	// at all.
 	BotSourceTenant string `json:"bot_source_tenant,omitempty" bson:"bot_source_tenant,omitempty"`
+	// BotSourceTier names the tier that SERVED this launch — BotSourceTierTeam,
+	// BotSourceTierPlatform or BotSourceTierBaked. BotSourceTenant already
+	// identifies a stored ROW, but its empty value conflates "baked catalog"
+	// with "nothing recorded", so it cannot answer which tier a launch
+	// resolved through. Empty here means the launch predates the stamp or
+	// resolved no bot at all (a loose .bot).
+	BotSourceTier string `json:"bot_source_tier,omitempty" bson:"bot_source_tier,omitempty"`
 	// KeyOverrides pins a BYOK key per LLM provider (provider → api_key id)
 	// for this run, persisted so cloud resume re-resolves with the same
 	// keys. Set by webhook launches carrying per-webhook key bindings;

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -303,6 +303,15 @@ export interface RunHeader {
   // run's repo identity (work_dir is a runner-pod path there). Empty
   // for local and repo-less runs.
   project_path?: string;
+  // Which tier resolved this run's bundle at launch: "team" (the
+  // launching team's own botsource row — a studio-editor fork), "platform"
+  // (a deployment-wide override) or "baked" (the catalog in the image).
+  // ABSENT on local runs and on runs predating the stamp — an absent tier
+  // is NOT "baked"; render nothing rather than a claim (runBotSourceMeta).
+  bot_source_tier?: string;
+  // Owner of the stored row bot_source_tier names — the team id, or the
+  // platform sentinel. Absent on the baked tier and on unstamped runs.
+  bot_source_tenant?: string;
   worktree?: boolean;
   // True when work_dir still exists on the server's filesystem — i.e. the
   // inline file editor + live diff surfaces can be served without a 409.

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5971,6 +5971,8 @@ export interface components {
             active_duration_ms: number;
             auto_merge?: boolean;
             backends_used?: components["schemas"]["BackendUsage"][];
+            bot_source_tenant?: string;
+            bot_source_tier?: string;
             budget?: components["schemas"]["RunBudget"];
             bundle_display_name?: string;
             bundle_name?: string;

--- a/studio/src/components/Runs/RunHeader.tsx
+++ b/studio/src/components/Runs/RunHeader.tsx
@@ -24,6 +24,7 @@ import { useServerInfoStore } from "@/store/serverInfo";
 
 import ForkDialog from "./ForkDialog";
 import ResumeDialog from "./ResumeDialog";
+import { botSourceTierMeta } from "./runBotSourceMeta";
 import { RunShellPanel } from "./RunShellPanel";
 import BackendsUsedRow from "./runHeader/BackendsUsedRow";
 import FallbacksUsedRow from "./runHeader/FallbacksUsedRow";
@@ -169,6 +170,7 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
   const startedRel = formatRelative(run.created_at);
   const finishedRel = run.finished_at ? formatRelative(run.finished_at) : null;
   const fileBase = run.file_path ? basename(run.file_path) : null;
+  const botSourceTier = botSourceTierMeta(run);
 
   const onRename = async (next: string) => {
     const trimmed = next.trim();
@@ -396,6 +398,21 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
               `/editor?file=${encodeURIComponent(p)}&from=${encodeURIComponent(run.id)}`,
             )
           } />
+          {/* Which BUNDLE of that bot ran. Only a tier that is not the
+              image's own catalog gets a chip — `baked` is the ordinary
+              case and states itself in "Launched with", and an
+              unrecorded tier renders nothing at all (botSourceTierMeta
+              returns null; an absent tier is not a claim). */}
+          {botSourceTier?.notable && (
+            <Tooltip content={botSourceTier.detail}>
+              <span
+                className="inline-flex items-center gap-1 rounded border border-border-default px-1.5 py-0.5 text-micro text-fg-subtle"
+                data-testid="run-bot-source-tier"
+              >
+                {botSourceTier.label}
+              </span>
+            </Tooltip>
+          )}
           {run.work_dir && !cloud && (
             <Tooltip content={run.work_dir}>
               <span className="inline-flex items-center gap-1 font-mono truncate max-w-[20rem]">

--- a/studio/src/components/Runs/leftPanel/overview/ConfigurationSection.test.tsx
+++ b/studio/src/components/Runs/leftPanel/overview/ConfigurationSection.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { RunHeader, RunStatus } from "@/api/runs";
+
+// Two vendor icon/UI barrels on this component's import path resolve
+// their ESM subpaths in a way vitest cannot follow (@lobehub/ui via the
+// shared chrome, @lobehub/icons via ProviderIcon). Both are pure
+// presentation and neither is on the branch under test — stub them so
+// the row-collection logic runs for real.
+vi.mock("@/components/ui", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/icons/ProviderIcon", () => ({
+  ProviderIcon: () => null,
+}));
+
+import { ConfigurationSection } from "./ConfigurationSection";
+
+afterEach(cleanup);
+
+function mkRun(partial: Partial<RunHeader>): RunHeader {
+  return {
+    id: "run_x",
+    workflow_name: "wf",
+    status: "finished" as RunStatus,
+    created_at: "2026-09-08T12:00:00Z",
+    updated_at: "2026-09-08T12:00:00Z",
+    active_duration_ms: 0,
+    ...partial,
+  } as RunHeader;
+}
+
+// The section is a collapsed <details>; jsdom still renders its children,
+// so the rows are queryable without driving the disclosure.
+function renderSection(run: RunHeader) {
+  render(<ConfigurationSection run={run} />);
+}
+
+// #871 — the "Launched with" summary states which bundle served the run,
+// and states NOTHING when the run recorded no tier. The defect this
+// closes was an inert tier that every surface read as a working one, so
+// the site that renders it must not manufacture an answer.
+describe("ConfigurationSection — bundle tier", () => {
+  it("names the team fork", () => {
+    renderSection(mkRun({ bot_source_tier: "team", bot_source_tenant: "acme" }));
+    expect(screen.getByText("Bundle")).toBeTruthy();
+    expect(screen.getByText("team bot")).toBeTruthy();
+  });
+
+  it("states the baked catalog positively", () => {
+    renderSection(mkRun({ bot_source_tier: "baked" }));
+    expect(screen.getByText("baked catalog")).toBeTruthy();
+  });
+
+  it("renders no bundle row when no tier was recorded", () => {
+    renderSection(mkRun({}));
+    expect(screen.queryByText("Bundle")).toBeNull();
+    // And in particular it does not fall back to the baked claim.
+    expect(screen.queryByText("baked catalog")).toBeNull();
+  });
+});

--- a/studio/src/components/Runs/leftPanel/overview/ConfigurationSection.tsx
+++ b/studio/src/components/Runs/leftPanel/overview/ConfigurationSection.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from "react";
 import { ProviderIcon } from "@/components/icons/ProviderIcon";
 import type { RunHeader, RunModelOverride } from "@/api/runs";
 
+import { botSourceTierMeta } from "../../runBotSourceMeta";
 import { Row, Section } from "../InfoPrimitives";
 
 interface ConfigurationSectionProps {
@@ -45,6 +46,17 @@ function collectLaunchedWith(run: RunHeader): LaunchedWithField[] {
           {run.bundle_display_name || run.bundle_name}
         </span>
       ),
+    });
+  }
+
+  // Which tier served the bundle. Absent when the run recorded no tier
+  // (a local run, or one launched before the stamp existed) — no row
+  // rather than a default, so a missing answer never reads as `baked`.
+  const tier = botSourceTierMeta(run);
+  if (tier) {
+    fields.push({
+      label: "Bundle",
+      render: <span title={tier.detail}>{tier.label}</span>,
     });
   }
 

--- a/studio/src/components/Runs/runBotSourceMeta.test.ts
+++ b/studio/src/components/Runs/runBotSourceMeta.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { RunHeader, RunStatus } from "@/api/runs";
+
+import { botSourceTierMeta } from "./runBotSourceMeta";
+
+function mkRun(partial: Partial<RunHeader>): RunHeader {
+  return {
+    id: "run_x",
+    workflow_name: "wf",
+    status: (partial.status ?? "finished") as RunStatus,
+    created_at: "2026-09-08T12:00:00Z",
+    updated_at: "2026-09-08T12:00:00Z",
+    active_duration_ms: 0,
+    ...partial,
+  } as RunHeader;
+}
+
+// #871 — the whole defect was an inert tier reading as a working one, so
+// the rule this helper exists to hold is: an absent or unknown tier is
+// NEVER rendered as a tier. Only a value the launcher actually recorded
+// gets a label.
+describe("botSourceTierMeta", () => {
+  it("names the team fork, and says which team owns the row", () => {
+    const m = botSourceTierMeta(
+      mkRun({ bot_source_tier: "team", bot_source_tenant: "acme" }),
+    );
+    expect(m?.label).toBe("team bot");
+    expect(m?.detail).toContain("acme");
+    expect(m?.notable).toBe(true);
+  });
+
+  it("names a platform override", () => {
+    const m = botSourceTierMeta(mkRun({ bot_source_tier: "platform" }));
+    expect(m?.label).toBe("platform override");
+    expect(m?.notable).toBe(true);
+  });
+
+  it("states `baked` positively, but never flags it as notable", () => {
+    const m = botSourceTierMeta(mkRun({ bot_source_tier: "baked" }));
+    expect(m?.label).toBe("baked catalog");
+    expect(m?.notable).toBe(false);
+  });
+
+  it("returns null when no tier was recorded — absence is not `baked`", () => {
+    expect(botSourceTierMeta(mkRun({}))).toBeNull();
+    expect(botSourceTierMeta(mkRun({ bot_source_tier: "" }))).toBeNull();
+    expect(botSourceTierMeta(mkRun({ bot_source_tier: "   " }))).toBeNull();
+  });
+
+  it("returns null for a tier this build does not know", () => {
+    // A newer server naming a fourth tier must render nothing rather than
+    // guess: a wrong claim about which bundle ran is worse than silence.
+    expect(botSourceTierMeta(mkRun({ bot_source_tier: "marketplace" }))).toBeNull();
+  });
+});

--- a/studio/src/components/Runs/runBotSourceMeta.ts
+++ b/studio/src/components/Runs/runBotSourceMeta.ts
@@ -1,0 +1,51 @@
+import type { RunHeader } from "@/api/runs";
+
+// Which bundle actually ran, for display. The server resolves a bot
+// through team → platform → baked and stamps the tier that served
+// (`bot_source_tier`); this is the single place the studio turns that
+// stamp into words.
+export interface BotSourceTierMeta {
+  // label is the short chip text ("team bot", "platform override", …).
+  label: string;
+  // detail is the sentence a tooltip shows.
+  detail: string;
+  // notable marks a tier that is NOT the bundle shipped in the image, so
+  // a surface can badge only the cases worth interrupting a reader for.
+  notable: boolean;
+}
+
+// botSourceTierMeta returns null for any run whose tier this build cannot
+// name — unrecorded (a local run, or one launched before the stamp
+// existed) or a value a newer server introduced.
+//
+// Null means RENDER NOTHING. It must never fall back to "baked": #871 was
+// a tier that had silently stopped applying while every surface kept
+// reading as though it had, and a default would rebuild exactly that. A
+// missing answer is shown as missing.
+export function botSourceTierMeta(run: RunHeader): BotSourceTierMeta | null {
+  switch (run.bot_source_tier?.trim()) {
+    case "team":
+      return {
+        label: "team bot",
+        detail: `Served by this team's own bot source${
+          run.bot_source_tenant ? ` (${run.bot_source_tenant})` : ""
+        } — a fork or a bot only this team has, not the bundle baked into the image.`,
+        notable: true,
+      };
+    case "platform":
+      return {
+        label: "platform override",
+        detail:
+          "Served by a deployment-wide platform override, not the bundle baked into the image.",
+        notable: true,
+      };
+    case "baked":
+      return {
+        label: "baked catalog",
+        detail: "Served by the bot catalog baked into this build's image.",
+        notable: false,
+      };
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
> **Arbitrated by the maintainer: ship it, and make the tier visible.** Both halves are in this PR. See *The contradiction* below for what was decided and why.

## Why

`resolveBotSource` called `resolveBotTiered(ctx, "", botID, "")` with the team id hardcoded **empty**, and that helper is what every automated launch surface uses. So a team that forks a catalog bot in the studio editor gets its fork on a manual launch and the **baked / platform** version on every webhook review, board card, trigger and schedule.

## The contradiction — read this before reviewing the diff

The empty team id is **not** an oversight. `bot_resolver.go:28` and `docs/platform-bots.md:41` both state it as a CONTRACT, with a rationale:

> The team tier is deliberately consulted ONLY where an active-team context exists (the studio launch surface): a team's experimental fork must not **silently** hijack that team's schedules/webhooks. […] That exclusion is a CONTRACT, not an oversight.

Meanwhile `CLAUDE.md` and the platform-bots index promise the opposite — *"team → platform → baked at every launch surface"*. Two documented sources of truth disagree, and #871 was filed from the second without noticing the first.

This PR resolves the contradiction **in favour of the index**, on one argument: the objection's load-bearing word is *silently*, and the tier stamp removes it. The fork is the team's own deliberate act, on its own tenant's automation, and the run now records which tier served it. If you would rather keep the exclusion, the honest alternative is a **documentation** fix — correct CLAUDE.md and the index to say the team tier is studio-only — and this PR becomes that instead. The revert is one parameter.

## What

| site | surface | identity it had at hand |
|---|---|---|
| `resolveBotSource` | the chokepoint | now takes `teamID` |
| `boardLaunchPreconditions` | board dispatcher | `tenant` |
| `serviceLauncher.Launch` | trigger spine | `plan.TenantID` |
| `launchScheduledBot` | cloudsched | `sb.TenantID` |
| `launchWebhookBot` | inbound webhooks | `cfg.TenantID` |
| `runs_launch.go` | manual launch | already correct |
| `bot_snapshot.go` | subbot children | already threaded — **and this is why the team id belongs on `resolveBotTiered`, not on `resolveBotTieredRaw`**: `Raw` alone would resolve the parent from the team row and its children from platform/baked |
| `resume_source.go` | resume with no persisted origin | `""` kept and allowlisted — the branch above already re-resolves a persisted row by its own `BotSourceTenant` |

Plus `bot_source_tier` (team | platform | baked) persisted on the run, following `bot_source_tenant` exactly — an inert tier was invisible precisely because nothing recorded the answer.

## Evidence

Red first, each test driving the **real** production entry point and asserting on the `LaunchSpec` the publisher actually receives:

```
--- FAIL: TestTeamForkServesTheBoardDispatcher
    board dispatch launched a bundle that is not the team's fork of `probe`
      (source: … printf '{"ok":"BAKED"}' …)
--- FAIL: TestTeamForkServesTheTriggerSpine
--- FAIL: TestTeamForkServesTheCloudSchedule
--- FAIL: TestTeamForkServesTheInboundWebhook
```

Four surfaces, four proofs — this defect exists precisely because four surfaces were assumed to behave like the fifth, so one proof would have repeated the mistake.

Canary per site: re-introducing `""` reddens **that site's test and only that one**. One canary is worth reporting because it found a hole in the guard rather than in the code: the trigger site's sweep stayed *green*, because the spine calls the authority through an injected `resolveBot` field rather than by name. The regex was widened and the canary re-run until the sweep names `trigger_launcher.go`.

`task check` exit 0; `-race` green on server/store/runview/cloudpublisher; Mongo conformance on a `mongo:8.0` replica set, the 21 package trees from `tests.yml`, all ok. `openapi.json` regenerated **byte-identical** — neither `bot_source_tier` nor `bot_source_tenant` is exposed today.

## Stated, not hidden

- **Local run docs record no tier** — they record neither `bot_id` nor `bot_source_tenant`; `CreateRun` has no seam for them. Out of scope.
- **The metadata lanes stay tenant-free** (`effectiveEntries*`, hand-off `produces:`/`consumes:`, command discovery, gate-var defaults). Pre-existing and present on the manual surface too, so this does not widen it — but a fork whose `manifest.yaml` differs from its origin's now *runs* as the fork while being *described* by the origin. Its own ticket.
- **New error semantics, deliberate**: a non-`ErrNotFound` botsource failure on the team tier now fails an automated launch instead of silently serving the baked bot. All four surfaces degrade sanely (card keeps its column and retries; webhook 502 + redelivery; schedule `last_error`; subscription `last_error` + outbox backoff).

## The visibility half (the maintainer's condition)

The argument for overriding the contract is that its load-bearing word is *silently*, and that the tier stamp removes it. That was only true in principle while `bot_source_tier` was persisted and **unexposed** — legible to whoever reads Mongo, which is not what the contract's author meant. So the stamp is now visible:

- `RunHeader` carries `bot_source_tier` + `bot_source_tenant`, threaded the way `project_path` already travels; `openapi.json` and `studio/src/api/schema.ts` regenerated together.
- One helper, `runBotSourceMeta.ts`, is the single place the stamp becomes words. A chip beside the bot chip for the tiers that are **not** the image's catalog, and a `Bundle` row where `baked` states itself positively — following the `permission_mode` precedent, which badges only `ask|deny` and stays silent on `off`.

**Absent must never render as `baked`**, since an inert tier reading as a working one is the whole defect. Held in three places: `omitempty` on the wire (the key is absent, not `""`); the helper returns `null` for absent, empty, whitespace **and for a tier this build does not know**, so a newer server naming a fourth tier renders nothing rather than guessing; both render sites drop their row on `null`.

Canaried on both sides. Stamping a constant `baked` in `headerFromRun` turns the cases apart — and note which two fire:

```
header.BotSourceTier = "baked", want "team"
bot_source_tier = baked on a run that recorded none — absence must stay absence,
                  or an unresolved tier reads as a deliberate one
```

The `baked` case stays green, which is the point: a constant is only detectable by the other two. The studio canary (`default:` returning the baked meta) reddens the pure helper test *and* the rendered site.

`task check` exit 0; studio 1343 tests; `tsc --noEmit` clean; `-race` green on runview and server.

Scoping call worth a word: the **run list** (`RunSummary`) does not carry the tier — only the run detail does. A per-row chip is a different projection on a different surface, and a plausible follow-up.

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)

