### PR TITLE
fix(test): persist Git fixture maintenance opt-outs

### DIFF
--- a/docs/test-process-cleanup.md
+++ b/docs/test-process-cleanup.md
@@ -115,18 +115,18 @@ settling-child test passed under `-race`; removing only the ECHILD accounting
 call made it fail with `settling child not observed then forgiven`. The
 overlays did not modify the committed sources.
 
-Not covered, and tracked separately in #974: the residual `git maintenance`
-hazard. `pkg/runtime`'s tests run 15 production writing-git commands
-(`commit -F -`, `merge --squash`,
-`merge --ff-only`) against `t.TempDir()` fixture repositories, through
-`worktree.go`'s own factory rather than `gittest.Cmd` — so they carry no
-`maintenance.auto=false`, and on CI's git (≥ 2.48, the version behind #821/#828)
-each detaches a maintenance process that the subreaper now adopts. Measured, a
-no-op `git maintenance run --auto` on such a repository takes ~4 ms against a
-500 ms window, so the settle window absorbs it; the durable fix is
-`gittest.InitRepo` writing the opt-out into the fixture repository's own config,
-exactly as it already does for the identity and the signing opt-out and for the
-same stated reason — "a command iterion itself spawns during the test does not
-inherit this package's environment". That is a change to `internal/gittest`,
-whose `TestCmd_GitItselfReportsAutoMaintenanceOff` currently asserts the key is
-NOT in the repository config, so it needs that control reworked with it.
+The Git fixture gap tracked in #974 is covered at repository creation:
+`gittest.InitRepo` persists `maintenance.auto=false` and `gc.auto=0` in the
+fixture's common config, just as it persists identity and the signing opt-out.
+Production Git commands invoked by tests (for example runtime worktree squash
+and fast-forward finalization) therefore inherit the opt-outs even when they
+do not use `gittest.Cmd`. Linked worktrees share that config. This changes only
+test-owned repositories; production Git policy and operator repositories are
+unaffected.
+
+The regression asks real Git to resolve both keys without Cmd's flags, in the
+source fixture and a linked worktree. Before the fix, all four queries reported
+unset; afterward they return the opt-outs. A separate repository initialized
+without `InitRepo` keeps the command-level control discriminating: both keys
+are unset without Cmd and set with it. These are configuration-resolution
+checks, not a timing claim about detached maintenance on the host's Git.

