### PR TITLE
fix(golden-master,modernize): a repairable certificate refusal no longer ends the run

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1905,7 +1905,13 @@ tool oracle_run:
         for act in acts:
             row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
             if act.get("id") in seen_act_ids:
-                row["forged"] = True
+                # REFUSED, not forged. The duplicate block was appended during this
+                # segment, so it sits ABOVE the run's base — and ledger_append_only
+                # only pins the text below it. Removing the extra block is a legal
+                # edit, which makes this a shape a repair pass can fix: the row
+                # stays not-ok, its paths stay out of ok_paths, refs_untouched goes
+                # false and the lot does not converge. `forged` is reserved for
+                # what NO pass can undo (see the two sites below).
                 row["problems"].append(
                     "a SECOND act block for %r — an id is acted once. Its "
                     "provenance would resolve on the FIRST act's commit, so any "
@@ -2057,13 +2063,20 @@ tool oracle_run:
                         continue
                     certified = acted_blobs.get(p)
                     if not certified:
-                        row["forged"] = True
+                        # REFUSED, not forged: the act block was appended in this
+                        # segment, so narrowing it back to the paths the subbot
+                        # certified is a legal append-only edit.
                         row["problems"].append(
                             "%s is recorded by the act but the subbot certified no "
                             "blob for it — a path appended to the record after the "
                             "act is not part of the act" % p)
                     elif blob_id("HEAD", p) != certified:
-                        row["forged"] = True
+                        # REFUSED, not forged: the repair is one commit — restore
+                        # the file to the blob the subbot certified. The trigger is
+                        # accidental and realistic (a repo-wide sweep by the lot's
+                        # own agent touching a reference after extend ran), and
+                        # ending the run there costs the whole campaign for
+                        # something the next pass undoes.
                         row["problems"].append(
                             "%s was rewritten after the act: HEAD carries blob %s, "
                             "the subbot certified %s — the certificate covers the "
@@ -4635,9 +4648,11 @@ tool oracle_run:
             xcommit(email="lot@run")                         # commit C, le lot reecrit
             v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
                                      acted_blobs={".golden-master/refs/2.txt": blob_b})
-            check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+            # Refusee sans etre FORGEE : la reparation est un commit (restaurer le
+            # blob certifie), donc le lot doit repasser, pas mourir.
+            check("reference reecrite apres l'acte certifie : refusee, reparable, pas exemptee",
                   [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
-                  [False, True, []])
+                  [False, None, []])
             v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
             check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
@@ -4717,10 +4732,10 @@ tool oracle_run:
                                       acted_blobs={".golden-master/refs/2.txt": blob_one},
                                       acted_ids={"E-1"})
             dup = v_dup["acted"][1]
-            check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+            check("second bloc `act` de meme id : refuse, reparable, et n'exempte rien",
                   [dup["ok"], dup.get("forged"),
                    ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
-                  [False, True, False])
+                  [False, None, False])
             check("l'acte du subbot reste certifie, lui",
                   [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
@@ -4754,11 +4769,11 @@ tool oracle_run:
                                        acted_blobs={".golden-master/refs/2.txt": blob_w},
                                        acted_ids={"E-1"})
             wide = v_wide["acted"][0]
-            check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+            check("bloc `act` du subbot elargi apres coup : refuse, reparable, "
                   "et le chemin ajoute n'est pas exempte",
                   [wide["ok"], wide.get("forged"),
                    ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
-                  [False, True, False])
+                  [False, None, False])
             check("et le chemin que le subbot a bien certifie n'exempte plus rien "
                   "non plus : c'est l'acte entier qui est refuse",
                   v_wide["ok_paths"], [])

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4666,6 +4666,33 @@ tool oracle_run:
                    v_sub.get("provenance"), v_rw2.get("provenance")],
                   ["legacy", "strict", "strict", "strict"])
 
