### PR TITLE
fix: distinguish human waits from stalled runs

### DIFF
--- a/docs/stall-human-waits.md
+++ b/docs/stall-human-waits.md
@@ -18,6 +18,14 @@ run, and deleted runs cannot be resurrected. FS and Mongo implement the same
 contract. Storage failures surface as execution errors; a failed cleanup cannot
 leave an exemption beyond the original timeout.
 
+A cleanup write failure also fails the node after answers were collected:
+continuing into the next node with stale proof could hide its genuine stall
+for the remaining sync timeout, possibly hours. The answers remain durable in
+the interaction store and are collected again on retry without a second human
+prompt. This favors a visible, recoverable storage failure over a hidden stall.
+Cleanup uses a separate five-second context; the filesystem writer retains its
+existing ten-second file-lock ceiling rather than honoring context cancellation.
+
 The shared lookup also follows `SubbotChildren` to a paused descendant or an
 active descendant sync point. Terminal subtrees are ignored. No proof, an
 expired marker, unreadable records, cycles, or exhaustion of the 256-record
@@ -25,11 +33,15 @@ probe budget never provide an exemption by themselves. A valid proof found
 elsewhere in the visited tree still qualifies, as in the original dispatcher
 oracle.
 
-Alert lookups run outside the event observer's mutex and have a five-second
-I/O bound cancelled by manager shutdown. The candidate is checked again after
+Human-wait lookups run outside the event observer's mutex with a five-second
+context deadline cancelled by manager shutdown. The candidate is checked again after
 the lookup, so progress arriving during a read prevents a stale alert. When
 the wait ends, the next poll applies the existing stall threshold to the last
 real progress event; the wait does not reset the watermark.
+
+The service's internal alert callbacks bootstrap identity from the known run
+ID, then scope descendant reads and the persisted health event to that run's
+tenant. A paused child belonging to another tenant cannot exempt the root.
 
 Regression coverage includes both original failures, answer/cancel/timeout,
 write and cleanup failure, parallel token isolation, stale saves, lifecycle

--- a/docs/stall-human-waits.md
+++ b/docs/stall-human-waits.md
@@ -1,0 +1,38 @@
+# Human waits and stall detection
+
+The dispatcher and runview alert manager both consult
+`store.HasBlockingHumanWait` before treating a silent run as stalled. The
+observer reads persisted state; the waiting worker does not emit fake progress.
+
+A running `await_answers` node records a per-invocation token, its node ID, and
+the expiry derived from its mandatory timeout. The token is written only after
+the node finds pending async questions and enters its synchronous wait. An
+`interaction: async` agent with outstanding questions has no such marker and
+remains subject to normal stall detection.
+
+Answer, timeout, and cancellation remove that invocation's token. Parallel
+waits have independent tokens. Status transitions discard execution-local
+markers; stale full-document saves cannot overwrite granular writes because
+they participate in the existing run-version fence. Additions require a running
+run, and deleted runs cannot be resurrected. FS and Mongo implement the same
+contract. Storage failures surface as execution errors; a failed cleanup cannot
+leave an exemption beyond the original timeout.
+
+The shared lookup also follows `SubbotChildren` to a paused descendant or an
+active descendant sync point. Terminal subtrees are ignored. No proof, an
+expired marker, unreadable records, cycles, or exhaustion of the 256-record
+probe budget never provide an exemption by themselves. A valid proof found
+elsewhere in the visited tree still qualifies, as in the original dispatcher
+oracle.
+
+Alert lookups run outside the event observer's mutex and have a five-second
+I/O bound cancelled by manager shutdown. The candidate is checked again after
+the lookup, so progress arriving during a read prevents a stale alert. When
+the wait ends, the next poll applies the existing stall threshold to the last
+real progress event; the wait does not reset the watermark.
+
+Regression coverage includes both original failures, answer/cancel/timeout,
+write and cleanup failure, parallel token isolation, stale saves, lifecycle
+clearing and deletion on both stores, descendant resume without a parent event,
+and real runview wiring across the alert poll interval. Negative cases keep
+genuinely silent runs eligible for alerts and cancellation.

