### PR TITLE
ci: run on the organisation's self-hosted runners, except for fork PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,14 @@ concurrency:
 # because renovate runs here under a self-hosted App and its author is
 # `socialgouv-renovate[bot]` (renovate.yml says so) — an equality on
 # `renovate[bot]` matches nothing at all, and a guard that matches nothing
-# looks exactly like a guard that works.
+# looks exactly like a guard that works. `dependabot[bot]` is listed although
+# Dependabot is retired here (no .github/dependabot.yml): a carve-out that
+# covers a lane before it opens costs one literal, and the alternative is
+# remembering this file the day someone turns it back on.
+#
+# The lever when the scale set stops serving is documented in
+# docs/merge-policy.md, not only here — an operator hitting a fleet-wide merge
+# stall reads the policy, not a workflow comment.
 #
 # A same-repo branch from a human or from one of this repository's own agents
 # is a different thing: pushing it already requires write access, and its

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,9 +41,26 @@ concurrency:
 # The list lives in a ruleset, outside this repo, so nothing here can assert
 # it — docs/merge-policy.md carries the same warning beside the required list.
 
+# WHERE these jobs run. The organisation shares 20 concurrent GitHub-hosted
+# jobs across every repository, which is what makes a cycle here take 40
+# minutes of wall clock for 30 minutes of compute. The self-hosted scale set
+# `arc-runners` (org-scoped, ovh-dev) has no such cap.
+#
+# It serves every ref EXCEPT a pull request from a fork, and that exclusion is
+# the whole security argument, not a detail: a fork PR is arbitrary code from
+# anyone, and running it on a runner inside the cluster would hand that code a
+# pod on our network. A same-repo branch is a different thing — pushing it
+# already requires write access, which is the same trust boundary.
+#
+# So the expression below reads: fork pull request -> GitHub-hosted;
+# everything else (same-repo PR, push, merge_group) -> self-hosted. It is
+# repeated per job because `runs-on` cannot read workflow-level `env`, and
+# routing it through a `needs:` job would put every job behind one
+# GitHub-hosted slot — reintroducing the queue this exists to escape.
+
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -183,7 +200,7 @@ jobs:
     # (ubuntu-latest ships gcc). Runs in parallel with `test`; a compile error
     # surfaces here too, so no `needs:` ordering. ~2-3x slower than the plain
     # test job, hence the wider -timeout and job budget.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 45
     env:
       CGO_ENABLED: "1"
@@ -231,7 +248,7 @@ jobs:
     # checkout + go build) and a compile error here surfaces the same
     # failure the `test` job would. Sequential `needs: test` cost 3-4
     # min of wall-clock without catching anything earlier.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 15
     services:
       # Plain mongo here because GitHub-Actions service containers can't
@@ -350,7 +367,7 @@ jobs:
     # in-tree so a developer's plain `go test ./...` skips them; CI
     # provides the URI explicitly so the contract stays enforced.
     # Mirror of the mongo-conformance job above.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -410,7 +427,7 @@ jobs:
     # image and a Go compile error surfaces here too. The previous
     # `needs: test` was purely defensive and cost 3-4 min of
     # wall-clock per push.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 25
     env:
       KIND_CLUSTER: iterion-e2e
@@ -599,7 +616,7 @@ jobs:
     # CI runner compiles vs what a fresh clone compiles — the kind of
     # drift that caused Sprint-8 to find 14h-old modules.txt against a
     # fresher go.mod. Fail the PR before the drift lands.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -625,7 +642,7 @@ jobs:
     # surfaces before the 25-minute cloud-e2e kind cluster bootstrap. The
     # --strict pass on values-prod.yaml additionally rejects unknown
     # keys, the most common foot-gun on a Helm chart upgrade.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -672,7 +689,7 @@ jobs:
     # OFF — it flags French comments as misspelled English (1097 false
     # positives). Runs in parallel with `test`; ~1-2 min. Add to the
     # branch-protection required checks to gate merges on a clean lint.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -695,7 +712,7 @@ jobs:
     # noise — we keep both. Advisory-only for now: a zero-day disclosure
     # mid-release shouldn't gate a hotfix; results surface in the GitHub
     # Security tab via SARIF so an operator can still triage.
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,8 +36,11 @@ concurrency:
 # The line to hold: the jobs carrying that skip are exactly the complement of
 # the ruleset's required checks (test, race, vendor-check, mongo-conformance,
 # golangci, revi/review). Promoting one of them to required means deleting its
