### PR TITLE
test: cancel and join helpers before fixture cleanup

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,60 @@
 # Billy — branch-improvement validation
 
+## 2026-09-08 — #964: quota stop after useful fixes, bank delivered locally
+
+- Status: **banked commits recovered and locally validated**. The campaign
+  did not reach its ledger or delivery gate, so this is not a successful
+  end-to-end Billy run.
+- Method: `/billy` on our PR #964 at 11:26:52Z, after Revi's medium finding
+  `R565a2f`. Run `01a080c5-585f-7574-8394-bb28803d6f24` completed planning,
+  peer review and revision, then entered campaign at 12:06:51Z. The PR was
+  removed from the merge queue while the fixer worked; the interactive owner
+  made no concurrent edits to its branch.
+- Result: the campaign reached the Claude session limit at 12:43:31Z and
+  stopped as `failed_resumable / USAGE_LIMIT_BLOCKED`, with `retry_armed` for
+  the 15:00Z reset. That reset was after its advertised working window. The
+  owner cancelled the parked run to disarm the retry, verified `cancelled`
+  with no running execution or continuation, then recovered its final bank.
+  No campaign was relaunched.
+- Recovery: `iterion/run-01a080c5-585f-7574-8394-bb28803d6f24` at
+  `e9b7e0576c9e7d1c9ab16ef9d3c51301c9666ed6` held nine commits, preserved by
+  fast-forward. `0f9c8c0df` adds settling; `fd59f26d9` bounds the server join;
+  `c4393c6f3` preserves the suite exit code; `f913b4ea8` groups imports;
+  `0d82611d9` records the audit; `5db295eec` narrows the fixture ownership
+  check; `cd143ff62` fixes final forgiveness accounting; `2a9c459fd` signals
+  late descendants at the reclaim deadline; `e9b7e0576` reflows the audit.
+- Finding ledger: **R565a2f fixed**. A child gets a 500 ms settle window before
+  a leak verdict, keyed by PID and process start time. True survivors still
+  fail the suite and are killed through verified owned process handles. The
+  server fixture cancels its process group and applies a ten-second WaitDelay
+  for inherited output pipes. The final timeout sweep remains best effort:
+  it fails the suite rather than claiming that every descendant was joined.
+- Live steering: checkpoint review identified an interleaving the campaign
+  had missed: a child can be seen alive and reaped in the same scan, then
+  disappear through ECHILD before its forgiveness is counted. A `runs send`
+  message at 12:34:29Z was consumed at 12:35:48Z. The campaign confirmed and
+  fixed it. Independent local falsification used Go overlays to delay the
+  per-PID reap by 1.1 seconds: the real settling-child fixture passed, then
+  failed when only the ECHILD accounting call was removed. No checked-out
+  source was modified by those canaries.
+- Validation after recovery: full Devbox `task check` passed. Complete race
+  suites passed for proctest, dispatcher, runview, runner, runtime, CLI and
+  E2E, with only the previously reproduced unrelated ordering test from #960
+  excluded from that race invocation. The non-race full suite retained it.
+  The proctest subprocess cases still cover a genuine surviving orphan,
+  settling exit, clean success and preservation of an existing failure code.
+- Value: real fixes for a false leak verdict and an unbounded inherited-pipe
+  join, plus a useful interaction between checkpoint review and live steering.
+  The bank saved the work when quota prevented delivery; the owner supplied
+  the missing final validation and ledger. Revi and CI still need to judge
+  the published head before merge-queue entry.
+- Frictions and boundaries: the final quota denial followed soft usage events
+  reporting `stopped=false`, including zero-percent readings just before the
+  denial; those events did not establish remaining capacity. The remaining
+  Git-maintenance gap in fixture repository config is tracked separately in
+  #974 after verification against main. No shared infrastructure, historical
+  orphan, other session's branch, or operator Git configuration was changed.
+
 ## The delivery tail's contract (bot 1.7.0)
 
 Three properties `push_back_tool` and `publish_verdict` now hold, in the order

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -54,6 +54,16 @@
   Git-maintenance gap in fixture repository config is tracked separately in
   #974 after verification against main. No shared infrastructure, historical
   orphan, other session's branch, or operator Git configuration was changed.
+- Independent review of the delivered bank found `Race656`: a missing Linux
+  child-scan/subreaper capability could fail or skip a whole package suite.
+  The owner completed this bounded follow-up after the quota stop, checking
+  first that no fixer was active on this PR. Startup now probes the scanner
+  before enabling adoption, logs unavailability, and runs the suite normally;
+  a post-activation scan failure still fails. A red-first capability-boundary
+  regression covers both missing capabilities, exactly-once suite execution,
+  preservation of success/failure results and later hard scan errors. The
+  original process-group comment was also corrected: it is not a pidfd-backed
+  group signal and does not prove PID reuse impossible.
 
 ## The delivery tail's contract (bot 1.7.0)
 

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -40,10 +40,10 @@ after the settle window, covers reclaiming a reported leak; when that bound
 expires the guard names and kills whatever is still alive before failing, so a
 descendant adopted late — inside the last settle window of the budget, before
 it could earn a verdict of its own — is still reported and reclaimed rather
