### PR TITLE
ci: the merge queue runs only the checks that can block a merge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# A job that is NOT a required status check cannot block a merge, so running
+# it inside the merge queue buys a verdict nobody can act on — while holding a
+# runner slot the queue needs. The org shares 20 concurrent jobs across every
+# repository, and a queue entry is a full CI cycle, so those slots are what
+# decides how long a merge takes. The four advisory jobs below therefore run
+# on the pull request and on main, and skip in `merge_group`.
+#
+# The line to hold: the jobs carrying that skip are exactly the complement of
+# the ruleset's required checks (test, race, vendor-check, mongo-conformance,
+# golangci, revi/review). Promoting one of them to required means deleting its
+# skip in the same change — a required check that never reports leaves the
+# queue waiting for check_response_timeout_minutes and then failing.
+# The list lives in a ruleset, outside this repo, so nothing here can assert
+# it — docs/merge-policy.md carries the same warning beside the required list.
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -327,6 +342,9 @@ jobs:
           echo "::endgroup::"
 
   nats-conformance:
+    # Advisory: not a required check, so it cannot block a merge — see the
+    # merge-queue note at the top of this file.
+    if: github.event_name != 'merge_group'
     # Runs the JetStream integration tests (mixed-version schema rollout,
     # issue #481) against a real broker. Gated on ITERION_TEST_NATS_URI
     # in-tree so a developer's plain `go test ./...` skips them; CI
@@ -378,6 +396,9 @@ jobs:
           go test -mod=vendor -v -timeout 5m ./pkg/runner/... ./pkg/queue/...
 
   cloud-e2e:
+    # Advisory: not a required check, so it cannot block a merge — see the
+    # merge-queue note at the top of this file.
+    if: github.event_name != 'merge_group'
     # Builds the iterion image, spins kind + Helm-installs the cloud
     # stack with bundled Mongo + NATS + MinIO (values-dev.yaml), then
     # exercises the full chain (server → NATS → runner → Mongo →
@@ -597,6 +618,9 @@ jobs:
           git diff --exit-code go.mod go.sum vendor/
 
   helm-lint:
+    # Advisory: not a required check, so it cannot block a merge — see the
+    # merge-queue note at the top of this file.
+    if: github.event_name != 'merge_group'
     # Catches values typing drift cheaply (~30s) so a broken values.yaml
     # surfaces before the 25-minute cloud-e2e kind cluster bootstrap. The
     # --strict pass on values-prod.yaml additionally rejects unknown
@@ -662,6 +686,9 @@ jobs:
         run: golangci-lint run --timeout 5m
 
   govulncheck:
+    # Advisory: not a required check, so it cannot block a merge — see the
+    # merge-queue note at the top of this file.
+    if: github.event_name != 'merge_group'
     # govulncheck is call-graph aware (only reports CVEs whose vulnerable
     # functions are actually reachable from this codebase). Trivy's
     # filesystem scan catches the broader set including unused-import

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -20,11 +20,20 @@ green.
   is what decides how long a merge takes, far more than how long any test runs.
   Measured 2026-09-08: nine jobs totalling ~31 min of compute took 44 min of
   wall clock, 19 of them waiting for a first slot, while five entries built in
-  parallel.
+  parallel. The queue is tuned against that cap — `max_entries_to_build: 2`
+  (at most two entries under CI at once, instead of five) and
+  `min_entries_to_merge: 3` (merges land in batches of 3-5, so the workflows
+  that fire on every push to `main` — Runner Image, Trivy, Sandbox, Brew Tap —
+  run once per batch). A lone PR still merges after
+  `min_entries_to_merge_wait_minutes` (5).
 - **Required checks** (the fast, reliable ones): `test`, `race`, `vendor-check`,
   `mongo-conformance`, `golangci`, `revi/review` — and `nats-conformance` once