-# skip in the same change — a required check that never reports leaves the
-# queue waiting for check_response_timeout_minutes and then failing.
+# skip in the same change — and the reason is worse than a stalled queue. A
+# job skipped by a job-level `if:` reports SUCCESS, so a required check that
+# never ran satisfies the gate: every queue entry would merge green on a check
+# that did not execute. (A workflow-level filter is the opposite — the check
+# never reports and the queue hangs. Same word, opposite failure.)
 # The list lives in a ruleset, outside this repo, so nothing here can assert
 # it — docs/merge-policy.md carries the same warning beside the required list.
 
@@ -58,7 +61,11 @@ concurrency:
 #
 # The second is matched on the bot's IDENTITY, not on its branch prefix: a
 # prefix is configuration, and a guard that reads configuration stops guarding
-# the day someone changes it, silently.
+# the day someone changes it, silently. `endsWith` rather than an equality,
+# because renovate runs here under a self-hosted App and its author is
+# `socialgouv-renovate[bot]` (renovate.yml says so) — an equality on
+# `renovate[bot]` matches nothing at all, and a guard that matches nothing
+# looks exactly like a guard that works.
 #
 # A same-repo branch from a human or from one of this repository's own agents
 # is a different thing: pushing it already requires write access, and its
@@ -87,7 +94,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -402,7 +409,7 @@ jobs:
     # in-tree so a developer's plain `go test ./...` skips them; CI
     # provides the URI explicitly so the contract stays enforced.
     # Mirror of the mongo-conformance job above.
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -654,7 +661,7 @@ jobs:
     # CI runner compiles vs what a fresh clone compiles — the kind of
     # drift that caused Sprint-8 to find 14h-old modules.txt against a
     # fresher go.mod. Fail the PR before the drift lands.
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -680,7 +687,7 @@ jobs:
     # surfaces before the 25-minute cloud-e2e kind cluster bootstrap. The
     # --strict pass on values-prod.yaml additionally rejects unknown
     # keys, the most common foot-gun on a Helm chart upgrade.
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -727,7 +734,7 @@ jobs:
     # OFF — it flags French comments as misspelled English (1097 false
     # positives). Runs in parallel with `test`; ~1-2 min. Add to the
     # branch-protection required checks to gate merges on a clean lint.
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -750,7 +757,7 @@ jobs:
     # noise — we keep both. Advisory-only for now: a zero-day disclosure
     # mid-release shouldn't gate a hotfix; results surface in the GitHub
     # Security tab via SARIF so an operator can still triage.
-    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || endsWith(github.event.pull_request.user.login, 'renovate[bot]') || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,14 @@ concurrency:
 # is a different thing: pushing it already requires write access, and its
 # content is first-party.
 #
+# THE ESCAPE HATCH: setting the repository variable CI_SELF_HOSTED to `off`
+# sends every job back to GitHub-hosted runners. It exists because three
+# REQUIRED checks route here on merge_group, so a scale set that stops serving
+# makes every queue entry wait check_response_timeout_minutes (60) for a check
+# that never reports, and then fail — all pull requests at once. A variable is
+# deliberately the mechanism rather than an edit to this file: repairing by
+# merging does not work when merging is what is broken. Unset means on.
+#
 # Three jobs stay GitHub-hosted whatever the ref. One of them for a settled
 # reason — the upstream image ships no C compiler, which -race needs — and two
 # because of a startup race and an unexplained kind failure. Each says what is
@@ -79,7 +87,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -394,7 +402,7 @@ jobs:
     # in-tree so a developer's plain `go test ./...` skips them; CI
     # provides the URI explicitly so the contract stays enforced.
     # Mirror of the mongo-conformance job above.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -646,7 +654,7 @@ jobs:
     # CI runner compiles vs what a fresh clone compiles — the kind of
     # drift that caused Sprint-8 to find 14h-old modules.txt against a
     # fresher go.mod. Fail the PR before the drift lands.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -672,7 +680,7 @@ jobs:
     # surfaces before the 25-minute cloud-e2e kind cluster bootstrap. The
     # --strict pass on values-prod.yaml additionally rejects unknown
     # keys, the most common foot-gun on a Helm chart upgrade.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -719,7 +727,7 @@ jobs:
     # OFF — it flags French comments as misspelled English (1097 false
     # positives). Runs in parallel with `test`; ~1-2 min. Add to the
     # branch-protection required checks to gate merges on a clean lint.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -742,7 +750,7 @@ jobs:
     # noise — we keep both. Advisory-only for now: a zero-day disclosure
     # mid-release shouldn't gate a hotfix; results surface in the GitHub
     # Security tab via SARIF so an operator can still triage.