+            # L'AUTO-ACTE EN UN SEUL COMMIT, isole. Le scenario de contrebande
+            # ci-dessous depose la demande et l'acte dans DEUX commits, donc c'est
+            # la regle des commits du subbot qui le refuse — la regle du commit
+            # unique n'y est jamais seule a decider, et un mutant qui la supprime
+            # y survivait (mesure : M3 survivant). Ici le commit qui depose est le
+            # commit du subbot lui-meme, donc tous les autres controles passent :
+            # l'acte est dans acted_commits, l'id est acte, le blob correspond.
+            # Seule la separation des pouvoirs ferme la porte, et elle doit rester
+            # TERMINALE : aucune passe ne defait deux enregistrements deja dans
+            # l'historique.
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("le filet se demande et s'acte tout seul\n")
+            xcommit(email="extend@golden-master.iterion")     # UN commit : demande + acte
+            sha_self = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_self = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                            xroot, timeout=60)[1].strip()
+            v_self = extension_verdict(
+                xroot, ".golden-master", xbase, acted_commits={sha_self},
+                acted_blobs={".golden-master/refs/2.txt": blob_self}, acted_ids={"E-1"})
+            check("demande et acte dans le MEME commit : refuse, forge, rien d'exempte "
+                  "(l'acte est pourtant dans les commits du subbot et son blob correspond)",
+                  [v_self["acted"][0]["ok"], v_self["acted"][0].get("forged"),
+                   v_self["ok_paths"]],
+                  [False, True, []])
+
             # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
             # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
             # s'acte la refusee en enregistrant le chemin que le subbot a

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -4453,6 +4453,33 @@ def _selftest():
                v_sub.get("provenance"), v_rw2.get("provenance")],
               ["legacy", "strict", "strict", "strict"])
 
+        # L'AUTO-ACTE EN UN SEUL COMMIT, isole. Le scenario de contrebande
+        # ci-dessous depose la demande et l'acte dans DEUX commits, donc c'est
+        # la regle des commits du subbot qui le refuse — la regle du commit
+        # unique n'y est jamais seule a decider, et un mutant qui la supprime
+        # y survivait (mesure : M3 survivant). Ici le commit qui depose est le
+        # commit du subbot lui-meme, donc tous les autres controles passent :
+        # l'acte est dans acted_commits, l'id est acte, le blob correspond.
+        # Seule la separation des pouvoirs ferme la porte, et elle doit rester
+        # TERMINALE : aucune passe ne defait deux enregistrements deja dans
+        # l'historique.
+        xreset()
+        xledger(("request", req2), ("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("le filet se demande et s'acte tout seul\n")
+        xcommit(email="extend@golden-master.iterion")     # UN commit : demande + acte
+        sha_self = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        blob_self = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                        xroot, timeout=60)[1].strip()
+        v_self = extension_verdict(
+            xroot, ".golden-master", xbase, acted_commits={sha_self},
+            acted_blobs={".golden-master/refs/2.txt": blob_self}, acted_ids={"E-1"})
+        check("demande et acte dans le MEME commit : refuse, forge, rien d'exempte "
+              "(l'acte est pourtant dans les commits du subbot et son blob correspond)",
+              [v_self["acted"][0]["ok"], v_self["acted"][0].get("forged"),
+               v_self["ok_paths"]],
+              [False, True, []])
+
         # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
         # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
         # s'acte la refusee en enregistrant le chemin que le subbot a

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1692,7 +1692,13 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
     for act in acts:
         row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
         if act.get("id") in seen_act_ids:
-            row["forged"] = True
+            # REFUSED, not forged. The duplicate block was appended during this
+            # segment, so it sits ABOVE the run's base — and ledger_append_only
+            # only pins the text below it. Removing the extra block is a legal
+            # edit, which makes this a shape a repair pass can fix: the row
+            # stays not-ok, its paths stay out of ok_paths, refs_untouched goes
+            # false and the lot does not converge. `forged` is reserved for
+            # what NO pass can undo (see the two sites below).
             row["problems"].append(
                 "a SECOND act block for %r — an id is acted once. Its "
                 "provenance would resolve on the FIRST act's commit, so any "
@@ -1844,13 +1850,20 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                     continue
                 certified = acted_blobs.get(p)
                 if not certified:
-                    row["forged"] = True
+                    # REFUSED, not forged: the act block was appended in this
+                    # segment, so narrowing it back to the paths the subbot
+                    # certified is a legal append-only edit.
                     row["problems"].append(
                         "%s is recorded by the act but the subbot certified no "
                         "blob for it — a path appended to the record after the "
                         "act is not part of the act" % p)
                 elif blob_id("HEAD", p) != certified:
-                    row["forged"] = True
+                    # REFUSED, not forged: the repair is one commit — restore
+                    # the file to the blob the subbot certified. The trigger is
+                    # accidental and realistic (a repo-wide sweep by the lot's
+                    # own agent touching a reference after extend ran), and
+                    # ending the run there costs the whole campaign for
+                    # something the next pass undoes.
                     row["problems"].append(
                         "%s was rewritten after the act: HEAD carries blob %s, "
                         "the subbot certified %s — the certificate covers the "
@@ -4422,9 +4435,11 @@ def _selftest():
         xcommit(email="lot@run")                         # commit C, le lot reecrit
         v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
                                  acted_blobs={".golden-master/refs/2.txt": blob_b})
-        check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+        # Refusee sans etre FORGEE : la reparation est un commit (restaurer le
+        # blob certifie), donc le lot doit repasser, pas mourir.
+        check("reference reecrite apres l'acte certifie : refusee, reparable, pas exemptee",
               [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
-              [False, True, []])
+              [False, None, []])
         v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                   acted_blobs={".golden-master/refs/2.txt": blob_b})
         check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
@@ -4504,10 +4519,10 @@ def _selftest():
                                   acted_blobs={".golden-master/refs/2.txt": blob_one},
                                   acted_ids={"E-1"})
         dup = v_dup["acted"][1]
