### PR TITLE
feat(pipelines): Retry from zero — a board action that forces a FRESH run

### DIFF
--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -172,7 +172,7 @@ sibling planner from the workflow entry:
 | `running` | Hold while the owner process lives (run lock held). A dead owner (SIGKILL, host crash — lock free, past the 2-minute grace window) is promoted by the dispatcher itself: checkpoint → `failed_resumable` (then resumed), none → `failed` (a fresh run becomes legitimate). This works in `--no-server` deployments too, which have no runview orphan reaper. |
 | `queued` | Hold without probing the run lock. Pipeline-queued runs deliberately have no lock owner until a concurrency slot opens; their queue owner advances their state machine. |
 | `failed_resumable` | Resume the **same** run id. Internal stops (stall reap, external state change, daemon shutdown) cancel the run context with `runtime.ErrRunInterrupted` as the cause, so the engine persists this status — which is what keeps stall/shutdown recovery automatic. |
-| `cancelled` | Hold, **never auto-resume**: only an operator produces this status now, and resuming it would undo their decision. The card is held before the claim with a visible reason; the way out is an explicit resume, or `iterion issue update --clear-last-run`. |
+| `cancelled` | Hold, **never auto-resume**: only an operator produces this status now, and resuming it would undo their decision. The card is held before the claim with a visible reason; the way out is an explicit resume, or dropping the pointer (⋯ → *Retry from zero* on the pipeline board, `iterion issue update --clear-last-run` from a terminal). |
 | `finished` | No hold: a fresh run is allowed — dragging the card back to an eligible column **is** the re-queue gesture. |
 | none, or hard `failed`, and the ticket is explicitly eligible | The only other legitimate fresh run. |
 
@@ -184,9 +184,13 @@ the dispatcher worker already returned when the run first parked, so
 `finishRun` is not in the loop.
 
 To really start over: drag a `finished` or hard-`failed` ticket back to
-`ready`. A `cancelled` `last_run` still holds the ticket (no fresh sibling)
-but is never auto-resumed — resume it explicitly, or clear it with
-`iterion issue update --clear-last-run`.
+`ready`. A `failed_resumable` one is not enough — the table above resumes it,
+so the board's **Retry** means *resume* on a dispatcher-owned board even
+though the studio's own admission loop would have minted a fresh run. Drop
+the pointer to make the restart deterministic: ⋯ → **Retry from zero** on the
+pipeline board, or `iterion issue update --clear-last-run`. Same for a
+`cancelled` `last_run`, which holds the ticket (no fresh sibling) but is
+never auto-resumed — resume it explicitly, or drop the pointer.
 
 ### In-progress transition (`agent.running_state`)
 

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -360,11 +360,30 @@ would leak a slot with no bound.
 
 **Getting back to a fresh run.** A ticket's `last_run_id` pointer is what the
 dispatcher resumes on the next dispatch (`resolveRunID` → `resumableRunID`),
-so a run that died in a way resuming cannot fix keeps being resumed. Drop the
-pointer with `iterion issue update <id> --clear-last-run` — the next dispatch
-mints a new run from the workflow entry instead. The run *history*
-(`Issue.runs`) is kept: those runs happened, and their consoles are the
-evidence.
+so a run that died in a way resuming cannot fix keeps being resumed — and
+plain **Retry** does not change that: it only restages the ticket, and
+whoever claims it decides what "retry" meant (the studio's admission loop
+mints a fresh run; a live `iterion dispatch` resumes the dead one).
+
+Two surfaces drop the pointer, and both keep the run *history*
+(`Issue.runs`) — those runs happened, and their consoles are the evidence:
+
+- **⋯ → Retry from zero** on the card (`POST
+  /api/v1/pipeline-board/tasks/{id}/reset` with `{"fresh": true}`) — the
+  board answer, offered wherever Retry is once the run has settled. It
+  cancels the tree, drops the pointer, then restages, so both launch
+  authorities can only mint a new run.
+- `iterion issue update <id> --clear-last-run` — the CLI equivalent, for a
+  ticket you are already driving from a terminal.
+
+Both **refuse while a run is still going**, and for the same reason: the
+pointer is also the sibling guard, so dropping it beside a live run lets a
+second one start on the same ticket. `fresh` refuses *before* its cancel
+sweep — nothing is cancelled, nothing is restaged, and the 409 names the run
+— which keeps it out of the window Reset's pin exists to close (Reset pins a
+still-dying run as the current attempt precisely so the relaunch waits for
+it). `fresh` reads the whole run **tree**; `--clear-last-run` reads the
+pointer run only.
 
 **Closing a pipeline.** `Close` (⋯ menu, every non-terminal lane) cancels
 everything still alive under the card and files the ticket as **abandoned**
@@ -464,7 +483,7 @@ perform an N+1 traversal over issues, checkpoints and child runs:
 | `/api/v1/pipeline-board/tasks/{id}/ready` | POST | `{ready}` stages Ready when hard deps are done, else parks in `waiting_deps` (or 409); unstage → backlog |
 | `/api/v1/pipeline-board/tasks/{id}` | PATCH | Edit a not-yet-run ticket (title, body, labels, priority, bot, bot_args, blockers) |
 | `/api/v1/pipeline-board/tasks/{id}` | DELETE | Delete a ticket (issue only, never a run); 409 while any run in its tree is active |
-| `/api/v1/pipeline-board/tasks/{id}/reset` | POST | Cancel every active run in the ticket's tree, then restage it to Ready |
+| `/api/v1/pipeline-board/tasks/{id}/reset` | POST | Cancel every active run in the ticket's tree, then restage it to Ready. Optional body `{"fresh": true}` (⋯ → *Retry from zero*) also drops `last_run_id` before restaging, so no launch authority can resume the discarded run; refused with 409 — before the sweep, nothing touched — while any run in the tree is non-terminal |
 | `/api/v1/pipeline-board/tasks/{id}/close` | POST | Cancel the ticket's tree and file it terminal (`blocked`, never `done`); also clears a dispatcher give-up stamp — Close is the acknowledgement |
 | `/api/v1/pipeline-board/tasks/{id}/dependency-graph` | GET | Limited-depth hard-dep graph (also `GET /api/v1/native/issues/{id}/dependency-graph`) |
 | `/api/v1/pipeline-board/bulk/ready` | POST | `{ids?\|family_id?\|pipeline_kind?}` stage many tickets Ready (skip open blockers by default) |

--- a/openapi.json
+++ b/openapi.json
@@ -3155,6 +3155,17 @@
         ],
         "type": "object"
       },