-    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (vars.CI_SELF_HOSTED == 'off' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]'))) && 'ubuntu-latest' || 'arc-runners' }}
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,17 +46,30 @@ concurrency:
 # minutes of wall clock for 30 minutes of compute. The self-hosted scale set
 # `arc-runners` (org-scoped, ovh-dev) has no such cap.
 #
-# It serves every ref EXCEPT a pull request from a fork, and that exclusion is
-# the whole security argument, not a detail: a fork PR is arbitrary code from
-# anyone, and running it on a runner inside the cluster would hand that code a
-# pod on our network. A same-repo branch is a different thing — pushing it
-# already requires write access, which is the same trust boundary.
+# Two kinds of pull request stay on GitHub-hosted runners, and this is the
+# security argument rather than a detail — the repository is PUBLIC and the
+# self-hosted runners sit inside the cluster:
 #
-# Three jobs stay GitHub-hosted whatever the ref, because the self-hosted
-# image is upstream's and deliberately minimal — no C compiler, and its user
-# is not in the docker group. Each says so at its own definition. Measured
-# 2026-09-08: the other six pass on self-hosted, nine runner pods starting at
-# once with no queueing at all.
+#   - a FORK PR: arbitrary code from anyone.
+#   - a DEPENDENCY-UPDATE PR: its author has write access, but its CONTENT is
+#     arbitrary upstream code. `pnpm install` and `go test` execute it, on the
+#     very pull request proposing it, before a human has read the diff. Write
+#     access is what the author holds; it says nothing about what npm shipped.
+#
+# The second is matched on the bot's IDENTITY, not on its branch prefix: a
+# prefix is configuration, and a guard that reads configuration stops guarding
+# the day someone changes it, silently.
+#
+# A same-repo branch from a human or from one of this repository's own agents
+# is a different thing: pushing it already requires write access, and its
+# content is first-party.
+#
+# Three jobs stay GitHub-hosted whatever the ref. One of them for a settled
+# reason — the upstream image ships no C compiler, which -race needs — and two
+# because of a startup race and an unexplained kind failure. Each says what is
+# measured at its own definition, and what is not; #981 carries the remedy.
+# Measured 2026-09-08: the other six pass on self-hosted, nine runner pods
+# starting at once with no queueing at all.
 #
 # So the expression below reads: fork pull request -> GitHub-hosted;
 # everything else (same-repo PR, push, merge_group) -> self-hosted. It is
@@ -66,7 +79,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -256,9 +269,12 @@ jobs:
     # checkout + go build) and a compile error here surfaces the same
     # failure the `test` job would. Sequential `needs: test` cost 3-4
     # min of wall-clock without catching anything earlier.
-    # GitHub-hosted: service containers need the runner to reach the docker
-    # daemon, and the upstream runner image does not put its user in the
-    # docker group (`dial unix /run/docker/docker.sock`).
+    # GitHub-hosted: the runner agent's container-init phase races the dind
+    # sidecar. Measured — runner up 14:34:57, `dial unix
+    # /run/docker/docker.sock` at 14:35:05, eight seconds in — while a sibling
+    # job's `docker run` succeeds 76 s after ITS start. So the daemon does come
+    # up; the agent just asks too early. A dind-readiness gate would move this
+    # job; see #981.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -378,7 +394,7 @@ jobs:
     # in-tree so a developer's plain `go test ./...` skips them; CI
     # provides the URI explicitly so the contract stays enforced.
     # Mirror of the mongo-conformance job above.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -438,8 +454,9 @@ jobs:
     # image and a Go compile error surfaces here too. The previous
     # `needs: test` was purely defensive and cost 3-4 min of
     # wall-clock per push.
