### PR TITLE
docs(usage-caps): the two shapes of a `usage cap:` line, and which one the cap can fix

### DIFF
--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -283,6 +283,50 @@ re-measures.
 - then the ordinary wait: `run_retry_scheduled` with `retry_after` at the
   window's reopening, and `run_auto_resumed` when it fires.
 
+### Two sentences, two very different situations
+
+The warn line comes in two shapes, and reading the wrong one wastes the time
+the cap was meant to save. Both begin `usage cap:`, and only one of them is
+about the cap.
+
+```
+usage cap: seven_day window at 76% ≥ 75% (week, hard), resets …
+```
+
+**We stopped ourselves.** The provider is still serving; iterion refused
+because its own telemetry crossed the operator's percentage. Raising the cap
+(`iterion remote admin caps set --week …`) lets work through immediately.
+
+```
+usage cap: provider rejected on the seven_day window (week cap 85%, hard), resets …
+```
+
+**The provider refused.** This wording is emitted only when the reading's
+status is *rejected* AND it carries no utilization number — a real refusal
+from the API, not a threshold crossing. The `(week cap 85%, hard)` in
+parentheses names the policy in force, **not the reason**, which is exactly
+what makes it easy to misread: touching the cap changes nothing, because the
+call never got as far as the cap. The only thing that helps is the reset
+instant, and the run is already waiting for it.
+
+Two consequences worth having in mind before touching anything:
+
+- The refusal shape can appear while the provider's own dashboard shows
+  headroom on the *other* window. A weekly wall and a five-hour wall are
+  independent, and a run refused on one says nothing about the other.
+- `iterion remote admin usage-readings clear` will happily forget a refusal
+  too, and it buys nothing: the next run is admitted and then refused at the
+  call instead of at admission. That command earns its keep on the *opposite*
+  shape — a dated reading trusted past a reset the ledger could not see (see
+  [A reading is trusted for a bounded time](#a-reading-is-trusted-for-a-bounded-time)).
+  Reach for it when the provider's dashboard disagrees with iterion, not when
+  the provider itself is saying no.
+
+Measured on 2026-09-08: fifteen review runs refused this way over an hour, on
+a deployment whose caps had just been lowered — the caps were not the cause,
+and every one of the fifteen resumed and delivered by itself once the window
+reopened.
+
 ## What a cap does NOT stop
 
 **A run is only refused in advance when it could not possibly avoid

--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -283,37 +283,48 @@ re-measures.
 - then the ordinary wait: `run_retry_scheduled` with `retry_after` at the
   window's reopening, and `run_auto_resumed` when it fires.
 
-### Two sentences, two very different situations
+### Two shapes, three situations — and the number is what tells them apart
 
-The warn line comes in two shapes, and reading the wrong one wastes the time
-the cap was meant to save. Both begin `usage cap:`, and only one of them is
-about the cap.
-
-```
-usage cap: seven_day window at 76% ≥ 75% (week, hard), resets …
-```
-
-**We stopped ourselves.** The provider is still serving; iterion refused
-because its own telemetry crossed the operator's percentage. Raising the cap
-(`iterion remote admin caps set --week …`) lets work through immediately.
+The warn line comes in two shapes, and the shape alone does **not** say who
+refused. Reading it as if it did is what wastes the time this page exists to
+save.
 
 ```
 usage cap: provider rejected on the seven_day window (week cap 85%, hard), resets …
 ```
 
-**The provider refused.** This wording is emitted only when the reading's
-status is *rejected* AND it carries no utilization number — a real refusal
-from the API, not a threshold crossing. The `(week cap 85%, hard)` in
-parentheses names the policy in force, **not the reason**, which is exactly
-what makes it easy to misread: touching the cap changes nothing, because the
-call never got as far as the cap. The only thing that helps is the reset
-instant, and the run is already waiting for it.
+**The provider refused, and said so without a number.** `evaluate` picks this
+wording only when the reading's status is *rejected* AND it carries no
+utilization figure. The `(week cap 85%, hard)` in parentheses names the policy
+in force, **not the reason** — which is what makes it easy to misread. Touching
+the cap changes nothing: the call never got as far as the cap.
+
+```
+usage cap: seven_day window at 76% ≥ 75% (week, hard), resets …
+```
+
+**This one is ambiguous, and the percentage resolves it.**
+
+- **Below 100%** — we stopped ourselves. The provider is still serving and
+  iterion refused because its own telemetry crossed the operator's percentage.
+  Raising the cap (`iterion remote admin caps set --week …`) lets work through
+  immediately.
+- **At or above 100%** — the provider refused, in the same words. A reading can
+  be *rejected* and still carry a number, and it then renders in this shape;
+  the Anthropic forfait probe marks every window at ≥100% rejected while
+  keeping the figure. A rejected reading is blocked at **any** cap — the guard
+  reads `if !rejected && pct < cap`, so even a cap of 100% refuses it. Raise
+  nothing; the reset instant is the only lever.
+
+So the rule to carry is not *"which sentence is it"* but **"is the reading
+rejected"**, and the two things that answer it are the missing number and the
+percentage at or above 100%.
 
 Two consequences worth having in mind before touching anything:
 
-- The refusal shape can appear while the provider's own dashboard shows
-  headroom on the *other* window. A weekly wall and a five-hour wall are
-  independent, and a run refused on one says nothing about the other.
+- A refusal can appear while the provider's own dashboard shows headroom on
+  the *other* window. The weekly and five-hour walls are independent, and a run
+  refused on one says nothing about the other.
 - `iterion remote admin usage-readings clear` will happily forget a refusal
   too, and it buys nothing: the next run is admitted and then refused at the
   call instead of at admission. That command earns its keep on the *opposite*
@@ -322,9 +333,9 @@ Two consequences worth having in mind before touching anything:
   Reach for it when the provider's dashboard disagrees with iterion, not when
   the provider itself is saying no.
 
-Measured on 2026-09-08: fifteen review runs refused this way over an hour, on
-a deployment whose caps had just been lowered — the caps were not the cause,
-and every one of the fifteen resumed and delivered by itself once the window
+Measured on 2026-09-08: fifteen review runs refused over an hour on a
+deployment whose caps had just been lowered — the caps were not the cause, and
+every one of the fifteen resumed and delivered by itself once the window
 reopened.
 
 ## What a cap does NOT stop


### PR DESCRIPTION
## Why

`docs/usage-caps.md` already says the `usage_cap` event is *"the only thing that distinguishes 'the provider refused us' from 'we stopped ourselves'"* — but it never says how to read that distinction in the **error message**, which is what an operator actually sees first: in `iterion remote runs list`, in the run's error field, in a paused-gate comment on a PR.

The refusal shape is genuinely misleading:

```
usage cap: provider rejected on the seven_day window (week cap 85%, hard), resets …
```

The `(week cap 85%, hard)` names the **policy in force**, not the reason. It reads like the cap fired at 85%. It did not: `pkg/usagecap/usagecap.go:520` emits that wording only when the reading's status is *rejected* **and** it carries no utilization number — a real API refusal, where the call never got as far as the cap.

**Two sessions in a row misread it**, and both reasoned about raising or lowering a cap that had nothing to do with the refusal — one of them wrote it into a handover as a fact. That is the definition of knowledge worth committing rather than leaving in a transcript.

## What

A subsection under *What it looks like when it fires*, showing both lines side by side with what each means and what actually helps. Plus two consequences that cost time on 2026-09-08:

- the refusal shape can appear while the provider's dashboard shows headroom on the **other** window — the weekly and five-hour walls are independent;
- `iterion remote admin usage-readings clear` *will* forget a refusal, and buys nothing — the next run is admitted and then refused at the call instead of at admission. It earns its keep on the opposite shape, a dated reading trusted past a reset the ledger could not see.

That second bullet was written the wrong way round first (as "does not apply") and corrected against the code: the command works mechanically, it is just useless here. A runbook that says "this does not work" about something that does is worse than saying nothing.

Grounded in the measurement: fifteen review runs refused this way in an hour on a deployment whose caps had just been lowered, and every one of them resumed and delivered by itself once the window reopened.

Docs only; no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
