### PR TITLE
fix(server): the reads that DESCRIBE a bot resolve the tier that runs it

### DIFF
--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -59,16 +59,43 @@ is CLI-first.
   because a board card, an agent's `set_bot` and a hand-written
   subscription all carry operator-typed names. A slug may legitimately be
   stored with `_` too, so the team tier compares both sides normalized.
-- **A metadata read must match the tier that will SERVE the launch**, or
-  the two disagree in silence — a fork that renames a `consumes:` var
-  gets an empty seed, not an error. Wired: the webhook hand-off seeds,
-  the gate-var defaults and the retry-policy manifest all read the team
-  row first (`effectiveFindByNameForTeam` / `botManifestFor`, both over
-  the same row resolution the launch uses). Still tenant-free, and
-  therefore still able to describe a bundle it will not run: the /bots
-  listing, the command-routing discovery, the config-share surface, and
-  the hand-off PRODUCER set (a deployment-wide question a per-team read
-  cannot answer). Tracked as **#946**.
+- **A metadata read matches the tier that will SERVE the launch**, or the
+  two disagree in silence — a fork that renames a `consumes:` var gets an
+  empty seed, a fork that renames its `/command` stamps the operator's
+  text under a var the running bundle never declared, and neither is an
+  error. Which tenant a lane passes depends on what it describes:
+  - **a delivery about to launch** reads the launching team's tier —
+    the webhook hand-off seeds, the gate-var defaults, the retry policy,
+    the command-routing discovery and the labeled-issue route, the
+    converse-bot existence probe, the config-share surface, the bot
+    home's "enable this trigger", and the forge auto-provisioning
+    lookups (which build the webhook's `CommandMap` and its event
+    subscription). The forms are `effectiveEntriesForTeam` /
+    `effectiveFindByNameForTeam` / `botManifestFor` / `botExistsForTeam`
+    / `entryOriginFor`, all over the same row resolution the launch uses,
+    so an operator-typed spelling reaches both;
+  - **a run that already launched** reads *that run's own*
+    `bot_source_tenant` — the pause-notice role and the hand-off PRODUCER
+    set (`teamBotManifest`). The ambient tenant is the wrong question
+    there: a team's own run may still have been served by the platform or
+    baked tier, and the run records which.
+
+  The two FS-catalog write paths (`PUT /api/v1/bots/{name}` and its
+  `/overlay`) refuse a stored bot with `409` instead of editing the
+  bundle every tenant shares. Deliberately tenant-free: the native
+  board's comment dispatcher (one local store, no tenancy) and the
+  platform + baked floor each team-aware form falls through to. A static
+  sweep (`bot_resolver_sweep_test.go`) fails a new tenant-free metadata
+  read that is not declared with its reason.
+- **Known gap — the pipelines control center.** Its "launch now" action
+  and its ticket-admission check resolve the bot on the platform + baked
+  tiers and launch by *filesystem path* (`entry.MainFile()`) rather than
+  through the tiered resolver, so a stored bundle has no path to launch
+  from: a team's fork of a catalog slug runs its ORIGIN there, and a bot
+  only the team authored cannot be carded at all. Both halves move
+  together — making the check tenant-aware alone would create cards that
+  can never launch — so it belongs with the launch-surface work of #871,
+  not the metadata pass. Tracked as **#970**.
 - **Launch**: the server resolves the override ONCE, materializes it to a
   temp dir, and compiles against it (prompts/ participate in IR and the
   workflow hash). The queue message (schema v9) carries a

