### PR TITLE
fix(runner): a new generation erased the checkpoint it should have read

### DIFF
--- a/pkg/runner/loop_checkpoint.go
+++ b/pkg/runner/loop_checkpoint.go
@@ -186,14 +186,27 @@ func (r *Runner) checkpointWorkspaceOnce(ctx context.Context, o sandboxObserverO
 // failure says which step could not be taken, because a silent one here is
 // indistinguishable from having had nothing to preserve.
 func (r *Runner) preserveSupersededCheckpoint(ctx context.Context, o sandboxObserverOpts, run sandbox.Run, ref, next string) {
+	// NO PIPELINE HERE. A POSIX pipeline exits with its LAST command's status,
+	// and `cut` exits 0 on empty input — so `ls-remote | cut -f1` reports
+	// success with empty output when ls-remote itself died (network flake,
+	// credential hiccup, exit 128). An UNREADABLE ref would then read as an
+	// ABSENT one, this function would return silently as "nothing to lose",
+	// and the force-push would destroy the very checkpoint it is here to save,
+	// in exactly the flaky conditions where a resume happens. The field is cut
+	// in Go instead, where the exit status is the one that matters.
 	res, err := run.Exec(ctx, []string{"sh", "-c",
-		"git ls-remote origin refs/heads/" + ref + " | cut -f1"}, sandbox.ExecOpts{})
+		"git ls-remote origin refs/heads/" + ref}, sandbox.ExecOpts{})
 	if err != nil || res.ExitCode != 0 {
-		r.cfg.Logger.Warn("runner: run %s: cannot read %s before overwriting it (%v; exit %d) — pushing anyway, but a previous generation's checkpoint may be lost",
-			o.runID, ref, err, res.ExitCode)
+		r.cfg.Logger.Warn("runner: run %s: cannot read %s before overwriting it (%v; exit %d): %s — pushing anyway, but a previous generation's checkpoint may be lost",
+			o.runID, ref, err, res.ExitCode, strings.TrimSpace(string(res.Stderr)))
+		r.recordCheckpoint(o, map[string]any{"ref": ref,
+			"error": "could not read the ref before overwriting it: " + strutilFirstLine(string(res.Stderr), err)})
 		return
 	}