--- a/internal/gittest/gittest_test.go
+++ b/internal/gittest/gittest_test.go
@@ -1,6 +1,7 @@
 package gittest
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +19,9 @@ import (
 // Falsified by construction: without `-c maintenance.auto=…`, both keys are
 // unset and `git config --get` exits 1 (checked below on the same repo).
 func TestCmd_GitItselfReportsAutoMaintenanceOff(t *testing.T) {
-	repo := SourceRepo(t)
+	// Keep this control independent of InitRepo's persisted fixture policy.
+	repo := t.TempDir()
+	Run(t, repo, "init", "-q", "-b", "main")
 
 	for _, tc := range []struct{ key, want string }{
 		{"maintenance.auto", "false"},
@@ -27,15 +30,39 @@ func TestCmd_GitItselfReportsAutoMaintenanceOff(t *testing.T) {
 		if got := Run(t, repo, "config", "--get", tc.key); got != tc.want {
 			t.Errorf("git resolved %s = %q, want %q — a writing command may detach `git maintenance run --auto` into a directory the test is about to delete", tc.key, got, tc.want)
 		}
+		// Without Cmd's flags, Git must report each key as unset (exit 1).
+		bare := exec.Command("git", "config", "--get", tc.key) // #nosec G204 -- fixed config keys
+		bare.Dir = repo
+		bare.Env = Env()
+		out, err := bare.CombinedOutput()
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) || exit.ExitCode() != 1 || len(out) != 0 {
+			t.Fatalf("control git config --get %s = %q, %v; want unset (exit 1)", tc.key, out, err)
+		}
 	}
+}
 
-	// The same question asked WITHOUT the helper: unset, so the assertion
-	// above is not vouching for a value git would report anyway.
-	bare := exec.Command("git", "config", "--get", "maintenance.auto") // #nosec G204 -- fixed argv
-	bare.Dir = repo
-	bare.Env = Env()
-	if out, err := bare.CombinedOutput(); err == nil {
-		t.Fatalf("maintenance.auto is set in the repository itself (%q) — this test cannot tell the helper's config apart from it", strings.TrimSpace(string(out)))
+// Production commands spawned during tests do not use Cmd. The repository's
+// common config must protect both its checkout and linked run worktrees.
+func TestSourceRepo_BareGitReportsAutoMaintenanceOff(t *testing.T) {
+	repo := SourceRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	Run(t, repo, "worktree", "add", "--detach", linked, "HEAD")
+	for _, checkout := range []struct{ name, dir string }{{"source", repo}, {"linked", linked}} {
+		t.Run(checkout.name, func(t *testing.T) {
+			for _, tc := range []struct{ key, want string }{
+				{"maintenance.auto", "false"},
+				{"gc.auto", "0"},
+			} {
+				bare := exec.Command("git", "config", "--get", tc.key) // #nosec G204 -- fixed config keys
+				bare.Dir = checkout.dir
+				bare.Env = Env()
+				out, err := bare.CombinedOutput()
+				if got := strings.TrimSpace(string(out)); err != nil || got != tc.want {
+					t.Errorf("bare git resolved %s = %q, %v; want %q from fixture config", tc.key, got, err, tc.want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/gittest/repo.go
+++ b/internal/gittest/repo.go
@@ -10,16 +10,19 @@ import (
 // InitRepo turns dir into a git repository with one commit on `main` and
 // returns that commit's SHA.
 //
-// The identity and the signing opt-out are written into the repository's own
-// config, not only into Env: a command iterion itself spawns during the test
-// (finalizeWorktree's squash, the runner's bank) does not inherit this
-// package's environment, and CI has no global identity to fall back on.
+// Identity, signing and auto-maintenance opt-outs live in the repository's
+// common config, shared by linked worktrees. Commands iterion itself spawns
+// during tests (finalizeWorktree's squash, the runner's bank) do not inherit
+// Cmd's flags or Env: they need an identity on CI and must not detach Git
+// maintenance into a fixture that t.TempDir is about to remove.
 func InitRepo(t testing.TB, dir string) string {
 	t.Helper()
 	Run(t, dir, "init", "-q", "-b", "main")
 	Run(t, dir, "config", "user.name", "iterion test")
 	Run(t, dir, "config", "user.email", "test@iterion.invalid")
 	Run(t, dir, "config", "commit.gpgsign", "false")
+	Run(t, dir, "config", "maintenance.auto", "false")
+	Run(t, dir, "config", "gc.auto", "0")
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("init\n"), 0o600); err != nil {
 		t.Fatalf("seed %s: %v", dir, err)
 	}

--- a/pkg/git/test_callers_test.go
+++ b/pkg/git/test_callers_test.go
@@ -38,9 +38,8 @@ func TestEveryTestGitCallerDisablesAutoMaintenance(t *testing.T) {
 			// scratch clones of other people's code (.local, .works, .repos).
 			name := info.Name()
 			// internal/gittest is the chokepoint itself: its Cmd applies the
-			// config, and its own test builds one bare command on purpose, to
-			// show the assertion is not vouching for a value git would report
-			// anyway.
+			// config. Its tests deliberately use bare read-only Git commands
+			// to distinguish Cmd's flags from InitRepo's persisted config.
 			if skipNames[name] || (strings.HasPrefix(name, ".") && path != root) ||
 				path == filepath.Join("..", "..", "internal", "gittest") {
 				return filepath.SkipDir


### PR DESCRIPTION
Production Git commands invoked by tests bypass `gittest.Cmd`, so test repositories could still spawn detached auto-maintenance after a command returned. `InitRepo` now persists `maintenance.auto=false` and `gc.auto=0` in the fixture's common config, covering its source checkout and linked worktrees without changing production Git policy.

Real Git configuration queries without helper flags fail on the old fixture and pass with this fix. The existing command-level regression uses a separately initialized repository and checks both keys are unset without `Cmd`, preserving its independent control.

Validation: full `task check`; `go test -race ./internal/gittest ./pkg/git ./pkg/runtime`. Both passed. Documentation updated with the measured regression and the scope of the protection.

Closes #974.