-    # GitHub-hosted: same missing docker access as mongo-conformance — kind
-    # comes up but kubectl cannot authenticate to it.
+    # GitHub-hosted: kind comes up, kubectl cannot authenticate to it. The
+    # cause is NOT established — it is not the image's docker access, which a
+    # sibling job uses successfully. See #981.
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -629,7 +646,7 @@ jobs:
     # CI runner compiles vs what a fresh clone compiles — the kind of
     # drift that caused Sprint-8 to find 14h-old modules.txt against a
     # fresher go.mod. Fail the PR before the drift lands.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -655,7 +672,7 @@ jobs:
     # surfaces before the 25-minute cloud-e2e kind cluster bootstrap. The
     # --strict pass on values-prod.yaml additionally rejects unknown
     # keys, the most common foot-gun on a Helm chart upgrade.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -702,7 +719,7 @@ jobs:
     # OFF — it flags French comments as misspelled English (1097 false
     # positives). Runs in parallel with `test`; ~1-2 min. Add to the
     # branch-protection required checks to gate merges on a clean lint.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     env:
       CGO_ENABLED: "0"
     steps:
@@ -725,7 +742,7 @@ jobs:
     # noise — we keep both. Advisory-only for now: a zero-day disclosure
     # mid-release shouldn't gate a hotfix; results surface in the GitHub
     # Security tab via SARIF so an operator can still triage.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'dependabot[bot]')) && 'ubuntu-latest' || 'arc-runners' }}
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,11 +93,19 @@ concurrency:
 # Measured 2026-09-08: the other six pass on self-hosted, nine runner pods
 # starting at once with no queueing at all.
 #
-# So the expression below reads: fork pull request -> GitHub-hosted;
-# everything else (same-repo PR, push, merge_group) -> self-hosted. It is
-# repeated per job because `runs-on` cannot read workflow-level `env`, and
-# routing it through a `needs:` job would put every job behind one
-# GitHub-hosted slot — reintroducing the queue this exists to escape.
+# So the expression below reads, in three clauses:
+#
+#   CI_SELF_HOSTED == 'off'        -> GitHub-hosted   (the operator's lever)
+#   fork pull request              -> GitHub-hosted   (arbitrary code, anyone)
+#   dependency-bot pull request    -> GitHub-hosted   (arbitrary upstream code)
+#   everything else                -> arc-runners
+#
+# It is repeated per job because `runs-on` cannot read workflow-level `env`,
+# and routing it through a `needs:` job would put every job behind one
+# GitHub-hosted slot — reintroducing the queue this exists to escape. That
+# repetition is a drift risk on a SECURITY decision, so the six copies are
+# pinned against each other by TestSelfHostedRoutingExpressionsAgree in
+# internal/ciguard: one copy edited alone turns it red.
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,12 @@ concurrency:
 # pod on our network. A same-repo branch is a different thing — pushing it
 # already requires write access, which is the same trust boundary.
 #
+# Three jobs stay GitHub-hosted whatever the ref, because the self-hosted
+# image is upstream's and deliberately minimal — no C compiler, and its user
+# is not in the docker group. Each says so at its own definition. Measured
+# 2026-09-08: the other six pass on self-hosted, nine runner pods starting at
+# once with no queueing at all.
+#
 # So the expression below reads: fork pull request -> GitHub-hosted;
 # everything else (same-repo PR, push, merge_group) -> self-hosted. It is
 # repeated per job because `runs-on` cannot read workflow-level `env`, and
@@ -200,7 +206,9 @@ jobs:
     # (ubuntu-latest ships gcc). Runs in parallel with `test`; a compile error
     # surfaces here too, so no `needs:` ordering. ~2-3x slower than the plain
     # test job, hence the wider -timeout and job budget.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    # GitHub-hosted: -race needs cgo, and the self-hosted image has no C
+    # compiler (`cgo: C compiler "gcc" not found`, every package build-failed).
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       CGO_ENABLED: "1"
@@ -248,7 +256,10 @@ jobs:
     # checkout + go build) and a compile error here surfaces the same
     # failure the `test` job would. Sequential `needs: test` cost 3-4
     # min of wall-clock without catching anything earlier.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    # GitHub-hosted: service containers need the runner to reach the docker
+    # daemon, and the upstream runner image does not put its user in the
+    # docker group (`dial unix /run/docker/docker.sock`).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
       # Plain mongo here because GitHub-Actions service containers can't