--- a/pkg/forge/command_map_test.go
+++ b/pkg/forge/command_map_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func invLookup(m map[string][]bundle.Invocation) BotInvocationsLookup {
-	return func(botID string) ([]bundle.Invocation, error) { return m[botID], nil }
+	return func(_ context.Context, _, botID string) ([]bundle.Invocation, error) { return m[botID], nil }
 }
 
 func cmdInv(name, mode, argsVar, disamb string, aliases ...string) bundle.Invocation {
@@ -26,7 +26,7 @@ func TestBuildCommandMap_SingleBotAndAliases(t *testing.T) {
 	o := &Orchestrator{Invocations: invLookup(map[string][]bundle.Invocation{
 		"feature-dev": {cmdInv("featurly", "board", "feature_prompt", "", "feature-dev")},
 	})}
-	m, err := o.buildCommandMap([]string{"feature-dev"})
+	m, err := o.buildCommandMap(context.Background(), "t1", []string{"feature-dev"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestBuildCommandMap_ArgsDisambiguation(t *testing.T) {
 		"review-pr":     {cmdInv("revi", "direct", "", "when_args_empty")},
 		"revi-converse": {cmdInv("revi", "direct", "converse_question", "when_args_present")},
 	})}
-	m, err := o.buildCommandMap([]string{"review-pr", "revi-converse"})
+	m, err := o.buildCommandMap(context.Background(), "t1", []string{"review-pr", "revi-converse"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestBuildCommandMap_CollisionRejected(t *testing.T) {
 		"bot-a": {cmdInv("dup", "direct", "", "")},
 		"bot-b": {cmdInv("dup", "direct", "", "")},
 	})}
-	_, err := o.buildCommandMap([]string{"bot-a", "bot-b"})
+	_, err := o.buildCommandMap(context.Background(), "t1", []string{"bot-a", "bot-b"})
 	if err == nil {
 		t.Fatal("expected collision error for two bots claiming /dup without disambiguation")
 	}
@@ -71,13 +71,13 @@ func TestBuildCommandMap_NilWhenNoCommands(t *testing.T) {
 	o := &Orchestrator{Invocations: invLookup(map[string][]bundle.Invocation{
 		"review-pr": {{Kind: bundle.InvocationKindForge, Forge: &bundle.InvocationForge{Event: bundle.ForgeEventPullRequest}}},
 	})}
-	m, err := o.buildCommandMap([]string{"review-pr"})
+	m, err := o.buildCommandMap(context.Background(), "t1", []string{"review-pr"})
 	if err != nil || m != nil {
 		t.Errorf("want nil map, got %v (err=%v)", m, err)
 	}
 
 	// No lookup wired at all → nil.
-	if m, _ := (&Orchestrator{}).buildCommandMap([]string{"x"}); m != nil {
+	if m, _ := (&Orchestrator{}).buildCommandMap(context.Background(), "t1", []string{"x"}); m != nil {
 		t.Errorf("nil Invocations should yield nil map, got %v", m)
 	}
 }
@@ -89,7 +89,7 @@ func TestProvision_CommandOnlyBot(t *testing.T) {
 	o, _, sealer := newTestOrch(t)
 	// "no-forge-bot" returns nil from testBotLookup (no forge: block); give it
 	// a command invocation so it becomes forge-reachable.
-	o.Invocations = func(botID string) ([]bundle.Invocation, error) {
+	o.Invocations = func(_ context.Context, _, botID string) ([]bundle.Invocation, error) {
 		if botID == "no-forge-bot" {
 			return []bundle.Invocation{
 				{Kind: bundle.InvocationKindCommand, Mode: bundle.ExecutionBoard, ArgsVar: "feature_prompt",

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -22,15 +22,22 @@ import (
 // BotForgeLookup returns a bot's declared forge requirements (its manifest
 // forge: block). A nil result with a nil error means the bot exists but
 // declares no forge: block — it cannot be auto-provisioned. A non-nil error
-// means the bot could not be resolved. The server wires this to
-// botregistry; tests pass a closure.
-type BotForgeLookup func(botID string) (*bundle.ForgeRequirements, error)
+// means the bot could not be resolved. The server wires this to its bot
+// resolver; tests pass a closure.
+//
+// teamID is the tenant being provisioned FOR: the deliveries this webhook
+// triggers launch on that team's tier, so the requirements are read there
+// too. A team's own bot resolves on no other tier, and a fork's events and
+// scopes are the ones its runs actually need.
+type BotForgeLookup func(ctx context.Context, teamID, botID string) (*bundle.ForgeRequirements, error)
 
 // BotInvocationsLookup returns a bot's manifest invocations (the typed
 // routing contract — bundle.EffectiveInvocations). Used by Provision to build
 // the webhook CommandMap. An empty slice (or a nil lookup) leaves the command
-// index empty. The server wires this to botregistry; tests pass a closure.
-type BotInvocationsLookup func(botID string) ([]bundle.Invocation, error)
+// index empty. Same tenant contract as BotForgeLookup: the provisioned
+// CommandMap must name the commands the launched bundle declares, or a
+// `/command` routes to a bot that does not answer to it.
+type BotInvocationsLookup func(ctx context.Context, teamID, botID string) ([]bundle.Invocation, error)
 
 // Orchestrator turns "enable bot(s) X on repo Y of connection C" into the
 // concrete trio — an iterion webhooks.Config, a forge-side hook, and a
@@ -307,13 +314,13 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 	frByBot := make(map[string]*bundle.ForgeRequirements, len(desiredBots))
 	invByBot := make(map[string][]bundle.Invocation, len(desiredBots))
 	for _, b := range desiredBots {
-		fr, err := o.Bots(b)
+		fr, err := o.Bots(ctx, req.TenantID, b)
 		if err != nil {
 			return ProvisionResult{}, fmt.Errorf("forge: resolve bot %q: %w", b, err)
 		}
 		var invs []bundle.Invocation
 		if o.Invocations != nil {
-			if invs, err = o.Invocations(b); err != nil {
+			if invs, err = o.Invocations(ctx, req.TenantID, b); err != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: resolve invocations for %q: %w", b, err)
 			}
 		}
@@ -482,7 +489,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 
 	// Build the command→bot route index from the co-enabled bots' command
 	// invocations. Rejects an un-disambiguated cross-bot command collision.
-	commandMap, err := o.buildCommandMap(desiredBots)
+	commandMap, err := o.buildCommandMap(ctx, req.TenantID, desiredBots)
 	if err != nil {
 		return ProvisionResult{}, err
 	}
@@ -1452,13 +1459,13 @@ func sortedKeys(set map[string]bool) []string {
 // states (the review-pr vs revi-converse pattern); any other collision is a
 // provision error. Returns nil when no bot declares a command invocation (or
 // the Invocations lookup isn't wired), leaving Config.CommandMap unset.
-func (o *Orchestrator) buildCommandMap(bots []string) (map[string][]webhooks.CommandRoute, error) {
+func (o *Orchestrator) buildCommandMap(ctx context.Context, teamID string, bots []string) (map[string][]webhooks.CommandRoute, error) {
 	if o.Invocations == nil {
 		return nil, nil
 	}
 	out := map[string][]webhooks.CommandRoute{}
 	for _, b := range bots {
-		invs, err := o.Invocations(b)
+		invs, err := o.Invocations(ctx, teamID, b)
 		if err != nil {
 			return nil, fmt.Errorf("forge: resolve invocations for %q: %w", b, err)
 		}

--- a/pkg/forge/orchestrator_test.go
+++ b/pkg/forge/orchestrator_test.go
@@ -81,7 +81,7 @@ func (f *fakeAdmin) ListHooks(_ context.Context, repo string) ([]HookHandle, err
 
 // --- fixtures ---
 
-func testBotLookup(botID string) (*bundle.ForgeRequirements, error) {
+func testBotLookup(_ context.Context, _, botID string) (*bundle.ForgeRequirements, error) {
 	switch botID {
 	case "review-pr":
 		return &bundle.ForgeRequirements{
@@ -657,7 +657,7 @@ func TestSyncSchedules_PreservesOperatorTuning(t *testing.T) {
 	ctx := context.Background()
 	sched := cloudsched.NewMemoryStore()
 	o.Schedules = sched
-	o.Invocations = func(botID string) ([]bundle.Invocation, error) {
+	o.Invocations = func(_ context.Context, _, botID string) ([]bundle.Invocation, error) {
 		if botID == "review-pr" {
 			return []bundle.Invocation{{
 				Kind:     bundle.InvocationKindSchedule,

--- a/pkg/forge/preview.go
+++ b/pkg/forge/preview.go
@@ -1,6 +1,10 @@
 package forge
 
-import "github.com/SocialGouv/iterion/pkg/bundle"
+import (
+	"context"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+)
 
 // EnablePreview is the read-only projection of what enabling a set of bots on
 // a repo will provision: the webhook events to subscribe to, the slash-command
@@ -19,7 +23,7 @@ type EnablePreview struct {
 // event) so the studio's enable dialog shows exactly what Provision will set
 // up — and, crucially, does NOT flag a command-only bot as a conflict. Pure:
 // no forge calls, no persistence.
-func PreviewEnable(botFn BotForgeLookup, invFn BotInvocationsLookup, bots []string) EnablePreview {
+func PreviewEnable(ctx context.Context, teamID string, botFn BotForgeLookup, invFn BotInvocationsLookup, bots []string) EnablePreview {
 	frByBot := map[string]*bundle.ForgeRequirements{}
 	invByBot := map[string][]bundle.Invocation{}
 	binds := map[string]string{}
@@ -29,14 +33,14 @@ func PreviewEnable(botFn BotForgeLookup, invFn BotInvocationsLookup, bots []stri
 	var provisionable []string
 
 	for _, b := range dedupSorted(bots) {
-		fr, err := botFn(b)
+		fr, err := botFn(ctx, teamID, b)
 		if err != nil {
 			conflicts = append(conflicts, b+": "+err.Error())
 			continue
 		}
 		var invs []bundle.Invocation
 		if invFn != nil {
-			invs, _ = invFn(b)
+			invs, _ = invFn(ctx, teamID, b)
 		}
 		if fr == nil && !hasForgeReachableInvocation(invs) {
 			conflicts = append(conflicts, b+": declares neither a forge: block nor a forge/command invocation — not installable")

--- a/pkg/forge/preview_test.go
+++ b/pkg/forge/preview_test.go
@@ -1,26 +1,27 @@
 package forge
 
 import (
+	"context"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
 )
 
 func TestPreviewEnable_CommandOnlyBotNotConflict(t *testing.T) {
-	botFn := func(b string) (*bundle.ForgeRequirements, error) {
+	botFn := func(_ context.Context, _, b string) (*bundle.ForgeRequirements, error) {
 		if b == "review-pr" {
 			return &bundle.ForgeRequirements{Events: []string{bundle.ForgeEventPullRequest}}, nil
 		}
 		return nil, nil // feature-dev declares no forge: block
 	}
-	invFn := func(b string) ([]bundle.Invocation, error) {
+	invFn := func(_ context.Context, _, b string) ([]bundle.Invocation, error) {
 		if b == "feature-dev" {
 			return []bundle.Invocation{{Kind: bundle.InvocationKindCommand, Mode: bundle.ExecutionBoard,
 				Command: &bundle.InvocationCommand{Name: "featurly"}}}, nil
 		}
 		return nil, nil
 	}
-	pv := PreviewEnable(botFn, invFn, []string{"review-pr", "feature-dev"})
+	pv := PreviewEnable(context.Background(), "t1", botFn, invFn, []string{"review-pr", "feature-dev"})
 	if len(pv.Conflicts) != 0 {
 		t.Fatalf("command-only bot must NOT be a conflict, got %v", pv.Conflicts)
 	}
@@ -37,9 +38,9 @@ func TestPreviewEnable_CommandOnlyBotNotConflict(t *testing.T) {
 }
 
 func TestPreviewEnable_NoForgeNoInvocationIsConflict(t *testing.T) {
-	pv := PreviewEnable(
-		func(string) (*bundle.ForgeRequirements, error) { return nil, nil },
-		func(string) ([]bundle.Invocation, error) { return nil, nil },
+	pv := PreviewEnable(context.Background(), "t1",
+		func(context.Context, string, string) (*bundle.ForgeRequirements, error) { return nil, nil },
+		func(context.Context, string, string) ([]bundle.Invocation, error) { return nil, nil },
 		[]string{"orchestrator"},
 	)
 	if len(pv.Conflicts) != 1 {

--- a/pkg/server/board_comment.go
+++ b/pkg/server/board_comment.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
@@ -39,7 +40,10 @@ func (s *Server) resolveBoardComment(iss native.Issue, body string) (bot string,
 	if cmd == "" {
 		return "", nil, "", false
 	}
-	route, found := s.cmdDiscovery().LookupCommand(cmd)
+	// The native board is a single local store with no tenancy — the launch
+	// it triggers resolves platform-over-baked too, so the discovery matches
+	// it by passing no team rather than inventing one.
+	route, found := s.cmdDiscoveryFor(context.Background(), "").LookupCommand(cmd)
 	if !found || !route.AllowsScope("issue") {
 		return "", nil, "", false
 	}

--- a/pkg/server/bot_metadata_team_tier_fixture_test.go
+++ b/pkg/server/bot_metadata_team_tier_fixture_test.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #946 — the metadata reads that DESCRIBE a launch must resolve the tier that
+// SERVES it. #871 made every launch surface tenant-aware, so a team's fork now
+// runs on its board cards, triggers, schedules and webhooks; a description read
+// from the origin's manifest disagrees with the bundle that executes, silently.
+//
+// One fixture, one lane per subtest: a baked `reviewer-bot` and team `t1`'s
+// fork of it, whose manifest differs in every field a lane reads.
+
+const metaBakedBot = "schema out:\n  ok: bool\n\nvars:\n  scope_notes: string = \"\"\n  fork_prompt: string = \"\"\n\ntool work:\n  command: `printf '{\"ok\":true}'`\n  output: out\n\nworkflow reviewer_bot:\n  worktree: none\n  entry: work\n  work -> done\n"
+
+const metaBakedManifest = `name: reviewer-bot
+display_name: Baked Revi
+version: 1.0.0
+invocations:
+  - kind: command
+    mode: board
+    args_var: scope_notes
+    command:
+      name: revi
+      scope: any
+      opens_mr: false
+  - kind: schedule
+    schedule:
+      suggested_cron: 0 2 * * 1
+produces:
+  - kind: review
+    node: publish_baked
+config_share:
+  config_path: baked.yaml
+  editable_paths:
+    - feeds
+forge:
+  events:
+    - pull_request
+`
+
+const metaForkManifest = `name: reviewer-bot
+display_name: Fork Revi
+version: 2.0.0
+invocations:
+  - kind: command
+    mode: board
+    args_var: fork_prompt
+    command:
+      name: revi
+      scope: any
+      opens_mr: true
+  - kind: schedule
+    schedule:
+      suggested_cron: 0 5 * * 3
+  - kind: command
+    args_var: fork_prompt
+    command:
+      name: revifork
+      scope: any
+produces:
+  - kind: review
+    node: publish_fork
+config_share:
+  config_path: fork.yaml
+  editable_paths:
+    - entries
+  editor_title: Fork editor
+forge:
+  events:
+    - pull_request_comment
+`
+
+// A team bot with a slug the catalog never carried — the shape that makes the
+// tenant-free reads answer "no such bot" rather than "the wrong bot".
+const metaTeamOnlyManifest = `name: teamonly-bot
+display_name: Teamonly
+version: 1.0.0
+invocations:
+  - kind: schedule
+    schedule:
+      suggested_cron: 0 7 * * 5
+  - kind: command
+    args_var: fork_prompt
+    command:
+      name: teamonly
+      scope: any
+produces:
+  - kind: review
+    node: publish_teamonly
+forge:
+  events:
+    - pull_request_comment
+`
+
+// newBotMetadataTeamServer bakes `reviewer-bot` into the catalog, gives team
+// t1 a fork of that slug plus a bot of its own (`teamonly-bot`).
+func newBotMetadataTeamServer(t *testing.T) *Server {
+	t.Helper()
+	s := newOrgTestServer(t)
+	seedGate(t, s, gateSpec{id: "t1"})
+	botsDir := t.TempDir()
+	bundleDir := filepath.Join(botsDir, "reviewer-bot")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "main.bot"), []byte(metaBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "manifest.yaml"), []byte(metaBakedManifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	s.botSources = botsource.NewMemoryStore()
+	ctx := store.WithTenant(context.Background(), "t1")
+	if _, err := s.botSources.Create(ctx, botsource.BotSource{
+		TenantID: "t1", Slug: "reviewer-bot",
+		Files: map[string]string{botsource.MainBotFile: metaBakedBot, "manifest.yaml": metaForkManifest},
+	}); err != nil {
+		t.Fatalf("seed the team's fork: %v", err)
+	}
+	if _, err := s.botSources.Create(ctx, botsource.BotSource{
+		TenantID: "t1", Slug: "teamonly-bot",
+		Files: map[string]string{botsource.MainBotFile: metaBakedBot, "manifest.yaml": metaTeamOnlyManifest},
+	}); err != nil {
+		t.Fatalf("seed the team's own bot: %v", err)
+	}
+	return s
+}

--- a/pkg/server/bot_metadata_team_tier_test.go
+++ b/pkg/server/bot_metadata_team_tier_test.go
@@ -1,0 +1,324 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/trigger"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+func TestBotMetadataReadsTheTierThatServesTheLaunch(t *testing.T) {
+	ctx := context.Background()
+
+	// Command discovery routes a /slash-command to a bot AND to the var its
+	// args land in. Read from the origin, a fork's command stamps the args
+	// under a var the running bundle never declares — an empty prompt, not an
+	// error.
+	t.Run("command discovery reads the fork's invocation", func(t *testing.T) {
+		s := newBotMetadataTeamServer(t)
+		route, ok := s.cmdDiscoveryFor(ctx, "t1").LookupCommand("revi")
+		if !ok {
+			t.Fatal("/revi did not resolve for the forking team")
+		}
+		if route.ArgsVar != "fork_prompt" {
+			t.Errorf("args var = %q, want the FORK's %q — the fork is the bundle that runs", route.ArgsVar, "fork_prompt")
+		}
+		if !route.OpensMR {
+			t.Error("opens_mr = false, want the FORK's true")
+		}
+		// A command only the fork declares must resolve for that team.
+		if _, ok := s.cmdDiscoveryFor(ctx, "t1").LookupCommand("revifork"); !ok {
+			t.Error("/revifork did not resolve — the fork declares it, and the fork is what launches")
+		}
+		// A bot only the team authored is reachable by its own command.
+		if r, ok := s.cmdDiscoveryFor(ctx, "t1").LookupCommand("teamonly"); !ok || r.BotID != "teamonly-bot" {
+			t.Errorf("/teamonly resolved to %+v (ok=%v), want the team's own bot", r, ok)
+		}
+		// Another team keeps the baked answer.
+		r2, ok := s.cmdDiscoveryFor(ctx, "t2").LookupCommand("revi")
+		if !ok || r2.ArgsVar != "scope_notes" || r2.OpensMR {
+			t.Errorf("a team with no fork got %+v (ok=%v), want the baked invocation", r2, ok)
+		}
+		if _, ok := s.cmdDiscoveryFor(ctx, "t2").LookupCommand("revifork"); ok {
+			t.Error("/revifork resolved for a team that has no fork — the team tier must not leak across tenants")
+		}
+	})
+
+	// The labeled-issue lane derives its route from the same invocation.
+	t.Run("board route for a label reads the fork's invocation", func(t *testing.T) {
+		s := newBotMetadataTeamServer(t)
+		route := s.boardRouteForLabel(ctx, "t1", "reviewer-bot")
+		if route.ArgsVar != "fork_prompt" {
+			t.Errorf("args var = %q, want the FORK's %q", route.ArgsVar, "fork_prompt")
+		}
+		if !route.OpensMR {
+			t.Error("opens_mr = false, want the FORK's true")
+		}
+	})
+
+	// The converse gate refuses to route to a bot it cannot see. A team's own
+	// bot launches (the team tier resolves it) but does not exist here.
+	t.Run("the existence probe sees the team's own bot", func(t *testing.T) {
+		s := newBotMetadataTeamServer(t)
+		cfg := webhooks.Config{ID: "wh-1", TenantID: "t1", WildcardBots: true}
+		if !s.canRouteToConverseBot(ctx, cfg, "teamonly-bot") {
+			t.Error("a team-authored bot is unroutable — the launch resolves it, so the gate must see it")
+		}
+		other := webhooks.Config{ID: "wh-2", TenantID: "t2", WildcardBots: true}
+		if s.canRouteToConverseBot(ctx, other, "teamonly-bot") {
+			t.Error("another team's bot must stay invisible")
+		}
+	})
+
+	// The config-share mint derives the grant from the bot's declared surface.
+	// Read from the origin, it pins paths into a file the fork does not use.
+	t.Run("the config-share surface comes from the fork", func(t *testing.T) {
+		s := newBotMetadataTeamServer(t)
+		spec := s.botConfigShareSpec(ctx, "t1", "reviewer-bot")
+		if spec == nil || spec.ConfigPath != "fork.yaml" {
+			t.Fatalf("config share = %+v, want the FORK's fork.yaml", spec)
+		}
+		if base := s.botConfigShareSpec(ctx, "t2", "reviewer-bot"); base == nil || base.ConfigPath != "baked.yaml" {
+			t.Fatalf("config share = %+v, want the baked baked.yaml for a team with no fork", base)
+		}
+	})
+
+	// The forge orchestrator's lookups build the provisioned CommandMap and the
+	// event subscription. A team bot the catalog never had makes them fail
+	// outright; a fork makes them describe the origin.
+	t.Run("the forge orchestrator lookups read the fork", func(t *testing.T) {
+		s := newBotMetadataTeamServer(t)
+		invs, err := s.forgeBotInvocations(ctx, "t1", "reviewer-bot")
+		if err != nil {
+			t.Fatalf("invocations: %v", err)
+		}
+		if len(invs) == 0 || invs[0].ArgsVar != "fork_prompt" {
+			t.Errorf("invocations = %+v, want the FORK's args var", invs)
+		}
+		if _, err := s.forgeBotInvocations(ctx, "t1", "teamonly-bot"); err != nil {
+			t.Errorf("a team-authored bot cannot be provisioned: %v", err)
+		}
+		fr, err := s.forgeBotForge(ctx, "t1", "reviewer-bot")
+		if err != nil {
+			t.Fatalf("forge requirements: %v", err)
+		}
+		if fr == nil || len(fr.Events) != 1 || fr.Events[0] != "pull_request_comment" {
+			t.Errorf("forge requirements = %+v, want the FORK's `pull_request_comment` event", fr)
+		}
+	})
+}
+
+// The hand-off PRODUCER side asks "where did THIS run write its review". The
+// run records the tier that served it (Run.BotSourceTenant), so a fork that
+// moves the node its `produces:` names is readable — and a team bot the catalog
+// never had produces at all.
+func TestHandoffProducerReadsTheRunsOwnTier(t *testing.T) {
+	ctx := context.Background()
+	// One server and one run store for the whole table: a runview service costs
+	// seconds to stop. Each case gets its own PR url, which is the scan's own
+	// filter, so the runs cannot see each other.
+	s := newBotMetadataTeamServer(t)
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = rs
+	s.runs = newTestRunviewService(t, "", runview.WithStore(rs))
+
+	seedRun := func(t *testing.T, prURL, botID, tenant, node string) {
+		t.Helper()
+		tctx := store.WithTenant(ctx, "t1")
+		run, err := rs.CreateRun(tctx, mustRunID(t), botID, map[string]any{"pr_url": prURL})
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFinished
+		run.BotID = botID
+		run.BotSourceTenant = tenant
+		run.BotSourceTier = store.BotSourceTierTeam
+		if tenant == "" {
+			run.BotSourceTier = store.BotSourceTierBaked
+		}
+		if err := rs.SaveRun(tctx, run); err != nil {
+			t.Fatal(err)
+		}
+		if err := rs.WriteArtifact(tctx, &store.Artifact{RunID: run.ID, NodeID: node, Data: map[string]any{
+			"total_findings": 1,
+			"findings": []any{map[string]any{
+				"severity": "high", "category": "correctness", "title": "off-by-one",
+				"file": "a.go", "line": float64(3),
+			}},
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name, prURL, botID, tenant, node, why string
+	}{
+		{
+			name:  "a fork's own produces: node is read",
+			prURL: "https://forge.example/acme/widgets/-/merge_requests/1", botID: "reviewer-bot",
+			tenant: "t1", node: "publish_fork",
+			why: "the origin's produces: node was read instead of the fork's",
+		},
+		{
+			name:  "a team-only bot's review is handed over",
+			prURL: "https://forge.example/acme/widgets/-/merge_requests/2", botID: "teamonly-bot",
+			tenant: "t1", node: "publish_teamonly",
+			why: "a team-authored producer is invisible to the hand-off",
+		},
+		{
+			// The tier a run was SERVED from decides, not the tenant asking.
+			name:  "a baked run still reads the baked produces: node",
+			prURL: "https://forge.example/acme/widgets/-/merge_requests/3", botID: "reviewer-bot",
+			tenant: "", node: "publish_baked",
+			why: "a baked run must still be described by the baked manifest",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			seedRun(t, c.prURL, c.botID, c.tenant, c.node)
+			got := s.realWebhookHandoff(ctx, webhooks.Config{ID: "wh-1", TenantID: "t1"},
+				bundle.HandoffKindReview, handoffQuery{PRURL: c.prURL})
+			if !strings.Contains(got, "off-by-one") {
+				t.Errorf("%s:\n%q", c.why, got)
+			}
+		})
+	}
+}
+
+// The bot home's one-click "enable this trigger" derives a Subscription from
+// the bot's manifest invocation and launches through the trigger spine, which
+// resolves the team tier (#871). Reading the origin's invocation there builds a
+// binding the running bundle never declared.
+func TestTriggerFromInvocationReadsTheTeamsFork(t *testing.T) {
+	s := newBotMetadataTeamServer(t)
+	s.cfg.TriggerStore = trigger.NewMemorySubscriptionStore()
+
+	enable := func(t *testing.T, team, bot string, index int) *httptest.ResponseRecorder {
+		t.Helper()
+		body, err := json.Marshal(triggerFromInvocationReq{Index: index})
+		if err != nil {
+			t.Fatal(err)
+		}
+		r := httptest.NewRequest(http.MethodPost, "/api/v1/bots/"+bot+"/triggers/from-invocation", strings.NewReader(string(body)))
+		r.SetPathValue("name", bot)
+		r = r.WithContext(auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", TeamID: team}))
+		w := httptest.NewRecorder()
+		s.handleTriggerFromInvocation(w, r)
+		return w
+	}
+
+	// Invocation 1 is the schedule in BOTH manifests, with different crons.
+	// The subscription launches through the trigger spine, which resolves the
+	// team tier — so the cron it carries must be the fork's.
+	w := enable(t, "t1", "reviewer-bot", 1)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var sub trigger.Subscription
+	if err := json.Unmarshal(w.Body.Bytes(), &sub); err != nil {
+		t.Fatal(err)
+	}
+	if sub.Cron != "0 5 * * 3" {
+		t.Errorf("cron = %q, want the FORK's %q — the spine launches the fork", sub.Cron, "0 5 * * 3")
+	}
+
+	// A bot only the team authored is enable-able from its own bot home.
+	if got := enable(t, "t1", "teamonly-bot", 0); got.Code != http.StatusCreated {
+		t.Errorf("status = %d — a team-authored bot is invisible to its own bot home: %s", got.Code, got.Body.String())
+	}
+}
+
+// A team's fork is not editable through the filesystem-catalog routes: the
+// write would land on the baked bundle every other tenant shares.
+func TestBotMetadataWritesRefuseATeamFork(t *testing.T) {
+	s := newBotMetadataTeamServer(t)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "t1"})
+
+	t.Run("the metadata PUT refuses", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/bots/reviewer-bot", strings.NewReader(`{"icon":"X"}`))
+		r.SetPathValue("name", "reviewer-bot")
+		r.Header.Set("Origin", "")
+		r = r.WithContext(ctx)
+		w := httptest.NewRecorder()
+		s.handleBotsPut(w, r)
+		if w.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 — editing a team fork through the FS catalog would write the baked bundle every tenant shares (body: %s)", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("the workspace overlay refuses", func(t *testing.T) {
+		s.cfg.WorkDir = t.TempDir()
+		enabled := false
+		body, _ := json.Marshal(botOverlayRequest{Enabled: &enabled})
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/bots/reviewer-bot/overlay", strings.NewReader(string(body)))
+		r.SetPathValue("name", "reviewer-bot")
+		r = r.WithContext(ctx)
+		w := httptest.NewRecorder()
+		s.handleBotOverlay(w, r)
+		if w.Code != http.StatusConflict {
+			t.Errorf("status = %d, want 409 — the workspace overlay is never consulted for a stored bot, so a 200 changes nothing (body: %s)", w.Code, w.Body.String())
+		}
+	})
+
+	// The launcher accepts `reviewer_bot` for `reviewer-bot`, so a refusal
+	// that only matched the canonical spelling would let the same edit
+	// through under the other one.
+	t.Run("a non-canonical spelling refuses too", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/bots/reviewer_bot", strings.NewReader(`{"icon":"X"}`))
+		r.SetPathValue("name", "reviewer_bot")
+		r = r.WithContext(ctx)
+		w := httptest.NewRecorder()
+		s.handleBotsPut(w, r)
+		if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "your team's own bot") {
+			t.Errorf("status = %d body = %s, want 409 naming the team's own bot", w.Code, w.Body.String())
+		}
+	})
+}
+
+// A PLATFORM override is refused by the same guard, and by the same spelling
+// rule: the origin label must not be stricter than the lookup it labels.
+func TestBotMetadataWritesRefuseAPlatformOverride(t *testing.T) {
+	s := newBotMetadataTeamServer(t)
+	if _, err := s.botSources.Create(
+		store.WithTenant(context.Background(), botsource.PlatformTenantID),
+		botsource.BotSource{
+			TenantID: botsource.PlatformTenantID, Slug: "reviewer-bot",
+			Files: map[string]string{botsource.MainBotFile: metaBakedBot, "manifest.yaml": metaBakedManifest},
+		}); err != nil {
+		t.Fatalf("seed the platform override: %v", err)
+	}
+	s.platformBots = s.newPlatformBotsResolver()
+	// No active team: the platform tier is what this caller sees.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1"})
+
+	for _, name := range []string{"reviewer-bot", "reviewer_bot"} {
+		r := httptest.NewRequest(http.MethodPut, "/api/v1/bots/"+name, strings.NewReader(`{"icon":"X"}`))
+		r.SetPathValue("name", name)
+		r = r.WithContext(ctx)
+		w := httptest.NewRecorder()
+		s.handleBotsPut(w, r)
+		if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), "platform override") {
+			t.Errorf("PUT %q: status = %d body = %s, want 409 naming the platform override", name, w.Code, w.Body.String())
+		}
+	}
+}
+
+// Compile-time proof that the forge seam carries a tenant: the orchestrator's
+// lookups are what the provisioned CommandMap is built from, and Provision
+// already knows the team it provisions for.
+var _ forge.BotInvocationsLookup = (&Server{}).forgeBotInvocations
+var _ forge.BotForgeLookup = (&Server{}).forgeBotForge

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -34,20 +34,32 @@ import (
 // substitution. A surface with no team id has none to invent: it resolves
 // platform-over-baked and says so by passing an empty team.
 //
-// The METADATA reads below are a separate, narrower view:
-// effectiveEntries* / effectiveFindByName / botExists / platformBotManifest
-// are tenant-context-FREE (platform over baked). A metadata read must match
-// the tier the LAUNCH it describes will resolve, or the two disagree in
-// silence — so a lane whose launch is tenant-aware reads through
-// effectiveFindByNameForTeam, and a lane whose launch is tenant-free keeps
-// the tenant-free view. Wired so far: the webhook hand-off `consumes:` seeds
-// and the gate-var defaults, the two that describe a delivery this file's
-// launch resolution now serves from the team tier. Still tenant-free, and
-// therefore still able to disagree with a team fork: the retry-policy
-// manifest read (botManifest), the command discovery, the /bots listing, and
-// the hand-off PRODUCER set — pre-existing on the manual surface, tracked as
-// #946. A caller that holds the tier a bot ACTUALLY resolved through — a
-// run's BotSourceTenant, stamped at launch — asks teamBotManifest instead.
+// A metadata read DESCRIBES a launch, so it resolves the tier that SERVES
+// that launch — the same three-tier order, from the same team id. Reading a
+// different tier is a disagreement with no diagnostic: a fork that renames
+// its `consumes:` var gets an empty seed, a fork that moves its gate context
+// greens a status nothing requires, a fork that renames its `/command`
+// stamps the operator's text under a var the running bundle never declared.
+//
+// Which tenant a lane passes depends on what it describes:
+//   - a delivery about to launch → the launching team (the webhook config's
+//     tenant, the request's active team): effectiveFindByNameForTeam,
+//     effectiveEntriesForTeam, botManifestFor, botExistsForTeam;
+//   - a run that ALREADY launched → that run's own BotSourceTenant, which
+//     records the tier it resolved through: teamBotManifest. The ambient
+//     tenant is the wrong question there — a team's own run may still have
+//     been served by the platform or baked tier.
+//
+// The tenant-free forms (effectiveEntriesWithSchema / effectiveFindByName /
+// botExists / platformBotManifest / botManifest) remain, as the platform +
+// baked floor every team-aware form falls through to, and as the answer for
+// the lanes that genuinely hold no tenant: the native board's comment
+// dispatcher (a single local store, no tenancy) and the deployment-wide
+// producer floor a hand-off scan starts from.
+//
+// The team tier's rows are read through teamBotRow, so an operator-typed
+// spelling (`feature_dev` for `feature-dev`) reaches the launch and the
+// metadata alike — one row resolution, never two that can diverge.
 
 // launchBot is a resolved, launch-ready bot. Cloud resolution freezes its
 // collection before compile and carries the same snapshot to the runner.
@@ -352,36 +364,77 @@ func (s *Server) invalidatePlatformBots() {
 
 // effectiveEntriesWithSchema returns the baked catalog overlaid with the
 // platform overrides: a platform entry REPLACES the same-slug baked entry,
-// a new-slug platform bot is appended. This is the metadata set every
-// tenant-context-free consumer (command discovery, hand-offs, gate-var
-// defaults) reads.
+// a new-slug platform bot is appended. The platform + baked floor —
+// effectiveEntriesForTeam adds the team tier on top for a lane that knows
+// which team its launch is for.
 func (s *Server) effectiveEntriesWithSchema() ([]botregistry.EntryWithSchema, error) {
 	catalog, err := botregistry.ListWithSchema(s.botListOptions())
 	if err != nil {
 		return nil, err
 	}
-	overrides := s.platformBotEntries()
-	if len(overrides) == 0 {
-		return catalog, nil
+	return overlayEntriesByName(catalog, s.platformBotEntries()), nil
+}
+
+// effectiveEntriesForTeam is effectiveEntriesWithSchema with teamID's own
+// rows overlaid last — the whole-set counterpart of
+// effectiveFindByNameForTeam, for the lanes that read the SET rather than
+// one name (command discovery, the label route's invocation).
+//
+// A team row REPLACES the same-slug platform/baked entry and a slug only the
+// team authored is appended, matching launch resolution exactly: reading a
+// narrower set means routing a command to a bundle that does not declare it,
+// or refusing one that does.
+//
+// It materialises the team's bundles (storedBotEntries), so it belongs on a
+// per-delivery path, not a per-run one; a lane that needs a single bot asks
+// effectiveFindByNameForTeam, which materialises one row.
+func (s *Server) effectiveEntriesForTeam(ctx context.Context, teamID string) ([]botregistry.EntryWithSchema, error) {
+	base, err := s.effectiveEntriesWithSchema()
+	if err != nil {
+		return nil, err
 	}
-	byName := make(map[string]int, len(catalog))
-	for i, e := range catalog {
+	if teamID == "" || s.botSources == nil {
+		return base, nil
+	}
+	return overlayEntriesByName(base, s.storedBotEntries(ctx, teamID)), nil
+}
+
+// overlayEntriesByName lays overrides over base by entry name: a same-name
+// override replaces in place (keeping the base's position, so a listing does
+// not reshuffle when an override appears), a new name is appended. The ONE
+// definition of the tier overlay, so the platform pass and the team pass
+// cannot acquire different precedence.
+func overlayEntriesByName(base, overrides []botregistry.EntryWithSchema) []botregistry.EntryWithSchema {
+	if len(overrides) == 0 {
+		return base
+	}
+	byName := make(map[string]int, len(base))
+	for i, e := range base {
 		byName[e.Name] = i
 	}
-	out := catalog
+	out := base
 	for _, e := range overrides {
 		if i, ok := byName[e.Name]; ok {
 			out[i] = e
 			continue
 		}
+		byName[e.Name] = len(out)
 		out = append(out, e)
 	}
-	return out, nil
+	return out
 }
 
 // effectiveEntries is effectiveEntriesWithSchema flattened to plain entries.
 func (s *Server) effectiveEntries() ([]botregistry.Entry, error) {
-	withSchema, err := s.effectiveEntriesWithSchema()
+	return flattenEntries(s.effectiveEntriesWithSchema())
+}
+
+// effectiveEntriesFor is effectiveEntriesForTeam flattened to plain entries.
+func (s *Server) effectiveEntriesFor(ctx context.Context, teamID string) ([]botregistry.Entry, error) {
+	return flattenEntries(s.effectiveEntriesForTeam(ctx, teamID))
+}
+
+func flattenEntries(withSchema []botregistry.EntryWithSchema, err error) ([]botregistry.Entry, error) {
 	if err != nil {
 		return nil, err
 	}
@@ -412,20 +465,51 @@ func (s *Server) platformBotManifest(slug string) *bundle.Manifest {
 // "platform" when a deployment override shadows it, else "catalog". Keeps
 // the detail/PUT responses consistent with the list's origin so the studio
 // badge doesn't flicker between surfaces.
+//
+// It answers for the platform + baked tiers only; a caller that must also
+// know whether the ACTIVE TEAM shadows the name (the two FS-catalog write
+// paths, which would otherwise edit the bundle every tenant shares) asks
+// entryOriginFor.
+//
+// The match is exact then NormalizeName-folded, the same two passes
+// effectiveFindByName makes: an origin stricter than the lookup it labels
+// would call a platform override "catalog" for every non-canonical spelling
+// the launcher accepts.
 func (s *Server) entryOrigin(name string) string {
-	for _, e := range s.platformBotEntries() {
+	entries := s.platformBotEntries()
+	for _, e := range entries {
 		if e.Name == name {
 			return "platform"
+		}
+	}
+	if nn := botregistry.NormalizeName(name); nn != "" {
+		for _, e := range entries {
+			if botregistry.NormalizeName(e.Name) == nn {
+				return "platform"
+			}
 		}
 	}
 	return "catalog"
 }
 
-// botExists reports whether a bot id resolves on this deployment (platform
-// override or baked catalog) WITHOUT materializing anything — the cheap
-// probe for callers that only route (e.g. the /revi converse gate). Team
-// bots are deliberately out of scope, matching launch resolution on the
-// tenant-context-free surfaces.
+// entryOriginFor is entryOrigin with the team tier consulted first —
+// "tenant" when teamID authored a row of that name. The tier vocabulary the
+// /bots views already render (botEntryView.Origin), resolved from one place.
+func (s *Server) entryOriginFor(ctx context.Context, teamID, name string) string {
+	if teamID != "" && s.botSources != nil && strings.TrimSpace(name) != "" {
+		if _, found, err := s.teamBotRow(ctx, teamID, name); err == nil && found {
+			return "tenant"
+		} else if err != nil {
+			s.logWarn("bot source %s/%s: %v — the origin was read from the platform tier", teamID, name, err)
+		}
+	}
+	return s.entryOrigin(name)
+}
+
+// botExists reports whether a bot id resolves on the platform + baked tiers
+// WITHOUT materializing anything — the cheap probe for callers that only
+// route. botExistsForTeam adds the team tier for a lane that knows the team
+// its launch is for.
 func (s *Server) botExists(botID string) bool {
 	for _, e := range s.platformBotEntries() {
 		if e.Name == botID {
@@ -436,15 +520,38 @@ func (s *Server) botExists(botID string) bool {
 	return err == nil
 }
 
+// botExistsForTeam reports whether a bot id resolves for teamID — its own
+// row first, then platform over baked. Same three tiers as the launch, so a
+// routing gate cannot refuse a bot the launch would have served: a team's
+// own bot exists nowhere in the catalog, and answering "no" for it silently
+// disables the whole command surface that bot was authored for.
+//
+// Still cheap enough for a hot path: the team pass is one indexed row read
+// (teamBotRow), and nothing is materialized on either tier.
+func (s *Server) botExistsForTeam(ctx context.Context, teamID, botID string) bool {
+	if teamID != "" && s.botSources != nil && strings.TrimSpace(botID) != "" {
+		switch _, found, err := s.teamBotRow(ctx, teamID, botID); {
+		case err != nil:
+			// A store blip is not "this team authored no such bot": say so,
+			// then fall through to the tiers that can still answer.
+			s.logWarn("bot source %s/%s: %v — the existence probe fell through to the platform tier", teamID, botID, err)
+		case found:
+			return true
+		}
+	}
+	return s.botExists(botID)
+}
+
 // teamBotManifest reads the manifest of a TEAM-authored bot row. It is for
 // callers holding the tier a bot actually resolved through — a run's
 // BotSourceTenant — so that a run's own manifest is read where the run came
 // from. Nil when the tenant names no team row (empty, the platform sentinel,
 // or no such slug), leaving the caller on the platform + baked tiers.
 //
-// Deliberately NOT folded into effectiveFindByName: see the contract at the
-// top of this file — a lane whose LAUNCH is tenant-free must stay blind to a
-// team fork, or it would describe a bundle it will not run.
+// Distinct from effectiveFindByNameForTeam by the QUESTION, not the tier: a
+// run's provenance is a fact already recorded, so this takes it verbatim and
+// never re-derives it from an ambient tenant — a team's own run may still
+// have been served by the platform or baked tier, and the run says which.
 //
 // It resolves the row through teamBotRow, so one row resolution serves the
 // launch, the entry metadata and the manifest: a card's spelling cannot
@@ -478,9 +585,10 @@ func (s *Server) teamBotManifest(ctx context.Context, tenantID, slug string) *bu
 // through teamBotRow, so the spelling a card carries reaches the same row on
 // both reads.
 //
-// Deliberately NOT the default: effectiveFindByName stays tenant-free for
-// the lanes whose launch is tenant-free too (see the contract at the top of
-// this file). Widening it is #946, not this seam.
+// It reads ONE name, materialising one row; a lane that needs the whole set
+// asks effectiveEntriesForTeam. effectiveFindByName remains as the platform
+// + baked floor this falls through to, and as the answer for the lanes that
+// hold no tenant at all (see the contract at the top of this file).
 func (s *Server) effectiveFindByNameForTeam(ctx context.Context, teamID, name string) (botregistry.EntryWithSchema, bool, error) {
 	if teamID != "" && s.botSources != nil && strings.TrimSpace(name) != "" {
 		bs, found, err := s.teamBotRow(ctx, teamID, name)

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -11,8 +11,8 @@ import (
 // The bot-resolution authority is bot_resolver.go: every pkg/server site
 // that turns a bot id into source, a manifest, or catalog metadata must go
 // through it, or a platform override is silently ignored on that surface
-// (grep-la-classe: the class is "sites that select a bot"). These two
-// static sweeps keep the class closed as the package grows.
+// (grep-la-classe: the class is "sites that select a bot"). These static
+// sweeps keep the class closed as the package grows.
 
 // resolverSweepAllowed lists the files that may call the raw botregistry
 // discovery/lookup functions, with the reason.
@@ -54,6 +54,7 @@ func TestBotResolutionSweep_NoRawRegistryReads(t *testing.T) {
 // to behave like the fifth.
 var teamlessResolveAllowed = map[string]string{
 	"resume_source.go": "the no-persisted-origin branch: a run whose BotSourceTenant is empty did NOT launch from a team row (the team branch above re-resolves that row by its own tenant)",
+	"board_comment.go": "the native board is a single local store with no tenancy — the launch its comment dispatcher triggers resolves platform-over-baked too",
 }
 
 func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
@@ -65,7 +66,7 @@ func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
 	// Only a LITERAL "" is decidable statically; a variable that happens to
 	// be empty at run time is the caller's own contract to keep.
 	teamless := regexp.MustCompile(
-		`(?:resolveBot(?:Source|Tiered(?:Raw)?)?|resolveRunRetryPolicy|handoffConsumersFor|botVarDefault|botManifestFor|effectiveFindByNameForTeam)\([^,]+,\s*""`)
+		`(?:resolveBot(?:Source|Tiered(?:Raw)?)?|resolveRunRetryPolicy|handoffConsumersFor|botVarDefault|botManifestFor|effectiveFindByNameForTeam|effectiveEntriesFor(?:Team)?|botExistsForTeam|botConfigShareSpec|boardRouteForLabel|cmdDiscoveryFor|entryOriginFor|teamHandoffProducers|forgeBot(?:Forge|Invocations))\([^,]+,\s*""`)
 	sweepServerFiles(t, func(name, body string) {
 		if !teamless.MatchString(body) {
 			return
@@ -74,6 +75,41 @@ func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
 			return
 		}
 		t.Errorf("%s resolves a bot with a hardcoded empty team — pass the team the launch is FOR (the card's, the subscription's, the schedule's, the webhook's) or add an allowlist entry saying why this surface has none", name)
+	})
+}
+
+// tenantFreeMetadataAllowed lists the files that may call a tenant-FREE
+// metadata form, with the reason. Each of these forms answers for the
+// platform + baked tiers only; a lane that holds a tenant and calls one
+// describes a bundle the launch will not run — silently (#946). The
+// team-aware counterpart of each is named in bot_resolver.go's contract.
+var tenantFreeMetadataAllowed = map[string]string{
+	"bot_resolver.go":            "the authority itself: these ARE the platform + baked floor every team-aware form falls through to",
+	"bots_routes.go":             "the /bots read paths consult tenantBotEntries first and refuseStoredBotEdit fences the two FS-catalog write paths; entryOrigin is the platform/catalog half of entryOriginFor",
+	"bots_create.go":             "confirms the scaffold it just WROTE to the filesystem is discoverable — a team row of the same name would shadow the file under test",
+	"config_shares_routes.go":    "botManifest is botManifestFor's platform + baked fall-through",
+	"forge_gate_pause_notice.go": "effectiveFindByName is teamBotManifest's fall-through, reached only when the run records no team row",
+	"webhooks_handoff.go":        "the deployment-wide producer FLOOR; teamHandoffProducers is the team half, and the scan picks per run by Run.BotSourceTenant",
+	// The pipelines control center launches by FILESYSTEM PATH
+	// (entry.MainFile()) instead of through resolveBotSource, so a stored
+	// bundle has no path to launch from and its admission check must match.
+	// Making the check tenant-aware alone would create cards that can never
+	// launch; both halves move together, in the #871 launch-surface class.
+	"pipeline_boards_tasks.go": "admission check for a lane whose launch is itself FS-path-based (tracked with the launch half)",
+	"pipeline_admission.go":    "same lane: launchTicketNow launches entry.MainFile(), not a resolved bundle",
+}
+
+func TestBotResolutionSweep_TenantFreeMetadataIsDeclared(t *testing.T) {
+	tenantFree := regexp.MustCompile(
+		`s\.(?:effectiveEntries\(\)|effectiveEntriesWithSchema\(\)|effectiveFindByName\(|botExists\(|botManifest\(|entryOrigin\(|findBot\()`)
+	sweepServerFiles(t, func(name, body string) {
+		if !tenantFree.MatchString(body) {
+			return
+		}
+		if _, ok := tenantFreeMetadataAllowed[name]; ok {
+			return
+		}
+		t.Errorf("%s reads bot metadata through a tenant-FREE form — a lane that knows its team reads the tier that will SERVE the launch (effectiveEntriesForTeam / effectiveFindByNameForTeam / botManifestFor / botExistsForTeam / entryOriginFor), or add an allowlist entry saying why this surface has no tenant", name)
 	})
 }
 

--- a/pkg/server/bots_routes.go
+++ b/pkg/server/bots_routes.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/botinstall"
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/bundle"
@@ -128,6 +129,9 @@ func (s *Server) handleBotsPut(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "bots: missing name")
 		return
 	}
+	if s.refuseStoredBotEdit(w, r, name) {
+		return
+	}
 	entry, ok, err := s.findBot(name)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "bots: %v", err)
@@ -142,12 +146,14 @@ func (s *Server) handleBotsPut(w http.ResponseWriter, r *http.Request) {
 			"bots: %q is a loose .bot file; convert it to a bundle (manifest.yaml + main.bot) to edit metadata", name)
 		return
 	}
-	// A stored (platform-override) entry carries an EMPTY path — joining it
-	// would write manifest.yaml relative to the server's CWD and silently
-	// lose the edit (the next read re-serves the untouched override).
+	// Fail closed on a path that must never be joined. refuseStoredBotEdit
+	// above is what names the tier and the surface that owns the edit; this
+	// guards the WRITE itself, because an empty path joins to a relative
+	// manifest.yaml under the server's CWD — a silently lost edit, and a file
+	// written where no bundle lives.
 	if entry.Path == "" {
 		s.httpErrorFor(w, r, http.StatusConflict,
-			"bots: %q is managed as a platform override; edit it via /api/admin/bots (or `iterion remote admin bots push`)", name)
+			"bots: %q resolves to a bundle with no filesystem path; edit it through the bot-source API, not the filesystem catalog", name)
 		return
 	}
 	var req botUpdateRequest
@@ -204,11 +210,11 @@ func (s *Server) handleBotOverlay(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "invalid request: %v", err)
 		return
 	}
-	// The workspace overlay is never consulted for a platform-override
-	// entry, so a hide/show toggle there would 200 and change nothing.
-	if s.entryOrigin(name) == "platform" {
-		s.httpErrorFor(w, r, http.StatusConflict,
-			"bots: %q is managed as a platform override; the workspace overlay does not apply (remove the override via /api/admin/bots to fall back to the catalog)", name)
+	// The workspace overlay is never consulted for a STORED entry (team or
+	// platform): botregistry reads it off the filesystem catalog, and a
+	// stored bundle is materialised without it. A toggle there would 200
+	// and change nothing.
+	if s.refuseStoredBotEdit(w, r, name) {
 		return
 	}
 	if err := botregistry.SetOverlayEnabled(s.cfg.WorkDir, name, req.Enabled); err != nil {
@@ -226,6 +232,30 @@ func (s *Server) handleBotOverlay(w http.ResponseWriter, r *http.Request) {
 // every tenant sees.
 func (s *Server) findBot(name string) (botregistry.EntryWithSchema, bool, error) {
 	return s.effectiveFindByName(name)
+}
+
+// refuseStoredBotEdit answers 409 when name resolves to a STORED bundle for
+// this caller — the active team's own row, or a platform override — and
+// reports whether it did.
+//
+// Both callers (the manifest PUT, the workspace overlay) act on the FILESYSTEM
+// catalog. A stored bot is not there: the PUT would write into the baked bundle
+// every tenant of this deployment shares, and the overlay would 200 while
+// changing nothing the stored bundle is read through. The refusal names the
+// surface that does own the edit.
+func (s *Server) refuseStoredBotEdit(w http.ResponseWriter, r *http.Request, name string) bool {
+	id, _ := auth.FromContext(r.Context())
+	switch s.entryOriginFor(r.Context(), id.TeamID, name) {
+	case "tenant":
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"bots: %q is your team's own bot; edit it via /api/teams/%s/bot-sources — this route writes the filesystem catalog every tenant shares", name, id.TeamID)
+		return true
+	case "platform":
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"bots: %q is managed as a platform override; edit it via /api/admin/bots (or `iterion remote admin bots push`)", name)
+		return true
+	}
+	return false
 }
 
 // respondBot re-resolves name (post-mutation) and writes it as JSON. It carries

--- a/pkg/server/config_editor_routes.go
+++ b/pkg/server/config_editor_routes.go
@@ -150,7 +150,9 @@ func (s *Server) handleConfigEditorList(w http.ResponseWriter, r *http.Request) 
 		v := editorShareView(sh)
 		m, ok := manifestCache[sh.BotID]
 		if !ok {
-			m = s.botManifest(sh.BotID)
+			// The share belongs to this team, so its bot's persona and
+			// editor branding come from the tier that team runs.
+			m = s.botManifestFor(r.Context(), teamID, sh.BotID)
 			manifestCache[sh.BotID] = m
 		}
 		if m != nil {

--- a/pkg/server/config_shares_routes.go
+++ b/pkg/server/config_shares_routes.go
@@ -118,8 +118,13 @@ func (s *Server) botManifest(botID string) *bundle.Manifest {
 // bot without a discoverable surface mints with explicit operator-supplied
 // paths — the block is a guard-rail + convenience for the common case, not the
 // trust boundary against the operator.
-func (s *Server) botConfigShareSpec(botID string) *bundle.ConfigShareSpec {
-	if m := s.botManifest(botID); m != nil {
+//
+// Read from teamID's own tier first: the share is minted FOR that team and the
+// bot it names is the bundle that team runs, so a fork's config file and
+// editable paths are the ones a share may be derived from. A share derived
+// from the origin pins paths into a file the running bundle never reads.
+func (s *Server) botConfigShareSpec(ctx context.Context, teamID, botID string) *bundle.ConfigShareSpec {
+	if m := s.botManifestFor(ctx, teamID, botID); m != nil {
 		return m.ConfigShare
 	}
 	return nil
@@ -160,7 +165,7 @@ func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request)
 	allowed := req.AllowedPaths
 	visible := req.VisiblePaths
 	derivedFromSpec := false
-	if spec := s.botConfigShareSpec(req.BotID); spec != nil {
+	if spec := s.botConfigShareSpec(r.Context(), teamID, req.BotID); spec != nil {
 		a, v, err := configshare.DeriveGrant(spec.EditablePaths, spec.VisiblePaths, req.Category, req.EditableFields...)
 		if err != nil {
 			httpError(w, http.StatusBadRequest, "%s", err.Error())

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -53,9 +53,10 @@ func (s *Server) githubAppConfig() forgegithub.AppConfig {
 
 // ---- factories (provider dispatch) ----
 
-// forgeBotForge resolves a bot's manifest forge: block for the orchestrator.
-func (s *Server) forgeBotForge(botID string) (*bundle.ForgeRequirements, error) {
-	entry, ok, err := s.findBot(botID)
+// forgeBotForge resolves a bot's manifest forge: block for the orchestrator,
+// on the tier the provisioned webhook's launches will resolve.
+func (s *Server) forgeBotForge(ctx context.Context, teamID, botID string) (*bundle.ForgeRequirements, error) {
+	entry, ok, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
 	if err != nil {
 		return nil, err
 	}
@@ -67,9 +68,10 @@ func (s *Server) forgeBotForge(botID string) (*bundle.ForgeRequirements, error) 
 
 // forgeBotInvocations resolves a bot's manifest invocations for the
 // orchestrator's command-map build (already the EffectiveInvocations set —
-// explicit block, else synthetic from a legacy forge: block).
-func (s *Server) forgeBotInvocations(botID string) ([]bundle.Invocation, error) {
-	entry, ok, err := s.findBot(botID)
+// explicit block, else synthetic from a legacy forge: block), on the tier the
+// provisioned webhook's launches will resolve.
+func (s *Server) forgeBotInvocations(ctx context.Context, teamID, botID string) ([]bundle.Invocation, error) {
+	entry, ok, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -334,7 +334,7 @@ func (s *Server) handlePreviewForgeEnable(w http.ResponseWriter, r *http.Request
 	// Mirror Provision exactly: a forge: block is optional, a command-only bot
 	// subscribes to the comment event. Without this, command-only bots would
 	// be (wrongly) flagged as conflicts and the Enable button disabled.
-	pv := forge.PreviewEnable(s.forgeOrchestrator.Bots, s.forgeOrchestrator.Invocations, botIDs)
+	pv := forge.PreviewEnable(r.Context(), teamID, s.forgeOrchestrator.Bots, s.forgeOrchestrator.Invocations, botIDs)
 	binds := make([]forgePreviewBind, 0, len(pv.Binds))
 	for _, b := range botIDs {
 		if secret, ok := pv.Binds[b]; ok {

--- a/pkg/server/forge_routes_test.go
+++ b/pkg/server/forge_routes_test.go
@@ -98,7 +98,7 @@ func newForgeTestServer(t *testing.T) *Server {
 	return s
 }
 
-func testForgeBotLookup(botID string) (*bundle.ForgeRequirements, error) {
+func testForgeBotLookup(_ context.Context, _, botID string) (*bundle.ForgeRequirements, error) {
 	if botID == "review-pr" {
 		return &bundle.ForgeRequirements{
 			Events:      []string{bundle.ForgeEventPullRequest, bundle.ForgeEventPullRequestComment},

--- a/pkg/server/invocation_dispatch.go
+++ b/pkg/server/invocation_dispatch.go
@@ -19,11 +19,30 @@ import (
 // wildcard webhook with no provisioned CommandMap (a hand-created webhook);
 // orchestrator-provisioned webhooks carry an authoritative CommandMap and
 // never reach this.
-type commandDiscovery struct{ s *Server }
+//
+// teamID is the tenant the resolved command will LAUNCH for, so the scan
+// reads the same three tiers the launch will: a fork that renames its
+// command, or moves its args var, routes and stamps as itself, and a bot the
+// team authored is reachable at all. Empty only where a surface genuinely has
+// no tenant (the native board, one local store).
+//
+// The ctx is carried on the struct because webhooks.CommandDiscovery takes
+// none: the adapter is built per delivery and used within it, so the request's
+// cancellation still reaches the store read.
+type commandDiscovery struct {
+	s      *Server
+	ctx    context.Context
+	teamID string
+}
 
 func (d commandDiscovery) LookupCommand(cmd string) (webhooks.CommandRoute, bool) {
-	entries, err := d.s.effectiveEntries()
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	entries, err := d.s.effectiveEntriesFor(ctx, d.teamID)
 	if err != nil {
+		d.s.logWarn("command discovery: cannot read the bot catalog, /%s will not resolve: %v", cmd, err)
 		return webhooks.CommandRoute{}, false
 	}
 	cmd = strings.ToLower(strings.TrimSpace(cmd))
@@ -61,9 +80,12 @@ func commandRouteFromInvocation(botID string, inv bundle.Invocation) webhooks.Co
 	}
 }
 
-// cmdDiscovery returns the live command-discovery fallback bound to this
-// server (nil-safe — commandDiscovery handles registry errors internally).
-func (s *Server) cmdDiscovery() webhooks.CommandDiscovery { return commandDiscovery{s: s} }
+// cmdDiscoveryFor returns the live command-discovery fallback bound to this
+// server and to the tenant the resolved command will launch for (nil-safe —
+// commandDiscovery handles registry errors internally).
+func (s *Server) cmdDiscoveryFor(ctx context.Context, teamID string) webhooks.CommandDiscovery {
+	return commandDiscovery{s: s, ctx: ctx, teamID: teamID}
+}
 
 // boardRouteForLabel builds a synthetic board-mode CommandRoute for a
 // label-triggered launch (an issue gains a trigger label → run the bot).
@@ -73,15 +95,20 @@ func (s *Server) cmdDiscovery() webhooks.CommandDiscovery { return commandDiscov
 // (so a labeled issue dispatches the bot exactly like its `/command` would),
 // defaulting to the implementer contract (feature_prompt + opens an MR) — the
 // shape every label-triggered bot (featurly et al.) follows.
-func (s *Server) boardRouteForLabel(botID string) webhooks.CommandRoute {
+//
+// teamID is the tenant the card will launch for: the invocation is read from
+// the tier that will serve it, so a fork's own args var is what the issue text
+// lands in.
+func (s *Server) boardRouteForLabel(ctx context.Context, teamID, botID string) webhooks.CommandRoute {
 	route := webhooks.CommandRoute{
 		BotID:   botID,
 		Mode:    string(bundle.ExecutionBoard),
 		ArgsVar: "feature_prompt",
 		OpensMR: true,
 	}
-	entries, err := s.effectiveEntries()
+	entries, err := s.effectiveEntriesFor(ctx, teamID)
 	if err != nil {
+		s.logWarn("board route: cannot read the bot catalog, %s falls back to the default label contract: %v", botID, err)
 		return route
 	}
 	for _, e := range entries {

--- a/pkg/server/triggers_routes.go
+++ b/pkg/server/triggers_routes.go
@@ -69,7 +69,12 @@ type triggerFromInvocationReq struct {
 // bot+kind is a 409 carrying the existing id.
 func (s *Server) handleTriggerFromInvocation(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimSpace(r.PathValue("name"))
-	entry, ok, err := s.findBot(name)
+	// The subscription this derives launches through the trigger spine, which
+	// resolves the tenant's own tier — so the invocation it is derived FROM
+	// comes from the same tier, or the binding describes a bundle that will
+	// not run (and a bot the team authored is not enable-able at all).
+	tenant := s.triggerTenant(r)
+	entry, ok, err := s.effectiveFindByNameForTeam(r.Context(), tenant, name)
 	if err != nil {
 		dispatcher.WriteErr(w, http.StatusInternalServerError, err)
 		return
@@ -104,7 +109,6 @@ func (s *Server) handleTriggerFromInvocation(w http.ResponseWriter, r *http.Requ
 
 	now := time.Now().UTC()
 	id := uuid.NewString()
-	tenant := s.triggerTenant(r)
 	var (
 		sub     trigger.Subscription
 		derived bool

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -495,7 +495,7 @@ func (s *Server) handleGitHubIssues(w http.ResponseWriter, r *http.Request, cfg 
 	// still launches (or a board coordinator owns it). repoRef empty → the
 	// runner clones the repo's default branch; featurly's worktree: auto
 	// branches from there.
-	route := s.boardRouteForLabel(botID)
+	route := s.boardRouteForLabel(ctx, cfg.TenantID, botID)
 	vars := applyWebhookVarLayers(issueLabeledVars(p, nil, route.ArgsVar), cfg)
 	s.dispatchInvocation(ctx, w, r, cfg, meta, idemKey, route, vars, p.CloneURL, "", payloadHash, srcIP)
 }

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -307,7 +307,7 @@ func (s *Server) handleGitLabIssueEvent(ctx context.Context, w http.ResponseWrit
 	// "gl|issue|" keeps the key space disjoint from the mr|/note|/cmd| paths.
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("gl|issue|%s|%s|%d|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.IssueIID, label)))
 
-	route := s.boardRouteForLabel(botID)
+	route := s.boardRouteForLabel(ctx, cfg.TenantID, botID)
 	vars := applyWebhookVarLayers(gitlabIssueLabeledVars(p, nil, route.ArgsVar), cfg)
 	// An issue carries no MR source branch — the bot opens its MR from the
 	// project default branch (finalize_mr cuts the branch from there).
@@ -426,7 +426,7 @@ func (s *Server) handleGitLabNote(ctx context.Context, w http.ResponseWriter, r 
 	// Classifying "is this a Revi thread" needs the bot's own identity, so it
 	// runs inside the gate (which resolves the forge token).
 	converseBot := s.roleBots().ReviConverse
-	if !s.canRouteToConverseBot(cfg, converseBot) {
+	if !s.canRouteToConverseBot(ctx, cfg, converseBot) {
 		filtered("no /revi trigger")
 		return
 	}
@@ -530,7 +530,7 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 		s.recordNoteDelivery(ctx, cfg, webhooks.StatusFiltered, payloadHash, srcIP, p, reason)
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 	}
-	route, ok := webhooks.ResolveCommandRoute(cfg, cmd, cmdArgs, s.cmdDiscovery())
+	route, ok := webhooks.ResolveCommandRoute(cfg, cmd, cmdArgs, s.cmdDiscoveryFor(ctx, cfg.TenantID))
 	if !ok {
 		filtered("no command route for /" + cmd)
 		return
@@ -906,12 +906,14 @@ func (s *Server) realWebhookReviewRequestGate(ctx context.Context, cfg webhooks.
 
 // canRouteToConverseBot reports whether the given conversational bot id
 // (the caller's roleBots snapshot — passed in so the gate and the launch
-// agree on ONE bot) is allowed by this webhook config and resolvable on
-// this deployment. The existence probe is metadata-only (cached platform
-// entries + a baked-path stat) — it must never materialize a bundle just
-// to answer a boolean on the note hot path.
-func (s *Server) canRouteToConverseBot(cfg webhooks.Config, converseBot string) bool {
-	return cfg.AllowsBot(converseBot) && s.botExists(converseBot)
+// agree on ONE bot) is allowed by this webhook config and resolvable for the
+// tenant this delivery launches for. It probes the same three tiers the
+// launch resolves, so the gate cannot refuse a bot the launch would serve —
+// a team-authored converse bot exists on no other tier. Metadata-only (one
+// indexed row read + cached platform entries + a baked-path stat): it must
+// never materialize a bundle just to answer a boolean on the note hot path.
+func (s *Server) canRouteToConverseBot(ctx context.Context, cfg webhooks.Config, converseBot string) bool {
+	return cfg.AllowsBot(converseBot) && s.botExistsForTeam(ctx, cfg.TenantID, converseBot)
 }
 
 // gitlabForkRefusal words the MR lane's fork refusal for the delivery row,

--- a/pkg/server/webhooks_handoff.go
+++ b/pkg/server/webhooks_handoff.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/botsource"
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -119,8 +120,9 @@ func (s *Server) realWebhookHandoff(ctx context.Context, cfg webhooks.Config, ki
 	if s.runs == nil || strings.TrimSpace(q.PRURL) == "" {
 		return ""
 	}
-	producers := s.handoffProducers(kind)
-	if len(producers) == 0 {
+	base := s.handoffProducers(kind)
+	team := s.teamHandoffProducers(ctx, cfg.TenantID, kind)
+	if len(base) == 0 && len(team) == 0 {
 		return ""
 	}
 	rs := s.runs.RunStore()
@@ -147,6 +149,14 @@ func (s *Server) realWebhookHandoff(ctx context.Context, cfg webhooks.Config, ki
 		if lerr != nil {
 			continue
 		}
+		// Each run is described by the tier it was SERVED from, which it
+		// records: a team-tier run of a forked slug declares its produces:
+		// in the fork's manifest, and the origin's node name would render
+		// nothing — indistinguishable from "nothing reviewed this PR".
+		producers := base
+		if cfg.TenantID != "" && run.BotSourceTenant == cfg.TenantID {
+			producers = team
+		}
 		spec, produces := producers[run.BotID]
 		if !produces {
 			continue
@@ -161,16 +171,9 @@ func (s *Server) realWebhookHandoff(ctx context.Context, cfg webhooks.Config, ki
 	return ""
 }
 
-// handoffProducers maps each discovered bot that declares it produces this kind
-// to the node layout to read it from.
-//
-// The PRODUCER side is resolved against the platform+baked set only, unlike
-// the consumer side above: this asks "who, anywhere on this deployment,
-// produces this kind", which a per-team read cannot answer without listing
-// every team's rows. So a team that forks a reviewer AND renames the node its
-// `produces:` block points at drops out of the hand-off — a real boundary,
-// stated here because a miss is silent and would otherwise read as "nothing
-// reviewed this PR". Closing it is #946.
+// handoffProducers maps each bot of the platform + baked tiers that declares
+// it produces this kind to the node layout to read it from — the deployment
+// floor, describing every run those two tiers served.
 func (s *Server) handoffProducers(kind bundle.HandoffKind) map[string]bundle.ProducedArtifact {
 	entries, err := s.effectiveEntries()
 	if err != nil {
@@ -182,11 +185,47 @@ func (s *Server) handoffProducers(kind bundle.HandoffKind) map[string]bundle.Pro
 	}
 	out := make(map[string]bundle.ProducedArtifact, 2)
 	for _, e := range entries {
-		for _, p := range e.Produces {
-			if p.Kind == kind {
-				out[e.Name] = p
-				break
-			}
+		out = addProducer(out, e.Name, e.Produces, kind)
+	}
+	return out
+}
+
+// teamHandoffProducers is handoffProducers over teamID's OWN rows — the set
+// that describes the runs the team tier served. Kept separate rather than
+// overlaid, because the scan picks per run: the question is "which manifest
+// did THIS run execute", and a team's run may still have been served by the
+// platform or baked tier.
+//
+// It reads the rows' manifests directly instead of materialising entries: the
+// scan runs on every hand-off resolution, and `produces:` needs no compiled
+// vars schema. Nil (and a warning) when the store cannot answer — never a
+// silent empty set, which would read as "this team's reviewer produced
+// nothing".
+func (s *Server) teamHandoffProducers(ctx context.Context, teamID string, kind bundle.HandoffKind) map[string]bundle.ProducedArtifact {
+	teamID = strings.TrimSpace(teamID)
+	if s.botSources == nil || teamID == "" || teamID == botsource.PlatformTenantID {
+		return nil
+	}
+	list, err := s.botSources.ListByTenant(store.WithTenant(ctx, teamID), teamID)
+	if err != nil {
+		s.logWarn("handoff: cannot read team %s's bots, a %s produced by one of its own bots will be missed: %v", teamID, kind, err)
+		return nil
+	}
+	out := make(map[string]bundle.ProducedArtifact, 2)
+	for i := range list {
+		if m := list[i].Manifest(); m != nil {
+			out = addProducer(out, list[i].Slug, m.Produces, kind)
+		}
+	}
+	return out
+}
+
+// addProducer records the bot's declaration for this kind, if it makes one.
+func addProducer(out map[string]bundle.ProducedArtifact, name string, produces []bundle.ProducedArtifact, kind bundle.HandoffKind) map[string]bundle.ProducedArtifact {
+	for _, p := range produces {
+		if p.Kind == kind {
+			out[name] = p
+			return out
 		}
 	}
 	return out

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -61,7 +61,7 @@ func (s *Server) handlePRForgeComment(ctx context.Context, w http.ResponseWriter
 		s.handlePRForgeReviewApprove(ctx, w, cfg, provider, p, reason, payloadHash, srcIP)
 		return
 	}
-	route, ok := webhooks.ResolveCommandRoute(cfg, cmd, cmdArgs, s.cmdDiscovery())
+	route, ok := webhooks.ResolveCommandRoute(cfg, cmd, cmdArgs, s.cmdDiscoveryFor(ctx, cfg.TenantID))
 	if !ok {
 		filtered("no command route for /" + cmd)
 		return
@@ -520,7 +520,7 @@ func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.Resp
 	// ONE role snapshot: the enable-gate and the launch below must name the
 	// same converse bot.
 	converseBot := s.roleBots().ReviConverse
-	if !s.canRouteToConverseBot(cfg, converseBot) {
+	if !s.canRouteToConverseBot(ctx, cfg, converseBot) {
 		filtered("converse bot not enabled on this webhook")
 		return
 	}


### PR DESCRIPTION
## Why

#871 (merged and **deployed this morning**) made a team's fork *run* on its board cards, triggers, schedules and webhooks. The lanes that *describe* a bot stayed tenant-free — so a fork whose `manifest.yaml` differs from its origin's **runs as the fork while being described by the origin**. Silently: nothing compares the two.

A fork that renames a `consumes:` var gets an empty seed. A fork that renames its `/command` stamps the operator's text under a var the running bundle never declares. Neither is an error.

## The ticket's list was neither complete nor accurate — I grepped the class instead

#940 carried a follow-up commit that already closed **four** of the lanes the ticket names, and rewrote the comment it quotes. Two of the ticket's remaining claims were wrong on top of that: the retry-policy read was fixed in that same commit, and the `/bots` listing was **never** tenant-free (`mergedBotEntries` overlays the JWT's active team).

The sweep found **four sites the ticket does not mention**: the trigger-from-invocation route, the forge auto-provisioning lookups (`CommandMap` + event set), and the two FS-catalog metadata **writes**.

## The table

| # | Site | What it reads | Disposition |
|---|---|---|---|
| 1–4 | hand-off `consumes:` seeds · gate-var defaults · retry policy · pause-notice role | | already fixed in #940 |
| 5 | `LookupCommand` | `/command` → bot + `args_var` + `opens_mr` | **fixed** |
| 6 | `boardRouteForLabel` | labeled-issue route | **fixed** |
| 7 | `canRouteToConverseBot` | converse routing gate | **fixed** |
| 8 | `handoffProducers` | `produces:` node, **per run** | **fixed** |
| 9 | `botConfigShareSpec` | `config_share:` surface | **fixed** |
| 10 | config editor | persona + branding | **fixed** |
| 11 | `handleTriggerFromInvocation` | `invocations:` → Subscription | **fixed** — not in the ticket |
| 12 | `forge.Orchestrator.Bots/Invocations` | provisioned `CommandMap` + events | **fixed** — not in the ticket; `pkg/forge` signature change |
| 13–14 | `PUT /api/v1/bots/{name}` and `/overlay` | metadata **writes** | **409** — not in the ticket |
| 15 | `/bots` list + detail | | already tenant-aware; the ticket's claim is wrong |
| 16–19 | board-comment dispatcher · post-scaffold probe · fork source read · staleness report | | tenant-free **by design**, each allowlisted with its reason |
| 20 | pipelines control center | | **NOT fixed — see below** |
| 21 | `requires:` (#858/#942) | | **not in the class**: both readers hold the bundle already |

**Which tenant a lane passes depends on what it describes**, and that split is now the contract at `bot_resolver.go:37`:

- *a delivery about to launch* → the launching team's tier;
- *a run that already launched* → **that run's own** `bot_source_tenant`. The ambient tenant is the wrong question there: a team's own run may still have been served by platform or baked, and the run records which. This is why `handoffProducers` is not a team overlay but two maps selected per run inside the scan.

## The "no" row, stated rather than papered over

**The pipelines control center** resolves tenant-free *and* launches by filesystem path (`entry.MainFile()`), bypassing `resolveBotTiered`. In cloud, a team that forked a catalog bot presses "launch now" and gets the **origin**; a team-authored bot has `Path == ""` and cannot be carded at all.

Not fixed here because it is a **launch**-surface hole (#871's class) whose halves are inseparable: making the admission check tenant-aware **alone would be worse than the bug** — cards that can never launch. Filed as **#970**, recorded in `docs/platform-bots.md` under "Known gap" and in the sweep allowlist, so it does not read as an oversight.

## Red first

A temporary probe on the shipped fixture, before the fix — nine lanes, nine origin-shaped answers on a delivery the fork serves:

```
LookupCommand(revi) = {BotID:reviewer-bot ArgsVar:scope_notes OpensMR:false}  — want the fork's fork_prompt + opens_mr true
LookupCommand(teamonly) ok=false                                             — want the team's own bot
botConfigShareSpec = {ConfigPath:baked.yaml …}                               — want the fork's fork.yaml
botManifest(reviewer-bot).DisplayName = "Baked Revi"                         — want "Fork Revi"
forgeBotInvocations(teamonly-bot): bot not found                             — a team-authored bot cannot be provisioned
realWebhookHandoff = ""                                                      — the fork's produces: node was not read
cron = "0 2 * * 1"                                                           — want the fork's "0 5 * * 3"
handleBotsPut on a team fork = 200, want 409
--- FAIL: TestProbe946   [9/9 subtests FAIL]
```

The `handleBotsPut` 200 is the sharpest: it returned the **fork's** entry (`respondBot` checks `tenantBotEntries` first) while having written the **catalog's** `manifest.yaml` — a write that looked applied and was not.

## Two decisions worth a reviewer's eye

- **`forge.BotForgeLookup` / `BotInvocationsLookup` now take `(ctx, teamID, botID)`.** Not optional: `invocation_dispatch.go`'s own comment says it mirrors `forge.Orchestrator.buildCommandMap` so the live-discovery fallback and the provisioned `CommandMap` agree. Fixing only the fallback would have made them disagree — a new defect.
- **`entryOrigin` now matches exactly *then* `NormalizeName`-folded**, mirroring `effectiveFindByName`. Without it the refusal was stricter than the lookup it labels, and `PUT /api/v1/bots/reviewer_bot` slipped past it into the empty-path backstop with the wrong message. Falsified: reverting the fold turns the platform-override test red with exactly that body.

## The guard

A third static sweep fails any `pkg/server` file calling a tenant-free metadata form unless it is declared in `tenantFreeMetadataAllowed` **with its reason**. Both new guards were falsified before being trusted (a canary appended to `webhooks_review_approve.go`, then reverted):

```
--- FAIL: TestBotResolutionSweep_TenantFreeMetadataIsDeclared
    webhooks_review_approve.go reads bot metadata through a tenant-FREE form — a lane that
    knows its team reads the tier that will SERVE the launch (…), or add an allowlist entry
    saying why this surface has no tenant
```

## Behaviour change worth naming

The studio's bot-home icon picker and enable/disable toggle call these two write routes for **any** entry. For a tenant bot in cloud they now surface a `409` naming `/api/teams/{id}/bot-sources` instead of a `200` that changed nothing (the toggle already visibly snapped back). Hiding those controls for `entry.editable` bots is a small SPA follow-up, deliberately not made here — an explicit error is strictly better than the silent no-op it replaces.

`task check` green; `-race` green on `pkg/server` + `pkg/forge`. `task openapi:gen`: no diff — only status codes and messages changed.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
