### PR TITLE
test(dispatcher): observe a stable operator cancellation

### DIFF
--- a/e2e/dispatcher_test.go
+++ b/e2e/dispatcher_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dispatcher"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/google/uuid"
 )
 
@@ -155,49 +156,67 @@ func TestDispatcherE2E_CancelInFlight(t *testing.T) {
 	c, ns, runner, cleanup := newDispatcherFixture(t, 50*time.Millisecond)
 	defer cleanup()
 
-	started := make(chan struct{}, 1)
-	// Whether the worker came back is what splits the two failures this row
-	// can have. Without it the timeout says only that the entry is still
-	// there, which is the symptom both halves share.
+	started := make(chan string, 1)
+	var calls atomic.Int32
 	var handlerReturned atomic.Bool
-	runner.Handler = func(ctx context.Context, _ dispatcher.DispatchSpec) error {
-		started <- struct{}{}
+	runner.Handler = func(ctx context.Context, spec dispatcher.DispatchSpec) error {
+		// Report only the first run: a regressed redispatch must not block the
+		// notification send and prevent fixture cleanup from cancelling it.
+		if calls.Add(1) == 1 {
+			started <- spec.RunID
+		}
 		<-ctx.Done()
 		handlerReturned.Store(true)
-		return ctx.Err()
+		// Match EngineRunner's operator-cancel outcome. context.Canceled means
+		// force-reap to finishRun: it releases the claim and permits a new run.
+		// The old stub took that path, so Running was empty only until the next
+		// poll and a delayed observer waited forever on a SECOND run (#943).
+		return runtime.ErrRunCancelled
 	}
 
-	iss, _ := ns.Create(native.Issue{Title: "hangs", State: "ready"})
-
+	iss, err := ns.Create(native.Issue{Title: "hangs", State: "ready"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var firstRunID string
 	select {
-	case <-started:
+	case firstRunID = <-started:
 	case <-time.After(10 * time.Second):
 		t.Fatal("worker never started")
 	}
 
 	c.Cancel(iss.ID)
 
-	// The cancel→handler-return→cmdRunFinished→finishRun chain completes in
-	// ~30ms unloaded, but it crosses the actor's command channel twice and a
-	// dispatch-worker teardown, so 10s is the hard ceiling that still catches a
-	// genuine cancel-flush hang. waitUntil logs the wait when it eats most of
-	// that budget and dumps goroutines on failure — this assertion has already
-	// been widened once for flakiness, and the passing runs said nothing about
-	// whether the margin was shrinking.
-	waitUntil(t, 10*time.Second, "cancel to flush the running entry",
-		func() bool { return len(c.Snapshot().Running) == 0 },
+	// An operator cancel frees the slot AND leaves the issue held. Requiring
+	// that stable outcome rejects the transient empty snapshot between a
+	// force-reap and its next dispatch. Keep the timeout as a hang detector.
+	waitUntil(t, 10*time.Second, "cancel to free the slot and hold the issue",
+		func() bool {
+			snap := c.Snapshot()
+			if len(snap.Running) != 0 {
+				return false
+			}
+			for _, skip := range snap.DispatchSkips {
+				if skip.IssueID == iss.ID && strings.Contains(skip.Reason, "cancelled by the operator") {
+					return true
+				}
+			}
+			return false
+		},
 		func() string {
-			// The measured shape of this wait is ~25ms or never (60 runs under
-			// -race on a starved box: 0.020-0.035s, no slow tail), so a
-			// timeout here is a park, not a slow machine — and no budget
-			// widens into it. It has been widened twice already (2s -> 10s,
-			// a354dc0a0 and 5368500f5 "flaky race job") and still reaches the
-			// ceiling on the race job. What the next occurrence needs is which
-			// half parked, not another number.
-			return fmt.Sprintf("handler returned=%v (false: the cancel never reached the worker's ctx; "+
-				"true: the worker came back and the actor never drained cmdRunFinished), snapshot=%+v",
-				handlerReturned.Load(), c.Snapshot())
+			return fmt.Sprintf("first run=%s, starts=%d, handler returned=%v, snapshot=%+v",
+				firstRunID, calls.Load(), handlerReturned.Load(), c.Snapshot())
 		})
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("dispatches = %d, want one cancelled run", got)
+	}
+	held, err := ns.Get(iss.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if held.Claim == "" {
+		t.Fatal("operator cancel released the claim; a future tick could redispatch")
+	}
 }
 
 func TestDispatcherE2E_RespectsTerminalStateChange(t *testing.T) {


### PR DESCRIPTION
The cancellation E2E test sometimes waited forever because its stub returned `context.Canceled`, which `finishRun` treats as a force-reap: the claim is released and the next poll starts a new run. The observer could miss the brief empty snapshot and then wait on that second run. The production EngineRunner returns `runtime.ErrRunCancelled` for an operator cancellation.

Make the fixture return that production outcome and require the stable result: the slot is free, the operator-cancel hold is visible, the claim remains held, and only one dispatch occurred. Diagnostics name the first run and the dispatch count; repeat dispatches cannot block the start notification and break fixture cleanup. No dispatcher code or timeout is changed.

Reproduction and validation:
- On the old test, delaying observation by 200 ms reproduced the timeout with `handler returned=true`.
- A separate diagnostic recorded two different run IDs 81 ms apart for the same cancelled issue, confirming redispatch. The temporary probe was removed.
- The same delayed observation passed with the corrected stub. Restoring `ctx.Err()` made the strengthened assertion fail; the mutation was restored.
- Dispatcher E2E rows passed five repetitions with `GOMAXPROCS=2`, `-race`, `-parallel=4`.
- `task check` passed.

Fixes #943.