-        check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+        check("second bloc `act` de meme id : refuse, reparable, et n'exempte rien",
               [dup["ok"], dup.get("forged"),
                ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
-              [False, True, False])
+              [False, None, False])
         check("l'acte du subbot reste certifie, lui",
               [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
               [True, [".golden-master/refs/2.txt"]])
@@ -4541,11 +4556,11 @@ def _selftest():
                                    acted_blobs={".golden-master/refs/2.txt": blob_w},
                                    acted_ids={"E-1"})
         wide = v_wide["acted"][0]
-        check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+        check("bloc `act` du subbot elargi apres coup : refuse, reparable, "
               "et le chemin ajoute n'est pas exempte",
               [wide["ok"], wide.get("forged"),
                ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
-              [False, True, False])
+              [False, None, False])
         check("et le chemin que le subbot a bien certifie n'exempte plus rien "
               "non plus : c'est l'acte entier qui est refuse",
               v_wide["ok_paths"], [])

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4614,6 +4614,33 @@ tool sync_harness:
                    v_sub.get("provenance"), v_rw2.get("provenance")],
                   ["legacy", "strict", "strict", "strict"])
 
+            # L'AUTO-ACTE EN UN SEUL COMMIT, isole. Le scenario de contrebande
+            # ci-dessous depose la demande et l'acte dans DEUX commits, donc c'est
+            # la regle des commits du subbot qui le refuse — la regle du commit
+            # unique n'y est jamais seule a decider, et un mutant qui la supprime
+            # y survivait (mesure : M3 survivant). Ici le commit qui depose est le
+            # commit du subbot lui-meme, donc tous les autres controles passent :
+            # l'acte est dans acted_commits, l'id est acte, le blob correspond.
+            # Seule la separation des pouvoirs ferme la porte, et elle doit rester
+            # TERMINALE : aucune passe ne defait deux enregistrements deja dans
+            # l'historique.
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("le filet se demande et s'acte tout seul\n")
+            xcommit(email="extend@golden-master.iterion")     # UN commit : demande + acte
+            sha_self = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            blob_self = run("git rev-parse HEAD:.golden-master/refs/2.txt",
+                            xroot, timeout=60)[1].strip()
+            v_self = extension_verdict(
+                xroot, ".golden-master", xbase, acted_commits={sha_self},
+                acted_blobs={".golden-master/refs/2.txt": blob_self}, acted_ids={"E-1"})
+            check("demande et acte dans le MEME commit : refuse, forge, rien d'exempte "
+                  "(l'acte est pourtant dans les commits du subbot et son blob correspond)",
+                  [v_self["acted"][0]["ok"], v_self["acted"][0].get("forged"),
+                   v_self["ok_paths"]],
+                  [False, True, []])
+
             # LE SCENARIO DE CONTREBANDE, rejoue en entier : le lot depose DEUX
             # demandes, le subbot en acte une et REFUSE l'autre, puis le lot
             # s'acte la refusee en enregistrant le chemin que le subbot a

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1853,7 +1853,13 @@ tool sync_harness:
         for act in acts:
             row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
             if act.get("id") in seen_act_ids:
