### PR TITLE
feat(bundle,runner,server): a bundle may declare the engine it needs, and every use path refuses an older one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,15 @@ the hours this one spent.
   role bots (`admin roles set --reviewer …`) and `sandbox: auto` default
   image (`admin sandbox set --default-image …`, pinned per RunMessage).
   Read it when a bot tweak seems to need a deploy, when a push must be
-  reverted, or when a run fails on "version drift".
+  reverted, or when a run fails on "version drift". Covers the **engine
+  contract** a bundle may declare (`requires: { iterion: ">= X.Y.Z" }` in
+  its manifest — [docs/bundles.md](docs/bundles.md#requires--the-engine-contract)):
+  `push` refuses `409` when the deployment's floor (min of the server's
+  build and the runner builds observed on recent runs) is below it,
+  `--force` overrides loudly, the launch refuses with a terminal
+  `BOT_REQUIRES_NEWER_ENGINE`, and `iterion validate` says the same
+  locally (C250/C251). Read it when a push is refused, or when a bot that
+  compiles dies at its first expression.
 - [docs/dispatcher.md](docs/dispatcher.md#claim-lease--watchdog-native-board-adr-096) —
   the board **claim lease + watchdog** (ADR-096,
   `ITERION_BOARD_CLAIM_REAPER`, default off): the fenced leased claim

--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -285,8 +285,9 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 // --- platform bot overrides (DB-backed catalog) ---
 
 var (
-	remoteAdminBotSlug string
-	remoteAdminBotOut  string
+	remoteAdminBotSlug  string
+	remoteAdminBotOut   string
+	remoteAdminBotForce bool
 )
 
 var remoteAdminBotsCmd = &cobra.Command{
@@ -299,6 +300,7 @@ the next launch; deleting it reverts to the baked catalog.
 
   iterion remote admin bots                       # list overrides (slug, version, digest)
   iterion remote admin bots push bots/review-pr   # push a local bundle dir
+  iterion remote admin bots push bots/review-pr --force   # ... even below its requires.iterion
   iterion remote admin bots show review-pr        # stored files + metadata
   iterion remote admin bots pull review-pr --out /tmp/review-pr
   iterion remote admin bots fork review-pr        # seed the override from the baked bundle
@@ -324,7 +326,7 @@ every mutation lands on the platform audit log with a content digest.`,
 			if err != nil {
 				return err
 			}
-			return cli.RemoteAdminBotsPush(cmd.Context(), c, p, dir, remoteAdminBotSlug)
+			return cli.RemoteAdminBotsPush(cmd.Context(), c, p, dir, remoteAdminBotSlug, remoteAdminBotForce)
 		case "show":
 			slug, err := needArg("slug")
 			if err != nil {
@@ -715,6 +717,7 @@ func init() {
 
 	remoteAdminBotsCmd.Flags().StringVar(&remoteAdminBotSlug, "slug", "", "Override slug (push; default: bundle dir basename)")
 	remoteAdminBotsCmd.Flags().StringVar(&remoteAdminBotOut, "out", "", "Output directory (pull; default: ./<slug>)")
+	remoteAdminBotsCmd.Flags().BoolVar(&remoteAdminBotForce, "force", false, "Push even when the deployment's engine is below the bundle's requires.iterion (the push then carries the warning)")
 
 	for _, role := range []string{"reviewer", "revi_converse", "brancher", "implementer"} {
 		flag := strings.ReplaceAll(role, "_", "-")

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -81,6 +81,10 @@ description: One-liner.
 author: Your Name <you@example.com>
 schema_version: 1         # required; iterion refuses unknown versions
 
+# Optional: the engine this bundle needs (see below)
+requires:
+  iterion: ">= 3.112.14"
+
 # Optional: map workflow attachment names → files inside attachments/
 attachments:
   logo: branding/logo.png
@@ -95,6 +99,64 @@ compat:
 The current schema version is **1**. Bundles that omit `schema_version`
 are treated as v1. iterion refuses any other value with an explicit
 upgrade hint.
+
+### `requires:` — the engine contract
+
+A bundle and the engine that evaluates it travel separately: a bundle is
+pushed or checked out in a second, an engine is installed or deployed. When
+the bundle uses something the engine does not have, the workflow **compiles**
+— a call to an unknown builtin parses generically — and dies at its first
+evaluation. Measured 2026-09-06: a bot pushed as a platform override used the
+variadic `min`/`max` of a newer release while the runners ran an older image;
+the run failed at `compute "delivery_reserve"` and auto-resumed in a loop.
+
+`requires:` is the declaration that closes it. One key today:
+
+```yaml
+requires:
+  iterion: ">= 3.112.14"    # or a bare "3.112.14" — the operator is optional
+```
+
+The grammar is deliberately total: `>=` (or nothing) followed by a dotted
+numeric version with an optional leading `v`. **Every other shape is a
+manifest parse error** — `< 1.2`, `^1.2`, `~> 1.2`, `== 1.2`, `1.2-rc1` — and
+so is an unknown key under `requires:` (the manifest decoder is strict). A
+requirement iterion cannot read is never a requirement iterion ignores; a
+build too old to know the key refuses the whole manifest rather than dropping
+the contract.
+
+It is a version FLOOR rather than a feature list because the only channel a
+deployment has to its runners is a version string — the build each runner
+stamps on the runs it executes. The cost is named: a fork or a backport
+carrying the feature under a different version reads as too old, and a build
+with no orderable version (`dev`, a fork's scheme) makes the check
+*inconclusive*, which is reported, never passed in silence.
+
+Four surfaces honour it, all through the same predicate
+(`bundle.CheckManifestEngine`):
+
+| Surface | Behaviour |
+|---|---|
+| `iterion validate` | **C250** (error) when unmet, **C251** (warning) when this build carries no orderable version |
+| `iterion remote admin bots push` (and any bot-source write) | **409** naming the floor and where it came from; `--force` pushes anyway and the response carries the overridden requirement as a warning |
+| `iterion run` / `resume`, studio, dispatcher, subbot children | refused before a worktree or sandbox is created; run ends `failed` with `BOT_REQUIRES_NEWER_ENGINE` |
+| cloud runner | refused before the first node; run ends `failed` (never `failed_resumable`) with `BOT_REQUIRES_NEWER_ENGINE`, the delivery is **acked** so no redelivery repeats the same arithmetic |
+
+The push guard's floor is the **minimum** of the server's own build and every
+runner build observed on runs in the last 7 days (`Run.runner_version`) — a
+queued run lands on whichever pod takes it, and the server is the half that
+compiles the bot.
+
+**Where the contract is deliberately NOT enforced.** Installing or packing a
+bundle for an engine you do not have yet is legitimate — you install, then
+upgrade — so `iterion bundle pack`, `iterion marketplace install` and
+`botinstall` (a `.botz` from a URL or a local path) do not check it; the launch
+and `iterion validate` do. The cloud **publisher** does not check it either:
+during a rolling deploy the fleet is mixed, and the publisher's floor (a
+minimum across pods) would refuse a run that the pod actually taking it could
+serve. The runner decides against its OWN build, which is exact. What every
+path shares is the manifest decoder: a `requires:` block iterion cannot read
+refuses the bundle wherever it is opened.
 
 ## Determinism
 

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -107,6 +107,46 @@ and the failure auto-resumes in a loop (#857, #858). The order that works:
 3. only then dogfood; a platform override is for iterating on a bot the
    deployed engine already supports.
 
+## A bundle may declare the engine it needs — `requires.iterion`
+
+The two-halves rule above was documented in prose, and a production push broke
+it anyway. A bundle can now state its own floor:
+
+```yaml
+# bots/<slug>/manifest.yaml
+requires:
+  iterion: ">= 3.112.14"
+```
+
+`push` then **refuses** (409) when the deployment cannot honour it, naming
+what the bot asked for, what the deployment runs, and where that number came
+from:
+
+```
+bot "branch-improve-loop": bot requires iterion >= 3.112.14 but this build is
+v3.112.7+abc123 — upgrade the engine (or the image this bot runs on), or relax
+the manifest's requires.iterion (floor from runner v3.112.7+abc123). Bump the
+runner image and restart the server first (docs/platform-bots.md § Shipping a
+baked-catalog change), or push anyway with --force
+```
+
+The floor is the **minimum** of this server's own build and every runner build
+observed on runs in the last 7 days (`Run.runner_version`, the build each
+runner stamps on what it executes — there is no other channel: the server
+follows `:edge`, the runners are pinned by digest). Both halves count: the
+server compiles the bot at launch, the runners evaluate it, and a queued run
+lands on whichever pod takes it.
+
+`--force` is the escape hatch — pushing ahead of a rollout is legitimate — and
+is never silent: the response carries the overridden requirement as a warning.
+
+If the push lands anyway (forced, or the guard could not decide), the **runner
+refuses at launch**: the run ends `failed` — not `failed_resumable` — with
+`BOT_REQUIRES_NEWER_ENGINE`, and the delivery is acked so no redelivery
+repeats the same arithmetic. `iterion validate` reports the same thing locally
+as **C250** (unmet) / **C251** (this build has no orderable version, so the
+check could not run). Full contract: [docs/bundles.md](bundles.md#requires--the-engine-contract).
+
 ## Trust model
 
 A platform override executes across **all tenants**, with each tenant's

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -188,6 +188,15 @@ except **C230**; warnings are surfaced but do not fail validation.
 | **C232** | warning | skill has no `description:` | A `skills/*.md` file has no `description:` frontmatter, so the router (Nexie) has no signal for when to select it | Add a `description:` saying what the skill is for and when it applies |
 | **C233** | warning | skill `description:` too terse | A skill `description:` is present but too short to route on (e.g. "Security stuff") | Describe what the skill does and the situation it applies to. Routability only — no phrasing template is imposed |
 | **C234** | warning | duplicate skill name | Two `skills/*.md` files declare the same `name:`, so one silently clobbers the other when mirrored | Give each skill a unique `name:` |
+| **C250** | error | engine requirement unmet | The manifest declares `requires: { iterion: ">= X.Y.Z" }` and this build is below it — the bundle uses something the running engine does not have | Upgrade iterion, or lower `requires.iterion` to a build that carries what the bot uses. The same predicate refuses the bundle at `iterion remote admin bots push` (409, `--force` overrides) and at launch on a runner (`BOT_REQUIRES_NEWER_ENGINE`, terminal) |
+| **C251** | warning | engine requirement unchecked | A `requires.iterion` is declared but this build carries no orderable version (a `dev` build, a fork's naming scheme), so the comparison could not run | Validate with a released build, or one built through `task build` (which injects the version). Reported rather than passed in silence — an unchecked contract that reads as satisfied is what the declaration exists to prevent |
+
+The engine-contract checks (**C250–C251**) hold a bundle's declared
+`requires.iterion` against the build reading it. The grammar is deliberately
+total: `>= X.Y.Z` or a bare version, dotted numeric, optional leading `v`;
+every other shape is a manifest parse error, and an unknown key under
+`requires:` is refused by the strict manifest decoder. A requirement iterion
+cannot read is never a requirement iterion ignores.
 
 The skill-authoring checks (**C231–C234**) guard *routability* — that a skill
 can be discovered and chosen by the router — not prose style. They impose no

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -102,7 +102,9 @@ Being one of the engine's own codes does not make a verdict re-decidable.
 `EXPRESSION_FAILED` (a `compute` node: no LLM, no shell, inputs from a
 checkpoint that does not move), `CONTEXT_LENGTH_EXCEEDED` (the in-node
 recipe already compacted twice and gave up; a resume rehydrates the same
-conversation), `IR_UNLOADABLE`, `WORKSPACE_SAFETY`,
+conversation), `IR_UNLOADABLE`, `BOT_REQUIRES_NEWER_ENGINE` (a comparison
+between two constants — the bundle's `requires.iterion` and the build's own
+version), `WORKSPACE_SAFETY`,
 `TOOL_FAILED_PERMANENT` and their peers reach the same verdict on every
 attempt. Which codes those are is **one table**,
 [`pkg/retrypolicy`'s classification](../pkg/retrypolicy/classify.go), read

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -66,6 +66,13 @@ type Manifest struct {
 	// produce a clear error pointing at the user's iterion build.
 	SchemaVersion int `yaml:"schema_version"`
 
+	// Requires states the engine this bundle needs — the contract that
+	// keeps a bot from reaching a build whose evaluator cannot run it.
+	// Deliberately NOT under Compat: a requirement is only worth
+	// declaring if the engine that cannot honour it refuses instead of
+	// dropping it. See requires.go.
+	Requires *Requires `yaml:"requires,omitempty"`
+
 	// Compat is a forward-compatible bag for additive fields. Unknown
 	// keys here are ignored without breaking loads from newer bundles.
 	Compat map[string]any `yaml:"compat,omitempty"`
@@ -948,6 +955,14 @@ func decodeManifest(body []byte, srcLabel string) (*Manifest, error) {
 	m.Icon = strings.TrimSpace(m.Icon)
 	if len(m.Icon) > maxIconLen {
 		return nil, fmt.Errorf("bundle: manifest %s: icon %q exceeds %d bytes — expected a short emoji", srcLabel, m.Icon, maxIconLen)
+	}
+	// The engine contract is parsed HERE, at the one door every manifest
+	// load goes through, so a requirement this build cannot read fails on
+	// the manifest rather than at the admission site that meant to enforce
+	// it — a requirement silently skipped is the failure mode the field
+	// exists to close.
+	if err := m.Requires.Validate(); err != nil {
+		return nil, fmt.Errorf("bundle: manifest %s: %w", srcLabel, err)
 	}
 	// Soft-normalize only — launch names may reference workflow vars,
 	// which the manifest loader cannot see, so nothing here hard-fails.

--- a/pkg/bundle/requires.go
+++ b/pkg/bundle/requires.go
@@ -1,0 +1,221 @@
+package bundle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// The engine contract a bundle may state about the build that runs it.
+//
+// A bot and the engine that evaluates it ship in two different halves of a
+// deployment: the bundle can be pushed in a second (a platform override, a
+// team bundle, a `.botz` from a git URL) while the runner image is pinned by
+// digest and moves only on a deploy. Nothing used to hold the two together —
+// a bot using a builtin the runner's evaluator did not have COMPILED (a
+// function call parses generically) and died at its first evaluation.
+//
+// `requires:` is the declaration that closes it:
+//
+//	requires:
+//	  iterion: ">= 3.112.14"
+//
+// It is deliberately a VERSION FLOOR rather than a feature list. The push
+// guard's only channel to the fleet is a version string (the build each
+// runner stamps on the runs it executes — store.Run.RunnerVersion), so a
+// feature list would have to be translated back into a version before it
+// could be checked there, which is the version comparison with an extra map
+// in front of it. The cost is honest and named: a fork or a backport carrying
+// the feature under a different version string reads as too old, and a build
+// with no orderable version reads as EngineUnknown — reported, never silently
+// passed.
+//
+// The manifest decoder is STRICT (yaml.UnmarshalStrict), which gives the
+// contract a property worth relying on: a build too old to know `requires:`
+// refuses the whole manifest rather than dropping the requirement, and so
+// does a build that does not know a key some future release adds under it.
+// A requirement iterion cannot read is never a requirement iterion ignores.
+
+// Requires is the bundle's engine contract. Every key is a separate
+// requirement and ALL of them must hold; an unknown key is refused by the
+// strict manifest decoder.
+type Requires struct {
+	// Iterion is the minimum engine build, as an `>= X.Y.Z` floor (the
+	// operator is optional — a bare version means the same thing).
+	Iterion string `yaml:"iterion,omitempty"`
+}
+
+// atLeast is the one operator the floor accepts. Anything else is refused
+// with this string in the message, so the accepted grammar is discoverable
+// from the error alone.
+const atLeast = ">="
+
+// EngineConstraint is a parsed version floor.
+type EngineConstraint struct {
+	// Raw is the constraint as authored, for error messages.
+	Raw string
+	// Min is the floor's dotted numeric components.
+	Min []int
+}
+
+// ParseEngineConstraint reads the `requires.iterion` grammar: an optional
+// `>=`, then a dotted numeric version with an optional `v` prefix. Every
+// other shape is an explicit error naming what is accepted — a constraint
+// this build cannot enforce must not be mistaken for one it satisfies.
+func ParseEngineConstraint(s string) (EngineConstraint, error) {
+	raw := strings.TrimSpace(s)
+	if raw == "" {
+		return EngineConstraint{}, fmt.Errorf("engine requirement is empty (expected %q, e.g. %q)", atLeast+" X.Y.Z", atLeast+" 3.112.14")
+	}
+	rest := raw
+	if strings.HasPrefix(rest, atLeast) {
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, atLeast))
+	}
+	parts, ok := numericVersionParts(rest)
+	if !ok {
+		return EngineConstraint{}, fmt.Errorf(
+			"engine requirement %q is not a version floor: expected %q or a bare version (dotted numbers, optional leading %q) — no other operator is enforced, so accepting one would promise a check that never runs",
+			raw, atLeast+" X.Y.Z", "v")
+	}
+	return EngineConstraint{Raw: raw, Min: parts}, nil
+}
+
+// Validate parses every declared requirement, so a manifest carrying one
+// iterion cannot read fails at decode instead of at launch.
+func (r *Requires) Validate() error {
+	if r == nil {
+		return nil
+	}
+	if _, err := ParseEngineConstraint(r.Iterion); err != nil {
+		return fmt.Errorf("requires.iterion: %w", err)
+	}
+	return nil
+}
+
+// EngineVerdict is the answer to "may this build run this bundle".
+type EngineVerdict int
+
+const (
+	// EngineOK: no requirement, or the build satisfies it.
+	EngineOK EngineVerdict = iota
+	// EngineTooOld: the build is ORDERED below the floor. The only verdict
+	// that refuses.
+	EngineTooOld
+	// EngineUnknown: a requirement exists but the build's own version is not
+	// orderable (a `dev` build, a fork's naming scheme). The check could not
+	// run — which is reported, never taken for a pass.
+	EngineUnknown
+)
+
+func (v EngineVerdict) String() string {
+	switch v {
+	case EngineTooOld:
+		return "too_old"
+	case EngineUnknown:
+		return "unknown"
+	default:
+		return "ok"
+	}
+}
+
+// CheckEngine holds a build against the declared floor and returns the
+// verdict plus the sentence an operator needs: what was required, what is
+// running, and what to do about it. The reason is empty only for EngineOK.
+func (r *Requires) CheckEngine(build string) (EngineVerdict, string) {
+	if r == nil || strings.TrimSpace(r.Iterion) == "" {
+		return EngineOK, ""
+	}
+	c, err := ParseEngineConstraint(r.Iterion)
+	if err != nil {
+		// Unreachable through decodeManifest, which validates. Reachable for
+		// a hand-built Manifest value, and silence there would be the very
+		// hole this type exists to close.
+		return EngineTooOld, fmt.Sprintf("bot requires iterion %q, which this build cannot read: %v", r.Iterion, err)
+	}
+	got, ok := numericVersionParts(build)
+	if !ok {
+		return EngineUnknown, fmt.Sprintf(
+			"bot requires iterion %s but the running build %q carries no orderable version — the requirement could not be checked",
+			c.Raw, build)
+	}
+	if compareVersionParts(got, c.Min) < 0 {
+		return EngineTooOld, fmt.Sprintf(
+			"bot requires iterion %s but this build is %s — upgrade the engine (or the image this bot runs on), or relax the manifest's requires.iterion",
+			c.Raw, build)
+	}
+	return EngineOK, ""
+}
+
+// CheckManifestEngine is the nil-safe form every admission site calls: a
+// bundle with no manifest, or no `requires:`, passes.
+func CheckManifestEngine(m *Manifest, build string) (EngineVerdict, string) {
+	if m == nil {
+		return EngineOK, ""
+	}
+	return m.Requires.CheckEngine(build)
+}
+
+// CompareVersions orders two free-form version strings by their dotted
+// numeric components: -1, 0 or +1, with ok=false when either side cannot be
+// ordered. A leading "v" is tolerated, a shorter version is zero-padded
+// (1.2 == 1.2.0), and components compare numerically so 0.10.0 > 0.9.0
+// (which a string compare gets backwards).
+//
+// KNOWN BLIND SPOT, shared by every caller: a suffixed version (0.8.0-rc1,
+// a build metadata tail) is unorderable. Widening this to full semver
+// precedence would mean deciding that -rc1 sorts BEFORE 0.8.0 for every
+// operator, which neither the free-form Manifest.Version contract nor the
+// engine's own build strings license.
+func CompareVersions(a, b string) (int, bool) {
+	pa, okA := numericVersionParts(a)
+	pb, okB := numericVersionParts(b)
+	if !okA || !okB {
+		return 0, false
+	}
+	return compareVersionParts(pa, pb), true
+}
+
+// compareVersionParts orders two already-parsed component lists.
+func compareVersionParts(pa, pb []int) int {
+	for i := 0; i < len(pa) || i < len(pb); i++ {
+		var ca, cb int
+		if i < len(pa) {
+			ca = pa[i]
+		}
+		if i < len(pb) {
+			cb = pb[i]
+		}
+		if ca != cb {
+			if ca < cb {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// numericVersionParts splits a version into its dotted numeric components.
+// A leading "v" is tolerated, and a `+commit` build tail is dropped (the
+// engine's own FullVersion carries one); anything else non-numeric makes the
+// whole version unorderable.
+func numericVersionParts(v string) ([]int, bool) {
+	s := strings.TrimSpace(v)
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexByte(s, '+'); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return nil, false
+	}
+	fields := strings.Split(s, ".")
+	out := make([]int, 0, len(fields))
+	for _, f := range fields {
+		n, err := strconv.Atoi(strings.TrimSpace(f))
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		out = append(out, n)
+	}
+	return out, true
+}

--- a/pkg/bundle/requires_test.go
+++ b/pkg/bundle/requires_test.go
@@ -1,0 +1,106 @@
+package bundle
+
+import "testing"
+
+// A manifest may state the engine it needs. The contract is greppable and
+// total: one accepted operator, dotted numeric versions, and an explicit
+// error on anything else — a requirement iterion cannot read must never be
+// a requirement iterion ignores.
+
+func TestRequiresParsesTheAcceptedGrammar(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want []int
+	}{
+		{">= 3.112.14", []int{3, 112, 14}},
+		{">=3.112.14", []int{3, 112, 14}},
+		{">= v3.112.14", []int{3, 112, 14}},
+		{"3.112.14", []int{3, 112, 14}},
+		{"  >=   3.116  ", []int{3, 116}},
+	} {
+		got, err := ParseEngineConstraint(tc.in)
+		if err != nil {
+			t.Fatalf("ParseEngineConstraint(%q): %v", tc.in, err)
+		}
+		if len(got.Min) != len(tc.want) {
+			t.Fatalf("ParseEngineConstraint(%q).Min = %v, want %v", tc.in, got.Min, tc.want)
+		}
+		for i := range tc.want {
+			if got.Min[i] != tc.want[i] {
+				t.Fatalf("ParseEngineConstraint(%q).Min = %v, want %v", tc.in, got.Min, tc.want)
+			}
+		}
+	}
+}
+
+func TestRequiresRefusesWhatItCannotEnforce(t *testing.T) {
+	for _, in := range []string{
+		"", "  ",
+		"< 3.112.14",  // an upper bound is a different contract
+		"^3.112.14",   // caret/tilde ranges are not a grammar we enforce
+		"~> 3.112",    //
+		"== 3.112.14", // equality would pin, not floor
+		">= latest",   // not a version
+		">= 3.112.14-rc1",
+		">= ",
+	} {
+		if got, err := ParseEngineConstraint(in); err == nil {
+			t.Errorf("ParseEngineConstraint(%q) = %+v, nil — an unreadable requirement must be an explicit error, never an ignored field", in, got)
+		}
+	}
+}
+
+func TestDecodeManifestRefusesAnUnreadableRequirement(t *testing.T) {
+	_, err := DecodeManifest([]byte("name: x\nrequires:\n  iterion: \"^3.1\"\n"), "t")
+	if err == nil {
+		t.Fatal("decodeManifest accepted requires.iterion \"^3.1\" — an unparsable requirement is exactly the failure mode the field exists to close")
+	}
+}
+
+func TestDecodeManifestRefusesAnUnknownRequirementKey(t *testing.T) {
+	// A requirement this build does not know must refuse the bundle, not be
+	// dropped: silence would make the contract a decoration.
+	_, err := DecodeManifest([]byte("name: x\nrequires:\n  features: [expr.variadic_minmax]\n"), "t")
+	if err == nil {
+		t.Fatal("decodeManifest accepted an unknown key under requires: — an unknown requirement must be an explicit error")
+	}
+}
+
+func TestCheckEngineVerdicts(t *testing.T) {
+	m, err := DecodeManifest([]byte("name: x\nrequires:\n  iterion: \">= 3.112.14\"\n"), "t")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, tc := range []struct {
+		build string
+		want  EngineVerdict
+	}{
+		{"v3.112.7+abc123", EngineTooOld},
+		{"v3.112.14", EngineOK},
+		{"v3.116.4+deadbeef", EngineOK},
+		{"3.113", EngineOK},
+		{"dev", EngineUnknown},
+		{"", EngineUnknown},
+	} {
+		got, reason := CheckManifestEngine(m, tc.build)
+		if got != tc.want {
+			t.Errorf("CheckManifestEngine(build %q) = %v (%s), want %v", tc.build, got, reason, tc.want)
+		}
+		if got != EngineOK && reason == "" {
+			t.Errorf("CheckManifestEngine(build %q) = %v with an empty reason — a refusal must say what it wanted and what it found", tc.build, got)
+		}
+	}
+}
+
+func TestCheckManifestEngineIsQuietWithoutARequirement(t *testing.T) {
+	m, err := DecodeManifest([]byte("name: x\n"), "t")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, _ := CheckManifestEngine(m, "dev"); got != EngineOK {
+		t.Errorf("a manifest with no requires: got %v, want EngineOK — the field is opt-in", got)
+	}
+	if got, _ := CheckManifestEngine(nil, "dev"); got != EngineOK {
+		t.Errorf("a nil manifest got %v, want EngineOK", got)
+	}
+}

--- a/pkg/bundlelint/engine_requirement_test.go
+++ b/pkg/bundlelint/engine_requirement_test.go
@@ -1,0 +1,82 @@
+package bundlelint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+)
+
+// `iterion validate` must surface the same requirement the push guard and the
+// runner enforce — locally, before the bundle is anywhere near a deployment.
+
+func requiresManifest(t *testing.T, iterion string) *bundle.Manifest {
+	t.Helper()
+	src := "name: needy\nversion: 1.6.0\n"
+	if iterion != "" {
+		src += "requires:\n  iterion: \"" + iterion + "\"\n"
+	}
+	m, err := bundle.DecodeManifest([]byte(src), "t")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return m
+}
+
+func findDiag(diags []Diag, code Code) (Diag, bool) {
+	for _, d := range diags {
+		if d.Code == code {
+			return d, true
+		}
+	}
+	return Diag{}, false
+}
+
+func TestEngineRequirementUnmetIsAnError(t *testing.T) {
+	diags := CheckConsistency(Input{Manifest: requiresManifest(t, ">= 3.112.14"), EngineBuild: "v3.112.7+abc"})
+	d, ok := findDiag(diags, DiagEngineRequirementUnmet)
+	if !ok {
+		t.Fatalf("no C250 for a bundle this build cannot run: %+v", diags)
+	}
+	if d.Severity != SeverityError {
+		t.Error("C250 must be an error — the run cannot succeed on this build")
+	}
+	if d.Field != "requires.iterion" {
+		t.Errorf("field = %q, want requires.iterion (the manifest is the attribution surface)", d.Field)
+	}
+	if !strings.Contains(d.Message, "3.112.14") || !strings.Contains(d.Message, "3.112.7") {
+		t.Errorf("message %q must name both the floor and the running build", d.Message)
+	}
+}
+
+func TestEngineRequirementUncheckableIsAWarning(t *testing.T) {
+	diags := CheckConsistency(Input{Manifest: requiresManifest(t, ">= 3.112.14"), EngineBuild: "dev"})
+	d, ok := findDiag(diags, DiagEngineRequirementUnchecked)
+	if !ok {
+		t.Fatalf("no C251 on a build with no orderable version: %+v", diags)
+	}
+	if d.Severity != SeverityWarning {
+		t.Error("C251 must WARN, not reject: refusing every dev build would make `iterion validate` unusable in the repo that authors the bundles")
+	}
+	if _, unmet := findDiag(diags, DiagEngineRequirementUnmet); unmet {
+		t.Error("an undecidable comparison must not also claim the requirement is unmet")
+	}
+}
+
+func TestEngineRequirementSatisfiedIsQuiet(t *testing.T) {
+	for _, tc := range []struct{ name, requires, build string }{
+		{"met exactly", ">= 3.112.14", "v3.112.14"},
+		{"met with room", ">= 3.112.14", "v3.116.4+deadbeef"},
+		{"no requirement", "", "v3.112.7"},
+		{"no build supplied", ">= 3.112.14", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := CheckConsistency(Input{Manifest: requiresManifest(t, tc.requires), EngineBuild: tc.build})
+			for _, code := range []Code{DiagEngineRequirementUnmet, DiagEngineRequirementUnchecked} {
+				if d, found := findDiag(diags, code); found {
+					t.Errorf("unexpected %s: %s", code, d.Message)
+				}
+			}
+		})
+	}
+}

--- a/pkg/bundlelint/lint.go
+++ b/pkg/bundlelint/lint.go
@@ -83,6 +83,24 @@ const (
 	// DiagSkillNameDuplicate: two skill files in the bundle declare the same
 	// `name:`, so one silently clobbers the other when mirrored.
 	DiagSkillNameDuplicate Code = "C234"
+
+	// Engine contract (C250–C251). The manifest may declare the engine build
+	// the bundle needs (`requires.iterion`); these hold it against the build
+	// doing the validating. The family lives here rather than in ir because
+	// the requirement is a MANIFEST fact — ir.Compile only ever sees the
+	// .bot AST, which carries no manifest at all.
+
+	// DiagEngineRequirementUnmet: the manifest declares a `requires.iterion`
+	// floor this build is below. An error: every node the bundle was written
+	// for may reach an evaluator that cannot serve it, and the failure lands
+	// mid-run rather than here.
+	DiagEngineRequirementUnmet Code = "C250"
+	// DiagEngineRequirementUnchecked: a `requires.iterion` is declared but
+	// this build carries no orderable version (a `dev` build, a fork's naming
+	// scheme), so the comparison could not run. A warning, never silence — an
+	// unchecked contract that reads as satisfied is the failure mode the
+	// declaration exists to close.
+	DiagEngineRequirementUnchecked Code = "C251"
 )
 
 // minRoutableDescription is the shortest `description:` the skill lint treats
@@ -143,6 +161,12 @@ type Input struct {
 	// I/O-free: the caller scans the files (via skilllib.ScanFrontmatter) and
 	// passes the results in, mirroring how Frontmatter is supplied.
 	Skills []SkillDoc
+	// EngineBuild is the iterion build the bundle is being validated against,
+	// for the `requires.iterion` check (C250/C251). Empty skips it — the
+	// caller supplies appinfo.FullVersion(); bundlelint stays I/O-free and
+	// never reads its own binary's identity, so a caller that has no build to
+	// hold the bundle against simply does not ask the question.
+	EngineBuild string
 }
 
 // SkillDoc is one bundle skill file's routability-relevant frontmatter. Path
@@ -170,6 +194,7 @@ func CheckConsistency(in Input) []Diag {
 	checkCapabilities(&diags, m, in.Workflow, in.Frontmatter)
 	checkBundleNameStability(&diags, m, in.Workflow, in.DirName)
 	checkSkills(&diags, in.Skills)
+	checkEngineRequirement(&diags, m, in.EngineBuild)
 
 	sort.SliceStable(diags, func(i, j int) bool {
 		if diags[i].Code != diags[j].Code {
@@ -451,4 +476,32 @@ func sameStringSet(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// checkEngineRequirement holds the manifest's declared engine floor against
+// the build validating it (C250/C251).
+//
+// It is the LOCAL half of a guard that also lives at the push admission
+// (pkg/server) and at the launch (pkg/runner) — three surfaces, one predicate
+// in pkg/bundle, so an author, an operator and a pod cannot read the same
+// manifest three different ways.
+func checkEngineRequirement(diags *[]Diag, m *bundle.Manifest, build string) {
+	if strings.TrimSpace(build) == "" {
+		return
+	}
+	verdict, reason := bundle.CheckManifestEngine(m, build)
+	switch verdict {
+	case bundle.EngineTooOld:
+		*diags = append(*diags, Diag{
+			Code: DiagEngineRequirementUnmet, Severity: SeverityError,
+			Field: "requires.iterion", Message: reason,
+			Hint: "upgrade iterion, or lower requires.iterion to a build that carries what the bot uses",
+		})
+	case bundle.EngineUnknown:
+		*diags = append(*diags, Diag{
+			Code: DiagEngineRequirementUnchecked, Severity: SeverityWarning,
+			Field: "requires.iterion", Message: reason,
+			Hint: "validate with a released build (or one built through `task build`, which injects the version) to check the requirement",
+		})
+	}
 }

--- a/pkg/cli/remote_admin_bots.go
+++ b/pkg/cli/remote_admin_bots.go
@@ -27,7 +27,14 @@ import (
 // binary file cannot ride it — the bundle keeps its baked form instead of
 // being silently corrupted. Server-side compile errors and push warnings
 // surface verbatim.
-func RemoteAdminBotsPush(ctx context.Context, c *RemoteClient, p *Printer, dir, slug string) error {
+//
+// force overrides the engine-requirement guard: the server refuses a bundle
+// whose manifest declares a `requires.iterion` above the deployment's own
+// build, because the launch would compile and then die on the pod. Forcing is
+// legitimate (pushing ahead of a rollout, a fork whose version does not
+// order) and is never silent — the response carries the overridden
+// requirement as a warning.
+func RemoteAdminBotsPush(ctx context.Context, c *RemoteClient, p *Printer, dir, slug string, force bool) error {
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("bundle dir: %w", err)
@@ -57,7 +64,11 @@ func RemoteAdminBotsPush(ctx context.Context, c *RemoteClient, p *Printer, dir, 
 	if err != nil {
 		return err
 	}
-	raw, err := c.Call(ctx, "PUT", "/api/admin/bots/"+slug, json.RawMessage(body), nil)
+	path := "/api/admin/bots/" + slug
+	if force {
+		path += "?force=1"
+	}
+	raw, err := c.Call(ctx, "PUT", path, json.RawMessage(body), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/bundlelint"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/internal/appinfo"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/skilllib"
 )
@@ -138,6 +139,10 @@ func RunValidate(path string, p *Printer) error {
 			Frontmatter: bundle.ParseFrontmatter(src), // reuse the bytes already read
 			DirName:     bundleDir,
 			Skills:      scanBundleSkills(bundleHandle.SkillsDir),
+			// The engine contract (C250/C251), held against THIS binary — the
+			// author's local half of the guard the push admission and the
+			// runner apply on a deployment.
+			EngineBuild: appinfo.FullVersion(),
 		})
 		for _, d := range diags {
 			result.BundleDiagnostics = append(result.BundleDiagnostics, d.Error())

--- a/pkg/retrypolicy/classify.go
+++ b/pkg/retrypolicy/classify.go
@@ -115,10 +115,17 @@ var classification = map[store.FailureCode]Disposition{
 	// smaller. Redelivering it burns MaxDeliver pods on one verdict.
 	store.FailureContextLengthExceeded: DispositionDeterministic,
 	store.FailureIRUnloadable:          DispositionDeterministic, // the same image compiles the same IR
-	store.FailureQueueSchemaMismatch:   DispositionDeterministic, // the same runner rejects the same envelope
-	store.FailureLaunchFailed:          DispositionDeterministic, // the run never left the launch path — no checkpoint exists
-	store.FailureDLQParked:             DispositionDeterministic, // the deliveries are already spent
-	store.FailureCancelled:             DispositionDeterministic, // an operator's decision, not a fault
+	// The bundle's manifest names an engine floor this build is below. The
+	// verdict is a comparison between two constants — the manifest's
+	// `requires.iterion` and the pod's own build — so every redelivery
+	// reaches it identically. This is the exact shape of the incident the
+	// table was written for: a bot pushed for a newer engine burned seven
+	// pods on one arithmetic.
+	store.FailureBotRequiresNewerEngine: DispositionDeterministic,
+	store.FailureQueueSchemaMismatch:    DispositionDeterministic, // the same runner rejects the same envelope
+	store.FailureLaunchFailed:           DispositionDeterministic, // the run never left the launch path — no checkpoint exists
+	store.FailureDLQParked:              DispositionDeterministic, // the deliveries are already spent
+	store.FailureCancelled:              DispositionDeterministic, // an operator's decision, not a fault
 	// The provider will not serve this model to this caller. Nothing in
 	// the request's content is at fault, so a different sample cannot
 	// help either — this is the one provider rejection that does not

--- a/pkg/runner/engine_requirement.go
+++ b/pkg/runner/engine_requirement.go
@@ -1,0 +1,105 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/internal/appinfo"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// ErrBotRequiresNewerEngine marks a run whose bundle declares an engine floor
+// (`requires.iterion`) this build is below. Deterministic for this pod AND for
+// every other pod of the same image, so the delivery is acked, not naked: a
+// redelivery reaches the same arithmetic, burns the delivery budget on it, and
+// parks the run on the DLQ with the diagnosis overwritten by DLQ_PARKED.
+//
+// The shape it closes: a bot pushed as a platform override (or baked into a
+// newer image than the runners run) used builtins the evaluator did not have.
+// The workflow COMPILED — a function call parses generically — then failed at
+// its first evaluation, seven pods in ten minutes.
+var ErrBotRequiresNewerEngine = errors.New("the bot requires a newer iterion engine than this runner")
+
+// engineBuild names the build a bundle's requirement is held against. A var so
+// a test can pin it: `go test` binaries carry appinfo.Version = "dev", which is
+// deliberately unorderable, so the guard would otherwise be permanently
+// inconclusive under test.
+var engineBuild = appinfo.FullVersion
+
+// guardEngineRequirement is the ONE point every bundle a run executes with
+// passes through — stored (a `bot_bundle` ref rebuilt from the DB) or baked
+// (the runner image's own catalog). It reads the bundle's declared engine
+// floor and, when this build is below it, writes the terminal verdict on the
+// run and returns ErrBotRequiresNewerEngine.
+//
+// Three outcomes, and the middle one is the point:
+//   - met, or nothing declared → nil, silently;
+//   - BELOW the floor → refused here, before any node executes, so nothing
+//     half-done is left behind and the operator reads the arithmetic instead
+//     of an expression error three nodes in;
+//   - UNDECIDABLE (this build carries no orderable version — a `dev` build, a
+//     fork's naming scheme) → a WARN and the run proceeds. Refusing would stop
+//     every developer build; passing in silence would make the declaration a
+//     decoration.
+func (r *Runner) guardEngineRequirement(ctx context.Context, msg *queue.RunMessage, b *bundle.Bundle) error {
+	if b == nil || b.Manifest == nil {
+		return nil
+	}
+	build := engineBuild()
+	verdict, reason := bundle.CheckManifestEngine(b.Manifest, build)
+	switch verdict {
+	case bundle.EngineOK:
+		return nil
+	case bundle.EngineUnknown:
+		r.cfg.Logger.Warn("runner: run %s: bot %q: %s — the run proceeds unchecked", msg.RunID, msg.BotID, reason)
+		return nil
+	}
+	err := fmt.Errorf("%w: bot %q: %s", ErrBotRequiresNewerEngine, msg.BotID, reason)
+	r.failBotRequiresNewerEngine(ctx, msg, b.Manifest, build, err)
+	return err
+}
+
+// failBotRequiresNewerEngine records the refusal on the run: a TERMINAL failed
+// with the typed code, plus a run_failed event carrying the pair an operator
+// needs to act — what the bot asked for, and what this pod is.
+//
+// Terminal rather than failed_resumable, unlike the IR-unloadable sibling: a
+// resume re-queues onto the same fleet and re-reads the same manifest, so the
+// only cures are a deploy or a bot edit, and after either the run is
+// RE-LAUNCHED (the fixed bot's IR is not the one this run would resume with).
+func (r *Runner) failBotRequiresNewerEngine(ctx context.Context, msg *queue.RunMessage, m *bundle.Manifest, build string, cause error) {
+	if r.cfg.Store == nil {
+		return
+	}
+	wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
+	required := ""
+	if m.Requires != nil {
+		required = m.Requires.Iterion
+	}
+	// UpdateRunOutcome keeps the cancelled-wins guard: a run the operator
+	// cancelled meanwhile is not flipped back into a failure.
+	if changed, err := r.cfg.Store.UpdateRunOutcome(idCtx, msg.RunID, store.RunStatusFailed, cause.Error(),
+		store.RunOutcomeMeta{Code: store.FailureBotRequiresNewerEngine, Continuation: store.ContinuationFinal},
+		store.RunnerVerdictFromStatuses()); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not record the engine requirement refusal: %v", msg.RunID, err)
+	} else if !changed {
+		r.cfg.Logger.Warn("runner: run %s: the engine-requirement verdict was declined (status drifted) — the document does not carry BOT_REQUIRES_NEWER_ENGINE", msg.RunID)
+	}
+	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
+		Type: store.EventRunFailed,
+		Data: map[string]any{
+			"code": string(store.FailureBotRequiresNewerEngine), "error": cause.Error(),
+			"runner_version": build, "runner_commit": appinfo.Commit,
+			"bot":      msg.BotID,
+			"required": required,
+			"hint":     "the bundle declares requires.iterion above this runner's build; bump the runner image (docs/cloud-deployment.md § pinning), or relax the bot's requirement — then RE-LAUNCH (a resume lands on the same fleet)",
+		},
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_failed for the engine requirement: %v", msg.RunID, err)
+	}
+}

--- a/pkg/runner/engine_requirement_test.go
+++ b/pkg/runner/engine_requirement_test.go
@@ -1,0 +1,228 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The production incident this file guards: a bot pushed as a platform
+// override used builtins the runner's evaluator did not have. It COMPILED
+// (a function call parses generically), then died at its first evaluation,
+// and the auto-resume looped on a verdict that could never change.
+//
+// The runner now reads the bundle's declared engine floor before any node
+// executes, and refuses terminally.
+
+// bundleRequiring writes a minimal bundle dir whose manifest carries the
+// given `requires:` block (empty = none) and opens it.
+func bundleRequiring(t *testing.T, requires string) *bundle.Bundle {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := "name: probe\nversion: 1.6.0\n"
+	if requires != "" {
+		manifest += "requires:\n  iterion: \"" + requires + "\"\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, bundle.MainBotFile), []byte("workflow main:\n  entry: done\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, bundle.ManifestFile), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b, err := bundle.OpenDir(dir)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	return b
+}
+
+// pinEngineBuild pins the build the guard compares against. `go test`
+// binaries carry appinfo.Version = "dev", which is deliberately unorderable,
+// so without this the guard would be permanently inconclusive under test.
+func pinEngineBuild(t *testing.T, v string) {
+	t.Helper()
+	prev := engineBuild
+	engineBuild = func() string { return v }
+	t.Cleanup(func() { engineBuild = prev })
+}
+
+func requirementRun(t *testing.T, id string) store.RunStore {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateRun(context.Background(), id, "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+// A bundle whose manifest names an engine floor above this build is refused
+// before any node executes, with the typed TERMINAL verdict on the run — not
+// a generic execution failure a redelivery would replay.
+func TestGuardEngineRequirement_RefusesABundleRequiringANewerEngine(t *testing.T) {
+	pinEngineBuild(t, "v3.112.7+abc123def456")
+	st := requirementRun(t, "run-req")
+	ctx := context.Background()
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+	msg := &queue.RunMessage{RunID: "run-req", WorkflowName: "main", BotID: "needy"}
+
+	err := r.guardEngineRequirement(ctx, msg, bundleRequiring(t, ">= 3.112.14"))
+	if !errors.Is(err, ErrBotRequiresNewerEngine) {
+		t.Fatalf("guard err = %v, want ErrBotRequiresNewerEngine", err)
+	}
+	if !strings.Contains(err.Error(), ">= 3.112.14") || !strings.Contains(err.Error(), "3.112.7") {
+		t.Fatalf("err = %q, want both the floor and the running build named", err)
+	}
+
+	run, _ := st.LoadRun(ctx, "run-req")
+	if run.Status != store.RunStatusFailed {
+		t.Fatalf("status = %q, want failed (NOT failed_resumable: an automatic resume re-queues onto the same fleet and re-reads the same manifest)", run.Status)
+	}
+	if run.FailureCode != store.FailureBotRequiresNewerEngine {
+		t.Fatalf("failure code = %q, want BOT_REQUIRES_NEWER_ENGINE", run.FailureCode)
+	}
+	if !strings.Contains(run.Error, ">= 3.112.14") {
+		t.Fatalf("final error = %q, want the floor it could not meet named", run.Error)
+	}
+	evs, _ := st.LoadEvents(ctx, "run-req")
+	var found bool
+	for _, ev := range evs {
+		if ev.Type == store.EventRunFailed && ev.Data["code"] == string(store.FailureBotRequiresNewerEngine) {
+			found = true
+			if ev.Data["runner_version"] == nil || ev.Data["required"] != ">= 3.112.14" {
+				t.Fatalf("run_failed must name the build and the requirement: %v", ev.Data)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no run_failed {code: BOT_REQUIRES_NEWER_ENGINE}: the refusal is not readable from the run")
+	}
+}
+
+// The negative case, without which the guard above proves nothing: a bundle
+// whose requirement this build MEETS, and one that declares none, both reach
+// the engine untouched. A guard that refuses everything is not a guard.
+func TestGuardEngineRequirement_AdmitsWhatThisBuildCanRun(t *testing.T) {
+	pinEngineBuild(t, "v3.112.14")
+	for _, tc := range []struct{ name, requires string }{
+		{"requirement met exactly", ">= 3.112.14"},
+		{"requirement met with room", ">= 3.100.0"},
+		{"no requirement at all", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := requirementRun(t, "run-ok")
+			r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+			msg := &queue.RunMessage{RunID: "run-ok", WorkflowName: "main", BotID: "modest"}
+			if err := r.guardEngineRequirement(context.Background(), msg, bundleRequiring(t, tc.requires)); err != nil {
+				t.Fatalf("guard refused a bundle this build can run: %v", err)
+			}
+			run, _ := st.LoadRun(context.Background(), "run-ok")
+			if run.Status == store.RunStatusFailed {
+				t.Fatalf("run was failed although %s", tc.name)
+			}
+		})
+	}
+}
+
+// A build with no orderable version (a `dev` build, a fork's naming scheme)
+// cannot decide the comparison. It must WARN and proceed — refusing would
+// stop every developer build, and passing in silence is the failure mode the
+// declaration exists to close.
+func TestGuardEngineRequirement_UnorderableBuildWarnsAndProceeds(t *testing.T) {
+	pinEngineBuild(t, "dev")
+	var logged strings.Builder
+	st := requirementRun(t, "run-dev")
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelWarn, &logged)}}
+	msg := &queue.RunMessage{RunID: "run-dev", WorkflowName: "main", BotID: "needy"}
+
+	if err := r.guardEngineRequirement(context.Background(), msg, bundleRequiring(t, ">= 3.112.14")); err != nil {
+		t.Fatalf("an inconclusive check refused the run: %v", err)
+	}
+	if !strings.Contains(logged.String(), "3.112.14") {
+		t.Fatalf("the unchecked requirement left no trace in the log: %q", logged.String())
+	}
+}
+
+// A nil bundle (a loose .bot, an unresolvable bot id) has no manifest and no
+// requirement — the guard must not invent one.
+func TestGuardEngineRequirement_NoBundleIsNoRequirement(t *testing.T) {
+	pinEngineBuild(t, "v3.112.7")
+	st := requirementRun(t, "run-none")
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+	if err := r.guardEngineRequirement(context.Background(), &queue.RunMessage{RunID: "run-none"}, nil); err != nil {
+		t.Fatalf("guard err = %v on a run with no bundle", err)
+	}
+}
+
+// The WIRING, without which every test above certifies a helper nobody calls:
+// executeRun, handed a message whose stored bundle names a newer engine,
+// refuses before the engine runs and returns the typed error.
+func TestExecuteRun_GuardsTheEngineRequirement(t *testing.T) {
+	pinEngineBuild(t, "v3.112.7+abc123def456")
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-wire", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	mem := botsource.NewMemoryStore()
+	created, err := mem.Create(store.WithTenant(ctx, botsource.PlatformTenantID), botsource.BotSource{
+		TenantID: botsource.PlatformTenantID,
+		Slug:     "needy",
+		Files: map[string]string{
+			botsource.MainBotFile: "workflow main:\n  entry: done\n",
+			"manifest.yaml":       "name: needy\nversion: 1.6.0\nrequires:\n  iterion: \">= 3.112.14\"\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	const src = "workflow main:\n  entry: a\n  a -> done\nagent a:\n  backend: \"claw\"\n  model: \"openai/gpt-5.4-mini\"\n  system: sys\nprompt sys:\n  hi\n"
+	pr := parser.Parse("main.bot", src)
+	body, err := ast.MarshalFile(pr.File)
+	if err != nil {
+		t.Fatalf("marshal AST: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, BotSources: mem, WorkDir: t.TempDir(), Logger: iterlog.New(iterlog.LevelDebug, nil)}}
+	msg := &queue.RunMessage{
+		RunID: "run-wire", WorkflowName: "main", BotID: "needy", IRCompiled: body,
+		BotBundle: &queue.BotBundleRef{TenantID: botsource.PlatformTenantID, Slug: "needy", Version: created.Version},
+	}
+	execErr := r.executeRun(ctx, msg, nil)
+	if !errors.Is(execErr, ErrBotRequiresNewerEngine) {
+		t.Fatalf("executeRun err = %v, want ErrBotRequiresNewerEngine — the guard is not on the path a run takes", execErr)
+	}
+	run, _ := st.LoadRun(ctx, "run-wire")
+	if run.Status != store.RunStatusFailed || run.FailureCode != store.FailureBotRequiresNewerEngine {
+		t.Fatalf("run = %s/%s, want failed/BOT_REQUIRES_NEWER_ENGINE written before the return", run.Status, run.FailureCode)
+	}
+}
+
+// The delivery decision: acked, never naked. A redelivery reaches the same
+// image and the same arithmetic — that loop is the incident.
+func TestClassifyExecResult_BotRequiresNewerEngineIsAcked(t *testing.T) {
+	got := classifyExecResult(errors.New("runner: "+ErrBotRequiresNewerEngine.Error()), "r1")
+	if got.action == actionAck && got.finalStatus == "bot_requires_newer_engine" {
+		t.Fatal("classifyExecResult matched on the error TEXT — it must match the sentinel, or a reworded message silently re-opens the redelivery loop")
+	}
+	wrapped := errors.New("wrapped")
+	got = classifyExecResult(errors.Join(ErrBotRequiresNewerEngine, wrapped), "r1")
+	if got.action != actionAck || got.finalStatus != "bot_requires_newer_engine" {
+		t.Fatalf("classified as %s/%v, want bot_requires_newer_engine/ack", got.finalStatus, got.action)
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -782,6 +782,20 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 			logArgs:     []any{runID, appinfo.Version, execErr},
 		}
 	}
+	// The bundle names an engine floor this build is below: a comparison
+	// between two constants, so every redelivery reaches the same verdict.
+	// Ack — the run is already terminal (failBotRequiresNewerEngine) and the
+	// cure is a deploy or a bot edit followed by a fresh launch.
+	if errors.Is(execErr, ErrBotRequiresNewerEngine) {
+		return execOutcome{
+			finalStatus: "bot_requires_newer_engine",
+			op:          "ack-bot-requires-newer-engine",
+			action:      actionAck,
+			level:       logError,
+			logFmt:      "runner: run %s: the bot declares an engine this runner (%s) is below — failed, NOT redelivered: bump the runner image or relax the bot's requires.iterion, then re-launch (%v)",
+			logArgs:     []any{runID, appinfo.Version, execErr},
+		}
+	}
 	// Operator cancel: terminal cancelled, acked (redelivery drops it).
 	if errors.Is(execErr, runtime.ErrRunCancelled) {
 		return execOutcome{
@@ -2309,6 +2323,10 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// children beside it (see subbotRunnerFor).
 	parentBundleDir := ""
 	snapshotRoot := ""
+	// runBundle is whichever bundle this run executes with, hoisted out of the
+	// two resolution branches so the engine-requirement guard below is ONE
+	// point both traverse rather than a check copied into each.
+	var runBundle *bundle.Bundle
 	if msg.BotBundle != nil {
 		b, cleanupBundle, berr := r.materializeBotBundle(ctx, msg.BotBundle)
 		if berr != nil {
@@ -2319,6 +2337,7 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		if msg.BotBundle.SnapshotDigest != "" {
 			snapshotRoot = filepath.Dir(b.Dir)
 		}
+		runBundle = b
 		engineOpts = append(engineOpts, runtime.WithBundle(b))
 	} else if msg.BotID != "" && len(r.cfg.BotsPaths) > 0 {
 		// Best-effort: an unresolvable bot id or a loose .bot just skips the
@@ -2327,6 +2346,7 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		if mainFile, rerr := botregistry.ResolveBotPath(msg.BotID, r.cfg.BotsPaths); rerr == nil {
 			parentBundleDir = filepath.Dir(mainFile)
 			if b, berr := bundle.OpenDir(filepath.Dir(mainFile)); berr == nil {
+				runBundle = b
 				engineOpts = append(engineOpts, runtime.WithBundle(b))
 			} else {
 				r.cfg.Logger.Warn("runner: bot %q bundle open: %v (skills not mirrored, devbox tools not provisioned)", msg.BotID, berr)
@@ -2334,6 +2354,12 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		} else {
 			r.cfg.Logger.Warn("runner: bot %q not resolvable in %v (skills not mirrored, devbox tools not provisioned)", msg.BotID, r.cfg.BotsPaths)
 		}
+	}
+	// The bundle and the image that executes it move independently — a push
+	// lands in a second, a runner digest bump is a deploy. A bundle that names
+	// an engine this build is below is refused HERE, before the first node.
+	if err := r.guardEngineRequirement(ctx, msg, runBundle); err != nil {
+		return err
 	}
 	// Plugin/library skills the LAUNCHING instance resolved for us. This pod's
 	// iterion home is ephemeral and empty, so local resolution would silently

--- a/pkg/runtime/engine_requirement.go
+++ b/pkg/runtime/engine_requirement.go
@@ -1,0 +1,54 @@
+package runtime
+
+import (
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/internal/appinfo"
+)
+
+// A bundle and the engine that evaluates it are shipped by two different
+// mechanisms — a bundle is pushed or checked out in a second, an engine is
+// installed or deployed. When the bundle uses something the engine does not
+// have, the workflow COMPILES (a builtin call parses generically) and dies at
+// its first evaluation, which is how a production bot burned seven pods in
+// ten minutes on 2026-09-06.
+//
+// A manifest may declare the build it needs (`requires.iterion`, pkg/bundle).
+// This gate is where every NON-cloud launch surface honours it in ONE place:
+// `iterion run` / `resume`, the studio, the dispatcher's direct engine path,
+// and a subbot child all reach Engine.Run or Engine.Resume with the bundle
+// attached. The cloud runner keeps its own gate ahead of this one — it must
+// also decide the delivery (ack, never redeliver), which is knowledge the
+// engine does not have.
+
+// engineBuild names the build a bundle's requirement is held against. A var so
+// a test can pin it: `go test` binaries carry appinfo.Version = "dev", which
+// is deliberately unorderable, so the comparison would otherwise never run
+// under test and every assertion would pass for the wrong reason.
+var engineBuild = appinfo.FullVersion
+
+// refuseBundleRequiringNewerEngine reports why this build must not execute the
+// attached bundle, or nil.
+//
+// A run with no bundle, or a bundle declaring nothing, passes silently. A
+// requirement this build cannot ORDER (a `dev` build, a fork's naming scheme)
+// warns and passes: refusing would stop every developer build, and passing in
+// silence would make the declaration a decoration.
+func (e *Engine) refuseBundleRequiringNewerEngine() error {
+	if e.bundle == nil || e.bundle.Manifest == nil {
+		return nil
+	}
+	build := engineBuild()
+	switch verdict, reason := bundle.CheckManifestEngine(e.bundle.Manifest, build); verdict {
+	case bundle.EngineTooOld:
+		return &RuntimeError{
+			Code:    ErrCodeBotRequiresNewerEngine,
+			Message: reason,
+			Hint:    "upgrade iterion to the build the bot declares, or lower its manifest's requires.iterion",
+		}
+	case bundle.EngineUnknown:
+		if e.logger != nil {
+			e.logger.Warn("runtime: %s — the run proceeds unchecked", reason)
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/engine_requirement_test.go
+++ b/pkg/runtime/engine_requirement_test.go
@@ -1,0 +1,136 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The engine is where every NON-cloud launch surface converges — `iterion
+// run`, the studio, the dispatcher's direct path, a subbot child. One gate
+// here is what keeps them from each needing their own copy of the arithmetic.
+
+func requireBundle(t *testing.T, requires string) *bundle.Bundle {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := "name: probe\nversion: 1.6.0\n"
+	if requires != "" {
+		manifest += "requires:\n  iterion: \"" + requires + "\"\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, bundle.MainBotFile), []byte("workflow main:\n  entry: done\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, bundle.ManifestFile), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b, err := bundle.OpenDir(dir)
+	if err != nil {
+		t.Fatalf("open bundle: %v", err)
+	}
+	return b
+}
+
+// pinEngineBuild pins the build the gate compares against. `go test` binaries
+// carry appinfo.Version = "dev", which is deliberately unorderable, so the
+// comparison would otherwise never run under test.
+func pinEngineBuild(t *testing.T, v string) {
+	t.Helper()
+	prev := engineBuild
+	engineBuild = func() string { return v }
+	t.Cleanup(func() { engineBuild = prev })
+}
+
+func requirementEngine(t *testing.T, requires string) (*Engine, store.RunStore) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := &ir.Workflow{Name: "main", Entry: "done", Nodes: map[string]ir.Node{
+		"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+	}}
+	return New(wf, st, nil, WithBundle(requireBundle(t, requires)), WithWorkDir(t.TempDir())), st
+}
+
+// A run whose bundle names a newer engine never starts: the gate fires before
+// a worktree or a sandbox is spun up for a doomed run, and the run is
+// TERMINAL with the typed code.
+func TestEngineRun_RefusesABundleRequiringANewerEngine(t *testing.T) {
+	pinEngineBuild(t, "v3.112.7+abc123def456")
+	e, st := requirementEngine(t, ">= 3.112.14")
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-eng", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	err := e.Run(ctx, "run-eng", nil)
+	if err == nil {
+		t.Fatal("Run accepted a bundle this build cannot run")
+	}
+	var rt *RuntimeError
+	if !errors.As(err, &rt) || rt.Code != ErrCodeBotRequiresNewerEngine {
+		t.Fatalf("err = %v, want a RuntimeError coded BOT_REQUIRES_NEWER_ENGINE", err)
+	}
+	if !strings.Contains(err.Error(), "3.112.14") {
+		t.Errorf("err = %q, want the floor named", err)
+	}
+	run, _ := st.LoadRun(ctx, "run-eng")
+	if run.Status != store.RunStatusFailed {
+		t.Fatalf("status = %q, want failed — nothing ran, and re-running the same pair reaches the same verdict", run.Status)
+	}
+	if run.FailureCode != store.FailureBotRequiresNewerEngine {
+		t.Fatalf("failure code = %q, want BOT_REQUIRES_NEWER_ENGINE", run.FailureCode)
+	}
+}
+
+// A resume is refused the same way, and BEFORE the claim: the run keeps the
+// status it had, so nothing is lost by asking.
+func TestEngineResume_RefusesABundleRequiringANewerEngine(t *testing.T) {
+	pinEngineBuild(t, "v3.112.7+abc123def456")
+	e, st := requirementEngine(t, ">= 3.112.14")
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, "run-eng-r", "main", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.FailRunResumable(ctx, "run-eng-r", &store.Checkpoint{NodeID: "done"}, "earlier", store.FailureExecutionFailed); err != nil {
+		t.Fatal(err)
+	}
+	err := e.Resume(ctx, "run-eng-r", nil)
+	if err == nil {
+		t.Fatal("Resume accepted a bundle this build cannot run")
+	}
+	var rt *RuntimeError
+	if !errors.As(err, &rt) || rt.Code != ErrCodeBotRequiresNewerEngine {
+		t.Fatalf("err = %v, want a RuntimeError coded BOT_REQUIRES_NEWER_ENGINE", err)
+	}
+	run, _ := st.LoadRun(ctx, "run-eng-r")
+	if run.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %q, want the resumable status untouched — the resume was refused before the claim", run.Status)
+	}
+}
+
+// The negative case: a bundle this build can run, and one that declares
+// nothing, both start normally.
+func TestEngineRun_AdmitsWhatThisBuildCanRun(t *testing.T) {
+	pinEngineBuild(t, "v3.116.4+deadbeef")
+	for _, requires := range []string{">= 3.112.14", ""} {
+		e, st := requirementEngine(t, requires)
+		ctx := context.Background()
+		if _, err := st.CreateRun(ctx, "run-ok", "main", nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.Run(ctx, "run-ok", nil); err != nil {
+			t.Fatalf("Run with requires %q failed: %v", requires, err)
+		}
+		run, _ := st.LoadRun(ctx, "run-ok")
+		if run.Status != store.RunStatusFinished {
+			t.Fatalf("status = %q with requires %q, want finished", run.Status, requires)
+		}
+	}
+}

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -98,6 +98,16 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 		return e.setupErr(ctx, fmt.Errorf("runtime: var validation: %w", err))
 	}
 
+	// Engine contract: the attached bundle may declare the build it needs.
+	// Beside the enum gate for the same reason — every launch surface reaches
+	// here, and a doomed run must be refused before a worktree or a sandbox
+	// is spun up for it. The RuntimeError's code rides through
+	// setupFailureCode, so the run is terminal and typed.
+	if err := e.refuseBundleRequiringNewerEngine(); err != nil {
+		e.markFailedBestEffort(ctx, runID, "engine requirement", err)
+		return e.setupErr(ctx, err)
+	}
+
 	// Worktree setup stays inline: the finalizeOnExit defer must
 	// capture the named return `err`, and the defer installation
 	// is the meaningful side effect — extracting it would require

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -43,6 +43,9 @@ const (
 	ErrCodeAuthFailed            = store.FailureAuthFailed
 	ErrCodeModelUnavailable      = store.FailureModelUnavailable
 	ErrCodeSchemaUnusable        = store.FailureSchemaUnusable
+	// Raised before the first node when the attached bundle declares a
+	// `requires.iterion` this build is below (engine_requirement.go).
+	ErrCodeBotRequiresNewerEngine = store.FailureBotRequiresNewerEngine
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -94,6 +94,14 @@ func (e *Engine) Resume(ctx context.Context, runID string, answers map[string]an
 	if rerr := e.refuseResumeOfSharedChild(ctx, r); rerr != nil {
 		return rerr
 	}
+	// The bundle may declare an engine this build is below. Refused BEFORE
+	// the claim, like the two guards above: the run keeps the resumable
+	// status it had, so an operator who then aligns the build can resume it —
+	// nothing is lost by asking, and re-executing on this build could only
+	// reach the same verdict at the first node.
+	if rerr := e.refuseBundleRequiringNewerEngine(); rerr != nil {
+		return rerr
+	}
 	switch r.Status {
 	case store.RunStatusPausedWaitingHuman:
 		return e.resumeFromPause(ctx, r, answers)

--- a/pkg/server/bot_sources_routes.go
+++ b/pkg/server/bot_sources_routes.go
@@ -203,7 +203,19 @@ func (s *Server) putBotSourceFor(w http.ResponseWriter, r *http.Request, tenantI
 		s.httpErrorFor(w, r, http.StatusBadRequest, "bot does not compile: %s", strings.Join(diags, "; "))
 		return
 	}
-	s.writeBotSource(w, r, tenantID, userID, bs, s.platformPushWarnings(tenantID, bs)...)
+	// Compiling here says nothing about the ENGINE that will evaluate it: a
+	// call to a builtin the runners' evaluator lacks parses generically. The
+	// manifest's `requires.iterion` is what closes that, held against the
+	// deployment's actual floor (engine_floor.go).
+	engineWarning, ok := s.guardBundleEngineRequirement(w, r, bs)
+	if !ok {
+		return
+	}
+	warnings := s.platformPushWarnings(tenantID, bs)
+	if engineWarning != "" {
+		warnings = append(warnings, engineWarning)
+	}
+	s.writeBotSource(w, r, tenantID, userID, bs, warnings...)
 }
 
 // platformPushWarnings surfaces the known gaps a platform push does NOT
@@ -281,6 +293,16 @@ func (s *Server) putBotSourceFileFor(w http.ResponseWriter, r *http.Request, ten
 	}
 	if diags := validateBundleCompile(bs.Files); len(diags) > 0 {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "bot does not compile: %s", strings.Join(diags, "; "))
+		return
+	}
+	// Same guard as the whole-bundle push: an edit to manifest.yaml alone can
+	// introduce (or raise) the requirement, and this path persists it too.
+	engineWarning, ok := s.guardBundleEngineRequirement(w, r, bs)
+	if !ok {
+		return
+	}
+	if engineWarning != "" {
+		s.writeBotSource(w, r, tenantID, userID, bs, engineWarning)
 		return
 	}
 	s.writeBotSource(w, r, tenantID, userID, bs)

--- a/pkg/server/engine_floor.go
+++ b/pkg/server/engine_floor.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/internal/appinfo"
+)
+
+// A bundle and the engine that executes it move independently on a
+// deployment: a push lands in a second, a runner image is pinned by digest and
+// moves only on a deploy. A bundle that needs a builtin the runners' evaluator
+// does not have COMPILES here (a function call parses generically) and dies at
+// its first evaluation on the pod — which is what happened on 2026-09-06.
+//
+// A manifest may now declare the engine it needs (`requires.iterion`), and
+// this file is what holds a push against the deployment's actual build.
+
+// runnerBuildObserver is the store capability that answers "what build is
+// actually EXECUTING runs here" — implemented by the Mongo store over the
+// `runner_version` each runner stamps on the runs it takes. Absent in local
+// mode, where server and engine are one process and appinfo answers already.
+type runnerBuildObserver interface {
+	ObservedRunnerBuilds(ctx context.Context, since time.Time, limit int) ([]string, error)
+}
+
+// engineFloorLookback bounds how far back a runner build counts as evidence
+// about TODAY's fleet. Long enough that a quiet weekend still reports, short
+// enough that an image retired last month does not veto a push.
+const engineFloorLookback = 7 * 24 * time.Hour
+
+// engineFloorSample caps the runs read per resolution.
+const engineFloorSample = 200
+
+// serverBuild names this process's own build. A var so a test can pin it:
+// `go test` binaries carry appinfo.Version = "dev", which is deliberately
+// unorderable, so the floor would otherwise be permanently inconclusive under
+// test and every refusal assertion would pass for the wrong reason.
+var serverBuild = appinfo.FullVersion
+
+// engineFloor is the build a bundle must satisfy to run anywhere on this
+// deployment: the MINIMUM over this server's own build and every runner build
+// observed recently.
+//
+// Both halves matter, and in both directions. The server COMPILES the bot at
+// launch, so a server below the requirement blocks just as hard as an old
+// runner; the runners EVALUATE it, and on cloud they are the half that lags
+// (`:edge` server, digest-pinned runners). The minimum is the honest answer
+// because a queued run lands on whichever pod takes it.
+//
+// Returns the floor build plus the sources it was taken from, so a refusal can
+// say where its number came from. A build no component can order (a `dev`
+// server, a fork's naming scheme) is returned AS the floor rather than skipped:
+// dropping it would let an orderable peer answer for a fleet that also carries
+// something nobody can compare, and the caller reports "could not check"
+// instead of passing.
+func (s *Server) engineFloor(ctx context.Context) (build string, sources []string) {
+	self := serverBuild()
+	build, sources = self, []string{"server " + self}
+	if s.runnerBuilds == nil {
+		return build, sources
+	}
+	observed, err := s.runnerBuilds.ObservedRunnerBuilds(ctx, time.Now().UTC().Add(-engineFloorLookback), engineFloorSample)
+	if err != nil {
+		// Observational: a floor that could not read the fleet is still the
+		// server's own build, and the log says the fleet half is missing.
+		s.logWarn("engine floor: could not read the runner builds (%v) — the requirement check sees only this server's build %s", err, self)
+		return build, sources
+	}
+	for _, v := range observed {
+		if lower(v, build) {
+			build, sources = v, []string{"runner " + v}
+		}
+	}
+	if len(observed) > 0 && build == self {
+		sources = append(sources, fmt.Sprintf("%d runner build(s) observed, none older", len(observed)))
+	}
+	return build, sources
+}
+
+// lower reports whether build a must replace the current floor b. An
+// UNORDERABLE build always wins: it is the participant the comparison cannot
+// clear, so it must be the answer the caller reports as unchecked.
+func lower(a, b string) bool {
+	if !orderableBuild(a) {
+		return true
+	}
+	if !orderableBuild(b) {
+		return false
+	}
+	c, _ := bundle.CompareVersions(a, b)
+	return c < 0
+}
+
+// orderableBuild reports whether a build string can be ordered at all. It
+// delegates to pkg/bundle so the grammar a manifest is validated against and
+// the grammar a build is measured with cannot drift apart.
+func orderableBuild(v string) bool {
+	_, ok := bundle.CompareVersions(v, v)
+	return ok
+}
+
+// guardBundleEngineRequirement holds a bundle about to be STORED against the
+// deployment's engine floor. It returns "" when the push may proceed, or the
+// warning it must carry when force was passed; a refusal is written to w and
+// signalled by ok=false.
+//
+// Refuse rather than warn, deliberately, on the one path where warning was
+// already tried: `docs/platform-bots.md` documents the two-halves rule in
+// prose, and a production push broke it anyway. The escape hatch is explicit
+// (`--force` / `?force=1`) and never silent — the forced push carries the
+// overridden requirement in its response warnings and in the audit trail the
+// write already produces.
+func (s *Server) guardBundleEngineRequirement(w http.ResponseWriter, r *http.Request, bs botsource.BotSource) (warning string, ok bool) {
+	m := bs.Manifest()
+	if m == nil || m.Requires == nil || strings.TrimSpace(m.Requires.Iterion) == "" {
+		return "", true
+	}
+	floor, sources := s.engineFloor(r.Context())
+	verdict, reason := bundle.CheckManifestEngine(m, floor)
+	forced := forceRequested(r)
+	switch verdict {
+	case bundle.EngineOK:
+		return "", true
+	case bundle.EngineUnknown:
+		// Never a silent pass: the operator learns the check did not run.
+		return fmt.Sprintf("%s (floor from %s) — the engine requirement could not be checked, so this push is unverified",
+			reason, strings.Join(sources, ", ")), true
+	}
+	if forced {
+		return fmt.Sprintf("FORCED past the engine-requirement guard: %s (floor from %s) — a launch of %q will be refused on any pod below the requirement",
+			reason, strings.Join(sources, ", "), bs.Slug), true
+	}
+	s.httpErrorFor(w, r, http.StatusConflict,
+		"bot %q: %s (floor from %s). Bump the runner image and restart the server first (docs/platform-bots.md § Shipping a baked-catalog change), or push anyway with --force",
+		bs.Slug, reason, strings.Join(sources, ", "))
+	return "", false
+}
+
+// forceRequested reads the explicit override off the request.
+func forceRequested(r *http.Request) bool {
+	switch strings.ToLower(strings.TrimSpace(r.URL.Query().Get("force"))) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}

--- a/pkg/server/engine_floor_test.go
+++ b/pkg/server/engine_floor_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/botsource"
+)
+
+// The push guard: `iterion remote admin bots push` must refuse a bundle the
+// deployment's engine cannot run, instead of storing it and letting the first
+// launch die on an expression the runner's evaluator does not have.
+
+// fakeBuildObserver stands in for the Mongo store's ObservedRunnerBuilds — the
+// runners' own report, read off the runs they stamped.
+type fakeBuildObserver struct {
+	builds []string
+	err    error
+	since  time.Time
+}
+
+func (f *fakeBuildObserver) ObservedRunnerBuilds(_ context.Context, since time.Time, _ int) ([]string, error) {
+	f.since = since
+	return f.builds, f.err
+}
+
+// pinServerBuild pins this process's declared build so the floor is decidable
+// under test — `go test` reports the unorderable "dev".
+func pinServerBuild(t *testing.T, v string) {
+	t.Helper()
+	prev := serverBuild
+	serverBuild = func() string { return v }
+	t.Cleanup(func() { serverBuild = prev })
+}
+
+func pushBundle(requires string) string {
+	manifest := "name: needy\nversion: 1.6.0\n"
+	if requires != "" {
+		manifest += "requires:\n  iterion: \"" + requires + "\"\n"
+	}
+	body, _ := json.Marshal(map[string]any{"files": map[string]string{
+		botsource.MainBotFile: "workflow main:\n  entry: done\n",
+		"manifest.yaml":       manifest,
+	}})
+	return string(body)
+}
+
+func adminBotsPutQuery(s *Server, id auth.Identity, slug, query, body string) *httptest.ResponseRecorder {
+	ctx := auth.WithIdentity(context.Background(), id)
+	url := "/api/admin/bots/" + slug
+	if query != "" {
+		url += "?" + query
+	}
+	r := httptest.NewRequest("PUT", url, strings.NewReader(body)).WithContext(ctx)
+	r.SetPathValue("slug", slug)
+	w := httptest.NewRecorder()
+	s.handleAdminPutPlatformBot(w, r)
+	return w
+}
+
+// A bundle requiring more than the OLDEST build observed on the fleet is
+// refused, and the refusal names the arithmetic.
+func TestAdminBotsPush_RefusesABundleTheFleetCannotRun(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, admin, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v99.0.0", "v3.112.7+abc123"}}
+
+	w := adminBotsPutQuery(s, admin, "needy", "", pushBundle(">= 3.112.14"))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("push = %d %s, want 409 — a bundle the fleet cannot run must not be stored", w.Code, w.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{">= 3.112.14", "3.112.7", "--force"} {
+		if !strings.Contains(errResp.Error, want) {
+			t.Errorf("refusal %q does not mention %q", errResp.Error, want)
+		}
+	}
+	// And nothing was persisted: a refused push must not half-land.
+	if _, err := s.botSources.GetBySlug(context.Background(), botsource.PlatformTenantID, "needy"); err == nil {
+		t.Fatal("the refused bundle was stored anyway")
+	}
+}
+
+// --force is the escape hatch this repo's doctrine requires — but it is never
+// silent: the push succeeds carrying the warning.
+func TestAdminBotsPush_ForceOverridesButWarns(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, admin, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v3.112.7+abc123"}}
+
+	w := adminBotsPutQuery(s, admin, "needy", "force=1", pushBundle(">= 3.112.14"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("forced push = %d %s, want 200", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(resp.Warnings, " | ")
+	if !strings.Contains(joined, "FORCED") || !strings.Contains(joined, ">= 3.112.14") {
+		t.Fatalf("forced push warnings = %q, want the overridden requirement named — a forced push must never be silent", joined)
+	}
+}
+
+// A manifest that does not DECODE must not be stored either. BotSource.Manifest
+// returns nil for an undecodable manifest, so a bundle carrying an unreadable
+// `requires:` would otherwise sail past the guard, land in the store, and fail
+// at every launch with "cannot open bundle" — the requirement dropped exactly
+// where it was supposed to bite.
+func TestAdminBotsPush_RefusesAnUndecodableManifest(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, admin, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v3.116.4+deadbeef"}}
+
+	body, _ := json.Marshal(map[string]any{"files": map[string]string{
+		botsource.MainBotFile: "workflow main:\n  entry: done\n",
+		// An operator grammar iterion does not enforce.
+		"manifest.yaml": "name: needy\nrequires:\n  iterion: \"^3.1\"\n",
+	}})
+	w := adminBotsPutQuery(s, admin, "needy", "", string(body))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("push = %d %s, want 400 — an unreadable manifest must be refused, not stored with its contract dropped", w.Code, w.Body.String())
+	}
+	if _, err := s.botSources.GetBySlug(context.Background(), botsource.PlatformTenantID, "needy"); err == nil {
+		t.Fatal("the bundle with the unreadable manifest was stored anyway")
+	}
+}
+
+// The negative case: a bundle the fleet CAN run is stored as before. A guard
+// that refuses everything is not a guard.
+func TestAdminBotsPush_AdmitsWhatTheFleetCanRun(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, admin, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v3.116.4+deadbeef"}}
+
+	for _, requires := range []string{">= 3.112.14", ""} {
+		w := adminBotsPutQuery(s, admin, "needy", "", pushBundle(requires))
+		if w.Code != http.StatusOK {
+			t.Fatalf("push with requires %q = %d %s, want 200", requires, w.Code, w.Body.String())
+		}
+	}
+}
+
+// The server's OWN build is part of the floor: it compiles the bot at launch,
+// so a server below the requirement is as blocking as an old runner. With no
+// observed runner at all (a fresh deployment) it is the whole floor — which is
+// what keeps the check from silently abstaining.
+func TestEngineFloor_TakesTheMinimumOfServerAndRunners(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, _, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v0.0.1"}}
+	build, sources := s.engineFloor(context.Background())
+	if build != "v0.0.1" {
+		t.Fatalf("floor = %q, want the OLDEST build — a run can land on any pod", build)
+	}
+	if len(sources) == 0 {
+		t.Fatal("the floor must say where it came from")
+	}
+
+	s.runnerBuilds = &fakeBuildObserver{builds: nil}
+	build, _ = s.engineFloor(context.Background())
+	if build != "v3.116.4+deadbeef" {
+		t.Fatalf("floor with no observed runner = %q, want this server's own build", build)
+	}
+}
+
+// A build the floor cannot order (a `dev` server, a fork) must not silently
+// drop out of the minimum and leave an ORDERABLE peer as the answer: an
+// unorderable participant makes the whole floor unknown, which the push guard
+// reports rather than passes.
+func TestEngineFloor_AnUnorderableParticipantIsNotDropped(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, _, _ := adminBotsServer(t)
+	s.runnerBuilds = &fakeBuildObserver{builds: []string{"v99.0.0", "some-fork-build"}}
+	build, _ := s.engineFloor(context.Background())
+	if orderableBuild(build) {
+		t.Fatalf("floor = %q (orderable), want an unorderable answer: one pod of the fleet carries a build nothing can order", build)
+	}
+}
+
+// The lookback the observer is asked for must be a bounded, recent window —
+// a build that last ran a month ago is not evidence about today's fleet.
+func TestEngineFloor_AsksForARecentWindow(t *testing.T) {
+	pinServerBuild(t, "v3.116.4+deadbeef")
+	s, _, _ := adminBotsServer(t)
+	obs := &fakeBuildObserver{builds: []string{"v3.116.4"}}
+	s.runnerBuilds = obs
+	s.engineFloor(context.Background())
+	age := time.Since(obs.since)
+	if age < time.Hour || age > 30*24*time.Hour {
+		t.Fatalf("observer asked for runs since %v ago, want a bounded recent window", age)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -199,6 +199,12 @@ type Server struct {
 	// tenant-scoped counterpart to the read-only baked catalog. Non-nil enables
 	// cloud bot editing (/api/teams/:id/bot-sources + bot_editing_enabled).
 	botSources botsource.Store
+	// runnerBuilds answers "what engine actually executes runs here", read off
+	// the build each runner stamps on the runs it takes. Nil in local mode
+	// (server and engine are one process) and on any store without the
+	// capability — the engine floor then reports this build alone
+	// (engine_floor.go).
+	runnerBuilds runnerBuildObserver
 	// botRoles / sandboxCfg are TTL resolvers over the platform settings
 	// families; the *Store fields are the write surfaces of the admin routes.
 	botRoles        *platformcfg.Resolver[platformcfg.BotRoles]
@@ -642,6 +648,11 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 	// exist for them — same reason the roles/sandbox resolvers are.
 	s.platformBots = s.newPlatformBotsResolver()
 	s.bakedCatalog = s.newBakedCatalogResolver()
+	// The fleet's own build report, when the store can serve it (Mongo).
+	// Absent in local mode, where appinfo already answers for both halves.
+	if obs, ok := cfg.Store.(runnerBuildObserver); ok {
+		s.runnerBuilds = obs
+	}
 	// Runtime usage-cap resolver: env defaults + the DB record, TTL-cached.
 	// A malformed env policy leaves it nil — the health echo reports the
 	// invalid value (existing behaviour) instead of a resolver quietly

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -152,6 +152,15 @@ const (
 	// redelivery lands on a healthy pod, where a stuck kubectl-exec pipe
 	// routinely clears.
 	FailureSandboxSetupTimeout FailureCode = "SANDBOX_SETUP_TIMEOUT"
+	// FailureBotRequiresNewerEngine: the bundle's manifest declares an
+	// engine floor (`requires.iterion`) this build is below. TERMINAL, not
+	// resumable: the bundle and the image are what disagree, and neither
+	// changes by re-running the same pod — a resume re-queues onto the same
+	// fleet and re-reads the same manifest. What clears it is a deploy or a
+	// bot edit, and after either the caller RE-LAUNCHES (the fixed bot's IR
+	// is not the one this run checkpointed). Written before any node
+	// executes, so there is nothing half-done to preserve.
+	FailureBotRequiresNewerEngine FailureCode = "BOT_REQUIRES_NEWER_ENGINE"
 	// FailureSandboxCapacity: the sandbox never STARTED because the
 	// cluster had no room for its pod (unschedulable past the start
 	// deadline, or still being brought up on the node it landed on).
@@ -212,6 +221,7 @@ var ReservedFailureCodes = []FailureCode{
 	FailureLaunchFailed,
 	FailureSandboxSetupTimeout,
 	FailureSandboxCapacity,
+	FailureBotRequiresNewerEngine,
 }
 
 // reservedFailureCodes indexes ReservedFailureCodes for lookup. Built

--- a/pkg/store/mongo/runner_builds_test.go
+++ b/pkg/store/mongo/runner_builds_test.go
@@ -1,0 +1,148 @@
+package mongo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/internal/mongotest"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// ObservedRunnerBuilds is a FILTER, and the one thing that can silently break
+// a filter is that it does not match what we think it matches — a `$ne: ""`
+// that also excludes documents where the field is absent, a `$gte` on a field
+// stored as something other than a date, a projection that drops the value.
+// Every one of those failure modes reads as "no runner observed", which the
+// push guard would report as "could not check" and let every push through.
+//
+//	docker run -d -p 27026:27026 mongo:8.0 --replSet rs0 --bind_ip_all --port 27026
+//	# then rs.initiate()
+//	ITERION_TEST_MONGO_URI='mongodb://localhost:27026/?replicaSet=rs0' \
+//	    devbox run -- go test ./pkg/store/mongo/ -run TestObservedRunnerBuilds
+
+func buildsTestStore(t *testing.T) *Store {
+	t.Helper()
+	uri := os.Getenv("ITERION_TEST_MONGO_URI")
+	if uri == "" {
+		t.Skip("ITERION_TEST_MONGO_URI not set; skipping the runner-build observation test")
+	}
+	ctx, cancel := mongotest.Ctx(t)
+	defer cancel()
+	s, err := New(ctx, Config{
+		URI:      uri,
+		Database: "iterion_builds_" + bsonNonce(t),
+		Blob:     newInMemoryBlob(),
+	})
+	if err != nil {
+		t.Fatalf("mongo New: %v", err)
+	}
+	t.Cleanup(func() {
+		drop, dcancel := mongotest.TeardownCtx()
+		defer dcancel()
+		_ = s.db.Drop(drop)
+		_ = s.Close(drop)
+	})
+	return s
+}
+
+func TestObservedRunnerBuilds(t *testing.T) {
+	s := buildsTestStore(t)
+	ctx := store.WithTenant(context.Background(), "team-builds")
+	now := time.Now().UTC()
+
+	seed := func(id, version string, age time.Duration) {
+		t.Helper()
+		if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if version != "" {
+			if err := s.SetRunnerVersion(ctx, id, version); err != nil {
+				t.Fatalf("stamp %s: %v", id, err)
+			}
+		}
+		// Age the row past/inside the lookback window. Written directly
+		// because every store setter refreshes updated_at by design.
+		if _, err := s.runs.UpdateOne(ctx, map[string]any{"_id": id},
+			map[string]any{"$set": map[string]any{"updated_at": now.Add(-age)}}); err != nil {
+			t.Fatalf("age %s: %v", id, err)
+		}
+	}
+
+	seed("rb-new", "v3.116.4+deadbeef", time.Minute)
+	seed("rb-old-build", "v3.112.7+abc123", time.Hour)
+	seed("rb-dup", "v3.116.4+deadbeef", 2*time.Hour) // same build twice → one entry
+	seed("rb-never-ran", "", 3*time.Hour)            // no runner_version at all
+	seed("rb-stale", "v2.0.0+ancient", 30*24*time.Hour)
+
+	got, err := s.ObservedRunnerBuilds(ctx, now.Add(-7*24*time.Hour), 200)
+	if err != nil {
+		t.Fatalf("ObservedRunnerBuilds: %v", err)
+	}
+	set := map[string]bool{}
+	for _, v := range got {
+		if set[v] {
+			t.Errorf("build %q returned twice — the caller compares a SET of builds", v)
+		}
+		set[v] = true
+	}
+	for _, want := range []string{"v3.116.4+deadbeef", "v3.112.7+abc123"} {
+		if !set[want] {
+			t.Errorf("build %q missing from %v — a filter that misses a live pod makes the guard blind", want, got)
+		}
+	}
+	if set["v2.0.0+ancient"] {
+		t.Errorf("a build last seen 30 days ago is in %v — it is not evidence about today's fleet", got)
+	}
+	if set[""] {
+		t.Errorf("an empty runner_version leaked into %v — a run nobody executed says nothing about the fleet", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want exactly the two recent distinct builds", got)
+	}
+
+	// The limit is honoured (and never returns everything by accident).
+	if one, err := s.ObservedRunnerBuilds(ctx, now.Add(-7*24*time.Hour), 1); err != nil || len(one) != 1 {
+		t.Fatalf("limit 1 = %v (%v), want a single build — the sort is newest-first", one, err)
+	}
+}
+
+// "What build executes runs here" is a PLATFORM question, and its callers ask
+// it from wherever they happen to be: the platform-bot push handler re-scopes
+// its context to the `platform:` sentinel tenant, under which no run exists.
+// A tenant-scoped query would answer "no runner observed" — and the push guard
+// reads that as "could not check" and lets every push through. Silent
+// blindness is the failure class this whole change exists to close, so the
+// method scopes itself.
+func TestObservedRunnerBuildsIgnoresTheCallersTenantScope(t *testing.T) {
+	s := buildsTestStore(t)
+	now := time.Now().UTC()
+
+	seed := func(tenant, id, version string) {
+		t.Helper()
+		tctx := store.WithTenant(context.Background(), tenant)
+		if _, err := s.CreateRun(tctx, id, "wf", nil); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+		if err := s.SetRunnerVersion(tctx, id, version); err != nil {
+			t.Fatalf("stamp %s: %v", id, err)
+		}
+	}
+	seed("team-a", "rb-a", "v3.116.4+aaa")
+	seed("team-b", "rb-b", "v3.112.7+bbb")
+
+	for _, name := range []string{"platform:", "team-a", ""} {
+		ctx := context.Background()
+		if name != "" {
+			ctx = store.WithTenant(ctx, name)
+		}
+		got, err := s.ObservedRunnerBuilds(ctx, now.Add(-time.Hour), 200)
+		if err != nil {
+			t.Fatalf("under tenant %q: %v", name, err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("under tenant %q got %v, want BOTH teams' builds — the fleet is one fleet whatever scope asks", name, got)
+		}
+	}
+}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -768,6 +768,65 @@ func (s *Store) SetRunnerVersion(ctx context.Context, id, version string) error 
 	return nil
 }
 
+// ObservedRunnerBuilds returns the distinct iterion builds that have EXECUTED
+// a run since `since`, newest first — the fleet's build, read from what the
+// fleet itself stamped (Run.RunnerVersion) rather than from a channel an
+// operator has to keep true.
+//
+// It exists because the server and the runners are two deployments that move
+// independently: the server follows a moving tag, each runner is pinned by
+// digest. Nothing else on the server can answer "what engine will actually
+// evaluate this bot" — its own appinfo answers for the wrong half.
+//
+// CROSS-TENANT by construction, and deliberately NOT routed through
+// withTenantFilter: the fleet is one fleet, so the answer must not depend on
+// the scope the caller happens to sit in. The platform-bot push handler
+// re-scopes its request to the `platform:` sentinel tenant, under which no run
+// has ever existed — a tenant-scoped read there returns nothing, and the push
+// guard reads nothing as "could not check" and lets every push through. That
+// silent blindness is the failure class this method was added to close.
+//
+// It is not a tenancy hole: what leaves is a set of BUILD STRINGS, deployment
+// configuration the server already publishes on /healthz — no run id, no
+// tenant, no payload.
+//
+// Bounded by `limit` and index-backed by `updated_desc`; the returned set is a
+// SAMPLE of the fleet, never a proof that no older pod exists.
+func (s *Store) ObservedRunnerBuilds(ctx context.Context, since time.Time, limit int) ([]string, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 200
+	}
+	filter := bson.M{
+		"runner_version": bson.M{"$exists": true, "$ne": ""},
+		"updated_at":     bson.M{"$gte": since},
+	}
+	cur, err := s.runs.Find(ctx, filter,
+		options.Find().
+			SetProjection(bson.M{"_id": 0, "runner_version": 1}).
+			SetSort(bson.M{"updated_at": -1}).
+			SetLimit(int64(limit)))
+	if err != nil {
+		return nil, fmt.Errorf("store/mongo: list observed runner builds: %w", err)
+	}
+	defer cur.Close(ctx)
+	var rows []struct {
+		RunnerVersion string `bson:"runner_version"`
+	}
+	if err := cur.All(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("store/mongo: decode observed runner builds: %w", err)
+	}
+	seen := make(map[string]bool, len(rows))
+	out := make([]string, 0, 4)
+	for _, r := range rows {
+		if r.RunnerVersion == "" || seen[r.RunnerVersion] {
+			continue
+		}
+		seen[r.RunnerVersion] = true
+		out = append(out, r.RunnerVersion)
+	}
+	return out, nil
+}
+
 // SetRunBudgetSnapshot persists the effective caps (see store.RunStore).
 // Granular $set (with $unset for nil), like SetRunBudgetOverrides, so the
 // status transition a resume just applied stays intact.


### PR DESCRIPTION
## Why

Observed in production on 2026-09-06: `iterion remote admin bots push bots/branch-improve-loop` pushed a bot using the variadic `min`/`max` builtins of #830 while the runners still ran an engine without them. The launch **compiled** — function calls parse generically — then `compute "delivery_reserve"` failed at runtime with `expr: max() takes …`, and auto-resume looped on a failure that could never succeed. The version-drift guard of `docs/platform-bots.md` covers the BOT ref; nothing covered the ENGINE the bot needs.

Layer 2 of #858 (rejecting an expression whose builtin arity the evaluator cannot satisfy) shipped in #881. **This is layer 1.**

## The manifest shape, and why a version floor rather than a feature list

```yaml
requires:
  iterion: ">= 3.112.14"     # or a bare "3.112.14"
```

The decision is forced by the **push guard's only channel**: the sole thing a deployment can learn about its runners is a *version string* — the build each runner stamps on the runs it executes (`Run.runner_version`, from #881). A feature list would have to be translated back into a version before it could be checked there, i.e. the same comparison with a map in front of it.

The cost is written in the doc rather than hidden: a fork or backport carrying the feature under a different version reads as too old, and a build with no orderable version (`dev`, a fork's scheme) makes the check **inconclusive — reported, never passed**.

The grammar is total: `>=` (or nothing) plus a dotted numeric, optional `v`. Every other shape (`<`, `^`, `~>`, `==`, `1.2-rc1`, `>= latest`) is a **manifest parse error**, and an unknown key under `requires:` is refused by the strict decoder — so a build too old to know the key refuses the whole manifest rather than dropping the contract on the floor.

## Where the contract is enforced, and where it deliberately is not

| site | disposition |
|---|---|
| `admin bots push` / team push / studio bundle push | **covered** — 409, with `--force` / `?force=1` |
| studio editor per-file save | **covered** — a manifest-only edit can raise the requirement |
| runner `executeRun`, stored ref **and** baked catalog | **covered** — hoisted so both branches cross one point |
| `Engine.Run` (local, studio, dispatcher, subbot children) and `Engine.Resume` | **covered** — before worktree and sandbox; Resume keeps the resumable status |
| `iterion validate` | **covered** — C250 (refusal) / C251 (inconclusive build, warns) |
| `bundle pack`, `marketplace install`, `botinstall` | **not covered, deliberate** — packing or installing for a future engine is legitimate; *use* refuses |
| `cloudpublisher` publish | **not covered, deliberate** — during a rolling deploy a minimum-across-pods floor would refuse a run the pod actually taking it can serve. The runner decides against its OWN build, which is exact |

All uncovered paths still share the manifest decoder, so an unreadable `requires:` refuses the bundle wherever it is opened.

## Evidence

The strongest canary is the runner one — with the guard's call site neutered, the run walks **into node execution**, which is the incident itself:

```
executeRun err = [EXECUTION_FAILED] node "a" execution failed: … claw backend: text generation
```

End to end on a version-stamped binary (`v3.116.4+deadbeef1234`):

```
error [C250] requires.iterion: bot requires iterion >= 99.0.0 but this build is
v3.116.4+deadbeef1234 — upgrade the engine … ; result: INVALID ; EXIT=1

iterion run needy →
  status = failed · failure_code = BOT_REQUIRES_NEWER_ENGINE
  run_failed {"code":"BOT_REQUIRES_NEWER_ENGINE","phase":"engine requirement"}
  .iterion/ → no worktrees/ directory (refused before one was created)
```

Non-resumable by construction, and the classification guards said so themselves before the code existed: `BOT_REQUIRES_NEWER_ENGINE … is missing from ReservedFailureCodes`, then `has no row in the automatic-resume classification`. That matters — the production incident was auto-resume looping.

The negative case is proved on every path (`met exactly`, `met with room`, `no requirement` → validate OK, push 200, run `finished`), plus the third state: an unorderable build **warns and proceeds**.

## A bug found on the way, red first on a real replica set

`handleAdminPutPlatformBot` re-scopes its request to the `platform:` sentinel tenant, so reading `ObservedRunnerBuilds` through `withTenantFilter` returned `[]`:

```
under tenant "platform:" got [], want BOTH teams' builds
```

The guard reads an empty set as "could not check" and lets **every** push through — the new guard would have been inert on the exact surface the incident came from. Fixed by scoping the method itself; what leaves is a set of build strings already public on `/healthz`.

## Judgement call worth review

The validate diagnostic went into **bundlelint (C250/C251)** rather than the C1xx `ir` family, because `requires:` is a manifest fact and `ir.Compile` only ever sees the `.bot` AST — it has no manifest. Both families share the same `TestDiagCodesAreUnique` / `TestDiagCodesAreDocumented` catalogue guards, which went red and are now green.

`task check` exit 0; `-race` on bundle/bundlelint/retrypolicy/store; Mongo conformance on a real `mongo:8.0` replica set; `openapi.json` byte-identical.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