+      "pipelineBoardResetRequest": {
+        "properties": {
+          "fresh": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "fresh"
+        ],
+        "type": "object"
+      },
       "pipelineBoardTaskRequest": {
         "properties": {
           "blockers": {
@@ -10914,9 +10925,26 @@
       ],
       "post": {
         "operationId": "postV1PipelineBoardTasksByIdReset",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/pipelineBoardResetRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
-          "default": {
-            "description": "Response"
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Issue"
+                }
+              }
+            },
+            "description": "OK"
           }
         },
         "summary": "POST /api/v1/pipeline-board/tasks/{id}/reset",

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -845,6 +845,39 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	if got, _ := store.Get(created.ID); len(got.Runs) != 2 || got.Runs[0].Workdir != "/tmp/wd-moved" {
 		t.Errorf("run history dedup-update failed: %+v", got.Runs)
 	}
+	// The CLEAR (empty run id) is the operator's way back to a fresh launch —
+	// the pipeline board's "Retry from zero" and `iterion issue update
+	// --clear-last-run` both call exactly this. It must drop the pointer,
+	// KEEP the history (those runs happened), and append no blank RunRef, on
+	// BOTH twins: a board reset from a cloud studio writes through the Mongo
+	// one, so a native-only guarantee would be a cloud hole.
+	if err := store.SetLastRun(created.ID, "", ""); err != nil {
+		t.Errorf("SetLastRun clear: %v", err)
+	}
+	if got, _ := store.Get(created.ID); got.LastRunID != "" || got.LastWorkdir != "" {
+		t.Errorf("SetLastRun clear did not drop the pointer: %+v", got)
+	}
+	if got, _ := store.Get(created.ID); len(got.Runs) != 2 {
+		t.Errorf("SetLastRun clear changed the run history: %+v", got.Runs)
+	} else {
+		for _, ref := range got.Runs {
+			if ref.RunID == "" {
+				t.Errorf("SetLastRun clear appended a blank run ref: %+v", got.Runs)
+			}
+		}
+	}
+	// Clearing an already-clear pointer is a no-op, not a second write.
+	if err := store.SetLastRun(created.ID, "", ""); err != nil {
+		t.Errorf("SetLastRun clear (idempotent): %v", err)
+	}
+	if got, _ := store.Get(created.ID); len(got.Runs) != 2 {
+		t.Errorf("SetLastRun repeat-clear grew the run history: %+v", got.Runs)
+	}
+	// Restore the pointer: the sections below (and the tracker suite) read a
+	// stamped card, and this suite shares one store per run.
+	if err := store.SetLastRun(created.ID, "run-1", "/tmp/wd-moved"); err != nil {
+		t.Errorf("SetLastRun re-stamp after clear: %v", err)
+	}
 
 	// SetAwaitingInput denormalizes the pause hint onto the card; set true,
 	// clear false, with parity to the native store (idempotent, tagged).