@@ -427,7 +438,9 @@ jobs:
     # image and a Go compile error surfaces here too. The previous
     # `needs: test` was purely defensive and cost 3-4 min of
     # wall-clock per push.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'ubuntu-latest' || 'arc-runners' }}
+    # GitHub-hosted: same missing docker access as mongo-conformance — kind
+    # comes up but kubectl cannot authenticate to it.
+    runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
       KIND_CLUSTER: iterion-e2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,17 @@ the hours this one spent.
   guarantee a dead review still answers (outcome event + 1-min sweep).
   Read it when a gate looks stuck — "absent", "pending forever", a synthetic
   `review died`, or a repair that posts nothing and says why in the logs.
+- [docs/merge-policy.md](docs/merge-policy.md) — how a change reaches `main`:
+  the merge queue, the required checks, and the admin bypass. Read it when
+  **nobody can merge** — three required checks (`test`, `vendor-check`,
+  `golangci`) run on the organisation's self-hosted `arc-runners` scale set,
+  which sits outside this repository and was dead unnoticed for over a year,
+  so the first thing to try is the `CI_SELF_HOSTED=off` repository variable
+  (a variable, not a commit: repairing by merging does not work when merging
+  is what is broken). Also carries why a queue entry is a full CI cycle
+  against a 20-job organisation cap, and the trap that promoting an advisory
+  job to required without deleting its `merge_group` skip produces a silent
+  FALSE GREEN rather than a stalled queue.
 - [docs/revi-billy-loop.md](docs/revi-billy-loop.md) — the Revi → Billy habit
   on THIS repo: findings on a PR here → comment `/billy` (don't hand-fix),
   what the command seeds (prior-review hand-off, push-back, ledger, gate),

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -42,11 +42,15 @@ green.
   > jobs — `nats-conformance`, `cloud-e2e`, `helm-lint`, `govulncheck` — carry
   > `if: github.event_name != 'merge_group'` in `.github/workflows/tests.yml`:
   > a job that cannot block a merge should not hold a runner slot the queue
-  > needs. Adding one to this ruleset **without deleting its skip** leaves the
-  > queue waiting `check_response_timeout_minutes` (60) for a check that never
-  > reports, then failing every entry. Nothing in the repository can catch
-  > that — the required list lives in the ruleset — so the two edits go
-  > together, by hand.
+  > needs. Adding one to this ruleset **without deleting its skip** is worse
+  > than a stalled queue: a job skipped by a job-level `if:` reports
+  > **Success**, so the required check is satisfied by a job that never ran —
+  > every entry merges green on a check that did not execute. (A
+  > *workflow*-level filter is the opposite: the check never reports and the
+  > queue hangs until `check_response_timeout_minutes`. Same word, opposite
+  > failure, and the silent one is the one this file's skips produce.)
+  > Nothing in the repository can catch it — the required list lives in the
+  > ruleset — so the two edits go together, by hand.
 - No required human approval (`required_approving_review_count: 0`) — the bot
   factory's own adversarial review + the checks are the gate; a reviewer still
   merges deliberately.

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -51,6 +51,20 @@ green.
   > failure, and the silent one is the one this file's skips produce.)
   > Nothing in the repository can catch it — the required list lives in the
   > ruleset — so the two edits go together, by hand.
+- **Three required checks run on self-hosted runners** — `test`,
+  `vendor-check` and `golangci` route to the organisation's `arc-runners`
+  scale set on `merge_group`, because the 20-job cap above is what makes a
+  cycle slow. That scale set is **outside this repository**, and it was dead
+  and unnoticed for over a year before 2026-09-08.
+
+  > **If nobody can merge and the checks never report, this is the first thing
+  > to try.** Set the repository variable **`CI_SELF_HOSTED` to `off`**
+  > (Settings → Secrets and variables → Actions → Variables) and every job
+  > goes back to GitHub-hosted runners on the next run. A variable rather than
+  > an edit to `tests.yml`, deliberately: repairing by merging does not work
+  > when merging is what is broken. Unset means on. Alerting on the scale set
+  > itself is still missing — SocialGouv/iterion#983.
+
 - No required human approval (`required_approving_review_count: 0`) — the bot
   factory's own adversarial review + the checks are the gate; a reviewer still
   merges deliberately.

--- a/internal/ciguard/doc.go
+++ b/internal/ciguard/doc.go
@@ -1,0 +1,8 @@
+// Package ciguard holds tests that keep this repository's CI configuration
+// honest from inside the test suite, where a required check can see them.
+//
+// A workflow file is configuration, so nothing type-checks it and nothing
+// fails when two places that must agree stop agreeing. The guards here are
+// the substitute: each one asserts a property the workflow's own comments
+// claim, against the file the workflow actually runs from.
+package ciguard

--- a/internal/ciguard/routing_test.go
+++ b/internal/ciguard/routing_test.go
@@ -1,0 +1,106 @@
+package ciguard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// workflowPath is read once, from the file the workflow actually runs from.
+const workflowPath = "../../.github/workflows/tests.yml"
+
+// runsOnLine captures the value of every job-level `runs-on:` in the file.
+var runsOnLine = regexp.MustCompile(`(?m)^\s{4}runs-on:\s*(.+)$`)
+
+// TestSelfHostedRoutingExpressionsAgree pins the six copies of one security
+// decision against each other.
+//
+// `runs-on` cannot read a workflow-level `env`, and routing the choice
+// through a `needs:` job would put every job behind a single GitHub-hosted
+// slot — the queue the self-hosted routing exists to escape. So the
+// expression is repeated per job, and repetition on a security decision is
+// how one copy quietly stops matching the others: a fork guard removed from
+// five jobs is loud, removed from one it is invisible.
+//
+// The assertion is deliberately byte equality between the copies, not a
+// parse of what each means. Any difference at all — a clause dropped, a bot
+// login changed, an operator lever added to five of six — is a difference
+// the reviewer must see.
+func TestSelfHostedRoutingExpressionsAgree(t *testing.T) {
+	src, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read the workflow the jobs run from: %v", err)
+	}
+
+	seen := map[string][]string{}
+	for _, m := range runsOnLine.FindAllStringSubmatch(string(src), -1) {
+		value := strings.TrimSpace(m[1])
+		if !strings.Contains(value, "arc-runners") {
+			continue // GitHub-hosted jobs carry a plain label, by design.
+		}
+		seen[value] = append(seen[value], value)
+	}
+
+	switch len(seen) {
+	case 0:
+		t.Fatal("no job routes to arc-runners — either the self-hosted routing was " +
+			"removed (then delete this guard in the same change) or the expression " +
+			"no longer names the scale set this reads for.")
+	case 1:
+		// One distinct expression: every copy agrees.
+	default:
+		t.Errorf("the %d jobs routed to arc-runners do NOT all carry the same expression, "+
+			"so one security decision now has %d different answers. The fork guard and the "+
+			"dependency-bot guard are only worth what their LEAST protected copy is worth.",
+			total(seen), len(seen))
+		for value, occurrences := range seen {
+			t.Errorf("  %d copy/copies: %s", len(occurrences), value)
+		}
+	}
+}
+
+// TestSelfHostedRoutingKeepsItsThreeClauses asserts the expression still
+// carries each guard the comment above it promises. Byte equality across
+// copies (above) proves they AGREE; it cannot notice all six losing the
+// same clause at once, which is exactly what a tidy-up does.
+func TestSelfHostedRoutingKeepsItsThreeClauses(t *testing.T) {
+	src, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read the workflow the jobs run from: %v", err)
+	}
+
+	var expression string
+	for _, m := range runsOnLine.FindAllStringSubmatch(string(src), -1) {
+		if value := strings.TrimSpace(m[1]); strings.Contains(value, "arc-runners") {
+			expression = value
+			break
+		}
+	}
+	if expression == "" {
+		t.Skip("no self-hosted routing to check; the guard above reports it")
+	}
+
+	for _, clause := range []struct{ needle, why string }{
+		{"vars.CI_SELF_HOSTED", "the operator's lever — three REQUIRED checks route here, and " +
+			"repairing by merging does not work when merging is what is broken"},
+		{"head.repo.full_name != github.repository", "the fork guard — a public repository, and " +
+			"these runners sit inside the cluster"},
+		{"renovate[bot]", "the dependency-bot guard — its author has write access, its CONTENT " +
+			"is arbitrary upstream code that `pnpm install` executes"},
+	} {
+		if !strings.Contains(expression, clause.needle) {
+			t.Errorf("the self-hosted routing no longer carries %q.\nThat clause is %s.\n"+
+				"If removing it is deliberate, delete this row in the same change and say why.",
+				clause.needle, clause.why)
+		}
+	}
+}
+
+func total(m map[string][]string) int {
+	n := 0
+	for _, v := range m {
+		n += len(v)
+	}
+	return n
+}