-                row["forged"] = True
+                # REFUSED, not forged. The duplicate block was appended during this
+                # segment, so it sits ABOVE the run's base — and ledger_append_only
+                # only pins the text below it. Removing the extra block is a legal
+                # edit, which makes this a shape a repair pass can fix: the row
+                # stays not-ok, its paths stay out of ok_paths, refs_untouched goes
+                # false and the lot does not converge. `forged` is reserved for
+                # what NO pass can undo (see the two sites below).
                 row["problems"].append(
                     "a SECOND act block for %r — an id is acted once. Its "
                     "provenance would resolve on the FIRST act's commit, so any "
@@ -2005,13 +2011,20 @@ tool sync_harness:
                         continue
                     certified = acted_blobs.get(p)
                     if not certified:
-                        row["forged"] = True
+                        # REFUSED, not forged: the act block was appended in this
+                        # segment, so narrowing it back to the paths the subbot
+                        # certified is a legal append-only edit.
                         row["problems"].append(
                             "%s is recorded by the act but the subbot certified no "
                             "blob for it — a path appended to the record after the "
                             "act is not part of the act" % p)
                     elif blob_id("HEAD", p) != certified:
-                        row["forged"] = True
+                        # REFUSED, not forged: the repair is one commit — restore
+                        # the file to the blob the subbot certified. The trigger is
+                        # accidental and realistic (a repo-wide sweep by the lot's
+                        # own agent touching a reference after extend ran), and
+                        # ending the run there costs the whole campaign for
+                        # something the next pass undoes.
                         row["problems"].append(
                             "%s was rewritten after the act: HEAD carries blob %s, "
                             "the subbot certified %s — the certificate covers the "
@@ -4583,9 +4596,11 @@ tool sync_harness:
             xcommit(email="lot@run")                         # commit C, le lot reecrit
             v_rw = extension_verdict(xroot, ".golden-master", xbase, acted_commits={sha_b},
                                      acted_blobs={".golden-master/refs/2.txt": blob_b})
-            check("reference reecrite apres l'acte certifie : refusee, pas exemptee",
+            # Refusee sans etre FORGEE : la reparation est un commit (restaurer le
+            # blob certifie), donc le lot doit repasser, pas mourir.
+            check("reference reecrite apres l'acte certifie : refusee, reparable, pas exemptee",
                   [v_rw["acted"][0]["ok"], v_rw["acted"][0].get("forged"), v_rw["ok_paths"]],
-                  [False, True, []])
+                  [False, None, []])
             v_rw2 = extension_verdict(xroot, ".golden-master", xbase, acted_commits={"0" * 40},
                                       acted_blobs={".golden-master/refs/2.txt": blob_b})
             check("sha inconnu ET contenu different : refuse", v_rw2["acted"][0]["ok"], False)
@@ -4665,10 +4680,10 @@ tool sync_harness:
                                       acted_blobs={".golden-master/refs/2.txt": blob_one},
                                       acted_ids={"E-1"})
             dup = v_dup["acted"][1]
-            check("second bloc `act` de meme id : refuse, forge, et n'exempte rien",
+            check("second bloc `act` de meme id : refuse, reparable, et n'exempte rien",
                   [dup["ok"], dup.get("forged"),
                    ".golden-master/refs/9.txt" in v_dup["ok_paths"]],
-                  [False, True, False])
+                  [False, None, False])
             check("l'acte du subbot reste certifie, lui",
                   [v_dup["acted"][0]["ok"], v_dup["ok_paths"]],
                   [True, [".golden-master/refs/2.txt"]])
@@ -4702,11 +4717,11 @@ tool sync_harness:
                                        acted_blobs={".golden-master/refs/2.txt": blob_w},
                                        acted_ids={"E-1"})
             wide = v_wide["acted"][0]
-            check("bloc `act` du subbot elargi apres coup : refuse, forge, "
+            check("bloc `act` du subbot elargi apres coup : refuse, reparable, "
                   "et le chemin ajoute n'est pas exempte",
                   [wide["ok"], wide.get("forged"),
                    ".golden-master/refs/9.txt" in v_wide["ok_paths"]],
-                  [False, True, False])
+                  [False, None, False])
             check("et le chemin que le subbot a bien certifie n'exempte plus rien "
                   "non plus : c'est l'acte entier qui est refuse",
                   v_wide["ok_paths"], [])

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -1317,10 +1317,12 @@ tool lot_verify:
                                    "; ".join(r.get("problems") or []))
                                 for r in bad)
                 report["refs_untouched"] = False
-            # Provenance refused = the constrained party acted its own request,
-            # or rewrote a certified reference: typed and terminal, never a
-            # repair pass — a resume from the banked branch would find the act
-            # at its base and certify it.
+            # Provenance refused = the constrained party acted its own
+            # request, or an act introduced outside the subbot's commits:
+            # typed and terminal, never a repair pass — a resume from the
+            # banked branch would find the act at its base and certify it.
+            # A rewritten certificate is NOT in this set: it is refused as an
+            # ordinary non-converged row above, and repaired by a pass.
             if any(r.get("forged") for r in (verdict.get("acted") or [])):
                 report["extension_forged"] = True
                 report["refs_untouched"] = False
