### PR TITLE
feat(runs): expose persisted workspace checkpoint recovery

### DIFF
--- a/docs/resume.md
+++ b/docs/resume.md
@@ -231,6 +231,33 @@ against the upstream node's claim (`dep-update-guard`'s `commit_check` is the
 worked example — it compares `align.applied` with the branch head and blocks on
 a contradiction). Git is the durable state; an uncommitted working tree is not.
 
+### Recovering a workspace checkpoint after a pod dies
+
+A copy-based sandbox can push a workspace checkpoint before teardown even if
+the run later dies without `final_branch` or `final_commit`. Inspect
+`iterion remote runs get <id>`: its `workspace_checkpoint` recovery hint names
+the latest successfully pushed checkpoint recorded in the run's timeline,
+with its ref, commit, event sequence and timestamp. The same hint is returned
+by `iterion remote runs commits <id>` when the commit list is unavailable.
+`available=false` and `reason=no_baseline` still mean that the API cannot
+produce the run's commit range; they do not imply that no saved work exists.
+
+The JSON paths are `run.workspace_checkpoint` on `GET /api/runs/{id}` and
+`workspace_checkpoint` on an unavailable `GET /api/runs/{id}/commits` response.
+`source=run_workspace_checkpoint` identifies the persisted event provenance.
+A later failed push does not erase the last successful record. If there is no
+successful record, the field is omitted; no ref is invented from the run ID.
+An event-store read failure remains an error, rather than an absent hint.
+
+Run the provided `fetch_command` from a clone of the run's repository with that
+repository configured as `origin`, then check `git rev-parse FETCH_HEAD`
+against the recorded `commit`. The record proves a push succeeded at that
+time, not that the ref still exists or still points to that SHA. A checkpoint
+may include unfinished or automatically committed work and is **not a delivery
+bank or proof of a passed delivery gate**: inspect and validate it before
+merging. Merely displaying this hint does not restore files, resume the run,
+or change merge eligibility.
+
 ## Source integrity and bundles
 
 The launch stores a SHA-256 workflow hash. Resume recompiles the source and

--- a/openapi.json
+++ b/openapi.json
@@ -2013,6 +2013,9 @@
           "workflow_name": {
             "type": "string"
           },
+          "workspace_checkpoint": {
+            "$ref": "#/components/schemas/WorkspaceCheckpoint"
+          },
           "worktree": {
             "type": "boolean"
           },
@@ -2466,6 +2469,42 @@
           "entry",
           "nodes",
           "edges"
+        ],
+        "type": "object"
+      },
+      "WorkspaceCheckpoint": {
+        "properties": {
+          "commit": {
+            "type": "string"
+          },
+          "event_seq": {
+            "type": "integer"
+          },
+          "fetch_command": {
+            "type": "string"
+          },
+          "recorded_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "warning": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ref",
+          "commit",
+          "source",
+          "event_seq",
+          "recorded_at",
+          "fetch_command",
+          "warning"
         ],
         "type": "object"
       },

--- a/pkg/cli/remote_runs.go
+++ b/pkg/cli/remote_runs.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runview"
 )
 
 // remoteRunSummary mirrors runview.RunSummary's CLI-visible fields.
@@ -196,13 +197,14 @@ func RemoteRunsUploadFile(ctx context.Context, c *RemoteClient, path string) (st
 func RemoteRunsGet(ctx context.Context, c *RemoteClient, p *Printer, id string) error {
 	var run struct {
 		Run struct {
-			ID         string     `json:"id"`
-			Name       string     `json:"name"`
-			Status     string     `json:"status"`
-			FilePath   string     `json:"file_path"`
-			CreatedAt  time.Time  `json:"created_at"`
-			FinishedAt *time.Time `json:"finished_at"`
-			Error      string     `json:"error"`
+			ID                  string                       `json:"id"`
+			Name                string                       `json:"name"`
+			Status              string                       `json:"status"`
+			FilePath            string                       `json:"file_path"`
+			CreatedAt           time.Time                    `json:"created_at"`
+			FinishedAt          *time.Time                   `json:"finished_at"`
+			Error               string                       `json:"error"`
+			WorkspaceCheckpoint *runview.WorkspaceCheckpoint `json:"workspace_checkpoint"`
 		} `json:"run"`
 	}
 	raw, err := c.Call(ctx, "GET", "/api/runs/"+id, nil, &run)
@@ -232,6 +234,13 @@ func RemoteRunsGet(ctx context.Context, c *RemoteClient, p *Printer, id string) 
 	}
 	if run.Run.Error != "" {
 		p.KV("Error", run.Run.Error)
+	}
+	if cp := run.Run.WorkspaceCheckpoint; cp != nil {
+		p.KV("Workspace checkpoint", cp.Ref)
+		p.KV("Checkpoint commit", cp.Commit)
+		p.KV("Checkpoint source", fmt.Sprintf("%s event %d at %s", cp.Source, cp.EventSeq, cp.RecordedAt.Format(time.RFC3339)))
+		p.KV("Fetch", cp.FetchCommand)
+		p.KV("Recovery note", cp.Warning)
 	}
 	return nil
 }

