### PR TITLE
fix(sandbox): a custom workdir over an oversized recipe streams the script, not a wrapper that re-embeds it

### DIFF
--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -944,7 +944,7 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 	// `<shell> -s` reads EOF, runs nothing, and exits 0. A size failure
 	// would then present as a SUCCESSFUL empty run instead of a loud,
 	// retryable E2BIG.
-	streamPayload := resolveStreamPayload(cmd, wrapped, customWorkDir, opts)
+	streamPayload, streamShell := resolveStreamPayload(cmd, wrapped, customWorkDir, opts, opts.WorkDir, opts.Env)
 
 	args := []string{"--namespace", r.namespace, "exec"}
 	if opts.Stdin != nil || opts.KeepStdinOpen || streamPayload != "" {
@@ -959,18 +959,21 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 		// semantics and exit codes).
 		args = appendEnvPrefix(args, opts.Env)
 		if streamPayload != "" {
-			// `<shell> -s` reads the script from stdin. cmd[0] is "sh"
-			// or "bash" (guaranteed by the predicate), so a bash recipe
-			// keeps bash semantics. The env prefix still precedes it and
-			// applies to the shell that reads the script.
-			args = append(args, cmd[0], "-s")
+			// `<shell> -s` reads the script from stdin. streamShell is
+			// the recipe's own shell, so a bash recipe keeps bash
+			// semantics. The env prefix still precedes it and applies to
+			// the shell that reads the script.
+			args = append(args, streamShell, "-s")
 		} else {
 			args = append(args, cmd...)
 		}
 	case streamPayload != "":
-		// The wrapper is the whole script; `sh -s` reads it from stdin
-		// and it still exec's cmd[0] itself, so a bash recipe keeps bash.
-		args = append(args, "sh", "-s")
+		// The payload is the whole script; `<shell> -s` reads it from
+		// stdin. streamShell is the recipe's own shell when the payload
+		// IS the recipe (chdir + exports + script inline, nothing left on
+		// argv), and plain `sh` when it is a wrapper that still exec's
+		// cmd[0] itself — either way the recipe keeps its shell.
+		args = append(args, streamShell, "-s")
 	default:
 		args = append(args, "sh", "-c", wrapped)
 	}
@@ -998,20 +1001,42 @@ func (r *Run) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) 
 //     one ending in `exec <prog>` runs identically under `sh -s` and
 //     `sh -c`.
 //
+// A custom workdir over an oversized `<shell> -c <script>` is the two
+// crossings AT ONCE, and streaming the wrapper alone would not fix it:
+// the wrapper ends in `exec <shell> -c '<script>'`, so the in-pod shell
+// re-issues the very execve the host just avoided, and MAX_ARG_STRLEN
+// applies there too — E2BIG relocated into the pod, for precisely the
+// shape this streaming exists to serve. That case therefore gets a
+// payload built by [buildShellChdirScript], which cds and then lets the
+// shell READ the script instead of passing it as an argument.
+//
+// The returned shell is the one to invoke as `<shell> -s`: the recipe's
+// own (so a bash recipe keeps bash semantics) when the payload is a
+// script, plain `sh` when it is a wrapper ending in `exec`.
+//
 // Both crossings refuse to touch a caller that owns stdin: an attached
 // reader (opts.Stdin) is never clobbered, and a caller that asked to
 // KEEP stdin open — pi_rpc, claw_backend and claude_code session mode
 // all wire cmd.StdinPipe() afterwards — must not have it commandeered,
 // which would fail their pipe with "exec: Stdin already set". Those
 // keep the argv path and its loud, retryable E2BIG.
