### PR TITLE
docs: ticket conformance validated on a real private Jira (+ the cross-tenant write it exposed, #997)

### DIFF
--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -8,6 +8,63 @@ pr_url` it also posts an inline forge review and an optional deterministic
 commit-status gate. Never edits or commits. See
 [bots/review-pr/](../../bots/review-pr/).
 
+## 2026-09-08 — ticket conformance validated on a REAL private Jira, and the cross-tenant write it exposed (runs 01a082a0 / 01a082a8 / 01a082b2)
+
+- Status: **validated** — the feature works end-to-end on the cloud instance
+  against a real, private Jira Cloud ticket. One engine defect found on the way.
+- Versions: bot review-pr 0.6.0 (baked, prod) · instance
+  iterion.fabrique.social.gouv.fr
+- Method, in three runs:
+  1. `01a082a0` — **probe** on `SocialGouv/iterion-test-appy-e2e` (GitHub) with
+     `tracker_api_base=https://api.github.com` pinned in the integration's
+     `launch_vars`, no credential bound. Proved the half the local dogfood
+     could not: the ref is extracted from the PR body with no `ticket_refs`,
+     the tracker is reachable **from the k8s sandbox**, and the
+     `### Ticket conformance` section lands on a real PR. It also reported,
+     unprompted, that `/run/iterion/secrets/tracker_token` was absent and that
+     the authenticated attempt 401'd — i.e. it named the limit of my own probe.
+  2. `01a082a8` — **first real Jira run** on the GitLab MR
+     `…/dematamiante/code/demat-amiante!2` (ticket `DAM-1978`, private Jira
+     Cloud `jira-mcas.atlassian.net`). Verdict: `unverifiable — tracker token
+     file does not exist; anonymous GET returned HTTP 404`. **The canary was
+     red**, and it was right: the secret was not reaching the run (see below).
+  3. `01a082b2` — same MR, same ticket, after fixing the wiring. Verdict:
+     `DAM-1978: not covered — ticket demands cutting the multi-hour
+     Elasticsearch reindexation runtime to enable a daily run; the branch adds
+     only a readme.md changelog template and changes no Java, batch, or
+     configuration code, while the PR body claims "Closes DAM-1978"` — content
+     it could only know by reading the private ticket. Plus a `[high]
+     requirements` finding and four sharp questions, one of them load-bearing
+     (*does `Closes DAM-1978` actually drive a Jira transition here? the
+     blocking severity hinges on it*).
+- Value: red-then-green on the SAME MR and the SAME ticket. The verdict flips
+  only because the credential arrives, so this is a test that bites in both
+  directions rather than a screenshot of a success.
+- Secret hygiene, measured (not asserted): over the run's 112 KB of events,
+  where the Jira host appears 5× and `DAM-1978` 112×, the token appears **0×**
+  — verbatim, as an 8-char fragment, as the base64 of the `Basic` header, and
+  as its `ATATT` prefix. The positive controls are what make that zero mean
+  something.
+- **Engine defect found (the reason run 2 was red): a team-scoped write goes
+  to the tenant of the CALLER'S TOKEN, not the team in the path.**
+  `POST /api/teams/{id}/secrets` and `POST /api/teams/{id}/bots/{bot}/bindings`
+  authorize on the path team (`canManageTeam`, which a super-admin or org admin
+  passes for any team) but never re-scope the request context —
+  `generic_secrets_routes.go` and `bot_bindings_routes.go` contain **zero**
+  `store.WithTenant`, where `forge_provisioning_routes.go` has four. The row is
+  written into the JWT's tenant partition carrying the path team's scope, so it
+  is invisible from BOTH teams' list endpoints and can never be resolved for a
+  run — and every call returns 200/201. `iterion remote secrets set --team X`
+  inherits the same fate. Reproduced twice here (secret, then binding); the
+  workaround is `iterion remote teams switch <target>` **before** creating
+  either. Issue #997.
+- Lessons for next run: (a) wire secret + binding from the target team, never
+  by path/`--team` from another one, until #997 lands; (b) `/revi` on a note is
+  the fidelity path — it applies the integration's `launch_vars`, a manual
+  launch does not; (c) `iterion remote runs list` is scoped to the active team,
+  so a run launched on another team is simply absent — switch before concluding
+  it never started.
+
 ## 2026-09-08 — a green gate is one pass, not a property: 1 finding → 0 across a docs-only commit, and four defects still there (#851)
 
 - Status: **observation**, not a bilan of a launched run — recorded because it

--- a/docs/ticket-context.md
+++ b/docs/ticket-context.md
@@ -61,6 +61,35 @@ For a local CLI run: `iterion secret set tracker_token`, then
 `iterion run bots/review-pr/main.bot --var pr_url=… --var
 tracker_api_base=… [--var ticket_refs=…]`.
 
+### Validated wiring (reference)
+
+The first production wiring, validated end-to-end on 2026-09-08 against a
+private Jira Cloud (bilan: [docs/bot-runs/review-pr.md](bot-runs/review-pr.md)):
+
+| | value |
+|---|---|
+| team | `PIC (GitLab)` — where the repo's integration lives |
+| secret | `jira_dam_token` (Jira Cloud API token, `--from-file`) |
+| binding | `review-pr` ← `tracker_token`, `allowed_hosts: [jira-mcas.atlassian.net]` |
+| launch_vars | `tracker_api_base: https://jira-mcas.atlassian.net`, `tracker_user: <service account email>` |
+| trigger | `/revi` on the MR — it applies the integration's `launch_vars`; a manual launch does **not** |
+
+Note the team choice is a real decision: a binding is per `(team, bot)`, so
+every repo of that team could read those tickets if someone set
+`tracker_api_base` on it. When a product deserves its own credential
+boundary, give it its own team (there is an empty `PIC DematAmiante` team
+waiting for exactly that move).
+
+> **Do steps 2 and 3 from the target team.** Until
+> [#997](https://github.com/SocialGouv/iterion/issues/997) lands, a secret or
+> binding created for another team — by path (`/api/teams/<other>/…`) or by
+> `--team` — is written into the tenant of your *active* team instead. It is
+> acknowledged (201), then invisible from both teams, and the run silently
+> finds no credential (the review reports `unverifiable — tracker token file
+> does not exist`). Run `iterion remote teams switch <team>` first, and
+> confirm with a list call from that same team. Measured on prod on
+> 2026-09-08 (see [docs/bot-runs/review-pr.md](bot-runs/review-pr.md)).
+
 ### Limits to know
 
 - A binding is per **(team, bot)** — one `tracker_token` per team for


### PR DESCRIPTION
Bilan of tonight's e2e on prod, plus the operational lesson it cost.

## What was validated

Revi's ticket-conformance feature (review-pr 0.6.0, merged in #630) now has its production proof, on the GitLab MR `…/dematamiante/code/demat-amiante!2` against **private** Jira Cloud ticket `DAM-1978`:

| | run | verdict |
|---|---|---|
| probe (GitHub, no credential) | `01a082a0` | section published on a real PR, ref extracted from the body, tracker reached from the k8s sandbox |
| first Jira run | `01a082a8` | 🔴 `unverifiable — tracker token file does not exist` |
| after fixing the wiring | `01a082b2` | 🟢 `not covered — ticket demands cutting the multi-hour Elasticsearch reindexation runtime…, the branch adds only a readme.md changelog template` |

Red-then-green on the same MR and the same ticket: the verdict flips only because the credential arrives, so it is a test that bites both ways. Secret hygiene measured rather than asserted — 0 occurrences of the token across 112 KB of run events (verbatim, 8-char fragment, base64 of the `Basic` header, `ATATT` prefix), in a corpus where the Jira host appears 5× and the ticket key 112×.

## What it exposed

The red run was right: the secret never reached it. Root cause filed as **#997** — `POST /api/teams/{id}/secrets` and `.../bindings` authorize on the path team but never re-scope the request context, so the row lands in the **caller's token tenant** carrying the path team's scope, invisible from both. `rg -c 'store.WithTenant'` returns 0 for those two handlers and 4 for `forge_provisioning_routes.go`. Silent (201 every time), and it sits exactly on the documented path for wiring a bot credential.

This PR is docs only: the bilan + a runbook warning + the validated wiring reference. The code fix is #997, deliberately left as its own change because it is a **class** (every `/api/teams/{id}` handler touching a tenant-scoped store), not two sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)