-than outliving the suite unnamed. Fixture
-cancellation is portable; the orphan-adoption guard is Linux-only. Like other
-TestMain postconditions it requires m.Run to return; a forced kill of the test
-binary cannot execute the postcondition.
+than outliving the suite unnamed. Fixture cancellation is portable; the
+orphan-adoption guard is Linux-only. Like other TestMain postconditions it
+requires m.Run to return; a forced kill of the test binary cannot execute the
+postcondition.
 
 ## Shell and helper sweep
 

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -18,16 +18,28 @@ runtime, CLI and E2E. On Linux it makes the test binary a child subreaper before
 running the suite: an orphaned descendant is adopted by this binary instead of
 escaping to init ([Linux subreaper semantics](https://man7.org/linux/man-pages/man2/PR_SET_CHILD_SUBREAPER.2const.html)).
 After all test cleanups, it checks every OS thread's direct children, reports
-live survivors, kills only its own children and repeats as grandchildren are
+survivors, kills only its own children and repeats as grandchildren are
 adopted. Already-exited adopted children are reaped. A leak makes a successful
 suite fail, while an existing failure exit code is preserved.
 
+"Cleanups returned" is not "the kernel finished the teardown", so a child is
+only a leak once it is **still alive after a settle window** — 500 ms, or
+`ITERION_PROCTEST_SETTLE`. A helper a cleanup signalled without joining, or one
+a test joins by proxy (a pidfile disappearing), gets to run its exit path and is
+forgiven — counted on stderr as `proctest: forgave N settling child(ren)`, never
+killed inside the window. The window is a ceiling, not a wait: a suite with no
+children breaks out immediately, and a child that exits at 30 ms is forgiven at
+30 ms. Survivors past it are still reported and reclaimed, so the canary the
+guard exists for is unchanged. The window and the tracking are per process,
+keyed on PID *and* start time, so a recycled PID cannot inherit an expired one.
+
 The guard never reaps while tests execute, where os/exec owns Wait. It never
 scans or signals another session's process tree: historical orphans and sibling
-package tests are outside its ancestry. Its five-second bound covers reclaiming
-a reported leak. Fixture cancellation is portable; the orphan-adoption guard
-is Linux-only. Like other TestMain postconditions it requires m.Run to return;
-a forced kill of the test binary cannot execute the postcondition.
+package tests are outside its ancestry. Its five-second bound, which starts
+after the settle window, covers reclaiming a reported leak. Fixture
+cancellation is portable; the orphan-adoption guard is Linux-only. Like other
+TestMain postconditions it requires m.Run to return; a forced kill of the test
+binary cannot execute the postcondition.
 
 ## Shell and helper sweep
 

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -22,6 +22,14 @@ survivors, kills only its own children and repeats as grandchildren are
 adopted. Already-exited adopted children are reaped. A leak makes a successful
 suite fail, while an existing failure exit code is preserved.
 
+The guard probes its child scanner before enabling adoption. If the kernel
+does not expose `/proc/self/task/*/children` or refuses the subreaper option,
+it prints `proctest: leak guard unavailable (...)` and still runs the suite,
+preserving its result. Errors after successful activation remain hard
+failures. The guard's own orphan fixtures skip after a clean subprocess
+detects this unsupported environment, before intentionally spawning an orphan;
+the other package suites continue to run.
+
 "Cleanups returned" is not "the kernel finished the teardown", so a child is
 only a leak once it is **still alive after a settle window** — 500 ms, or
 `ITERION_PROCTEST_SETTLE`. A helper a cleanup signalled without joining, or one

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -36,7 +36,11 @@ keyed on PID *and* start time, so a recycled PID cannot inherit an expired one.
 The guard never reaps while tests execute, where os/exec owns Wait. It never
 scans or signals another session's process tree: historical orphans and sibling
 package tests are outside its ancestry. Its five-second bound, which starts
-after the settle window, covers reclaiming a reported leak. Fixture
+after the settle window, covers reclaiming a reported leak; when that bound
+expires the guard names and kills whatever is still alive before failing, so a
+descendant adopted late — inside the last settle window of the budget, before
+it could earn a verdict of its own — is still reported and reclaimed rather
+than outliving the suite unnamed. Fixture
 cancellation is portable; the orphan-adoption guard is Linux-only. Like other
 TestMain postconditions it requires m.Run to return; a forced kill of the test
 binary cannot execute the postcondition.

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -85,6 +85,14 @@ the forgiveness COUNT, without which it would pass identically to the clean
 case even with the settle logic deleted. Both mutations were checked to fail
 it: latching on first sight, and forgiving without counting.
 
+That count is settled on two paths, and a unit test pins the one no fixture
+can schedule: the guard reaps each child in the same pass that reads its
+state, so a child dying in between is gone from `/proc` before the next pass
+and never reaches the per-pass accounting. It is forgiven where the scan ends
+instead — on the kernel's ECHILD verdict, with no children left — which is
+why `forgiven` takes the remaining set as an argument and is asserted directly
+on a nil one.
+
 Not covered, and known: the residual `git maintenance` hazard. `pkg/runtime`'s
 tests run 15 production writing-git commands (`commit -F -`, `merge --squash`,
 `merge --ff-only`) against `t.TempDir()` fixture repositories, through

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -64,7 +64,7 @@ shell family and the relevant process-owning fixtures have these dispositions:
 | `e2e/sec_audit_cap_findings_test.go`, `sec_audit_scan_health_test.go`, `sec_audit_deps_heuristics_test.go` | Synchronous local fixture post-processing, joined before assertions. |
 | `e2e/feed_watch_test.go` shell plan and Python tools | Synchronous script execution, joined before parsing output/cleanup; no detached sentinel helper. |
 | `e2e/mcp_server_test.go` | Explicit stdin-close and cmd.Wait stop; CLI runner lifecycles remain the subject of those E2E tests. |
-| `e2e/cli_server_boot_test.go` server/runner processes | Join the server Wait goroutine during cleanup too, including early failure. Other runner commands are synchronously joined; E2E suite guarded. |
+| `e2e/cli_server_boot_test.go` server/runner processes | Join the server Wait goroutine during cleanup too, including early failure — bounded, since that join is only safe once cancellation kills the process GROUP (`cmd.Cancel`, mirroring `proc.TerminateGroupOnCancel`, which `e2e/` cannot import) and `cmd.WaitDelay` bounds a descendant that escapes it via `setsid`. Both are load-bearing: with a leader-only kill and no delay, a grandchild holding the inherited stdout/stderr pipes blocks `cmd.Wait` forever and the join hangs the whole E2E binary (measured on a standalone probe). Other runner commands are synchronously joined; E2E suite guarded. |
 | `e2e/claw_tool_coverage_live_test.go` Xvfb | Live-only fixture explicitly kills and waits for the started process. |
 | Other `true`, git/build and inspection commands | Finite synchronous helpers or no-op command factories; no sentinel/background lifetime. Git ownership is covered by gittest and #828/#870. |
 

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -78,4 +78,24 @@ remained: no process leak. The probe was removed afterward.
 
 The guard's own subprocess tests check clean success, preservation of an
 existing failure, detection/reaping of an orphan after its launcher exits, and
-preservation of an existing failure when a leak is also found.
+preservation of an existing failure when a leak is also found. A fifth case
+covers the other side of the settle boundary — an orphan that exits well
+inside a widened window is forgiven, silently, and still reaped — and asserts
+the forgiveness COUNT, without which it would pass identically to the clean
+case even with the settle logic deleted. Both mutations were checked to fail
+it: latching on first sight, and forgiving without counting.
+
+Not covered, and known: the residual `git maintenance` hazard. `pkg/runtime`'s
+tests run 15 production writing-git commands (`commit -F -`, `merge --squash`,
+`merge --ff-only`) against `t.TempDir()` fixture repositories, through
+`worktree.go`'s own factory rather than `gittest.Cmd` — so they carry no
+`maintenance.auto=false`, and on CI's git (≥ 2.48, the version behind #821/#828)
+each detaches a maintenance process that the subreaper now adopts. Measured, a
+no-op `git maintenance run --auto` on such a repository takes ~4 ms against a
+500 ms window, so the settle window absorbs it; the durable fix is
+`gittest.InitRepo` writing the opt-out into the fixture repository's own config,
+exactly as it already does for the identity and the signing opt-out and for the
+same stated reason — "a command iterion itself spawns during the test does not
+inherit this package's environment". That is a change to `internal/gittest`,
+whose `TestCmd_GitItselfReportsAutoMaintenanceOff` currently asserts the key is
+NOT in the repository config, so it needs that control reworked with it.

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -1,0 +1,69 @@
+# Test helpers end with their test
+
+Issue #956 exposed a sentinel loop in the dispatcher subbot lock fixture:
+writing the release file in `t.Cleanup` did not join the dispatch. The workspace
+could disappear before the shell saw the file, leaving it polling forever.
+The fixture now cancels the dispatch context and joins it before its runner and
+temporary directories are cleaned up. The tool executor's process-group
+cancellation from #955 then reaches both the shell and its children.
+
+The CLI, runtime and cloud-runner fake shared sandboxes also use
+`proc.TerminateGroupOnCancel` when constructing host commands. A fake sandbox's
+`Exec` must have the same lifetime contract as the real host driver.
+
+## Suite guard
+
+`internal/proctest.NoProcessLeaks` wraps TestMain in dispatcher, runview, runner,
+runtime, CLI and E2E. On Linux it makes the test binary a child subreaper before
+running the suite: an orphaned descendant is adopted by this binary instead of
+escaping to init ([Linux subreaper semantics](https://man7.org/linux/man-pages/man2/PR_SET_CHILD_SUBREAPER.2const.html)).
+After all test cleanups, it checks every OS thread's direct children, reports
+live survivors, kills only its own children and repeats as grandchildren are
+adopted. Already-exited adopted children are reaped. A leak makes a successful
+suite fail, while an existing failure exit code is preserved.
+
+The guard never reaps while tests execute, where os/exec owns Wait. It never
+scans or signals another session's process tree: historical orphans and sibling
+package tests are outside its ancestry. Its five-second bound covers reclaiming
+a reported leak. Fixture cancellation is portable; the orphan-adoption guard
+is Linux-only. Like other TestMain postconditions it requires m.Run to return;
+a forced kill of the test binary cannot execute the postcondition.
+
+## Shell and helper sweep
+
+The sweep used `exec.Command`, its `CommandContext` and `osexec` aliases, plus
+sentinel loops and long-lived DSL tool recipes in `_test.go` files. Each direct
+shell family and the relevant process-owning fixtures have these dispositions:
+
+| Sites | Disposition |
+|---|---|
+| `dispatcher/engine_runner_subbot_test.go` sentinel | Cancel and join before cleanup; dispatcher suite guarded. |
+| `runview/subbot_reconcile_test.go` sentinel and `subbot_child_control_test.go` sleeps | Service Stop/Cancel owns the run and joins it; tool group cancellation reaches helpers; runview suite guarded. |
+| `runner/subbot_test.go`, `runtime/sandbox_shared_test.go`, `cli/subbot_shared_sandbox_test.go` fake sandboxes | Add group cancellation; all three suites guarded. |
+| `runner/loop_checkpoint_test.go` three shell invocations | Synchronous finite checkpoint scripts; Output joins each before assertions/TempDir cleanup. |
+| `backend/model/executor_tool_escaping_test.go` four shell invocations | Synchronous finite quoting recipes; Run/Output joins. |
+| `backend/model/executor_tool_test.go` fake copy sandbox | Command runs through the real tool-executor cancellation wrapper; fake Exec only records calls and starts no process. |
+| `backend/delegate/cliagent_test.go` and `askuser_http_test.go` sandbox commands | Real CLI backend applies group cancellation before starting these fake commands. |
+| `backend/delegate/pisdk/client_test.go` shell producer | Finite 5,000-line producer; Client.Close cleanup and exited-channel join. |
+| `backend/delegate/claudesdk/process_test.go` process fixtures | Own process-group lifecycle under test; explicit reap/cancel paths; shell `exit 0` is finite. |
+| `internal/proc/proc_unix_test.go` four shell invocations | Tests group-cancel versus detach semantics directly, with explicit cancellation/join; do not replace the primitive under test. |
+| `internal/shellquote/shellquote_test.go` | Synchronous `printf` quoting check. |
+| `sandbox/kubernetes/workspace_test.go` four shell invocations | Synchronous finite workspace/git fixup scripts. |
+| `e2e/sec_audit_cap_findings_test.go`, `sec_audit_scan_health_test.go`, `sec_audit_deps_heuristics_test.go` | Synchronous local fixture post-processing, joined before assertions. |
+| `e2e/feed_watch_test.go` shell plan and Python tools | Synchronous script execution, joined before parsing output/cleanup; no detached sentinel helper. |
+| `e2e/mcp_server_test.go` | Explicit stdin-close and cmd.Wait stop; CLI runner lifecycles remain the subject of those E2E tests. |
+| `e2e/cli_server_boot_test.go` server/runner processes | Join the server Wait goroutine during cleanup too, including early failure. Other runner commands are synchronously joined; E2E suite guarded. |
+| `e2e/claw_tool_coverage_live_test.go` Xvfb | Live-only fixture explicitly kills and waits for the started process. |
+| Other `true`, git/build and inspection commands | Finite synchronous helpers or no-op command factories; no sentinel/background lifetime. Git ownership is covered by gittest and #828/#870. |
+
+## Failure-path evidence
+
+A temporary probe made the lock fixture's shell report its PID, waited for it
+to start, deleted its workspace and called Fatal before normal release. With
+the old cleanup, the suite guard reported and reclaimed a surviving bash and
+sleep. With cancel-and-join cleanup, only the deliberately injected test failure
+remained: no process leak. The probe was removed afterward.
+
+The guard's own subprocess tests check clean success, preservation of an
+existing failure, detection/reaping of an orphan after its launcher exits, and
+preservation of an existing failure when a leak is also found.

--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -39,8 +39,10 @@ package tests are outside its ancestry. Its five-second bound, which starts
 after the settle window, covers reclaiming a reported leak; when that bound
 expires the guard names and kills whatever is still alive before failing, so a
 descendant adopted late — inside the last settle window of the budget, before
-it could earn a verdict of its own — is still reported and reclaimed rather
-than outliving the suite unnamed. Fixture cancellation is portable; the
+it could earn a verdict of its own — is still reported and signalled. This
+deadline path fails the suite and is a final best-effort kill, not proof that
+all descendants were joined: only the normal ECHILD exit establishes that
+none remain. Fixture cancellation is portable; the
 orphan-adoption guard is Linux-only. Like other TestMain postconditions it
 requires m.Run to return; a forced kill of the test binary cannot execute the
 postcondition.
@@ -89,16 +91,25 @@ the forgiveness COUNT, without which it would pass identically to the clean
 case even with the settle logic deleted. Both mutations were checked to fail
 it: latching on first sight, and forgiving without counting.
 
-That count is settled on two paths, and a unit test pins the one no fixture
-can schedule: the guard reaps each child in the same pass that reads its
-state, so a child dying in between is gone from `/proc` before the next pass
+That count is settled on two paths, and a unit test pins an interleaving an
+ordinary fixture cannot reliably schedule: the guard reaps each child in the
+same pass that reads its state, so a child dying in between is gone from
+`/proc` before the next pass
 and never reaches the per-pass accounting. It is forgiven where the scan ends
 instead — on the kernel's ECHILD verdict, with no children left — which is
 why `forgiven` takes the remaining set as an argument and is asserted directly
 on a nil one.
 
-Not covered, and known: the residual `git maintenance` hazard. `pkg/runtime`'s
-tests run 15 production writing-git commands (`commit -F -`, `merge --squash`,
+An independent delivery canary also exercised the call site through the real
+subprocess fixture. A Go overlay delayed each per-PID reap by 1.1 seconds, so
+the one-second helper was observed alive and reaped by that same scan. The
+settling-child test passed under `-race`; removing only the ECHILD accounting
+call made it fail with `settling child not observed then forgiven`. The
+overlays did not modify the committed sources.
+
+Not covered, and tracked separately in #974: the residual `git maintenance`
+hazard. `pkg/runtime`'s tests run 15 production writing-git commands
+(`commit -F -`, `merge --squash`,
 `merge --ff-only`) against `t.TempDir()` fixture repositories, through
 `worktree.go`'s own factory rather than `gittest.Cmd` — so they carry no
 `maintenance.auto=false`, and on CI's git (≥ 2.48, the version behind #821/#828)

--- a/e2e/cli_server_boot_test.go
+++ b/e2e/cli_server_boot_test.go
@@ -256,7 +256,11 @@ func TestServerCommandBootsLocalModeAndShutsDownOnSignal(t *testing.T) {
 		t.Fatalf("start iterion server: %v", err)
 	}
 	exitCh := make(chan error, 1)
-	go func() { exitCh <- cmd.Wait() }()
+	waitDone := make(chan struct{})
+	go func() {
+		exitCh <- cmd.Wait()
+		close(waitDone)
+	}()
 	// Failsafe: if the test panics or times out mid-way, kill the
 	// subprocess so it doesn't leak an open port and a running server.
 	t.Cleanup(func() {
@@ -264,6 +268,7 @@ func TestServerCommandBootsLocalModeAndShutsDownOnSignal(t *testing.T) {
 			_ = cmd.Process.Signal(syscall.SIGKILL)
 		}
 		cancel()
+		<-waitDone
 	})
 
 	waitServerHealthy(t, base, exitCh, &stderr)

--- a/e2e/cli_server_boot_test.go
+++ b/e2e/cli_server_boot_test.go
@@ -238,6 +238,33 @@ func TestServerCommandBootsLocalModeAndShutsDownOnSignal(t *testing.T) {
 	// Detach into its own process group so a SIGINT to the parent test
 	// process (Ctrl-C) doesn't cascade and eat our own SIGTERM assertion.
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Cancellation kills the whole GROUP, mirroring proc.TerminateGroupOnCancel
+	// (which e2e, outside pkg/, cannot import). cmd.Stdout/cmd.Stderr are not
+	// *os.File, so os/exec wires pipes plus copy goroutines that cmd.Wait
+	// joins: a descendant of the server holding an inherited write end would
+	// block Wait — and therefore the cleanup's join below — forever, hanging
+	// the whole e2e binary until the go-test timeout. Setpgid with no Pgid
+	// makes the child its own group leader, so the negative PID addresses
+	// exactly the subtree this test created, and os/exec only calls Cancel
+	// before Wait reaps, so it can never be a recycled PID.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone // already gone: nothing to interrupt
+			}
+			return err
+		}
+		return nil
+	}
+	// Residual bound for a descendant that escapes the group with its own
+	// setsid, where no signal can reach it: the join then fails loudly with
+	// exec.ErrWaitDelay instead of hanging. The clock starts at process exit
+	// or cancel, so the lame-duck and 75s SIGTERM assertions are untouched,
+	// and the clean path still returns nil (its pipes close at once).
+	cmd.WaitDelay = 10 * time.Second
 	cmd.Dir = workDir // avoid the repo-root .env walk-up
 	cmd.Env = append(cleanEnvForSubprocess(),
 		"HOME="+homeDir,
@@ -263,10 +290,9 @@ func TestServerCommandBootsLocalModeAndShutsDownOnSignal(t *testing.T) {
 	}()
 	// Failsafe: if the test panics or times out mid-way, kill the
 	// subprocess so it doesn't leak an open port and a running server.
+	// cancel() runs the group kill wired above; joining Wait afterwards is
+	// what makes the process actually reaped before the suite guard looks.
 	t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGKILL)
-		}
 		cancel()
 		<-waitDone
 	})