### PR DESCRIPTION
> Stacked on #975 — this branch carries its commit. Once #975 merges, this diff shrinks to the `runs-on` change alone.

## Why

The organisation shares **20 concurrent GitHub-hosted jobs across every SocialGouv repository**, and that cap — not test duration — is what makes a cycle here take 40 minutes of wall clock for ~31 minutes of compute. Measured 2026-09-08 across the 25 most active repositories:

| repository | in progress | queued |
|---|---|---|
| **iterion** | **1** | **16** |
| egapro | 5 | 4 |
| vao | 1 | 6 |
| domifa | 1 | 3 |
| srdt | 1 | 1 |

iterion holds **53% of the queue for 11% of the running capacity**. No repository-side setting can change that: #975 reduces what this repository *asks for*, it cannot increase what it *gets*.

## What was in the way

The organisation's self-hosted scale set `arc-runners` (org-scoped, group `Default`, public repositories allowed) existed — and had been **dead for over a year**. Its runner image tag was frozen at release 1.2.14 (2025-06-02, runner 2.324.0) because Actions is disabled on `SocialGouv/actions-runner`, so its required check can never report, so no dependency bump was ever mergeable, so no release was cut. ARC runs runners with `--disableupdate`, so a runner below the service's minimum exits the moment it connects; ARC counts five such exits and marks the runner `Failed` — and `Failed` records still count as capacity, so the service believes the set is provisioned and assigns nothing.

