### PR TITLE
fix(platform-bots): four defects inside the shadow guard, found after #851 merged

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -28,6 +28,102 @@ real git repositories (`bots/push_back_banked_branch_test.go`).
   revisions (HEAD and `origin/<branch>`), so a claim that contradicts the
   campaign's own commit count is falsifiable instead of merely surprising.
 
+## 2026-09-08 — the campaign delivered, the tail never ran: a provider cap killed the run at minute 53 and the banked branch was the only receipt (run 01a07f7a)
+
+- Status: **partial** — the review work is complete and correct; the delivery
+  tail was never exercised, so this run says nothing about it.
+- Versions: bot resolved from the baked catalog on runner
+  `iterion-runner-devbox@sha256:001a8431…` (no platform override active) ·
+  server v3.115.1 (`f47ff6e1`) · repo manifest 1.7.0.
+- Method: `/billy` on PR #851 (the override-staleness guard), after three
+  rounds of hand-fixing on the same PR had produced six real Revi findings.
+  The decision to hand it over was the point of the run.
+- Result: **not converged — `failed_resumable` at 06:18Z**, 53 min in, $3.32,
+  on the provider's own 5-hour session limit inside the `campaign` node
+  (`rate_limited (claude_code): You've hit your session limit · resets 10am`).
+  Outputs stop after `delivery_reserve`/`delivery_deadline`; neither
+  `push_back_tool` nor `publish_verdict` ever ran. Six commits were banked on
+  `refs/heads/iterion/run-01a07f7a-…` @ `bf2aa2072` — the campaign commits in
+  stride, so the work survived the death of the run that made it. The pull
+  request itself **merged at 05:57Z, 21 min before he died**: its gate had gone
+  green at 05:34 on a pass that reported zero findings, and the last check
+  cleared while he was still reading. So his final commits were written against
+  a branch already squashed onto main, and none of them shipped with it.
+- Value: **high, and it is the anti-hand-fix argument made concrete.** Four
+  defects, all inside code I had written and twice reviewed:
+  a shadowed TEAM row was handed the PLATFORM remedy (`8ff4d37b3`); an
+  unreadable platform overlay was read as empty instead of unknown
+  (`9282bee42`); a platform row with no `version:` counted as absent rather
+  than present (`5c032a0a5`); the shadow fields were promised on the team
+  listing in prose but typed only on the admin one (`8096529c0`). Plus one
+  finding he chose to **document rather than fix** (`220ecbbf1`: the catalog
+  walk escapes `platformcfg`'s 3 s fetch timeout, and cancelling a blocked
+  filesystem walk would trade bounded blocking for a goroutine leak per TTL) —
+  the right call, argued in the commit body.
+- Findings / misses: the sharpest one is `bf2aa2072` — **two comments that my
+  own commits had inverted**. `41c38d43c` wrote "the dedup check runs BEFORE
+  the catalog walk"; `6f08d55f1` then moved the `LoadOrStore` after the
+  comparison *on purpose* and left the claim standing, so the file documented
+  the opposite of what it did. A reviewer reading one chunk at a time does not
+  catch that; a campaign that re-reads the whole branch does.
+- Engine hardening: none from the bot. The run surfaced a **diagnostics**
+  defect elsewhere — see the cap note below.
+- Lessons for next run:
+  - **The delivery tail is the fragile half, and a long campaign will keep
+    dying before it.** 53 min of campaign against a 5-hour provider window is
+    a coin flip. The banked branch is what saved this run, and it is reachable
+    only by someone who knows the ref convention (#773 again, from the other
+    side: here there was no verdict at all to name it).
+  - When the tail cannot run, the work is still deliverable by hand, but only
+    if it is **verified independently**: `go build ./...`, the full
+    `pkg/server` suite, and `task openapi:gen` producing no diff. That is a
+    better receipt than the bot's own verdict would have been.
+  - **Cancel the parked run before taking its commits.** A `failed_resumable`
+    campaign has a retry armed (1/5, here for ~10:10Z); left alone it resumes
+    onto a branch that has moved.
+  - **Re-read the pull request's state immediately before pushing — taking a
+    campaign's commits by hand means taking its guards too.** #851 merged at
+    05:57Z, while the campaign was still running; the operator had last read
+    `OPEN` at 05:36Z and pushed `bf2aa2072` onto the closed branch an hour
+    later. Nothing was lost (a merged branch still accepts commits, they are
+    simply orphaned) but the work needed a second pull request onto main.
+    This is the exact case `push_back_tool` interrogates the server about, and
+    it is worth restating why git alone cannot answer it: after a squash merge
+    the source branch still exists and its head is no ancestor of the base, so
+    a merged pull request reads locally as an open one. The bot's contract was
+    written from this failure; the hand path has no such contract, so the check
+    has to be deliberate.
+
+### The cap that stopped it — and the message that misdiagnoses it
+
+Worth recording because it cost a wrong recommendation. Eight runs parked the
+same morning with:
+
+```
+usage cap: provider rejected on the seven_day window (week cap 85%, hard),
+resets 2026-09-08T21:00:00Z
+```
+
+That reads as "your 85 % weekly cap fired". It did not. In
+[pkg/usagecap/usagecap.go](../../pkg/usagecap/usagecap.go) a provider refusal
+short-circuits the threshold test (`if !rejected && pct < wp.MaxPercent`), and
+the branch that prints this message is `rejected && pct == 0` — *the provider
+refused and gave no utilization number*. The `85%` is the configured cap
+printed beside a comparison that never happened. Raising it to 95 or 100 would
+change nothing: `Enabled()` is `MaxPercent > 0`, so only `0`/`off` disarms the
+policy, and that would merely move the failure from pre-flight to the API call.
+
+The real shape was two exhausted tiers, which the publisher log states plainly:
+the org forfait (`fp=2b36a854…`) refused on its **five_hour** window until
+10:00Z, falling through to the platform credential (`fp=53d82df9…`), refused on
+its **seven_day** window until 21:00Z. Both empty means no claude_code capacity
+at all. The outage therefore ends at **10:00Z**, not 21:00Z, and the retries
+armed for ~10:00–10:10Z target the right reopening.
+
+Read the `cloudpublisher: … SKIPPED … fp=` lines before the cap record: they
+name the credential, the window and the reopening. The run error names none of
+the three.
+
 ## 2026-09-06 — 1.6.0 dogfooded live: three runs, the third validates the reserve and finds a real bug in the code it reviewed (runs 01a07804, 01a0782f, 01a07840)
 
 - Status: **validated** (run 3) — after two runs that validated nothing about

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -8,6 +8,43 @@ pr_url` it also posts an inline forge review and an optional deterministic
 commit-status gate. Never edits or commits. See
 [bots/review-pr/](../../bots/review-pr/).
 
+## 2026-09-08 — a green gate is one pass, not a property: 1 finding → 0 across a docs-only commit, and four defects still there (#851)
+
+- Status: **observation**, not a bilan of a launched run — recorded because it
+  bears directly on how much a `revi/review: success` is worth.
+- The measurement. PR #851 was reviewed twice, 21 minutes apart:
+
+  | head | reviewed | verdict |
+  |---|---|---|
+  | `6f08d55f1` | 05:13:15Z | **1 finding (medium)** |
+  | `fd61efe93` | 05:34:51Z | **0 findings** → `revi/review: success` |
+
+  The only commit between them adds ten lines of prose to
+  `docs/bot-runs/review-pr.md` — **no Go changed**. The severity floor is
+  `medium`, so the earlier finding would have been kept had it been raised
+  again. The PR merged on that green gate at 05:57Z.
+- What makes it falsifiable rather than a hunch: a `branch-improve-loop`
+  campaign was reading the same branch at the same time, in an independent
+  context. It re-verified the dropped finding **still present at the current
+  head** ("the branch moved twice since that review but this anchor is
+  untouched") and found three more defects plus two comments the branch's own
+  commits had inverted. Four real defects survived the pass that reported none.
+- Not a same-sha pair, so it still does not measure run-to-run variance — the
+  heads differ by one commit. But it is the closest approach in the data, and
+  it constrains the shape: what varies between passes is **the finding set**,
+  on input that is identical where it matters.
+- Consequence for the gate. `revi/review: success` is a statement about one
+  pass ("this reading found nothing ≥ `gate_severity`"), never about the
+  branch. That is the honest reading of a deterministic count over a
+  non-deterministic input, and it is why the gate blocks merges rather than
+  certifying code. Do not read a green gate as "reviewed clean"; on a change
+  that matters, a second reader is a second sample, and the campaign bots are
+  the cheaper one to add.
+- Open question this sharpens rather than answers (#685): whether the 0.7.0
+  frugality clause ("triage, don't sweep") is what drops findings between
+  passes. The experiment is unchanged — re-review with the clause disabled and
+  diff the finding sets — but the target is now the *finding set*, not the cost.
+
 ## 2026-09-05 — two guard-tier reviews die at the cost cap, no verdict (#780, #785)
 
 - Runs: `01a072d6-24ab` (#780, head `4aee1d641`) — `budget exceeded: cost_usd (36/12)`,

--- a/openapi.json
+++ b/openapi.json
@@ -8262,8 +8262,15 @@
       "get": {
         "operationId": "getTeamsByIdBotSources",
         "responses": {
-          "default": {
-            "description": "Response"
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/botSourceListView"
+                }
+              }
+            },
+            "description": "OK"
           }
         },
         "summary": "GET /api/teams/{id}/bot-sources",

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -153,9 +153,21 @@ func (s *Server) versionsBelow(tenantID string) (map[string]string, bool) {
 	if tenantID == botsource.PlatformTenantID {
 		return baked, true
 	}
+	if s.botSources == nil {
+		// No stored tier at all on this deployment: the bake IS what serves
+		// below a team row, and there is nothing unknown about that.
+		return baked, true
+	}
 	set := s.platformBotSetCached()
 	if set == nil {
-		return baked, true
+		// A SUCCESSFUL read that found nothing returns a non-nil set with an
+		// empty map, so nil here is never "no platform rows" — it is a
+		// cold-start failure of the platform read. Answering "the bake" would
+		// measure a team row deliberately pinned to match an older platform
+		// override against the bake instead, and the warn path caches only
+		// POSITIVE verdicts, so that false line could never be superseded once
+		// the overlay recovered. Unknown, exactly as an unreadable catalog is.
+		return nil, false
 	}
 	// Copy: the cached catalog map is shared, and the platform overlay is
 	// per-tenant-tier.

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -113,6 +113,18 @@ type bakedCatalog struct {
 // the verdict: a cached verdict would outlive the platform-override overlay it
 // was computed against. A walk failure propagates, so the resolver logs it and
 // serves the LAST-KNOWN map rather than an empty one.
+//
+// THE CONTEXT IS DELIBERATELY DISCARDED, and that is a documented deviation,
+// not an oversight: botregistry.List takes no ctx, so platformcfg's 3s
+// fetchTimeout — which bounds every OTHER resolver's fetch — does not bound
+// this one. A cold-start caller therefore blocks for however long the bot-root
+// walk takes (the walk is a LOCAL filesystem read; on a network mount that is
+// not a bound anyone chose). Wrapping the walk in a goroutine and selecting on
+// ctx would NOT fix it — it cannot cancel a blocked walk, only abandon it, and
+// since Resolver.Get re-arms the TTL after a failure a wedged mount would
+// strand a fresh goroutine every refresh interval: bounded blocking traded for
+// an unbounded leak. The real remedy is cooperative cancellation inside
+// botregistry (or one long-lived single-flight walker), both out of scope here.
 func (s *Server) newBakedCatalogResolver() *platformcfg.Resolver[bakedCatalog] {
 	return platformcfg.NewResolverFunc(func(context.Context) (*bakedCatalog, error) {
 		entries, err := botregistry.List(s.botListOptions())

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -230,6 +230,19 @@ func (s *Server) warnIfOverrideShadowsNewerBake(tenantID, slug, origin, storedVe
 	if _, seen := staleOverrideWarned.LoadOrStore(key, struct{}{}); seen {
 		return
 	}
-	s.logger.Warn("bot %q serves the %s override of tenant %s at version %s while this deployment would otherwise serve %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s)",
-		slug, origin, tenantID, storedVersion, below, slug, slug)
+	s.logger.Warn("bot %q serves the %s override of tenant %s at version %s while this deployment would otherwise serve %s — the override wins by design, so the newer bundle will not serve until it is re-pushed or removed (%s)",
+		slug, origin, tenantID, storedVersion, below, shadowRemedy(tenantID, slug))
+}
+
+// shadowRemedy names the endpoints that clear the shadow FOR THIS ROW's tier.
+// The team and platform tiers are both first-class here (storedLaunchBot warns
+// for either origin), and they live at different endpoints: handing a team row
+// the platform remedy sends the operator to a 404 — or, for a super-admin, to
+// deleting the PLATFORM override of that slug, a different row whose removal
+// changes what every tenant is served.
+func shadowRemedy(tenantID, slug string) string {
+	if tenantID != botsource.PlatformTenantID {
+		return fmt.Sprintf("re-push it, or DELETE /api/teams/%s/bot-sources/%s", tenantID, slug)
+	}
+	return fmt.Sprintf("iterion remote admin bots push bots/%s, or DELETE /api/admin/bots/%s", slug, slug)
 }

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -171,9 +171,18 @@ func (s *Server) versionsBelow(tenantID string) (map[string]string, bool) {
 	}
 	// Copy: the cached catalog map is shared, and the platform overlay is
 	// per-tenant-tier.
-	out := make(map[string]string, len(baked)+len(set.manifests))
+	out := make(map[string]string, len(baked)+len(set.slugs))
 	for k, v := range baked {
 		out[k] = v
+	}
+	// A platform row SERVES for its slug whatever version it carries — so the
+	// baked version is never what a team row holds back once one exists. Drop
+	// it first, then put back only the versions actually known: a platform row
+	// with no manifest (a fork of a loose <name>.bot copies none) or an empty
+	// version leaves the slug UNORDERED, which reports nothing — rather than
+	// naming the bake, a bundle removing this team row would not serve.
+	for slug := range set.slugs {
+		delete(out, slug)
 	}
 	for slug, m := range set.manifests {
 		if m == nil {

--- a/pkg/server/bot_override_staleness.go
+++ b/pkg/server/bot_override_staleness.go
@@ -84,26 +84,18 @@ func numericVersionParts(v string) ([]int, bool) {
 	return out, true
 }
 
-// bakedVersions walks the catalog ONCE and returns slug → manifest version.
-//
-// Callers comparing several rows build it once and reuse it: resolving a
-// version per row would re-walk every configured bot root and re-parse every
-// manifest for each one, turning a listing into O(rows × catalog) filesystem
-// work. The version comes straight off botregistry.Entry, which already
-// mirrors the manifest field — loading the manifest again would re-read what
-// the walk just produced.
-//
-// "Baked" means whatever THIS server discovers on disk, deliberately the same
-// source every other bot lookup uses: the field answers "what would serve if
-// this override were removed", not "what some image ships". With no
-// --bots-path pinned that follows the live WorkDir, so on a local studio the
-// answer legitimately changes with the open project — which is the correct
-// answer to the question the field asks.
 // bakedCatalog is the cached slug → version projection of the on-disk catalog.
 // A struct rather than a bare map so "never read successfully" (nil) stays
 // distinguishable from "read, and it holds nothing" (empty map): reporting a
 // broken catalog as a clean inventory would be a lie told by the very endpoint
 // the runbook calls the check to run after a release.
+//
+// "Baked" means whatever THIS server discovers on disk, deliberately the same
+// source every other bot lookup uses: it answers "what would serve if this
+// override were removed", not "what some image ships". With no --bots-path
+// pinned that follows the live WorkDir, so on a local studio the answer
+// legitimately changes with the open project — which is the correct answer to
+// the question the field asks.
 type bakedCatalog struct {
 	versions map[string]string
 }
@@ -141,6 +133,15 @@ func (s *Server) newBakedCatalogResolver() *platformcfg.Resolver[bakedCatalog] {
 	}, s.logger.Warn)
 }
 
+// bakedVersions serves the cached slug → version projection, with false when
+// the catalog has never been read successfully — the caller must then report
+// "unknown", never "nothing is shadowed".
+//
+// A caller comparing several rows takes the map ONCE and reuses it: resolving
+// a version per row would re-walk every configured bot root and re-parse every
+// manifest for each one, turning a listing into O(rows × catalog) filesystem
+// work. The returned map is the SHARED cached one — read-only for callers;
+// versionsBelow copies before overlaying the platform tier onto it.
 func (s *Server) bakedVersions() (map[string]string, bool) {
 	c := s.bakedCatalog.Get(context.Background())
 	if c == nil {
@@ -242,8 +243,14 @@ var staleOverrideWarned sync.Map
 // otherwise serve a newer one. Deliberately observational: the launch proceeds
 // on the override.
 //
-// The dedup check runs BEFORE the catalog walk, so a repeat launch of the same
-// row costs a map lookup rather than a full discovery pass.
+// The dedup check runs LAST, after the comparison — deliberately, and not the
+// cheaper order. Consuming the key first would make the dedup a cache of the
+// VERDICT, and a negative verdict must stay recomputable: the platform overlay
+// a team row is measured against is a TTL cache that every `admin bots push`
+// refills, so a shadow can appear mid-process on inputs that changed under a
+// key already burned. What keeps the repeat launch cheap is that the expensive
+// half — the catalog walk — is itself TTL-cached (bakedCatalog), leaving a map
+// copy and an overlay merge per call rather than a discovery pass.
 func (s *Server) warnIfOverrideShadowsNewerBake(tenantID, slug, origin, storedVersion string) {
 	if s.logger == nil || strings.TrimSpace(storedVersion) == "" {
 		return

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -329,6 +329,58 @@ func TestBotSourceListing_AnUnreadableCatalogIsNotACleanInventory(t *testing.T) 
 	}
 }
 
+// docs/platform-bots.md promises the shadow fields on BOTH listings, and one
+// handler (listBotSourcesFor) serves both — so both must name the payload's
+// type in the generated spec. The team operation was left untyped ("default:
+// Response"), which makes the doc a promise with nothing to verify it against:
+// the documented-but-unverifiable shape this whole family exists to end.
+func TestOpenAPI_BothBotSourceListingsAreTypedWithTheShadowFields(t *testing.T) {
+	s := &Server{mux: newRecordingMux()}
+	s.mux.Handle("GET /api/admin/bots", http.NotFoundHandler())
+	s.mux.Handle("GET /api/teams/{id}/bot-sources", http.NotFoundHandler())
+
+	doc := s.buildOpenAPI()
+	paths := doc["paths"].(map[string]any)
+	for _, p := range []string{"/api/admin/bots", "/api/teams/{id}/bot-sources"} {
+		item, ok := paths[p].(map[string]any)
+		if !ok {
+			t.Fatalf("%s absent from the spec", p)
+		}
+		resp, ok := item["get"].(map[string]any)["responses"].(map[string]any)["200"].(map[string]any)
+		if !ok {
+			t.Errorf("%s has no typed 200 response: %+v", p, item["get"])
+			continue
+		}
+		schema := resp["content"].(map[string]any)["application/json"].(map[string]any)["schema"].(map[string]any)
+		if ref, _ := schema["$ref"].(string); ref != "#/components/schemas/botSourceListView" {
+			t.Errorf("%s 200 $ref = %q, want botSourceListView", p, ref)
+		}
+	}
+
+	// And the named type must carry the field names the runbook tells an
+	// operator to read, or the reference is typed but still not the contract.
+	schemas := doc["components"].(map[string]any)["schemas"].(map[string]any)
+	props := func(name string) map[string]any {
+		t.Helper()
+		sch, ok := schemas[name].(map[string]any)
+		if !ok {
+			t.Fatalf("components.schemas missing %q", name)
+		}
+		p, _ := sch["properties"].(map[string]any)
+		return p
+	}
+	for _, f := range []string{"bot_sources", "shadow_check_unavailable"} {
+		if _, ok := props("botSourceListView")[f]; !ok {
+			t.Errorf("botSourceListView is missing %q", f)
+		}
+	}
+	for _, f := range []string{"bundle_version", "shadowed_version", "shadows_newer_version"} {
+		if _, ok := props("botSourceMetaView")[f]; !ok {
+			t.Errorf("botSourceMetaView is missing %q", f)
+		}
+	}
+}
+
 // A platform row that carries NO version still serves — storedLaunchBot asks
 // only for a non-empty main.bot, and forking a loose <name>.bot copies no
 // manifest at all (POST /api/admin/bots/{slug}/fork reaches exactly that).

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/botsource"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/platformcfg"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -324,6 +326,43 @@ func TestBotSourceListing_AnUnreadableCatalogIsNotACleanInventory(t *testing.T) 
 		if v.ShadowsNewerVersion {
 			t.Errorf("no row may claim a verdict when the check could not run; got %+v", v)
 		}
+	}
+}
+
+// A team row is measured against the platform overlay, so an overlay that
+// could not be READ is unknown — not "no platform rows". Answering "the bake"
+// there reports a team row deliberately pinned to match an older platform
+// override as shadowing, and warnIfOverrideShadowsNewerBake caches only
+// positive verdicts, so that false line could never be superseded once the
+// overlay recovered.
+func TestVersionsBelow_AnUnreadablePlatformOverlayIsUnknown(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+
+	// The overlay read fails from cold: the resolver has no last-known value,
+	// so Get serves nil — the same shape a Mongo blip produces at boot.
+	s.platformBots = platformcfg.NewResolverFunc(func(context.Context) (*platformBotSet, error) {
+		return nil, errors.New("bot-source store unavailable")
+	}, nil)
+
+	if below, ok := s.versionsBelow("t1"); ok {
+		t.Errorf("an unreadable platform overlay must read as unknown; got below=%v ok=%v", below, ok)
+	}
+
+	// And the warn path must stay silent rather than name a shadow it cannot
+	// establish.
+	var buf bytes.Buffer
+	s.logger = iterlog.New(iterlog.LevelWarn, &buf)
+	staleOverrideWarned.Range(func(k, _ any) bool { staleOverrideWarned.Delete(k); return true })
+	s.warnIfOverrideShadowsNewerBake("t1", "reviewer", "team", "0.7.0")
+	if strings.Contains(buf.String(), "serves the") {
+		t.Errorf("no shadow may be claimed while the overlay is unreadable; got:\n%s", buf.String())
+	}
+
+	// The platform tier itself is measured against the bake, which IS
+	// readable — the outage must not blind that half too.
+	if below, ok := s.versionsBelow(botsource.PlatformTenantID); !ok || below["reviewer"] != "0.8.0" {
+		t.Errorf("a platform row still compares against the readable bake; got below=%v ok=%v", below, ok)
 	}
 }
 

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -329,6 +329,47 @@ func TestBotSourceListing_AnUnreadableCatalogIsNotACleanInventory(t *testing.T) 
 	}
 }
 
+// A platform row that carries NO version still serves — storedLaunchBot asks
+// only for a non-empty main.bot, and forking a loose <name>.bot copies no
+// manifest at all (POST /api/admin/bots/{slug}/fork reaches exactly that).
+// Reading such a row as absent left the BAKED version standing as "what would
+// serve below this team row", so the team row was reported as shadowing a
+// bundle that removing it would not serve.
+func TestVersionsBelow_AnUnversionedPlatformRowIsPresentNotAbsent(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		files map[string]string
+	}{
+		{"no manifest at all", map[string]string{botsource.MainBotFile: testBotMain}},
+		{"a manifest with no version", map[string]string{
+			botsource.MainBotFile: testBotMain,
+			"manifest.yaml":       "name: reviewer\n",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, _ := newBotSourceTestServer(t)
+			seedBakedBot(t, s, "reviewer", "0.8.0")
+			pctx := store.WithTenant(context.Background(), botsource.PlatformTenantID)
+			if _, err := s.botSources.Create(pctx, botsource.BotSource{
+				TenantID: botsource.PlatformTenantID,
+				Slug:     "reviewer",
+				Files:    tc.files,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			s.invalidatePlatformBots()
+
+			below, shadowed := shadowsNewerVersionFor(t, s, "t1", "reviewer", "0.7.0")
+			if shadowed {
+				t.Errorf("the platform row serves here, so nothing orderable is shadowed; got below=%q", below)
+			}
+			if below != "" {
+				t.Errorf("shadowed_version must not name the bake, which removing the team row would not serve; got %q", below)
+			}
+		})
+	}
+}
+
 // A team row is measured against the platform overlay, so an overlay that
 // could not be READ is unknown — not "no platform rows". Answering "the bake"
 // there reports a team row deliberately pinned to match an older platform

--- a/pkg/server/bot_override_staleness_test.go
+++ b/pkg/server/bot_override_staleness_test.go
@@ -232,6 +232,40 @@ func TestWarnOverrideShadow_ReportsAShadowThatAppearsMidProcess(t *testing.T) {
 	}
 }
 
+// The remedy in the warning must name THIS ROW's tier. Both origins reach this
+// warning, but they live at different endpoints — a team row handed the
+// platform remedy sends the operator to a 404, or (as a super-admin) to
+// deleting the PLATFORM override of that slug, a different row whose removal
+// changes what every tenant is served (Revi R03fa85).
+func TestWarnOverrideShadow_RemedyNamesTheRowsOwnTier(t *testing.T) {
+	s, _, _ := newBotSourceTestServer(t)
+	seedBakedBot(t, s, "reviewer", "0.8.0")
+	var buf bytes.Buffer
+	s.logger = iterlog.New(iterlog.LevelWarn, &buf)
+	staleOverrideWarned.Range(func(k, _ any) bool { staleOverrideWarned.Delete(k); return true })
+
+	s.warnIfOverrideShadowsNewerBake("t1", "reviewer", "team", "0.7.0")
+	line := buf.String()
+	if !strings.Contains(line, "DELETE /api/teams/t1/bot-sources/reviewer") {
+		t.Errorf("a team row must be pointed at its own endpoint; got:\n%s", line)
+	}
+	if strings.Contains(line, "/api/admin/bots") || strings.Contains(line, "admin bots push") {
+		t.Errorf("a team row must NOT be pointed at the platform tier; got:\n%s", line)
+	}
+
+	buf.Reset()
+	s.warnIfOverrideShadowsNewerBake(botsource.PlatformTenantID, "reviewer", "platform", "0.7.0")
+	line = buf.String()
+	for _, want := range []string{"iterion remote admin bots push bots/reviewer", "DELETE /api/admin/bots/reviewer"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("a platform row must name %q; got:\n%s", want, line)
+		}
+	}
+	if strings.Contains(line, "/bot-sources/") {
+		t.Errorf("a platform row must NOT be pointed at the team tier; got:\n%s", line)
+	}
+}
+
 // An unreadable catalog must read as UNKNOWN, never as a clean inventory — on
 // the very endpoint the runbook calls the check to run after a release
 // (Revi Re7858f).
@@ -305,8 +339,8 @@ func TestWarnOverrideShadow_DedupsPerTenantNotPerSlug(t *testing.T) {
 
 	s.warnIfOverrideShadowsNewerBake("team-a", "reviewer", "team", "0.7.0")
 	s.warnIfOverrideShadowsNewerBake("team-b", "reviewer", "team", "0.7.0")
-	// Count LINES, not slug occurrences — the message names the slug three
-	// times (subject + both remedies).
+	// Count LINES, not slug occurrences — the message names the slug more
+	// than once (subject + remedy).
 	if got := strings.Count(buf.String(), "serves the"); got != 2 {
 		t.Errorf("two tenants shadowing the same slug must BOTH warn; got %d line(s):\n%s", got, buf.String())
 	}

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -216,6 +216,14 @@ func (s *Server) resolveBotSource(ctx context.Context, botID string) (*launchBot
 type platformBotSet struct {
 	entries   []botregistry.EntryWithSchema
 	manifests map[string]*bundle.Manifest
+	// slugs is EVERY platform row, versioned or not — a row still WINS
+	// resolution when it carries no manifest (storedLaunchBot asks only for a
+	// non-empty main.bot), so "does a platform row serve this slug" cannot be
+	// answered from manifests. Nor from entries: materializeBotEntries drops a
+	// row whose Materialize failed and returns nil on a ListWithSchema error,
+	// so absence there is not absence in the store. The list read is the
+	// authority, and this is its projection.
+	slugs map[string]struct{}
 }
 
 // platformBotSetCached returns the resolver-cached set (30s TTL,
@@ -255,8 +263,10 @@ func (s *Server) newPlatformBotsResolver() *platformcfg.Resolver[platformBotSet]
 		set := platformBotSet{
 			entries:   s.materializeBotEntries(list),
 			manifests: make(map[string]*bundle.Manifest, len(list)),
+			slugs:     make(map[string]struct{}, len(list)),
 		}
 		for i := range list {
+			set.slugs[list[i].Slug] = struct{}{}
 			if m := list[i].Manifest(); m != nil {
 				set.manifests[list[i].Slug] = m
 			}

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -81,6 +81,13 @@ func routeSchemas() map[string]routeOp {
 		"DELETE /api/admin/bots/{slug}":    {},
 		"POST /api/admin/bots/{slug}/fork": {request: botSourceForkReq{}, response: botSourceView{}},
 
+		// Team bot sources — the SAME handler (listBotSourcesFor), so the same
+		// payload, including the shadow fields docs/platform-bots.md promises
+		// on this endpoint. Left untyped, that promise had no spec behind it:
+		// documented-but-unverifiable is the exact shape this family exists
+		// to end.
+		"GET /api/teams/{id}/bot-sources": {response: botSourceListView{}},
+
 		// Forge integrations (connections + self-service OAuth/GitHub apps).
 		"GET /api/teams/{id}/forge/connections": {
 			response: struct {

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -10990,12 +10990,14 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Response */
-            default: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["botSourceListView"];
+                };
             };
         };
     };


### PR DESCRIPTION
Follow-up to #851 (merged as `8ce6262cb`). A `branch-improve-loop` campaign was
reviewing that branch when it merged and kept working for another 21 minutes;
its commits therefore missed the squash. They are reproduced here on `main`,
unchanged except for the rebase.

All four are defects **inside** the guard #851 added — none asks it to change
direction.

| commit | defect |
|---|---|
| `b42ac406` | a shadowed **team** row was handed the **platform** remedy. Team rows live at `PUT\|DELETE /api/teams/{id}/bot-sources/{slug}`; an operator following the message either 404s or, holding super-admin, deletes the platform override for that slug — a different row, and dropping it changes what every tenant is served. |
| `03cac9b8` | an unreadable platform overlay was read as *no platform rows* instead of *unknown*. The file builds the explicit-unknown machinery (`shadow_check_unavailable`) and then did not use it for this input. |
| `9604f7d8` | a platform row with **no `version:`** counted as absent, so a team row was measured against the baked catalog rather than against what would actually serve. |
| `ec2ac87a` | `listBotSourcesFor` serves both listings and `docs/platform-bots.md` promises the shadow fields on the team one — but only the admin response was typed in the spec. |

Two more commits carry no behaviour change and are worth reading anyway:

- `84e689f7` records that `newBakedCatalogResolver`'s fetch discards its
  `context.Context` (because `botregistry.List` takes none), so `platformcfg`'s
  3 s fetch timeout does **not** bound this resolver. Documented rather than
  "fixed": running the walk in a goroutine cannot cancel a blocked filesystem
  walk, only abandon it, and `Resolver.Get` re-arms the TTL after a failure —
  so a wedged mount would strand a fresh goroutine every refresh interval,
  trading bounded blocking for an unbounded leak. The real remedy belongs in
  `botregistry`.
- `1f1aa374` repairs two comments that #851's own later commits had inverted:
  one still claimed the dedup check runs *before* the catalog walk (`6f08d55`
  deliberately moved it after, so a negative verdict stays recomputable), and
  `bakedVersions`' doc comment had been orphaned onto the `bakedCatalog` type
  introduced between them.

## Verification

Run on this branch, on top of `7725057b2`:

```
$ CGO_ENABLED=0 devbox run -- go build ./...          # clean
$ devbox run -- go test ./pkg/server/ -count=1
ok  	github.com/SocialGouv/iterion/pkg/server	46.781s
$ devbox run -- task openapi:gen && git status --short  # no drift
```

The two doc commits are the mandated dogfood bilans: the campaign's own
(`docs/bot-runs/branch-improve-loop.md`, including why it died and why the run
error misdiagnoses the cap that killed it) and one for Revi
(`docs/bot-runs/review-pr.md`) recording that #851's gate went green on a pass
reporting zero findings while these four defects were present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)