--- a/e2e/cli_server_boot_test.go
+++ b/e2e/cli_server_boot_test.go
@@ -244,9 +244,9 @@ func TestServerCommandBootsLocalModeAndShutsDownOnSignal(t *testing.T) {
 	// joins: a descendant of the server holding an inherited write end would
 	// block Wait — and therefore the cleanup's join below — forever, hanging
 	// the whole e2e binary until the go-test timeout. Setpgid with no Pgid
-	// makes the child its own group leader, so the negative PID addresses
-	// exactly the subtree this test created, and os/exec only calls Cancel
-	// before Wait reaps, so it can never be a recycled PID.
+	// makes the child its own group leader; cancellation uses that group ID,
+	// matching the shared process primitive. It is not a pidfd-backed group
+	// signal, and WaitDelay below covers descendants that leave the group.
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/internal/gittest"
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
 // e2eParallelCap bounds how many of this package's tests run at once.
@@ -41,7 +42,7 @@ const e2eParallelEnv = "ITERION_E2E_PARALLEL"
 // package when that count moves, and names the test that moved it.
 func TestMain(m *testing.M) {
 	capParallelism()
-	os.Exit(gittest.NoWorktreeLeaks(m))
+	os.Exit(proctest.NoProcessLeaks(func() int { return gittest.NoWorktreeLeaks(m) }))
 }
 
 // capParallelism lowers `-parallel` to e2eParallelCap when the operator left

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -1,0 +1,144 @@
+//go:build linux
+
+// Package proctest checks OS resources owned by a test binary.
+package proctest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// NoProcessLeaks runs a suite as a Linux child subreaper: an orphaned helper
+// remains its descendant instead of escaping to init. After the suite (and
+// all t.Cleanup callbacks) returns, any surviving process fails the suite and
+// is reclaimed. Other test binaries and pre-existing session orphans are not
+// descendants and cannot be reported or signalled by this guard.
+//
+// Compose it in TestMain: os.Exit(proctest.NoProcessLeaks(m.Run)). A guard
+// around an existing suite wrapper works too. It never reaps during run:
+// os/exec owns Wait while tests are executing.
+func NoProcessLeaks(run func() int) int {
+	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: enable test process leak guard: %v\n", err)
+		return 1
+	}
+	code := run()
+	leaked := false
+	// Killing a leaked parent reparents its children to us; rescan until the
+	// entire owned tree is gone. This is a teardown bound, not a test budget.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		children, err := childPIDs()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: inspect test descendants: %v\n", err)
+			return 1
+		}
+		if len(children) == 0 {
+			// A thread can exit and hand its children to another thread
+			// between /proc reads. Only the kernel's process-wide ECHILD
+			// verdict proves that no owned descendant remains.
+			var status unix.WaitStatus
+			_, err := unix.Wait4(-1, &status, unix.WNOHANG, nil)
+			if errors.Is(err, unix.ECHILD) {
+				break
+			}
+			if err != nil && !errors.Is(err, unix.EINTR) {
+				fmt.Fprintf(os.Stderr, "FAIL: inspect remaining test children: %v\n", err)
+				return 1
+			}
+		}
+		for _, pid := range children {
+			p, err := os.FindProcess(pid) // Linux uses a pidfd, avoiding PID reuse on Signal.
+			if err != nil {
+				continue
+			}
+			state, parent, err := processState(pid)
+			if err != nil || parent != os.Getpid() {
+				_ = p.Release()
+				continue
+			}
+			if state != "Z" && state != "X" {
+				leaked = true
+				name, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+				fmt.Fprintf(os.Stderr, "FAIL: test process survived suite cleanup: pid=%d command=%s\n", pid, strings.TrimSpace(string(name)))
+				if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+					fmt.Fprintf(os.Stderr, "FAIL: reclaim test process %d: %v\n", pid, err)
+				}
+			}
+			_ = p.Release()
+			// Nonblocking: a just-killed child may not be waitable yet. Only this
+			// known direct child is reaped; never wait on another test's processes.
+			var status unix.WaitStatus
+			_, _ = unix.Wait4(pid, &status, unix.WNOHANG, nil)
+		}
+		if time.Now().After(deadline) {
+			fmt.Fprintln(os.Stderr, "FAIL: test descendants did not exit after cleanup")
+			return 1
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if leaked && code == 0 {
+		return 1
+	}
+	return code
+}
+
+// Children can belong to any OS thread in this Go process, not just the
+// thread-group leader. Reading its task entries is narrower than scanning
+// the host process table and remains isolated from concurrent test packages.
+func childPIDs() ([]int, error) {
+	paths, err := filepath.Glob("/proc/self/task/*/children")
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("/proc task children unavailable")
+	}
+	seen := map[int]bool{}
+	var result []int
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		} // an OS thread exited during the scan
+		if err != nil {
+			return nil, err
+		}
+		for _, field := range strings.Fields(string(data)) {
+			pid, err := strconv.Atoi(field)
+			if err != nil {
+				return nil, err
+			}
+			if !seen[pid] {
+				seen[pid] = true
+				result = append(result, pid)
+			}
+		}
+	}
+	return result, nil
+}
+
+func processState(pid int) (state string, parent int, err error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", 0, err
+	}
+	// comm is parenthesized and can itself contain spaces or parentheses.
+	end := strings.LastIndexByte(string(data), ')')
+	if end < 0 {
+		return "", 0, fmt.Errorf("invalid process stat for %d", pid)
+	}
+	fields := strings.Fields(string(data[end+1:]))
+	if len(fields) < 2 {
+		return "", 0, fmt.Errorf("short process stat for %d", pid)
+	}
+	parent, err = strconv.Atoi(fields[1])
+	return fields[0], parent, err
+}

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -122,11 +122,7 @@ func NoProcessLeaks(run func() int) int {
 				if now.Sub(since) >= settle && !reported[key] {
 					leaked = true
 					reported[key] = true
-					name, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-					fmt.Fprintf(os.Stderr, "FAIL: test process survived suite cleanup: pid=%d command=%s\n", pid, strings.TrimSpace(string(name)))
-					if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-						fmt.Fprintf(os.Stderr, "FAIL: reclaim test process %d: %v\n", pid, err)
-					}
+					reclaim(p)
 				}
 			}
 			_ = p.Release()