-  an admin adds it to ruleset 18857412 (a token with `repo` scope can read the
-  ruleset but gets a 404 on PUT). The `nats-conformance` job runs the JetStream
+  an admin adds it to ruleset 18857412. Editing that ruleset from the API needs
+  `PUT /repos/{owner}/{repo}/rulesets/{id}` with the **complete** representation
+  (`name`, `target`, `enforcement`, `bypass_actors`, `conditions`, `rules`); a
+  `PATCH`, or a `PUT` missing any of those, answers `404` — which reads exactly
+  like a permission ceiling and is not one. Read the ruleset first and send it
+  back with the one field changed. The `nats-conformance` job runs the JetStream
   schema-rollout integration tests (#481); until it is required, a regression
   there merges green. The slow container-image build is intentionally NOT
   required — it builds on merge to `main` and would stall the queue 12 min/PR.

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -15,6 +15,12 @@ green.
 - The queue creates a temporary branch = `main` + earlier-queued PRs + this PR,
   runs the required checks on it, and squash-merges only if green. Grouping is
   `ALLGREEN` (a failing entry drops out; the rest still merge).
+- **A queue entry is a full CI cycle**, and the organisation shares 20
+  concurrent jobs across every repository — so how many entries build at once
+  is what decides how long a merge takes, far more than how long any test runs.
+  Measured 2026-09-08: nine jobs totalling ~31 min of compute took 44 min of
+  wall clock, 19 of them waiting for a first slot, while five entries built in
+  parallel.
 - **Required checks** (the fast, reliable ones): `test`, `race`, `vendor-check`,
   `mongo-conformance`, `golangci`, `revi/review` — and `nats-conformance` once
   an admin adds it to ruleset 18857412 (a token with `repo` scope can read the
@@ -22,6 +28,16 @@ green.
   schema-rollout integration tests (#481); until it is required, a regression
   there merges green. The slow container-image build is intentionally NOT
   required — it builds on merge to `main` and would stall the queue 12 min/PR.
+
+  > **Promoting a check to required is a two-file change.** The four advisory
+  > jobs — `nats-conformance`, `cloud-e2e`, `helm-lint`, `govulncheck` — carry
+  > `if: github.event_name != 'merge_group'` in `.github/workflows/tests.yml`:
+  > a job that cannot block a merge should not hold a runner slot the queue
+  > needs. Adding one to this ruleset **without deleting its skip** leaves the
+  > queue waiting `check_response_timeout_minutes` (60) for a check that never
+  > reports, then failing every entry. Nothing in the repository can catch
+  > that — the required list lives in the ruleset — so the two edits go
+  > together, by hand.
 - No required human approval (`required_approving_review_count: 0`) — the bot
   factory's own adversarial review + the checks are the gate; a reviewer still
   merges deliberately.


### PR DESCRIPTION
## The measurement

CI is the bottleneck, and it is not because the tests are slow. One full cycle on this repository, measured 2026-09-08:

| job | duration | required? |
|---|---|---|
| `test` | 8 min 14 | **yes** |
| `race` | 8 min 04 | **yes** |
| `cloud-e2e` | 4 min 53 | no |
| `golangci` | 3 min 21 | **yes** |
| `mongo-conformance` | 2 min 49 | **yes** |
| `nats-conformance` | 2 min 11 | no |
| `govulncheck` | 1 min 20 | no |
| `vendor-check` | 37 s | **yes** |
| `helm-lint` | 14 s | no |

**~31 min of compute, 44 min of wall clock** — and the first job started **19 minutes** after the run was created. Jobs then trickled in as slots freed: 12:08, 12:08, 12:08, 12:14, 12:15, 12:15, 12:19, 12:21, 12:24.

The scarce resource is **runner slots**: the organisation is on the Free plan with **20 concurrent jobs shared across every SocialGouv repository**, and no self-hosted runners. The merge queue builds up to five entries at once (`max_entries_to_build: 5`), each a full nine-job cycle — so one busy queue can ask for 45 slots out of 20.

The corollary worth stating, because the instinct runs the other way: **splitting `test` into a matrix would make this worse.** Under a slot cap, more parallelism is more contention for the same work.

## The change

Four of the nine jobs are **advisory** — `nats-conformance`, `cloud-e2e`, `helm-lint`, `govulncheck` are not in ruleset 18857412's required list. Inside the merge queue their verdict **cannot block a merge**, so running them there buys an answer nobody can act on while holding a slot the queue needs.

They now skip on `merge_group`, and keep running on every pull request and on `main`, where their answer is read and acted on.

**No gate loses anything.** The checks that decide a merge — `test`, `race`, `vendor-check`, `mongo-conformance`, `golangci`, `revi/review` — are untouched. A queue entry goes from 9 jobs to 5, and from ~31 min of compute to ~23.

## The trap this opens, named in both files

Promoting one of the four to required **without deleting its skip** leaves the queue waiting `check_response_timeout_minutes` (60) for a check that never reports, then failing every entry. `nats-conformance` is the promotion already planned (#481), so the warning sits beside it in `docs/merge-policy.md`.

**No test can catch this**, and I did not pretend otherwise: the required list lives in a ruleset, outside the repository, so a guard could only mirror it — a second copy to drift, which is the failure this repo argues against elsewhere. The rule is instead written where the person doing the promotion will already be: the ruleset's own doc section, and the workflow's header comment.

## The other half: the queue is retuned, and the doc that said it was impossible is corrected

`docs/merge-policy.md` claimed a `repo`-scoped token "gets a 404 on PUT" on ruleset 18857412. **It does not.** `PUT /repos/{owner}/{repo}/rulesets/{id}` succeeds when it carries the **complete** representation — `name`, `target`, `enforcement`, `bypass_actors`, `conditions`, `rules`. A `PATCH`, or a `PUT` missing any of those, answers `404`, which reads exactly like a permission ceiling and is not one. That false line is fixed here, with the working recipe.

The queue is retuned against the 20-slot cap:

```
max_entries_to_build : 5 → 2     at most two entries under CI at once
min_entries_to_merge : 1 → 3     merges land in batches of 3-5
```

The second one matters more than it looks: **Runner Image, Trivy, Sandbox Base Images and Brew Tap all fire on every push to `main`**, so batching three merges into one runs them once instead of three times. A lone PR still merges after `min_entries_to_merge_wait_minutes` (5), so the latency cost is bounded.

Verified field by field against the ruleset read immediately before the write: required checks, bypass actors, conditions and enforcement all unchanged; exactly the two intended fields moved.

Still open, and a bigger lever than either of these: **self-hosted runners** on the cluster that already hosts the buildkit-operator would remove the cap entirely — with the discipline a public repository requires: trusted refs only (`merge_group`, `push`), fork pull requests staying on GitHub-hosted runners.

Self-hosted runners on the cluster that already hosts the buildkit-operator would remove the cap entirely — with the discipline a public repository requires: trusted refs only (`merge_group`, `push`), fork pull requests staying on GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

