### PR TITLE
chore(deps): bump claw to the codex version gpt-6-astra actually requires

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad h1:5vokAXjPSzPuV3lcu5GeKK2CnPTVTmVz4+dtoBMxNpo=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba h1:J/EWLztoU3pmJ7YOUorC7Ic+Z+t5eyiu//BK4noG1bo=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/provider.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/provider.go
@@ -16,10 +16,28 @@ const (
 // ChatGPTClientVersion is the codex-cli release claw presents on the
 // ChatGPT-Codex wire (`version:` header + User-Agent) when the caller passes
 // no OpenAIClientVersion. The backend gates model availability on it: a model
-// newer than the release claw claims is refused with "requires a newer
-// version of Codex" (measured 2026-09-07: gpt-6-astra refused at 0.139.0,
-// served at 0.144.6). Bump it when a new model line ships.
-const ChatGPTClientVersion = "0.144.6"
+// newer than the release claw claims is refused with
+//
+//	400 {"detail":"The '<model>' model requires a newer version of Codex.
+//	     Please upgrade to the latest app or CLI and try again."}
+//
+// The gate is PER MODEL, and each model line raises it. Measured against the
+// live endpoint on 2026-09-08, one request per cell, body held identical and
+// only the `version:` header varied:
+//
+//	                0.130.0  0.139.0  0.144.6  0.150.0  0.152.0  0.153.0
+//	gpt-5.6-sol     refused  refused  served   served   served   served
+//	gpt-6-astra     refused  refused  refused  refused  refused  served
+//
+// So a value that unlocks one line says nothing about the next: 0.144.6 was
+// enough for gpt-5.6-sol and is refused for gpt-6-astra, whose floor is
+// exactly 0.153.0.
+//
+// Measure before bumping. The body must carry `store: false`, or the endpoint
+// rejects it on that first and never reaches the model gate — a probe without
+// it reports every version as equally "passing", which is how the previous
+// value in this comment came to be wrong.
+const ChatGPTClientVersion = "0.153.4"
 
 // ProviderConfig holds the credentials and settings needed to create a provider client.
 type ProviderConfig struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
 # github.com/SherClockHolmes/webpush-go v1.4.0
 ## explicit; go 1.13
 github.com/SherClockHolmes/webpush-go
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260907213801-b6e34a390fad
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
## Summary

Follow-up to #917, which is in the merge queue and cannot be updated. Stacked on `fix/codex-client-version`; retargets to `main` when it lands.

#917 makes the runner present a codex-cli version that never downgrades below claw's baked floor. That floor is **0.144.6**, chosen on the strength of a comment in claw asserting `gpt-6-astra` was "served at 0.144.6". It is not. Merged as-is, #917 unlocks `gpt-5.6-sol` and still refuses `gpt-6-astra` with:

```
400 {"detail":"The 'gpt-6-astra' model requires a newer version of Codex.
     Please upgrade to the latest app or CLI and try again."}
```

## Measurement

Live endpoint (`chatgpt.com/backend-api/codex/responses`), 2026-09-08, one request per cell. Body held identical, only the `version:` header varied:

| model | 0.130.0 | 0.139.0 | 0.144.6 | 0.150.0 | 0.152.0 | 0.153.0 |
|---|---|---|---|---|---|---|
| `gpt-5.6-sol` | refused | refused | **served** | served | served | served |
| `gpt-6-astra` | refused | refused | refused | refused | refused | **served** |

The gate is **per model**, and each model line raises it. `gpt-6-astra`'s floor is exactly **0.153.0**.

Confirmed end-to-end from a cloud run before and after the credential that was masking this: with the old floor, `gpt-5.6-sol` answers (19 tokens, $0.00038) and `gpt-6-astra` returns the version refusal on the same run.

## Why the earlier value was wrong, and how not to repeat it

A probe that omits `store: false` from the body is rejected on the body first (`400 {"detail":"Store must be set to false"}`) and **never reaches the model gate** — so every version comes back looking equally acceptable. That is how 0.144.6 came to be recorded as sufficient for astra. The claw constant's doc comment now carries both the measured table and this trap, so the next bump is measured rather than inferred.

## What changed

`go.mod` / vendor bump to claw `dd630c6`, which raises `api.ChatGPTClientVersion` from `0.144.6` to `0.153.4` and replaces the doc comment's incorrect claim with the table above. No engine code changes.

`go build ./...` clean, `go test ./pkg/backend/model/` → 1107 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