@@ -138,6 +134,29 @@ func NoProcessLeaks(run func() int) int {
 		forgave += forgiven(firstSeen, alive, reported)
 		firstSeen = alive
 		if time.Now().After(deadline) {
+			// The budget is spent, so every window still open is spent with it.
+			// Without this sweep a descendant first seen inside the last
+			// `settle` of the budget would leave unnamed and alive — the guard
+			// killed on sight before the window existed, and the promise that
+			// a survivor is always reported and reclaimed must not lapse on
+			// the one path where a teardown proved hardest.
+			for key := range firstSeen {
+				if reported[key] {
+					continue // already named, already signalled; it just won't die
+				}
+				p, err := os.FindProcess(key.pid)
+				if err != nil {
+					continue
+				}
+				// Same PID-reuse standard as procKey, and the same definition of
+				// alive as the scan above: an entry that died between the last
+				// scan and here is not a survivor, and must not be named as one.
+				if stat, err := processState(key.pid); err == nil && stat.start == key.start &&
+					stat.parent == os.Getpid() && stat.state != "Z" && stat.state != "X" {
+					reclaim(p)
+				}
+				_ = p.Release()
+			}
 			fmt.Fprintln(os.Stderr, "FAIL: test descendants did not exit after cleanup")
 			return failing(code)
 		}
@@ -150,6 +169,17 @@ func NoProcessLeaks(run func() int) int {
 		return 1
 	}
 	return code
+}
+
+// reclaim names a survivor and kills it. It takes the *os.Process the caller
+// already verified rather than a bare PID: on Linux that handle is a pidfd,
+// so the signal cannot land on whoever inherits the number next.
+func reclaim(p *os.Process) {
+	name, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", p.Pid))
+	fmt.Fprintf(os.Stderr, "FAIL: test process survived suite cleanup: pid=%d command=%s\n", p.Pid, strings.TrimSpace(string(name)))
+	if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		fmt.Fprintf(os.Stderr, "FAIL: reclaim test process %d: %v\n", p.Pid, err)
+	}
 }
 
 // forgiven counts the children of prev that are gone from cur without ever

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -51,10 +51,26 @@ type procKey struct {
 // Compose it in TestMain: os.Exit(proctest.NoProcessLeaks(m.Run)). A guard
 // around an existing suite wrapper works too. It never reaps during run:
 // os/exec owns Wait while tests are executing.
+// If the kernel cannot support the guard, it reports that limitation and
+// still runs the suite. An inspection failure after activation remains fatal.
 func NoProcessLeaks(run func() int) int {
-	if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0); err != nil {
-		fmt.Fprintf(os.Stderr, "FAIL: enable test process leak guard: %v\n", err)
-		return 1
+	return noProcessLeaks(run, func() error {
+		return unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0)
+	}, childPIDs)
+}
+
+// Keep the capability boundary injectable so unsupported startup and a scan
+// failure after activation can be distinguished without changing the host.
+func noProcessLeaks(run func() int, enableSubreaper func() error, inspectChildren func() ([]int, error)) int {
+	// Probe the scanner before enabling adoption. Otherwise an unsupported
+	// /proc leaves the process adopting children it cannot subsequently find.
+	if _, err := inspectChildren(); err != nil {
+		fmt.Fprintf(os.Stderr, "proctest: leak guard unavailable (child scan: %v); running unguarded\n", err)
+		return run()
+	}
+	if err := enableSubreaper(); err != nil {
+		fmt.Fprintf(os.Stderr, "proctest: leak guard unavailable (subreaper: %v); running unguarded\n", err)
+		return run()
 	}
 	settle := settleWindow()
 	code := run()
@@ -70,7 +86,7 @@ func NoProcessLeaks(run func() int) int {
 	// entire owned tree is gone. This is a teardown bound, not a test budget.
 	deadline := time.Now().Add(settle + reclaimBudget)
 	for {
-		children, err := childPIDs()
+		children, err := inspectChildren()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAIL: inspect test descendants: %v\n", err)
 			return failing(code)

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -82,6 +82,14 @@ func NoProcessLeaks(run func() int) int {
 			var status unix.WaitStatus
 			_, err := unix.Wait4(-1, &status, unix.WNOHANG, nil)
 			if errors.Is(err, unix.ECHILD) {
+				// Nothing of ours is left, so anything still awaiting a verdict
+				// finished on its own. This is not the same set the loop below
+				// settles: a child seen alive by one pass and reaped by that
+				// SAME pass (the per-PID Wait4 runs after the state read) stays
+				// in firstSeen and is gone from /proc before the next pass, so
+				// it never reaches that accounting — and forgiveness would
+				// under-count exactly the children that exited fastest.
+				forgave += forgiven(firstSeen, nil, reported)
 				break
 			}
 			if err != nil && !errors.Is(err, unix.EINTR) {
@@ -127,14 +135,7 @@ func NoProcessLeaks(run func() int) int {
 			var status unix.WaitStatus
 			_, _ = unix.Wait4(pid, &status, unix.WNOHANG, nil)
 		}
-		// A child seen alive and no longer alive finished inside its window.
-		// Counting it is what keeps the forgiveness path observable: forgiving
-		// is otherwise silent, indistinguishable from never having seen it.
-		for key := range firstSeen {
-			if _, still := alive[key]; !still && !reported[key] {
-				forgave++
-			}
-		}
+		forgave += forgiven(firstSeen, alive, reported)
 		firstSeen = alive
 		if time.Now().After(deadline) {
 			fmt.Fprintln(os.Stderr, "FAIL: test descendants did not exit after cleanup")
@@ -149,6 +150,26 @@ func NoProcessLeaks(run func() int) int {
 		return 1
 	}
 	return code
+}
+
+// forgiven counts the children of prev that are gone from cur without ever
+// having produced a verdict: each was seen alive and then finished inside its
+// window. Counting them is what keeps the forgiveness path observable —
+// forgiving is otherwise silent, indistinguishable from never having seen the
+// child at all. A nil cur is the end of the scan, where nothing of ours is
+// left and every entry still pending is therefore forgiven.
+//
+// It must be called on every path that drops entries from the tracking map,
+// and each key must be dropped exactly once, or the count drifts from the
+// number of children the guard actually forgave.
+func forgiven(prev, cur map[procKey]time.Time, reported map[procKey]bool) int {
+	n := 0
+	for key := range prev {
+		if _, still := cur[key]; !still && !reported[key] {
+			n++
+		}
+	}
+	return n
 }
 
 // failing turns a teardown verdict into an exit code without overwriting the

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -73,7 +73,7 @@ func NoProcessLeaks(run func() int) int {
 		children, err := childPIDs()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "FAIL: inspect test descendants: %v\n", err)
-			return 1
+			return failing(code)
 		}
 		if len(children) == 0 {
 			// A thread can exit and hand its children to another thread
@@ -86,7 +86,7 @@ func NoProcessLeaks(run func() int) int {
 			}
 			if err != nil && !errors.Is(err, unix.EINTR) {
 				fmt.Fprintf(os.Stderr, "FAIL: inspect remaining test children: %v\n", err)
-				return 1
+				return failing(code)
 			}
 		}
 		now := time.Now()
@@ -138,7 +138,7 @@ func NoProcessLeaks(run func() int) int {
 		firstSeen = alive
 		if time.Now().After(deadline) {
 			fmt.Fprintln(os.Stderr, "FAIL: test descendants did not exit after cleanup")
-			return 1
+			return failing(code)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -149,6 +149,15 @@ func NoProcessLeaks(run func() int) int {
 		return 1
 	}
 	return code
+}
+
+// failing turns a teardown verdict into an exit code without overwriting the
+// suite's own: both are failures, and the one the reader needs is the test's.
+func failing(code int) int {
+	if code != 0 {
+		return code
+	}
+	return 1
 }
 
 // settleWindow reads [settleEnv], falling back to [defaultSettle]. A zero

--- a/internal/proctest/leakguard_linux.go
+++ b/internal/proctest/leakguard_linux.go
@@ -15,11 +15,38 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// defaultSettle is how long a child observed alive after the suite is given
+// to finish exiting before it counts as a leak. "Cleanups returned" is not
+// "the kernel finished the teardown": a helper a cleanup already signalled,
+// or one a test joins only by proxy (a pidfile disappearing, a status flip),
+// still has its own exit path to run.
+const defaultSettle = 500 * time.Millisecond
+
+// reclaimBudget bounds the teardown AFTER a leak verdict: killing a leaked
+// parent reparents its children onto us, and each generation is rescanned.
+const reclaimBudget = 5 * time.Second
+
+// settleEnv overrides defaultSettle with a Go duration. The guard's own
+// fixtures use it to make both sides of the boundary explicit; a slow CI
+// runner can widen it without touching the code.
+const settleEnv = "ITERION_PROCTEST_SETTLE"
+
+// procKey identifies a process across scans. The PID alone would not: the
+// kernel is free to hand it to an unrelated process once ours is reaped, and
+// that newcomer must not inherit an already-expired settle window.
+type procKey struct {
+	pid   int
+	start uint64
+}
+
 // NoProcessLeaks runs a suite as a Linux child subreaper: an orphaned helper
 // remains its descendant instead of escaping to init. After the suite (and
-// all t.Cleanup callbacks) returns, any surviving process fails the suite and
-// is reclaimed. Other test binaries and pre-existing session orphans are not
-// descendants and cannot be reported or signalled by this guard.
+// all t.Cleanup callbacks) returns, a process STILL ALIVE after a short
+// settle window (see [settleEnv]) fails the suite and is reclaimed; one that
+// finishes its exit path inside that window is forgiven and merely counted,
+// so a cleanup that signalled without joining is not reported as a leak.
+// Other test binaries and pre-existing session orphans are not descendants
+// and cannot be reported or signalled by this guard.
 //
 // Compose it in TestMain: os.Exit(proctest.NoProcessLeaks(m.Run)). A guard
 // around an existing suite wrapper works too. It never reaps during run:
@@ -29,11 +56,19 @@ func NoProcessLeaks(run func() int) int {
 		fmt.Fprintf(os.Stderr, "FAIL: enable test process leak guard: %v\n", err)
 		return 1
 	}
+	settle := settleWindow()
 	code := run()
 	leaked := false
+	forgave := 0
+	// When each surviving child was first seen alive, and which ones already
+	// produced a verdict. The window is a ceiling, not a wait: a child that
+	// exits at 30ms is forgiven at 30ms, and a suite with no children at all
+	// breaks out below before any of this is consulted.
+	firstSeen := map[procKey]time.Time{}
+	reported := map[procKey]bool{}
 	// Killing a leaked parent reparents its children to us; rescan until the
 	// entire owned tree is gone. This is a teardown bound, not a test budget.
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(settle + reclaimBudget)
 	for {
 		children, err := childPIDs()
 		if err != nil {
@@ -54,22 +89,36 @@ func NoProcessLeaks(run func() int) int {
 				return 1
 			}
 		}
+		now := time.Now()
+		alive := make(map[procKey]time.Time, len(children))
 		for _, pid := range children {
 			p, err := os.FindProcess(pid) // Linux uses a pidfd, avoiding PID reuse on Signal.
 			if err != nil {
 				continue
 			}
-			state, parent, err := processState(pid)
-			if err != nil || parent != os.Getpid() {
+			stat, err := processState(pid)
+			if err != nil || stat.parent != os.Getpid() {
 				_ = p.Release()
 				continue
 			}
-			if state != "Z" && state != "X" {
-				leaked = true
-				name, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-				fmt.Fprintf(os.Stderr, "FAIL: test process survived suite cleanup: pid=%d command=%s\n", pid, strings.TrimSpace(string(name)))
-				if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
-					fmt.Fprintf(os.Stderr, "FAIL: reclaim test process %d: %v\n", pid, err)
+			if stat.state != "Z" && stat.state != "X" {
+				key := procKey{pid: pid, start: stat.start}
+				since, seen := firstSeen[key]
+				if !seen {
+					since = now
+				}
+				alive[key] = since
+				// Only a child still alive past its window is a leak. Do not
+				// kill inside it: killing on first sight would erase the very
+				// distinction between "exiting" and "survived".
+				if now.Sub(since) >= settle && !reported[key] {
+					leaked = true
+					reported[key] = true
+					name, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+					fmt.Fprintf(os.Stderr, "FAIL: test process survived suite cleanup: pid=%d command=%s\n", pid, strings.TrimSpace(string(name)))
+					if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+						fmt.Fprintf(os.Stderr, "FAIL: reclaim test process %d: %v\n", pid, err)
+					}
 				}
 			}
 			_ = p.Release()
@@ -78,16 +127,43 @@ func NoProcessLeaks(run func() int) int {
 			var status unix.WaitStatus
 			_, _ = unix.Wait4(pid, &status, unix.WNOHANG, nil)
 		}
+		// A child seen alive and no longer alive finished inside its window.
+		// Counting it is what keeps the forgiveness path observable: forgiving
+		// is otherwise silent, indistinguishable from never having seen it.
+		for key := range firstSeen {
+			if _, still := alive[key]; !still && !reported[key] {
+				forgave++
+			}
+		}
+		firstSeen = alive
 		if time.Now().After(deadline) {
 			fmt.Fprintln(os.Stderr, "FAIL: test descendants did not exit after cleanup")
 			return 1
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	if forgave > 0 {
+		fmt.Fprintf(os.Stderr, "proctest: forgave %d settling child(ren)\n", forgave)
+	}
 	if leaked && code == 0 {
 		return 1
 	}
 	return code
+}
+
+// settleWindow reads [settleEnv], falling back to [defaultSettle]. A zero
+// duration is legitimate — it latches a verdict on first sight.
+func settleWindow() time.Duration {
+	raw := os.Getenv(settleEnv)
+	if raw == "" {
+		return defaultSettle
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d < 0 {
+		fmt.Fprintf(os.Stderr, "proctest: ignoring invalid %s=%q, using %s\n", settleEnv, raw, defaultSettle)
+		return defaultSettle
+	}
+	return d
 }
 
 // Children can belong to any OS thread in this Go process, not just the
@@ -125,20 +201,35 @@ func childPIDs() ([]int, error) {
 	return result, nil
 }
 
-func processState(pid int) (state string, parent int, err error) {
+type procStat struct {
+	state  string
+	parent int
+	start  uint64 // boot-relative start time; the tiebreaker against PID reuse
+}
+
+func processState(pid int) (procStat, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
-		return "", 0, err
+		return procStat{}, err // unwrapped: callers test it with os.IsNotExist
 	}
 	// comm is parenthesized and can itself contain spaces or parentheses.
 	end := strings.LastIndexByte(string(data), ')')
 	if end < 0 {
-		return "", 0, fmt.Errorf("invalid process stat for %d", pid)
+		return procStat{}, fmt.Errorf("invalid process stat for %d", pid)
 	}
+	// Once the parenthesized comm is dropped, stat field N is at index N-3:
+	// state (3) and ppid (4) lead, starttime (22) lands on index 19.
 	fields := strings.Fields(string(data[end+1:]))
-	if len(fields) < 2 {
-		return "", 0, fmt.Errorf("short process stat for %d", pid)
+	if len(fields) < 20 {
+		return procStat{}, fmt.Errorf("short process stat for %d", pid)
 	}
-	parent, err = strconv.Atoi(fields[1])
-	return fields[0], parent, err
+	parent, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return procStat{}, fmt.Errorf("process stat ppid for %d: %w", pid, err)
+	}
+	start, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return procStat{}, fmt.Errorf("process stat starttime for %d: %w", pid, err)
+	}
+	return procStat{state: fields[0], parent: parent, start: start}, nil
 }

--- a/internal/proctest/leakguard_linux_test.go
+++ b/internal/proctest/leakguard_linux_test.go
@@ -40,6 +40,15 @@ func TestMain(m *testing.M) {
 	}))
 }
 
+// isHelper reports whether pid is still THIS fixture's own orphaned helper,
+// matched on the unique argv[0] it was symlinked under. A reaped PID belongs
+// to the kernel again, so neither the reclaim assertion nor the canary kill
+// may act on the number alone.
+func isHelper(pid int, helper string) bool {
+	argv, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	return err == nil && strings.HasPrefix(string(argv), helper+"\x00")
+}
+
 func TestNoProcessLeaks(t *testing.T) {
 	// Both sides of the settle boundary, made explicit: `settle` orphans a
 	// helper that exits well inside a widened window (forgiven, silent, still
@@ -80,10 +89,7 @@ func TestNoProcessLeaks(t *testing.T) {
 					return
 				}
 				if p, err := os.FindProcess(pid); err == nil {
-					// Match this fixture's unique argv before signalling a pidfd;
-					// an already-reaped PID could have been reused by another session.
-					argv, _ := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
-					if strings.HasPrefix(string(argv), helper+"\x00") {
+					if isHelper(pid, helper) {
 						_ = p.Kill()
 					}
 					_ = p.Release()
@@ -126,8 +132,11 @@ func TestNoProcessLeaks(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if _, err := processState(pid); !os.IsNotExist(err) {
-					t.Fatalf("fixture process %d was not reclaimed: %v", pid, err)
+				// A PID that still resolves is not proof on its own: it was
+				// reaped, so the kernel is free to have handed it to somebody
+				// else since. Only this fixture's own argv makes it ours.
+				if _, err := processState(pid); !os.IsNotExist(err) && isHelper(pid, helper) {
+					t.Fatalf("fixture process %d was not reclaimed", pid)
 				}
 			}
 		})

--- a/internal/proctest/leakguard_linux_test.go
+++ b/internal/proctest/leakguard_linux_test.go
@@ -21,10 +21,13 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 	}
 	os.Exit(NoProcessLeaks(func() int {
-		if strings.HasPrefix(mode, "orphan") {
+		if lifetime := os.Getenv("ITERION_PROCTEST_LIFETIME"); lifetime != "" {
 			// Intentionally orphan a helper after its launcher exits; the suite
 			// guard must find it even though the immediate parent has disappeared.
-			c := exec.Command("sh", "-c", `"$1" 600 </dev/null >/dev/null 2>&1 & echo $! > "$2"`, "sh", os.Getenv("ITERION_PROCTEST_HELPER"), os.Getenv("ITERION_PROCTEST_PIDFILE"))
+			// Its lifetime picks the side of the settle boundary under test: one
+			// that outlives the window is a leak, one that exits inside it is
+			// forgiven.
+			c := exec.Command("sh", "-c", `"$1" "$3" </dev/null >/dev/null 2>&1 & echo $! > "$2"`, "sh", os.Getenv("ITERION_PROCTEST_HELPER"), os.Getenv("ITERION_PROCTEST_PIDFILE"), lifetime)
 			if err := c.Run(); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				return 8
@@ -38,11 +41,23 @@ func TestMain(m *testing.M) {
 }
 
 func TestNoProcessLeaks(t *testing.T) {
+	// Both sides of the settle boundary, made explicit: `settle` orphans a
+	// helper that exits well inside a widened window (forgiven, silent, still
+	// reaped), the `orphan` pair one that outlives a narrowed one (reported).
+	// Without the `settle` row the guard could latch on first sight — the
+	// behaviour this table exists to forbid — and stay green.
 	for _, tc := range []struct {
-		mode string
-		code int
+		mode     string
+		code     int
+		settle   string // ITERION_PROCTEST_SETTLE; empty leaves the default
+		lifetime string // seconds the orphaned helper sleeps; empty spawns none
+		leak     bool
 	}{
-		{"clean", 0}, {"failure", 7}, {"orphan", 1}, {"orphan-failure", 7},
+		{mode: "clean", code: 0},
+		{mode: "failure", code: 7},
+		{mode: "settle", code: 0, settle: "10s", lifetime: "1"},
+		{mode: "orphan", code: 1, settle: "100ms", lifetime: "600", leak: true},
+		{mode: "orphan-failure", code: 7, settle: "100ms", lifetime: "600", leak: true},
 	} {
 		t.Run(tc.mode, func(t *testing.T) {
 			dir := t.TempDir()
@@ -77,7 +92,8 @@ func TestNoProcessLeaks(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			c := exec.CommandContext(ctx, os.Args[0], "-test.run=^$")
-			c.Env = append(os.Environ(), "ITERION_PROCTEST_FIXTURE="+tc.mode, "ITERION_PROCTEST_PIDFILE="+pidfile, "ITERION_PROCTEST_HELPER="+helper)
+			c.Env = append(os.Environ(), "ITERION_PROCTEST_FIXTURE="+tc.mode, "ITERION_PROCTEST_PIDFILE="+pidfile,
+				"ITERION_PROCTEST_HELPER="+helper, "ITERION_PROCTEST_LIFETIME="+tc.lifetime, settleEnv+"="+tc.settle)
 			out, err := c.CombinedOutput()
 			code := 0
 			if err != nil {
@@ -90,10 +106,18 @@ func TestNoProcessLeaks(t *testing.T) {
 			if code != tc.code {
 				t.Fatalf("exit=%d want %d: %s", code, tc.code, out)
 			}
-			if strings.HasPrefix(tc.mode, "orphan") {
-				if !strings.Contains(string(out), "test process survived suite cleanup") {
-					t.Fatalf("missing leak diagnosis: %s", out)
+			if reported := strings.Contains(string(out), "test process survived suite cleanup"); reported != tc.leak {
+				t.Fatalf("leak reported=%v want %v: %s", reported, tc.leak, out)
+			}
+			if tc.lifetime != "" && !tc.leak {
+				// A forgiven child is silent by design, so without this count
+				// the case would pass identically to `clean` even with the
+				// settle logic deleted.
+				if !strings.Contains(string(out), "forgave 1 settling child(ren)") {
+					t.Fatalf("settling child not observed then forgiven: %s", out)
 				}
+			}
+			if tc.lifetime != "" {
 				data, err := os.ReadFile(pidfile)
 				if err != nil {
 					t.Fatal(err)
@@ -102,8 +126,8 @@ func TestNoProcessLeaks(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if _, _, err := processState(pid); !os.IsNotExist(err) {
-					t.Fatalf("leaked fixture process %d still exists: %v", pid, err)
+				if _, err := processState(pid); !os.IsNotExist(err) {
+					t.Fatalf("fixture process %d was not reclaimed: %v", pid, err)
 				}
 			}
 		})

--- a/internal/proctest/leakguard_linux_test.go
+++ b/internal/proctest/leakguard_linux_test.go
@@ -49,6 +49,37 @@ func isHelper(pid int, helper string) bool {
 	return err == nil && strings.HasPrefix(string(argv), helper+"\x00")
 }
 
+// The subprocess table below cannot reach the scan-ended case: it needs a
+// child to die inside the microseconds between the guard's state read and its
+// per-PID reap, which no fixture can schedule. So the accounting is pinned
+// here instead — without the nil-cur row, that child is silently dropped and
+// the `settle` fixture's count assertion is flaky rather than wrong.
+func TestForgiven(t *testing.T) {
+	settling := procKey{pid: 11, start: 100}
+	survivor := procKey{pid: 22, start: 200}
+	seen := map[procKey]time.Time{settling: {}, survivor: {}}
+	reported := map[procKey]bool{survivor: true}
+	for _, tc := range []struct {
+		name string
+		cur  map[procKey]time.Time
+		want int
+	}{
+		{name: "still-alive", cur: seen, want: 0},
+		{name: "settling-child-gone", cur: map[procKey]time.Time{survivor: {}}, want: 1},
+		// The ECHILD break: no children left at all, so the entry the previous
+		// pass reaped after seeing it alive is forgiven here or nowhere.
+		{name: "scan-ended", cur: nil, want: 1},
+		// A leak already has its verdict; the count is forgiveness, not exits.
+		{name: "reported-never-forgiven", cur: map[procKey]time.Time{settling: {}}, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := forgiven(seen, tc.cur, reported); got != tc.want {
+				t.Fatalf("forgiven = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNoProcessLeaks(t *testing.T) {
 	// Both sides of the settle boundary, made explicit: `settle` orphans a
 	// helper that exits well inside a widened window (forgiven, silent, still

--- a/internal/proctest/leakguard_linux_test.go
+++ b/internal/proctest/leakguard_linux_test.go
@@ -49,6 +49,49 @@ func isHelper(pid int, helper string) bool {
 	return err == nil && strings.HasPrefix(string(argv), helper+"\x00")
 }
 
+func TestNoProcessLeaksCapabilityBoundary(t *testing.T) {
+	for _, stage := range []string{"children-unavailable", "subreaper-unavailable", "scan-failed-after-suite"} {
+		for _, suiteCode := range []int{0, 7} {
+			t.Run(fmt.Sprintf("%s/suite-exit-%d", stage, suiteCode), func(t *testing.T) {
+				calls, enables, scans := 0, 0, 0
+				unavailable := errors.New("capability unavailable in this environment")
+				got := noProcessLeaks(func() int {
+					calls++
+					return suiteCode
+				}, func() error {
+					enables++
+					if stage == "subreaper-unavailable" {
+						return unavailable
+					}
+					return nil
+				}, func() ([]int, error) {
+					scans++
+					if stage == "children-unavailable" || (stage == "scan-failed-after-suite" && calls > 0) {
+						return nil, unavailable
+					}
+					return nil, nil
+				})
+				if calls != 1 {
+					t.Fatalf("suite ran %d times, want exactly once even without guard support", calls)
+				}
+				want := suiteCode
+				if stage == "scan-failed-after-suite" && want == 0 {
+					want = 1
+				}
+				if got != want {
+					t.Fatalf("exit = %d, want %d", got, want)
+				}
+				if stage == "children-unavailable" && enables != 0 {
+					t.Fatal("adoption was enabled without a usable child scan")
+				}
+				if stage == "scan-failed-after-suite" && (enables != 1 || scans != 2) {
+					t.Fatalf("post-suite scan error was not distinguished from startup: enables=%d scans=%d", enables, scans)
+				}
+			})
+		}
+	}
+}
+
 // The subprocess table below cannot reach the scan-ended case: it needs a
 // child to die inside the microseconds between the guard's state read and its
 // per-PID reap, which no fixture can schedule. So the accounting is pinned
@@ -81,6 +124,7 @@ func TestForgiven(t *testing.T) {
 }
 
 func TestNoProcessLeaks(t *testing.T) {
+	unsupported := false
 	// Both sides of the settle boundary, made explicit: `settle` orphans a
 	// helper that exits well inside a widened window (forgiven, silent, still
 	// reaped), the `orphan` pair one that outlives a narrowed one (reported).
@@ -143,6 +187,13 @@ func TestNoProcessLeaks(t *testing.T) {
 			if code != tc.code {
 				t.Fatalf("exit=%d want %d: %s", code, tc.code, out)
 			}
+			// The clean subprocess is also the capability probe, before any
+			// intentional orphan is spawned. Other package suites still run
+			// unguarded on this host; only this kernel-specific fixture skips.
+			if strings.Contains(string(out), "proctest: leak guard unavailable (") {
+				unsupported = true
+				return
+			}
 			if reported := strings.Contains(string(out), "test process survived suite cleanup"); reported != tc.leak {
 				t.Fatalf("leak reported=%v want %v: %s", reported, tc.leak, out)
 			}
@@ -171,5 +222,8 @@ func TestNoProcessLeaks(t *testing.T) {
 				}
 			}
 		})
+		if unsupported {
+			t.Skip("kernel does not support the process leak guard")
+		}
 	}
 }

--- a/internal/proctest/leakguard_linux_test.go
+++ b/internal/proctest/leakguard_linux_test.go
@@ -1,0 +1,111 @@
+//go:build linux
+
+package proctest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	mode := os.Getenv("ITERION_PROCTEST_FIXTURE")
+	if mode == "" {
+		os.Exit(m.Run())
+	}
+	os.Exit(NoProcessLeaks(func() int {
+		if strings.HasPrefix(mode, "orphan") {
+			// Intentionally orphan a helper after its launcher exits; the suite
+			// guard must find it even though the immediate parent has disappeared.
+			c := exec.Command("sh", "-c", `"$1" 600 </dev/null >/dev/null 2>&1 & echo $! > "$2"`, "sh", os.Getenv("ITERION_PROCTEST_HELPER"), os.Getenv("ITERION_PROCTEST_PIDFILE"))
+			if err := c.Run(); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 8
+			}
+		}
+		if strings.HasSuffix(mode, "failure") {
+			return 7
+		}
+		return 0
+	}))
+}
+
+func TestNoProcessLeaks(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		code int
+	}{
+		{"clean", 0}, {"failure", 7}, {"orphan", 1}, {"orphan-failure", 7},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			dir := t.TempDir()
+			pidfile := filepath.Join(dir, "child.pid")
+			// Preserve argv[0] basename: Nix coreutils is a multicall binary.
+			helper := filepath.Join(dir, "sleep")
+			sleep, err := exec.LookPath("sleep")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(sleep, helper); err != nil {
+				t.Fatal(err)
+			}
+			// Even a deliberately disabled guard can be canaried without leaving
+			// the fixture's own sleep running after this assertion fails.
+			t.Cleanup(func() {
+				data, _ := os.ReadFile(pidfile)
+				pid, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+				if pid <= 0 {
+					return
+				}
+				if p, err := os.FindProcess(pid); err == nil {
+					// Match this fixture's unique argv before signalling a pidfd;
+					// an already-reaped PID could have been reused by another session.
+					argv, _ := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+					if strings.HasPrefix(string(argv), helper+"\x00") {
+						_ = p.Kill()
+					}
+					_ = p.Release()
+				}
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			c := exec.CommandContext(ctx, os.Args[0], "-test.run=^$")
+			c.Env = append(os.Environ(), "ITERION_PROCTEST_FIXTURE="+tc.mode, "ITERION_PROCTEST_PIDFILE="+pidfile, "ITERION_PROCTEST_HELPER="+helper)
+			out, err := c.CombinedOutput()
+			code := 0
+			if err != nil {
+				var exit *exec.ExitError
+				if !errors.As(err, &exit) {
+					t.Fatalf("fixture: %v (%s)", err, out)
+				}
+				code = exit.ExitCode()
+			}
+			if code != tc.code {
+				t.Fatalf("exit=%d want %d: %s", code, tc.code, out)
+			}
+			if strings.HasPrefix(tc.mode, "orphan") {
+				if !strings.Contains(string(out), "test process survived suite cleanup") {
+					t.Fatalf("missing leak diagnosis: %s", out)
+				}
+				data, err := os.ReadFile(pidfile)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, _, err := processState(pid); !os.IsNotExist(err) {
+					t.Fatalf("leaked fixture process %d still exists: %v", pid, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/proctest/leakguard_other.go
+++ b/internal/proctest/leakguard_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package proctest
+
+// NoProcessLeaks runs the suite. Orphan adoption requires Linux subreaper
+// support; portable fixture cancellation still runs on other platforms.
+func NoProcessLeaks(run func() int) int { return run() }

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/internal/gittest"
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
 // `iterion run` takes its workspace from the process cwd — this package's own
@@ -16,5 +17,5 @@ import (
 // The guard fails the package when the registry the tests run in gained such
 // an entry, and names the test that left it.
 func TestMain(m *testing.M) {
-	os.Exit(gittest.NoWorktreeLeaks(m))
+	os.Exit(proctest.NoProcessLeaks(func() int { return gittest.NoWorktreeLeaks(m) }))
 }

--- a/pkg/cli/subbot_shared_sandbox_test.go
+++ b/pkg/cli/subbot_shared_sandbox_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/internal/proc"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
@@ -29,6 +30,7 @@ func (f *cliParentSandboxFake) Command(ctx context.Context, cmd []string, opts s
 	f.commands++
 	f.mu.Unlock()
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	proc.TerminateGroupOnCancel(c)
 	c.Dir = opts.WorkDir
 	c.Env = os.Environ()
 	for k, v := range opts.Env {

--- a/pkg/dispatcher/engine_runner_subbot_test.go
+++ b/pkg/dispatcher/engine_runner_subbot_test.go
@@ -204,7 +204,7 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEngineRunner: %v", err)
 	}
-	defer func() { _ = runner.Close() }()
+	t.Cleanup(func() { _ = runner.Close() })
 	runID, err := store.GenerateRunID()
 	if err != nil {
 		t.Fatalf("GenerateRunID: %v", err)
@@ -217,9 +217,18 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 	// reached the node" and "the child is alive and the probe cannot see it".
 	var seenMu sync.Mutex
 	var seen []string
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
+	var dispatchErr error
+	dispatched := false
+	t.Cleanup(func() {
+		cancel()
+		if !dispatched {
+			<-done
+		}
+	})
 	go func() {
-		done <- runner.Dispatch(context.Background(), DispatchSpec{
+		done <- runner.Dispatch(ctx, DispatchSpec{
 			RunID:         runID,
 			WorkspacePath: workspace,
 			StoreDir:      storeDir,
@@ -234,18 +243,14 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 
 	// Catch the child mid-pass and prove its lock is held. The child blocks
 	// until release-lock-probe exists, so there is no timing window to race.
-	// Cleanup writes the release file even on a Fatal path, so the dispatch
-	// goroutine always drains instead of leaking a forever-polling child into
-	// the next test.
+	// Cleanup cancels AND joins the dispatch on a Fatal path. Merely writing
+	// the sentinel does not join the shell before TempDir removes its workspace.
 	release := filepath.Join(workspace, "release-lock-probe")
-	t.Cleanup(func() { _ = os.WriteFile(release, []byte("go"), 0o644) })
 	childID := ""
 	held := false
 	// Watch the dispatch goroutine while polling. The child blocks until the
 	// release file exists, so Dispatch returning here means it never reached
 	// the subbot node — and its error is the diagnosis.
-	var dispatchErr error
-	dispatched := false
 	// The wait is bounded by the HARNESS's budget, never by a clock of this
 	// test's own: nothing here is timing-sensitive (the child blocks on the
 	// release file), so a bound only covers the parent reaching the subbot
@@ -352,6 +357,7 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 
 	if !dispatched {
 		dispatchErr = <-done
+		dispatched = true
 	}
 	if dispatchErr != nil {
 		t.Fatalf("Dispatch: %v", dispatchErr)

--- a/pkg/dispatcher/main_test.go
+++ b/pkg/dispatcher/main_test.go
@@ -1,0 +1,9 @@
+package dispatcher
+
+import (
+	"github.com/SocialGouv/iterion/internal/proctest"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/dispatcher/main_test.go
+++ b/pkg/dispatcher/main_test.go
@@ -1,9 +1,14 @@
 package dispatcher
 
 import (
-	"github.com/SocialGouv/iterion/internal/proctest"
 	"os"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
+// The subbot fixtures here park a child on a sentinel file, so a dispatch
+// that is not joined leaves a shell polling forever — issue #956, which the
+// cancel-and-join cleanup in engine_runner_subbot_test.go fixes. The guard is
+// what keeps that fix from silently rotting.
 func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/runner/main_test.go
+++ b/pkg/runner/main_test.go
@@ -1,9 +1,14 @@
 package runner
 
 import (
-	"github.com/SocialGouv/iterion/internal/proctest"
 	"os"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
+// The fake shared sandbox here runs subbot children as real host commands.
+// A fake whose lifetime contract diverges from the real driver's leaves them
+// running; the guard fails the package instead of exporting the leak to
+// whatever runs next.
 func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/runner/main_test.go
+++ b/pkg/runner/main_test.go
@@ -1,0 +1,9 @@
+package runner
+
+import (
+	"github.com/SocialGouv/iterion/internal/proctest"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/runner/subbot_test.go
+++ b/pkg/runner/subbot_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/internal/proc"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -384,6 +385,7 @@ func (f *parentSandboxFake) Command(ctx context.Context, cmd []string, opts sand
 	f.commands++
 	f.mu.Unlock()
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	proc.TerminateGroupOnCancel(c)
 	c.Dir = opts.WorkDir
 	c.Env = os.Environ()
 	for k, v := range opts.Env {

--- a/pkg/runtime/main_test.go
+++ b/pkg/runtime/main_test.go
@@ -1,0 +1,9 @@
+package runtime
+
+import (
+	"github.com/SocialGouv/iterion/internal/proctest"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/runtime/main_test.go
+++ b/pkg/runtime/main_test.go
@@ -1,9 +1,15 @@
 package runtime
 
 import (
-	"github.com/SocialGouv/iterion/internal/proctest"
 	"os"
 	"testing"
+
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
+// Tool nodes and the fake shared sandboxes here start real shells, and a
+// shell's own children (a `sleep` in a polling loop) only die because #955
+// cancels the whole process group. The guard is the postcondition for that:
+// it fails the package when a helper outlived the test that started it,
+// instead of letting it run on into the next one.
 func TestMain(m *testing.M) { os.Exit(proctest.NoProcessLeaks(m.Run)) }

--- a/pkg/runtime/sandbox_shared_test.go
+++ b/pkg/runtime/sandbox_shared_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/SocialGouv/iterion/internal/gittest"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/internal/proc"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/sandbox/docker"
 	"github.com/SocialGouv/iterion/pkg/sandbox/kubernetes"
@@ -35,6 +36,7 @@ func (f *sharedFakeRun) Command(ctx context.Context, cmd []string, opts sandbox.
 	f.commands++
 	f.mu.Unlock()
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
+	proc.TerminateGroupOnCancel(c)
 	c.Dir = opts.WorkDir
 	c.Env = os.Environ()
 	for k, v := range opts.Env {

--- a/pkg/runview/main_test.go
+++ b/pkg/runview/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/internal/gittest"
+	"github.com/SocialGouv/iterion/internal/proctest"
 )
 
 // A Service launched without WithWorkDir hands the engine os.Getwd() — this
@@ -16,5 +17,5 @@ import (
 // The guard makes that visible: it fails the package when the repository the
 // tests run in gained a dead worktree entry, and names the test that left it.
 func TestMain(m *testing.M) {
-	os.Exit(gittest.NoWorktreeLeaks(m))
+	os.Exit(proctest.NoProcessLeaks(func() int { return gittest.NoWorktreeLeaks(m) }))
 }


### PR DESCRIPTION
The dispatcher subbot lock fixture could leave its sentinel shell polling forever after an early failure: cleanup only wrote a release file, while TempDir could remove the workspace before dispatch exited. Cancel and join the dispatch before closing its runner and deleting temporary directories. The local-server E2E fixture also joins its Wait goroutine on early cleanup, with process-group cancellation and a ten-second WaitDelay for inherited output pipes.

Add a Linux TestMain process guard in dispatcher, runview, runner, runtime, CLI and E2E. A child subreaper retains orphaned descendants. After suite cleanup, each live child gets a 500 ms settle window (`ITERION_PROCTEST_SETTLE` can override it); true survivors fail the suite and are reclaimed through verified owned process handles. PID and process start time distinguish repeated scans, and historical orphans and sibling packages remain outside the guard's ancestry. Existing failure codes are preserved, and os/exec remains responsible for Wait while tests run. Fake shared sandboxes in runner/runtime/CLI apply group cancellation.

If a Linux environment lacks the child scanner or refuses the subreaper capability, the guard reports its unavailability and still executes the suite. The scanner is probed before adoption is enabled. Once activation succeeds, subsequent inspection errors remain failures; only the guard's own capability-dependent orphan fixture is skipped on an unsupported host.

Validation:

- Original early-failure canary: wait for the helper to start, delete its workspace, fail before release. Old cleanup leaked bash + sleep; new cleanup leaked neither. Temporary probes removed.
- Real subprocess tests cover settling exit, true surviving orphans, clean success and existing failure codes. An independent overlay forces the child to exit between its state read and reap: the fixed test passes, and removing only final ECHILD accounting makes it fail.
- Full Devbox `task check` passed after recovering the review fixes.
- The portability regression was red first for unavailable capabilities; the corrected guard passes under `-race`. Independent overlays disable each capability through the public wrapper: real runner tests still execute and pass, while the orphan fixture skips before creating a leaked helper.
- Complete race suites passed for proctest, dispatcher, runview, runner, runtime, CLI and E2E. Only the unrelated ordering regression previously reproduced on main and tracked in #960 was excluded from this race invocation; the full non-race suite retained it.

R565a2f and the subsequent portability finding Race656 are fixed. Billy stopped on the Claude session limit before publishing; its nine final-bank commits were inspected and validated locally, its scheduled retry was disarmed, and the preserved chain is delivered here. The bounded portability follow-up was completed locally after that quota stop, with no active fixer on this PR. The dated bilan is in `docs/bot-runs/branch-improve-loop.md`.

The audit in `docs/test-process-cleanup.md` describes the guard's bounds: only normal ECHILD completion proves no descendants remain; reclaim-timeout failure includes a final best-effort kill. The remaining fixture Git-maintenance configuration gap is tracked separately in #974.

Fixes #956.