-func resolveStreamPayload(cmd []string, wrapped string, customWorkDir bool, opts sandbox.ExecOpts) string {
+func resolveStreamPayload(cmd []string, wrapped string, customWorkDir bool, opts sandbox.ExecOpts, workDir string, env map[string]string) (string, string) {
 	if !customWorkDir {
-		return sandbox.ShouldStreamScriptViaStdin(cmd, opts)
+		if script := sandbox.ShouldStreamScriptViaStdin(cmd, opts); script != "" {
+			return script, cmd[0]
+		}
+		return "", ""
 	}
-	if opts.Stdin != nil || opts.KeepStdinOpen || len(wrapped) <= sandbox.MaxInlineArgBytes {
-		return ""
+	if opts.Stdin != nil || opts.KeepStdinOpen {
+		return "", ""
 	}
-	return wrapped
+	if script := sandbox.ShouldStreamScriptViaStdin(cmd, opts); script != "" {
+		return buildShellChdirScript(workDir, env, script), cmd[0]
+	}
+	if len(wrapped) <= sandbox.MaxInlineArgBytes {
+		return "", ""
+	}
+	return wrapped, "sh"
 }
 
 // cmdContext finalises the *exec.Cmd: ctx, args, stdin pipe, pgid.

--- a/pkg/sandbox/kubernetes/exec_stdin_test.go
+++ b/pkg/sandbox/kubernetes/exec_stdin_test.go
@@ -108,33 +108,45 @@ func TestCommand_SmallScriptKeepsArgvPath(t *testing.T) {
 	}
 }
 
-// The custom-workdir path wraps the recipe in `cd <dir> && exec …`, so
-// the wrapper is at least as large as the recipe it embeds: it has to
-// take the same route, or the fix would only cover half the callers.
-func TestCommand_OversizedScriptWithCustomWorkDirStreamsToo(t *testing.T) {
+// A custom workdir over an oversized recipe is BOTH crossings at once.
+// Streaming the `cd … && exec bash -c '<script>'` wrapper would only
+// move the problem: the in-pod shell re-issues that execve, and the
+// kernel's per-argument cap applies there too. So the payload must
+// carry the script for the shell to READ, with nothing oversized left
+// on any argv — the host's or the pod's.
+func TestCommand_OversizedScriptWithCustomWorkDirStreamsTheScriptItself(t *testing.T) {
 	r := testRun()
 	big := strings.Repeat("y", sandbox.MaxInlineArgBytes+1)
 
-	cmd := r.Command(context.Background(), []string{"bash", "-c", big}, sandbox.ExecOpts{WorkDir: "/elsewhere"})
+	cmd := r.Command(context.Background(), []string{"bash", "-c", big},
+		sandbox.ExecOpts{WorkDir: "/elsewhere", Env: map[string]string{"FOO": "bar baz"}})
 
 	assertStdinAnnounced(t, cmd)
-	if !argvHas(cmd.Args, "--stdin") {
-		t.Errorf("kubectl needs --stdin to forward the streamed wrapper; args=%v", cmd.Args)
-	}
 	for _, a := range cmd.Args {
 		if strings.Contains(a, big) {
-			t.Fatalf("oversized wrapper leaked into argv (E2BIG risk); arg len=%d", len(a))
+			t.Fatalf("oversized script leaked into host argv (E2BIG risk); arg len=%d", len(a))
 		}
 	}
-	if n := len(cmd.Args); n < 2 || cmd.Args[n-2] != "sh" || cmd.Args[n-1] != "-s" {
-		t.Fatalf("argv must terminate with `sh -s`; got tail %v", cmd.Args[max(0, len(cmd.Args)-4):])
+	// The recipe's own shell reads it, so bash stays bash.
+	if n := len(cmd.Args); n < 2 || cmd.Args[n-2] != "bash" || cmd.Args[n-1] != "-s" {
+		t.Fatalf("argv must terminate with `bash -s`; got tail %v", cmd.Args[max(0, len(cmd.Args)-4):])
 	}
+
 	got := readStdin(t, cmd.Stdin)
 	if !strings.Contains(got, "/elsewhere") {
-		t.Errorf("streamed wrapper must still cd into the requested workdir; got %.120q", got)
+		t.Errorf("payload must cd into the requested workdir; got %.120q", got)
 	}
 	if !strings.Contains(got, big) {
-		t.Error("streamed wrapper must still carry the recipe")
+		t.Error("payload must carry the recipe")
+	}
+	if !strings.Contains(got, "export 'FOO=bar baz'") {
+		t.Errorf("per-call env must survive as an export line; got %.200q", got)
+	}
+	// The regression itself: the payload must not hand the script to a
+	// nested shell as an argument, which is the execve the pod would
+	// then fail on.
+	if strings.Contains(got, "exec bash -c") || strings.Contains(got, "bash -c '") {
+		t.Errorf("payload re-embeds the script as an argv element — E2BIG merely relocated into the pod; got %.200q", got)
 	}
 }
 

--- a/pkg/sandbox/kubernetes/strings.go
+++ b/pkg/sandbox/kubernetes/strings.go
@@ -89,6 +89,28 @@ func appendEnvPrefix(args []string, env map[string]string) []string {
 // Each argv element is single-quoted with embedded ' escaped per
 // POSIX rules. We don't use Go's strconv because shell quoting
 // follows different rules.
+
+func buildShellChdirExec(dir string, argv []string, env map[string]string) string {
+	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellquote.Quote(dir))
+	b.WriteString(" && exec ")
+	if len(env) > 0 {
+		b.WriteString("env ")
+		for _, k := range slices.Sorted(maps.Keys(env)) {
+			b.WriteString(shellquote.Quote(k + "=" + env[k]))
+			b.WriteByte(' ')
+		}
+	}
+	for i, a := range argv {
+		if i > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(shellquote.Quote(a))
+	}
+	return b.String()
+}
+
 // buildShellChdirScript renders a chdir + env + INLINE script payload for
 // a shell reading it on stdin (`<shell> -s`). Unlike
 // [buildShellChdirExec] it never puts the script back on an argv
@@ -110,26 +132,5 @@ func buildShellChdirScript(dir string, env map[string]string, script string) str
 		b.WriteByte('\n')
 	}
 	b.WriteString(script)
-	return b.String()
-}
-
-func buildShellChdirExec(dir string, argv []string, env map[string]string) string {
-	var b strings.Builder
-	b.WriteString("cd ")
-	b.WriteString(shellquote.Quote(dir))
-	b.WriteString(" && exec ")
-	if len(env) > 0 {
-		b.WriteString("env ")
-		for _, k := range slices.Sorted(maps.Keys(env)) {
-			b.WriteString(shellquote.Quote(k + "=" + env[k]))
-			b.WriteByte(' ')
-		}
-	}
-	for i, a := range argv {
-		if i > 0 {
-			b.WriteByte(' ')
-		}
-		b.WriteString(shellquote.Quote(a))
-	}
 	return b.String()
 }

--- a/pkg/sandbox/kubernetes/strings.go
+++ b/pkg/sandbox/kubernetes/strings.go
@@ -121,6 +121,14 @@ func buildShellChdirExec(dir string, argv []string, env map[string]string) strin
 // because there is no command to prefix: the script runs in the shell
 // that read it. `cd` failing aborts instead of running the script in the
 // wrong directory.
+//
+// Quoting, stated because it differs from [buildShellChdirExec]: `dir`
+// and each `K=V` pair are shell-quoted, but `script` is written RAW and
+// unquoted — it IS shell source, and quoting it would stop it being
+// executable. So this builder gives the script no isolation whatsoever
+// from the surrounding payload, by design; the caller's script is trusted
+// exactly as much as it was when it arrived as `<shell> -c <script>`,
+// which is where every caller of this path gets it from.
 func buildShellChdirScript(dir string, env map[string]string, script string) string {
 	var b strings.Builder
 	b.WriteString("cd ")

--- a/pkg/sandbox/kubernetes/strings.go
+++ b/pkg/sandbox/kubernetes/strings.go
@@ -89,6 +89,30 @@ func appendEnvPrefix(args []string, env map[string]string) []string {
 // Each argv element is single-quoted with embedded ' escaped per
 // POSIX rules. We don't use Go's strconv because shell quoting
 // follows different rules.
+// buildShellChdirScript renders a chdir + env + INLINE script payload for
+// a shell reading it on stdin (`<shell> -s`). Unlike
+// [buildShellChdirExec] it never puts the script back on an argv
+// element, so nothing in the payload is subject to the kernel's
+// per-argument cap — the point of streaming it in the first place.
+//
+// Env arrives as `export` lines rather than an `env K=V ...` prefix
+// because there is no command to prefix: the script runs in the shell
+// that read it. `cd` failing aborts instead of running the script in the
+// wrong directory.
+func buildShellChdirScript(dir string, env map[string]string, script string) string {
+	var b strings.Builder
+	b.WriteString("cd ")
+	b.WriteString(shellquote.Quote(dir))
+	b.WriteString(" || exit 1\n")
+	for _, k := range slices.Sorted(maps.Keys(env)) {
+		b.WriteString("export ")
+		b.WriteString(shellquote.Quote(k + "=" + env[k]))
+		b.WriteByte('\n')
+	}
+	b.WriteString(script)
+	return b.String()
+}
+
 func buildShellChdirExec(dir string, argv []string, env map[string]string) string {
 	var b strings.Builder
 	b.WriteString("cd ")


### PR DESCRIPTION
## Summary

Follow-up to #937, addressing its remaining review finding **R6a7f93**. Stacked on `fix/k8s-exec-stdin-streaming` because that branch is in the merge queue and cannot be updated; this retargets to `main` when it lands.

#937 streams an oversized recipe through stdin so it never occupies a single argv element. On the **custom-workdir** path it streamed the wrapper:

```
cd '<dir>' && exec bash -c '<script>'
```

That keeps the script off the *host* argv, but the in-pod shell then re-issues `execve("bash", ["bash", "-c", "<script>"])` — and `MAX_ARG_STRLEN` applies to that exec too. E2BIG was relocated into the pod, not removed, for precisely the shape the streaming exists to serve.

## Reachability

Latent today, and worth stating rather than implying. The measured 140 516-byte case is the tool node, which runs `bash -c <recipe>` with `sandbox.ExecOpts{Env: env}` and **no** `WorkDir` (`pkg/backend/model/executor_tool.go:635`) — so it takes the default-workdir arm, which #937 already handles correctly. No current caller combines a custom `WorkDir` with an oversized `<shell> -c <script>`; `claude_code.go:249,1250` set `WorkDir: cwd` but do not put a prompt on argv. So this closes a correctness hole nothing exercises yet, which is also why it is a follow-up rather than a reason to dequeue #937.

## What changed

A custom workdir over an oversized recipe is both crossings at once, so it gets its own payload. `buildShellChdirScript` cds, exports the per-call env as `export` lines (there is no command left to prefix with `env`), and appends the script for the shell to **read**:

```
cd '/elsewhere' || exit 1
export 'FOO=bar baz'
<script>
```

Nothing oversized remains on any argv — the host's or the pod's. The shell to invoke as `-s` is now derived from the same call that decides the payload: the recipe's own shell when the payload *is* the recipe (so a bash recipe keeps bash), plain `sh` when it is a wrapper that still ends in `exec <prog>`.

The non-shell shape is deliberately unchanged: `prog --flag <60KB> --flag <60KB>` crosses the cap only in aggregate, no single element does, and streaming its wrapper genuinely removes the problem.

## Test

The custom-workdir case now asserts the **guarantee** rather than the site — that was the flaw in #937's version of this test, which used `[bash,-c,<big>]`, an input shape where both conditions coincide, and so could not see the divergence. It now checks: no oversized argv anywhere; argv ends in `bash -s`, not `sh -s`, so the recipe keeps its shell; the workdir and env survive as `cd` + `export 'FOO=bar baz'`; and the payload must **not** contain a nested `bash -c '<script>'`.

It fails on the pre-fix driver (argv tail `sh -s`). `go test ./pkg/sandbox/... ./pkg/runtime/...` green, `go vet ./...` and `golangci-lint run pkg/sandbox/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