-	prev := strings.TrimSpace(string(res.Stdout))
+	// `<sha>\t<ref>`, one line per match; empty output means the ref does not
+	// exist. Reached only on a SUCCESSFUL read, so empty now means absent.
+	prev, _, _ := strings.Cut(strings.TrimSpace(string(res.Stdout)), "\t")
+	prev = strings.TrimSpace(prev)
 	// Nothing there (first generation), or the very commit we are about to
 	// write: in both cases the force-push destroys nothing.
 	if prev == "" || prev == next {

--- a/pkg/runner/loop_checkpoint.go
+++ b/pkg/runner/loop_checkpoint.go
@@ -133,6 +133,22 @@ func (r *Runner) checkpointWorkspaceOnce(ctx context.Context, o sandboxObserverO
 		return last
 	}
 
+	// The FIRST push of this runner generation is the destructive one.
+	// Whatever the ref holds was written by a PREVIOUS generation, and the
+	// force below erases it — which is fine when the resume continued the
+	// same tree, and irreversible when it did not.
+	//
+	// Measured 08/09: a sandbox died mid-gate, the workspace export died with
+	// it, and the resume reset the tree to the run's LAUNCH ref. Ten minutes
+	// later this push replaced the pre-crash checkpoint with the reset one.
+	// The dead attempt's work — 8 files, +197 lines, and a held-out set —
+	// survived only because it was fetched by hand in the gap, out of an
+	// object already unreferenced and waiting for GC. The safety net was
+	// destroyed by the one gesture that should have consulted it.
+	if last == "" {
+		r.preserveSupersededCheckpoint(cctx, o, run, ref, sha)
+	}
+
 	push := "git push --force origin " + sha + ":refs/heads/" + ref
 	pres, perr := run.Exec(cctx, []string{"sh", "-c", push}, sandbox.ExecOpts{})
 	if perr != nil || pres.ExitCode != 0 {
@@ -147,6 +163,54 @@ func (r *Runner) checkpointWorkspaceOnce(ctx context.Context, o sandboxObserverO
 	r.cfg.Logger.Info("runner: run %s: workspace checkpoint pushed: %s -> %s", o.runID, sha[:min(12, len(sha))], ref)
 	r.recordCheckpoint(o, map[string]any{"ref": ref, "commit": sha})
 	return state
+}
+
+// preserveSupersededCheckpoint copies what the checkpoint ref already holds to
+// a ref of its own, before a new generation force-pushes over it.
+//
+// The name carries its own infix on purpose, like bankAttemptRef's: a pruning
+// policy has to tell them apart by name alone. `-parked-` is the half-done work
+// of a run that may still be alive; `-checkpoint-superseded-` is a safety net a
+// later generation was about to erase, and it is only ever written when the two
+// actually differ.
+//
+// The fetch is not optional and not a detail: the pod is pushing a commit it
+// does NOT have. After a resume that reset the workspace, the previous
+// generation's checkpoint is not in this clone at all, and `git push <sha>:...`
+// resolves its argument locally. Fetching it first is what makes the copy
+// possible; without it the push fails and the ref is lost exactly when it
+// mattered most.
+//
+// Best-effort throughout, like every gesture in this file: a run's outcome is
+// decided by its nodes, never by whether its safety net could be laid. Each
+// failure says which step could not be taken, because a silent one here is
+// indistinguishable from having had nothing to preserve.
+func (r *Runner) preserveSupersededCheckpoint(ctx context.Context, o sandboxObserverOpts, run sandbox.Run, ref, next string) {
+	res, err := run.Exec(ctx, []string{"sh", "-c",
+		"git ls-remote origin refs/heads/" + ref + " | cut -f1"}, sandbox.ExecOpts{})
+	if err != nil || res.ExitCode != 0 {
+		r.cfg.Logger.Warn("runner: run %s: cannot read %s before overwriting it (%v; exit %d) — pushing anyway, but a previous generation's checkpoint may be lost",
+			o.runID, ref, err, res.ExitCode)
+		return
+	}
+	prev := strings.TrimSpace(string(res.Stdout))
+	// Nothing there (first generation), or the very commit we are about to
+	// write: in both cases the force-push destroys nothing.
+	if prev == "" || prev == next {
+		return
+	}
+	keep := ref + "-superseded-" + shortSHA(prev)
+	cmd := "git fetch --no-tags origin " + prev + " && git push origin " + prev + ":refs/heads/" + keep
+	pres, perr := run.Exec(ctx, []string{"sh", "-c", cmd}, sandbox.ExecOpts{})
+	if perr != nil || pres.ExitCode != 0 {
+		r.cfg.Logger.Warn("runner: run %s: could NOT preserve %s @ %.12s as %s (%v; exit %d): %s — it is about to be overwritten and will survive only as an unreferenced object",
+			o.runID, ref, prev, keep, perr, pres.ExitCode, strings.TrimSpace(string(pres.Stderr)))
+		r.recordCheckpoint(o, map[string]any{"ref": keep, "commit": prev,
+			"error": strutilFirstLine(string(pres.Stderr), perr)})
+		return
+	}
+	r.cfg.Logger.Info("runner: run %s: previous generation's checkpoint preserved: %.12s -> %s", o.runID, prev, keep)
+	r.recordCheckpoint(o, map[string]any{"ref": keep, "commit": prev, "superseded": true})
 }
 
 // checkpointState splits the script's answer into what identifies the WORK

--- a/pkg/runner/loop_checkpoint_test.go
+++ b/pkg/runner/loop_checkpoint_test.go
@@ -40,6 +40,11 @@ type checkpointRun struct {
 	shas   []string // answers for successive checkpoint-script execs
 	pushRC int      // exit code the push exec returns
 	pushEr string
+	// remote is what `git ls-remote` reports the checkpoint ref already
+	// holds; empty means the ref does not exist yet (first generation).
+	remote string
+	keepRC int // exit code of the fetch+push that preserves it
+	keepEr string
 }
 
 func (f *checkpointRun) Driver() string { return "fake-k8s" }
@@ -54,6 +59,16 @@ func (f *checkpointRun) Exec(_ context.Context, cmd []string, _ sandbox.ExecOpts
 	f.execs = append(f.execs, script)
 	if strings.HasPrefix(script, "git push") {
 		return sandbox.ExecResult{ExitCode: f.pushRC, Stderr: []byte(f.pushEr)}, nil
+	}
+	// Dispatched BEFORE the scripted-sha fallback: answering ls-remote out of
+	// the `shas` queue would silently shift every later tick's answer, which
+	// is how adding one exec to the product broke two tests that had nothing
+	// to do with it.
+	if strings.HasPrefix(script, "git ls-remote") {
+		return sandbox.ExecResult{Stdout: []byte(f.remote + "\n")}, nil
+	}
+	if strings.HasPrefix(script, "git fetch") {
+		return sandbox.ExecResult{ExitCode: f.keepRC, Stderr: []byte(f.keepEr)}, nil
 	}
 	answer := "h0 t0 aaaaaaaa"
 	if len(f.shas) > 0 {
@@ -339,4 +354,110 @@ func TestCheckpointsWorkspaceOnlyWhereWorkCanBeLost(t *testing.T) {
 	if checkpointsWorkspace(copyBased, child) {
 		t.Fatal("a shared child must not open a second loop on its parent's pod")
 	}
+}
+
+// A checkpoint ref is force-pushed to ONE name per run, so the first push of a
+// new runner generation destroys what the previous one left. That is harmless
+// when the resume continued the same tree and irreversible when it did not —
+// measured 08/09: a sandbox died mid-gate, the workspace export died with it,
+// the resume reset the tree to the run's LAUNCH ref, and ten minutes later the
+// checkpoint of that reset tree replaced the pre-crash one. The dead attempt's
+// work survived only because it was fetched by hand in the gap, out of an
+// object already unreferenced and waiting for GC.
+func TestCheckpointPreservesWhatANewGenerationWouldErase(t *testing.T) {
+	t.Run("a differing ref is copied aside FIRST, then overwritten", func(t *testing.T) {
+		r := checkpointRunner(t, "R1")
+		run := &checkpointRun{shas: []string{"h9 t9 newsha0"}, remote: "0123456789abcdef0123"}
+		o := sandboxObserverOpts{runID: "R1", tenantID: "team-a", checkpoint: true}
+
+		// last == "" is the generation's first push: the destructive one.
+		r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+
+		var keep, force int
+		var keepBeforeForce bool
+		for _, e := range run.execs {
+			switch {
+			case strings.HasPrefix(e, "git fetch"):
+				keep++
+				if force == 0 {
+					keepBeforeForce = true
+				}
+			case strings.HasPrefix(e, "git push --force"):
+				force++
+			}
+		}
+		if keep != 1 || force != 1 {
+			t.Fatalf("want one preserve and one checkpoint push, got keep=%d force=%d: %v", keep, force, run.execs)
+		}
+		if !keepBeforeForce {
+			t.Fatal("the copy must happen BEFORE the force-push — after it, there is nothing left to copy")
+		}
+		// The fetch is what makes the copy possible at all: the pod is pushing
+		// a commit it does not have, because the reset clone never contained
+		// the previous generation's checkpoint.
+		var kept string
+		for _, e := range run.execs {
+			if strings.HasPrefix(e, "git fetch") {
+				kept = e
+			}
+		}
+		if !strings.Contains(kept, "git fetch --no-tags origin 0123456789abcdef0123") {
+			t.Fatalf("the previous commit must be fetched before it can be pushed: %q", kept)
+		}
+		if !strings.Contains(kept, ":refs/heads/iterion/run-R1-checkpoint-superseded-0123456789ab") {
+			t.Fatalf("the copy must land on its own name, distinguishable by name alone: %q", kept)
+		}
+	})
+
+	t.Run("nothing is copied when there is nothing to lose", func(t *testing.T) {
+		for name, run := range map[string]*checkpointRun{
+			"first generation — the ref does not exist":        {shas: []string{"h1 t1 c0ffee"}, remote: ""},
+			"the ref already holds what we are about to write": {shas: []string{"h1 t1 c0ffee"}, remote: "c0ffee"},
+		} {
+			r := checkpointRunner(t, "R2")
+			o := sandboxObserverOpts{runID: "R2", tenantID: "team-a", checkpoint: true}
+			r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+			for _, e := range run.execs {
+				if strings.HasPrefix(e, "git fetch") {
+					t.Fatalf("%s: preserved a ref that was not at risk: %v", name, run.execs)
+				}
+			}
+		}
+	})
+
+	t.Run("only the FIRST push of a generation pays for it", func(t *testing.T) {
+		r := checkpointRunner(t, "R3")
+		run := &checkpointRun{shas: []string{"h1 t1 aaa111", "h1 t2 bbb222"}, remote: "0123456789abcdef0123"}
+		o := sandboxObserverOpts{runID: "R3", tenantID: "team-a", checkpoint: true}
+
+		last := r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+		last = r.checkpointWorkspaceOnce(context.Background(), o, run, last)
+		_ = last
+
+		keeps := 0
+		for _, e := range run.execs {
+			if strings.HasPrefix(e, "git fetch") {
+				keeps++
+			}
+		}
+		if keeps != 1 {
+			t.Fatalf("the copy is a per-generation cost, not a per-tick one: %d fetches in %v", keeps, run.execs)
+		}
+	})
+
+	t.Run("a failed copy does not stop the checkpoint", func(t *testing.T) {
+		r := checkpointRunner(t, "R4")
+		run := &checkpointRun{shas: []string{"h1 t1 c0ffee"}, remote: "0123456789abcdef0123",
+			keepRC: 1, keepEr: "remote rejected"}
+		o := sandboxObserverOpts{runID: "R4", tenantID: "team-a", checkpoint: true}
+
+		// Best-effort by construction: a run's outcome is decided by its
+		// nodes, never by whether its safety net could be laid.
+		if last := r.checkpointWorkspaceOnce(context.Background(), o, run, ""); last != "h1 t1" {
+			t.Fatalf("the checkpoint must still land when the copy fails: last=%q", last)
+		}
+		if len(run.pushes()) != 1 {
+			t.Fatalf("want the checkpoint push despite the failed copy: %v", run.pushes())
+		}
+	})
 }

--- a/pkg/runner/loop_checkpoint_test.go
+++ b/pkg/runner/loop_checkpoint_test.go
@@ -45,6 +45,7 @@ type checkpointRun struct {
 	remote string
 	keepRC int // exit code of the fetch+push that preserves it
 	keepEr string
+	lsRC   int // exit code of the ls-remote that READS the ref
 }
 
 func (f *checkpointRun) Driver() string { return "fake-k8s" }
@@ -65,7 +66,26 @@ func (f *checkpointRun) Exec(_ context.Context, cmd []string, _ sandbox.ExecOpts
 	// is how adding one exec to the product broke two tests that had nothing
 	// to do with it.
 	if strings.HasPrefix(script, "git ls-remote") {
-		return sandbox.ExecResult{Stdout: []byte(f.remote + "\n")}, nil
+		// The real command answers `<sha>\t<ref>`; lsRC makes the READ fail.
+		out, rc, errOut := f.remote+"\trefs/heads/x\n", f.lsRC, "fatal: unable to access origin"
+		if f.remote == "" {
+			out = ""
+		}
+		if rc != 0 {
+			out = ""
+		}
+		// A REAL `sh -c` is emulated here for the one property that matters:
+		// a POSIX pipeline exits with its LAST stage's status, and `cut` exits
+		// 0 on empty input. Without this, a fake that reports the FIRST
+		// stage's status makes the piped and unpiped forms indistinguishable —
+		// and the test that exists to forbid the pipeline passes over it.
+		if strings.Contains(script, "| cut") {
+			rc, errOut = 0, ""
+			if i := strings.IndexByte(out, '\t'); i >= 0 {
+				out = out[:i] + "\n"
+			}
+		}
+		return sandbox.ExecResult{ExitCode: rc, Stdout: []byte(out), Stderr: []byte(errOut)}, nil
 	}
 	if strings.HasPrefix(script, "git fetch") {
 		return sandbox.ExecResult{ExitCode: f.keepRC, Stderr: []byte(f.keepEr)}, nil
@@ -460,4 +480,32 @@ func TestCheckpointPreservesWhatANewGenerationWouldErase(t *testing.T) {
 			t.Fatalf("want the checkpoint push despite the failed copy: %v", run.pushes())
 		}
 	})
+}
+
+// An UNREADABLE ref is not an ABSENT one, and conflating them destroys the
+// very checkpoint this preservation exists to save.
+//
+// The first version of this probe ran `git ls-remote … | cut -f1`. A POSIX
+// pipeline exits with its LAST command's status and `cut` exits 0 on empty
+// input, so a dead ls-remote — a network flake, a credential hiccup, exit 128
+// — reported success with no output. That read as "the ref does not exist,
+// the force-push destroys nothing", in exactly the flaky conditions where a
+// resume happens in the first place.
+func TestCheckpointDoesNotReadAFailedProbeAsAnEmptyRef(t *testing.T) {
+	var buf bytes.Buffer
+	r := checkpointRunner(t, "R5")
+	r.cfg.Logger = iterlog.New(iterlog.LevelWarn, &buf)
+	run := &checkpointRun{shas: []string{"h1 t1 c0ffee"}, remote: "", lsRC: 128}
+	o := sandboxObserverOpts{runID: "R5", tenantID: "team-a", checkpoint: true}
+
+	r.checkpointWorkspaceOnce(context.Background(), o, run, "")
+
+	if !strings.Contains(buf.String(), "cannot read") {
+		t.Fatalf("a failed read must SAY so — a silent one is indistinguishable from an absent ref: %q", buf.String())
+	}
+	// And it must still checkpoint: refusing to preserve the new work because
+	// the old could not be read trades one loss for another.
+	if len(run.pushes()) != 1 {
+		t.Fatalf("the checkpoint must still land: %v", run.pushes())
+	}
 }


### PR DESCRIPTION
The workspace checkpoint is force-pushed to **one ref per run**, so the first push of a new runner generation destroys what the previous one left. Harmless when the resume continued the same tree; irreversible when it did not.

### Measured, on a live campaign

`15:53:23Z` — the sandbox goes to phase `Failed`. Three events in the same second:

```
node_recovery                    cannot exec into a container in a completed pod
run_failed                       EXECUTION_FAILED, resumable: true
sandbox_workspace_export_failed  in-pod tar …: same cause
```

`15:53:25Z` — `run_workspace_reset {reason: resume, repo_sha: <the run's LAUNCH ref>}`.
`16:06Z` — the first checkpoint of the reset tree **force-pushes over the pre-crash one**.

| diff | result |
|---|---|
| launch bank → pre-crash checkpoint | 8 files, **+197 / −36** — the attempt's work |
| launch bank → post-resume checkpoint | 21 files, −290, **zero additions** |

The work survived only because it was fetched by hand inside that ten-minute gap, out of an object already unreferenced and waiting for GC. **The safety net was destroyed by the one gesture that should have consulted it.**

### What this changes

The first push of a generation copies the ref aside first, under `-checkpoint-superseded-<sha12>` — its own infix, like `bankAttemptRef`'s, because a pruning policy has to tell them apart by name alone (`-parked-` is the half-done work of a run that may still be alive).

The `git fetch` is load-bearing, not incidental: **the pod is pushing a commit it does not have.** The reset clone never contained the previous generation's checkpoint, and `git push <sha>:refs/heads/...` resolves its argument locally.

Cost: one `ls-remote` per generation, and a fetch+push only when the ref actually holds something else. Best-effort throughout — a run's outcome is decided by its nodes, never by whether its safety net could be laid — and each failure names the step it could not take, because a silent one is indistinguishable from having had nothing to preserve.

### Scope, stated plainly

**This does not make the resume smarter. It makes its mistake recoverable.** The resume still restarts from the launch ref rather than the run's own last checkpoint — that is the larger question, and it is not this PR. #988 exposes the checkpoint for reading; nothing yet stopped it being overwritten, which is what this closes.

### Falsification

Removing the call reddens two of four cases:

| case | with | without |
|---|---|---|
| copy happens, and BEFORE the force-push | PASS | **FAIL** |
| once per generation, not per tick | PASS | **FAIL** |
| no copy when the ref is absent or already holds the same commit | PASS | PASS (vacuously) |
| a failed copy still lets the checkpoint land | PASS | PASS (vacuously) |

`pkg/runner` green (18.8s). The fake driver learned to answer `ls-remote` separately — answering it from the scripted-sha queue shifted every later tick and broke two unrelated tests, which is its own small lesson about fakes that answer everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)