--- a/pkg/dispatcher/resolve_run_id_fresh_test.go
+++ b/pkg/dispatcher/resolve_run_id_fresh_test.go
@@ -1,0 +1,118 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestResolveRunID_LastRunPointerDecidesResumeVsFresh drives the REAL
+// resolution path — resolveRunID → LastRunForIssue (native.Adapter) →
+// resumableRunID (real run store) — over a real native board, so the answer
+// comes from the producer rather than a stub.
+//
+// It is the second half of the board's `fresh` reset: the endpoint writes the
+// persisted shape (last_run_id dropped), and THIS is what that shape buys —
+// the dispatcher stops resuming the dead run and mints a new id, agreeing
+// with the studio admission loop instead of racing it.
+func TestResolveRunID_LastRunPointerDecidesResumeVsFresh(t *testing.T) {
+	dir := t.TempDir()
+
+	runStore, err := store.New(dir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	run, err := runStore.CreateRun(context.Background(), "run-deterministic-fail", "wf", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// The #494 shape: a failure a resume cannot cure, parked resumable.
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{NodeID: "record_contracts_incomplete"}
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	iss, err := ns.Create(native.Issue{Title: "deterministic", State: native.StateReady, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ns.SetLastRun(iss.ID, "run-deterministic-fail", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	cfg := &Config{
+		Name:      "test",
+		Workflow:  filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:   TrackerConfig{Kind: "native"},
+		Polling:   PollingConfig{IntervalMS: 50},
+		Agent:     AgentConfig{MaxConcurrent: 4, RunningState: "in_progress"},
+		Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(cfg.Workspace.Root)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	// A resume target with no workspace restarts fresh for its own reason
+	// (missingResumeWorkspace), which would mask the pointer's effect —
+	// materialise the generation the run owns.
+	if _, _, err := ws.CreateForRun(iss.ID, "run-deterministic-fail"); err != nil {
+		t.Fatalf("CreateForRun: %v", err)
+	}
+	c, err := New(Options{
+		Config:     cfg,
+		Tracker:    native.NewAdapter(ns),
+		Runner:     &StubRunner{},
+		Workspaces: ws,
+		Logger:     iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		StoreDir:   dir,
+		HostMarker: "test-host-1",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	trackerIssue := tracker.Issue{ID: iss.ID, Identifier: iss.ID, Title: iss.Title, WorkflowState: native.StateReady}
+
+	// With the pointer: the dispatcher RESUMES the dead run. This is what
+	// makes a board Retry mean "resume" on a dispatcher-owned board.
+	runID, resumeFrom, _, ok := c.resolveRunID(context.Background(), trackerIssue)
+	if !ok {
+		t.Fatalf("resolveRunID refused the dispatch outright (runID=%q resumeFrom=%q)", runID, resumeFrom)
+	}
+	if resumeFrom != "run-deterministic-fail" {
+		t.Fatalf("resumeFromRunID = %q, want %q — the resume half of the race is not being exercised",
+			resumeFrom, "run-deterministic-fail")
+	}
+	if runID != "run-deterministic-fail" {
+		t.Fatalf("runID = %q, want the resumed run", runID)
+	}
+
+	// The board's `fresh` reset writes exactly this: SetLastRun with an
+	// empty run id (native.BoardStore's documented clear).
+	if err := ns.SetLastRun(iss.ID, "", ""); err != nil {
+		t.Fatalf("SetLastRun clear: %v", err)
+	}
+
+	runID, resumeFrom, _, ok = c.resolveRunID(context.Background(), trackerIssue)
+	if !ok {
+		t.Fatalf("resolveRunID refused after the clear (runID=%q resumeFrom=%q) — the ticket is stuck, not fresh", runID, resumeFrom)
+	}
+	if resumeFrom != "" {
+		t.Fatalf("resumeFromRunID = %q, want \"\" — the cleared pointer must not resume anything", resumeFrom)
+	}
+	if runID == "" || runID == "run-deterministic-fail" {
+		t.Fatalf("runID = %q, want a freshly minted id", runID)
+	}
+}

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -144,6 +144,13 @@ func routeSchemas() map[string]routeOp {
 			request:  pipelineBoardUpdateRequest{},
 			response: native.Issue{},
 		},
+		// The reset body is optional; `fresh` is what makes the restart
+		// deterministic (the last-run pointer is dropped, so no launch
+		// authority can resume the run being discarded).
+		"POST /api/v1/pipeline-board/tasks/{id}/reset": {
+			request:  pipelineBoardResetRequest{},
+			response: native.Issue{},
+		},
 		"GET /api/v1/pipeline-board/tasks/{id}/dependency-graph": {response: DependencyGraphResponse{}},
 		"GET /api/v1/native/issues/{id}/dependency-graph":        {response: DependencyGraphResponse{}},
 		"POST /api/v1/pipeline-board/bulk/ready": {

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 
@@ -103,6 +105,24 @@ func loadRunIndex(ctx context.Context, runs *runview.Service) (map[string]*store
 	return index, nil
 }
 
+// firstLiveTreeRun returns the first run in a ticket's tree that has not
+// reached a terminal status, or nil once the whole tree has settled. It is
+// the single "is anything still going under this card?" answer shared by
+// Delete (which refuses to detach a live pipeline from its ticket) and
+// Reset's `fresh` option (which refuses to drop the pointer that holds one).
+// One helper rather than a repeated loop: the two guards must agree on what
+// "still going" means, and `failed_resumable` — terminal, and precisely the
+// status a fresh restart exists to abandon — is where a divergence would
+// hurt.
+func firstLiveTreeRun(issue *native.Issue, runs map[string]*store.Run) *store.Run {
+	for _, run := range issueTreeRuns(issue, runs) {
+		if !run.Status.IsTerminal() {
+			return run
+		}
+	}
+	return nil
+}
+
 // handlePipelineBoardTaskDelete removes a ticket the operator no longer
 // wants — the backend of the Backlog card's Delete button. It only deletes
 // the native ISSUE, never a run: past attempts stay in the run store (they
@@ -141,12 +161,10 @@ func (s *Server) handlePipelineBoardTaskDelete(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board delete: list runs: %v", err)
 		return
 	}
-	for _, run := range issueTreeRuns(issue, runIndex) {
-		if !run.Status.IsTerminal() {
-			s.httpErrorFor(w, r, http.StatusConflict,
-				"pipeline board delete: run %s is still %s — cancel or reset the ticket first", run.ID, run.Status)
-			return
-		}
+	if live := firstLiveTreeRun(issue, runIndex); live != nil {
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"pipeline board delete: run %s is still %s — cancel or reset the ticket first", live.ID, live.Status)
+		return
 	}
 	if err := boardStore.Delete(id); err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board delete: %v", err)
@@ -154,6 +172,35 @@ func (s *Server) handlePipelineBoardTaskDelete(w http.ResponseWriter, r *http.Re
 	}
 	s.reflectAllowedOrigin(w, r)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// pipelineBoardResetRequest is the reset action's OPTIONAL body.
+type pipelineBoardResetRequest struct {
+	// Fresh additionally drops the ticket's last-run pointer, so the next
+	// launch cannot resume the run this reset discards. Without it the
+	// pointer survives and "what happens next" depends on who picks the
+	// ticket up — the studio admission loop mints a fresh run,
+	// `iterion dispatch` resolves the pointer and resumes from its
+	// checkpoint (resolveRunID → LastRunForIssue → resumableRunID).
+	Fresh bool `json:"fresh"`
+}
+
+// readPipelineResetRequest decodes the reset body, which is OPTIONAL: this
+// endpoint shipped without one and clients still POST it empty. An absent or
+// blank body is the historical (pointer-keeping) reset; a body that is
+// present but malformed is an ERROR, never silently read as `fresh: false` —
+// the flag decides whether a run pointer is discarded, so a typo'd request
+// must not be answered with the safe-looking default.
+func readPipelineResetRequest(r *http.Request) (pipelineBoardResetRequest, error) {
+	var req pipelineBoardResetRequest
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return req, err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return req, nil
+	}
+	return req, json.Unmarshal(raw, &req)
 }
 
 // handlePipelineBoardTaskReset restarts an in-progress ticket from zero —
@@ -165,6 +212,13 @@ func (s *Server) handlePipelineBoardTaskDelete(w http.ResponseWriter, r *http.Re
 // (pipelineTicketLaunchable holds the launch until the old run is
 // terminal). If any run cannot be cancelled from this process the reset is
 // refused with 409 and the ticket is left untouched.
+//
+// `fresh: true` additionally clears the last-run pointer, which is what
+// makes the restart deterministic: with the pointer gone both launch
+// authorities mint a new run, instead of the studio minting one and a live
+// dispatcher resuming the dead one. It is REFUSED while anything in the
+// ticket's tree is still non-terminal, and refused BEFORE the cancel sweep
+// so nothing is touched — see the guard below.
 func (s *Server) handlePipelineBoardTaskReset(w http.ResponseWriter, r *http.Request) {
 	if !s.requireSafeOrigin(w, r) {
 		return
@@ -183,6 +237,11 @@ func (s *Server) handlePipelineBoardTaskReset(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board reset: missing task id")
 		return
 	}
+	req, err := readPipelineResetRequest(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board reset: invalid request: %v", err)
+		return
+	}
 	issue, err := boardStore.Get(id)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board reset: %v", err)
@@ -199,6 +258,38 @@ func (s *Server) handlePipelineBoardTaskReset(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board reset: list runs: %v", err)
 		return
+	}
+	// THE PIN'S WINDOW. The sweep below only SIGNALS a cancel, so a run can
+	// still be unwinding when it returns — which is why reset pins that run
+	// as the ticket's current attempt (see below) instead of letting the
+	// relaunch start beside it. `fresh` deletes exactly that pointer, so
+	// running it in that window would reopen the hole the pin closes.
+	//
+	// The guard therefore refuses rather than waits, and refuses HERE,
+	// before the sweep: waiting would hold an HTTP request for however long
+	// an agent takes to reach its next safe boundary and still have to
+	// refuse on timeout, while refusing first leaves the ticket, the runs
+	// and the pointer exactly as they were — a 409 the operator can act on
+	// (stop or plain-reset it, then start over) rather than a half-done
+	// reset. The consequence is that `fresh` only ever runs on a settled
+	// tree, where the sweep and the pin are both no-ops.
+	//
+	// Same predicate as Delete's guard (firstLiveTreeRun) and the same
+	// dead-vs-live discrimination as `iterion issue update
+	// --clear-last-run` (refuseClearWhileRunAlive): `failed_resumable` and
+	// `cancelled` are dead and clearable — they are the whole point —
+	// while running/queued/paused hold the pointer. A server with no run
+	// service reads an empty index and so admits the clear: it launches
+	// nothing itself (the launch endpoint refuses outright), and both
+	// siblings resolve that same unknowable the same way rather than
+	// bricking the escape hatch.
+	if req.Fresh {
+		if live := firstLiveTreeRun(issue, runIndex); live != nil {
+			s.httpErrorFor(w, r, http.StatusConflict,
+				"pipeline board reset: ticket %s cannot start fresh while run %s is still %s — discarding its last-run pointer now would let a second run start beside it; stop or reset it first, then start over once it is terminal",
+				id, live.ID, live.Status)
+			return
+		}
 	}
 	// Roots before descendants (tree walk order): cancelling the root first
 	// lets the engine's own context propagation stop in-process children,
@@ -236,6 +327,25 @@ func (s *Server) handlePipelineBoardTaskReset(w http.ResponseWriter, r *http.Req
 				}
 			}
 			break
+		}
+	}
+	// Drop the pointer BEFORE the restage, never after: restaging is what
+	// makes the ticket eligible again, so a window where it is Ready and
+	// still names a resumable run is a window in which a dispatcher resumes
+	// the very run this call was told to discard.
+	//
+	// Its failure is RAISED, not logged: the operator asked for a fresh
+	// start, and restaging with the pointer intact would hand them the
+	// race they clicked to avoid. Nothing has been restaged yet, so the
+	// 409 leaves a coherent card (its runs cancelled, its state unchanged).
+	if req.Fresh {
+		if err := boardStore.SetLastRun(id, "", ""); err != nil {
+			s.httpErrorFor(w, r, http.StatusInternalServerError,
+				"pipeline board reset: ticket %s: clear the last-run pointer: %v — the ticket was NOT restaged, so nothing can resume the discarded run", id, err)
+			return
+		}
+		if s.logger != nil {
+			s.logger.Info("pipeline board: reset ticket %s dropped its last-run pointer (was %s) — the next launch starts fresh", id, issue.LastRunID)
 		}
 	}
 	// Reset is an OPERATOR gesture: a terminal ticket restaged is a

--- a/pkg/server/pipeline_board_reset_fresh_test.go
+++ b/pkg/server/pipeline_board_reset_fresh_test.go
@@ -1,0 +1,358 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// resetTaskWith POSTs the reset action with an explicit body, so a test can
+// exercise the `fresh` opt-in and the historical (pointer-keeping) shape
+// through the same endpoint.
+func resetTaskWith(t *testing.T, env *pipelineBoardTestEnv, id, body string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(
+		env.http.URL+"/api/v1/pipeline-board/tasks/"+id+"/reset",
+		"application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST reset: %v", err)
+	}
+	return resp
+}
+
+func respBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(raw)
+}
+
+// lastRunAsTheDispatcherSeesIt reads the pointer through the SAME interface
+// the dispatcher's resolveRunID type-asserts for (native.Adapter's
+// LastRunForIssue) — not through the raw issue field. That is the first link
+// of the real resolution chain: whatever this returns is what
+// resumableRunID is handed.
+func lastRunAsTheDispatcherSeesIt(t *testing.T, env *pipelineBoardTestEnv, issueID string) string {
+	t.Helper()
+	type lastRunLookup interface {
+		LastRunForIssue(id string) (string, error)
+	}
+	var look lastRunLookup = native.NewAdapter(env.board)
+	prev, err := look.LastRunForIssue(issueID)
+	if err != nil {
+		t.Fatalf("LastRunForIssue(%s): %v", issueID, err)
+	}
+	return prev
+}
+
+// Reset with `fresh` is the board-side answer to "start over, discard that
+// run": it drops the last-run pointer the dispatcher resumes from, so a run
+// that died in a way resuming cannot fix stops being resumed for ever.
+//
+// The pointer is read back through the dispatcher's OWN lookup, and the
+// negative half (a plain reset) pins today's behaviour so `fresh` cannot
+// quietly become the default.
+func TestPipelineBoardResetFreshDropsTheResumePointer(t *testing.T) {
+	seed := func(t *testing.T, env *pipelineBoardTestEnv, runID string) *native.Issue {
+		t.Helper()
+		issue, err := env.board.Create(native.Issue{
+			Title: "Deterministic failure", State: native.StateInProgress, Bot: "review",
+		})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, runID, "review", store.RunStatusFailedResumable, func(run *store.Run) {
+			run.FilePath = env.botPath
+			run.Checkpoint = &store.Checkpoint{NodeID: "approval"}
+		})
+		if err := env.board.SetLastRun(issue.ID, runID, ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != runID {
+			t.Fatalf("seed: LastRunForIssue = %q, want %q", got, runID)
+		}
+		return issue
+	}
+
+	t.Run("fresh clears it", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue := seed(t, env, "fresh-clear")
+
+		resp := resetTaskWith(t, env, issue.ID, `{"fresh":true}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		var updated native.Issue
+		decodeJSONResp(t, resp, &updated)
+		if updated.State != native.StateReady {
+			t.Errorf("state = %q, want %q", updated.State, native.StateReady)
+		}
+		if updated.LastRunID != "" {
+			t.Errorf("response still carries last_run_id %q — the body contradicts its own write", updated.LastRunID)
+		}
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != "" {
+			t.Errorf("LastRunForIssue = %q, want \"\" — the dispatcher would still resume the dead run", got)
+		}
+		// History is kept: the run happened, and its record is the only
+		// place the failure is written down.
+		after, err := env.board.Get(issue.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		found := false
+		for _, ref := range after.Runs {
+			if ref.RunID == "fresh-clear" {
+				found = true
+			}
+			if ref.RunID == "" {
+				t.Errorf("a blank run ref was appended by the clear: %+v", after.Runs)
+			}
+		}
+		if !found {
+			t.Errorf("run history lost the attempt: %+v", after.Runs)
+		}
+		if _, err := env.runStore(t).LoadRun(context.Background(), "fresh-clear"); err != nil {
+			t.Errorf("the run record was deleted: %v", err)
+		}
+	})
+
+	t.Run("without fresh the pointer is kept", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue := seed(t, env, "keep-pointer")
+
+		resp := resetTaskWith(t, env, issue.ID, `{}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		resp.Body.Close()
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != "keep-pointer" {
+			t.Errorf("LastRunForIssue = %q, want %q — a plain reset must not change what Retry means", got, "keep-pointer")
+		}
+	})
+
+	t.Run("an absent body is still a plain reset", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue := seed(t, env, "no-body")
+
+		req, err := http.NewRequest(http.MethodPost, env.http.URL+"/api/v1/pipeline-board/tasks/"+issue.ID+"/reset", nil)
+		if err != nil {
+			t.Fatalf("build POST: %v", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST reset: %v", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		resp.Body.Close()
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != "no-body" {
+			t.Errorf("LastRunForIssue = %q, want %q", got, "no-body")
+		}
+	})
+
+	t.Run("a malformed body is refused, not silently read as not-fresh", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue := seed(t, env, "bad-body")
+
+		resp := resetTaskWith(t, env, issue.ID, `{"fresh":`)
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("reset status = %d, want 400 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		resp.Body.Close()
+		after, err := env.board.Get(issue.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if after.State != native.StateInProgress {
+			t.Errorf("state = %q, want untouched %q", after.State, native.StateInProgress)
+		}
+	})
+}
+
+// The clear must land BEFORE the restage. Both orders end in the same
+// persisted state, so only the ORDER of the board's own events tells them
+// apart — and the order is what matters: restaging is what makes the ticket
+// eligible again, so a Ready ticket that still names a resumable run is a
+// window in which a live dispatcher resumes the run this call was told to
+// discard.
+func TestPipelineBoardResetFreshClearsThePointerBeforeRestaging(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Order matters", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "order-run", "review", store.RunStatusFailedResumable, func(run *store.Run) {
+		run.FilePath = env.botPath
+	})
+	if err := env.board.SetLastRun(issue.ID, "order-run", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	resp := resetTaskWith(t, env, issue.ID, `{"fresh":true}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200 (body: %s)", resp.StatusCode, respBody(t, resp))
+	}
+	resp.Body.Close()
+
+	// events.jsonl is append-only, so its order IS the write order: the
+	// clear (issue_last_run_updated carrying an empty run_id) must precede
+	// the restage to Ready.
+	clearedAt, restagedAt, seq := -1, -1, 0
+	if err := env.board.ScanEvents(func(ev *native.Event) bool {
+		if ev.IssueID != issue.ID {
+			return true
+		}
+		seq++
+		switch ev.Type {
+		case native.EvtIssueLastRun:
+			if id, _ := ev.Payload["run_id"].(string); id == "" {
+				clearedAt = seq
+			}
+		case native.EvtIssueState:
+			if to, _ := ev.Payload["to"].(string); to == native.StateReady {
+				restagedAt = seq
+			}
+		}
+		return true
+	}); err != nil {
+		t.Fatalf("ScanEvents: %v", err)
+	}
+	if clearedAt < 0 {
+		t.Fatal("no last-run clear event on the ticket — the pointer was never dropped")
+	}
+	if restagedAt < 0 {
+		t.Fatalf("no restage-to-%s event on the ticket", native.StateReady)
+	}
+	if clearedAt > restagedAt {
+		t.Errorf("the pointer was cleared AFTER the restage (clear at #%d, restage at #%d) — between them the ticket is Ready and still names a resumable run",
+			clearedAt, restagedAt)
+	}
+}
+
+// THE PIN CANARY. Reset deliberately PINS a still-dying run as the ticket's
+// current attempt so the relaunch waits for it to stop. Clearing the pointer
+// in that window reopens exactly what the pin closes, so `fresh` refuses
+// while anything in the ticket's tree is non-terminal — and refuses BEFORE
+// the cancel sweep, so nothing at all is touched.
+//
+// Falsification: delete the guard and this test goes red four ways — the run
+// is cancelled, the pointer is dropped, the ticket is restaged, and the
+// status is 200.
+func TestPipelineBoardResetFreshRefusedWhileARunIsNonTerminal(t *testing.T) {
+	t.Run("the pointer run itself", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue, err := env.board.Create(native.Issue{Title: "Still parked", State: native.StateInProgress, Bot: "review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, "fresh-parked", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+			run.FilePath = env.botPath
+			run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-1"}
+		})
+		if err := env.board.SetLastRun(issue.ID, "fresh-parked", ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+
+		resp := resetTaskWith(t, env, issue.ID, `{"fresh":true}`)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("reset status = %d, want 409 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		body := respBody(t, resp)
+		if !strings.Contains(body, "fresh-parked") {
+			t.Errorf("refusal does not name the run holding it back: %s", body)
+		}
+
+		// Nothing was touched: the refusal is side-effect free.
+		run, err := env.runStore(t).LoadRun(context.Background(), "fresh-parked")
+		if err != nil {
+			t.Fatalf("LoadRun: %v", err)
+		}
+		if run.Status != store.RunStatusPausedWaitingHuman {
+			t.Errorf("run status = %q, want untouched %q — the refusal cancelled it anyway", run.Status, store.RunStatusPausedWaitingHuman)
+		}
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != "fresh-parked" {
+			t.Errorf("LastRunForIssue = %q, want %q — the pointer was dropped on a LIVE run", got, "fresh-parked")
+		}
+		after, err := env.board.Get(issue.ID)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if after.State != native.StateInProgress {
+			t.Errorf("state = %q, want untouched %q", after.State, native.StateInProgress)
+		}
+	})
+
+	// The guard reads the whole ticket TREE, not just the pointer: a
+	// descendant still parked under a terminal root is exactly the run the
+	// pin exists for (it never stamped LastRunID).
+	t.Run("a non-terminal descendant of a terminal root", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue, err := env.board.Create(native.Issue{Title: "Live child", State: native.StateInProgress, Bot: "review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, "fresh-dead-root", "review", store.RunStatusFailedResumable, func(run *store.Run) {
+			run.FilePath = env.botPath
+		})
+		env.seedRun(t, "fresh-live-child", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+			run.FilePath = env.botPath
+			run.ParentRunID = "fresh-dead-root"
+			run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-2"}
+		})
+		if err := env.board.SetLastRun(issue.ID, "fresh-dead-root", ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+
+		resp := resetTaskWith(t, env, issue.ID, `{"fresh":true}`)
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("reset status = %d, want 409 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		if body := respBody(t, resp); !strings.Contains(body, "fresh-live-child") {
+			t.Errorf("refusal does not name the live descendant: %s", body)
+		}
+		if got := lastRunAsTheDispatcherSeesIt(t, env, issue.ID); got != "fresh-dead-root" {
+			t.Errorf("LastRunForIssue = %q, want %q", got, "fresh-dead-root")
+		}
+	})
+
+	// The same card, reset WITHOUT fresh, keeps today's behaviour: the
+	// parked run is cancelled and the ticket restaged. The guard is scoped
+	// to the clear, never to reset itself.
+	t.Run("a plain reset on the same card still cancels and restages", func(t *testing.T) {
+		env := newPipelineBoardTestEnv(t)
+		issue, err := env.board.Create(native.Issue{Title: "Still parked", State: native.StateInProgress, Bot: "review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, "plain-parked", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+			run.FilePath = env.botPath
+			run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-3"}
+		})
+		if err := env.board.SetLastRun(issue.ID, "plain-parked", ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+
+		resp := resetTaskWith(t, env, issue.ID, `{"fresh":false}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200 (body: %s)", resp.StatusCode, respBody(t, resp))
+		}
+		resp.Body.Close()
+		run, err := env.runStore(t).LoadRun(context.Background(), "plain-parked")
+		if err != nil {
+			t.Fatalf("LoadRun: %v", err)
+		}
+		if run.Status != store.RunStatusCancelled {
+			t.Errorf("run status = %q, want cancelled", run.Status)
+		}
+	})
+}

--- a/studio/src/api/pipelineBoards.test.ts
+++ b/studio/src/api/pipelineBoards.test.ts
@@ -5,6 +5,7 @@ import {
   getPipelineBoard,
   markPipelineTaskReady,
   normalizePipelineBoard,
+  resetPipelineTask,
   updatePipelineTask,
 } from "./pipelineBoards";
 
@@ -374,6 +375,36 @@ describe("markPipelineTaskReady", () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toEqual({ ready: false });
+  });
+});
+
+describe("resetPipelineTask", () => {
+  it("sends fresh:false by default — a plain reset keeps the last-run pointer", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resetPipelineTask("iss 1/a");
+
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/api/v1/pipeline-board/tasks/iss%201%2Fa/reset");
+    expect(init.method).toBe("POST");
+    // Explicit false, never an omitted key: the server reads a missing body
+    // as a plain reset, and being explicit keeps the wire self-describing.
+    expect(JSON.parse(String(init.body))).toEqual({ fresh: false });
+  });
+
+  it("sends fresh:true when the caller asks for a from-zero retry", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resetPipelineTask("iss-9", { fresh: true });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({ fresh: true });
   });
 });
 

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -638,10 +638,20 @@ export async function deletePipelineTask(taskId: string): Promise<void> {
 // cancels every still-active run in the ticket's tree, then restages the
 // ticket to Ready so the admission loop relaunches it fresh. Refused (409)
 // when a run is held by another process.
-export async function resetPipelineTask(taskId: string): Promise<void> {
+//
+// `fresh` additionally drops the ticket's last-run pointer, which is what
+// makes the restart deterministic — without it a live `iterion dispatch`
+// resolves that pointer and RESUMES the discarded run from its checkpoint
+// while the studio's own loop would have started a new one. The server
+// refuses `fresh` (409) while anything in the ticket's tree is still
+// non-terminal, and touches nothing when it does.
+export async function resetPipelineTask(
+  taskId: string,
+  opts: { fresh?: boolean } = {},
+): Promise<void> {
   await apiRequest<unknown>(
     `${BASE}/tasks/${encodeURIComponent(taskId)}/reset`,
-    { method: "POST", body: JSON.stringify({}) },
+    { method: "POST", body: JSON.stringify({ fresh: opts.fresh === true }) },
   );
 }
 

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6373,6 +6373,9 @@ export interface components {
         pipelineBoardReadyRequest: {
             ready: boolean;
         };
+        pipelineBoardResetRequest: {
+            fresh: boolean;
+        };
         pipelineBoardTaskRequest: {
             blockers?: string[];
             body?: string;
@@ -13258,14 +13261,20 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["pipelineBoardResetRequest"];
+            };
+        };
         responses: {
-            /** @description Response */
-            default: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["Issue"];
+                };
             };
         };
     };

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -216,8 +216,11 @@ describe("PipelineCardDetailsBody", () => {
     expect(html).toContain("The dispatcher gave up after 3 attempts");
     expect(html).toContain("kaboom"); // the underlying reason stays
     // Retry must not be sold as "starts it over": a live dispatcher resumes
-    // the same dead run unless the last-run pointer is cleared first.
-    expect(html).toContain("--clear-last-run");
+    // the same dead run unless the last-run pointer is dropped first. The
+    // banner names the board affordance that does it (#496) — an operator
+    // looking at a board must not be sent to a terminal.
+    expect(html).toContain("Retry from zero");
+    expect(html).not.toContain("--clear-last-run");
     expect(html).not.toContain("Retry starts it over");
   });
 

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -581,9 +581,9 @@ export function PipelineCardDetailsBody({
             // does not read a terminal ticket as somebody's decision.
             <InlineBanner tone="warning" layout="inline">
               {giveUpSentence(card.gave_up)} Retry restages the ticket — a
-              running dispatcher resumes this run from its checkpoint, so use{" "}
-              <code>iterion issue update {card.issue_id} --clear-last-run</code>{" "}
-              first to force a fresh one. Close acknowledges the give-up.
+              running dispatcher resumes this run from its checkpoint, so pick{" "}
+              <strong>Retry from zero</strong> in the card menu to discard it
+              and start over instead. Close acknowledges the give-up.
             </InlineBanner>
           )}
           {card.error && (

--- a/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
@@ -1047,6 +1047,95 @@ describe("botEditorPath", () => {
   });
 });
 