@@ -1783,12 +1785,22 @@ workflow modernize:
   ## the timeout is: the engine takes the first `when` that holds, and this
   ## verdict may ALSO carry a pending request — routed to `extend`, the net's
   ## own subbot would act on a tree that already carries a forged reference.
-  ## And it is structurally unrepairable by a pass: dropping the act block
-  ## breaks `ledger_append_only`, deleting the reference makes the recorded
-  ## path absent at HEAD, amending yields a sha still outside the subbot's
-  ## commits, and a harness sync is the net owner's act — so each repair pass
-  ## would be a guaranteed-red campaign plus a full exit gate, paid
-  ## max_passes times (review finding, executed).
+  ## And what reaches this edge is structurally unrepairable by a pass: the
+  ## act was introduced OUTSIDE the subbot's commits (amending yields a sha
+  ## still outside them), the requester acted its own request (the two commits
+  ## are in history), or the net's harness never said it applied the rule and
+  ## a sync is the net owner's act. Each repair pass would be a guaranteed-red
+  ## campaign plus a full exit gate, paid max_passes times.
+  ##
+  ## What does NOT reach it, since the certificate-content refusals stopped
+  ## setting `forged`: a duplicate act block, a path recorded without a
+  ## certificate, a certified reference rewritten after the act. Those sit
+  ## ABOVE the run's base — and `ledger_append_only` is
+  ## `head_txt.startswith(base_txt)`, which pins only the text below it — so
+  ## narrowing the block or restoring the blob is a legal edit and one pass
+  ## does it. They stay ordinary non-converged refusals and go round the
+  ## repair loop, which is where they went before the provenance work
+  ## (review finding Rf213cf, executed).
   lot_gate -> extension_provenance when forged
 
   ## Repair the net BEFORE deciding the lot, and on every outcome — a converged


### PR DESCRIPTION
`#882` merged at 16:14Z on head `900c161535ee`. This fix was pushed to that branch at 17:05Z — an hour after the merge — so it never reached `main`. Carried here on top of current `main`, unchanged, with the test that proves it.

## What is wrong on main today

`lot_gate -> extension_provenance when forged` lands on a `resumable: false` fail declared ahead of the repair loop, so **every** shape that sets `forged` ends the campaign run outright. The justification written above that edge — "dropping the act block breaks `ledger_append_only`" — holds for two of the five sites that set it, and `ledger_append_only` is `head_txt.startswith(base_txt)`: it pins only the text BELOW the run's base, so a block appended during the segment can be narrowed or dropped legally.

Three shapes go back to being ordinary non-converged refusals, which is where they were before the provenance work:

- **a duplicate act block** — above base, removing it is legal;
- **a path recorded with no certificate** — above base, narrowing back is legal;
- **a certified reference rewritten after the act** — the repair is one commit: restore the blob the subbot certified. The trigger is accidental and realistic: a lot's own agent sweeping the repo and touching `.golden-master/refs/<x>` after `extend` ran.

Nothing else was needed for them to route correctly: a not-ok row already keeps its paths out of `ok_paths`, has its problems reported by `lot_verify`, and sets `refs_untouched` false — so the lot does not converge and the pass happens. No new flag: one that nothing reads would be dead code documented as a guard.

`forged` now means only what no pass can undo: the requester acted its own request, or the act was introduced outside the subbot's commits. The comment on the edge and the one on the flag say which shapes each covers instead of claiming the universal.

Net effect: a lot that incidentally rewrites a certified reference repairs it next pass instead of forfeiting the campaign.

## Proof

- selftest **261 verifications**; `./bots/` and `./e2e/` green (87 s / 57 s);
- three assertions inverted — refused AND repairable, still exempting nothing;
- **four mutants, all killed**. One of them first SURVIVED and found a real gap: removing `forged` from the same-commit self-act turned nothing red, because the smuggling scenario files the request and the act in TWO commits and is therefore refused by the other rule. One of the two shapes `forged` is now reserved for was asserted by nothing. The second commit adds the isolated fixture: request and act in ONE commit, and that commit is the subbot's own — the act is in `acted_commits`, its id is acted, its blob matches, every other control passes. Only the separation of powers closes the door.

Reported by Revi as Rf213cf on #882 (medium, non-blocking).
