### PR TITLE
fix(bots): a campaign verify node refuses a dirty tree instead of judging it

### DIFF
--- a/bots/adr-cartograph/main.bot
+++ b/bots/adr-cartograph/main.bot
@@ -1077,6 +1077,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/adr-cartograph/main.bot
+++ b/bots/adr-cartograph/main.bot
@@ -1088,6 +1088,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -1546,6 +1546,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -1557,6 +1557,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -1873,6 +1873,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -1884,6 +1884,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -1024,6 +1024,14 @@ else:
     if pre:
         dirty_paths = sorted(pre)
         print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+        # A refusal must not leave the PREVIOUS pass's verify.log looking
+        # current: the operator opens it to see why, and would read an
+        # unrelated build.
+        try:
+            with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+                lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+        except OSError:
+            pass
         raise SystemExit(0)
     rc = 0
     out = ''

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -1013,6 +1013,18 @@ else:
         print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
         raise SystemExit(0)
     pre = tree_state()
+    # NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+    # PREVIOUS pass's uncommitted work reaching the gate, not the build's
+    # failure. An interrupted attempt retried on the same tree, or a pass
+    # stopped mid-unit, leaves edits on disk; judging that tree would call
+    # THEIR failure the gate's. Refuse with a typed verdict so the campaign
+    # loops back on 'commit first', not on 'the build broke'. Skipped when
+    # tree_state() returned None (git error / not a repo) -- the drift tail
+    # already fails open there.
+    if pre:
+        dirty_paths = sorted(pre)
+        print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+        raise SystemExit(0)
     rc = 0
     out = ''
     try:

--- a/bots/e2e_coverage_matrix_gate_test.go
+++ b/bots/e2e_coverage_matrix_gate_test.go
@@ -58,6 +58,11 @@ func TestE2ECoverageMatrixGate(t *testing.T) {
 
 	runTarget := func(t *testing.T, ws, scratch, target string) verifyResult {
 		t.Helper()
+		// Commit whatever the test set up before verify_run runs. The
+		// net_dirty gate (issue #799) refuses a dirty tree; the campaign
+		// contract already commits its work before the deterministic gate,
+		// so the test represents the SAME state a real pass would present.
+		commitFixture(t, ws)
 		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
 		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
 		cmd = strings.ReplaceAll(cmd, "{{vars.matrix_path}}", matrixRel)

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -1169,6 +1169,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -1158,6 +1158,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -948,6 +948,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -937,6 +937,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -819,6 +819,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -808,6 +808,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -3122,6 +3122,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -3133,6 +3133,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -964,6 +964,14 @@ else:
     if pre:
         dirty_paths = sorted(pre)
         print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+        # A refusal must not leave the PREVIOUS pass's verify.log looking
+        # current: the operator opens it to see why, and would read an
+        # unrelated build.
+        try:
+            with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+                lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+        except OSError:
+            pass
         raise SystemExit(0)
     rc = 0
     out = ''

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -953,6 +953,18 @@ else:
         print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
         raise SystemExit(0)
     pre = tree_state()
+    # NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+    # PREVIOUS pass's uncommitted work reaching the gate, not the build's
+    # failure. An interrupted attempt retried on the same tree, or a pass
+    # stopped mid-unit, leaves edits on disk; judging that tree would call
+    # THEIR failure the gate's. Refuse with a typed verdict so the campaign
+    # loops back on 'commit first', not on 'the build broke'. Skipped when
+    # tree_state() returned None (git error / not a repo) -- the drift tail
+    # already fails open there.
+    if pre:
+        dirty_paths = sorted(pre)
+        print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+        raise SystemExit(0)
     rc = 0
     out = ''
     try:

--- a/bots/verify_run_drift_test.go
+++ b/bots/verify_run_drift_test.go
@@ -48,6 +48,11 @@ func TestVerifyRunDriftTail(t *testing.T) {
 
 	run := func(t *testing.T, ws, scratch string) verifyResult {
 		t.Helper()
+		// Commit whatever the test set up before verify_run runs. The
+		// net_dirty gate (issue #799) refuses a dirty tree; the campaign
+		// contract already commits its work before the deterministic gate,
+		// so the test represents the SAME state a real pass would present.
+		commitFixture(t, ws)
 		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
 		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
 		out, err := exec.Command("sh", "-c", cmd).Output()
@@ -301,6 +306,11 @@ func TestVerifyRunMaskedPipeline(t *testing.T) {
 	}
 	run := func(t *testing.T, ws, scratch string) verifyResult {
 		t.Helper()
+		// Commit whatever the test set up before verify_run runs. The
+		// net_dirty gate (issue #799) refuses a dirty tree; the campaign
+		// contract already commits its work before the deterministic gate,
+		// so the test represents the SAME state a real pass would present.
+		commitFixture(t, ws)
 		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
 		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
 		out, err := exec.Command("sh", "-c", cmd).Output()
@@ -440,6 +450,11 @@ func TestAppDevVerifyRunEnforcesTheSameTail(t *testing.T) {
 	}
 	run := func(t *testing.T, ws, scratch string) {
 		t.Helper()
+		// Commit whatever the test set up before verify_run runs. The
+		// net_dirty gate (issue #799) refuses a dirty tree; the campaign
+		// contract already commits its work before the deterministic gate,
+		// so the test represents the SAME state a real pass would present.
+		commitFixture(t, ws)
 		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
 		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
 		out, err := exec.Command("sh", "-c", cmd).Output()
@@ -535,6 +550,31 @@ func TestVerifyBuildSkillPromiseMatchesItsBot(t *testing.T) {
 func verifyRunCommand(t *testing.T, rel string) string {
 	t.Helper()
 	return toolCommand(t, rel, "verify_run")
+}
+
+// commitFixture makes the test's workspace fixture the tree HEAD, the way a
+// campaign pass would leave it before the deterministic verify gate runs.
+// Since the net_dirty gate (issue #799) refuses a dirty tree BEFORE running
+// verify.sh, a test that writes files into ws without committing them would
+// hit the refusal instead of exercising verify_run's actual concern.
+// commitFixture is a no-op when the tree is already clean OR when ws is not
+// a git repository at all (the subtests that assert graceful degradation on
+// a non-git workspace keep their shape).
+func commitFixture(t *testing.T, ws string) {
+	t.Helper()
+	status, err := gittest.Try(ws, "status", "--porcelain")
+	if err != nil {
+		// Not a git repo (or git otherwise refused to answer): let the
+		// verify_run guard handle it. tree_state() will return nil there
+		// and the net_dirty check falls through, which is the same
+		// fail-open path a bot's greenfield run takes.
+		return
+	}
+	if status == "" {
+		return
+	}
+	gittest.Run(t, ws, "add", "-A")
+	gittest.Run(t, ws, "commit", "-q", "-m", "test fixture")
 }
 
 func toolCommand(t *testing.T, rel, node string) string {

--- a/bots/verify_run_net_dirty_test.go
+++ b/bots/verify_run_net_dirty_test.go
@@ -1,0 +1,227 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/internal/gittest"
+)
+
+// The campaign contract's clean-tree clause tells the agent to end every
+// pass on a committed tree so the deterministic gate reads HEAD. When it
+// doesn't — a pod dying mid-pass, an oracle-gate retry inheriting a mutant
+// left applied by an interrupted falsification pass, a pass stopped
+// mid-unit — the tree still carries the previous attempt's uncommitted
+// edits, and the gate silently judges THEM as the build's failure.
+//
+// Incident #799: a lot's verify node ran for 7 676 s, its exec stream cut,
+// the engine retried the node on the SAME tree where a golden-master
+// mutant had been applied and never reverted; the second attempt called
+// that tree the build's, went red on a package the mutant deleted, and
+// the run finished not converged with hours of budget left.
+//
+// #807 (merged) closed the harness half — mutants are now self-reverted
+// at the next gate. This test is the ENGINE-SIDE half done in the bot:
+// every campaign verify_run refuses a dirty tree with a typed verdict
+// BEFORE running verify.sh, so the first red is "commit first" (which
+// the campaign loops on) not "the build broke" (which the campaign spends
+// a pass trying to fix a phantom).
+//
+// The class is not "every verify.sh gate carrier": dep-update-guard's
+// verify_run gates align → verify_run → commit, so align intentionally
+// leaves the tree dirty for verify_run to judge — the whole point of
+// its validate-then-commit pattern. Adding this gate there would break
+// the bot.
+var netDirtyGateCarriers = []struct {
+	rel  string
+	node string
+}{
+	{"adr-cartograph/main.bot", "verify_run"},
+	{"app-dev/main.bot", "verify_run"},
+	{"branch-improve-loop/main.bot", "verify_run"},
+	{"e2e-coverage/main.bot", "verify_run"},
+	{"feature-dev/main.bot", "verify_run"},
+	{"feature-gap-fill/main.bot", "verify_run"},
+	{"instrument/main.bot", "verify_run"},
+	{"secured-renovacy/main.bot", "p2_verify_run"},
+	{"test-coverage/main.bot", "verify_run"},
+	{"whole-improve-loop/main.bot", "verify_run"},
+}
+
+// TestVerifyRunRefusesDirtyTree stands each carrier's REAL verify_run
+// command up against a real git repo whose tree carries an uncommitted
+// edit, and asserts the gate refuses BEFORE running verify.sh — with a
+// typed net_dirty verdict, a passed=false, and a log_tail that names
+// the offending path and tells the agent what to do about it.
+//
+// The gate must mord: it refuses on the pre-existing dirty tree, not on
+// output verify.sh happened to leave behind. To prove that, verify.sh is
+// benign here — a script that would be trivially green on a clean tree.
+// Today (pre-fix), that green passes and the drift tail's post-pre check
+// stays quiet because no NEW paths appear; the run reads "build passed"
+// while the tree it just judged is one nobody committed. The `net_dirty`
+// verdict is what the fix installs, and what this test pins down.
+func TestVerifyRunRefusesDirtyTree(t *testing.T) {
+	for _, bin := range []string{"python3", "git", "sh"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH", bin)
+		}
+	}
+
+	type verifyResult struct {
+		Passed   bool   `json:"passed"`
+		Skipped  bool   `json:"skipped"`
+		ExitCode int    `json:"exit_code"`
+		NetDirty bool   `json:"net_dirty"`
+		LogTail  string `json:"log_tail"`
+	}
+
+	// runVerifyRun executes the carrier's verify_run command against
+	// (ws, scratch) via `sh -c`, the same shell iterion's tool nodes use.
+	runVerifyRun := func(t *testing.T, cmd, ws, scratch string) verifyResult {
+		t.Helper()
+		expanded := strings.ReplaceAll(cmd, "{{vars.workspace_dir}}", ws)
+		expanded = strings.ReplaceAll(expanded, "{{vars.scratch_dir}}", scratch)
+		// Some carriers thread more vars (verify_timeout_s / matrix_path /
+		// target); default any that remain so the shell can still run.
+		expanded = strings.ReplaceAll(expanded, "{{vars.verify_timeout_s}}", "600")
+		expanded = strings.ReplaceAll(expanded, "{{vars.matrix_path}}", "")
+		expanded = strings.ReplaceAll(expanded, "{{vars.target}}", "")
+		out, err := exec.Command("sh", "-c", expanded).Output()
+		if err != nil {
+			t.Fatalf("verify_run command failed to execute: %v (out %q)", err, out)
+		}
+		var res verifyResult
+		if uerr := json.Unmarshal(out, &res); uerr != nil {
+			t.Fatalf("verify_run output is not verify_result JSON: %v (out %q)", uerr, out)
+		}
+		return res
+	}
+
+	// setupDirtyRepo makes a real git repo with one committed baseline
+	// file, then edits it in place so `git status --porcelain` reports
+	// it dirty. The scratch dir carries a benign verify.sh whose exit
+	// code alone would be a green pass — the test proves the gate refuses
+	// on the tree state, not on what the script did.
+	setupDirtyRepo := func(t *testing.T, dirty string) (ws, scratch string) {
+		t.Helper()
+		ws, scratch = t.TempDir(), t.TempDir()
+		gittest.Run(t, ws, "init", "-q")
+		if err := os.WriteFile(filepath.Join(ws, "README.md"), []byte("baseline\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		gittest.Run(t, ws, "add", "README.md")
+		gittest.Run(t, ws, "commit", "-q", "-m", "baseline")
+		if err := os.WriteFile(filepath.Join(ws, dirty), []byte("uncommitted mid-pass edit\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"),
+			[]byte("#!/bin/sh\nset -e\necho ok\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return ws, scratch
+	}
+
+	for _, c := range netDirtyGateCarriers {
+		c := c
+		t.Run(c.rel+"/"+c.node, func(t *testing.T) {
+			cmd := toolCommand(t, c.rel, c.node)
+
+			t.Run("dirty_tree_is_refused_with_net_dirty_verdict", func(t *testing.T) {
+				ws, scratch := setupDirtyRepo(t, "README.md")
+				res := runVerifyRun(t, cmd, ws, scratch)
+				if res.Passed {
+					t.Fatalf("dirty tree passed the gate — it judged the previous pass's "+
+						"uncommitted work as HEAD. Result: %+v", res)
+				}
+				if !res.NetDirty {
+					t.Errorf("verify_result lacks the typed net_dirty verdict — the campaign "+
+						"cannot tell 'commit first' from 'the build broke', so it spends a "+
+						"pass fixing a phantom. Result: %+v", res)
+				}
+				if !strings.Contains(res.LogTail, "NET DIRTY") {
+					t.Errorf("log_tail must name the defect for the operator and the agent, "+
+						"got %q", res.LogTail)
+				}
+				if !strings.Contains(res.LogTail, "README.md") {
+					t.Errorf("log_tail must name the offending path so the agent knows what "+
+						"to commit or discard; got %q", res.LogTail)
+				}
+			})
+
+			t.Run("dirty_untracked_file_is_refused", func(t *testing.T) {
+				// A brand-new file the agent forgot to `git add`. `git status --porcelain`
+				// reports it as `?? path`, so tree_state() sees it.
+				ws, scratch := setupDirtyRepo(t, "half_done.py")
+				// Undo the modification setupDirtyRepo made to README.md so the
+				// ONLY dirt is the new untracked file — proves untracked paths
+				// alone are enough to refuse.
+				gittest.Run(t, ws, "checkout", "--", "README.md")
+				res := runVerifyRun(t, cmd, ws, scratch)
+				if res.Passed || !res.NetDirty {
+					t.Fatalf("an untracked half-done file must refuse the gate, got %+v", res)
+				}
+				if !strings.Contains(res.LogTail, "half_done.py") {
+					t.Errorf("log_tail must name the untracked path, got %q", res.LogTail)
+				}
+			})
+
+			t.Run("clean_tree_still_passes", func(t *testing.T) {
+				// Symmetry: the gate must not shift green→red on a clean tree.
+				// A committed baseline plus a benign verify.sh must PASS.
+				ws, scratch := t.TempDir(), t.TempDir()
+				gittest.Run(t, ws, "init", "-q")
+				if err := os.WriteFile(filepath.Join(ws, "README.md"), []byte("baseline\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				gittest.Run(t, ws, "add", "README.md")
+				gittest.Run(t, ws, "commit", "-q", "-m", "baseline")
+				if err := os.WriteFile(filepath.Join(scratch, "verify.sh"),
+					[]byte("#!/bin/sh\nset -e\necho ok\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				res := runVerifyRun(t, cmd, ws, scratch)
+				if !res.Passed {
+					t.Fatalf("clean tree + green verify.sh must pass, got %+v", res)
+				}
+				if res.NetDirty {
+					t.Errorf("clean tree must not carry net_dirty=true, got %+v", res)
+				}
+			})
+		})
+	}
+}
+
+// TestVerifyRunNetDirtyGatePresentInAllCarriers is the anti-regression
+// grep: every campaign carrier ships the guard. Complements the functional
+// test above (which proves the guard mords) with a marker check that
+// catches a copy-paste omission a functional test only reveals as a
+// mysterious silent pass.
+//
+// The class is enumerated in netDirtyGateCarriers rather than discovered.
+// A discovered list would silently accept a new campaign bot that forgot
+// the gate; an enumerated one fails loudly on the missing entry, which is
+// the point of the class rule ("fix at the CLASS, not one site").
+func TestVerifyRunNetDirtyGatePresentInAllCarriers(t *testing.T) {
+	for _, c := range netDirtyGateCarriers {
+		c := c
+		t.Run(c.rel, func(t *testing.T) {
+			src, err := os.ReadFile(c.rel)
+			if err != nil {
+				t.Fatalf("read %s: %v", c.rel, err)
+			}
+			body := string(src)
+			for _, marker := range []string{"NET DIRTY", "'net_dirty': True"} {
+				if !strings.Contains(body, marker) {
+					t.Errorf("%s lacks the net_dirty gate (missing %q) — a retried "+
+						"attempt of an interrupted node will inherit the previous "+
+						"attempt's dirty tree and be judged on it", c.rel, marker)
+				}
+			}
+		})
+	}
+}

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -1077,6 +1077,18 @@ if masked:
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 5, 'log_tail': 'MASKED EXIT STATUS: ' + str(len(masked)) + ' line(s) of ' + script + ' pipe a gating command into an output filter, so the pipeline reports the FILTER and a failed check reads as success (pipefail is not POSIX -- this runs under /bin/sh). Capture the status FIRST and filter the log after: <cmd> >step.log 2>&1 || { tail -50 step.log >&2; exit 1; } -- or append  ' + chr(124) + chr(124) + ' true  to a pipeline that is deliberately not a gate. The script was moved to ' + rejected + ' and is regenerated next pass. Offending lines:' + chr(10) + chr(10).join(masked[:20])}))
     raise SystemExit(0)
 pre = tree_state()
+# NET DIRTY REFUSAL (issue #799): a dirty tree at verify start is the
+# PREVIOUS pass's uncommitted work reaching the gate, not the build's
+# failure. An interrupted attempt retried on the same tree, or a pass
+# stopped mid-unit, leaves edits on disk; judging that tree would call
+# THEIR failure the gate's. Refuse with a typed verdict so the campaign
+# loops back on 'commit first', not on 'the build broke'. Skipped when
+# tree_state() returned None (git error / not a repo, e.g. an app-dev
+# greenfield before git init) -- the drift tail already fails open there.
+if pre:
+    dirty_paths = sorted(pre)
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    raise SystemExit(0)
 rc = 0
 out = ''
 try:

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -1088,6 +1088,13 @@ pre = tree_state()
 if pre:
     dirty_paths = sorted(pre)
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 2, 'net_dirty': True, 'log_tail': 'NET DIRTY: ' + str(len(dirty_paths)) + ' path(s) uncommitted at verify start; this gate judges HEAD, so a dirty tree is refused BEFORE the build runs (the campaign contract ends every pass on a clean tree). End on a commit (git commit -m ...) or discard the edits (git restore --staged --worktree <paths>), then relaunch. Paths:' + chr(10) + chr(10).join(dirty_paths[:50])}))
+    # A refusal must not leave the PREVIOUS pass's verify.log looking current:
+    # the operator opens it to see why, and would read an unrelated build.
+    try:
+        with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+            lf.write('NET DIRTY: refused before running; no build output for this pass.' + chr(10))
+    except OSError:
+        pass
     raise SystemExit(0)
 rc = 0
 out = ''


### PR DESCRIPTION
## Why

A tool node whose whole contract is *"judge HEAD"* was judging whatever the previous attempt had left on disk.

Measured once: a golden-master gate ran **7,676 s** until the pod's exec stream broke, the engine classified the failure `NETWORK_TRANSIENT` and **re-executed the node on the same tree** — where a mutant the harness had applied for its falsification pass was still there. The second attempt judged a mutated program and called it the lot's. The run finished not-converged, with a clean bank and hours of budget left.

## Scope — and why this is not the engine half

The **harness half landed in #807** (2026-09-06), so the exact incident cannot recur. Checked before starting, because it changes what this change should be: what remains is defense in depth, not fire-fighting.

**Deliberately NOT an engine DSL field.** A `judges_head:`-style field would make every tool node declare it, with a `Cxxx` diagnostic and a compile-time contract, for a fire that is already out — defense in depth priced as fire-fighting. The gate lives in the bots instead, where the contract already is.

## The class, rendered

Ten campaign carriers get the gate on their `verify_run` node (`p2_verify_run` for secured-renovacy): adr-cartograph, app-dev, branch-improve-loop, e2e-coverage, feature-dev, feature-gap-fill, instrument, secured-renovacy, test-coverage, whole-improve-loop.

**One carrier deliberately does NOT**, and the reason is the interesting part: `dep-update-guard`'s flow is `align (mutating) → verify_build → verify_run → commit`. Its `align` step leaves the tree dirty **on purpose**, so a gate there would refuse the bot's normal path — the gate would be the defect.

Non-members checked and named rather than assumed: `verify_probe` (read-only `sh -n`, does not judge HEAD), `devbox-setup/verify_devbox`, `feed-watch/verify_message`, `product-docs/verify_publish`, and `modernize/lot_verify` (a per-lot contract file, with its own refusal already encoded).

## What the operator sees

The harness already says `WORKSPACE NOT COMMITTED`. The gate turns that into a **typed `net_dirty` verdict before the build gate runs**, so the first red is the right one — today it surfaces as a build failure on a package that exists, with a message that has nothing to do with the cause.

## The gate bites

Removing it from a single bot turns that bot's two subtests red, naming the bot and the case:

```
--- FAIL: TestVerifyRunRefusesDirtyTree/feature-dev/main.bot/verify_run/dirty_tree_is_refused_with_net_dirty_verdict
--- FAIL: TestVerifyRunRefusesDirtyTree/feature-dev/main.bot/verify_run/dirty_untracked_file_is_refused
```

Verified independently before merging, not taken on report. `TestVerifyRunNetDirtyGatePresentInAllCarriers` is the drift guard: a new campaign carrier without the gate turns it red.

The gate stays stack- and repo-agnostic, as `bots/catalog_universality_test.go` requires.

Refs #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