+// #496: on a needs-attention card, Retry only restages the ticket and lets
+// whoever claims it decide what that meant — the studio's admission loop
+// mints a fresh run, a live `iterion dispatch` resumes the dead one. "Retry
+// from zero" is the deterministic form: the server drops the last-run
+// pointer, so neither authority can resume.
+describe("Retry from zero menu entry", () => {
+  const kinds = (card: PipelineBoardCard) =>
+    resolveMenuItems(card, resolvePrimaryAction(card).kind).map((i) => i.kind);
+  const needsAttention = makeCard({
+    id: "na",
+    column_id: "needs_attention",
+    kind: "run",
+    issue_id: "iss-1",
+    run_id: "run-1",
+    status: "failed_resumable",
+    failed: true,
+    title: "Gave up",
+  });
+
+  it("sits beside Resume from checkpoint, so both deliberate exits are named", () => {
+    const items = resolveMenuItems(
+      needsAttention,
+      resolvePrimaryAction(needsAttention).kind,
+    );
+    expect(items.find((i) => i.kind === "retry_fresh")?.label).toBe(
+      "Retry from zero",
+    );
+    expect(items.find((i) => i.kind === "resume")?.label).toBe(
+      "Resume from checkpoint",
+    );
+  });
+
+  it("is marked destructive — it discards the ticket's run pointer", () => {
+    const items = resolveMenuItems(
+      needsAttention,
+      resolvePrimaryAction(needsAttention).kind,
+    );
+    expect(items.find((i) => i.kind === "retry_fresh")?.danger).toBe(true);
+  });
+
+  it("is offered on a failed Closed card too, where Retry is", () => {
+    expect(
+      kinds(
+        makeCard({
+          ...needsAttention,
+          column_id: "closed",
+          status: "cancelled",
+        }),
+      ),
+    ).toContain("retry_fresh");
+  });
+
+  // The server refuses `fresh` while anything in the ticket's tree is still
+  // non-terminal (it would reopen the window Reset's pin closes), so the
+  // menu must not offer it there.
+  it("is withheld while the run is still live", () => {
+    for (const status of ["running", "queued", "paused_operator", "paused_waiting_human"]) {
+      expect(
+        kinds(makeCard({ ...needsAttention, status })),
+      ).not.toContain("retry_fresh");
+    }
+  });
+
+  it("is withheld on a card with no ticket or no run to discard", () => {
+    expect(
+      kinds(makeCard({ ...needsAttention, issue_id: undefined })),
+    ).not.toContain("retry_fresh");
+    expect(
+      kinds(makeCard({ ...needsAttention, run_id: undefined })),
+    ).not.toContain("retry_fresh");
+  });
+
+  it("is withheld on lanes where Retry itself is not offered", () => {
+    expect(
+      kinds(
+        makeCard({
+          ...needsAttention,
+          column_id: "in_progress",
+          failed: false,
+          status: "running",
+        }),
+      ),
+    ).not.toContain("retry_fresh");
+    expect(
+      kinds(makeCard({ ...needsAttention, column_id: "opened", kind: "task" })),
+    ).not.toContain("retry_fresh");
+  });
+});
+
 describe("Edit bot menu entry", () => {
   const withBot = makeCard({
     id: "d",

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -43,6 +43,7 @@ import {
   canPauseRun,
   canResetTicket,
   canResumeRun,
+  canRetryFromZero,
   canStopRun,
   canUnmarkReady,
   isTicketEditable,
@@ -77,6 +78,7 @@ export {
   canPauseRun,
   canResetTicket,
   canResumeRun,
+  canRetryFromZero,
   canStopRun,
   canUnmarkReady,
   isTicketEditable,
@@ -185,6 +187,7 @@ export interface PipelineCardActions {
   onResume: (card: PipelineBoardCardDTO) => void;
   onStop: (card: PipelineBoardCardDTO) => void;
   onReset: (card: PipelineBoardCardDTO) => void;
+  onRetryFromZero: (card: PipelineBoardCardDTO) => void;
   onDelete: (card: PipelineBoardCardDTO) => void;
   onClose: (card: PipelineBoardCardDTO) => void;
 }
@@ -282,6 +285,38 @@ export function PipelineColumns({
       )
         return;
       await runAction(() => resetPipelineTask(card.issue_id as string));
+    },
+    // Retry from zero DISCARDS a run: say so before doing it, and name the
+    // run being dropped. Its checkpoint survives in the run store — only the
+    // ticket's pointer to it goes — so the honest wording is "this ticket
+    // stops resuming it", not "the run is deleted".
+    onRetryFromZero: async (card) => {
+      if (
+        !(await confirm({
+          title: "Retry from zero?",
+          message: (
+            <div className="space-y-2">
+              <p>
+                The ticket stops pointing at{" "}
+                {card.run_id ? <code>{card.run_id}</code> : "its last run"}, so
+                the next launch starts from the beginning instead of resuming
+                that checkpoint — whichever process picks the ticket up.
+              </p>
+              <p>
+                The run itself is kept: its history, artifacts and logs stay
+                readable in the run console. Use{" "}
+                <em>Resume from checkpoint</em> instead to continue it.
+              </p>
+            </div>
+          ),
+          confirmLabel: "Retry from zero",
+          confirmVariant: "danger",
+        }))
+      )
+        return;
+      await runAction(() =>
+        resetPipelineTask(card.issue_id as string, { fresh: true }),
+      );
     },
     onDelete: async (card) => {
       if (
@@ -813,6 +848,9 @@ export function PipelineCard({
       case "reset":
         actions?.onReset(card);
         break;
+      case "retry_fresh":
+        actions?.onRetryFromZero(card);
+        break;
       case "stop":
         actions?.onStop(card);
         break;
@@ -1297,21 +1335,23 @@ function ClosedStatus({ card }: { card: PipelineBoardCardDTO }) {
 // ticket, and whoever picks it up decides: the studio's admission loop mints a
 // fresh run, a live dispatcher resumes this one from its checkpoint. Saying
 // "starts it over" would send the operator to re-burn the budget on the same
-// checkpoint; the details panel names the tool that forces a fresh run.
+// checkpoint — "Retry from zero" in the card menu is the deterministic form.
 function giveUpTitle(
   giveUp: NonNullable<PipelineBoardCardDTO["gave_up"]>,
 ): string {
+  const exit =
+    "Nobody decided this — retry it (from zero, if resuming cannot fix it), or close the card to acknowledge it.";
   const filed = giveUp.state ? ` and filed the ticket as "${giveUp.state}"` : "";
   // A reasoned give-up is the watchdog's own verdict (a recorded run that
   // is gone), not a retry budget: say the reason, not an attempt count.
   if (giveUp.reason) {
-    return `The dispatcher gave up${filed}: ${giveUp.reason} Nobody decided this — retry it, or close the card to acknowledge it.`;
+    return `The dispatcher gave up${filed}: ${giveUp.reason} ${exit}`;
   }
   const attempts =
     giveUp.attempts && giveUp.attempts > 0
       ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
       : "after exhausting its attempts";
-  return `The dispatcher gave up ${attempts}${filed}. Nobody decided this — retry it, or close the card to acknowledge it.`;
+  return `The dispatcher gave up ${attempts}${filed}. ${exit}`;
 }
 
 function NeedsAttentionStatus({ card }: { card: PipelineBoardCardDTO }) {

--- a/studio/src/views/PipelineBoard/cardCapabilities.ts
+++ b/studio/src/views/PipelineBoard/cardCapabilities.ts
@@ -75,6 +75,39 @@ export function canStopRun(card: PipelineBoardCard): boolean {
   return card.column_id === "in_progress" && !!card.run_id && !card.issue_id;
 }
 
+// A run status the engine will never move again on its own. Mirrors Go's
+// store.RunStatus.IsTerminal() — the predicate the server's own `fresh`
+// guard uses — so the menu never offers an action the backend would 409.
+const TERMINAL_RUN_STATUSES = new Set([
+  "finished",
+  "failed",
+  "failed_resumable",
+  "cancelled",
+]);
+
+export function isTerminalRunStatus(status: string | undefined): boolean {
+  return !!status && TERMINAL_RUN_STATUSES.has(status);
+}
+
+// canRetryFromZero: Retry, minus the ambiguity. Plain Retry only restages
+// the ticket and lets whoever claims it decide what that meant — the studio
+// admission loop mints a fresh run, a live `iterion dispatch` resumes the
+// dead one from its checkpoint. This offers the deterministic form: the
+// server drops the last-run pointer first, so neither authority can resume.
+//
+// Offered wherever Retry is (the two failed lanes), and only once the root
+// run has settled: the server refuses while anything in the ticket's tree is
+// non-terminal, and the tree it reads includes descendants this card cannot
+// see — so the affordance mirrors the guard it can evaluate and the 409
+// remains the authority for the rest.
+export function canRetryFromZero(card: PipelineBoardCard): boolean {
+  if (!card.issue_id || !card.run_id || card.failed !== true) return false;
+  if (card.column_id !== "needs_attention" && card.column_id !== "closed") {
+    return false;
+  }
+  return isTerminalRunStatus(card.status);
+}
+
 // canCloseCard: file this pipeline for good — cancel whatever is still
 // alive under it and move it to Closed. It is the release valve for the
 // needs-attention lane, where a card holds a concurrency slot until it is

--- a/studio/src/views/PipelineBoard/primaryAction.ts
+++ b/studio/src/views/PipelineBoard/primaryAction.ts
@@ -7,6 +7,7 @@ import {
   canPauseRun,
   canResetTicket,
   canResumeRun,
+  canRetryFromZero,
   canStopRun,
   canUnmarkReady,
   isTicketEditable,
@@ -36,6 +37,9 @@ export type MenuItemKind =
   | "pause"
   | "stop"
   | "reset"
+  // retry_fresh is Retry with the last-run pointer dropped first, so the
+  // relaunch cannot be turned into a resume by whoever claims the ticket.
+  | "retry_fresh"
   | "close"
   | "full_page"
   | "edit_bot"
@@ -139,6 +143,13 @@ export function resolveMenuItems(
 
   if (card.column_id === "needs_attention") {
     if (canMarkReady(card)) add({ kind: "retry", label: "Retry" });
+    // The two DELIBERATE exits sit side by side and say exactly what they
+    // do: from zero (the pointer is discarded first, so nothing can resume
+    // it) or from the checkpoint. Plain Retry above leaves the choice to
+    // whoever claims the ticket.
+    if (canRetryFromZero(card)) {
+      add({ kind: "retry_fresh", label: "Retry from zero", danger: true });
+    }
     // Resume picks the run back up at its checkpoint instead of re-running
     // from zero — only meaningful when the engine actually saved one.
     if (card.status === "failed_resumable" && card.run_id) {
@@ -153,6 +164,9 @@ export function resolveMenuItems(
   if (card.column_id === "closed") {
     if (card.failed && canMarkReady(card)) {
       add({ kind: "retry", label: "Retry" });
+    }
+    if (canRetryFromZero(card)) {
+      add({ kind: "retry_fresh", label: "Retry from zero", danger: true });
     }
     if (isTicketEditable(card)) add({ kind: "edit", label: "Edit" });
     if (card.run_id) add({ kind: "open_run", label: "Open run console" });


### PR DESCRIPTION
## Why

On a `needs_attention` card, **Retry** restages the ticket to Ready and lets whoever picks it up decide what retry meant: the studio's admission loop mints a fresh run, while a live `iterion dispatch` finds the `LastRunForIssue` pointer and **resumes the same run from its checkpoint**. So Retry is race-dependent, and on a dispatcher-owned board it is effectively *Resume* — beside a menu that already offers *Resume from checkpoint* as its own deliberate action.

The cost is not cosmetic: for a run that died in a way resuming cannot fix, Retry **re-burns the budget on the same checkpoint, every time**. PR #495 shipped the honest stopgap (`iterion issue update --clear-last-run` plus a banner naming it) — which sends an operator looking at a board to a terminal.

## What

Shape **1** from the ticket: a `fresh` option on Reset, surfaced as **⋯ → "Retry from zero"**.

Not shape 2 (redefining Retry itself): that changes every needs-attention card — including the ones where resuming is the cheap right answer — and turns a confirm-less primary button into a destructive one. Shape 1 is additive and puts the two *deliberate* exits side by side: **Retry from zero** and **Resume from checkpoint**.

## The pin window: refuse, and why that is stronger than waiting

The ticket names the subtlety — Reset deliberately **pins** a still-dying run, so clearing the pointer while a run is stopping reopens the window the pin exists to close.

`fresh` **refuses (409) while anything in the ticket's tree is non-terminal, before the cancel sweep**, so nothing at all is touched. A wait would be unbounded (the cascade only *signals*; an agent's next safe boundary can be minutes), would hold an HTTP request open, and would still have to refuse on timeout — strictly more code for the same verdict, plus latency. Refusing first leaves ticket, runs and pointer exactly as they were: a 409 the operator can act on, rather than a half-done reset.

The consequence is structural, not merely polite: **`fresh` only ever runs on a settled tree, where the sweep and the pin are both no-ops.** The two regimes are disjoint, so the pin's window is never entered.

Two supporting decisions: the clear lands **before** the restage — restaging is what makes the ticket eligible, so a Ready ticket still naming a resumable run *is* the window — and `Delete`'s identical scan was extracted to one shared `firstLiveTreeRun`, so the two guards cannot drift on what "still going" means.

## The race is closed against the real producer, not a stub

`resolveRunID` is unexported, so the chain is proved at both ends:

- **server side** — the test reads the pointer back through `native.NewAdapter(...).LastRunForIssue`, *the exact interface `resolveRunID` type-asserts for*, not the raw `issue.LastRunID` field;
- **dispatcher side** — `TestResolveRunID_LastRunPointerDecidesResumeVsFresh` drives the **real** `resolveRunID` over a real `native.Store`, real adapter, real run store and a materialised workspace: with the pointer it returns `resumeFrom == "run-deterministic-fail"` (the defect); after the very `SetLastRun(id,"","")` the endpoint makes, it returns `resumeFrom == ""` and a freshly minted id.

## Red first, then five canaries

```
--- FAIL: TestPipelineBoardResetFreshDropsTheResumePointer/fresh_clears_it
    response still carries last_run_id "fresh-clear" — the body contradicts its own write
    LastRunForIssue = "fresh-clear", want "" — the dispatcher would still resume the dead run
--- FAIL: .../a_malformed_body_is_refused,_not_silently_read_as_not-fresh
    reset status = 200, want 400
--- FAIL: TestPipelineBoardResetFreshRefusedWhileARunIsNonTerminal/the_pointer_run_itself
--- FAIL: .../a_non-terminal_descendant_of_a_terminal_root
    reset status = 200, want 409
```

| canary | result |
|---|---|
| pin guard disabled | RED — 409→200, run cancelled, `last_run_id` gone **while parked**, ticket restaged |
| guard widened to treat `failed_resumable` as live | RED — the *target* case starts refusing |
| clear moved **after** the restage (identical end state) | RED — **only** the ordering test caught it |
| studio `canRetryFromZero` drops the terminality check | RED |
| `boardmongo.SetLastRun` early-returns on an empty id | RED on the Mongo twin |

The third is the one worth noting: an end-state assertion would have passed it.

## Cloud parity

No new persisted state and no new seam — `fresh` reuses `BoardStore.SetLastRun(id,"","")`, a mandatory contract method on both twins. But the *clear* was only covered on the native store (#495), so it is now in the **shared** conformance suite: drops the pointer, keeps the history, appends no blank ref, idempotent. Canary 5 proves that non-vacuous on Mongo.

## Two residual disagreements, stated not hidden

1. **Plain Retry is still race-dependent.** This adds a deterministic sibling; it does not remove the ambiguity from Retry itself — that is shape 2 and a separate call. Mitigated in wording only (banner + tooltip now point at *Retry from zero*).
2. **`--clear-last-run` reads only the POINTER run; `fresh` reads the whole TREE.** So the CLI can still drop the pointer while a non-pointer descendant is alive — a shape an existing Delete test proves reachable. Pre-existing (#495), not a regression; unifying it needs `issueTreeRuns` moved out of `pkg/server`, which was judged out of scope while other agents hold that package.

`task check` exit 0 (137 packages); studio 1343 tests; `openapi:check` no drift; Mongo conformance on port 27027.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
