### PR TITLE
feat(runview): expose a shared workflow diagnostic projection

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -767,6 +767,79 @@
         ],
         "type": "object"
       },
+      "DiagnosticEvidence": {
+        "properties": {
+          "details": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "node_id": {
+            "type": "string"
+          },
+          "seq": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "seq",
+          "type"
+        ],
+        "type": "object"
+      },
+      "DiagnosticProjection": {
+        "properties": {
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/DiagnosticEvidence"
+            },
+            "type": "array"
+          },
+          "failure_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "next_action": {
+            "type": "string"
+          },
+          "node_id": {
+            "type": "string"
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "parent_run_id": {
+            "type": "string"
+          },
+          "recoverable": {
+            "type": "boolean"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "run_id",
+          "status",
+          "outcome",
+          "recoverable",
+          "next_action"
+        ],
+        "type": "object"
+      },
       "ExecutionState": {
         "properties": {
           "branch_id": {
@@ -2089,6 +2162,9 @@
       },
       "RunSnapshot": {
         "properties": {
+          "diagnostic": {
+            "$ref": "#/components/schemas/DiagnosticProjection"
+          },
           "executions": {
             "items": {
               "$ref": "#/components/schemas/ExecutionState"
@@ -7066,6 +7142,37 @@
         {
           "in": "path",
           "name": "sha",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/runs/{id}/diagnostic": {
+      "get": {
+        "operationId": "getRunsByIdDiagnostic",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiagnosticProjection"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "GET /api/runs/{id}/diagnostic",
+        "tags": [
+          "runs"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
           "required": true,
           "schema": {
             "type": "string"

--- a/pkg/runview/diagnostic.go
+++ b/pkg/runview/diagnostic.go
@@ -1,0 +1,380 @@
+package runview
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// DiagnosticVersion is the wire version of DiagnosticProjection. The
+// projection is deliberately additive: consumers can ignore fields they do
+// not know while the persisted run and event formats remain unchanged.
+const DiagnosticVersion = 1
+
+// DiagnosticOutcome is a conclusion for an operator or a watcher. It is not
+// a persisted RunStatus and must never be used as a replacement for one.
+type DiagnosticOutcome string
+
+const (
+	DiagnosticActive      DiagnosticOutcome = "active"
+	DiagnosticFinished    DiagnosticOutcome = "finished"
+	DiagnosticBlocked     DiagnosticOutcome = "blocked"
+	DiagnosticInterrupted DiagnosticOutcome = "interrupted"
+	DiagnosticFailed      DiagnosticOutcome = "failed"
+)
+
+// DiagnosticAction is the next safe action suggested by the persisted
+// lifecycle state. It intentionally stays coarse: interpreting arbitrary
+// workflow output as an engine policy would create a second, unreliable
+// business-rule validator.
+type DiagnosticAction string
+
+const (
+	DiagnosticActionNone          DiagnosticAction = "none"
+	DiagnosticActionResume        DiagnosticAction = "resume"
+	DiagnosticActionWait          DiagnosticAction = "wait"
+	DiagnosticActionAnswer        DiagnosticAction = "answer_or_resume"
+	DiagnosticActionInspect       DiagnosticAction = "inspect"
+	DiagnosticActionFixThenResume DiagnosticAction = "fix_then_resume"
+)
+
+// DiagnosticEvidence is a bounded, allow-listed projection of an event.
+// Arbitrary output payloads are deliberately excluded; only fields whose
+// purpose is operational diagnosis are copied.
+type DiagnosticEvidence struct {
+	Seq     int64             `json:"seq"`
+	Type    store.EventType   `json:"type"`
+	NodeID  string            `json:"node_id,omitempty"`
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// DiagnosticProjection is the common read model exposed by runview and the
+// HTTP API. It combines the typed run outcome with the latest bounded event
+// evidence so CLI, Studio, Copi and watchers can consume the same contract.
+type DiagnosticProjection struct {
+	Version     int                  `json:"version"`
+	RunID       string               `json:"run_id"`
+	ParentRunID string               `json:"parent_run_id,omitempty"`
+	Status      store.RunStatus      `json:"status"`
+	Outcome     DiagnosticOutcome    `json:"outcome"`
+	Recoverable bool                 `json:"recoverable"`
+	FailureCode store.FailureCode    `json:"failure_code,omitempty"`
+	NodeID      string               `json:"node_id,omitempty"`
+	Message     string               `json:"message,omitempty"`
+	NextAction  DiagnosticAction     `json:"next_action"`
+	Evidence    []DiagnosticEvidence `json:"evidence,omitempty"`
+}
+
+const (
+	diagnosticEvidenceLimit = 12
+	diagnosticValueLimit    = 2048
+)
+
+// BuildDiagnostic loads a run and projects its current diagnostic state.
+// ScanEvents keeps memory bounded even for long runs; only the latest small
+// set of operational events is retained.
+func BuildDiagnostic(ctx context.Context, s store.RunStore, runID string) (*DiagnosticProjection, error) {
+	run, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	d := newDiagnosticProjection(run)
+	if err := s.ScanEvents(ctx, runID, d.observeEvent); err != nil {
+		return nil, err
+	}
+	d.finalize(run)
+	return d, nil
+}
+
+func newDiagnosticProjection(run *store.Run) *DiagnosticProjection {
+	d := &DiagnosticProjection{
+		Version:    DiagnosticVersion,
+		NextAction: DiagnosticActionNone,
+	}
+	if run != nil {
+		d.RunID = run.ID
+		d.ParentRunID = run.ParentRunID
+		d.Status = run.Status
+		d.FailureCode = run.FailureCode
+		d.Message = run.Error
+		d.setStatusOutcome(run.Status)
+		d.recomputeAction(run)
+	}
+	return d
+}
+
+// observeEvent keeps only the current execution episode. A resume starts a
+// new episode, so a watcher does not mistake an old failure for a new one.
+func (d *DiagnosticProjection) observeEvent(evt *store.Event) bool {
+	if evt == nil {
+		return true
+	}
+	switch evt.Type {
+	case store.EventRunStarted, store.EventRunResumed, store.EventRunAutoResumed:
+		d.Evidence = nil
+		d.NodeID = ""
+		d.Message = ""
+		d.FailureCode = ""
+		d.Outcome = DiagnosticActive
+		d.Recoverable = false
+		d.NextAction = DiagnosticActionNone
+		return true
+	case store.EventRunFinished:
+		d.Outcome = DiagnosticFinished
+		d.Recoverable = false
+		d.NextAction = DiagnosticActionNone
+		return true
+	case store.EventRunInterrupted:
+		d.Outcome = DiagnosticInterrupted
+		d.Recoverable = true
+		d.NextAction = DiagnosticActionResume
+	case store.EventRunPaused:
+		d.Outcome = DiagnosticBlocked
+		d.Recoverable = true
+		d.NextAction = DiagnosticActionAnswer
+	case store.EventHumanInputRequested:
+		// Async questions do not pause the run and therefore must not
+		// trigger a watcher resume/answer loop.
+		if store.IsAsyncHumanInput(*evt) {
+			return true
+		}
+		d.Outcome = DiagnosticBlocked
+		d.Recoverable = true
+		d.NextAction = DiagnosticActionAnswer
+	case store.EventRunCancelled:
+		d.Outcome = DiagnosticFailed
+		d.Recoverable = false
+		d.NextAction = DiagnosticActionInspect
+	case store.EventRunFailed:
+		resumable, _ := evt.Data["resumable"].(bool)
+		interrupted, _ := evt.Data["interrupted"].(bool)
+		if interrupted || diagnosticCode(evt.Data) == string(store.FailureInterrupted) {
+			d.Outcome = DiagnosticInterrupted
+			d.Recoverable = true
+			d.NextAction = DiagnosticActionResume
+		} else if resumable {
+			d.Outcome = DiagnosticBlocked
+			d.Recoverable = true
+			d.NextAction = DiagnosticActionResume
+		} else {
+			d.Outcome = DiagnosticFailed
+			d.Recoverable = false
+			d.NextAction = DiagnosticActionInspect
+		}
+	case store.EventRunRetryScheduled:
+		d.Outcome = DiagnosticBlocked
+		d.Recoverable = true
+		d.NextAction = DiagnosticActionWait
+	case store.EventRunRetrySkipped:
+		d.Outcome = DiagnosticFailed
+		d.Recoverable = false
+		d.NextAction = DiagnosticActionInspect
+	case store.EventNodeRecovery:
+		// Keep the run active while a bounded node retry is in progress.
+		if d.Outcome == "" || d.Outcome == DiagnosticFinished {
+			d.Outcome = DiagnosticActive
+		}
+	case store.EventRunHealth:
+		// Health evidence is useful to watchers, but its kind is not an
+		// engine failure classification. Do not change the outcome here.
+	case store.EventNodeFinished:
+		// Node output is an observational proof only. In particular, the
+		// declared `output.detail` field must be visible to diagnostics,
+		// while the rest of the arbitrary output remains private.
+	default:
+		return true
+	}
+
+	details := projectDiagnosticDetails(evt.Data)
+	if len(details) == 0 && evt.Type != store.EventRunFailed && evt.Type != store.EventRunInterrupted {
+		return true
+	}
+	d.Evidence = append(d.Evidence, DiagnosticEvidence{
+		Seq:     evt.Seq,
+		Type:    evt.Type,
+		NodeID:  evt.NodeID,
+		Details: details,
+	})
+	if len(d.Evidence) > diagnosticEvidenceLimit {
+		d.Evidence = d.Evidence[len(d.Evidence)-diagnosticEvidenceLimit:]
+	}
+	if evt.NodeID != "" {
+		d.NodeID = evt.NodeID
+	}
+	if code := diagnosticCode(evt.Data); code != "" {
+		d.FailureCode = store.FailureCode(code)
+	}
+	if msg, ok := diagnosticString(evt.Data, "error"); ok {
+		d.Message = msg
+	}
+	return true
+}
+
+func (d *DiagnosticProjection) finalize(run *store.Run) {
+	if run == nil {
+		return
+	}
+	d.RunID = run.ID
+	d.ParentRunID = run.ParentRunID
+	d.Status = run.Status
+	if run.FailureCode != "" {
+		d.FailureCode = run.FailureCode
+	}
+	if run.Error != "" {
+		d.Message = run.Error
+	}
+	if d.NodeID == "" && len(d.Evidence) > 0 {
+		d.NodeID = d.Evidence[len(d.Evidence)-1].NodeID
+	}
+	d.setStatusOutcome(run.Status)
+	d.recomputeAction(run)
+}
+
+// refreshRun updates run-level fields while preserving the current event
+// episode. SnapshotBuilder calls this when a live run document changes.
+func (d *DiagnosticProjection) refreshRun(run *store.Run) {
+	if run == nil {
+		return
+	}
+	d.RunID = run.ID
+	d.ParentRunID = run.ParentRunID
+	d.Status = run.Status
+	if run.FailureCode != "" {
+		d.FailureCode = run.FailureCode
+	}
+	if run.Error != "" {
+		d.Message = run.Error
+	}
+	d.setStatusOutcome(run.Status)
+	d.recomputeAction(run)
+}
+
+func (d *DiagnosticProjection) setStatusOutcome(status store.RunStatus) {
+	switch {
+	case status.IsFinalSuccess():
+		d.Outcome, d.Recoverable = DiagnosticFinished, false
+	case status == store.RunStatusFailedResumable:
+		if d.Outcome != DiagnosticInterrupted {
+			d.Outcome = DiagnosticBlocked
+		}
+		d.Recoverable = true
+	case status.IsPaused():
+		d.Outcome, d.Recoverable = DiagnosticBlocked, true
+	case status.IsFinalFailure():
+		d.Outcome, d.Recoverable = DiagnosticFailed, false
+	case status == store.RunStatusCancelled:
+		d.Outcome, d.Recoverable = DiagnosticFailed, false
+	case status == store.RunStatusRunning:
+		d.Outcome, d.Recoverable = DiagnosticActive, false
+	case status.IsQueued():
+		d.Outcome, d.Recoverable = DiagnosticActive, false
+	default:
+		d.Outcome, d.Recoverable = DiagnosticFailed, false
+	}
+}
+
+func (d *DiagnosticProjection) recomputeAction(run *store.Run) {
+	switch {
+	case d.Status.IsFinalSuccess():
+		d.NextAction = DiagnosticActionNone
+	case d.Status == store.RunStatusRunning:
+		d.NextAction = DiagnosticActionNone
+	case d.Status.IsQueued():
+		d.NextAction = DiagnosticActionNone
+	case d.Status.IsPaused():
+		d.NextAction = DiagnosticActionAnswer
+	case d.Status == store.RunStatusFailedResumable:
+		if run != nil && run.RetryState != nil && run.RetryState.RetryAfter != nil {
+			d.NextAction = DiagnosticActionWait
+		} else {
+			d.NextAction = DiagnosticActionResume
+		}
+	case d.Status.IsFinalFailure():
+		d.NextAction = DiagnosticActionInspect
+	case d.Status == store.RunStatusCancelled:
+		d.NextAction = DiagnosticActionInspect
+	default:
+		d.NextAction = DiagnosticActionInspect
+	}
+}
+
+func projectDiagnosticDetails(data map[string]any) map[string]string {
+	if len(data) == 0 {
+		return nil
+	}
+	keys := []string{
+		"code", "error", "phase", "reason", "resumable", "interrupted",
+		"retry_after", "attempt", "max_attempts", "delay_ms", "reset_source",
+		"kind", "axis", "budget_pct", "detail",
+	}
+	out := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := diagnosticScalar(data[key]); ok {
+			out[key] = value
+		}
+	}
+	// node_finished wraps the producer output under `output`. Preserve only
+	// its declared scalar detail as evidence; never flatten the arbitrary
+	// output map into the operator-facing projection.
+	if _, exists := out["detail"]; !exists {
+		if output, ok := data["output"].(map[string]any); ok {
+			if detail, ok := diagnosticScalar(output["detail"]); ok {
+				out["detail"] = detail
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func diagnosticCode(data map[string]any) string {
+	if code, ok := diagnosticString(data, "code"); ok {
+		return code
+	}
+	return ""
+}
+
+func diagnosticString(data map[string]any, key string) (string, bool) {
+	if len(data) == 0 {
+		return "", false
+	}
+	value, ok := data[key]
+	if !ok {
+		return "", false
+	}
+	return diagnosticScalar(value)
+}
+
+func diagnosticScalar(value any) (string, bool) {
+	var out string
+	switch v := value.(type) {
+	case string:
+		out = v
+	case bool:
+		out = strconv.FormatBool(v)
+	case int:
+		out = strconv.Itoa(v)
+	case int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		out = fmt.Sprint(v)
+	case float32, float64:
+		out = fmt.Sprint(v)
+	case json.Number:
+		out = v.String()
+	default:
+		return "", false
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", false
+	}
+	if len(out) > diagnosticValueLimit {
+		out = out[:diagnosticValueLimit] + "…"
+	}
+	return out, true
+}

--- a/pkg/runview/diagnostic_test.go
+++ b/pkg/runview/diagnostic_test.go
@@ -1,0 +1,233 @@
+package runview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestBuildDiagnostic_ProjectsResumableFailureAndRetryEvidence(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "diagnostic-retry"
+	if _, err := st.CreateRun(ctx, runID, "workflow", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	retryAt := time.Now().Add(time.Hour).UTC()
+	run, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	run.RetryState = &store.RunRetryState{
+		RetryAfter: &retryAt,
+		Reason:     "usage_window",
+		Code:       string(store.FailureUsageLimitBlocked),
+		Attempts:   2,
+	}
+	if err := st.SaveRun(ctx, run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if err := st.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailedResumable,
+		"provider quota is exhausted", store.FailureUsageLimitBlocked); err != nil {
+		t.Fatalf("UpdateRunStatusCoded: %v", err)
+	}
+	for _, event := range []store.Event{
+		{Type: store.EventRunStarted, RunID: runID},
+		{Type: store.EventRunFailed, RunID: runID, NodeID: "render", Data: map[string]any{
+			"error": "provider quota is exhausted", "code": string(store.FailureUsageLimitBlocked), "resumable": true,
+		}},
+		{Type: store.EventRunRetryScheduled, RunID: runID, NodeID: "render", Data: map[string]any{
+			"code": string(store.FailureUsageLimitBlocked), "retry_after": retryAt.Format(time.RFC3339), "attempt": 2,
+		}},
+	} {
+		if _, err := st.AppendEvent(ctx, runID, event); err != nil {
+			t.Fatalf("AppendEvent(%s): %v", event.Type, err)
+		}
+	}
+
+	diagnostic, err := BuildDiagnostic(ctx, st, runID)
+	if err != nil {
+		t.Fatalf("BuildDiagnostic: %v", err)
+	}
+	if diagnostic.Version != DiagnosticVersion {
+		t.Fatalf("version = %d, want %d", diagnostic.Version, DiagnosticVersion)
+	}
+	if diagnostic.Outcome != DiagnosticBlocked || !diagnostic.Recoverable {
+		t.Fatalf("outcome/recoverable = %q/%v, want blocked/true", diagnostic.Outcome, diagnostic.Recoverable)
+	}
+	if diagnostic.NextAction != DiagnosticActionWait {
+		t.Fatalf("next_action = %q, want wait", diagnostic.NextAction)
+	}
+	if diagnostic.FailureCode != store.FailureUsageLimitBlocked {
+		t.Fatalf("failure_code = %q, want %q", diagnostic.FailureCode, store.FailureUsageLimitBlocked)
+	}
+	if diagnostic.NodeID != "render" {
+		t.Fatalf("node_id = %q, want render", diagnostic.NodeID)
+	}
+	if len(diagnostic.Evidence) != 2 {
+		t.Fatalf("evidence count = %d, want 2", len(diagnostic.Evidence))
+	}
+	if got := diagnostic.Evidence[1].Details["retry_after"]; got != retryAt.Format(time.RFC3339) {
+		t.Fatalf("retry_after evidence = %q, want %q", got, retryAt.Format(time.RFC3339))
+	}
+}
+
+func TestBuildDiagnostic_ResumeStartsANewEvidenceEpisode(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "diagnostic-episodes"
+	if _, err := st.CreateRun(ctx, runID, "workflow", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed,
+		"second failure", store.FailureSchemaValidation); err != nil {
+		t.Fatalf("UpdateRunStatusCoded: %v", err)
+	}
+	for _, event := range []store.Event{
+		{Type: store.EventRunStarted, RunID: runID},
+		{Type: store.EventRunFailed, RunID: runID, NodeID: "first", Data: map[string]any{
+			"error": "first failure", "code": string(store.FailureAuthFailed),
+		}},
+		{Type: store.EventRunResumed, RunID: runID},
+		{Type: store.EventRunFailed, RunID: runID, NodeID: "second", Data: map[string]any{
+			"error": "second failure", "code": string(store.FailureSchemaValidation),
+		}},
+	} {
+		if _, err := st.AppendEvent(ctx, runID, event); err != nil {
+			t.Fatalf("AppendEvent(%s): %v", event.Type, err)
+		}
+	}
+
+	diagnostic, err := BuildDiagnostic(ctx, st, runID)
+	if err != nil {
+		t.Fatalf("BuildDiagnostic: %v", err)
+	}
+	if diagnostic.NodeID != "second" || diagnostic.Message != "second failure" {
+		t.Fatalf("current failure = node %q/message %q, want second/second failure", diagnostic.NodeID, diagnostic.Message)
+	}
+	if len(diagnostic.Evidence) != 1 || diagnostic.Evidence[0].NodeID != "second" {
+		t.Fatalf("evidence = %+v, want only the post-resume failure", diagnostic.Evidence)
+	}
+	if diagnostic.FailureCode != store.FailureSchemaValidation {
+		t.Fatalf("failure_code = %q, want %q", diagnostic.FailureCode, store.FailureSchemaValidation)
+	}
+}
+
+func TestBuildDiagnostic_AllowListsEvidenceFields(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "diagnostic-evidence"
+	if _, err := st.CreateRun(ctx, runID, "workflow", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed,
+		"invalid output", store.FailureSchemaValidation); err != nil {
+		t.Fatalf("UpdateRunStatusCoded: %v", err)
+	}
+	if _, err := st.AppendEvent(ctx, runID, store.Event{
+		Type: store.EventRunFailed, RunID: runID, NodeID: "validate", Data: map[string]any{
+			"error":  "invalid output",
+			"code":   string(store.FailureSchemaValidation),
+			"detail": "field `items` exceeds its bound",
+			"secret": "must never leave the event projection",
+			"output": map[string]any{"password": "sensitive"},
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	diagnostic, err := BuildDiagnostic(ctx, st, runID)
+	if err != nil {
+		t.Fatalf("BuildDiagnostic: %v", err)
+	}
+	if len(diagnostic.Evidence) != 1 {
+		t.Fatalf("evidence count = %d, want 1", len(diagnostic.Evidence))
+	}
+	details := diagnostic.Evidence[0].Details
+	if details["detail"] == "" || details["error"] == "" || details["code"] == "" {
+		t.Fatalf("expected diagnostic fields in %+v", details)
+	}
+	if _, ok := details["secret"]; ok {
+		t.Fatalf("arbitrary secret field leaked into evidence: %+v", details)
+	}
+	if _, ok := details["output"]; ok {
+		t.Fatalf("output payload leaked into evidence: %+v", details)
+	}
+}
+
+func TestBuildDiagnostic_ProjectsNestedNodeOutputDetail(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "diagnostic-node-detail"
+	if _, err := st.CreateRun(ctx, runID, "workflow", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := st.AppendEvent(ctx, runID, store.Event{
+		Type: store.EventNodeFinished, RunID: runID, NodeID: "validate", Data: map[string]any{
+			"output": map[string]any{
+				"detail": "field items exceeds its bound",
+				"secret": "must not be projected",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	diagnostic, err := BuildDiagnostic(ctx, st, runID)
+	if err != nil {
+		t.Fatalf("BuildDiagnostic: %v", err)
+	}
+	if len(diagnostic.Evidence) != 1 {
+		t.Fatalf("evidence count = %d, want 1", len(diagnostic.Evidence))
+	}
+	if got := diagnostic.Evidence[0].Details["detail"]; got != "field items exceeds its bound" {
+		t.Fatalf("nested detail = %q", got)
+	}
+	if _, ok := diagnostic.Evidence[0].Details["secret"]; ok {
+		t.Fatalf("nested arbitrary output leaked: %+v", diagnostic.Evidence[0].Details)
+	}
+}
+
+func TestSnapshotBuilder_IncludesTheSameDiagnosticProjection(t *testing.T) {
+	run := &store.Run{
+		ID:          "snapshot-diagnostic",
+		Status:      store.RunStatusFailed,
+		FailureCode: store.FailureSchemaValidation,
+		Error:       "invalid output",
+	}
+	builder := NewSnapshotBuilder(run)
+	builder.Apply(&store.Event{
+		Seq:    1,
+		Type:   store.EventRunFailed,
+		RunID:  run.ID,
+		NodeID: "writer",
+		Data: map[string]any{
+			"error": "invalid output", "code": string(store.FailureSchemaValidation),
+		},
+	})
+
+	snapshot := builder.Snapshot()
+	if snapshot.Diagnostic == nil {
+		t.Fatal("snapshot diagnostic is nil")
+	}
+	if snapshot.Diagnostic.Version != DiagnosticVersion || snapshot.Diagnostic.NodeID != "writer" {
+		t.Fatalf("snapshot diagnostic = %+v", snapshot.Diagnostic)
+	}
+	if snapshot.Diagnostic.Outcome != DiagnosticFailed || snapshot.Diagnostic.NextAction != DiagnosticActionInspect {
+		t.Fatalf("snapshot outcome/action = %q/%q, want failed/inspect", snapshot.Diagnostic.Outcome, snapshot.Diagnostic.NextAction)
+	}
+}

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -362,6 +362,10 @@ type RunSnapshot struct {
 	Run        RunHeader        `json:"run"`
 	Executions []ExecutionState `json:"executions"`
 	LastSeq    int64            `json:"last_seq"`
+	// Diagnostic is the common, versioned operator projection. It is
+	// additive and derived from the same run/events stream; callers may
+	// ignore it when they have not adopted the contract yet.
+	Diagnostic *DiagnosticProjection `json:"diagnostic,omitempty"`
 }
 
 // SnapshotBuilder is a stateful incremental reducer: feed it events in
@@ -381,10 +385,11 @@ type RunSnapshot struct {
 const NoEventsSeq int64 = -1
 
 type SnapshotBuilder struct {
-	header    RunHeader
-	execs     map[string]*ExecutionState
-	order     []string                  // execution_id in first-seen order; defines snapshot.Executions order
-	nodeCount map[string]map[string]int // branch_id → ir_node_id → next iteration index (LEGACY, for fallback int-iter path)
+	header     RunHeader
+	diagnostic *DiagnosticProjection
+	execs      map[string]*ExecutionState
+	order      []string                  // execution_id in first-seen order; defines snapshot.Executions order
+	nodeCount  map[string]map[string]int // branch_id → ir_node_id → next iteration index (LEGACY, for fallback int-iter path)
 	// lastExecID maps (branch → nodeID → exec_id) to the most recent
 	// node_started exec_id for that node. currentExec uses it to find
 	// the in-flight execution for downstream events (node_finished,
@@ -478,6 +483,7 @@ func NewSnapshotBuilder(run *store.Run) *SnapshotBuilder {
 	}
 	if run != nil {
 		b.header = headerFromRun(run)
+		b.diagnostic = newDiagnosticProjection(run)
 	}
 	return b
 }
@@ -496,6 +502,11 @@ func (b *SnapshotBuilder) SetRun(run *store.Run) {
 	prevAnchor := b.header.CurrentRunStart
 	hadEventDerivedTimer := b.lastSeq != NoEventsSeq
 	b.header = headerFromRun(run)
+	if b.diagnostic == nil {
+		b.diagnostic = newDiagnosticProjection(run)
+	} else {
+		b.diagnostic.refreshRun(run)
+	}
 	if hadEventDerivedTimer {
 		b.header.ActiveDurationMs = prevDuration
 		b.header.CurrentRunStart = prevAnchor
@@ -514,6 +525,9 @@ func (b *SnapshotBuilder) Apply(evt *store.Event) {
 		return
 	}
 	b.lastSeq = evt.Seq
+	if b.diagnostic != nil {
+		b.diagnostic.observeEvent(evt)
+	}
 
 	// Authoritative monotonic active-duration base (BUG A fix): when the
 	// engine stamped Event.ActiveMs (SharedBudget CLOCK_MONOTONIC
@@ -604,11 +618,35 @@ func (b *SnapshotBuilder) Snapshot() *RunSnapshot {
 		cp := *b.workspaceCheckpoint
 		header.WorkspaceCheckpoint = &cp
 	}
+	var diagnostic *DiagnosticProjection
+	if b.diagnostic != nil {
+		copyOfDiagnostic := *b.diagnostic
+		copyOfDiagnostic.Evidence = cloneDiagnosticEvidence(b.diagnostic.Evidence)
+		diagnostic = &copyOfDiagnostic
+	}
 	return &RunSnapshot{
 		Run:        header,
 		Executions: execs,
 		LastSeq:    b.lastSeq,
+		Diagnostic: diagnostic,
 	}
+}
+
+func cloneDiagnosticEvidence(in []DiagnosticEvidence) []DiagnosticEvidence {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]DiagnosticEvidence, len(in))
+	for i, evidence := range in {
+		out[i] = evidence
+		if evidence.Details != nil {
+			out[i].Details = make(map[string]string, len(evidence.Details))
+			for key, value := range evidence.Details {
+				out[i].Details[key] = value
+			}
+		}
+	}
+	return out
 }
 
 // buildLoopProgress assembles the run-level named-loop indicator from

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -124,7 +124,8 @@ func routeSchemas() map[string]routeOp {
 				Runs []runview.RunSummary `json:"runs"`
 			}{},
 		},
-		"GET /api/runs/{id}": {response: runview.RunSnapshot{}},
+		"GET /api/runs/{id}":            {response: runview.RunSnapshot{}},
+		"GET /api/runs/{id}/diagnostic": {response: runview.DiagnosticProjection{}},
 		"GET /api/runs/{id}/children": {
 			response: struct {
 				Runs []runview.RunSummary `json:"runs"`

--- a/pkg/server/runs.go
+++ b/pkg/server/runs.go
@@ -30,6 +30,7 @@ func (s *Server) registerRunRoutes() {
 	s.mux.HandleFunc("GET /api/runs/{id}", s.handleGetRun)
 	s.mux.HandleFunc("GET /api/runs/{id}/children", s.handleListRunChildren)
 	s.mux.HandleFunc("GET /api/runs/{id}/events", s.handleGetRunEvents)
+	s.mux.HandleFunc("GET /api/runs/{id}/diagnostic", s.handleGetRunDiagnostic)
 	s.mux.HandleFunc("GET /api/runs/{id}/workflow", s.handleGetRunWorkflow)
 	s.mux.HandleFunc("GET /api/runs/{id}/artifacts", s.handleListAllArtifacts)
 	s.mux.HandleFunc("GET /api/runs/{id}/artifacts/{node}", s.handleListArtifacts)

--- a/pkg/server/runs_detail.go
+++ b/pkg/server/runs_detail.go
@@ -146,6 +146,47 @@ func (s *Server) handleGetRunEvents(w http.ResponseWriter, r *http.Request) {
 	s.writeJSONFor(w, r, map[string]any{"events": events})
 }
 
+// handleGetRunDiagnostic serves the common, versioned operator projection.
+// It is read-only and additive to the existing snapshot/events endpoints so
+// older clients keep their current behaviour.
+func (s *Server) handleGetRunDiagnostic(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "missing run id")
+		return
+	}
+	if xs, _, err := s.resolveCrossStore(r); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "%v", err)
+		return
+	} else if xs != nil {
+		diagnostic, err := runview.BuildDiagnostic(r.Context(), xs, id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if errors.Is(err, store.ErrRunDeleted) {
+				status = http.StatusGone
+			} else if errors.Is(err, store.ErrRunNotFound) {
+				status = http.StatusNotFound
+			}
+			s.httpErrorFor(w, r, status, "load diagnostic from cross-store: %v", err)
+			return
+		}
+		s.writeJSONFor(w, r, diagnostic)
+		return
+	}
+	diagnostic, err := runview.BuildDiagnostic(r.Context(), s.runs.RunStore(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, store.ErrRunDeleted) {
+			status = http.StatusGone
+		} else if errors.Is(err, store.ErrRunNotFound) {
+			status = http.StatusNotFound
+		}
+		s.httpErrorFor(w, r, status, "load diagnostic: %v", err)
+		return
+	}
+	s.writeJSONFor(w, r, diagnostic)
+}
+
 func (s *Server) handleGetRunWorkflow(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {

--- a/pkg/server/runs_test.go
+++ b/pkg/server/runs_test.go
@@ -261,6 +261,49 @@ func TestGetEvents_FromTo(t *testing.T) {
 	})
 }
 
+func TestGetDiagnostic_ProjectsTypedFailure(t *testing.T) {
+	srv, hs := newTestServer(t)
+	ctx := context.Background()
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatalf("open seed store: %v", err)
+	}
+	const runID = "run-diagnostic"
+	if _, err := st.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := st.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailedResumable,
+		"schema rejected", store.FailureSchemaValidation); err != nil {
+		t.Fatalf("UpdateRunStatusCoded: %v", err)
+	}
+	if _, err := st.AppendEvent(ctx, runID, store.Event{
+		Type: store.EventRunFailed, RunID: runID, NodeID: "writer", Data: map[string]any{
+			"error": "schema rejected", "code": string(store.FailureSchemaValidation), "resumable": true,
+		},
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	resp, err := http.Get(hs.URL + "/api/runs/" + runID + "/diagnostic")
+	if err != nil {
+		t.Fatalf("GET diagnostic: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var diagnostic runview.DiagnosticProjection
+	decodeJSONResp(t, resp, &diagnostic)
+	if diagnostic.Version != runview.DiagnosticVersion {
+		t.Errorf("version = %d, want %d", diagnostic.Version, runview.DiagnosticVersion)
+	}
+	if diagnostic.Outcome != runview.DiagnosticBlocked || diagnostic.NextAction != runview.DiagnosticActionResume {
+		t.Errorf("outcome/action = %q/%q, want blocked/resume", diagnostic.Outcome, diagnostic.NextAction)
+	}
+	if diagnostic.NodeID != "writer" || diagnostic.FailureCode != store.FailureSchemaValidation {
+		t.Errorf("diagnostic node/code = %q/%q", diagnostic.NodeID, diagnostic.FailureCode)
+	}
+}
+
 func TestCancelInactive_ReportsCurrentStatus(t *testing.T) {
 	srv, hs := newTestServer(t)
 	seedRun(t, srv, "run-1", "wf", store.RunStatusFinished)

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -512,6 +512,43 @@ export interface RunSnapshot {
   run: RunHeader;
   executions: ExecutionState[];
   last_seq: number; // -1 sentinel when no events have been applied
+  diagnostic?: DiagnosticProjection;
+}
+
+export type DiagnosticOutcome =
+  | "active"
+  | "finished"
+  | "blocked"
+  | "interrupted"
+  | "failed";
+
+export type DiagnosticAction =
+  | "none"
+  | "resume"
+  | "wait"
+  | "answer_or_resume"
+  | "inspect"
+  | "fix_then_resume";
+
+export interface DiagnosticEvidence {
+  seq: number;
+  type: string;
+  node_id?: string;
+  details?: Record<string, string>;
+}
+
+export interface DiagnosticProjection {
+  version: number;
+  run_id: string;
+  parent_run_id?: string;
+  status: string;
+  outcome: DiagnosticOutcome;
+  recoverable: boolean;
+  failure_code?: string;
+  node_id?: string;
+  message?: string;
+  next_action: DiagnosticAction;
+  evidence?: DiagnosticEvidence[];
 }
 
 // RunEvent (mirror of store.Event) lives in ./events.ts as a

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -2552,6 +2552,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/runs/{id}/diagnostic": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/runs/{id}/diagnostic */
+        get: operations["getRunsByIdDiagnostic"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs/{id}/events": {
         parameters: {
             query?: never;
@@ -5645,6 +5664,27 @@ export interface components {
             pushed: boolean;
             verifiable: boolean;
         };
+        DiagnosticEvidence: {
+            details?: {
+                [key: string]: string;
+            };
+            node_id?: string;
+            seq: number;
+            type: string;
+        };
+        DiagnosticProjection: {
+            evidence?: components["schemas"]["DiagnosticEvidence"][];
+            failure_code?: string;
+            message?: string;
+            next_action: string;
+            node_id?: string;
+            outcome: string;
+            parent_run_id?: string;
+            recoverable: boolean;
+            run_id: string;
+            status: string;
+            version: number;
+        };
         ExecutionState: {
             branch_id: string;
             current_event_seq: number;
@@ -6057,6 +6097,7 @@ export interface components {
             workdir?: string;
         };
         RunSnapshot: {
+            diagnostic?: components["schemas"]["DiagnosticProjection"];
             executions: components["schemas"]["ExecutionState"][];
             last_seq: number;
             run: components["schemas"]["RunHeader"];
@@ -9919,6 +9960,28 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    getRunsByIdDiagnostic: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiagnosticProjection"];
+                };
             };
         };
     };


### PR DESCRIPTION
Refs #1006

## Résumé

Cette PR livre la première tranche opérationnelle de l’epic : un diagnostic partagé, versionné et borné, issu de l’état typé du run et des événements persistés. Elle évite de créer une seconde machine d’état ou une couche de retry parallèle.

- ajoute `runview.DiagnosticProjection` avec cause, code, nœud, récupérabilité, action suggérée et preuves allow-listées ;
- réinitialise les preuves à chaque reprise et ignore les questions humaines asynchrones pour éviter les boucles de watchers ;
- expose `GET /api/runs/{id}/diagnostic`, y compris pour les cross-stores, avec les statuts 404/410 adaptés ;
- ajoute la projection aux snapshots REST/WebSocket existants ;
- propage le détail déclaré de `node_finished.output.detail` sans exposer le payload métier arbitraire ;
- met à jour OpenAPI et les types Studio générés.

## Vérifications

- `go test -timeout 1200s ./...`
- `go test ./pkg/runview ./pkg/server`
- `go vet ./pkg/runview ./pkg/server`
- `corepack pnpm exec tsc -b`
- `corepack pnpm test` (151 fichiers, 1 351 tests)
- `corepack pnpm lint` (0 erreur ; avertissements existants uniquement)

## Suite

Les contrats de contexte et d’artefacts, la correction bornée, la coordination des retries et l’adoption par les watchers restent des tranches suivantes de #1006. Cette PR fournit le contrat commun sur lequel elles peuvent s’appuyer.