### PR TITLE
fix(server): a launch field the request does not declare is refused, not dropped

### DIFF
--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -3,9 +3,14 @@
 package httpx
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+	"sort"
+	"strings"
 )
 
 // maxBody bounds request bodies read by DecodeJSON (10 MB).
@@ -38,4 +43,72 @@ func DecodeJSON(r *http.Request, dst any) error {
 		return err
 	}
 	return json.Unmarshal(body, dst)
+}
+
+// DecodeJSONStrict is DecodeJSON with unknown fields REFUSED instead of
+// dropped, and the accepted names put in the error.
+//
+// A silently ignored field is indistinguishable, from the client, from one
+// that was honoured: the request is accepted, the parameter does nothing,
+// and the caller learns it from the behaviour of whatever it started rather
+// than from the answer it got. Measured 2026-09-08: a launch sent its
+// parameter under a name the request struct does not declare, the field was
+// dropped, the run took the workflow's own default for it — the opposite of
+// what was asked — and ten hours were spent before anyone read the value
+// back out of the run instead of out of the payload.
+//
+// The names are listed because a suggestion by string distance would not
+// have helped that case: the two names were semantically related and
+// textually unrelated. The list is.
+func DecodeJSONStrict(r *http.Request, dst any) error {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBody))
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		if names := acceptedFields(dst); strings.Contains(err.Error(), "unknown field") && names != "" {
+			return fmt.Errorf("%w; accepted fields: %s", err, names)
+		}
+		return err
+	}
+	return nil
+}
+
+// acceptedFields lists the JSON names dst declares, comma-separated and
+// sorted. Embedded structs are walked so an inherited field is offered like
+// any other; a field tagged "-" is not a name a caller may send.
+func acceptedFields(dst any) string {
+	t := reflect.TypeOf(dst)
+	for t != nil && (t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice) {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return ""
+	}
+	var names []string
+	var walk func(reflect.Type)
+	walk = func(t reflect.Type) {
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			tag := strings.Split(f.Tag.Get("json"), ",")[0]
+			if tag == "-" {
+				continue
+			}
+			if f.Anonymous && tag == "" && f.Type.Kind() == reflect.Struct {
+				walk(f.Type)
+				continue
+			}
+			if tag == "" {
+				tag = f.Name
+			}
+			if f.IsExported() {
+				names = append(names, tag)
+			}
+		}
+	}
+	walk(t)
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }

--- a/internal/httpx/httpx_strict_test.go
+++ b/internal/httpx/httpx_strict_test.go
@@ -1,0 +1,87 @@
+package httpx
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type strictNested struct {
+	Depth int `json:"depth"`
+}
+
+type strictEmbedded struct {
+	Inherited string `json:"inherited"`
+}
+
+type strictTarget struct {
+	strictEmbedded
+	Vars   map[string]string `json:"vars,omitempty"`
+	BotID  string            `json:"bot_id,omitempty"`
+	Nested strictNested      `json:"nested,omitempty"`
+	Secret string            `json:"-"`
+	hidden string            //nolint:unused // an unexported field is not a name a caller may send
+}
+
+// The measured failure, in the shape it arrived: a parameter sent under a
+// name the struct does not declare. Dropped, it is indistinguishable from
+// one that was honoured — the request is accepted and the value does
+// nothing. Refused, the caller reads the answer instead of the behaviour.
+func TestDecodeJSONStrict_RefusesAnUnknownFieldAndNamesTheAcceptedOnes(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", strings.NewReader(`{"inputs":{"adversarial":"false"}}`))
+	var dst strictTarget
+	err := DecodeJSONStrict(r, &dst)
+	if err == nil {
+		t.Fatal("an undeclared field was accepted — the caller cannot tell it did nothing")
+	}
+	if !strings.Contains(err.Error(), "inputs") {
+		t.Errorf("the error must name the field it refused: %v", err)
+	}
+	// The list is the whole point: `inputs` and `vars` are semantically
+	// related and textually unrelated, so a "did you mean" by string
+	// distance would not have offered the one the caller wanted.
+	if !strings.Contains(err.Error(), "vars") {
+		t.Errorf("the error must name what IS accepted: %v", err)
+	}
+}
+
+// The other half. A body of declared fields decodes exactly as before —
+// including through an embedded struct — or the guard is a wall, not a door.
+func TestDecodeJSONStrict_AcceptsWhatTheStructDeclares(t *testing.T) {
+	r := httptest.NewRequest("POST", "/",
+		strings.NewReader(`{"vars":{"adversarial":"false"},"bot_id":"golden-master","inherited":"x","nested":{"depth":2}}`))
+	var dst strictTarget
+	if err := DecodeJSONStrict(r, &dst); err != nil {
+		t.Fatalf("a well-formed body was refused: %v", err)
+	}
+	if dst.Vars["adversarial"] != "false" || dst.BotID != "golden-master" ||
+		dst.Inherited != "x" || dst.Nested.Depth != 2 {
+		t.Fatalf("decoded shape = %+v", dst)
+	}
+}
+
+// Unknown fields nest: a parameter misspelled INSIDE a declared object is
+// dropped by exactly the same mechanism.
+func TestDecodeJSONStrict_RefusesAnUnknownFieldInsideADeclaredObject(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", strings.NewReader(`{"nested":{"deph":2}}`))
+	var dst strictTarget
+	if err := DecodeJSONStrict(r, &dst); err == nil {
+		t.Fatal("a misspelled nested field was accepted")
+	}
+}
+
+// What the caller may send is what the struct offers — no more.
+func TestAcceptedFields_OffersOnlyWhatACallerMaySend(t *testing.T) {
+	got := acceptedFields(&strictTarget{})
+	for _, want := range []string{"vars", "bot_id", "nested", "inherited"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q missing from %q", want, got)
+		}
+	}
+	if strings.Contains(got, "Secret") || strings.Contains(got, "hidden") {
+		t.Errorf("a field no caller may send was offered: %q", got)
+	}
+	if got != "bot_id, inherited, nested, vars" {
+		t.Errorf("names = %q, want them sorted and complete", got)
+	}
+}

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -290,7 +290,12 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	var req launchRunRequest
-	if err := readJSON(r, &req); err != nil {
+	// STRICT: an unknown field is refused, not dropped. A launch is the one
+	// request whose parameters are read back hours later — a name this
+	// struct does not declare took its value with it, the run used the
+	// workflow's own default instead, and the payload the client kept is
+	// indistinguishable from one that worked.
+	if err := readJSONStrict(r, &req); err != nil {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "invalid request: %v", err)
 		span.SetStatus(codes.Error, "invalid request")
 		return

--- a/pkg/server/runs_launch_strict_test.go
+++ b/pkg/server/runs_launch_strict_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Measured 2026-09-08. A launch sent its parameter as `inputs`, a name
+// launchRunRequest does not declare. The field was dropped, the 202 said
+// nothing, the run took the workflow's own default for that parameter — the
+// opposite of what was asked — and ten hours of a long run were spent before
+// anyone read the value back out of the run instead of out of the payload
+// they had kept. From the client, a parameter refused and a parameter
+// swallowed were the same answer.
+func TestLaunchRefusesAFieldItDoesNotDeclare(t *testing.T) {
+	_, hs := newTestServer(t)
+	body := `{"bot_id":"golden-master","inputs":{"adversarial":"false"}}`
+	resp, err := http.Post(hs.URL+"/api/runs", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/runs: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 — a swallowed parameter is a run that does the opposite of what was asked", resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), "inputs") {
+		t.Errorf("the refusal must name the field: %s", raw)
+	}
+	// `inputs` and `vars` are semantically related and textually unrelated,
+	// so the accepted list is what points at the right one — a suggestion by
+	// string distance would not have.
+	if !strings.Contains(string(raw), "vars") {
+		t.Errorf("the refusal must name what IS accepted: %s", raw)
+	}
+}
+
+// The other half: every field the struct declares still launches. A guard
+// that refused a legitimate parameter would be worse than the defect.
+func TestLaunchStillAcceptsEveryDeclaredField(t *testing.T) {
+	var req launchRunRequest
+	raw, err := json.Marshal(map[string]any{
+		"bot_id": "golden-master", "vars": map[string]string{"adversarial": "false"},
+		"preset": "p", "timeout": "30m", "merge_into": "main", "branch_name": "b",
+		"merge_strategy": "squash", "auto_merge": true, "run_id": "r1",
+		"budget": map[string]any{"max_duration": "8h"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest("POST", "/api/runs", bytes.NewReader(raw))
+	if err := readJSONStrict(r, &req); err != nil {
+		t.Fatalf("a body of declared fields was refused: %v", err)
+	}
+	if req.Vars["adversarial"] != "false" || req.BotID != "golden-master" {
+		t.Fatalf("decoded shape = %+v", req)
+	}
+}

--- a/pkg/server/server_files.go
+++ b/pkg/server/server_files.go
@@ -49,6 +49,14 @@ func readJSON(r *http.Request, v any) error {
 	return httpx.DecodeJSON(r, v)
 }
 
+// readJSONStrict refuses a field the destination does not declare, and names
+// the ones it does. For requests whose parameters are consumed long after the
+// 200 — a launch above all — where a dropped field is read back as the
+// workflow's own default and the payload gives no sign.
+func readJSONStrict(r *http.Request, v any) error {
+	return httpx.DecodeJSONStrict(r, v)
+}
+
 // decodeJSON reads+unmarshals the request body into *dst, writing a 400
 // "invalid request: %v" on failure. Returns true on success, false if it
 // already wrote an error response. Intended for the dominant handler-boilerplate


### PR DESCRIPTION
## A launch field the request does not declare is refused, not dropped

From the client, **a parameter that was refused and one that was swallowed are the same answer**: the request is accepted, the value does nothing, and the caller learns it from the behaviour of whatever it started rather than from what it was told.

## Measurement

2026-09-08. A launch sent its parameter under `inputs`; `launchRunRequest` declares `vars` (`pkg/server/runs_launch.go:54`). `encoding/json` dropped the field without a word, the run took the workflow's own default for that parameter — the **opposite** of what was asked — and **ten hours** of a long run were spent before anyone read the value back out of the run's checkpoint instead of out of the payload they still had.

The trap was already written down. What had not been corrected was the payload, and nothing in the answer could have told them apart.

## The change

- **`httpx.DecodeJSONStrict`** — `DecodeJSON` with unknown fields refused instead of dropped, same 10 MB bound, and the **accepted names put in the error**.
- The launch handler uses it. Nothing else does: this is scoped to the one request whose parameters are consumed hours after the 200.

The names are **listed**, not guessed at by string distance. That is the load-bearing detail of the measured case: `inputs` and `vars` are semantically related and textually unrelated, so a "did you mean" would have offered nothing, where the list offers `vars`.

## Blast radius, measured rather than assumed

Rejecting a field an API never honoured is a contract change, so I checked the callers instead of hoping:

- `pkg/cli/remote_runs.go`, `contrib/mattermost-clarify/launch.go`, `studio/src/api/schema.ts` — declared fields only.
- `cmd/iterion/mcp_control.go:259` forwards the tool's raw arguments, with the comment *"Pass through the raw args so the server's `launchRunRequest` schema is the source of truth"*. That is precisely what this makes true: an agent inventing a field now hears about it instead of starting a run that quietly ignores it. Every field in that tool's schema is declared.
- `go test ./pkg/server/` — 147 launch-path tests green unchanged.

Unknown fields **nest**, so a parameter misspelled inside `budget` or a `model_overrides` entry is refused on the same terms.

## Proof

`TestLaunchRefusesAFieldItDoesNotDeclare` drives the measured body through the real endpoint and requires a 400 naming both the refused field and `vars`. `TestLaunchStillAcceptsEveryDeclaredField` is the other half — a body carrying ten declared fields, including a nested `budget`, still decodes — because a guard that refused a legitimate parameter would be worse than the defect. At the helper level: an unknown field inside a declared object, and `acceptedFields` offering exactly what a caller may send (an embedded struct's fields walked; `json:"-"` and unexported fields absent).

Four mutants, each red on its own test, each asserted to have changed the tree before running:

| mutant | red on |
|---|---|
| the launch handler goes back to the permissive decode | `TestLaunchRefusesAFieldItDoesNotDeclare` |
| the refusal stops naming what IS accepted | `TestDecodeJSONStrict_RefusesAnUnknownField…` |
| a `json:"-"` field is offered to callers | `TestAcceptedFields_OffersOnlyWhatACallerMaySend` |
| the embedded struct is no longer walked (an inherited field refused) | same |

`go test ./pkg/server/ ./internal/httpx/ ./pkg/cli/` green, `golangci-lint` 0 issues, gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