--- a/pkg/cli/remote_runs_recovery_test.go
+++ b/pkg/cli/remote_runs_recovery_test.go
@@ -1,0 +1,44 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/cli"
+)
+
+func TestRemoteRunsGetWorkspaceCheckpoint(t *testing.T) {
+	for _, known := range []bool{false, true} {
+		for _, format := range []cli.OutputFormat{cli.OutputHuman, cli.OutputJSON} {
+			t.Run(fmt.Sprintf("known=%t/format=%v", known, format), func(t *testing.T) {
+				cp := `,"workspace_checkpoint":{"ref":"saved/work","commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","source":"run_workspace_checkpoint","event_seq":8,"recorded_at":"2026-09-08T10:00:00Z","fetch_command":"git fetch origin refs/heads/saved/work","warning":"Checkpoint only; validate before merging."}`
+				if !known {
+					cp = ""
+				}
+				c := remoteTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodGet || r.URL.Path != "/api/runs/r" {
+						t.Errorf("request = %s %s", r.Method, r.URL.Path)
+					}
+					fmt.Fprint(w, `{"run":{"id":"r","status":"failed_resumable"`+cp+`}}`)
+				}))
+				p, buf := remotePrinter(format)
+				if err := cli.RemoteRunsGet(context.Background(), c, p, "r"); err != nil {
+					t.Fatal(err)
+				}
+				out := buf.String()
+				if known {
+					for _, want := range []string{"saved/work", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "run_workspace_checkpoint", "2026-09-08T10:00:00Z", "git fetch origin refs/heads/saved/work", "validate before merging"} {
+						if !strings.Contains(out, want) {
+							t.Errorf("missing %q in %s", want, out)
+						}
+					}
+				} else if strings.Contains(strings.ToLower(out), "checkpoint") {
+					t.Fatalf("invented recovery: %s", out)
+				}
+			})
+		}
+	}
+}

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -164,6 +164,9 @@ type RunHeader struct {
 	FinalCommit      string `json:"final_commit,omitempty"`
 	FinalBranch      string `json:"final_branch,omitempty"`
 	FinalBranchError string `json:"final_branch_error,omitempty"`
+	// WorkspaceCheckpoint is the last successful checkpoint push observed in
+	// the persisted timeline. It is not a completed delivery bank.
+	WorkspaceCheckpoint *WorkspaceCheckpoint `json:"workspace_checkpoint,omitempty"`
 	// Outcome bookkeeping (see store.Run): the episode counter, the
 	// typed cause of the last terminal transition, and who owns the
 	// continuation. This is what lets an outcome consumer act on the
@@ -448,7 +451,8 @@ type SnapshotBuilder struct {
 	// deployTraceCommit is the commit the traceability gate resolved from
 	// git. Held separately from deployment.Commit so the two groups can
 	// arrive in either order; buildDeployment applies the precedence.
-	deployTraceCommit string
+	deployTraceCommit   string
+	workspaceCheckpoint *WorkspaceCheckpoint
 }
 
 // backendAgg accumulates one (backend, model) pair while folding events.
@@ -532,6 +536,10 @@ func (b *SnapshotBuilder) Apply(evt *store.Event) {
 	}
 
 	switch evt.Type {
+	case store.EventRunWorkspaceCheckpoint:
+		if cp := workspaceCheckpointFromEvent(evt); cp != nil {
+			b.workspaceCheckpoint = cp
+		}
 	case store.EventNodeStarted:
 		b.handleNodeStarted(evt, branch)
 	case store.EventNodeFinished:
@@ -592,6 +600,10 @@ func (b *SnapshotBuilder) Snapshot() *RunSnapshot {
 	// snapshot already handed out under the documented incremental usage.
 	header.FallbacksUsed = append([]FallbackUsage(nil), b.fallbacksUsed...)
 	header.Deployment = b.buildDeployment()
+	if b.workspaceCheckpoint != nil {
+		cp := *b.workspaceCheckpoint
+		header.WorkspaceCheckpoint = &cp
+	}
 	return &RunSnapshot{
 		Run:        header,
 		Executions: execs,

--- a/pkg/runview/workspace_checkpoint.go
+++ b/pkg/runview/workspace_checkpoint.go
@@ -1,0 +1,70 @@
+package runview
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
+	"github.com/SocialGouv/iterion/pkg/internal/shellquote"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// WorkspaceCheckpoint is a recovery hint from a successful persisted push
+// event, not a delivery bank or a claim that the remote ref still exists.
+// It never changes Run.FinalBranch, FinalCommit or merge eligibility.
+type WorkspaceCheckpoint struct {
+	Ref          string          `json:"ref"`
+	Commit       string          `json:"commit"`
+	Source       store.EventType `json:"source"`
+	EventSeq     int64           `json:"event_seq"`
+	RecordedAt   time.Time       `json:"recorded_at"`
+	FetchCommand string          `json:"fetch_command"`
+	Warning      string          `json:"warning"`
+}
+
+var checkpointCommitPattern = regexp.MustCompile(`^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$`)
+
+func workspaceCheckpointFromEvent(evt *store.Event) *WorkspaceCheckpoint {
+	if evt == nil || evt.Type != store.EventRunWorkspaceCheckpoint {
+		return nil
+	}
+	if _, failed := evt.Data["error"]; failed {
+		return nil
+	}
+	ref, _ := evt.Data["ref"].(string)
+	commit, _ := evt.Data["commit"].(string)
+	if gitlib.ValidateBranchName(ref) != nil || !checkpointCommitPattern.MatchString(commit) {
+		return nil
+	}
+	fetchRef := ref
+	if !strings.HasPrefix(fetchRef, "refs/") {
+		fetchRef = "refs/heads/" + fetchRef
+	}
+	return &WorkspaceCheckpoint{
+		Ref: ref, Commit: commit, Source: evt.Type, EventSeq: evt.Seq, RecordedAt: evt.Timestamp,
+		FetchCommand: "git fetch origin " + shellquote.Quote(fetchRef),
+		Warning:      "Checkpoint only; delivery gate not established. From a clone of the run's repository (origin), verify FETCH_HEAD matches the recorded commit and validate before merging. The ref may have moved or been deleted.",
+	}
+}
+
+// LoadWorkspaceCheckpoint reads only persisted events, with the caller's
+// identity. A failed later push does not erase the last known success. Event
+// read failures are returned rather than disguised as no recoverable work.
+func LoadWorkspaceCheckpoint(ctx context.Context, s store.RunStore, runID string) (*WorkspaceCheckpoint, error) {
+	if _, err := s.LoadRun(ctx, runID); err != nil {
+		return nil, err
+	}
+	var latest *WorkspaceCheckpoint
+	err := s.ScanEvents(ctx, runID, func(evt *store.Event) bool {
+		if cp := workspaceCheckpointFromEvent(evt); cp != nil && (latest == nil || cp.EventSeq > latest.EventSeq) {
+			latest = cp
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return latest, nil
+}

--- a/pkg/runview/workspace_checkpoint_test.go
+++ b/pkg/runview/workspace_checkpoint_test.go
@@ -1,0 +1,127 @@
+package runview
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestWorkspaceCheckpointReducerKeepsLatestSuccessAcrossRunRefresh(t *testing.T) {
+	run := &store.Run{ID: "orphaned", Status: store.RunStatusFailedResumable}
+	b := NewSnapshotBuilder(run)
+	sha := strings.Repeat("a", 40)
+	b.Apply(evt(1, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": "saved/first", "commit": sha}))
+	first := b.Snapshot()
+	b.Apply(evt(2, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": "saved/latest", "commit": strings.Repeat("b", 64)}))
+	want := *b.Snapshot().Run.WorkspaceCheckpoint
+	for i, data := range []map[string]any{
+		{"ref": "failed/push", "error": "offline"},
+		{"ref": "ambiguous/push", "commit": sha, "error": "offline"},
+		{"ref": "missing/sha"},
+		{"ref": "invalid/sha", "commit": "not-a-commit"},
+		{"ref": "invalid:ref", "commit": sha},
+	} {
+		b.Apply(evt(int64(i+3), store.EventRunWorkspaceCheckpoint, "", "", data))
+	}
+	// A stale replay and a refreshed Run document cannot erase event-derived state.
+	b.Apply(evt(1, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": "stale", "commit": sha}))
+	b.SetRun(run)
+	got := b.Snapshot()
+	if !reflect.DeepEqual(got.Run.WorkspaceCheckpoint, &want) {
+		t.Fatalf("latest success lost: %+v", got.Run.WorkspaceCheckpoint)
+	}
+	if got.Run.FinalBranch != "" || got.Run.FinalCommit != "" || got.Run.MergeStatus != "" {
+		t.Fatalf("checkpoint made merge eligible: %+v", got.Run)
+	}
+	if first.Run.WorkspaceCheckpoint.Ref != "saved/first" {
+		t.Fatal("later event mutated previous snapshot")
+	}
+	got.Run.WorkspaceCheckpoint.Ref = "caller mutation"
+	if b.Snapshot().Run.WorkspaceCheckpoint.Ref != want.Ref {
+		t.Fatal("snapshot aliases reducer state")
+	}
+}
+
+// Legal Git ref characters must remain one literal shell argument. Execute
+// only argument parsing, not fetch: the command substitution is a harmless
+// canary that would change the recorded name if quoting were dropped.
+func TestWorkspaceCheckpointFetchQuotesRecordedRef(t *testing.T) {
+	for _, ref := range []string{"refs/heads/ready", "saved/$(printf-injected)'semi;colon"} {
+		cp := workspaceCheckpointFromEvent(evt(1, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": ref, "commit": strings.Repeat("a", 40)}))
+		if cp == nil {
+			t.Fatalf("valid ref rejected: %q", ref)
+		}
+		cmd := exec.Command("sh", "-c", "set -- "+cp.FetchCommand+"; printf '%s\n' \"$@\"") // #nosec G204 -- parse the generated recovery command without executing fetch
+		out, err := cmd.CombinedOutput()
+		wantRef := ref
+		if !strings.HasPrefix(ref, "refs/") {
+			wantRef = "refs/heads/" + ref
+		}
+		if want := "git\nfetch\norigin\n" + wantRef + "\n"; err != nil || string(out) != want {
+			t.Fatalf("shell arguments = %q, %v; want %q", out, err, want)
+		}
+	}
+}
+
+type checkpointReadStore struct {
+	store.RunStore
+	loadErr, scanErr error
+	loaded, scanned  bool
+	t                *testing.T
+}
+
+func (s *checkpointReadStore) LoadRun(ctx context.Context, id string) (*store.Run, error) {
+	s.loaded = true
+	if tid, _ := store.TenantFromContext(ctx); tid != "tenant-a" || id != "r" {
+		s.t.Fatal("load lost identity or run id")
+	}
+	return &store.Run{ID: id}, s.loadErr
+}
+
+func (s *checkpointReadStore) ScanEvents(ctx context.Context, id string, visit func(*store.Event) bool) error {
+	s.scanned = true
+	if tid, _ := store.TenantFromContext(ctx); tid != "tenant-a" || id != "r" {
+		s.t.Fatal("scan lost identity or run id")
+	}
+	visit(evt(2, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": "saved/new", "commit": strings.Repeat("b", 40)}))
+	visit(evt(1, store.EventRunWorkspaceCheckpoint, "", "", map[string]any{"ref": "saved/old", "commit": strings.Repeat("a", 40)}))
+	return s.scanErr
+}
+
+func TestLoadWorkspaceCheckpointIdentityAndReadFailures(t *testing.T) {
+	denied := errors.New("run not visible")
+	unreadable := errors.New("event store unavailable")
+	for _, tc := range []struct {
+		name             string
+		loadErr, scanErr error
+	}{
+		{name: "latest sequence"}, {name: "denied", loadErr: denied}, {name: "scan failed", scanErr: unreadable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &checkpointReadStore{t: t, loadErr: tc.loadErr, scanErr: tc.scanErr}
+			cp, err := LoadWorkspaceCheckpoint(store.WithTenant(context.Background(), "tenant-a"), st, "r")
+			if !st.loaded || st.scanned != (tc.loadErr == nil) {
+				t.Fatal("ownership was not checked before scanning")
+			}
+			wantErr := tc.loadErr
+			if wantErr == nil {
+				wantErr = tc.scanErr
+			}
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("error = %v, want %v", err, wantErr)
+			}
+			if wantErr != nil {
+				if cp != nil {
+					t.Fatalf("partial scan masquerades as latest checkpoint: %+v", cp)
+				}
+			} else if cp == nil || cp.Ref != "saved/new" {
+				t.Fatalf("latest sequence lost: %+v", cp)
+			}
+		})
+	}
+}

--- a/pkg/server/runs_commits.go
+++ b/pkg/server/runs_commits.go
@@ -8,6 +8,7 @@ import (
 
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -23,13 +24,14 @@ import (
 // value so the user sees the proposed message before clicking, and
 // toggles into edit mode only when they want to override.
 type runCommitsResponse struct {
-	Commits              []gitlib.CommitInfo `json:"commits"`
-	Count                int                 `json:"count"`
-	BaseCommit           string              `json:"base_commit,omitempty"`
-	HeadCommit           string              `json:"head_commit,omitempty"`
-	DefaultSquashMessage string              `json:"default_squash_message,omitempty"`
-	Available            bool                `json:"available"`
-	Reason               string              `json:"reason,omitempty"`
+	Commits              []gitlib.CommitInfo          `json:"commits"`
+	Count                int                          `json:"count"`
+	BaseCommit           string                       `json:"base_commit,omitempty"`
+	HeadCommit           string                       `json:"head_commit,omitempty"`
+	DefaultSquashMessage string                       `json:"default_squash_message,omitempty"`
+	Available            bool                         `json:"available"`
+	Reason               string                       `json:"reason,omitempty"`
+	WorkspaceCheckpoint  *runview.WorkspaceCheckpoint `json:"workspace_checkpoint,omitempty"`
 }
 
 // handleListRunCommits returns the per-iteration commits the workflow
@@ -108,21 +110,27 @@ func (s *Server) handleListRunCommits(w http.ResponseWriter, r *http.Request) {
 		// end-of-life state for an old run, not a server fault: render
 		// the structured empty-state instead of a 500 with git stderr.
 		if errors.Is(logErr, gitlib.ErrNotGitRepo) || errors.Is(logErr, gitlib.ErrUnknownRevision) {
-			s.writeJSONFor(w, r, runCommitsResponse{
-				Commits:   []gitlib.CommitInfo{},
-				Available: false,
-				Reason:    "history_unavailable",
-			})
+			s.writeUnavailableRunCommits(w, r, run, "history_unavailable")
 			return
 		}
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "git log: %v", logErr)
 		return
 	}
 
+	s.writeUnavailableRunCommits(w, r, run, reasonForCommits(run))
+}
+
+func (s *Server) writeUnavailableRunCommits(w http.ResponseWriter, r *http.Request, run *store.Run, reason string) {
+	cp, err := runview.LoadWorkspaceCheckpoint(r.Context(), s.runs.RunStore(), run.ID)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "load workspace checkpoint: %v", err)
+		return
+	}
 	s.writeJSONFor(w, r, runCommitsResponse{
-		Commits:   []gitlib.CommitInfo{},
-		Available: false,
-		Reason:    reasonForCommits(run),
+		Commits:             []gitlib.CommitInfo{},
+		Available:           false,
+		Reason:              reason,
+		WorkspaceCheckpoint: cp,
 	})
 }
 

--- a/pkg/server/runs_recovery_test.go
+++ b/pkg/server/runs_recovery_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// An orphaned pod can leave no final bank or baseline but a successful
+// checkpoint push on its timeline. Both normal inspection surfaces must name it.
+func TestRunWorkspaceCheckpointRecovery(t *testing.T) {
+	for _, known := range []bool{false, true} {
+		t.Run(map[bool]string{false: "no_success", true: "persisted_checkpoint"}[known], func(t *testing.T) {
+			srv, hs := newTestServer(t)
+			st := srv.runs.RunStore()
+			ctx := context.Background()
+			run, err := st.CreateRun(ctx, "orphaned", "wf", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			run.Status = store.RunStatusFailedResumable
+			run.FailureCode = store.FailureProcessOrphaned
+			run.ContinuationState = store.ContinuationFinal
+			run.WorkDir = "/missing/runner-pod/workspace"
+			if err := st.SaveRun(ctx, run); err != nil {
+				t.Fatal(err)
+			}
+			var success *store.Event
+			sha := strings.Repeat("b", 40)
+			// A deliberately non-conventional name proves we read the event.
+			ref := "recovery/operator-selected-checkpoint"
+			if known {
+				if _, err := st.AppendEvent(ctx, run.ID, store.Event{Type: store.EventRunWorkspaceCheckpoint,
+					Data: map[string]any{"ref": "recovery/older", "commit": strings.Repeat("a", 40)}}); err != nil {
+					t.Fatal(err)
+				}
+				success, err = st.AppendEvent(ctx, run.ID, store.Event{Type: store.EventRunWorkspaceCheckpoint,
+					Data: map[string]any{"ref": ref, "commit": sha}})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			// A failed later push is not evidence that its ref holds work.
+			if _, err := st.AppendEvent(ctx, run.ID, store.Event{Type: store.EventRunWorkspaceCheckpoint,
+				Data: map[string]any{"ref": "recovery/failed", "error": "push failed"}}); err != nil {
+				t.Fatal(err)
+			}
+			var recovery map[string]any
+			for _, suffix := range []string{"", "/commits"} {
+				resp, err := http.Get(hs.URL + "/api/runs/" + run.ID + suffix)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("%s status = %d", suffix, resp.StatusCode)
+				}
+				var out map[string]any
+				decodeJSONResp(t, resp, &out)
+				if suffix == "" {
+					out = out["run"].(map[string]any)
+					if out["final_branch"] != nil || out["final_commit"] != nil {
+						t.Fatalf("checkpoint became final bank: %v", out)
+					}
+					if out["status"] != "failed_resumable" {
+						t.Fatalf("status changed: %v", out)
+					}
+				} else {
+					if out["available"] != false || out["reason"] != "no_baseline" || len(out["commits"].([]any)) != 0 {
+						t.Fatalf("no-baseline contract changed: %v", out)
+					}
+				}
+				raw := out["workspace_checkpoint"]
+				if !known {
+					if raw != nil {
+						t.Fatalf("invented checkpoint: %v", raw)
+					}
+					continue
+				}
+				cp, ok := raw.(map[string]any)
+				if !ok {
+					t.Fatalf("%s: persisted checkpoint missing: %v", suffix, out)
+				}
+				if cp["ref"] != ref || cp["commit"] != sha || cp["source"] != "run_workspace_checkpoint" || cp["event_seq"] != float64(success.Seq) {
+					t.Fatalf("wrong provenance: %v", cp)
+				}
+				var at string
+				encoded, _ := json.Marshal(success.Timestamp)
+				if err := json.Unmarshal(encoded, &at); err != nil {
+					t.Fatal(err)
+				}
+				if cp["recorded_at"] != at || cp["fetch_command"] != "git fetch origin refs/heads/"+ref || !strings.Contains(cp["warning"].(string), "validate before merging") {
+					t.Fatalf("missing recovery instructions: %v", cp)
+				}
+				if recovery != nil && !reflect.DeepEqual(recovery, cp) {
+					t.Fatalf("inspection/commits disagree: %v != %v", recovery, cp)
+				}
+				recovery = cp
+			}
+		})
+	}
+}
+
+type recoveryReadStore struct {
+	store.RunStore
+	scanErr error
+	scans   int
+}
+
+func (s *recoveryReadStore) LoadRun(ctx context.Context, id string) (*store.Run, error) {
+	if tid, _ := store.TenantFromContext(ctx); tid != "tenant-a" {
+		return nil, store.ErrRunNotFound
+	}
+	return s.RunStore.LoadRun(ctx, id)
+}
+
+func (s *recoveryReadStore) ScanEvents(ctx context.Context, id string, visit func(*store.Event) bool) error {
+	s.scans++
+	if tid, _ := store.TenantFromContext(ctx); tid != "tenant-a" {
+		return store.ErrRunNotFound
+	}
+	if s.scanErr != nil {
+		return s.scanErr
+	}
+	return s.RunStore.ScanEvents(ctx, id, visit)
+}
+
+func TestRunCommitsRecoveryReadBoundary(t *testing.T) {
+	srv, _ := newTestServer(t)
+	original := srv.runs
+	t.Cleanup(func() { srv.runs = original })
+	st := original.RunStore()
+	run, err := st.CreateRun(context.Background(), "saved", "wf", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.WorkDir = "/missing/pod"
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AppendEvent(context.Background(), run.ID, store.Event{Type: store.EventRunWorkspaceCheckpoint,
+		Data: map[string]any{"ref": "saved/work", "commit": strings.Repeat("a", 40)}}); err != nil {
+		t.Fatal(err)
+	}
+	guarded := &recoveryReadStore{RunStore: st}
+	srv.runs = newTestRunviewService(t, srv.cfg.StoreDir, runview.WithStore(guarded))
+	for _, tc := range []struct {
+		name, tenant string
+		scanErr      error
+		status       int
+		wantScan     bool
+	}{
+		{name: "owner sees saved work", tenant: "tenant-a", status: 200, wantScan: true},
+		{name: "another tenant cannot discover it", tenant: "tenant-b", status: 404},
+		{name: "unreadable is not absent", tenant: "tenant-a", scanErr: errors.New("event store offline"), status: 500, wantScan: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			guarded.scanErr = tc.scanErr
+			guarded.scans = 0
+			req := httptest.NewRequest(http.MethodGet, "/api/runs/saved/commits", nil)
+			req.SetPathValue("id", "saved")
+			req = req.WithContext(store.WithTenant(req.Context(), tc.tenant))
+			rec := httptest.NewRecorder()
+			srv.handleListRunCommits(rec, req)
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+			}
+			if (guarded.scans > 0) != tc.wantScan {
+				t.Fatalf("event scans = %d, want scan %t", guarded.scans, tc.wantScan)
+			}
+			if tc.status == http.StatusOK {
+				if !strings.Contains(rec.Body.String(), `"ref":"saved/work"`) {
+					t.Fatalf("successful control missing recovery: %s", rec.Body.String())
+				}
+			} else if strings.Contains(rec.Body.String(), "saved/work") {
+				t.Fatalf("recovery leaked through failed read: %s", rec.Body.String())
+			}
+		})
+	}
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -280,7 +280,9 @@ const (
 	// bank: the run doc is untouched (no FinalBranch — a half-done run
 	// must not read as merge-eligible), the commit is authored by
 	// iterion rather than by the run, and this event is the only durable
-	// record that the ref exists. Data:
+	// record of the successful push. Run inspection projects the latest
+	// success as workspace_checkpoint, separately from final-bank fields.
+	// Data:
 	//   - ref / commit: the checkpoint ref and what it holds — the
 	//     success shape
 	//   - ref / error: why the push failed and the work is still only

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6036,6 +6036,7 @@ export interface components {
             work_dir?: string;
             workflow_hash?: string;
             workflow_name: string;
+            workspace_checkpoint?: components["schemas"]["WorkspaceCheckpoint"];
             worktree?: boolean;
             worktree_available: boolean;
         };
@@ -6168,6 +6169,16 @@ export interface components {
             name: string;
             nodes: components["schemas"]["WireNode"][];
             stale_hash?: boolean;
+        };
+        WorkspaceCheckpoint: {
+            commit: string;
+            event_seq: number;
+            fetch_command: string;
+            /** Format: date-time */
+            recorded_at: string;
+            ref: string;
+            source: string;
+            warning: string;
         };
         apiKeyView: {
             alive_runs?: number;


### PR DESCRIPTION
A pod can die after pushing useful checkpoint work while the run has no final bank or baseline. Run inspection now exposes the latest successfully persisted `run_workspace_checkpoint` event as `run.workspace_checkpoint`; unavailable commit listings include the same recovery hint while retaining their existing `available=false` and reason (including `no_baseline`).

The hint includes the recorded ref and SHA, event sequence/time, a shell-quoted fetch command and an explicit validation note. A failed later push does not erase the last known success. Missing or malformed success records produce no hint, and event-store failures remain errors. This is an event projection: no new stored fields, inferred ref names, automatic recovery, final-bank changes or merge eligibility changes.

`iterion remote runs get` displays the hint in human output; JSON inspection and commits preserve it. The recovery guide explains using a clone whose origin is the run’s repository, checking FETCH_HEAD against the recorded SHA, and validating unfinished checkpoint work before merging.

Validation: the orphaned-run API regression failed before the implementation and now passes. Full `task check`, `task openapi:check`, `task studio:typecheck` and race suites for runview/server/CLI; focused read-boundary tests cover same-tenant success, cross-tenant refusal and event-store failure. Additional tests cover latest-success selection, malformed events, snapshot refresh/immutability, SHA-256 records, shell metacharacters and CLI absence/presence.

Closes #972.