--- a/pkg/alert/human_wait_test.go
+++ b/pkg/alert/human_wait_test.go
@@ -1,0 +1,99 @@
+package alert
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestStallReadsPersistedHumanWaitAndRearms(t *testing.T) {
+	ctx := context.Background()
+	s, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateRun(ctx, "child", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(ctx, "child", store.RunStatusPausedWaitingHuman, ""); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	m := NewManager(WithStallTimeout(time.Minute), WithHumanWaitLookup(func(ctx context.Context, _ string, _ time.Time) bool {
+		child, err := s.LoadRun(ctx, "child")
+		return err == nil && child.Status.IsPaused()
+	}))
+	defer m.Stop()
+	m.Observe(store.Event{RunID: "parent", Type: store.EventNodeStarted, NodeID: "subbot", Timestamp: base})
+	if got := m.checkStalls(base.Add(10 * time.Minute)); len(got) != 0 {
+		t.Fatalf("human wait raised a false stall: %+v", got)
+	}
+	// No parent event is emitted when an external actor resumes the child.
+	// The next observation must pull that new state and re-arm the watchdog.
+	if err := s.UpdateRunStatus(ctx, "child", store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.checkStalls(base.Add(11 * time.Minute)); len(got) != 1 || got[0].Kind != KindStall {
+		t.Fatalf("genuine silence after the wait was muted: %+v", got)
+	}
+}
+
+func TestHumanWaitLookupDoesNotBlockObserveOrAlertFromAStaleView(t *testing.T) {
+	base := time.Now()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	m := NewManager(WithStallTimeout(time.Minute), WithHumanWaitLookup(func(ctx context.Context, _ string, _ time.Time) bool {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return false
+	}))
+	defer m.Stop()
+	m.Observe(store.Event{RunID: "r", Type: store.EventNodeStarted, Timestamp: base})
+	done := make(chan []Alert, 1)
+	go func() { done <- m.checkStalls(base.Add(10 * time.Minute)) }()
+	<-entered
+	// Observe must remain available while the persisted lookup is blocked.
+	observed := make(chan struct{})
+	go func() {
+		m.Observe(store.Event{RunID: "r", Type: store.EventToolCalled, Timestamp: base.Add(10 * time.Minute)})
+		close(observed)
+	}()
+	select {
+	case <-observed:
+	case <-time.After(time.Second):
+		m.Stop()
+		t.Fatal("lookup held the observer mutex")
+	}
+	close(release)
+	if got := <-done; len(got) != 0 {
+		t.Fatalf("lookup notified from a stale view: %+v", got)
+	}
+}
+
+func TestStopCancelsHumanWaitLookup(t *testing.T) {
+	entered := make(chan struct{})
+	m := NewManager(WithStallTimeout(time.Minute), WithHumanWaitLookup(func(ctx context.Context, _ string, _ time.Time) bool {
+		close(entered)
+		<-ctx.Done()
+		return false
+	}))
+	base := time.Now()
+	m.Observe(store.Event{RunID: "r", Type: store.EventNodeStarted, Timestamp: base})
+	done := make(chan []Alert, 1)
+	go func() { done <- m.checkStalls(base.Add(10 * time.Minute)) }()
+	<-entered
+	m.Stop()
+	select {
+	case got := <-done:
+		if len(got) != 0 {
+			t.Fatalf("Stop produced a late alert: %+v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the persisted lookup")
+	}
+}

--- a/pkg/alert/manager.go
+++ b/pkg/alert/manager.go
@@ -49,11 +49,14 @@ type Manager struct {
 	sinks  []Sink
 	logger *iterlog.Logger
 
-	stallTimeout  time.Duration
-	notifyTimeout time.Duration
-	baseURL       string
-	runLookup     func(runID string) (name string, ok bool)
-	now           func() time.Time
+	stallTimeout    time.Duration
+	notifyTimeout   time.Duration
+	baseURL         string
+	runLookup       func(runID string) (name string, ok bool)
+	humanWaitLookup func(context.Context, string, time.Time) bool
+	humanWaitCtx    context.Context
+	humanWaitCancel context.CancelFunc
+	now             func() time.Time
 	// storeSink, when set, receives every fired alert so the host can
 	// persist a store-event twin (EventRunHealth) — the ephemeral
 	// broker sink is deliberately never persisted (feedback-loop
@@ -91,6 +94,12 @@ func WithRunLookup(fn func(runID string) (string, bool)) Option {
 	return func(m *Manager) { m.runLookup = fn }
 }
 
+// WithHumanWaitLookup supplies persisted proof that a silent run is waiting
+// for human input. Missing or unreadable proof must return false.
+func WithHumanWaitLookup(fn func(context.Context, string, time.Time) bool) Option {
+	return func(m *Manager) { m.humanWaitLookup = fn }
+}
+
 // WithSinks appends delivery sinks.
 func WithSinks(sinks ...Sink) Option {
 	return func(m *Manager) { m.sinks = append(m.sinks, sinks...) }
@@ -106,8 +115,10 @@ func WithStoreSink(fn func(Alert)) Option {
 
 // NewManager builds a Manager. Call Start to begin stall polling.
 func NewManager(opts ...Option) *Manager {
+	waitCtx, waitCancel := context.WithCancel(context.Background())
 	m := &Manager{
-		runs:          make(map[string]*runState),
+		runs:         make(map[string]*runState),
+		humanWaitCtx: waitCtx, humanWaitCancel: waitCancel,
 		stallTimeout:  DefaultStallTimeout,
 		notifyTimeout: defaultNotifyTimeout,
 		now:           time.Now,
@@ -263,15 +274,20 @@ func (m *Manager) Start(ctx context.Context) {
 
 // Stop terminates the stall-polling goroutine.
 func (m *Manager) Stop() {
-	m.stopOnce.Do(func() { close(m.stop) })
+	m.stopOnce.Do(func() { m.humanWaitCancel(); close(m.stop) })
 }
 
 // checkStalls fires a stall alert for every non-terminal run whose last
 // progress is older than the stall timeout (once per episode), reaps
 // long-terminal runs, and returns the alerts fired (for testing).
 func (m *Manager) checkStalls(now time.Time) []Alert {
+	type candidate struct {
+		id       string
+		state    *runState
+		progress time.Time
+	}
 	m.mu.Lock()
-	var fired []Alert
+	var candidates []candidate
 	for id, rs := range m.runs {
 		if rs.terminal {
 			if !rs.terminalAt.IsZero() && now.Sub(rs.terminalAt) > terminalRetention {
@@ -279,31 +295,42 @@ func (m *Manager) checkStalls(now time.Time) []Alert {
 			}
 			continue
 		}
-		if m.stallTimeout <= 0 {
+		if m.stallTimeout <= 0 || rs.paused || rs.lastProgressAt.IsZero() || rs.stallAlerted || now.Sub(rs.lastProgressAt) <= m.stallTimeout {
 			continue
 		}
-		// A run waiting on a human form (or an operator pause) is not
-		// stalled — it's intentionally idle. Don't fire a false alarm.
-		if rs.paused {
-			continue
+		candidates = append(candidates, candidate{id, rs, rs.lastProgressAt})
+	}
+	m.mu.Unlock()
+
+	var fired []Alert
+	for _, c := range candidates {
+		waiting := false
+		if m.humanWaitLookup != nil {
+			// Store I/O must not hold the event observer's mutex. Stop cancels a
+			// blocked lookup; failure/no proof leaves stall detection armed.
+			ctx, cancel := context.WithTimeout(m.humanWaitCtx, 5*time.Second)
+			waiting = m.humanWaitLookup(ctx, c.id, now)
+			cancel()
 		}
-		if rs.lastProgressAt.IsZero() || rs.stallAlerted {
-			continue
-		}
-		idle := now.Sub(rs.lastProgressAt)
-		if idle <= m.stallTimeout {
+		m.mu.Lock()
+		rs := m.runs[c.id]
+		// An event or another polling pass may have changed the candidate
+		// while the lookup was in flight. Never notify from that stale view.
+		if m.humanWaitCtx.Err() != nil || rs != c.state || rs.terminal || rs.paused || rs.stallAlerted || !rs.lastProgressAt.Equal(c.progress) || waiting {
+			m.mu.Unlock()
 			continue
 		}
 		rs.stallAlerted = true
-		reason := fmt.Sprintf("no activity for %s", idle.Round(time.Second))
+		reason := fmt.Sprintf("no activity for %s", now.Sub(rs.lastProgressAt).Round(time.Second))
 		fired = append(fired, m.alertLocked(KindStall, rs, rs.currentNode, reason, "", 0, now))
+		m.mu.Unlock()
 	}
+	m.mu.Lock()
 	var sinks []Sink
 	if len(fired) > 0 {
 		sinks = m.snapshotSinksLocked()
 	}
 	m.mu.Unlock()
-
 	m.dispatch(sinks, fired)
 	return fired
 }

--- a/pkg/dispatcher/stall_await_answers_test.go
+++ b/pkg/dispatcher/stall_await_answers_test.go
@@ -1,0 +1,46 @@
+package dispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestReconcileStalled_AwaitAnswersNeedsLiveProof(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	s, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.CreateRun(ctx, "r", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteInteraction(ctx, &store.Interaction{ID: "q", RunID: "r", NodeID: "ask", Kind: store.InteractionKindAsync, RequestedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	c := newStallTestDispatcher(t, dir)
+	for _, tc := range []struct {
+		name       string
+		wait       *store.AwaitAnswersWait
+		wantCancel bool
+	}{
+		{"pending question only", nil, true},
+		{"parked sync point", &store.AwaitAnswersWait{NodeID: "sync", Until: time.Now().Add(time.Hour)}, false},
+		{"expired sync point", &store.AwaitAnswersWait{NodeID: "sync", Until: time.Now().Add(-time.Hour)}, true},
+		{"cleared sync point", nil, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.SetAwaitAnswersWait(ctx, "r", "invocation", tc.wait); err != nil {
+				t.Fatal(err)
+			}
+			cancelled := seedStalledEntry(c, "fake:wait", "r")
+			c.reconcileStalled(ctx, c.cfg.Load())
+			if *cancelled != tc.wantCancel {
+				t.Fatalf("cancelled=%v, want %v", *cancelled, tc.wantCancel)
+			}
+		})
+	}
+}

--- a/pkg/dispatcher/stall_parked.go
+++ b/pkg/dispatcher/stall_parked.go
@@ -2,89 +2,14 @@ package dispatcher
 
 import (
 	"context"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// maxParkedProbeRuns bounds how many run records one parked-descendant probe
-// reads. The answer a parked run needs is found at depth 1 (its own children),
-// so the budget only bites on a deep or wide tree in which NOTHING is paused —
-// exactly the tree that should be reaped. Exceeding it therefore returns "not
-// parked", the fail-closed answer.
-const maxParkedProbeRuns = 256
-
-// parkedOnPausedDescendant reports whether a silent run is silent BECAUSE a
-// run below it is parked on a pause only an operator can lift.
-//
-// It is the stall watchdog's exemption oracle, and it is a PULL from persisted
-// truth rather than a heartbeat the parked code pushes: a parent blocked in
-// runview.AwaitSubbotTerminal emits no event and books no work, so any signal
-// it produced itself would either be invisible to the dispatcher or would have
-// to fake node progress on the run's timeline. What it does leave behind is
-// exact — the child id under SubbotChildren (written before the child engine
-// runs) and the child's own paused status — so the watchdog reads that instead.
-//
-// The exemption is self-limiting by construction: the moment the operator
-// answers, the descendant leaves its paused status and the next tick judges the
-// run on its silence alone. A run that is merely wedged, at any depth, is never
-// exempt.
-//
-// Fails CLOSED. An unreadable record, a pruned child, a cycle in a corrupt
-// SubbotChildren map, or a probe past its budget all read as "not parked": no
-// information is not a licence to disarm the watchdog.
+// Keep the dispatcher seam while sharing the persisted oracle with alerts.
 func parkedOnPausedDescendant(ctx context.Context, rs store.RunStore, runID string) bool {
-	if rs == nil || runID == "" {
-		return false
-	}
-	// Breadth-first over SubbotChildren, one store read per run. `seen` is what
-	// guarantees termination on a corrupt map that points back at an ancestor;
-	// the budget only bounds cost.
-	seen := map[string]bool{runID: true}
-	frontier := []string{runID}
-	budget := maxParkedProbeRuns
-	// The ROOT's own pause is deliberately NOT an exemption: a run that pauses
-	// itself returns from the engine, and finishRun's pause arm parks the card
-	// and frees the slot. Only a descendant keeps a parent silent while the
-	// parent is still `running`.
-	root := true
-
-	for len(frontier) > 0 && budget > 0 {
-		var next []string
-		for _, id := range frontier {
-			if budget <= 0 {
-				break
-			}
-			run, err := rs.LoadRun(ctx, id)
-			budget--
-			if err != nil || run == nil {
-				continue
-			}
-			if !root {
-				// IsPaused is the same predicate finishRun's pause arm reads,
-				// so "what parks a card" and "what exempts a parent" cannot
-				// drift apart.
-				if run.Status.IsPaused() {
-					return true
-				}
-				// IsTerminal matches runview.AwaitSubbotTerminal's own terminal
-				// set: a child in one of those states is something the parent
-				// stops waiting on, so its subtree is not worth walking.
-				if run.Status.IsTerminal() {
-					continue
-				}
-			}
-			for _, childID := range run.SubbotChildren {
-				if childID == "" || seen[childID] {
-					continue
-				}
-				seen[childID] = true
-				next = append(next, childID)
-			}
-		}
-		frontier = next
-		root = false
-	}
-	return false
+	return store.HasBlockingHumanWait(ctx, rs, runID, time.Now())
 }
 
 // exemptParkedFromStall answers reconcileStalled's question for one entry:
@@ -100,13 +25,13 @@ func (c *Dispatcher) exemptParkedFromStall(ctx context.Context, rs store.RunStor
 	case parked && !r.parkedNoticed:
 		r.parkedNoticed = true
 		c.logger.Info(
-			"dispatcher: %s is silent because a subbot descendant of run %s awaits human input — exempt from the stall watchdog until it is answered",
+			"dispatcher: %s is silent because run %s or a subbot descendant awaits human input — exempt from the stall watchdog until it is answered",
 			r.Identifier, r.RunID,
 		)
 	case !parked && r.parkedNoticed:
 		r.parkedNoticed = false
 		c.logger.Info(
-			"dispatcher: %s no longer waits on a paused descendant (run=%s) — the stall watchdog applies again",
+			"dispatcher: %s no longer has a recorded human wait (run=%s) — the stall watchdog applies again",
 			r.Identifier, r.RunID,
 		)
 	}

--- a/pkg/runtime/await_answers_node.go
+++ b/pkg/runtime/await_answers_node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/google/uuid"
 )
 
 // awaitAnswersPollInterval is the store re-check cadence while an
@@ -39,7 +40,22 @@ func SetAwaitAnswersPollInterval(d time.Duration) time.Duration {
 // for the From node (or the whole run), bounded by the mandatory
 // timeout. On success it returns {answers: [...]} with every answered
 // async question in scope.
-func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID string, an *ir.AwaitAnswersNode) (map[string]any, error) {
+func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID string, an *ir.AwaitAnswersNode) (out map[string]any, resultErr error) {
+	until := time.Now().Add(an.Timeout)
+	token := ""
+	defer func() {
+		if token == "" {
+			return
+		}
+		// Cancellation must still remove this invocation's proof, preserving
+		// tenant identity while bounding the cleanup independently of the wait.
+		clearCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := e.store.SetAwaitAnswersWait(clearCtx, rs.runID, token, nil); err != nil {
+			resultErr = errors.Join(resultErr, &RuntimeError{Code: ErrCodeExecutionFailed, NodeID: nodeID, Message: "clear await_answers wait", Cause: err})
+		}
+	}()
+
 	deadline := time.NewTimer(an.Timeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(awaitAnswersPollInterval)
@@ -70,6 +86,14 @@ func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID str
 		}
 		if len(pending) == 0 {
 			return e.awaitAnswersOutput(ctx, rs.runID, nodeID, an.From)
+		}
+
+		if token == "" {
+			candidate := uuid.NewString()
+			if err := e.store.SetAwaitAnswersWait(ctx, rs.runID, candidate, &store.AwaitAnswersWait{NodeID: nodeID, Until: until}); err != nil {
+				return nil, &RuntimeError{Code: ErrCodeExecutionFailed, NodeID: nodeID, Message: "persist await_answers wait", Cause: err}
+			}
+			token = candidate
 		}
 
 		select {

--- a/pkg/runtime/await_answers_node.go
+++ b/pkg/runtime/await_answers_node.go
@@ -52,6 +52,10 @@ func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID str
 		clearCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()
 		if err := e.store.SetAwaitAnswersWait(clearCtx, rs.runID, token, nil); err != nil {
+			// Fail closed even after collecting answers: carrying this proof
+			// into the next node could hide a real stall until the sync timeout
+			// (possibly hours). Answers remain in the interaction store and
+			// can be collected again on retry without asking the human twice.
 			resultErr = errors.Join(resultErr, &RuntimeError{Code: ErrCodeExecutionFailed, NodeID: nodeID, Message: "clear await_answers wait", Cause: err})
 		}
 	}()

--- a/pkg/runtime/await_answers_park_test.go
+++ b/pkg/runtime/await_answers_park_test.go
@@ -149,3 +149,54 @@ func TestAwaitAnswersReportsPersistenceFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestAwaitAnswersFailsClosedWhenAnsweredMarkerCannotBeCleared(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		s := tmpStore(t)
+		if _, err := s.CreateRun(ctx, "r", "wf", nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.WriteInteraction(ctx, &store.Interaction{ID: "q", RunID: "r", NodeID: "ask", Kind: store.InteractionKindAsync, RequestedAt: time.Now()}); err != nil {
+			t.Fatal(err)
+		}
+		failure := errors.New("cannot clear wait proof")
+		e := New(&ir.Workflow{Name: "wf"}, failingAwaitWaitStore{RunStore: s, failClear: true, err: failure}, newStubExecutor())
+		rs := e.newRunState("r", nil)
+		rs.ctx = ctx
+		done := make(chan error, 1)
+		go func() {
+			_, err := e.awaitAsyncAnswers(ctx, rs, "sync", &ir.AwaitAnswersNode{Timeout: time.Hour})
+			done <- err
+		}()
+		synctest.Wait()
+		joined := false
+		defer func() {
+			cancel()
+			if !joined {
+				<-done
+			}
+		}()
+		if _, err := store.AnswerInteraction(ctx, s, "r", "q", map[string]any{"answer": "blue"}); err != nil {
+			t.Fatal(err)
+		}
+		e.NotifyInteractionAnswered()
+		result := <-done
+		joined = true
+		if !errors.Is(result, failure) {
+			t.Fatalf("continued into work with stale wait proof: %v", result)
+		}
+		// Answers are durable interaction records, not lost output. A retry
+		// can recover them without asking the human again. Continuing after
+		// this failed clear would exempt the next genuinely wedged node for
+		// the rest of the one-hour sync timeout.
+		out, err := e.awaitAsyncAnswers(ctx, rs, "sync", &ir.AwaitAnswersNode{Timeout: time.Hour})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if answers, ok := out["answers"].([]any); !ok || len(answers) != 1 {
+			t.Fatalf("answered interaction lost on retry: %+v", out)
+		}
+	})
+}

--- a/pkg/runtime/await_answers_park_test.go
+++ b/pkg/runtime/await_answers_park_test.go
@@ -1,0 +1,151 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestAwaitAnswersPersistsOnlyWhileParked(t *testing.T) {
+	for _, exit := range []string{"cancel", "answer", "timeout"} {
+		t.Run(exit, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				s := tmpStore(t)
+				const id = "await-park"
+				if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.WriteInteraction(ctx, &store.Interaction{ID: "question", RunID: id, NodeID: "asker", Kind: store.InteractionKindAsync, RequestedAt: time.Now()}); err != nil {
+					t.Fatal(err)
+				}
+				e := New(&ir.Workflow{Name: "wf"}, s, newStubExecutor())
+				rs := e.newRunState(id, nil)
+				rs.ctx = ctx
+				done := make(chan error, 1)
+				go func() {
+					_, err := e.awaitAsyncAnswers(ctx, rs, "sync", &ir.AwaitAnswersNode{Timeout: 10 * time.Second})
+					done <- err
+				}()
+				joined := false
+				defer func() {
+					cancel()
+					synctest.Wait()
+					if !joined {
+						<-done
+					}
+				}()
+				synctest.Wait()
+				run, err := s.LoadRun(ctx, id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(run.AwaitAnswersWaits) != 1 {
+					t.Fatalf("persisted waits=%v, want exactly the parked sync point", run.AwaitAnswersWaits)
+				}
+				for _, wait := range run.AwaitAnswersWaits {
+					if wait.NodeID != "sync" || !wait.Until.Equal(time.Now().Add(10*time.Second)) {
+						t.Fatalf("park proof=%+v", wait)
+					}
+				}
+				switch exit {
+				case "cancel":
+					cancel()
+				case "answer":
+					if _, err := store.AnswerInteraction(ctx, s, id, "question", map[string]any{"answer": "blue"}); err != nil {
+						t.Fatal(err)
+					}
+					e.NotifyInteractionAnswered()
+				case "timeout":
+					time.Sleep(10 * time.Second)
+				}
+				synctest.Wait()
+				result := <-done
+				joined = true
+				if exit == "answer" && result != nil {
+					t.Fatalf("answered wait: %v", result)
+				}
+				if exit == "cancel" && !errors.Is(result, context.Canceled) {
+					t.Fatalf("cancelled wait: %v", result)
+				}
+				if exit == "timeout" {
+					var re *RuntimeError
+					if !errors.As(result, &re) || re.Code != ErrCodeTimeout {
+						t.Fatalf("timed out wait: %v", result)
+					}
+				}
+				run, err = s.LoadRun(context.Background(), id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(run.AwaitAnswersWaits) != 0 {
+					t.Fatalf("cancelled sync point still exempts the run: %+v", run.AwaitAnswersWaits)
+				}
+			})
+		})
+	}
+}
+
+type failingAwaitWaitStore struct {
+	store.RunStore
+	failClear bool
+	err       error
+}
+
+func (s failingAwaitWaitStore) SetAwaitAnswersWait(ctx context.Context, id, token string, wait *store.AwaitAnswersWait) error {
+	if (wait == nil) == s.failClear {
+		return s.err
+	}
+	return s.RunStore.SetAwaitAnswersWait(ctx, id, token, wait)
+}
+
+func TestAwaitAnswersReportsPersistenceFailure(t *testing.T) {
+	for _, failClear := range []bool{false, true} {
+		name := "enter"
+		if failClear {
+			name = "leave"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				s := tmpStore(t)
+				if _, err := s.CreateRun(ctx, "r", "wf", nil); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.WriteInteraction(ctx, &store.Interaction{ID: "q", RunID: "r", NodeID: "ask", Kind: store.InteractionKindAsync, RequestedAt: time.Now()}); err != nil {
+					t.Fatal(err)
+				}
+				failure := errors.New("wait write unavailable")
+				e := New(&ir.Workflow{Name: "wf"}, failingAwaitWaitStore{RunStore: s, failClear: failClear, err: failure}, newStubExecutor())
+				rs := e.newRunState("r", nil)
+				rs.ctx = ctx
+				done := make(chan error, 1)
+				go func() {
+					_, err := e.awaitAsyncAnswers(ctx, rs, "sync", &ir.AwaitAnswersNode{Timeout: time.Minute})
+					done <- err
+				}()
+				synctest.Wait()
+				cancel()
+				result := <-done
+				if !errors.Is(result, failure) {
+					t.Fatalf("lost storage error: %v", result)
+				}
+				if failClear && !errors.Is(result, context.Canceled) {
+					t.Fatalf("cleanup erased cancellation: %v", result)
+				}
+				if !failClear && store.HasBlockingHumanWait(context.Background(), s, "r", time.Now()) {
+					t.Fatal("failed write left a false wait exemption")
+				}
+				if store.HasBlockingHumanWait(context.Background(), s, "r", time.Now().Add(time.Minute)) {
+					t.Fatal("failed cleanup left an unbounded exemption")
+				}
+			})
+		})
+	}
+}

--- a/pkg/runview/alert_human_wait_test.go
+++ b/pkg/runview/alert_human_wait_test.go
@@ -2,6 +2,7 @@ package runview
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -56,6 +57,107 @@ func TestAlertManagerWiresPersistedHumanWait(t *testing.T) {
 			}
 		default:
 			t.Fatal("genuine parent silence was muted after child resumed")
+		}
+	})
+}
+
+// Enforce Mongo's context contract over the real filesystem store. The alert
+// manager has no request context; its internal callbacks must recover identity
+// from the known root run and scope descendant reads and event writes to it.
+type tenantAlertStore struct{ store.RunStore }
+
+func (s tenantAlertStore) LoadRun(ctx context.Context, id string) (*store.Run, error) {
+	r, err := s.RunStore.LoadRun(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	tenant, ok := store.TenantFromContext(ctx)
+	if ok && tenant == r.TenantID || !ok && store.IsWithoutTenantFilter(ctx) {
+		return r, nil
+	}
+	return nil, fmt.Errorf("run %s is outside the context tenant", id)
+}
+
+func (s tenantAlertStore) AppendEvent(ctx context.Context, id string, event store.Event) (*store.Event, error) {
+	r, err := s.RunStore.LoadRun(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	tenant, _ := store.TenantFromContext(ctx)
+	if tenant == "" || tenant != r.TenantID {
+		return nil, fmt.Errorf("health event has no run tenant")
+	}
+	event.TenantID = tenant
+	return s.RunStore.AppendEvent(ctx, id, event)
+}
+
+func TestAlertHumanWaitRecoversTenantAndScopesDescendants(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, id := range []string{"parent", "child", "foreign"} {
+			r, err := s.CreateRun(ctx, id, "wf", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.TenantID = "team-a"
+			if id == "foreign" {
+				r.TenantID = "team-b"
+			}
+			if err := s.SaveRun(ctx, r); err != nil {
+				t.Fatal(err)
+			}
+			if id != "parent" {
+				if err := s.SetSubbotChild(ctx, "parent", id, id); err != nil {
+					t.Fatal(err)
+				}
+				if err := s.UpdateRunStatus(ctx, id, store.RunStatusPausedWaitingHuman, ""); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		got := make(chan alert.Alert, 8)
+		svc := &Service{store: tenantAlertStore{s}, logger: iterlog.Nop()}
+		m := svc.buildAlertManager(AlertSettings{StallTimeout: time.Second, DesktopSink: alert.FuncSink(func(_ context.Context, a alert.Alert) { got <- a })})
+		m.Start(ctx)
+		defer func() { m.Stop(); synctest.Wait() }()
+		m.Observe(store.Event{RunID: "parent", Type: store.EventNodeStarted, Timestamp: time.Now()})
+		time.Sleep(6 * time.Second)
+		synctest.Wait()
+		if len(got) != 0 {
+			t.Fatal("missing tenant identity raised a false stall")
+		}
+		if err := s.UpdateRunStatus(ctx, "child", store.RunStatusRunning, ""); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		select {
+		case a := <-got:
+			if a.Kind != alert.KindStall {
+				t.Fatalf("alert=%+v", a)
+			}
+		default:
+			t.Fatal("a foreign paused descendant muted this tenant's real stall")
+		}
+		events, err := s.LoadEvents(ctx, "parent")
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, e := range events {
+			if e.Type == store.EventRunHealth {
+				found = true
+				if e.TenantID != "team-a" {
+					t.Fatalf("health event tenant=%q", e.TenantID)
+				}
+			}
+		}
+		if !found {
+			t.Fatal("stall health event was not persisted under the run tenant")
 		}
 	})
 }

--- a/pkg/runview/alert_human_wait_test.go
+++ b/pkg/runview/alert_human_wait_test.go
@@ -1,0 +1,61 @@
+package runview
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/alert"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestAlertManagerWiresPersistedHumanWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		s, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, id := range []string{"parent", "child"} {
+			if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := s.SetSubbotChild(ctx, "parent", "subbot", "child"); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UpdateRunStatus(ctx, "child", store.RunStatusPausedWaitingHuman, ""); err != nil {
+			t.Fatal(err)
+		}
+		got := make(chan alert.Alert, 8)
+		svc := &Service{store: s, logger: iterlog.Nop()}
+		m := svc.buildAlertManager(AlertSettings{StallTimeout: time.Second, DesktopSink: alert.FuncSink(func(_ context.Context, a alert.Alert) { got <- a })})
+		m.Start(ctx)
+		defer func() { m.Stop(); synctest.Wait() }()
+		m.Observe(store.Event{RunID: "parent", Type: store.EventNodeStarted, NodeID: "subbot", Timestamp: time.Now()})
+		// The manager polls at least every five seconds, even with a shorter
+		// stall threshold. Cross that first poll while the child is paused.
+		time.Sleep(6 * time.Second)
+		synctest.Wait()
+		select {
+		case a := <-got:
+			t.Fatalf("paused child raised an alert: %+v", a)
+		default:
+		}
+		if err := s.UpdateRunStatus(ctx, "child", store.RunStatusRunning, ""); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(5 * time.Second)
+		synctest.Wait()
+		select {
+		case a := <-got:
+			if a.Kind != alert.KindStall || a.RunID != "parent" {
+				t.Fatalf("alert=%+v", a)
+			}
+		default:
+			t.Fatal("genuine parent silence was muted after child resumed")
+		}
+	})
+}

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -1106,6 +1106,9 @@ func (s *Service) buildAlertManager(set AlertSettings) *alert.Manager {
 	opts := []alert.Option{
 		alert.WithSinks(sinks...),
 		alert.WithRunLookup(runLookup),
+		alert.WithHumanWaitLookup(func(ctx context.Context, id string, now time.Time) bool {
+			return store.HasBlockingHumanWait(ctx, s.store, id, now)
+		}),
 		alert.WithBaseURL(set.BaseURL),
 		alert.WithStallTimeout(set.StallTimeout),
 		alert.WithLogger(s.logger),

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -1089,11 +1089,30 @@ func (s *Service) buildAlertManager(set AlertSettings) *alert.Manager {
 		})
 	}))
 
-	runLookup := func(id string) (string, bool) {
+	// Alert callbacks run outside request contexts. Bootstrap the identity
+	// from the exact run already observed by this internal manager, then
+	// restore its tenant for descendant reads and the persisted health event.
+	loadAlertRun := func(ctx context.Context, id string) (*store.Run, context.Context, error) {
 		if s.store == nil {
-			return "", false
+			return nil, ctx, fmt.Errorf("alert store unavailable")
 		}
-		r, err := s.store.LoadRun(context.Background(), id)
+		systemCtx := store.WithoutTenantFilter(ctx)
+		r, err := s.store.LoadRun(systemCtx, id)
+		if err != nil {
+			return nil, ctx, fmt.Errorf("load alert run %s: %w", id, err)
+		}
+		if r == nil {
+			return nil, ctx, fmt.Errorf("alert run %s is missing", id)
+		}
+		if r.TenantID == "" {
+			ctx = systemCtx // local/legacy runs have no tenant identity
+		}
+		return r, store.WithIdentity(ctx, r.TenantID, r.OwnerID), nil
+	}
+	runLookup := func(id string) (string, bool) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		r, _, err := loadAlertRun(ctx, id)
 		if err != nil || r == nil {
 			return "", false
 		}
@@ -1107,6 +1126,10 @@ func (s *Service) buildAlertManager(set AlertSettings) *alert.Manager {
 		alert.WithSinks(sinks...),
 		alert.WithRunLookup(runLookup),
 		alert.WithHumanWaitLookup(func(ctx context.Context, id string, now time.Time) bool {
+			_, ctx, err := loadAlertRun(ctx, id)
+			if err != nil {
+				return false
+			}
 			return store.HasBlockingHumanWait(ctx, s.store, id, now)
 		}),
 		alert.WithBaseURL(set.BaseURL),
@@ -1122,6 +1145,13 @@ func (s *Service) buildAlertManager(set AlertSettings) *alert.Manager {
 		opts = append(opts, alert.WithStoreSink(func(a alert.Alert) {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
+			_, ctx, err := loadAlertRun(ctx, a.RunID)
+			if err != nil {
+				if s.logger != nil {
+					s.logger.Warn("alert: recover run identity for %s: %v", a.RunID, err)
+				}
+				return
+			}
 			if _, err := s.store.AppendEvent(ctx, a.RunID, store.Event{
 				Type:      store.EventRunHealth,
 				RunID:     a.RunID,

--- a/pkg/store/await_answers_conformance_test.go
+++ b/pkg/store/await_answers_conformance_test.go
@@ -1,0 +1,15 @@
+package store_test
+
+import (
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/store/storetest"
+	"testing"
+)
+
+func TestAwaitAnswersWaitConformance(t *testing.T) {
+	s, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	storetest.RunAwaitAnswersWaitConformance(t, s)
+}

--- a/pkg/store/await_answers_wait.go
+++ b/pkg/store/await_answers_wait.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// AwaitAnswersWait is an active, bounded sync point, not an outstanding
+// question. Its execution token separates parallel and repeated invocations.
+type AwaitAnswersWait struct {
+	NodeID string    `json:"node_id" bson:"node_id"`
+	Until  time.Time `json:"until" bson:"until"`
+}
+
+// ValidateAwaitAnswersWait keeps execution tokens safe as map keys on every
+// backend. A past expiry is valid data, but it never exempts a run from stalls.
+func ValidateAwaitAnswersWait(token string, wait *AwaitAnswersWait) error {
+	if token == "" || strings.ContainsAny(token, ".$\x00") {
+		return fmt.Errorf("invalid await_answers execution token %q", token)
+	}
+	if wait != nil && (wait.NodeID == "" || wait.Until.IsZero()) {
+		return fmt.Errorf("await_answers wait requires a node and expiry")
+	}
+	return nil
+}
+
+func (s *FilesystemRunStore) SetAwaitAnswersWait(_ context.Context, runID, token string, wait *AwaitAnswersWait) error {
+	if err := ValidateAwaitAnswersWait(token, wait); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, err := s.loadRunRaw(runID)
+	if err != nil {
+		return err
+	}
+	if wait != nil {
+		if run.Status != RunStatusRunning {
+			return fmt.Errorf("cannot park await_answers on run %s in state %s", runID, run.Status)
+		}
+		if run.AwaitAnswersWaits == nil {
+			run.AwaitAnswersWaits = make(map[string]AwaitAnswersWait)
+		}
+		run.AwaitAnswersWaits[token] = *wait
+	} else {
+		delete(run.AwaitAnswersWaits, token)
+	}
+	run.UpdatedAt = time.Now().UTC()
+	return s.writeRun(run)
+}

--- a/pkg/store/human_wait.go
+++ b/pkg/store/human_wait.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// maxParkedProbeRuns bounds the cost of one persisted wait probe. If no proof
+// is found within this budget, stall detection remains armed.
+const maxParkedProbeRuns = 256
+
+// HasBlockingHumanWait reports persisted proof of an active await_answers
+// sync point or a paused subbot descendant. Pending async questions alone
+// never qualify. An expired sync-point marker never qualifies either.
+//
+// It is the stall watchdog's exemption oracle, and it is a PULL from persisted
+// truth rather than a heartbeat the parked code pushes: a parent blocked in
+// runview.AwaitSubbotTerminal emits no event and books no work, so any signal
+// it produced itself would either be invisible to the dispatcher or would have
+// to fake node progress on the run's timeline. What it does leave behind is
+// exact — the child id under SubbotChildren (written before the child engine
+// runs) and the child's own paused status — so the watchdog reads that instead.
+//
+// Answering a paused descendant or leaving the sync point removes its proof.
+// Sync-point proof also expires at the node's mandatory timeout, so a crashed
+// worker cannot leave an indefinite exemption. Both the dispatcher and alert
+// manager use this predicate; no synthetic progress event is needed.
+//
+// Fails CLOSED. An unreadable record, a pruned child, a cycle in a corrupt
+// SubbotChildren map, or a probe past its budget all read as "not parked": no
+// information is not a licence to disarm the watchdog.
+func HasBlockingHumanWait(ctx context.Context, rs RunStore, runID string, now time.Time) bool {
+	if rs == nil || runID == "" {
+		return false
+	}
+	// Breadth-first over SubbotChildren, one store read per run. `seen` is what
+	// guarantees termination on a corrupt map that points back at an ancestor;
+	// the budget only bounds cost.
+	seen := map[string]bool{runID: true}
+	frontier := []string{runID}
+	budget := maxParkedProbeRuns
+	// The ROOT's own pause is deliberately NOT an exemption: a run that pauses
+	// itself returns from the engine, and finishRun's pause arm parks the card
+	// and frees the slot. Only a descendant keeps a parent silent while the
+	// parent is still `running`.
+	root := true
+
+	for len(frontier) > 0 && budget > 0 {
+		var next []string
+		for _, id := range frontier {
+			if budget <= 0 {
+				break
+			}
+			run, err := rs.LoadRun(ctx, id)
+			budget--
+			if err != nil || run == nil {
+				continue
+			}
+			// The sync point itself (including a root) may wait silently, but
+			// merely having async questions outstanding is never evidence.
+			if run.Status == RunStatusRunning {
+				for _, wait := range run.AwaitAnswersWaits {
+					if wait.NodeID != "" && !wait.Until.IsZero() && now.Before(wait.Until) {
+						return true
+					}
+				}
+			}
+			if run.Status.IsTerminal() {
+				continue
+			}
+			if !root {
+				// IsPaused is the same predicate finishRun's pause arm reads,
+				// so "what parks a card" and "what exempts a parent" cannot
+				// drift apart.
+				if run.Status.IsPaused() {
+					return true
+				}
+			}
+			for _, childID := range run.SubbotChildren {
+				if childID == "" || seen[childID] {
+					continue
+				}
+				seen[childID] = true
+				next = append(next, childID)
+			}
+		}
+		frontier = next
+		root = false
+	}
+	return false
+}

--- a/pkg/store/human_wait_test.go
+++ b/pkg/store/human_wait_test.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type unreadableHumanWaitStore struct {
+	RunStore
+	unreadable string
+}
+
+func (s unreadableHumanWaitStore) LoadRun(ctx context.Context, id string) (*Run, error) {
+	if id == s.unreadable {
+		return nil, errors.New("unreadable run")
+	}
+	return s.RunStore.LoadRun(ctx, id)
+}
+
+func TestHasBlockingHumanWait(t *testing.T) {
+	for _, mode := range []string{"pending-question", "root-wait", "expired-wait", "paused-child", "paused-grandchild", "terminal-child", "terminal-root", "cycle", "unreadable", "invalid-marker"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			s := newTestStore(t)
+			now := time.Now()
+			for _, id := range []string{"root", "child", "grandchild"} {
+				if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+					t.Fatal(err)
+				}
+			}
+			link := func(parent, key, child string) {
+				t.Helper()
+				if err := s.SetSubbotChild(ctx, parent, key, child); err != nil {
+					t.Fatal(err)
+				}
+			}
+			state := func(id string, status RunStatus) {
+				t.Helper()
+				if err := s.UpdateRunStatus(ctx, id, status, ""); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var reader RunStore = s
+			want := false
+			switch mode {
+			case "pending-question":
+				if err := s.WriteInteraction(ctx, &Interaction{ID: "q", RunID: "root", NodeID: "agent", Kind: InteractionKindAsync, RequestedAt: now}); err != nil {
+					t.Fatal(err)
+				}
+			case "root-wait", "expired-wait":
+				until := now.Add(time.Minute)
+				want = true
+				if mode == "expired-wait" {
+					until = now
+					want = false
+				}
+				if err := s.SetAwaitAnswersWait(ctx, "root", "execution", &AwaitAnswersWait{NodeID: "sync", Until: until}); err != nil {
+					t.Fatal(err)
+				}
+			case "paused-child", "terminal-root", "unreadable":
+				link("root", "subbot", "child")
+				state("child", RunStatusPausedWaitingHuman)
+				want = mode == "paused-child"
+				if mode == "terminal-root" {
+					state("root", RunStatusFinished)
+				}
+				if mode == "unreadable" {
+					reader = unreadableHumanWaitStore{s, "child"}
+				}
+			case "paused-grandchild", "terminal-child":
+				link("root", "subbot", "child")
+				link("child", "subbot", "grandchild")
+				state("grandchild", RunStatusPausedWaitingHuman)
+				want = mode == "paused-grandchild"
+				if mode == "terminal-child" {
+					state("child", RunStatusFinished)
+				}
+			case "cycle":
+				link("root", "subbot", "child")
+				link("child", "back", "root")
+			case "invalid-marker":
+				r, err := s.LoadRun(ctx, "root")
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.AwaitAnswersWaits = map[string]AwaitAnswersWait{"broken": {Until: now.Add(time.Hour)}}
+				if err := s.SaveRun(ctx, r); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := HasBlockingHumanWait(ctx, reader, "root", now); got != want {
+				t.Fatalf("waiting=%v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -167,6 +167,12 @@ type RunStore interface {
 	AddWatchedIssues(ctx context.Context, runID string, issueIDs []string) ([]string, error)
 	RemoveWatchedIssues(ctx context.Context, runID string, issueIDs []string) ([]string, error)
 
+	// SetAwaitAnswersWait records one active await_answers invocation. The
+	// token isolates parallel/repeated invocations. Nil removes only that
+	// token; additions require a running run. Both forms are granular writes
+	// and fence stale SaveRun copies through the run version.
+	SetAwaitAnswersWait(ctx context.Context, runID, token string, wait *AwaitAnswersWait) error
+
 	// Subbot re-attach map (subbot restart-safety). SetSubbotChild records
 	// childRunID under key in the parent run's SubbotChildren map;
 	// ClearSubbotChild removes it. Both are atomic per-key writes so

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -254,6 +254,7 @@ func markLogicalDescendants(n ast.Node, marked map[ast.Node]bool) {
 // reason here.
 var negativeSpaceAllowlist = map[string]allowEntry{
 	// -- pkg/store: transition machinery + harnesses.
+	"pkg/store/storetest/await_answers_wait.go :: Cancelled+Failed+Queued":                                                             {[]string{"RunAwaitAnswersWaitConformance"}, "test-only transition fixtures exercise distinct mutation APIs clearing wait proof, not a production status-classification set"},
 	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {[]string{"applyStatusTransitionOutcome"}, "FinishedAt-stamping side-effect switch (renamed by the outcome-bookkeeping merge)"},
 	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {[]string{"applyStatusTransitionOutcome"}, "FinishedAt-clear pair (resume paths un-freeze the duration ticker)"},
 	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {[]string{"ListNotifiableRuns", "SaveRun"}, "the notifiable-sweep terminal $in + SaveRun's terminal-arrival episode increment (a bson filter/pipeline cannot call a predicate; both are IsTerminal's set — the transition choke point itself now derives via predicates in statusTransitionSet)"},

--- a/pkg/store/mongo/await_answers_wait.go
+++ b/pkg/store/mongo/await_answers_wait.go
@@ -1,0 +1,34 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func (s *Store) SetAwaitAnswersWait(ctx context.Context, runID, token string, wait *store.AwaitAnswersWait) error {
+	if err := store.ValidateAwaitAnswersWait(token, wait); err != nil {
+		return err
+	}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": runID}))
+	set := bson.M{"updated_at": time.Now().UTC()}
+	update := bson.M{"$set": set}
+	key := "await_answers_waits." + token
+	if wait != nil {
+		filter["status"] = store.RunStatusRunning
+		set[key] = *wait
+	} else {
+		update["$unset"] = bson.M{key: ""}
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, versionRunUpdate(update))
+	if err != nil {
+		return fmt.Errorf("store/mongo: update await_answers wait: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return fmt.Errorf("store/mongo: run %s missing or no longer running", runID)
+	}
+	return nil
+}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -217,6 +217,9 @@ func notDeleted(filter bson.M) bson.M {
 // SaveRun replaces the run document atomically. Tenant-scoped
 // callers can only overwrite documents belonging to their tenant.
 func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
+	if r.Status != store.RunStatusRunning {
+		r.AwaitAnswersWaits = nil
+	}
 	if err := s.guardNotDeleted(ctx, r.ID); err != nil {
 		return err
 	}
@@ -965,6 +968,11 @@ func statusTransitionSet(status store.RunStatus, runErr string, meta store.RunOu
 		"updated_at": now,
 		"version":    bson.M{"$add": bson.A{bson.M{"$ifNull": bson.A{"$version", 0}}, 1}},
 	}
+	if status == store.RunStatusRunning {
+		set["await_answers_waits"] = bson.M{"$cond": bson.A{statusChanged, "$$REMOVE", bson.M{"$ifNull": bson.A{"$await_answers_waits", "$$REMOVE"}}}}
+	} else {
+		set["await_answers_waits"] = "$$REMOVE"
+	}
 	// The error message: a transition always states its own (empty
 	// included); a same-status rewrite that states nothing keeps the
 	// transition's message — the runner's continuation promote must not
@@ -1343,7 +1351,7 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 		// platform continuation statement — same discipline as
 		// statusTransitionSet, which this checkpoint-coupled write
 		// bypasses.
-		"$unset": bson.M{"finished_at": "", "failure_code": "", "continuation_state": ""},
+		"$unset": bson.M{"finished_at": "", "failure_code": "", "continuation_state": "", "await_answers_waits": ""},
 	}
 	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), update,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: pause %s", id))

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -496,9 +496,14 @@ type Run struct {
 	// losing the answered child's work. Empty for parents with no subbot
 	// nodes and for runs that predate this field. Set only on the parent.
 	SubbotChildren map[string]string `json:"subbot_children,omitempty" bson:"subbot_children,omitempty"`
-	WorkflowName   string            `json:"workflow_name" bson:"workflow_name"`
-	WorkflowHash   string            `json:"workflow_hash,omitempty" bson:"workflow_hash,omitempty"` // SHA-256 of the .bot source at run start
-	FilePath       string            `json:"file_path,omitempty" bson:"file_path,omitempty"`         // absolute .bot source path captured at launch (resume without re-supplying file)
+
+	// AwaitAnswersWaits contains only nodes currently parked at await_answers.
+	// Expiry bounds stale markers; a state transition ends their execution.
+	AwaitAnswersWaits map[string]AwaitAnswersWait `json:"await_answers_waits,omitempty" bson:"await_answers_waits,omitempty"`
+
+	WorkflowName string `json:"workflow_name" bson:"workflow_name"`
+	WorkflowHash string `json:"workflow_hash,omitempty" bson:"workflow_hash,omitempty"` // SHA-256 of the .bot source at run start
+	FilePath     string `json:"file_path,omitempty" bson:"file_path,omitempty"`         // absolute .bot source path captured at launch (resume without re-supplying file)
 	// WorkflowSource is the .bot text as it was AT LAUNCH. WorkflowHash
 	// answers "did the source change since?"; this answers "which node
 	// changed", which is what `iterion rewind --auto` needs to target the

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -137,6 +137,9 @@ func (s *FilesystemRunStore) CreateQueuedRun(_ context.Context, id, workflowName
 // finalize path concurrent with an engine status update, would
 // otherwise read-modify-write through each other and lose fields.
 func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
+	if r.Status != RunStatusRunning {
+		r.AwaitAnswersWaits = nil
+	}
 	if err := s.guardNotDeleted(r.ID); err != nil {
 		return err
 	}
@@ -630,6 +633,9 @@ func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, run
 func (s *FilesystemRunStore) applyStatusTransitionOutcome(r *Run, status RunStatus, runErr string, meta RunOutcomeMeta) error {
 	terminal := status.IsFinalSuccess() || status.IsFinalFailure() || status.IsTerminalResumable()
 	transition := r.Status != status
+	if transition || status != RunStatusRunning {
+		r.AwaitAnswersWaits = nil
+	}
 	if terminal && transition {
 		r.OutcomeSeq++
 	}
@@ -768,6 +774,7 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 	}
 	r.Checkpoint = cp
 	r.Status = RunStatusPausedWaitingHuman
+	r.AwaitAnswersWaits = nil
 	// A paused run has no platform continuation statement — same
 	// discipline as FailureCode below.
 	r.ContinuationState = ""

--- a/pkg/store/storetest/await_answers_wait.go
+++ b/pkg/store/storetest/await_answers_wait.go
@@ -1,0 +1,116 @@
+package storetest
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// RunAwaitAnswersWaitConformance is shared by the filesystem and Mongo suites.
+func RunAwaitAnswersWaitConformance(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	const id = "await-wait-conformance"
+	if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	// Mongo creates queued runs; the engine must own the execution first.
+	if err := s.UpdateRunStatus(ctx, id, store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	wait := store.AwaitAnswersWait{NodeID: "sync", Until: time.Now().UTC().Add(time.Hour).Truncate(time.Millisecond)}
+	stale, err := s.LoadRun(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := make(chan error, 2)
+	for _, token := range []string{"branch-a", "branch-b"} {
+		go func() { results <- s.SetAwaitAnswersWait(ctx, id, token, &wait) }()
+	}
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatal(err)
+		}
+	}
+	read := func(t *testing.T) *store.Run {
+		t.Helper()
+		r, err := s.LoadRun(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+	if got := read(t); len(got.AwaitAnswersWaits) != 2 {
+		t.Fatalf("concurrent waits clobbered: %+v", got.AwaitAnswersWaits)
+	}
+	if err := s.SaveRun(ctx, stale); !errors.Is(err, store.ErrRunConflict) {
+		t.Fatalf("stale save could erase wait proof: %v", err)
+	}
+	if err := s.SetAwaitAnswersWait(ctx, id, "branch-a", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := read(t); len(got.AwaitAnswersWaits) != 1 || got.AwaitAnswersWaits["branch-b"].NodeID != "sync" {
+		t.Fatalf("clearing one invocation removed its sibling: %+v", got.AwaitAnswersWaits)
+	}
+	if !store.HasBlockingHumanWait(ctx, s, id, time.Now()) {
+		t.Fatal("live wait not observed")
+	}
+	if store.HasBlockingHumanWait(ctx, s, id, wait.Until) {
+		t.Fatal("expired proof disarmed the watchdog")
+	}
+	for _, token := range []string{"", "bad.key", "$bad", "bad\x00key"} {
+		if err := s.SetAwaitAnswersWait(ctx, id, token, &wait); err == nil {
+			t.Fatalf("accepted unsafe token %q", token)
+		}
+	}
+	if err := s.SetAwaitAnswersWait(ctx, "missing", "token", &wait); err == nil {
+		t.Fatal("marked a missing run")
+	}
+
+	transitions := map[string]func(*testing.T) error{
+		"pause":  func(*testing.T) error { return s.PauseRun(ctx, id, &store.Checkpoint{NodeID: "gate"}) },
+		"cancel": func(*testing.T) error { return s.UpdateRunStatus(ctx, id, store.RunStatusCancelled, "cancelled") },
+		"failure": func(*testing.T) error {
+			return s.FailRunResumable(ctx, id, &store.Checkpoint{NodeID: "sync"}, "failed", store.FailureExecutionFailed)
+		},
+		"save-queued": func(t *testing.T) error { r := read(t); r.Status = store.RunStatusQueued; return s.SaveRun(ctx, r) },
+	}
+	for name, transition := range transitions {
+		t.Run(name, func(t *testing.T) {
+			if err := s.UpdateRunStatus(ctx, id, store.RunStatusRunning, ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.SetAwaitAnswersWait(ctx, id, "active", &wait); err != nil {
+				t.Fatal(err)
+			}
+			if err := transition(t); err != nil {
+				t.Fatal(err)
+			}
+			if got := read(t); len(got.AwaitAnswersWaits) != 0 {
+				t.Fatalf("wait outlived its execution: %+v", got.AwaitAnswersWaits)
+			}
+			if err := s.SetAwaitAnswersWait(ctx, id, "late-writer", &wait); err == nil {
+				t.Fatal("late writer parked a non-running run")
+			}
+			if err := s.SetAwaitAnswersWait(ctx, id, "active", nil); err != nil {
+				t.Fatalf("cleanup after terminal: %v", err)
+			}
+			if err := s.UpdateRunStatus(ctx, id, store.RunStatusRunning, ""); err != nil {
+				t.Fatal(err)
+			}
+			if store.HasBlockingHumanWait(ctx, s, id, time.Now()) {
+				t.Fatal("old marker exempted a new execution")
+			}
+		})
+	}
+	if err := s.DeleteRun(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	for _, w := range []*store.AwaitAnswersWait{&wait, nil} {
+		if err := s.SetAwaitAnswersWait(ctx, id, "late", w); err == nil {
+			t.Fatal("wait write resurrected a deleted run")
+		}
+	}
+}

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -80,6 +80,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("CapabilitiesReported", func(t *testing.T) { testCapabilitiesReported(t, factory(t)) })
 	t.Run("UserMessagesInbox", func(t *testing.T) { testUserMessagesInbox(t, factory(t)) })
 	t.Run("WatchedIssues", func(t *testing.T) { testWatchedIssues(t, factory(t)) })
+	t.Run("AwaitAnswersWaits", func(t *testing.T) { RunAwaitAnswersWaitConformance(t, factory(t)) })
 	t.Run("SubbotChildren", func(t *testing.T) { testSubbotChildren(t, factory(t)) })
 	t.Run("NodesServed", func(t *testing.T) { testNodesServed(t, factory(t)) })
 	t.Run("ReverseTreeQueries", func(t *testing.T) { testReverseTreeQueries(t, factory(t)) })


### PR DESCRIPTION
`await_answers` stays running while it waits for a human, so silence could trigger the dispatcher watchdog. A parent waiting on a paused subbot was already spared by the dispatcher but still produced a false runview stall alert.

Persist an explicit, expiring marker only while the runtime is parked at the sync point, with independent tokens for parallel invocations. FS and Mongo clear execution-local markers on state transitions and fence stale writes. Both observers now consult the same bounded persisted-state lookup; unanswered async questions alone never exempt a working or wedged agent. Human-wait lookups run outside the event mutex and revalidate progress before notifying. Internal alert callbacks recover the run tenant before probing descendants or persisting health events; a foreign paused child cannot exempt the root.

Validation:
- Both original failures reproduced before implementation, plus the missing-tenant alert callback reproduced before its fix.
- Answer/cancel/timeout, persistence failures, token concurrency, lifecycle cleanup and real runview wiring pass under the race detector; existing await_answers E2E workflows pass under race.
- Full Mongo conformance passes on an isolated Mongo 8.3 replica set (including the new wait contract).
- Oracle forced always-true makes real-stall assertions fail; forced always-false makes legitimate-wait assertions fail. Go overlays keep these canaries out of the source tree.
- Full `task check` passes.

The lookup fails closed without proof and never synthesizes progress events. A failed cleanup stops the node even after answers were collected, so stale proof cannot hide a stall in subsequent work. Answers remain durable and recoverable on retry; the marker also expires at the node timeout. Details and lifecycle contract: `docs/stall-human-waits.md`.

Closes #933.