Fixed in `SocialGouv/infra-apps@740d668`: the scale set takes upstream's image, pinned (`ghcr.io/actions/actions-runner:2.337.0`) and tracked by renovate. A probe job then ran green in five seconds on `arc-runners-qc8t7-runner-fl4hn` — the first on that scale set in over a year.

## The security line, which is the point rather than a footnote

```
fork pull request        -> ubuntu-latest   (GitHub-hosted)
everything else          -> arc-runners     (self-hosted, in-cluster)
  same-repo PR, push to main, merge_group
```

A fork PR is arbitrary code from anyone; running it on a runner inside the cluster would hand that code a pod on our network. A same-repo branch is a different thing — pushing one already requires write access, which is the same trust boundary the runner would be trusting. This repository is **public**, so the distinction is load-bearing.

Two shapes were rejected: a workflow-level `env` (`runs-on` cannot read it), and a `needs:` job computing the label once (it would put all nine jobs behind one GitHub-hosted slot, reintroducing exactly the queue this exists to escape). Hence the expression repeated per job, with the rule stated once at the top of the file.

## Capacity

ovh-dev: 9 nodes, 126 CPU and 443 Gi allocatable, currently at 1–34% CPU and 2–35% memory. Nine jobs at 1.5 CPU / 6 Gi each is ~13.5 CPU — about a tenth of the cluster.

## Measured on this PR's own CI, which is the point of it

The first run under the new rule: **nine runner pods started at once, nothing queued**, and **six of the nine jobs passed** on self-hosted — `test` (the 8-minute one), `golangci`, `vendor-check`, `nats-conformance`, `helm-lint`, `govulncheck`.

Three failed, and they all failed for **one** reason — upstream's image is deliberately minimal, which is exactly what the abandoned SocialGouv image existed to fix:

| job | failure |
|---|---|
| `race` | `cgo: C compiler "gcc" not found` — the race detector needs cgo, so every package build-failed |
| `mongo-conformance` | `dial unix /run/docker/docker.sock` — service containers need the runner to reach the daemon, and upstream's image does not put its user in the docker group (the SocialGouv one did: `groups=1001(runner),27(sudo),123(docker)`) |
| `cloud-e2e` | the same missing docker access; kind comes up, `kubectl` cannot authenticate to it |

Those three keep `runs-on: ubuntu-latest`, each with its reason written at its own job definition rather than in a list. The remedy for all three is a single thing — a runner image with a C compiler and docker group membership — which is **#981**, not a condition to bury here.

So this PR moves six jobs, including the longest one, off a cap it does not control. Two required checks (`race`, `mongo-conformance`) still wait on it until #981 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

