### PR TITLE
fix(server): a team-scoped write must land in the PATH team, not the caller's tenant (closes #997)

### DIFF
--- a/pkg/secrets/bindings.go
+++ b/pkg/secrets/bindings.go
@@ -287,37 +287,44 @@ func NewMemoryBotSecretBindingStore() *MemoryBotSecretBindingStore {
 	return &MemoryBotSecretBindingStore{bindings: make(map[string]BotSecretBinding)}
 }
 
-func (m *MemoryBotSecretBindingStore) Create(_ context.Context, b BotSecretBinding) error {
+// The memory store mirrors the Mongo one's tenant semantics (stamp on
+// write, filter on read) — see stampTenant / visibleToTenant in generic.go
+// for why a permissive double hides a whole class of bugs (#997).
+func (m *MemoryBotSecretBindingStore) Create(ctx context.Context, b BotSecretBinding) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	b.TenantID = stampTenant(ctx, b.TenantID)
 	m.bindings[b.ID] = b
 	return nil
 }
 
-func (m *MemoryBotSecretBindingStore) Get(_ context.Context, id string) (BotSecretBinding, error) {
+func (m *MemoryBotSecretBindingStore) Get(ctx context.Context, id string) (BotSecretBinding, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	b, ok := m.bindings[id]
-	if !ok {
+	if !ok || !visibleToTenant(ctx, b.TenantID) {
 		return BotSecretBinding{}, ErrBindingNotFound
 	}
 	return b, nil
 }
 
-func (m *MemoryBotSecretBindingStore) Update(_ context.Context, b BotSecretBinding) error {
+func (m *MemoryBotSecretBindingStore) Update(ctx context.Context, b BotSecretBinding) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.bindings[b.ID]; !ok {
+	cur, ok := m.bindings[b.ID]
+	if !ok || !visibleToTenant(ctx, cur.TenantID) {
 		return ErrBindingNotFound
 	}
+	b.TenantID = stampTenant(ctx, cur.TenantID)
 	m.bindings[b.ID] = b
 	return nil
 }
 
-func (m *MemoryBotSecretBindingStore) Delete(_ context.Context, id string) error {
+func (m *MemoryBotSecretBindingStore) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.bindings[id]; !ok {
+	b, ok := m.bindings[id]
+	if !ok || !visibleToTenant(ctx, b.TenantID) {
 		return ErrBindingNotFound
 	}
 	delete(m.bindings, id)

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -414,11 +414,15 @@ func (m *MemoryApiKeyStore) Create(ctx context.Context, k ApiKey) error {
 	return nil
 }
 
-func (m *MemoryApiKeyStore) Get(_ context.Context, id string) (ApiKey, error) {
+// Create already stamps the ctx tenant; the reads MUST filter on it too,
+// or the double cannot express the failure the Mongo store produces (a row
+// written under one tenant, invisible under another) and a tenant-scoping
+// regression passes its tests. See stampTenant / visibleToTenant (#997).
+func (m *MemoryApiKeyStore) Get(ctx context.Context, id string) (ApiKey, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.keys[id]
-	if !ok {
+	if !ok || !visibleToTenant(ctx, k.TenantID) {
 		return ApiKey{}, ErrApiKeyNotFound
 	}
 	return k, nil
@@ -438,20 +442,23 @@ func (m *MemoryApiKeyStore) GetOwned(_ context.Context, id, ownerUserID string) 
 	return k, nil
 }
 
-func (m *MemoryApiKeyStore) Update(_ context.Context, k ApiKey) error {
+func (m *MemoryApiKeyStore) Update(ctx context.Context, k ApiKey) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.keys[k.ID]; !ok {
+	cur, ok := m.keys[k.ID]
+	if !ok || !visibleToTenant(ctx, cur.TenantID) {
 		return ErrApiKeyNotFound
 	}
+	k.TenantID = stampTenant(ctx, cur.TenantID)
 	m.keys[k.ID] = k
 	return nil
 }
 
-func (m *MemoryApiKeyStore) Delete(_ context.Context, id string) error {
+func (m *MemoryApiKeyStore) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.keys[id]; !ok {
+	k, ok := m.keys[id]
+	if !ok || !visibleToTenant(ctx, k.TenantID) {
 		return ErrApiKeyNotFound
 	}
 	delete(m.keys, id)

--- a/pkg/secrets/generic.go
+++ b/pkg/secrets/generic.go
@@ -226,29 +226,58 @@ func NewMemoryGenericSecretStore() *MemoryGenericSecretStore {
 	return &MemoryGenericSecretStore{secrets: make(map[string]GenericSecret)}
 }
 
-func (m *MemoryGenericSecretStore) Create(_ context.Context, s GenericSecret) error {
+// stampTenant mirrors the Mongo store's write behaviour: the row's
+// TenantID comes from the CONTEXT, not from the caller's struct. Without
+// this the memory store cannot express the failure the Mongo one produces
+// — a row written under one tenant and read under another — so a whole
+// class of tenant-scoping bugs stays invisible to tests that use it
+// (measured: the credential-wiring defect of #997 survived every unit
+// test precisely here). A ctx with no tenant leaves the caller's value
+// untouched, which keeps the many tenant-less fixtures working.
+func stampTenant(ctx context.Context, current string) string {
+	if t, ok := store.TenantFromContext(ctx); ok {
+		return t
+	}
+	return current
+}
+
+// visibleToTenant mirrors the Mongo store's READ filter. A row that was
+// never stamped (TenantID empty — a tenant-less fixture) stays visible to
+// everyone; a stamped row is visible only under its own tenant.
+func visibleToTenant(ctx context.Context, rowTenant string) bool {
+	t, ok := store.TenantFromContext(ctx)
+	if !ok || rowTenant == "" {
+		return true
+	}
+	return rowTenant == t
+}
+
+func (m *MemoryGenericSecretStore) Create(ctx context.Context, s GenericSecret) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	s.TenantID = stampTenant(ctx, s.TenantID)
 	m.secrets[s.ID] = s
 	return nil
 }
 
-func (m *MemoryGenericSecretStore) Get(_ context.Context, id string) (GenericSecret, error) {
+func (m *MemoryGenericSecretStore) Get(ctx context.Context, id string) (GenericSecret, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	s, ok := m.secrets[id]
-	if !ok {
+	if !ok || !visibleToTenant(ctx, s.TenantID) {
 		return GenericSecret{}, ErrGenericSecretNotFound
 	}
 	return s, nil
 }
 
-func (m *MemoryGenericSecretStore) Update(_ context.Context, s GenericSecret) error {
+func (m *MemoryGenericSecretStore) Update(ctx context.Context, s GenericSecret) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.secrets[s.ID]; !ok {
+	cur, ok := m.secrets[s.ID]
+	if !ok || !visibleToTenant(ctx, cur.TenantID) {
 		return ErrGenericSecretNotFound
 	}
+	s.TenantID = stampTenant(ctx, cur.TenantID)
 	m.secrets[s.ID] = s
 	return nil
 }
@@ -287,10 +316,11 @@ func (m *MemoryGenericSecretStore) UpdateIfFingerprint(_ context.Context, s Gene
 	return nil
 }
 
-func (m *MemoryGenericSecretStore) Delete(_ context.Context, id string) error {
+func (m *MemoryGenericSecretStore) Delete(ctx context.Context, id string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.secrets[id]; !ok {
+	s, ok := m.secrets[id]
+	if !ok || !visibleToTenant(ctx, s.TenantID) {
 		return ErrGenericSecretNotFound
 	}
 	delete(m.secrets, id)

--- a/pkg/server/bot_bindings_routes.go
+++ b/pkg/server/bot_bindings_routes.go
@@ -34,7 +34,7 @@ func (s *Server) validateBindingSecret(r *http.Request, teamID, secretID string)
 	if s.genericSecrets == nil {
 		return true // can't validate; allow (binding still tenant-scoped)
 	}
-	sec, err := s.genericSecrets.Get(r.Context(), secretID)
+	sec, err := s.genericSecrets.Get(teamTenantCtx(r.Context(), teamID), secretID)
 	if err != nil {
 		return false
 	}
@@ -42,7 +42,7 @@ func (s *Server) validateBindingSecret(r *http.Request, teamID, secretID string)
 }
 
 func (s *Server) bindingForTenantBot(w http.ResponseWriter, r *http.Request, teamID, botID, bindingID string) (secrets.BotSecretBinding, bool) {
-	b, err := s.botBindings.Get(r.Context(), bindingID)
+	b, err := s.botBindings.Get(teamTenantCtx(r.Context(), teamID), bindingID)
 	if err != nil || b.TenantID != teamID || b.BotID != botID {
 		httpError(w, http.StatusNotFound, "binding not found")
 		return secrets.BotSecretBinding{}, false
@@ -57,7 +57,7 @@ func (s *Server) handleListBotBindings(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusForbidden, "not a member")
 		return
 	}
-	list, err := s.botBindings.ListByTenantBot(r.Context(), teamID, botID)
+	list, err := s.botBindings.ListByTenantBot(teamPathTenantCtx(r), teamID, botID)
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -101,7 +101,10 @@ func (s *Server) handleCreateBotBinding(w http.ResponseWriter, r *http.Request) 
 		CreatedAt:             now,
 		UpdatedAt:             now,
 	}
-	if err := s.botBindings.Create(r.Context(), b); err != nil {
+	// The binding must land in the team it is created FOR — a binding
+	// stamped with the caller's active tenant is invisible to that team's
+	// runs, so the bot silently runs without the credential (#997).
+	if err := s.botBindings.Create(teamPathTenantCtx(r), b); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
@@ -139,7 +142,7 @@ func (s *Server) handleUpdateBotBinding(w http.ResponseWriter, r *http.Request) 
 		b.AllowedHosts = req.AllowedHosts
 	}
 	b.UpdatedAt = time.Now().UTC()
-	if err := s.botBindings.Update(r.Context(), b); err != nil {
+	if err := s.botBindings.Update(teamPathTenantCtx(r), b); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
@@ -157,7 +160,7 @@ func (s *Server) handleDeleteBotBinding(w http.ResponseWriter, r *http.Request) 
 	if _, ok := s.bindingForTenantBot(w, r, teamID, botID, r.PathValue("binding_id")); !ok {
 		return
 	}
-	if err := s.botBindings.Delete(r.Context(), r.PathValue("binding_id")); err != nil {
+	if err := s.botBindings.Delete(teamPathTenantCtx(r), r.PathValue("binding_id")); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}

--- a/pkg/server/byok_routes.go
+++ b/pkg/server/byok_routes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/secrets"
-	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
@@ -180,26 +179,6 @@ func (s *Server) writeApiKeyList(w http.ResponseWriter, r *http.Request, keys []
 	return true
 }
 
-// apiKeyTenantCtx scopes the store context to the team a route names in its
-// path, instead of the caller's ACTIVE team that requireAuth stamped.
-//
-// The api-keys store derives tenant_id from the context — on write it stamps
-// the row, on read it filters. So a key created for a team other than the
-// caller's active one used to land as (scope_team = target, tenant_id =
-// caller's active team): listable from the context that created it, and
-// INVISIBLE to the runs of the team it was meant to fund. Nothing failed —
-// the run simply resolved no key and fell back to the platform credential,
-// which is the one shape a credential bug must never take.
-//
-// Routes with no {id} (the /api/me family) keep the active team: there the
-// caller's own tenant IS the scope.
-func apiKeyTenantCtx(r *http.Request) context.Context {
-	if teamID := r.PathValue("id"); teamID != "" {
-		return store.WithTenant(r.Context(), teamID)
-	}
-	return r.Context()
-}
-
 // auditApiKey routes an api-key mutation to the right audit log: platform
 // rows (ScopeTeamID == secrets.PlatformTenantID) are super-admin actions on
 // the deployment's own fallback credentials and land in the PLATFORM log —
@@ -222,7 +201,7 @@ func (s *Server) handleListTeamApiKeys(w http.ResponseWriter, r *http.Request) {
 	}
 	// Team admins see all team-wide keys + their own user-scoped
 	// keys (matches BYOK plan). Members only see what's visible.
-	keys, err := s.apiKeys.ListByTeam(apiKeyTenantCtx(r), teamID, id.UserID)
+	keys, err := s.apiKeys.ListByTeam(teamPathTenantCtx(r), teamID, id.UserID)
 	s.writeApiKeyList(w, r, keys, err)
 }
 
@@ -307,7 +286,7 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 
 		MaxConcurrentRuns: req.MaxConcurrentRuns,
 	}
-	ctx := apiKeyTenantCtx(r)
+	ctx := teamPathTenantCtx(r)
 	if err := s.apiKeys.Create(ctx, key); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -341,7 +320,7 @@ func (s *Server) refuseApiKey(w http.ResponseWriter, r *http.Request, teamID, ke
 func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	keyID := r.PathValue("key_id")
-	ctx := apiKeyTenantCtx(r)
+	ctx := teamPathTenantCtx(r)
 	key, err := s.apiKeys.Get(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrApiKeyNotFound) {
@@ -408,7 +387,7 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteApiKey(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	keyID := r.PathValue("key_id")
-	ctx := apiKeyTenantCtx(r)
+	ctx := teamPathTenantCtx(r)
 	key, err := s.apiKeys.Get(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrApiKeyNotFound) {

--- a/pkg/server/byok_routes_test.go
+++ b/pkg/server/byok_routes_test.go
@@ -73,7 +73,7 @@ func TestApiKeyTenantCtx_UsesThePathTeamNotTheActiveOne(t *testing.T) {
 	r.SetPathValue("id", "team-b")
 	r = r.WithContext(store.WithTenant(r.Context(), "team-a")) // what requireAuth stamped
 
-	got, ok := store.TenantFromContext(apiKeyTenantCtx(r))
+	got, ok := store.TenantFromContext(teamPathTenantCtx(r))
 	if !ok || got != "team-b" {
 		t.Fatalf("want the path team team-b, got %q (ok=%v)", got, ok)
 	}
@@ -88,7 +88,7 @@ func TestApiKeyTenantCtx_KeepsTheActiveTeamWhenNoPathTeam(t *testing.T) {
 	}
 	r = r.WithContext(store.WithTenant(r.Context(), "team-a"))
 
-	got, ok := store.TenantFromContext(apiKeyTenantCtx(r))
+	got, ok := store.TenantFromContext(teamPathTenantCtx(r))
 	if !ok || got != "team-a" {
 		t.Fatalf("want the active team team-a, got %q (ok=%v)", got, ok)
 	}

--- a/pkg/server/generic_secrets_routes.go
+++ b/pkg/server/generic_secrets_routes.go
@@ -78,7 +78,7 @@ func (s *Server) handleListTeamSecrets(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusForbidden, "not a member")
 		return
 	}
-	records, err := s.genericSecrets.ListByTeam(r.Context(), teamID, id.UserID)
+	records, err := s.genericSecrets.ListByTeam(teamPathTenantCtx(r), teamID, id.UserID)
 	writeGenericSecretList(w, records, err)
 }
 
@@ -140,7 +140,9 @@ func (s *Server) handleCreateGenericSecret(w http.ResponseWriter, r *http.Reques
 		CreatedAt:    now,
 		Fingerprint:  secrets.FingerprintSHA256(req.Secret),
 	}
-	if err := s.genericSecrets.Create(r.Context(), rec); err != nil {
+	// The row must land in the team it is CREATED FOR, not in the caller's
+	// active one (#997) — see teamPathTenantCtx.
+	if err := s.genericSecrets.Create(teamTenantCtx(r.Context(), teamID), rec); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
@@ -151,7 +153,8 @@ func (s *Server) handleCreateGenericSecret(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleUpdateGenericSecret(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	secretID := r.PathValue("secret_id")
-	rec, err := s.genericSecrets.Get(r.Context(), secretID)
+	ctx := teamPathTenantCtx(r)
+	rec, err := s.genericSecrets.Get(ctx, secretID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrGenericSecretNotFound) {
 			httpError(w, http.StatusNotFound, "secret not found")
@@ -186,7 +189,7 @@ func (s *Server) handleUpdateGenericSecret(w http.ResponseWriter, r *http.Reques
 		rec.Last4 = secrets.Last4(*req.Secret)
 		rec.Fingerprint = secrets.FingerprintSHA256(*req.Secret)
 	}
-	if err := s.genericSecrets.Update(r.Context(), rec); err != nil {
+	if err := s.genericSecrets.Update(ctx, rec); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
@@ -197,7 +200,8 @@ func (s *Server) handleUpdateGenericSecret(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleDeleteGenericSecret(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	secretID := r.PathValue("secret_id")
-	rec, err := s.genericSecrets.Get(r.Context(), secretID)
+	ctx := teamPathTenantCtx(r)
+	rec, err := s.genericSecrets.Get(ctx, secretID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrGenericSecretNotFound) {
 			w.WriteHeader(http.StatusNoContent)
@@ -210,7 +214,7 @@ func (s *Server) handleDeleteGenericSecret(w http.ResponseWriter, r *http.Reques
 		httpError(w, http.StatusForbidden, "cannot delete this secret")
 		return
 	}
-	if err := s.genericSecrets.Delete(r.Context(), rec.ID); err != nil {
+	if err := s.genericSecrets.Delete(ctx, rec.ID); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}

--- a/pkg/server/team_path_tenant_test.go
+++ b/pkg/server/team_path_tenant_test.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/identity"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A team-scoped write must land in the team named in the PATH, not in the
+// tenant the caller's token happens to be pinned to (#997).
+//
+// The two are routinely different: canManageTeam admits a super-admin (and
+// an org admin over any team of their org) on a team that is not their
+// active one — that is the documented way an SRE wires another team's bot
+// credential. Before the fix the row was stamped with the caller's tenant,
+// so it was invisible from the target team AND from the caller's own list
+// (which filters on the path team's scope), and the target team's runs
+// resolved no credential at all. Nothing errored.
+//
+// Measured in production on 2026-09-08 while wiring the Jira credential of
+// `demat-amiante`: see docs/bot-runs/review-pr.md.
+func newTenantScopeTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := newOrgTestServer(t)
+	s.genericSecrets = secrets.NewMemoryGenericSecretStore()
+	s.botBindings = secrets.NewMemoryBotSecretBindingStore()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	sealer, err := secrets.NewAESGCMSealer(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.sealer = sealer
+	ctx := context.Background()
+	for _, id := range []string{"team-caller", "team-target"} {
+		if _, err := s.authStore().CreateTeam(ctx, identity.Team{
+			ID: id, Name: id, Slug: id, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s
+}
+
+// callerCtx is a super-admin whose ACTIVE team is team-caller — the shape
+// `stampAuthedContext` produces for a real request.
+func callerCtx() context.Context {
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		UserID: "admin", IsSuperAdmin: true, TeamID: "team-caller",
+	})
+	return store.WithIdentity(ctx, "team-caller", "admin")
+}
+
+// targetRunCtx is what a RUN of the target team reads with — the context
+// that must be able to see the credential that was wired for it.
+func targetRunCtx() context.Context {
+	return store.WithTenant(context.Background(), "team-target")
+}
+
+func TestTeamSecretWrittenFromAnotherActiveTeamIsVisibleToThatTeam(t *testing.T) {
+	s := newTenantScopeTestServer(t)
+
+	w := httptest.NewRecorder()
+	req := bindReq(callerCtx(), "POST", "/api/teams/team-target/secrets",
+		`{"name":"jira_token","secret":"s3cr3t-value"}`, "team-target", "", "")
+	s.handleCreateTeamSecret(w, req)
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("create: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil || created.ID == "" {
+		t.Fatalf("bad create body %s (%v)", w.Body.String(), err)
+	}
+
+	// The run of the team the secret was created FOR must find it.
+	if _, err := s.genericSecrets.Get(targetRunCtx(), created.ID); err != nil {
+		t.Fatalf("secret created for team-target is invisible to its own runs: %v", err)
+	}
+
+	// And the API list for that team must show it.
+	w = httptest.NewRecorder()
+	s.handleListTeamSecrets(w, bindReq(callerCtx(), "GET", "/api/teams/team-target/secrets", "", "team-target", "", ""))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var listed struct {
+		Secrets []struct {
+			ID string `json:"id"`
+		} `json:"secrets"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &listed)
+	found := false
+	for _, sec := range listed.Secrets {
+		if sec.ID == created.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("secret absent from the target team's list: %s", w.Body.String())
+	}
+}
+
+func TestBotBindingWrittenFromAnotherActiveTeamIsResolvableByThatTeam(t *testing.T) {
+	s := newTenantScopeTestServer(t)
+
+	// The secret the binding will reference, already correctly scoped.
+	if err := s.genericSecrets.Create(targetRunCtx(), secrets.GenericSecret{
+		ID: "sec-1", TenantID: "team-target", ScopeTeamID: "team-target",
+		Name: "jira_token", SealedSecret: []byte("x"), CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	s.handleCreateBotBinding(w, bindReq(callerCtx(), "POST",
+		"/api/teams/team-target/bots/review-pr/bindings",
+		`{"secret_id":"sec-1","secret_name_for_workflow":"tracker_token"}`,
+		"team-target", "review-pr", ""))
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("create binding: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// The publisher resolves bindings under the RUN's tenant.
+	list, err := s.botBindings.ListByTenantBot(targetRunCtx(), "team-target", "review-pr")
+	if err != nil {
+		t.Fatalf("list bindings: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("binding created for team-target is invisible to its own runs (%d found) — the credential silently never reaches the bot", len(list))
+	}
+}

--- a/pkg/server/tenant_ctx.go
+++ b/pkg/server/tenant_ctx.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// teamPathTenantCtx scopes the store context to the team a route names in
+// its PATH, instead of the caller's ACTIVE team that requireAuth stamped.
+//
+// WHY THIS EXISTS, and why every tenant-scoped handler under
+// /api/teams/{id}/... must use it:
+//
+// The auth middleware stamps ONE tenant on the request — the one on the
+// caller's JWT (stampAuthedContext). The tenant-scoped stores derive
+// everything from that context: on write they STAMP the row's tenant_id,
+// on read they FILTER on it. Meanwhile authorization is checked against
+// the team in the PATH (canManageTeam admits a super-admin, and an org
+// admin over any team of their org). So the two routinely differ — that
+// divergence IS the documented way an SRE wires another team's
+// credential.
+//
+// When they differ and the handler forgets to re-scope, the row lands as
+// (scope_team = the path team, tenant_id = the caller's active team):
+// invisible from the target team's list, invisible to that team's runs,
+// and the API answers 201. Nothing fails — the bot simply runs without
+// the credential it was given, which is the one shape a credential bug
+// must never take.
+//
+// Paid twice: once on the BYOK api-keys (fixed at that site only), then
+// again on generic secrets AND bot bindings, measured in production on
+// 2026-09-08 while wiring a Jira credential — a review reported
+// "unverifiable: tracker token file does not exist" for a secret the
+// console showed as created (#997, docs/bot-runs/review-pr.md).
+//
+// Routes with no {id} (the /api/me family) keep the active team: there
+// the caller's own tenant IS the scope.
+func teamPathTenantCtx(r *http.Request) context.Context {
+	return teamTenantCtx(r.Context(), r.PathValue("id"))
+}
+
+// teamTenantCtx is the explicit-team form, for handlers that already hold
+// the team id (or read it from another path segment).
+func teamTenantCtx(ctx context.Context, teamID string) context.Context {
+	if teamID == "" {
+		return ctx
+	}
+	return store.WithTenant(ctx, teamID)
+}

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -308,11 +308,11 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		}
 		cfg.HMACSecretSealed = sealed
 	}
-	if err := s.validateKeyOverrides(r.Context(), teamID, cfg.KeyOverrides); err != nil {
+	if err := s.validateKeyOverrides(teamTenantCtx(r.Context(), teamID), teamID, cfg.KeyOverrides); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	if err := s.validateSecretOverrides(r.Context(), teamID, cfg.SecretOverrides); err != nil {
+	if err := s.validateSecretOverrides(teamTenantCtx(r.Context(), teamID), teamID, cfg.SecretOverrides); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
@@ -493,14 +493,14 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 		cfg.LaunchVars = req.LaunchVars
 	}
 	if req.KeyOverrides != nil {
-		if err := s.validateKeyOverrides(r.Context(), teamID, req.KeyOverrides); err != nil {
+		if err := s.validateKeyOverrides(teamTenantCtx(r.Context(), teamID), teamID, req.KeyOverrides); err != nil {
 			httpError(w, http.StatusBadRequest, "%s", err.Error())
 			return
 		}
 		cfg.KeyOverrides = req.KeyOverrides
 	}
 	if req.SecretOverrides != nil {
-		if err := s.validateSecretOverrides(r.Context(), teamID, req.SecretOverrides); err != nil {
+		if err := s.validateSecretOverrides(teamTenantCtx(r.Context(), teamID), teamID, req.SecretOverrides); err != nil {
 			httpError(w, http.StatusBadRequest, "%s", err.Error())
 			return
 		}


### PR DESCRIPTION
Closes #997 — the defect the ticket-context e2e surfaced last night.

## The defect

The auth middleware stamps **one** tenant (the caller's JWT), while authorization is checked against the team in the **path** — and `canManageTeam` deliberately admits a super-admin, or an org admin, on a team that is not their active one. That divergence is the documented way an SRE wires another team's credential.

When a handler forgot to re-scope, the row landed as *(scope_team = path team, tenant_id = caller's team)*: invisible from both list endpoints, invisible to the target team's runs, and the API answered **201**. The bot then ran **without the credential it had just been given** — the one shape a credential bug must never take.

Measured on prod on 2026-09-08 while wiring a Jira token: the review reported `unverifiable — tracker token file does not exist` for a secret the console showed as created.

## Fixed at the class

The same defect had already been met and fixed **on the BYOK api-keys alone** (`apiKeyTenantCtx`, whose comment describes it exactly) — which is precisely how it survived on its siblings. So:

- that helper is promoted to a shared `teamPathTenantCtx` / `teamTenantCtx` ([tenant_ctx.go](pkg/server/tenant_ctx.go)) carrying the full rationale;
- applied to **generic secrets** (list/create/update/delete), **bot bindings** (all six store calls, including the secret validation that made the binding 400 on a legitimate secret), and the **webhook override validators** (where the wrong tenant made a valid override read as "not found");
- a sweep over every `pkg/server` handler reading a team from its path now reports **zero** remaining raw-context call sites on a ctx-filtered store.

## Why no test caught it — fixed too

The **memory** stores ignored the ctx tenant while the Mongo ones stamp on write and filter on read, so the double could not express the failure at all. They now mirror those semantics (generic secrets, bot bindings, api keys — the last stamped already but never filtered). A tenant-less fixture stays visible, so existing fixtures are unaffected; a row written under the wrong tenant is not.

The new test is a **canary**, verified red before the fix:

```
--- FAIL: TestTeamSecretWrittenFromAnotherActiveTeamIsVisibleToThatTeam
    secret created for team-target is invisible to its own runs
--- FAIL: TestBotBindingWrittenFromAnotherActiveTeamIsResolvableByThatTeam
    create binding: code=400 secret_id is not a team-scoped secret in this org
```

## Verification

`task lint` 0 issues; `go test ./pkg/... ./e2e/...` with no FAIL (one `pkg/backend/delegate` flake under parallel load, green in isolation and untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)