### PR TITLE
fix(server): an avatar recorded after a failed store write is iterion's fault, not the forge's

### DIFF
--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -127,7 +127,7 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		// of it carries a forge sentinel or a *url.Error, so it would fall
 		// through the handler's 502 default and blame the forge for
 		// iterion's own seal — the #969 inversion, one step earlier.
-		return conn, "", NewIterionFault(err)
+		return conn, "", newIterionFault(err)
 	}
 	setter, ok := admin.(forge.AvatarSetter)
 	if !ok {
@@ -250,7 +250,7 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 		// really is iterion's) instead of the 502 its default arm serves
 		// for a forge that broke. Body still names the connection and the
 		// underlying cause so the operator can act on it.
-		return conn, avatarURL, NewIterionFault(fmt.Errorf("avatar uploaded but could not be recorded on connection %s: %w", conn.ID, err))
+		return conn, avatarURL, newIterionFault(fmt.Errorf("avatar uploaded but could not be recorded on connection %s: %w", conn.ID, err))
 	}
 	return recorded, avatarURL, nil
 }

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -119,7 +119,15 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 	defer cancel()
 	admin, err := s.forgeAdminFor(ctx, conn)
 	if err != nil {
-		return conn, "", err
+		// Nothing has reached the forge yet, and on the only kind that gets
+		// here this call cannot: the switch above refuses every kind but
+		// KindPAT, so forgeAdminFor opens the sealed token (a nil sealer, a
+		// master key that no longer opens the blob, a payload that will not
+		// unmarshal) and builds a bearer client — all local. Unmarked, none
+		// of it carries a forge sentinel or a *url.Error, so it would fall
+		// through the handler's 502 default and blame the forge for
+		// iterion's own seal — the #969 inversion, one step earlier.
+		return conn, "", NewIterionFault(err)
 	}
 	setter, ok := admin.(forge.AvatarSetter)
 	if !ok {
@@ -301,13 +309,16 @@ func (s *Server) handleForgeConnectionAvatar(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err != nil {
-		// This route mixes two failure sources under one default arm: the
-		// forge round-trip (502 is the true code for what the classifier
-		// does not recognise — a broken transport, a body that is not the
-		// shape pkg/forge parses) AND iterion's OWN state failing AFTER
-		// the upload landed (persist below). NewIterionFault marks the
-		// second so it answers 500 instead of the 502 it would otherwise
-		// share with a genuine forge outage — the inversion #969 is about.
+		// This route mixes three failure sources under one default arm.
+		// Only ONE of them is the forge's: the round-trip (502 is the true
+		// code for what the classifier does not recognise — a broken
+		// transport, a body that is not the shape pkg/forge parses). The
+		// other two are iterion's own state — the seal/client construction
+		// BEFORE any forge call (forgeAdminFor), and the persist AFTER the
+		// upload already landed — and both are marked at their wrap site,
+		// where which step failed is still known, so they answer 500
+		// instead of sharing the 502 a genuine forge outage gets. That
+		// sharing is the inversion #969 is about.
 		if isIterionFault(err) {
 			httpError(w, http.StatusInternalServerError, "%v", err)
 			return

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -237,7 +237,12 @@ func (s *Server) applyBotAvatar(parent context.Context, conn forge.Connection, v
 	now := time.Now().UTC()
 	recorded, err := persist(&now, "")
 	if err != nil {
-		return conn, avatarURL, fmt.Errorf("avatar uploaded but could not be recorded on connection %s: %w", conn.ID, err)
+		// The forge answered 200 to the upload; iterion's OWN store then
+		// failed to write it down. Mark it so the handler answers 500 (this
+		// really is iterion's) instead of the 502 its default arm serves
+		// for a forge that broke. Body still names the connection and the
+		// underlying cause so the operator can act on it.
+		return conn, avatarURL, NewIterionFault(fmt.Errorf("avatar uploaded but could not be recorded on connection %s: %w", conn.ID, err))
 	}
 	return recorded, avatarURL, nil
 }
@@ -296,6 +301,17 @@ func (s *Server) handleForgeConnectionAvatar(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if err != nil {
+		// This route mixes two failure sources under one default arm: the
+		// forge round-trip (502 is the true code for what the classifier
+		// does not recognise — a broken transport, a body that is not the
+		// shape pkg/forge parses) AND iterion's OWN state failing AFTER
+		// the upload landed (persist below). NewIterionFault marks the
+		// second so it answers 500 instead of the 502 it would otherwise
+		// share with a genuine forge outage — the inversion #969 is about.
+		if isIterionFault(err) {
+			httpError(w, http.StatusInternalServerError, "%v", err)
+			return
+		}
 		if !writeForgeUpstreamError(w, err, "%v", err) {
 			httpError(w, http.StatusBadGateway, "%v", err)
 		}

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -807,3 +807,30 @@ func TestForgeConnectionAvatar_UpstreamSetAvatarFailureStays502(t *testing.T) {
 		t.Errorf("uploads = %d, want 1", gl.count())
 	}
 }
+
+// The route's THIRD failure source, and the one that fails BEFORE the forge
+// is ever contacted: forgeAdminFor opens the connection's sealed token. On
+// the only kind that reaches it (KindPAT) that is pure local work, so a
+// sealer that will not open the blob is iterion's own state — yet it carries
+// no forge sentinel and no *url.Error, which is exactly what the handler's
+// 502 default arm serves. Blaming the forge for a key iterion cannot use
+// sends the operator to the forge's status page for an outage that is not
+// there. The upload count is the proof it never left the process.
+func TestForgeConnectionAvatar_SealFailureBeforeUploadIsIterionFault500(t *testing.T) {
+	s := newForgeTestServer(t)
+	gl := &mockGitLabAvatar{bot: true}
+	srv := gl.server()
+	defer srv.Close()
+	// Seed with the live sealer (the blob is well-formed), then take the
+	// sealer away — the shape of a rotated or unreadable master key.
+	seedAvatarConn(t, s, forge.Connection{ID: "c-seal-fail", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1_bot_x", AccountKind: forge.AccountKindBot, ForgeBaseURL: srv.URL})
+	s.sealer = nil
+
+	w := avatarReq(s, "c-seal-fail", "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("a seal that will not open is iterion's own and must answer 500, got %d: body=%s", w.Code, w.Body.String())
+	}
+	if gl.count() != 0 {
+		t.Errorf("uploads = %d, want 0 — this failure precedes any forge call", gl.count())
+	}
+}

--- a/pkg/server/forge_avatar_routes_test.go
+++ b/pkg/server/forge_avatar_routes_test.go
@@ -737,3 +737,73 @@ func TestForgeConnectionAvatar_UnreachableForgeIsNotAVouchMatter(t *testing.T) {
 		t.Fatalf("404 on /user: code=%d body=%s", w.Code, w.Body.String())
 	}
 }
+
+// failingUpdateStore wraps the memory ConnectionStore and injects a caller-
+// controlled failure on Update. It exists to prove that a persist error
+// AFTER a successful forge round-trip does not answer 502 — the doctrine
+// forgeUpstreamStatus writes down: only an iterion fault reaches 500.
+type failingUpdateStore struct {
+	forge.ConnectionStore
+	failOnUpdate error
+}
+
+func (f *failingUpdateStore) Update(ctx context.Context, conn forge.Connection) error {
+	if f.failOnUpdate != nil {
+		return f.failOnUpdate
+	}
+	return f.ConnectionStore.Update(ctx, conn)
+}
+
+// A persist that fails AFTER SetAvatar succeeded is iterion's own state
+// failing — the forge did answer, and the answer was 200. Answering 502
+// tells the operator, the logs, Sentry and every alert that the forge
+// broke; the truth is that iterion could not write down what the forge
+// gave it. The route must answer 500, and its body must still name the
+// connection and the underlying cause so the operator can act on it.
+func TestForgeConnectionAvatar_StoreFailAfterUploadIsIterionFault500(t *testing.T) {
+	s := newForgeTestServer(t)
+	failing := &failingUpdateStore{
+		ConnectionStore: s.forgeConnections,
+		failOnUpdate:    errors.New("mongo: connection reset by peer"),
+	}
+	s.forgeConnections = failing
+	gl := &mockGitLabAvatar{bot: true}
+	srv := gl.server()
+	defer srv.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-persist-fail", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1_bot_x", AccountKind: forge.AccountKindBot, ForgeBaseURL: srv.URL})
+
+	w := avatarReq(s, "c-persist-fail", "")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("a store write that failed AFTER a successful upload must answer 500 (iterion's own), got %d: body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "c-persist-fail") {
+		t.Errorf("body must name the connection to act on it: body=%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "connection reset by peer") {
+		t.Errorf("body must carry the underlying cause: body=%s", w.Body.String())
+	}
+	if gl.count() != 1 {
+		t.Errorf("uploads = %d, want 1 — the upload landed before persist failed", gl.count())
+	}
+}
+
+// A SetAvatar that failed IS the forge's answer: 502 is the true code. The
+// fix for the mixed case must not accidentally reroute the upstream half
+// through the iterion-fault arm.
+func TestForgeConnectionAvatar_UpstreamSetAvatarFailureStays502(t *testing.T) {
+	s := newForgeTestServer(t)
+	// The forge answers 503 to the upload; forgeUpstreamStatus maps this
+	// onto 502 (the forge's own fault, not iterion's).
+	gl := &mockGitLabAvatar{bot: true, status: http.StatusServiceUnavailable}
+	srv := gl.server()
+	defer srv.Close()
+	seedAvatarConn(t, s, forge.Connection{ID: "c-upstream-503", Provider: forge.ProviderGitLab, Kind: forge.KindPAT, AccountLogin: "group_1_bot_x", AccountKind: forge.AccountKindBot, ForgeBaseURL: srv.URL})
+
+	w := avatarReq(s, "c-upstream-503", "")
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("an upstream 5xx on SetAvatar must stay 502 (the forge's fault), got %d: body=%s", w.Code, w.Body.String())
+	}
+	if gl.count() != 1 {
+		t.Errorf("uploads = %d, want 1", gl.count())
+	}
+}

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -126,6 +126,13 @@ func (s *Server) connectForgePAT(w http.ResponseWriter, r *http.Request, teamID,
 			return
 		}
 		if !writeForgeUpstreamError(w, err, "could not reach %s: %v", provider, err) {
+			// Safe default: every error at this site comes from the
+			// WhoAmI probe against the forge (a round-trip that must
+			// succeed BEFORE any store write). An error the classifier
+			// does not name yet is still an unreachable forge — never
+			// iterion's own state — so 502 is the true code. Unlike the
+			// avatar route (#969), this arm is not mixed with a
+			// post-forge store write.
 			httpError(w, http.StatusBadGateway, "could not reach %s: %v", provider, err)
 		}
 		return

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -126,13 +126,16 @@ func (s *Server) connectForgePAT(w http.ResponseWriter, r *http.Request, teamID,
 			return
 		}
 		if !writeForgeUpstreamError(w, err, "could not reach %s: %v", provider, err) {
-			// Safe default: every error at this site comes from the
-			// WhoAmI probe against the forge (a round-trip that must
-			// succeed BEFORE any store write). An error the classifier
-			// does not name yet is still an unreachable forge — never
-			// iterion's own state — so 502 is the true code. Unlike the
-			// avatar route (#969), this arm is not mixed with a
-			// post-forge store write.
+			// Safe default, and this one IS clean — traced, not assumed.
+			// The client is a plain bearer built above from the pasted
+			// token (forgeAdminForToken, which has its own 400 arm), so
+			// there is no seal to open and no App JWT to sign lazily on
+			// the first call — the way an App client fails locally inside
+			// what looks like a round-trip (see newIterionFault's doc).
+			// WhoAmI is therefore the only thing that can fail here, and
+			// it must succeed BEFORE any store write. An error the
+			// classifier does not name yet is still an unreachable forge
+			// — never iterion's own state — so 502 is the true code.
 			httpError(w, http.StatusBadGateway, "could not reach %s: %v", provider, err)
 		}
 		return

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -490,7 +490,7 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 				// that is not parseable PEM — before it opens a socket.
 				// Both answer 502 today: the #969 inversion, still open
 				// here. Ending it belongs in the mint chain, which alone
-				// knows which step failed; a blanket NewIterionFault over
+				// knows which step failed; a blanket newIterionFault over
 				// mint() would stamp a genuine GitHub 5xx as iterion's —
 				// the same lie reversed. Residual on #969.
 				httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -479,6 +479,14 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 				return
 			}
 			if !writeForgeUpstreamError(w, err, "security-read token mint: %v", err) {
+				// Safe default: every error at this site comes from the
+				// GitHub App token mint (a forge round-trip). An error the
+				// classifier does not name yet is still a forge outage —
+				// never iterion's own state — so 502 is the true code.
+				// Unlike the avatar route (#969), no post-forge store
+				// write ships here that could turn this arm into a mixed
+				// one; if that changes, mark the store step with
+				// NewIterionFault so 500 answers it here.
 				httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
 			}
 			return
@@ -564,6 +572,11 @@ func (s *Server) handleListForgeRepos(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !writeForgeUpstreamError(w, err, "list repos: %v", err) {
+			// Safe default: every error at this site comes from the forge
+			// listing (ListRepos). An error the classifier does not name
+			// yet is still a forge outage — never iterion's own state —
+			// so 502 is the true code. Unlike the avatar route (#969),
+			// this arm is not mixed with a post-forge store write.
 			httpError(w, http.StatusBadGateway, "list repos: %v", err)
 		}
 		return

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -479,14 +479,20 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 				return
 			}
 			if !writeForgeUpstreamError(w, err, "security-read token mint: %v", err) {
-				// Safe default: every error at this site comes from the
-				// GitHub App token mint (a forge round-trip). An error the
-				// classifier does not name yet is still a forge outage —
-				// never iterion's own state — so 502 is the true code.
-				// Unlike the avatar route (#969), no post-forge store
-				// write ships here that could turn this arm into a mixed
-				// one; if that changes, mark the store step with
-				// NewIterionFault so 500 answers it here.
+				// Default, and NOT a clean one. Most of what lands here is
+				// the App token mint failing against the forge, where 502
+				// is the true code — but the mint's PRE-FLIGHT is
+				// iterion's own and arrives unmarked:
+				// githubAppConfigForConnection answers "no github app
+				// available" for a store read that failed as much as for
+				// an App key that will not unseal, and
+				// MintInstallationToken signs the App JWT — a stored key
+				// that is not parseable PEM — before it opens a socket.
+				// Both answer 502 today: the #969 inversion, still open
+				// here. Ending it belongs in the mint chain, which alone
+				// knows which step failed; a blanket NewIterionFault over
+				// mint() would stamp a genuine GitHub 5xx as iterion's —
+				// the same lie reversed. Residual on #969.
 				httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
 			}
 			return
@@ -572,11 +578,16 @@ func (s *Server) handleListForgeRepos(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !writeForgeUpstreamError(w, err, "list repos: %v", err) {
-			// Safe default: every error at this site comes from the forge
-			// listing (ListRepos). An error the classifier does not name
-			// yet is still a forge outage — never iterion's own state —
-			// so 502 is the true code. Unlike the avatar route (#969),
-			// this arm is not mixed with a post-forge store write.
+			// Default, and NOT a clean one for a github_app connection.
+			// A PAT connection's ListRepos is a pure round-trip, so 502
+			// is the true code there; an App's goes through
+			// AppClient.rest, which mints an installation token and signs
+			// the App JWT locally FIRST — a stored key that is not
+			// parseable PEM fails before any socket and answers 502 here.
+			// The #969 inversion, still open on this arm; the fix belongs
+			// in the mint chain (see the security-read arm above).
+			// Residual on #969. The route's pre-forge half IS right:
+			// forgeAdminFor above already answers 500.
 			httpError(w, http.StatusBadGateway, "list repos: %v", err)
 		}
 		return

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -102,6 +102,12 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 		// may wait out, a grant it will never get — instead of one 502 for
 		// every cause.
 		if !writeForgeUpstreamError(w, err, "read pull request %s#%d: %v", repo, number, err) {
+			// Safe default: the only failure at this site is the forge's
+			// pull-request read. An error the classifier does not name yet
+			// is still a forge outage — never iterion's own state — so
+			// 502 is the true code. Unlike the avatar route (#969), this
+			// route reads and nothing else, so no post-forge store write
+			// can mix in.
 			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
 		}
 		return

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -102,12 +102,16 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 		// may wait out, a grant it will never get — instead of one 502 for
 		// every cause.
 		if !writeForgeUpstreamError(w, err, "read pull request %s#%d: %v", repo, number, err) {
-			// Safe default: the only failure at this site is the forge's
-			// pull-request read. An error the classifier does not name yet
-			// is still a forge outage — never iterion's own state — so
-			// 502 is the true code. Unlike the avatar route (#969), this
-			// route reads and nothing else, so no post-forge store write
-			// can mix in.
+			// Default, and NOT a clean one for a github_app connection.
+			// This route reads and nothing else, so no post-forge store
+			// write can mix in the way the avatar route's does (#969) —
+			// but the read itself is not purely upstream: an App's
+			// GetPullRequest goes through scopedREST, which mints an
+			// installation token and signs the App JWT locally FIRST, so
+			// a stored key that is not parseable PEM fails before any
+			// socket and answers 502 here. The same inversion, still open
+			// on this arm; the fix belongs in the mint chain, which alone
+			// knows which step failed. Residual on #969.
 			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
 		}
 		return

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -148,6 +148,16 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 // A route whose ONLY failure path is a forge round-trip does NOT need
 // this: an unclassified error there IS a forge error the classifier does
 // not yet know about, and defaulting to 502 is the safe assumption.
+//
+// That premise is far easier to assert than to establish, and asserting
+// it wrongly is how the inversion spreads. A forge CLIENT METHOD is not
+// the same thing as a forge round-trip: pkg/forge/github's App client
+// mints an installation token and signs the App JWT — parsing a stored
+// private key — before its first socket, so a key that is not parseable
+// PEM fails inside what reads like a pure `admin.ListRepos(ctx)`. Trace
+// the call to its first byte on the wire before concluding a site is
+// clean; three arms on this branch were cleared on the shorter reading
+// and were wrong (see the residuals named at each).
 type iterionFault struct{ err error }
 
 // newIterionFault wraps err so a handler whose default arm is 502 can

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -150,10 +150,19 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 // not yet know about, and defaulting to 502 is the safe assumption.
 type iterionFault struct{ err error }
 
-// NewIterionFault wraps err so a handler whose default arm is 502 can
+// newIterionFault wraps err so a handler whose default arm is 502 can
 // tell iterion's own faults apart (answer 500) from a forge that
 // answered or fell silent (keep 502 / the taxonomy code).
-func NewIterionFault(err error) error {
+//
+// The mark is INERT on its own, and reading it as sufficient is the
+// mistake to avoid: forgeUpstreamStatus has no iterionFault case and
+// writeForgeUpstreamError only consults that, so a marked error still
+// falls through to whatever the caller's own default arm is — 502 on
+// every route but the avatar one, the only handler that carries the
+// isIterionFault check. Marking a new site therefore takes TWO edits,
+// and the SECOND is the one that changes an answer. A mark alone is a
+// comment.
+func newIterionFault(err error) error {
 	if err == nil {
 		return nil
 	}

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -133,6 +133,43 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 	return true
 }
 
+// iterionFault marks an error as iterion's own state failing — a store
+// write, a marshal, a seal that will not open — on a route whose default
+// arm answers 502 to serve the forge's own failures. Without the marker,
+// the shared taxonomy cannot tell the two apart: forgeUpstreamStatus
+// returning 0 means "not an answer from the forge", which is the truth
+// AND the definition of iterion's own, but a route that ALSO makes a
+// forge call after which its own state may fail (the avatar route: upload
+// then persist) cannot safely default to 500 — an unclassified upstream
+// error would then be blamed on iterion. The marker resolves it at the
+// wrap site, where which step failed is known: mark the store-write
+// failure; leave the raw forge error alone.
+//
+// A route whose ONLY failure path is a forge round-trip does NOT need
+// this: an unclassified error there IS a forge error the classifier does
+// not yet know about, and defaulting to 502 is the safe assumption.
+type iterionFault struct{ err error }
+
+// NewIterionFault wraps err so a handler whose default arm is 502 can
+// tell iterion's own faults apart (answer 500) from a forge that
+// answered or fell silent (keep 502 / the taxonomy code).
+func NewIterionFault(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &iterionFault{err: err}
+}
+
+func (e *iterionFault) Error() string { return e.err.Error() }
+func (e *iterionFault) Unwrap() error { return e.err }
+
+// isIterionFault reports whether err (or anything it wraps) was marked
+// with iterionFault, so a 502-default handler can answer 500 instead.
+func isIterionFault(err error) bool {
+	var f *iterionFault
+	return errors.As(err, &f)
+}
+
 // retryAfterHeader renders a delay as delta-seconds, the form every client
 // reads. Zero (the forge said nothing) renders empty — never a guess.
 func retryAfterHeader(d time.Duration) string {

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -158,6 +158,16 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 // the call to its first byte on the wire before concluding a site is
 // clean; three arms on this branch were cleared on the shorter reading
 // and were wrong (see the residuals named at each).
+//
+// Finally: the 502 default is a per-route CHOICE, not the package's
+// rule, and this marker exists for the routes that make it. A handler
+// that can enumerate the forge's refusals and treat everything left as
+// its own defaults to 500 instead and needs no marker —
+// writeForgeOAuthAppError is that shape. A handler that cannot must
+// keep 502 (an unclassified upstream error must not be blamed on
+// iterion), and the marker is then the ONLY way it can ever answer 500.
+// The two are not one doctrine: pick the default the route's error
+// surface actually supports.
 type iterionFault struct{ err error }
 
 // newIterionFault wraps err so a handler whose default arm is 502 can


### PR DESCRIPTION
> **Corrigé après revue.** Ce corps affirmait que quatre des cinq arms qui retombent sur 502 sont justes. **Trois ne le sont pas**, et le fixer l'a démontré — voir la section « Ce que la revue a réfuté » plus bas. La correction est dans la branche ; ce paragraphe est là pour que le corps ne mente pas au lecteur qui le lira après le merge.

## Why

`forgeUpstreamStatus` returns `0` to mean **"NOT an answer from the forge"**, and its own doc says the caller then answers with *its* fault status — *"Only that arm may be a 500."* The avatar route rendered that arm **502 Bad Gateway**, so a `persist` failure **after an upload that had already landed on the forge** was reported as a forge outage.

That is the exact inversion the classifier was written to end (*"a rate limit answered 500 tells everyone that iterion broke, when the truth is that a third party is throttling us"*), running the other way: Sentry, the alerts and any client that retries on 502 were told a third party broke when iterion's own store did.

## The fix

A **typed marker at the wrap site**, where which step failed is already known, rather than flipping the fallback to 500 — a route that also makes a forge round-trip can meet an upstream error the taxonomy does not classify yet, and blaming iterion for it would be the same lie in the other direction. The doctrine already exists and is proven: `TestWriteForgeOAuthAppError_IterionFaultStays500` on the oauth-app route.

Red first:

```
--- FAIL: TestForgeConnectionAvatar_StoreFailAfterUploadIsIterionFault500
    a store write that failed AFTER a successful upload must answer 500
    (iterion's own), got 502: body={"error":"avatar uploaded but could not be
    recorded on connection c-persist-fail: mongo: connection reset by peer"}
```

Dropping the marker reproduces that exact line. The upstream-failure case stayed green throughout — that is the invariant the fix must not break.

## Ce que la revue a réfuté, et qui vaut mieux que la version d'origine

La valeur annoncée de cette PR était qu'un lecteur n'ait plus à re-dériver « cet arm est-il la faute de la forge ou d'iterion ? » par site. **Trois des quatre paragraphes ajoutés dérivaient FAUX**, et une dérivation fausse et confiante est pire qu'aucune : elle ferme la question.

Les trois manquaient la même chose — **le mint de token d'une GitHub App signe son JWT AVANT d'ouvrir une socket** (`MintInstallationToken` → `signAppJWT` → `parseRSAPrivateKey`, dont l'erreur est nue : `github: app private key is not valid PEM`, vérifié à `app_client.go:558` et `app_jwt.go:57`). Une clé stockée qui ne parse pas est donc un état d'iterion, et elle atterrit dans ces arms en 502 :

- **security-read mint** — plus `githubAppConfigForConnection`, qui répond « no github app available » pour une lecture de store qui a **échoué** aussi bien que pour une App absente ;
- **list repos** — `AppClient.rest` mint avant de lister ;
- **read pull request** — `scopedREST` mint avant de lire.

Et une troisième source d'échec sous l'arm de la route avatar, que le commentaire d'origine réduisait à deux : **`forgeAdminFor` tourne AVANT tout appel forge** et, sur le seul kind qui l'atteint, ne fait que du travail local — ouvrir le token scellé (sealer nil, clé maîtresse qui n'ouvre plus le blob, payload qui ne se démarshale pas) puis construire un client. Rien de tout ça ne porte de sentinelle forge ni de `*url.Error`.

La branche corrige les quatre.

## What is NOT in this PR

The ticket's **second site** — `gateLaunch` failing OPEN on *any* `GetTeam` error, so a transient store outage is served as the business fact "no such tenant" — is deliberately untouched: it lives in files a parallel session currently holds. It stays open on #969, with the fix shape agreed (split `ErrNotFound` from a degraded read; do **not** close the fail-open).

Refs #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)
