### PR TITLE
fix(golden-master): a duplicate reference group is proved by a mutant, not by a note

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1901,6 +1901,48 @@ tool oracle_run:
                             "added entry id %r derives a reference path outside "
                             "refs/ — a write to an existing reference wearing an "
                             "addition's name" % (aid,))
+                # ADDITIONS-ONLY APPLIES INSIDE THE FREED KEY TOO.
+                #
+                # `duplicate_groups` was freed from the freeze because the lot that
+                # ADDS an entry is the one that can create a new byte-identical
+                # class, and telling it to declare a separator in a key another
+                # judge refuses it is a remedy nobody can apply. That argument frees
+                # ADDING a declaration — and adding is the half that is VERIFIED: a
+                # bogus separator is refused at the gate by measurement.
+                #
+                # Rewriting or deleting one is verified by nothing. Swapping a
+                # still-valid separator for another still-valid separator silently
+                # reassigns a class this lot never touched, and a deletion only
+                # re-opens the undeclared-duplicate refusal for whoever comes next.
+                # Exempting the whole key turned "an extension adds entries and
+                # touches nothing else" into a sentence with an exception nobody
+                # bounded.
+                base_decls = duplicate_group_decls(base_c)
+                head_decls = duplicate_group_decls(head_c)
+                added_str = {str(a) for a in added_ids}
+                for key, seps in sorted(base_decls.items()):
+                    if key in head_decls:
+                        if set(head_decls[key]) != set(seps):
+                            corpus_problems.append(
+                                "`duplicate_groups` for class %s was RE-ADJUDICATED "
+                                "(%s -> %s) — an extension may declare a class it "
+                                "creates, never re-decide one it did not"
+                                % (json.dumps(list(key)), json.dumps(list(seps)),
+                                   json.dumps(list(head_decls[key]))))
+                        continue
+                    # A pre-existing class may only disappear into a SUPERSET that
+                    # an added entry joined: a new entry landing on an existing
+                    # byte-identical class re-keys it, and may need more separators
+                    # to keep the members pairwise distinguishable. That is the
+                    # legitimate case the exemption exists for; everything else is
+                    # a withdrawal.
+                    if not any(set(k) > set(key) and (set(k) - set(key)) & added_str
+                               for k in head_decls):
+                        corpus_problems.append(
+                            "`duplicate_groups` for class %s was WITHDRAWN — a "
+                            "deletion re-opens the undeclared-duplicate refusal for "
+                            "whoever comes next, and it is not this lot's "
+                            "adjudication to withdraw" % json.dumps(list(key)))
                 claimed = set()
                 for act in acts:
                     req = requests.get(act.get("id"))
@@ -5437,6 +5479,59 @@ tool oracle_run:
             check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
                   [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
                   ["", True])
+
+            # LE CANAL N'EST PAS UN DROIT DE REVISION. La cle est liberee du gel
+            # parce que le lot qui AJOUTE une entree est celui qui peut creer une
+            # nouvelle classe byte-identique. AJOUTER une declaration est verifie —
+            # un separateur bidon est refuse a la porte par la mesure. La REECRIRE
+            # ou la SUPPRIMER n'est verifie par rien : echanger un separateur
+            # valide contre un autre separateur valide rejuge en silence la classe
+            # d'un autre lot, et une suppression rouvre le refus « doublon non
+            # declare » pour le suivant.
+            xreset()
+            dg_a, dg_b = dict(base_entry, id="20"), dict(base_entry, id="21")
+            dg_c = dict(base_entry, id="22")
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dg_a, dg_b],
+                           "duplicate_groups": [{"ids": ["20", "21"],
+                                                 "separated_by": "sep-old"}]}, f)
+            xcommit()
+            xbase_dg = fixture_git(xroot, "rev-parse", "HEAD")
+
+            def xdg(groups):
+                """Un lot qui ajoute l'entree 22, sur une base qui PORTE deja une
+                declaration — et qui touche `duplicate_groups` comme indique."""
+                fixture_git(xroot, "reset", "-q", "--hard", xbase_dg)
+                fixture_git(xroot, "clean", "-qfd")
+                xledger(("request",
+                         '{"id": "E-G", "lot": "L", "corpus_entries": [{"id": "22"}]}'),
+                        ("act", '{"id": "E-G", "lot": "L",'
+                                ' "recorded_paths": [".golden-master/corpus.json"]}'))
+                with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                    json.dump({"entries": [base_entry, dg_a, dg_b, dg_c],
+                               "duplicate_groups": groups}, f)
+                xcommit()
+                return xverdict(xbase_dg)["acted"][0]["problems"]
+
+            check("echanger un separateur valide contre un autre : REFUSE",
+                  any("RE-ADJUDICATED" in pb
+                      for pb in xdg([{"ids": ["20", "21"],
+                                      "separated_by": "sep-new"}])), True)
+            check("supprimer la declaration d'un autre lot : REFUSE",
+                  any("WITHDRAWN" in pb for pb in xdg([])), True)
+            # Le cas legitime que l'exemption existe pour servir : l'entree ajoutee
+            # REJOINT la classe, qui se recle en sur-ensemble et peut demander un
+            # separateur de plus pour garder les membres distinguables deux a deux.
+            check("une entree ajoutee qui rejoint la classe la recle sans refus",
+                  [pb for pb in xdg([{"ids": ["20", "21", "22"],
+                                      "separated_by": ["sep-old", "sep-2"]}])
+                   if "duplicate_groups" in pb], [])
+            # Et DECLARER reste libre : ajouter une classe neuve ne touche a
+            # l'adjudication de personne.
+            check("declarer une classe neuve reste libre",
+                  [pb for pb in xdg([{"ids": ["20", "21"], "separated_by": "sep-old"},
+                                     {"ids": ["1", "22"], "separated_by": "sep-3"}])
+                   if "duplicate_groups" in pb], [])
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3197,6 +3197,43 @@ tool oracle_run:
         return all(v.get("revert_clean", True) for v in verdicts)
 
 
+    def measurement_hygiene(verdicts, held):
+        """`collateral`, `unstable_controls` and the line that NAMES them — over the
+        visible AND the held-out verdicts.
+
+        `score_pct` must stay visible-only: averaging a sealed set into the headline
+        is the resemblance this bot refuses. But these two are not a score, they are
+        HYGIENE OF MEASUREMENT — did a mutant move what it does not declare, does a
+        control reproduce itself — and `overall_revert_clean` already crosses both
+        sets for exactly that reason.
+
+        It became load-bearing the day a held verdict started DECIDING something:
+        `unproven_duplicate_groups` credits a separator's `collateral` as proof that
+        it moved a group member, and score_mutant PINS every group member into that
+        separator's control sample so the measurement exists. Read from `verdicts`
+        alone, the identical measurement was a hard red when the separator was
+        visible (`collateral == 0` is a gate term, in the graph AND in the standalone
+        runner) and a silent proof when it was held. A class cannot be discharged
+        through a channel the gate is forbidden to look at.
+
+        The detail ranges over the same set as the count — a headline that counts
+        what it does not list is the defect this file just removed from the
+        duplicate-group refusal — and each line says which set it came from, because
+        a held-out finding reads differently even though it is just as actionable.
+        """
+        held_ids = {v.get("id") for v in held}
+        both = list(verdicts) + list(held)
+        return {
+            "collateral": sum(len(v.get("collateral") or []) for v in both),
+            "unstable_controls": sorted({c for v in both
+                                         for c in (v.get("unstable_controls") or [])}),
+            "detail": "; ".join(
+                "%s moved %s%s" % (v.get("id"), v["collateral"],
+                                   " (held-out)" if v.get("id") in held_ids else "")
+                for v in both if v.get("collateral")),
+        }
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -6258,6 +6295,27 @@ tool oracle_run:
                   [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
                     "undetected_targets": [], "collateral": []}])],
               [])
+        # ...et l'AUTRE moitie de ce contrat : ce que ce separateur tenu a l'ecart a
+        # deplace doit atteindre les memes termes de porte qu'un separateur visible.
+        # Le meme verdict etait un rouge dur quand il etait visible (`collateral == 0`
+        # est un terme de la porte) et une preuve silencieuse quand il etait retenu :
+        # une classe ne peut pas etre acquittee par un canal que la porte n'a pas le
+        # droit de regarder.
+        _hy = measurement_hygiene(
+            [{"id": "vis", "collateral": ["005"]}],
+            [{"id": "held-sep", "collateral": ["009"], "unstable_controls": ["012"]}])
+        check("le collateral du jeu tenu a l'ecart compte dans le total",
+              _hy["collateral"], 2)
+        check("et ses temoins instables aussi",
+              _hy["unstable_controls"], ["012"])
+        # La liste couvre le meme ensemble que le compte — un titre qui compte ce
+        # qu'il ne nomme pas est le defaut que ce fichier vient de retirer au refus
+        # des doublons — et chaque ligne dit d'ou elle vient.
+        check("et chaque ligne nomme sa provenance",
+              _hy["detail"], "vis moved ['005']; held-sep moved ['009'] (held-out)")
+        check("un jeu tenu a l'ecart propre ne change rien",
+              measurement_hygiene([{"id": "vis", "collateral": ["005"]}], []),
+              {"collateral": 1, "unstable_controls": [], "detail": "vis moved ['005']"})
 
         # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
         # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
@@ -6971,6 +7029,7 @@ tool oracle_run:
                     if scoring_must_stop(v, ws):
                         stopped = v
                         break
+            hygiene = measurement_hygiene(verdicts, held)
             if stopped is not None:
                 note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
                      "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
@@ -6994,9 +7053,8 @@ tool oracle_run:
                 detected=len(detected),
                 score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
                 revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
-                collateral=sum(len(v.get("collateral") or []) for v in verdicts),
-            unstable_controls=sorted({c for v in verdicts
-                                      for c in (v.get("unstable_controls") or [])}),
+                collateral=hygiene["collateral"],
+                unstable_controls=hygiene["unstable_controls"],
                 uncontrolled=[v["id"] for v in valid if not v.get("control_covered")],
                 blind_lanes=blind,
                 holdout_total=len([v for v in held if v.get("valid")]),
@@ -7073,10 +7131,7 @@ tool oracle_run:
                                 "cover. Not averaged away, not weighted: this list must be "
                                 "empty. %s" % json.dumps(blind, ensure_ascii=False))
             if report["collateral"]:
-                detail = "; ".join(
-                    "%s moved %s" % (v["id"], v["collateral"])
-                    for v in verdicts if v.get("collateral")
-                )
+                detail = hygiene["detail"]
                 problems.append("collateral drift on %d control entries — a mutant moves "
                                 "responses it does not declare as targets. Either its "
                                 "`targets` under-state its blast radius, or the capture is "

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -7536,11 +7536,16 @@ tool oracle_run:
             # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
             # separator to a lot's re-anchoring — the mutant now moves both members,
             # and the pair proves nothing at all.
+            #
             # verdicts + held. A declared separator may live in the held-out set —
-            # score_mutant pins its group unconditionally, so the deciding
-            # measurement really IS taken — but it lands in `held`, not `verdicts`.
-            # Passing only the latter made the gate report a separator it had just
-            # scored as never scored, and refuse the group on its own blind spot.
+            # score_mutant pins its group into the control sample there too, so the
+            # deciding measurement really IS taken — but it lands in `held`, not
+            # `verdicts`. Passing only the latter made the gate report a separator it
+            # had just scored as never scored, and refuse the group on its own blind
+            # spot. What that held measurement finds reaches the gate's own hygiene
+            # terms through `measurement_hygiene`, so a class cannot be discharged
+            # through a channel the gate is forbidden to look at.
+            #
             # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
             # `held` est vide par construction, et un separateur qui en vient n'est
             # pas absent, il est retenu.
@@ -7554,8 +7559,7 @@ tool oracle_run:
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
                 bool(only), withheld_ids, in_the_set)
-            for shape in duplicate_groups_shape_problems(corpus):
-                problems.append(shape)
+            problems.extend(duplicate_groups_shape_problems(corpus))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 problems.append(duplicate_groups_refusal(

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -178,6 +178,16 @@ schema mutation_report:
   corpus_total: int
   corpus_distinct: int
   duplicate_refs: json
+  ## The DISCHARGE record, not a diagnostic. A byte-identical class is not
+  ## automatically a defect — on a refusal lane the second entry is a control
+  ## proving a mutant moved only the first — but the claim is data, and it is
+  ## acquitted by MEASUREMENT: the corpus names the separating mutant(s) in
+  ## `duplicate_groups`, the harness pins every member into that mutant's
+  ## control sample, and a class is discharged only when the members are
+  ## pairwise distinguishable. What stays here is what the measurement did NOT
+  ## acquit, so it must be empty — a waiver is believed, a proof obligation is
+  ## executed and goes red by itself the day its separator dies.
+  duplicate_groups_unproven: json
   ## The emitted net must be runnable from a clean checkout. A gitignored
   ## harness ships references nobody can replay — the very defect this bot
   ## exists to expose in other people's deliveries.
@@ -7555,7 +7565,16 @@ compute oracle_gate:
     ## DISTINCT references: two entries with a byte-identical reference are one
     ## observation, and a corpus padded with duplicates is narrower than it
     ## looks.
-    converged: "outputs.oracle_run.stable && outputs.oracle_run.noop_silent && outputs.oracle_run.revert_clean && outputs.oracle_run.collateral == 0 && length(outputs.oracle_run.unstable_controls) == 0 && length(outputs.oracle_run.uncontrolled) == 0 && length(outputs.oracle_run.blind_lanes) == 0 && length(outputs.oracle_run.missing_archetypes) == 0 && outputs.oracle_run.corpus_distinct >= vars.min_corpus && outputs.oracle_run.runner_replayable && length(outputs.oracle_run.holdout_reused) == 0 && outputs.oracle_run.score_pct >= vars.mutation_floor && outputs.oracle_run.holdout_detected == outputs.oracle_run.holdout_total"
+    ##
+    ## And `duplicate_groups_unproven` is a TERM, not a note. A class the corpus
+    ## claims is a deliberate control must NAME the mutant that separates it and
+    ## have that mutant measured moving a strict subset. Computed but unwired,
+    ## the obligation reached the operator only through `log_tail` — the message
+    ## rendered once `converged` is already false — so a corpus whose single
+    ## defect was an unproved class went green while every docstring in the
+    ## harness claimed the gate checked it. A proof obligation nothing refuses is
+    ## a waiver with extra steps.
+    converged: "outputs.oracle_run.stable && outputs.oracle_run.noop_silent && outputs.oracle_run.revert_clean && outputs.oracle_run.collateral == 0 && length(outputs.oracle_run.unstable_controls) == 0 && length(outputs.oracle_run.uncontrolled) == 0 && length(outputs.oracle_run.blind_lanes) == 0 && length(outputs.oracle_run.missing_archetypes) == 0 && length(outputs.oracle_run.duplicate_groups_unproven) == 0 && outputs.oracle_run.corpus_distinct >= vars.min_corpus && outputs.oracle_run.runner_replayable && length(outputs.oracle_run.holdout_reused) == 0 && outputs.oracle_run.score_pct >= vars.mutation_floor && outputs.oracle_run.holdout_detected == outputs.oracle_run.holdout_total"
     fail_log: "outputs.oracle_run.log_tail"
 
 ## emit_runner — one entry point for CI and for humans, plus the report a
@@ -7601,6 +7620,12 @@ tool emit_runner:
         "ok=(r.get(\"stable\") and r.get(\"noop_silent\") and r.get(\"revert_clean\")\n"
         "    and r.get(\"collateral\")==0 and not r.get(\"uncontrolled\")\n"
         "    and not r.get(\"blind_lanes\") and not r.get(\"missing_archetypes\")\n"
+        # And so does `duplicate_groups_unproven`, for the same reason: a
+        # byte-identical class the corpus declares as a deliberate control is
+        # discharged by a MEASURED separator, and a class nothing separated is a
+        # corpus narrower than it reports. Absent here, the entry point CI runs
+        # would approve exactly the tree the graph gate refuses.
+        "    and not r.get(\"duplicate_groups_unproven\")\n"
         # `holdout_reused` belongs here too. Without it the standalone entry
         # point is WEAKER than the graph gate on the one term that stops a
         # spent, published set from being replayed as if it were fresh -- and

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1832,10 +1832,12 @@ tool oracle_run:
                 # declaration would otherwise be dropped in silence by
                 # duplicate_group_decls and read as "no declaration at all".
                 for g in (head_c.get("duplicate_groups") or []):
+                    _sep = g.get("separated_by") if isinstance(g, dict) else None
+                    _seps = [_sep] if isinstance(_sep, str) else _sep
                     if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
                             or len(g.get("ids") or []) < 2 \
-                            or not isinstance(g.get("separated_by"), str) \
-                            or not g.get("separated_by"):
+                            or not isinstance(_seps, list) or not _seps \
+                            or not all(isinstance(m, str) and m for m in _seps):
                         corpus_problems.append(
                             "a `duplicate_groups` entry is malformed (%r) — it needs "
                             "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3475,9 +3477,15 @@ tool oracle_run:
                 continue
             ids = g.get("ids")
             sep = g.get("separated_by")
-            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+            # One separator or several: a class of two needs one mutant to split it,
+            # a class of four needs enough of them to tell all four apart. Written
+            # as a bare string for the common case, a list when resolution costs
+            # more than one.
+            seps = [sep] if isinstance(sep, str) else sep
+            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+                    or not seps or not all(isinstance(m, str) and m for m in seps):
                 continue
-            out[tuple(sorted(str(i) for i in ids))] = sep
+            out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
         return out
 
 
@@ -3486,18 +3494,28 @@ tool oracle_run:
         if not mutant_id:
             return set()
         ids = set()
-        for group, sep in duplicate_group_decls(corpus).items():
-            if sep == mutant_id:
+        for group, seps in duplicate_group_decls(corpus).items():
+            if mutant_id in seps:
                 ids.update(group)
         return ids
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
-        """Which byte-identical groups are NOT discharged by a measured separator.
+        """Which byte-identical classes are NOT discharged by measured separators.
 
-        Returns one record per group that fails, with the reason IN the record —
-        the gate turns them into its refusal, and the selftest calls this same
-        function, so what is tested is what runs.
+        `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
+        sha256 — so a class of three or more cannot be declared as a set of pairs:
+        the declaration is keyed on the class itself. What several separators buy is
+        RESOLUTION. A class is discharged when the members are pairwise
+        distinguishable: for each one, the pattern of which declared separators move
+        it must be unique. One separator over a pair reduces to "moves one, not the
+        other"; four members need enough separators to tell all four apart, which is
+        exactly what the campaign's own notes describe when they name `sep-04` for
+        one member and `sep-05` for two others.
+
+        Returns one record per class that fails, with the reason IN the record — the
+        gate turns them into its refusal, and the selftest calls this same function,
+        so what is tested is what runs.
         """
         decls = duplicate_group_decls(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3505,48 +3523,54 @@ tool oracle_run:
         # never `undetected_targets` nor `collateral` — score_mutant returns before
         # they are set — so crediting it would read "moved every declared target"
         # from a measurement that never ran. And that is exactly how a separator
-        # dies when a lot re-anchors it: its apply.sh stops working. The group would
+        # dies when a lot re-anchors it: its apply.sh stops working. The class would
         # have been reported PROVED by the failure it exists to catch.
         scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
         seen_ids = {v.get("id") for v in verdicts if v.get("id")}
         unproven = []
         for g in sorted(observed):
-            sep = decls.get(g)
-            if not sep:
+            seps = decls.get(g)
+            if not seps:
                 unproven.append({"ids": list(g), "why":
-                                 "no `duplicate_groups` entry declares this group. Either one "
+                                 "no `duplicate_groups` entry declares this class. Either a "
                                  "member is redundant — drop it — or the identity is a control, "
-                                 "and then it must name the mutant that separates it."})
+                                 "and then it must name the mutant(s) that tell them apart."})
                 continue
-            v = scored.get(sep)
-            if v is None:
-                unproven.append({"ids": list(g), "separated_by": sep, "why":
-                                 ("the declared separator ran but came back INVALID — it proves "
-                                  "nothing, and a separator that stops applying is exactly how "
-                                  "this group loses its proof")
-                                 if sep in seen_ids else
-                                 ("the declared separator was not scored in this pass (absent "
-                                  "from the mutant set%s)" %
-                                  (", or excluded by GM_MUTANTS" if restricted else ""))})
+            missing = [m for m in seps if m not in scored]
+            if missing:
+                unproven.append({"ids": list(g), "separated_by": list(seps), "why":
+                                 "declared separator(s) %s %s" %
+                                 (", ".join(sorted(missing)),
+                                  "ran but came back INVALID — a separator that stops applying "
+                                  "is exactly how this class loses its proof"
+                                  if all(m in seen_ids for m in missing) else
+                                  ("were not scored in this pass (absent from the mutant set%s)"
+                                   % (", or excluded by GM_MUTANTS" if restricted else "")))})
                 continue
-            moved = ((set(v.get("targets_declared") or [])
-                      - set(v.get("undetected_targets") or []))
-                     | set(v.get("collateral") or []))
-            inside = moved & set(g)
-            if not inside:
-                unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
-                                 "the declared separator moves NO member of the group — it "
-                                 "does not separate anything"})
-            elif inside == set(g):
-                unproven.append({"ids": list(g), "separated_by": sep,
-                                 "moved": sorted(inside), "why":
-                                 "the declared separator moves EVERY member together, so it no "
-                                 "longer tells them apart. Draw one that moves a strict subset, "
-                                 "or accept that the group is redundant."})
+            # One signature per member: which of the declared separators move it.
+            # Pairwise-distinct signatures IS "the references are distinguishable";
+            # anything less leaves two members that no declared mutant separates.
+            sig = {}
+            for m in g:
+                bits = []
+                for sep in seps:
+                    v = scored[sep]
+                    moved = ((set(v.get("targets_declared") or [])
+                              - set(v.get("undetected_targets") or []))
+                             | set(v.get("collateral") or []))
+                    bits.append(m in moved)
+                sig.setdefault(tuple(bits), []).append(m)
+            collided = sorted(sorted(ms) for ms in sig.values() if len(ms) > 1)
+            if collided:
+                unproven.append({"ids": list(g), "separated_by": list(seps),
+                                 "indistinguishable": collided, "why":
+                                 "every declared separator treats these members identically, so "
+                                 "none of them tells the references apart. Draw one that moves a "
+                                 "strict subset, or accept that they are redundant."})
         for g in sorted(set(decls) - observed):
-            unproven.append({"ids": list(g), "separated_by": decls[g], "why":
-                             "declared, but these references are no longer byte-identical — the "
-                             "claim has nothing left to justify. Remove the declaration."})
+            unproven.append({"ids": list(g), "separated_by": list(decls[g]), "why":
+                             "declared, but these references are not a byte-identical class — the "
+                             "claim has nothing left to justify. Remove or re-key the declaration."})
         return unproven
 
 
@@ -6051,7 +6075,17 @@ tool oracle_run:
                          {"ids": ["019", "012"], "separated_by": ""},
                          "pas-un-dict"]}
         check("une declaration se lit triee, et les malformees sont ignorees",
-              duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+              duplicate_group_decls(corpus_dg), {("012", "013"): ("sep-01",)})
+        # Un separateur ou plusieurs : une classe de quatre demande assez de mutants
+        # pour distinguer les quatre, pas un seul qui coupe quelque part.
+        check("plusieurs separateurs se lisent, dedupliques et ordonnes",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b", "c"], "separated_by": ["s2", "s1", "s2"]}]}),
+              {("a", "b", "c"): ("s2", "s1")})
+        check("une liste vide ou non-textuelle est ignoree",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b"], "separated_by": []},
+                  {"ids": ["c", "d"], "separated_by": [1]}]}), {})
         check("les ids d'un groupe sont epingles pour SON separateur",
               separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
         check("et pour aucun autre",
@@ -6110,6 +6144,69 @@ tool oracle_run:
             [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
         check("et le motif dit qu'il a tourne, pas qu'il est absent",
               [("INVALID" in x["why"]) for x in _inv], [True])
+
+        # Une CLASSE de quatre, le cas reel du corpus : `sep-04` deplace un membre,
+        # `sep-05` en deplace deux — ensemble ils donnent quatre signatures
+        # distinctes, donc les quatre references sont distinguables.
+        C4 = [{"ids": ["074", "075", "076", "110"],
+               "separated_by": ["sep-04", "sep-05"]}]
+        def _v(mid, moved):
+            return {"id": mid, "valid": True, "targets_declared": sorted(moved),
+                    "undetected_targets": [], "collateral": []}
+        # Et le resultat est celui du corpus REEL, pas celui qu'on esperait :
+        # `sep-04` isole 074, `sep-05` deplace 076 ET 110 ensemble — donc ces deux-la
+        # partagent leur signature et rien ne les separe. Deux separateurs ne
+        # suffisent pas a distinguer quatre references ; le banc l'a appris du
+        # produit apres avoir affirme le contraire.
+        check("deux separateurs ne distinguent pas quatre membres",
+              [x.get("indistinguishable") for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": C4},
+                  [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"})])],
+              [[["076", "110"]]])
+        # Avec un troisieme qui ne bouge que 110, les quatre signatures deviennent
+        # distinctes et la classe est acquittee.
+        check("un separateur de plus les distingue toutes : acquittee",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["074", "075", "076", "110"],
+                       "separated_by": ["sep-04", "sep-05", "sep-06"]}]},
+                  [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"}),
+                   _v("sep-06", {"110"})])],
+              [])
+        # 076 et 110 partagent la meme signature : deux membres que rien ne separe.
+        check("deux membres de meme signature : la classe n'est PAS acquittee",
+              [x.get("indistinguishable") for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["074", "075", "076", "110"], "separated_by": ["sep-04"]}]},
+                  [_v("sep-04", {"074"})])],
+              [[["075", "076", "110"]]])
+        # Et une declaration en PAIRES sur une classe de trois ne la couvre pas :
+        # la cle est la classe maximale, pas un decoupage choisi par le lot.
+        check("des paires ne declarent pas une classe de trois",
+              sorted(x["ids"] for x in unproven_duplicate_groups(
+                  [["a", "b", "c"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["a", "b"], "separated_by": "s1"},
+                      {"ids": ["b", "c"], "separated_by": "s1"}]},
+                  [_v("s1", {"a"})])),
+              [["a", "b"], ["a", "b", "c"], ["b", "c"]])
+
+        # Le CONTRAT que le site d'appel doit honorer : un separateur fourni parmi
+        # les verdicts du jeu tenu a l'ecart est reconnu comme les autres. La
+        # fonction est agnostique — c'est l'appelant qui doit composer les deux
+        # listes, et CE cablage-la n'est pas couvert par ce banc (le rejouer
+        # demanderait une porte complete). La limite est ecrite plutot que masquee.
+        check("un separateur venu du jeu tenu a l'ecart est reconnu",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["012", "013"], "separated_by": "held-sep"}]},
+                  [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
+                    "undetected_targets": [], "collateral": []}])],
+              [])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -6941,8 +7038,13 @@ tool oracle_run:
             # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
             # separator to a lot's re-anchoring — the mutant now moves both members,
             # and the pair proves nothing at all.
+            # verdicts + held. A declared separator may live in the held-out set —
+            # score_mutant pins its group unconditionally, so the deciding
+            # measurement really IS taken — but it lands in `held`, not `verdicts`.
+            # Passing only the latter made the gate report a separator it had just
+            # scored as never scored, and refuse the group on its own blind spot.
             unproven = unproven_duplicate_groups(
-                report["duplicate_refs"], corpus, verdicts, bool(only))
+                report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 # The headline counts what the payload lists. Interpolating the

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1809,11 +1809,38 @@ tool oracle_run:
                     "not crashed")
                 head_c = base_c = None
             if head_c is not None and base_c is not None:
-                if {k: v for k, v in head_c.items() if k != "entries"} != \
-                        {k: v for k, v in base_c.items() if k != "entries"}:
+                # `duplicate_groups` is the ONE key outside `entries` an extension
+                # may write, and the reason is not convenience: every other key here
+                # is frozen because it is TRUSTED, while this one is VERIFIED. A
+                # group declaration is discharged at the gate by a mutant that must
+                # really move part of the group and leave the rest still, so a lot
+                # gains nothing by writing one — a bogus separator refuses, and
+                # deleting a declaration turns its group back into an undeclared
+                # duplicate, which also refuses.
+                #
+                # Without this the gate named a remedy another judge forbade: the
+                # lot that ADDS an entry is the very lot that can create a new
+                # byte-identical pair, and it would have been told to declare a
+                # separator in a key it is refused permission to touch.
+                FREE_KEYS = {"entries", "duplicate_groups"}
+                if {k: v for k, v in head_c.items() if k not in FREE_KEYS} != \
+                        {k: v for k, v in base_c.items() if k not in FREE_KEYS}:
                     corpus_problems.append(
                         "corpus.json keys outside `entries` changed — an "
                         "extension adds entries and touches nothing else")
+                # Structure is judged HERE, truth at the gate. A malformed
+                # declaration would otherwise be dropped in silence by
+                # duplicate_group_decls and read as "no declaration at all".
+                for g in (head_c.get("duplicate_groups") or []):
+                    if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
+                            or len(g.get("ids") or []) < 2 \
+                            or not isinstance(g.get("separated_by"), str) \
+                            or not g.get("separated_by"):
+                        corpus_problems.append(
+                            "a `duplicate_groups` entry is malformed (%r) — it needs "
+                            "at least two `ids` and a non-empty `separated_by`, or it "
+                            "is dropped in silence and reads as no declaration at all"
+                            % (g,))
                 # An id names ONE observation. Duplicated ids collapse in every
                 # by-id index (this one, the capture map, the refs map), so the
                 # equality check would read the surviving twin while the capture
@@ -3474,7 +3501,14 @@ tool oracle_run:
         """
         decls = duplicate_group_decls(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
-        scored = {v.get("id"): v for v in verdicts if v.get("id")}
+        # VALID only. A failed or inert verdict carries `targets_declared` but
+        # never `undetected_targets` nor `collateral` — score_mutant returns before
+        # they are set — so crediting it would read "moved every declared target"
+        # from a measurement that never ran. And that is exactly how a separator
+        # dies when a lot re-anchors it: its apply.sh stops working. The group would
+        # have been reported PROVED by the failure it exists to catch.
+        scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
+        seen_ids = {v.get("id") for v in verdicts if v.get("id")}
         unproven = []
         for g in sorted(observed):
             sep = decls.get(g)
@@ -3487,9 +3521,13 @@ tool oracle_run:
             v = scored.get(sep)
             if v is None:
                 unproven.append({"ids": list(g), "separated_by": sep, "why":
-                                 "the declared separator was not scored in this pass (absent "
-                                 "from the mutant set%s)" %
-                                 (", or excluded by GM_MUTANTS" if restricted else "")})
+                                 ("the declared separator ran but came back INVALID — it proves "
+                                  "nothing, and a separator that stops applying is exactly how "
+                                  "this group loses its proof")
+                                 if sep in seen_ids else
+                                 ("the declared separator was not scored in this pass (absent "
+                                  "from the mutant set%s)" %
+                                  (", or excluded by GM_MUTANTS" if restricted else ""))})
                 continue
             moved = ((set(v.get("targets_declared") or [])
                       - set(v.get("undetected_targets") or []))
@@ -5082,6 +5120,49 @@ tool oracle_run:
             check("ref ajoutee non declaree par la demande -> refusee",
                   xverdict(xbase)["acted"][0]["ok"], False)
 
+            # LE CANAL DE DECLARATION : le lot qui AJOUTE une entree est celui qui
+            # peut creer une nouvelle paire byte-identique, donc celui a qui la
+            # porte demande de declarer son separateur. Si le juge d'extension gelait
+            # cette cle, la porte nommerait un remede qu'un autre juge refuse — le
+            # defaut que le canal existe pour supprimer, simplement deplace.
+            xreset()
+            dup_entry = dict(base_entry, id="7", path="/dup")
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": [{"ids": ["1", "7"],
+                                                 "separated_by": "sep-x"}]}, f)
+            xcommit()
+            _vd = xverdict(xbase)["acted"][0]
+            check("declarer un groupe de doublons n'est PAS un gel viole",
+                  [pb for pb in _vd["problems"] if "keys outside" in pb], [])
+            # Et le gel tient pour tout le reste : une cle voisine refuse toujours.
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry], "baseline": "reecrite"}, f)
+            xcommit()
+            check("mais toute AUTRE cle hors `entries` reste gelee",
+                  any("keys outside" in pb
+                      for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+            # Une declaration malformee est refusee ICI plutot que jetee en silence
+            # par le lecteur, ou elle se lirait comme « aucune declaration ».
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": [{"ids": ["1"], "separated_by": ""}]}, f)
+            xcommit()
+            check("une declaration malformee est refusee, pas ignoree",
+                  any("malformed" in pb
+                      for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
             xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "1"}]}'),
@@ -5987,7 +6068,7 @@ tool oracle_run:
         # rougit avec lui.
         def whys(group, decls, moved_by):
             corpus_ = {"entries": [], "duplicate_groups": decls}
-            verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+            verdicts_ = [{"id": mid, "valid": True, "targets_declared": sorted(mv),
                           "undetected_targets": [], "collateral": []}
                          for mid, mv in moved_by.items()]
             out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
@@ -6006,6 +6087,29 @@ tool oracle_run:
                         dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
         check("aucun epinglage pour un mutant qui ne separe rien",
               v_nopin["collateral"], [])
+
+        # Un separateur INVALIDE ne prouve rien. Son verdict porte
+        # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc
+        # le crediter revient a lire « toutes les cibles ont bouge » d'une mesure
+        # qui n'a pas eu lieu — et c'est precisement ainsi qu'un separateur meurt.
+        check("un separateur INVALIDE ne prouve pas le groupe",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+                  [{"id": "sep-01", "valid": False,
+                    "targets_declared": ["013"], "reason": "apply.sh a echoue"}])],
+              [["012", "013"]])
+        # Le motif, lu sans indexer a l'aveugle : si le groupe repassait "prouve",
+        # un `[0]` planterait au lieu de RAPPORTER, et un banc qui plante dit qu'il
+        # s'est passe quelque chose sans dire quoi.
+        _inv = unproven_duplicate_groups(
+            [["012", "013"]],
+            {"entries": [], "duplicate_groups": [
+                {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+            [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
+        check("et le motif dit qu'il a tourne, pas qu'il est absent",
+              [("INVALID" in x["why"]) for x in _inv], [True])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -6027,7 +6131,7 @@ tool oracle_run:
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]],
                   {"entries": [], "duplicate_groups": D},
-                  [{"id": "sep-01", "targets_declared": ["013"],
+                  [{"id": "sep-01", "valid": True, "targets_declared": ["013"],
                     "undetected_targets": [], "collateral": ["012"]}])],
               [["012", "013"]])
         # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
@@ -6035,7 +6139,7 @@ tool oracle_run:
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]],
                   {"entries": [], "duplicate_groups": D},
-                  [{"id": "sep-01", "targets_declared": ["012", "013"],
+                  [{"id": "sep-01", "valid": True, "targets_declared": ["012", "013"],
                     "undetected_targets": ["012", "013"], "collateral": []}])],
               [["012", "013"]])
 
@@ -6841,14 +6945,21 @@ tool oracle_run:
                 report["duplicate_refs"], corpus, verdicts, bool(only))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
-                problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                                "so the corpus is %d observations wide, not %d — and their identity "
-                                "is NOT proved. A group may legitimately repeat (a refusal lane's "
-                                "second entry is a control), but the claim is discharged by a mutant "
-                                "that moves part of the group and leaves the rest still, declared in "
-                                "`duplicate_groups` and checked here. Unproved: %s"
-                                % (len(report["duplicate_refs"]), report["corpus_distinct"],
-                                   report["corpus_total"],
+                # The headline counts what the payload lists. Interpolating the
+                # OBSERVED total while listing only the unproved ones told the
+                # operator "5 groups are not proved" beside a list of one — and the
+                # two do not even range over the same set: a stale declaration is
+                # unproved while its references are, by definition, no longer
+                # identical. On a gate whose whole point is precise adjudication,
+                # that gap is the defect.
+                problems.append("%d reference group(s) are not proved (out of %d byte-identical "
+                                "across DIFFERENT entries; the corpus is %d observations wide, "
+                                "not %d). A group may legitimately repeat — a refusal lane's "
+                                "second entry is a control — but the claim is discharged by a "
+                                "mutant that moves part of the group and leaves the rest still, "
+                                "declared in `duplicate_groups` and checked here: %s"
+                                % (len(unproven), len(report["duplicate_refs"]),
+                                   report["corpus_distinct"], report["corpus_total"],
                                    json.dumps(unproven, ensure_ascii=False)))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3656,7 +3656,7 @@ tool oracle_run:
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                                  withheld=()):
+                                  withheld=(), in_the_set=()):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3712,14 +3712,29 @@ tool oracle_run:
             if missing and all(m in set(withheld) for m in missing):
                 continue
             if missing:
-                unproven.append({"ids": list(g), "separated_by": list(seps), "why":
-                                 "declared separator(s) %s %s" %
-                                 (", ".join(sorted(missing)),
-                                  "ran but came back INVALID — a separator that stops applying "
-                                  "is exactly how this class loses its proof"
-                                  if all(m in seen_ids for m in missing) else
-                                  ("were not scored in this pass (absent from the mutant set%s)"
-                                   % (", or excluded by GM_MUTANTS" if restricted else "")))})
+                # THREE reasons, and they send the campaign to three different
+                # places. It RAN and came back invalid — the separator is broken,
+                # fix it. It is IN the mutant set but was not reached — scoring
+                # stopped before it, or GM_MUTANTS excluded it; nothing here is the
+                # campaign's to fix, the class is simply not proved yet. It is
+                # genuinely ABSENT — the declaration names a mutant that does not
+                # exist. Collapsing the middle one into "absent from the mutant set"
+                # is a refusal nothing the campaign does can lift, which is the same
+                # dead end WITHHELD-is-not-ABSENT removed one commit earlier.
+                if all(m in seen_ids for m in missing):
+                    why = ("ran but came back INVALID — a separator that stops applying "
+                           "is exactly how this class loses its proof")
+                elif all(m in set(in_the_set) for m in missing):
+                    why = ("are IN the mutant set but were not scored in this pass — "
+                           "scoring stopped before them%s. The class is not proved yet; "
+                           "nothing in the corpus is wrong" %
+                           (", or GM_MUTANTS excluded them" if restricted else ""))
+                else:
+                    why = ("were not scored in this pass (absent from the mutant set%s)"
+                           % (", or excluded by GM_MUTANTS" if restricted else ""))
+                unproven.append({"ids": list(g), "separated_by": list(seps),
+                                 "why": "declared separator(s) %s %s"
+                                        % (", ".join(sorted(missing)), why)})
                 continue
             # One signature per member: which of the declared separators move it.
             # Pairwise-distinct signatures IS "the references are distinguishable";
@@ -6496,6 +6511,29 @@ tool oracle_run:
         check("mais un separateur simplement ABSENT en produit un",
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+        # Et le TROISIEME cas, celui qui restait confondu avec le second : un
+        # separateur que le scan n'a pas ATTEINT (arret apres un revert sale,
+        # GM_MUTANTS restreint) existe bel et bien. Le refus doit rester — rien n'est
+        # prouve — mais dire « absent du jeu de mutants » envoyait la campagne
+        # corriger une absence qui n'en est pas une, exactement le cul-de-sac que
+        # RETENU-n'est-pas-ABSENT venait de retirer.
+        check("un separateur NON ATTEINT refuse en le disant, pas en criant l'absence",
+              [x["why"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, [], ["held-sep"])],
+              ["declared separator(s) held-sep are IN the mutant set but were not "
+               "scored in this pass — scoring stopped before them. The class is not "
+               "proved yet; nothing in the corpus is wrong"])
+        check("et un separateur vraiment absent garde son motif",
+              [("absent from the mutant set" in x["why"])
+               for x in unproven_duplicate_groups(
+                   [["012", "013"]], _wd, [], False, [], ["un-autre"])], [True])
+        # Un separateur qui a TOURNE et qui est invalide garde le sien : le fait
+        # d'etre dans le jeu ne doit pas masquer qu'il a echoue.
+        check("un separateur INVALIDE reste un INVALIDE meme s'il est dans le jeu",
+              [("INVALID" in x["why"]) for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd,
+                  [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
+                  False, [], ["held-sep"])], [True])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -7334,9 +7372,14 @@ tool oracle_run:
             # pas absent, il est retenu.
             withheld_ids = ([m.get("id") for m in held_meta]
                             if (mode == "selfcheck" and not held) else [])
+            # Ce que le JEU DE MUTANTS contient, score ou non. Un separateur que le
+            # scan n'a pas atteint — l'arret apres un revert sale, un GM_MUTANTS
+            # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
+            # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
+            in_the_set = [m.get("id") for m in visible + held_meta]
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
-                bool(only), withheld_ids)
+                bool(only), withheld_ids, in_the_set)
             for shape in duplicate_groups_shape_problems(corpus):
                 problems.append(shape)
             report["duplicate_groups_unproven"] = unproven

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3763,6 +3763,38 @@ tool oracle_run:
         return unproven
 
 
+    def duplicate_groups_refusal(unproven, duplicate_refs, corpus_distinct, corpus_total):
+        """The gate's refusal, phrased over the TWO populations it actually has.
+
+        An OBSERVED byte-identical class that is not discharged is "N of M"; a STALE
+        declaration is unproved precisely BECAUSE its references are no longer
+        identical, so it is not one of the M and can never be. Counted into one
+        ratio the line read "4 reference group(s) are not proved (out of 1
+        byte-identical …)", which is arithmetic nobody can act on — on a gate whose
+        whole point is precise adjudication, a headline that cannot be read is
+        itself the defect.
+
+        Named rather than inline in main() so the self-test drives THIS text and not
+        a re-implementation of it.
+        """
+        observed = {tuple(sorted(g)) for g in duplicate_refs}
+        stale = [u for u in unproven if tuple(sorted(u["ids"])) not in observed]
+        head = []
+        if len(unproven) - len(stale):
+            head.append("%d of %d byte-identical reference group(s) across DIFFERENT entries "
+                        "are not proved (the corpus is %d observations wide, not %d)"
+                        % (len(unproven) - len(stale), len(duplicate_refs),
+                           corpus_distinct, corpus_total))
+        if stale:
+            head.append("%d `duplicate_groups` declaration(s) no longer describe a "
+                        "byte-identical class, so the claim has nothing left to justify"
+                        % len(stale))
+        return ("%s. A group may legitimately repeat — a refusal lane's second entry is a "
+                "control — but the claim is discharged by a mutant that moves part of the "
+                "group and leaves the rest still, declared in `duplicate_groups` and checked "
+                "here: %s" % ("; ".join(head), json.dumps(unproven, ensure_ascii=False)))
+
+
     def control_ids(corpus, targets, seed):
         """Deterministic sample of non-target entries, to measure collateral."""
         pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -6561,6 +6593,27 @@ tool oracle_run:
                   [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
                   False, [], ["held-sep"])], [True])
 
+        # LE TITRE, et il porte sur DEUX populations. Une classe OBSERVEE non
+        # acquittee se compte « N sur M » ; une declaration CADUQUE est non prouvee
+        # justement parce que ses references ne sont plus identiques, donc elle
+        # n'est pas l'un des M et ne peut pas l'etre. Comptees dans un seul rapport,
+        # la ligne annoncait « 4 reference group(s) are not proved (out of 1
+        # byte-identical …) » — une arithmetique sur laquelle personne n'agit.
+        _mixed = [{"ids": ["012", "013"], "why": "x"},
+                  {"ids": ["019", "077"], "why": "caduque"},
+                  {"ids": ["080", "081"], "why": "caduque aussi"}]
+        _head = duplicate_groups_refusal(_mixed, [["012", "013"]], 11, 14)
+        check("le titre separe les classes observees des declarations caduques",
+              [("1 of 1 byte-identical" in _head),
+               ("2 `duplicate_groups` declaration(s) no longer describe" in _head)],
+              [True, True])
+        check("et une seule population ne fait pas parler de l'autre",
+              [("no longer describe" in duplicate_groups_refusal(
+                  [{"ids": ["012", "013"], "why": "x"}], [["012", "013"]], 11, 14)),
+               ("byte-identical reference group(s)" in duplicate_groups_refusal(
+                   [{"ids": ["019", "077"], "why": "caduque"}], [], 14, 14))],
+              [False, False])
+
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
               whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -7410,22 +7463,9 @@ tool oracle_run:
                 problems.append(shape)
             report["duplicate_groups_unproven"] = unproven
             if unproven:
-                # The headline counts what the payload lists. Interpolating the
-                # OBSERVED total while listing only the unproved ones told the
-                # operator "5 groups are not proved" beside a list of one — and the
-                # two do not even range over the same set: a stale declaration is
-                # unproved while its references are, by definition, no longer
-                # identical. On a gate whose whole point is precise adjudication,
-                # that gap is the defect.
-                problems.append("%d reference group(s) are not proved (out of %d byte-identical "
-                                "across DIFFERENT entries; the corpus is %d observations wide, "
-                                "not %d). A group may legitimately repeat — a refusal lane's "
-                                "second entry is a control — but the claim is discharged by a "
-                                "mutant that moves part of the group and leaves the rest still, "
-                                "declared in `duplicate_groups` and checked here: %s"
-                                % (len(unproven), len(report["duplicate_refs"]),
-                                   report["corpus_distinct"], report["corpus_total"],
-                                   json.dumps(unproven, ensure_ascii=False)))
+                problems.append(duplicate_groups_refusal(
+                    unproven, report["duplicate_refs"],
+                    report["corpus_distinct"], report["corpus_total"]))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                              "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3517,13 +3517,43 @@ tool oracle_run:
         re-anchored their mutant, silently, while the notes still claimed the pair
         was controlled.
         """
-        out = {}
+        # A class declared TWICE is REFUSED, not resolved. `out[key] = ...` let the
+        # later declaration win an ordering nobody audits: ["a","b"] and ["b","a"]
+        # normalise to one key, and which adjudication decided the class was decided
+        # by position in a JSON list. The second-order harm is worse than the
+        # overwrite — separator_group_ids reads THIS map, so the discarded
+        # declaration's separator never gets its group pinned into a control sample
+        # and the measurement that would decide the class is not taken at all.
+        #
+        # Dropping the key is FAIL-CLOSED: the class then reads as declared by
+        # nobody and the gate refuses it, with unproven_duplicate_groups naming the
+        # collision rather than an absence. A class declared twice with the SAME
+        # separators is merely repetitious, not ambiguous — order there decides
+        # nothing, so it is kept.
+        return {k: v[0] for k, v in duplicate_group_index(corpus).items()
+                if len({frozenset(s) for s in v}) == 1}
+
+
+    def duplicate_group_index(corpus):
+        """Every well-formed declaration, grouped by the class it keys.
+
+        `{class_key: [separator tuples, one per declaration that named it]}` — the
+        shape that makes a collision VISIBLE instead of resolving it silently.
+        """
+        seen = {}
         for g in duplicate_group_raw(corpus):
             norm = duplicate_group_decl(g)
             if norm is None:
                 continue
-            out[norm[0]] = norm[1]
-        return out
+            seen.setdefault(norm[0], []).append(norm[1])
+        return seen
+
+
+    def duplicate_group_conflicts(corpus):
+        """Classes with two declarations that do NOT say the same thing."""
+        return {k: [list(s) for s in v]
+                for k, v in duplicate_group_index(corpus).items()
+                if len({frozenset(s) for s in v}) > 1}
 
 
     def duplicate_group_raw(corpus):
@@ -3587,13 +3617,21 @@ tool oracle_run:
             return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                     "every declared group then reads as undeclared"
                     % type(raw).__name__]
+        out = []
         bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
         if bad:
-            return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
-                    "each needs at least two `ids` and a non-empty `separated_by` "
-                    "(a string, or a list of them): %s"
-                    % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
-        return []
+            out.append("%d `duplicate_groups` entr%s malformed and silently ignored — "
+                       "each needs at least two `ids` and a non-empty `separated_by` "
+                       "(a string, or a list of them): %s"
+                       % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad)))
+        for key, seps in sorted(duplicate_group_conflicts(corpus).items()):
+            out.append(
+                "class %s is declared TWICE with different separators (%s) — the ids "
+                "are normalised, so ['a','b'] and ['b','a'] are ONE class and nothing "
+                "here can say which adjudication is meant. Both are dropped, and the "
+                "class is refused until one declaration remains."
+                % (json.dumps(list(key)), " vs ".join(json.dumps(s) for s in seps)))
+        return out
 
 
     def separator_group_ids(corpus, mutant_id):
@@ -3626,6 +3664,7 @@ tool oracle_run:
         so what is tested is what runs.
         """
         decls = duplicate_group_decls(corpus)
+        conflicts = duplicate_group_conflicts(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
         # VALID only. A failed or inert verdict carries `targets_declared` but
         # never `undetected_targets` nor `collateral` — score_mutant returns before
@@ -3639,6 +3678,15 @@ tool oracle_run:
         for g in sorted(observed):
             seps = decls.get(g)
             if not seps:
+                # Declared twice is not declared once, but it is not UNDECLARED
+                # either — and sending the campaign to write a declaration it has
+                # already written twice is the dead end this file keeps removing.
+                if g in conflicts:
+                    unproven.append({"ids": list(g), "conflicting": conflicts[g], "why":
+                                     "this class is declared TWICE with different separators, and "
+                                     "the ids normalise to ONE key — nothing here can say which "
+                                     "adjudication is meant, so neither is used. Keep one."})
+                    continue
                 unproven.append({"ids": list(g), "why":
                                  "no `duplicate_groups` entry declares this class. Either a "
                                  "member is redundant — drop it — or the identity is a control, "
@@ -6397,6 +6445,35 @@ tool oracle_run:
               len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
         check("le refus de forme nomme exactement les autres",
               len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
+
+        # DEUX declarations pour UNE classe : refusees, pas departagees. Les ids sont
+        # normalises, donc ["a","b"] et ["b","a"] sont la MEME classe et c'est la
+        # POSITION dans la liste qui tranchait. Le mal du second ordre est pire que
+        # l'ecrasement : separator_group_ids lit cette meme carte, donc le separateur
+        # perdant n'epingle jamais son groupe dans son echantillon de temoins — la
+        # mesure qui deciderait la classe n'est pas prise du tout.
+        _clash = {"duplicate_groups": [{"ids": ["a", "b"], "separated_by": "first"},
+                                       {"ids": ["b", "a"], "separated_by": "second"}]}
+        check("une classe declaree deux fois n'est pas departagee par l'ordre",
+              duplicate_group_decls(_clash), {})
+        check("et le perdant n'epingle plus rien en silence",
+              [separator_group_ids(_clash, "first"), separator_group_ids(_clash, "second")],
+              [set(), set()])
+        check("la collision est REFUSEE nommement",
+              [("declared TWICE" in p) for p in duplicate_groups_shape_problems(_clash)],
+              [True])
+        # Et le refus dit la collision, pas une absence : envoyer ecrire une
+        # declaration deja ecrite deux fois est le cul-de-sac que ce fichier retire.
+        check("le motif nomme la collision, pas une declaration manquante",
+              [[("declared TWICE" in x["why"]), x.get("conflicting")]
+               for x in unproven_duplicate_groups([["a", "b"]], _clash, [])],
+              [[True, [["first"], ["second"]]]])
+        # Repeter la MEME adjudication n'est pas ambigu : l'ordre n'y decide rien.
+        check("la meme adjudication ecrite deux fois reste lisible",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b"], "separated_by": ["s1", "s2"]},
+                  {"ids": ["b", "a"], "separated_by": ["s2", "s1"]}]}),
+              {("a", "b"): ("s1", "s2")})
 
         # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
         # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3876,8 +3876,19 @@ tool oracle_run:
         # deterministic slice of the corpus, and a member that fell outside it could
         # move unseen — which is precisely the claim the declaration makes, so the
         # one measurement that decides it must not be left to the sampling stride.
+        #
+        # Pinned against the CORPUS, and that intersection is load-bearing.
+        # `control_covered` is `len(sample)`, and the gate refuses a mutant whose
+        # coverage is 0 — "collateral: 0" with nothing to control against is vacuous
+        # rather than earned. An id that no entry declares is never captured and
+        # never compared (capture() iterates entries; diverged() reads None on both
+        # sides and calls it equal), so pinning one would have raised the coverage
+        # with a control that does not exist and silenced that refusal. A
+        # declaration naming an id the corpus does not have is refused where it
+        # belongs — as a class nothing observes — not by inflating a count here.
         sample = control_ids(corpus, set(targets), seed)
-        pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+        corpus_ids = {e["id"] for e in corpus["entries"]}
+        pinned = (separator_group_ids(corpus, meta.get("id")) & corpus_ids) - set(targets)
         if pinned:
             sample = sorted(set(sample) | pinned)
         captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
@@ -6329,6 +6340,21 @@ tool oracle_run:
                         dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
         check("aucun epinglage pour un mutant qui ne separe rien",
               v_nopin["collateral"], [])
+        # Et JAMAIS un id que le corpus n'a pas. `control_covered` est len(sample),
+        # et la porte refuse un mutant dont la couverture est nulle — « collateral
+        # 0 » sans rien a controler est vide, pas merite. Un id qu'aucune entree ne
+        # declare n'est jamais capture ni compare : l'epingler aurait leve la
+        # couverture avec un temoin qui n'existe pas, et eteint ce refus-la.
+        # Lu sans planter : si l'epinglage repassait large, la capture serait
+        # interrogee sur un id qu'elle n'a pas — et un banc qui plante dit qu'il
+        # s'est passe quelque chose sans dire quoi.
+        try:
+            _vg = score(["001"], [], ["001"],
+                        dup_groups=[{"ids": ["001", "fantome"], "separated_by": "t"}])
+            _ghost = [_vg["control_covered"], _vg["collateral"]]
+        except Exception as e:                              # noqa: BLE001 - c'est le test
+            _ghost = "%s: %s" % (type(e).__name__, e)
+        check("un id absent du corpus n'est pas epingle comme temoin", _ghost, [0, []])
 
         # Un separateur INVALIDE ne prouve rien. Son verdict porte
         # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3426,6 +3426,92 @@ tool oracle_run:
         return sorted(i for i in ids if refs.get(i) != captured.get(i))
 
 
+    def duplicate_group_decls(corpus):
+        """The corpus's `duplicate_groups` declarations, normalised.
+
+        Two entries whose references are byte-identical are not automatically a
+        defect: on a refusal lane the second is a CONTROL proving a mutant moved
+        only the first. But a note saying so is prose, and the gate cannot read
+        prose — so the claim is declared as data and DISCHARGED by measurement:
+        each group names the mutant that separates it, and the gate checks that the
+        mutant really moves some members and leaves the others still.
+
+        That is the difference between a waiver and a proof obligation. A waiver is
+        believed; this is executed, and it goes red by itself the day its separator
+        dies — which is exactly what happened to two of these groups when a lot
+        re-anchored their mutant, silently, while the notes still claimed the pair
+        was controlled.
+        """
+        out = {}
+        for g in (corpus.get("duplicate_groups") or []):
+            if not isinstance(g, dict):
+                continue
+            ids = g.get("ids")
+            sep = g.get("separated_by")
+            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+                continue
+            out[tuple(sorted(str(i) for i in ids))] = sep
+        return out
+
+
+    def separator_group_ids(corpus, mutant_id):
+        """Every id of every group this mutant is declared to separate."""
+        if not mutant_id:
+            return set()
+        ids = set()
+        for group, sep in duplicate_group_decls(corpus).items():
+            if sep == mutant_id:
+                ids.update(group)
+        return ids
+
+
+    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+        """Which byte-identical groups are NOT discharged by a measured separator.
+
+        Returns one record per group that fails, with the reason IN the record —
+        the gate turns them into its refusal, and the selftest calls this same
+        function, so what is tested is what runs.
+        """
+        decls = duplicate_group_decls(corpus)
+        observed = {tuple(sorted(g)) for g in duplicate_refs}
+        scored = {v.get("id"): v for v in verdicts if v.get("id")}
+        unproven = []
+        for g in sorted(observed):
+            sep = decls.get(g)
+            if not sep:
+                unproven.append({"ids": list(g), "why":
+                                 "no `duplicate_groups` entry declares this group. Either one "
+                                 "member is redundant — drop it — or the identity is a control, "
+                                 "and then it must name the mutant that separates it."})
+                continue
+            v = scored.get(sep)
+            if v is None:
+                unproven.append({"ids": list(g), "separated_by": sep, "why":
+                                 "the declared separator was not scored in this pass (absent "
+                                 "from the mutant set%s)" %
+                                 (", or excluded by GM_MUTANTS" if restricted else "")})
+                continue
+            moved = ((set(v.get("targets_declared") or [])
+                      - set(v.get("undetected_targets") or []))
+                     | set(v.get("collateral") or []))
+            inside = moved & set(g)
+            if not inside:
+                unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
+                                 "the declared separator moves NO member of the group — it "
+                                 "does not separate anything"})
+            elif inside == set(g):
+                unproven.append({"ids": list(g), "separated_by": sep,
+                                 "moved": sorted(inside), "why":
+                                 "the declared separator moves EVERY member together, so it no "
+                                 "longer tells them apart. Draw one that moves a strict subset, "
+                                 "or accept that the group is redundant."})
+        for g in sorted(set(decls) - observed):
+            unproven.append({"ids": list(g), "separated_by": decls[g], "why":
+                             "declared, but these references are no longer byte-identical — the "
+                             "claim has nothing left to justify. Remove the declaration."})
+        return unproven
+
+
     def control_ids(corpus, targets, seed):
         """Deterministic sample of non-target entries, to measure collateral."""
         pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -3534,7 +3620,15 @@ tool oracle_run:
         if meta.get("needs_restart", True):
             app_restart(config, ws)
 
+        # An entry named in a duplicate-group declaration is ALWAYS controlled when
+        # the mutant that claims to separate it runs. The sample is otherwise a
+        # deterministic slice of the corpus, and a member that fell outside it could
+        # move unseen — which is precisely the claim the declaration makes, so the
+        # one measurement that decides it must not be left to the sampling stride.
         sample = control_ids(corpus, set(targets), seed)
+        pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+        if pinned:
+            sample = sorted(set(sample) | pinned)
         captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
         moved = diverged(refs, captured, targets)
         verdict["detected"] = bool(moved)
@@ -3906,10 +4000,12 @@ tool oracle_run:
                     (i in self.moved) if self.applied else (i in self.unstable)) else "")
                     for i in ids}
 
-        def score(targets, sample, moved, unstable=(), revert_code=0):
+        def score(targets, sample, moved, unstable=(), revert_code=0, dup_groups=None):
             ids = ["%03d" % n for n in range(1, 13)]
             refs = {i: "ref-" + i for i in ids}
             corpus = {"entries": [{"id": i, "surface": "http"} for i in ids]}
+            if dup_groups:
+                corpus["duplicate_groups"] = dup_groups
             meta = {"id": "t", "dir": "/dev/null", "class": "code", "surface": "http",
                     "archetype": "value_change", "targets": list(targets), "needs_restart": False}
             w = World(refs, moved, unstable)
@@ -5860,6 +5956,89 @@ tool oracle_run:
         check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
         check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
+        # ─── Groupes de references identiques : la preuve, pas la parole ──────────
+        #
+        # Deux entrees byte-identiques ne sont pas fautives en soi : sur une lane de
+        # refus, la seconde est un CONTROLE qui prouve qu'un mutant n'a deplace que
+        # la premiere. Ce que la porte ne pouvait pas faire, c'est distinguer ce cas
+        # d'un doublon — une note en prose ne se verifie pas. La declaration nomme
+        # le mutant separateur, et elle est ACQUITTEE par la mesure.
+        corpus_dg = {"entries": [{"id": "012"}, {"id": "013"}, {"id": "019"}],
+                     "duplicate_groups": [
+                         {"ids": ["013", "012"], "separated_by": "sep-01"},
+                         {"ids": ["019"], "separated_by": "trop-court"},
+                         {"ids": ["019", "012"], "separated_by": ""},
+                         "pas-un-dict"]}
+        check("une declaration se lit triee, et les malformees sont ignorees",
+              duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+        check("les ids d'un groupe sont epingles pour SON separateur",
+              separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
+        check("et pour aucun autre",
+              separator_group_ids(corpus_dg, "sep-02"), set())
+        check("un mutant sans id n'epingle rien",
+              separator_group_ids(corpus_dg, None), set())
+
+        # Le verdict lui-meme : ce que la porte conclut de ce qu'un separateur a
+        # REELLEMENT deplace. La forme qui compte est la derniere — un separateur
+        # qui deplace TOUT le groupe ne le separe plus, et c'est exactement ce qui
+        # est arrive a deux paires quand un lot a reancre leur mutant.
+        # Appelle la FONCTION QUE LA PORTE APPELLE — pas une reimplementation.
+        # Un banc qui rejoue la logique reste vert quand le produit derive ; celui-ci
+        # rougit avec lui.
+        def whys(group, decls, moved_by):
+            corpus_ = {"entries": [], "duplicate_groups": decls}
+            verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+                          "undetected_targets": [], "collateral": []}
+                         for mid, mv in moved_by.items()]
+            out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
+            return [x["ids"] for x in out]
+
+        # L'EPINGLAGE, et c'est la moitie porteuse : sans lui la mesure qui decide
+        # n'existe pas. Un membre du groupe hors de l'echantillon deterministe
+        # pourrait bouger sans etre vu, et la porte conclurait "sous-ensemble strict,
+        # groupe prouve" sur une separation qui n'a plus lieu.
+        v_pin = score(["001"], ["005"], ["001", "009"],
+                      dup_groups=[{"ids": ["001", "009"], "separated_by": "t"}])
+        check("un membre du groupe hors echantillon est quand meme controle",
+              v_pin["collateral"], ["009"])
+        # Et rien n'est epingle pour un mutant qui ne separe aucun groupe.
+        v_nopin = score(["001"], ["005"], ["001", "009"],
+                        dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
+        check("aucun epinglage pour un mutant qui ne separe rien",
+              v_nopin["collateral"], [])
+
+        D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
+        check("separateur qui deplace UN membre : preuve acquittee",
+              whys(["012", "013"], D, {"sep-01": {"013"}}), [])
+        check("separateur qui deplace TOUT le groupe : refuse",
+              whys(["012", "013"], D, {"sep-01": {"012", "013"}}), [["012", "013"]])
+        check("separateur qui ne deplace AUCUN membre : refuse",
+              whys(["012", "013"], D, {"sep-01": {"099"}}), [["012", "013"]])
+        check("separateur absent du jeu score : refuse",
+              whys(["012", "013"], D, {"autre": {"013"}}), [["012", "013"]])
+        check("groupe observe mais non declare : refuse",
+              whys(["012", "013"], [], {}), [["012", "013"]])
+        check("declaration devenue caduque : refuse",
+              whys(["012", "013"], D + [{"ids": ["019", "077"], "separated_by": "sep-02"}],
+                   {"sep-01": {"013"}}), [["019", "077"]])
+        # Le collateral compte comme un deplacement : un membre que le separateur ne
+        # DECLARE pas mais deplace quand meme casse la separation aussi surement.
+        check("un membre deplace en collateral casse la separation",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": D},
+                  [{"id": "sep-01", "targets_declared": ["013"],
+                    "undetected_targets": [], "collateral": ["012"]}])],
+              [["012", "013"]])
+        # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
+        check("une cible declaree mais immobile ne prouve rien",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": D},
+                  [{"id": "sep-01", "targets_declared": ["012", "013"],
+                    "undetected_targets": ["012", "013"], "collateral": []}])],
+              [["012", "013"]])
+
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))
             for f in failures:
@@ -6012,6 +6191,7 @@ tool oracle_run:
                   "holdout_detected": 0, "holdout_total": 0, "stable": False,
                   "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
                   "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
+                  "duplicate_groups_unproven": [],
                   "runner_replayable": False,
                   "holdout_reused": [],
                   "log_tail": ""}
@@ -6643,18 +6823,33 @@ tool oracle_run:
             if report["score_pct"] < floor:
                 problems.append("mutation score %d%% is under the %d%% floor"
                                 % (report["score_pct"], floor))
-            if report["duplicate_refs"]:
+            # Byte-identical references are not automatically a defect — on a
+            # refusal lane the second entry is a CONTROL proving a mutant moved only
+            # the first. What was missing is the difference between that and a
+            # redundant pair, and it cannot be settled by a note: the gate reads
+            # data, not prose. So the corpus DECLARES the separating mutant per
+            # group, and the declaration is discharged by MEASUREMENT — the mutant
+            # must move some members and leave the others still, with every member
+            # pinned into its control sample so the answer exists.
+            #
+            # A proof obligation, not a waiver. It goes red by itself the day the
+            # separator dies, which is what a waiver could never do: measured 08/09,
+            # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
+            # separator to a lot's re-anchoring — the mutant now moves both members,
+            # and the pair proves nothing at all.
+            unproven = unproven_duplicate_groups(
+                report["duplicate_refs"], corpus, verdicts, bool(only))
+            report["duplicate_groups_unproven"] = unproven
+            if unproven:
                 problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                                "so the corpus is %d observations wide, not %d. This is NOT always a "
-                                "defect: on a refusal lane two entries legitimately capture the same "
-                                "302, and the second is a control proving a mutant moved only the "
-                                "first. It IS a defect when the endpoints were meant to differ — then "
-                                "either one is redundant, or they differ on a path this fixture does "
-                                "not exercise and the difference is captured NOWHERE. Decide which, "
-                                "per group: %s"
+                                "so the corpus is %d observations wide, not %d — and their identity "
+                                "is NOT proved. A group may legitimately repeat (a refusal lane's "
+                                "second entry is a control), but the claim is discharged by a mutant "
+                                "that moves part of the group and leaves the rest still, declared in "
+                                "`duplicate_groups` and checked here. Unproved: %s"
                                 % (len(report["duplicate_refs"]), report["corpus_distinct"],
                                    report["corpus_total"],
-                                   json.dumps(report["duplicate_refs"], ensure_ascii=False)))
+                                   json.dumps(unproven, ensure_ascii=False)))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                              "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1831,13 +1831,22 @@ tool oracle_run:
                 # Structure is judged HERE, truth at the gate. A malformed
                 # declaration would otherwise be dropped in silence by
                 # duplicate_group_decls and read as "no declaration at all".
-                for g in (head_c.get("duplicate_groups") or []):
-                    _sep = g.get("separated_by") if isinstance(g, dict) else None
-                    _seps = [_sep] if isinstance(_sep, str) else _sep
-                    if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
-                            or len(g.get("ids") or []) < 2 \
-                            or not isinstance(_seps, list) or not _seps \
-                            or not all(isinstance(m, str) and m for m in _seps):
+                #
+                # Through duplicate_group_raw / duplicate_group_decl, which is the
+                # SAME predicate the gate reads. Hand-written here, the container
+                # loop was `for g in (head_c.get("duplicate_groups") or [])` and
+                # `{"duplicate_groups": 5}` raised a TypeError — this judge runs
+                # outside the gate's try/finally, so no mutant is stranded, but the
+                # mode prints a stack trace where the campaign expects its verdict.
+                # The file's own doctrine, one screen up: refused, not crashed.
+                if head_c.get("duplicate_groups") is not None \
+                        and not isinstance(head_c.get("duplicate_groups"), list):
+                    corpus_problems.append(
+                        "`duplicate_groups` is %s, not a list — every declaration in "
+                        "it is ignored whole and reads as undeclared"
+                        % type(head_c.get("duplicate_groups")).__name__)
+                for g in duplicate_group_raw(head_c):
+                    if duplicate_group_decl(g) is None:
                         corpus_problems.append(
                             "a `duplicate_groups` entry is malformed (%r) — it needs "
                             "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3509,29 +3518,58 @@ tool oracle_run:
         was controlled.
         """
         out = {}
-        # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
-        # que le mutant est applique et AVANT le revert : une exception y tue le
-        # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
-        # fichier est explicite une vis plus haut — « refused, not crashed ». Le
-        # refus, lui, est prononce par duplicate_groups_shape_problems.
-        raw = corpus.get("duplicate_groups") or []
-        if not isinstance(raw, list):
-            return out
-        for g in raw:
-            if not isinstance(g, dict):
+        for g in duplicate_group_raw(corpus):
+            norm = duplicate_group_decl(g)
+            if norm is None:
                 continue
-            ids = g.get("ids")
-            sep = g.get("separated_by")
-            # One separator or several: a class of two needs one mutant to split it,
-            # a class of four needs enough of them to tell all four apart. Written
-            # as a bare string for the common case, a list when resolution costs
-            # more than one.
-            seps = [sep] if isinstance(sep, str) else sep
-            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
-                    or not seps or not all(isinstance(m, str) and m for m in seps):
-                continue
-            out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
+            out[norm[0]] = norm[1]
         return out
+
+
+    def duplicate_group_raw(corpus):
+        """The declarations as written — the list, or [] when the key is absent or
+        is not a list at all.
+
+        Ne LEVE JAMAIS, et c'est la moitie porteuse. Ce lecteur est atteint depuis
+        score_mutant, donc APRES que le mutant est applique et AVANT le revert : une
+        exception y tue le harnais sans imprimer son rapport et laisse l'arbre MUTE.
+        La doctrine du fichier est explicite quelques vis plus haut — « refused, not
+        crashed ». Le refus, lui, est prononce ailleurs : par
+        duplicate_groups_shape_problems a la porte, par le juge d'extension sur le
+        canal. Un `for g in (corpus.get("duplicate_groups") or [])` ecrit a la main
+        leve un TypeError sur `5` ou `true` — il y en avait trois copies, il n'y en
+        a plus qu'une.
+        """
+        raw = corpus.get("duplicate_groups")
+        return raw if isinstance(raw, list) else []
+
+
+    def duplicate_group_decl(g):
+        """ONE declaration, read once — the single shape predicate of this file.
+
+        Returns `(class_key, separators)` normalised, or None when the entry is
+        malformed. `class_key` is the sorted tuple of ids, which is what makes the
+        declaration keyed on the byte-identical CLASS rather than on an ordering the
+        lot chose; `separators` is deduplicated and order-preserving.
+
+        One separator or several: a class of two needs one mutant to split it, a
+        class of four needs enough of them to tell all four apart. Written as a bare
+        string for the common case, a list when resolution costs more than one.
+
+        It exists as one function because the predicate had been written three
+        times — the reader, the shape refusal, and the extension judge — and three
+        copies of a rule is three chances for a corpus to be well-formed for one
+        reader and malformed for another.
+        """
+        if not isinstance(g, dict):
+            return None
+        ids = g.get("ids")
+        sep = g.get("separated_by")
+        seps = [sep] if isinstance(sep, str) else sep
+        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+                or not seps or not all(isinstance(m, str) and m for m in seps):
+            return None
+        return tuple(sorted(str(i) for i in ids)), tuple(dict.fromkeys(seps))
 
 
     def duplicate_groups_shape_problems(corpus):
@@ -3549,17 +3587,7 @@ tool oracle_run:
             return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                     "every declared group then reads as undeclared"
                     % type(raw).__name__]
-        bad = []
-        for g in raw:
-            if not isinstance(g, dict):
-                bad.append(repr(g)[:80])
-                continue
-            sep = g.get("separated_by")
-            seps = [sep] if isinstance(sep, str) else sep
-            if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
-                    or not isinstance(seps, list) or not seps \
-                    or not all(isinstance(m, str) and m for m in seps):
-                bad.append(repr(g)[:80])
+        bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
         if bad:
             return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
                     "each needs at least two `ids` and a non-empty `separated_by` "
@@ -5274,6 +5302,25 @@ tool oracle_run:
             check("une declaration malformee est refusee, pas ignoree",
                   any("malformed" in pb
                       for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+            # Et le CONTENEUR lui-meme : `duplicate_groups: 5` faisait lever un
+            # TypeError a la boucle ecrite a la main ici — ce juge tourne hors du
+            # try/finally de la porte, donc aucun mutant n'est abandonne, mais le
+            # mode imprimait une traceback la ou la campagne attend son verdict.
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": 5}, f)
+            xcommit()
+            try:
+                _cv, _craised = xverdict(xbase)["acted"][0], ""
+            except Exception as e:                          # noqa: BLE001 - c'est le test
+                _cv, _craised = {}, "%s: %s" % (type(e).__name__, e)
+            check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
+                  [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
+                  ["", True])
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
@@ -6330,6 +6377,26 @@ tool oracle_run:
                   {"ids": ["a"], "separated_by": "s"}]})), 1)
         check("et un corpus sans declaration ne dit rien",
               duplicate_groups_shape_problems({"entries": []}), [])
+        # UN SEUL predicat de forme. Il en existait trois copies — le lecteur, le
+        # refus de forme, le juge d'extension — et trois copies d'une regle sont
+        # trois occasions qu'un corpus soit bien forme pour l'un et malforme pour
+        # l'autre. Ce banc pince l'accord plutot que chaque copie : ce que le
+        # normaliseur refuse est exactement ce que le lecteur laisse tomber et
+        # exactement ce que le refus nomme.
+        _shapes = [{"ids": ["a", "b"], "separated_by": "s"},          # bien forme
+                   {"ids": ["a", "b"], "separated_by": ["s", "s"]},   # bien forme
+                   {"ids": ["a"], "separated_by": "s"},               # trop court
+                   {"ids": ["a", "b"], "separated_by": []},           # sans separateur
+                   {"ids": ["a", "b"], "separated_by": [1]},          # non textuel
+                   {"ids": "ab", "separated_by": "s"},                # ids non-liste
+                   "pas-un-dict"]
+        check("le normaliseur et le refus de forme s'accordent entree par entree",
+              [duplicate_group_decl(g) is None for g in _shapes],
+              [False, False, True, True, True, True, True])
+        check("et le lecteur ne garde que ce que le normaliseur accepte",
+              len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
+        check("le refus de forme nomme exactement les autres",
+              len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
 
         # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
         # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3472,7 +3472,15 @@ tool oracle_run:
         was controlled.
         """
         out = {}
-        for g in (corpus.get("duplicate_groups") or []):
+        # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
+        # que le mutant est applique et AVANT le revert : une exception y tue le
+        # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
+        # fichier est explicite une vis plus haut — « refused, not crashed ». Le
+        # refus, lui, est prononce par duplicate_groups_shape_problems.
+        raw = corpus.get("duplicate_groups") or []
+        if not isinstance(raw, list):
+            return out
+        for g in raw:
             if not isinstance(g, dict):
                 continue
             ids = g.get("ids")
@@ -3489,6 +3497,40 @@ tool oracle_run:
         return out
 
 
+    def duplicate_groups_shape_problems(corpus):
+        """Ce que le LECTEUR laisse tomber en silence, dit a voix haute.
+
+        duplicate_group_decls ignore ce qu'il ne sait pas lire — il le doit, il
+        tourne avec un mutant applique. Mais une declaration ignoree se lit comme
+        « aucune declaration », donc comme un groupe non declare : le message
+        envoie corriger une absence alors que le defaut est une faute de frappe.
+        """
+        raw = corpus.get("duplicate_groups")
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
+                    "every declared group then reads as undeclared"
+                    % type(raw).__name__]
+        bad = []
+        for g in raw:
+            if not isinstance(g, dict):
+                bad.append(repr(g)[:80])
+                continue
+            sep = g.get("separated_by")
+            seps = [sep] if isinstance(sep, str) else sep
+            if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
+                    or not isinstance(seps, list) or not seps \
+                    or not all(isinstance(m, str) and m for m in seps):
+                bad.append(repr(g)[:80])
+        if bad:
+            return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
+                    "each needs at least two `ids` and a non-empty `separated_by` "
+                    "(a string, or a list of them): %s"
+                    % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
+        return []
+
+
     def separator_group_ids(corpus, mutant_id):
         """Every id of every group this mutant is declared to separate."""
         if not mutant_id:
@@ -3500,7 +3542,8 @@ tool oracle_run:
         return ids
 
 
-    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
+                                  withheld=()):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3537,6 +3580,14 @@ tool oracle_run:
                                  "and then it must name the mutant(s) that tell them apart."})
                 continue
             missing = [m for m in seps if m not in scored]
+            # WITHHELD is not MISSING. In selfcheck the held-out set is deliberately
+            # not scored — `held` is empty by construction — so a separator drawn
+            # from it would be reported "absent from the mutant set", which is false
+            # and which the campaign cannot fix: the mutant IS in the set, its
+            # result is simply reserved for the final gate. Saying so is the whole
+            # difference between a work item and a dead end.
+            if missing and all(m in set(withheld) for m in missing):
+                continue
             if missing:
                 unproven.append({"ids": list(g), "separated_by": list(seps), "why":
                                  "declared separator(s) %s %s" %
@@ -6208,6 +6259,32 @@ tool oracle_run:
                     "undetected_targets": [], "collateral": []}])],
               [])
 
+        # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
+        # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
+        # sinon une faute de frappe se lit comme « groupe non declare » et envoie
+        # corriger une absence.
+        check("un `duplicate_groups` non-liste ne fait pas planter le lecteur",
+              duplicate_group_decls({"duplicate_groups": 5}), {})
+        check("et il est REFUSE, pas ignore",
+              len(duplicate_groups_shape_problems({"duplicate_groups": 5})), 1)
+        check("une entree malformee est refusee nommement",
+              len(duplicate_groups_shape_problems({"duplicate_groups": [
+                  {"ids": ["a"], "separated_by": "s"}]})), 1)
+        check("et un corpus sans declaration ne dit rien",
+              duplicate_groups_shape_problems({"entries": []}), [])
+
+        # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
+        # n'est pas score, donc un separateur qui en vient est retenu, pas manquant
+        # — et le dire autrement produit un refus que la campagne ne peut pas lever.
+        _wd = {"entries": [], "duplicate_groups": [
+            {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+        check("un separateur RETENU ne produit pas de refus",
+              unproven_duplicate_groups([["012", "013"]], _wd, [], False,
+                                        ["held-sep"]), [])
+        check("mais un separateur simplement ABSENT en produit un",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
               whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -7043,8 +7120,16 @@ tool oracle_run:
             # measurement really IS taken — but it lands in `held`, not `verdicts`.
             # Passing only the latter made the gate report a separator it had just
             # scored as never scored, and refuse the group on its own blind spot.
+            # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
+            # `held` est vide par construction, et un separateur qui en vient n'est
+            # pas absent, il est retenu.
+            withheld_ids = ([m.get("id") for m in held_meta]
+                            if (mode == "selfcheck" and not held) else [])
             unproven = unproven_duplicate_groups(
-                report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
+                report["duplicate_refs"], corpus, list(verdicts) + list(held),
+                bool(only), withheld_ids)
+            for shape in duplicate_groups_shape_problems(corpus):
+                problems.append(shape)
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 # The headline counts what the payload lists. Interpolating the

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -3698,7 +3698,7 @@ tool oracle_run:
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                                  withheld=(), in_the_set=()):
+                                  withheld=(), in_the_set=(), deferred=None):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3714,7 +3714,30 @@ tool oracle_run:
         Returns one record per class that fails, with the reason IN the record — the
         gate turns them into its refusal, and the selftest calls this same function,
         so what is tested is what runs.
+
+        A class whose every missing separator is WITHHELD lands in the caller's
+        `deferred` sink, never in the return value.
         """
+        # WITHHELD is neither ABSENT nor PROVED, and this used to discharge it.
+        # Skipping the class outright removed the false refusal at the cost of a
+        # false PROOF: with `seps = [held, visible]` where the visible one separates
+        # nothing, the class came back discharged without the scored separator ever
+        # being consulted. A term of convergence cannot be handed that.
+        #
+        # So it is DEFERRED — said out loud, in a sink the caller owns, never in the
+        # field the gate reads. A deferral is the absence of a verdict, not a
+        # verdict.
+        #
+        # No sink, no deferral — but the REASON must stay true. A withheld
+        # separator is IN the mutant set; folding it there makes the fallback say
+        # so, instead of shouting an absence that would send the campaign to fix a
+        # mutant that exists. Strictest AND honest: a caller that forgets the sink
+        # can only get a HARSHER verdict, never a softer one, and never a lying one.
+        if deferred is None:
+            in_the_set = list(in_the_set) + list(withheld)
+            withheld = set()
+        else:
+            withheld = set(withheld)
         decls = duplicate_group_decls(corpus)
         conflicts = duplicate_group_conflicts(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3752,6 +3775,12 @@ tool oracle_run:
             # result is simply reserved for the final gate. Saying so is the whole
             # difference between a work item and a dead end.
             if missing and all(m in set(withheld) for m in missing):
+                deferred.append({"ids": list(g), "separated_by": list(seps),
+                                 "withheld": sorted(missing), "why":
+                                 "every unscored separator belongs to the held-out set, whose "
+                                 "verdicts this pass reserves — not scored here, and not scorable "
+                                 "here. Neither proved nor refuted until the final gate scores "
+                                 "them."})
                 continue
             if missing:
                 # THREE reasons, and they send the campaign to three different
@@ -6658,9 +6687,34 @@ tool oracle_run:
         # — et le dire autrement produit un refus que la campagne ne peut pas lever.
         _wd = {"entries": [], "duplicate_groups": [
             {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+        _sink = []
         check("un separateur RETENU ne produit pas de refus",
               unproven_duplicate_groups([["012", "013"]], _wd, [], False,
-                                        ["held-sep"]), [])
+                                        ["held-sep"], (), _sink), [])
+        # ...ET IL EST DIFFERE, PAS EFFACE. Sauter la classe retirait le faux refus
+        # au prix d'une fausse PREUVE : avec `seps = [retenu, visible]` ou le
+        # visible ne separe rien, la classe ressortait dechargee sans que le
+        # separateur score soit jamais consulte. Un terme de convergence ne peut pas
+        # recevoir ca.
+        check("... et la classe est DIFFEREE, pas effacee",
+              [(x["ids"], x["withheld"]) for x in _sink],
+              [(["012", "013"], ["held-sep"])])
+        # SANS PUITS, PAS DE REPORT — et le motif reste VRAI : un separateur retenu
+        # est dans le jeu, pas absent. Le defaut ne peut que RESSERRER, jamais
+        # mentir.
+        check("sans puits, RETENU redevient un refus, et un refus qui ne ment pas",
+              [x["why"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, ["held-sep"])],
+              ["declared separator(s) held-sep are IN the mutant set but were not "
+               "scored in this pass — scoring stopped before them. The class is not "
+               "proved yet; nothing in the corpus is wrong"])
+        # A LA PORTE FINALE RIEN N'EST RETENU : la voie du report y est
+        # inatteignable, donc elle ne peut pas adoucir le verdict qui decide.
+        _sink2 = []
+        check("porte finale : aucun report possible, le refus tient",
+              [[x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, (), (), _sink2)], _sink2],
+              [[["012", "013"]], []])
         check("mais un separateur simplement ABSENT en produit un",
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
@@ -6894,6 +6948,10 @@ tool oracle_run:
                   "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
                   "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
                   "duplicate_groups_unproven": [],
+                  # Rapporte, jamais gate : un report est l'absence d'un verdict,
+                  # pas un verdict. Il existe pour qu'un selfcheck ne lise pas
+                  # PROUVE ce qu'il n'a fait que ne pas pouvoir mesurer.
+                  "duplicate_groups_deferred": [],
                   "runner_replayable": False,
                   "holdout_reused": [],
                   "log_tail": ""}
@@ -7556,11 +7614,17 @@ tool oracle_run:
             # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
             # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
             in_the_set = [m.get("id") for m in visible + held_meta]
+            # Le puits des classes DIFFEREES. Il est fourni, donc `withheld` est
+            # honore ; sans lui la fonction retombe sur le refus le plus severe.
+            # Rien n'est retenu a la porte finale (`withheld_ids` y est vide), donc
+            # cette voie ne peut pas adoucir le verdict qui decide.
+            deferred = []
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
-                bool(only), withheld_ids, in_the_set)
+                bool(only), withheld_ids, in_the_set, deferred)
             problems.extend(duplicate_groups_shape_problems(corpus))
             report["duplicate_groups_unproven"] = unproven
+            report["duplicate_groups_deferred"] = deferred
             if unproven:
                 problems.append(duplicate_groups_refusal(
                     unproven, report["duplicate_refs"],

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1618,13 +1618,22 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
             # Structure is judged HERE, truth at the gate. A malformed
             # declaration would otherwise be dropped in silence by
             # duplicate_group_decls and read as "no declaration at all".
-            for g in (head_c.get("duplicate_groups") or []):
-                _sep = g.get("separated_by") if isinstance(g, dict) else None
-                _seps = [_sep] if isinstance(_sep, str) else _sep
-                if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
-                        or len(g.get("ids") or []) < 2 \
-                        or not isinstance(_seps, list) or not _seps \
-                        or not all(isinstance(m, str) and m for m in _seps):
+            #
+            # Through duplicate_group_raw / duplicate_group_decl, which is the
+            # SAME predicate the gate reads. Hand-written here, the container
+            # loop was `for g in (head_c.get("duplicate_groups") or [])` and
+            # `{"duplicate_groups": 5}` raised a TypeError — this judge runs
+            # outside the gate's try/finally, so no mutant is stranded, but the
+            # mode prints a stack trace where the campaign expects its verdict.
+            # The file's own doctrine, one screen up: refused, not crashed.
+            if head_c.get("duplicate_groups") is not None \
+                    and not isinstance(head_c.get("duplicate_groups"), list):
+                corpus_problems.append(
+                    "`duplicate_groups` is %s, not a list — every declaration in "
+                    "it is ignored whole and reads as undeclared"
+                    % type(head_c.get("duplicate_groups")).__name__)
+            for g in duplicate_group_raw(head_c):
+                if duplicate_group_decl(g) is None:
                     corpus_problems.append(
                         "a `duplicate_groups` entry is malformed (%r) — it needs "
                         "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3296,29 +3305,58 @@ def duplicate_group_decls(corpus):
     was controlled.
     """
     out = {}
-    # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
-    # que le mutant est applique et AVANT le revert : une exception y tue le
-    # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
-    # fichier est explicite une vis plus haut — « refused, not crashed ». Le
-    # refus, lui, est prononce par duplicate_groups_shape_problems.
-    raw = corpus.get("duplicate_groups") or []
-    if not isinstance(raw, list):
-        return out
-    for g in raw:
-        if not isinstance(g, dict):
+    for g in duplicate_group_raw(corpus):
+        norm = duplicate_group_decl(g)
+        if norm is None:
             continue
-        ids = g.get("ids")
-        sep = g.get("separated_by")
-        # One separator or several: a class of two needs one mutant to split it,
-        # a class of four needs enough of them to tell all four apart. Written
-        # as a bare string for the common case, a list when resolution costs
-        # more than one.
-        seps = [sep] if isinstance(sep, str) else sep
-        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
-                or not seps or not all(isinstance(m, str) and m for m in seps):
-            continue
-        out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
+        out[norm[0]] = norm[1]
     return out
+
+
+def duplicate_group_raw(corpus):
+    """The declarations as written — the list, or [] when the key is absent or
+    is not a list at all.
+
+    Ne LEVE JAMAIS, et c'est la moitie porteuse. Ce lecteur est atteint depuis
+    score_mutant, donc APRES que le mutant est applique et AVANT le revert : une
+    exception y tue le harnais sans imprimer son rapport et laisse l'arbre MUTE.
+    La doctrine du fichier est explicite quelques vis plus haut — « refused, not
+    crashed ». Le refus, lui, est prononce ailleurs : par
+    duplicate_groups_shape_problems a la porte, par le juge d'extension sur le
+    canal. Un `for g in (corpus.get("duplicate_groups") or [])` ecrit a la main
+    leve un TypeError sur `5` ou `true` — il y en avait trois copies, il n'y en
+    a plus qu'une.
+    """
+    raw = corpus.get("duplicate_groups")
+    return raw if isinstance(raw, list) else []
+
+
+def duplicate_group_decl(g):
+    """ONE declaration, read once — the single shape predicate of this file.
+
+    Returns `(class_key, separators)` normalised, or None when the entry is
+    malformed. `class_key` is the sorted tuple of ids, which is what makes the
+    declaration keyed on the byte-identical CLASS rather than on an ordering the
+    lot chose; `separators` is deduplicated and order-preserving.
+
+    One separator or several: a class of two needs one mutant to split it, a
+    class of four needs enough of them to tell all four apart. Written as a bare
+    string for the common case, a list when resolution costs more than one.
+
+    It exists as one function because the predicate had been written three
+    times — the reader, the shape refusal, and the extension judge — and three
+    copies of a rule is three chances for a corpus to be well-formed for one
+    reader and malformed for another.
+    """
+    if not isinstance(g, dict):
+        return None
+    ids = g.get("ids")
+    sep = g.get("separated_by")
+    seps = [sep] if isinstance(sep, str) else sep
+    if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+            or not seps or not all(isinstance(m, str) and m for m in seps):
+        return None
+    return tuple(sorted(str(i) for i in ids)), tuple(dict.fromkeys(seps))
 
 
 def duplicate_groups_shape_problems(corpus):
@@ -3336,17 +3374,7 @@ def duplicate_groups_shape_problems(corpus):
         return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                 "every declared group then reads as undeclared"
                 % type(raw).__name__]
-    bad = []
-    for g in raw:
-        if not isinstance(g, dict):
-            bad.append(repr(g)[:80])
-            continue
-        sep = g.get("separated_by")
-        seps = [sep] if isinstance(sep, str) else sep
-        if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
-                or not isinstance(seps, list) or not seps \
-                or not all(isinstance(m, str) and m for m in seps):
-            bad.append(repr(g)[:80])
+    bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
     if bad:
         return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
                 "each needs at least two `ids` and a non-empty `separated_by` "
@@ -5061,6 +5089,25 @@ def _selftest():
         check("une declaration malformee est refusee, pas ignoree",
               any("malformed" in pb
                   for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+        # Et le CONTENEUR lui-meme : `duplicate_groups: 5` faisait lever un
+        # TypeError a la boucle ecrite a la main ici — ce juge tourne hors du
+        # try/finally de la porte, donc aucun mutant n'est abandonne, mais le
+        # mode imprimait une traceback la ou la campagne attend son verdict.
+        xreset()
+        xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                ("act", '{"id": "E-D", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, dup_entry],
+                       "duplicate_groups": 5}, f)
+        xcommit()
+        try:
+            _cv, _craised = xverdict(xbase)["acted"][0], ""
+        except Exception as e:                          # noqa: BLE001 - c'est le test
+            _cv, _craised = {}, "%s: %s" % (type(e).__name__, e)
+        check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
+              [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
+              ["", True])
 
         # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
         xreset()
@@ -6117,6 +6164,26 @@ def _selftest():
               {"ids": ["a"], "separated_by": "s"}]})), 1)
     check("et un corpus sans declaration ne dit rien",
           duplicate_groups_shape_problems({"entries": []}), [])
+    # UN SEUL predicat de forme. Il en existait trois copies — le lecteur, le
+    # refus de forme, le juge d'extension — et trois copies d'une regle sont
+    # trois occasions qu'un corpus soit bien forme pour l'un et malforme pour
+    # l'autre. Ce banc pince l'accord plutot que chaque copie : ce que le
+    # normaliseur refuse est exactement ce que le lecteur laisse tomber et
+    # exactement ce que le refus nomme.
+    _shapes = [{"ids": ["a", "b"], "separated_by": "s"},          # bien forme
+               {"ids": ["a", "b"], "separated_by": ["s", "s"]},   # bien forme
+               {"ids": ["a"], "separated_by": "s"},               # trop court
+               {"ids": ["a", "b"], "separated_by": []},           # sans separateur
+               {"ids": ["a", "b"], "separated_by": [1]},          # non textuel
+               {"ids": "ab", "separated_by": "s"},                # ids non-liste
+               "pas-un-dict"]
+    check("le normaliseur et le refus de forme s'accordent entree par entree",
+          [duplicate_group_decl(g) is None for g in _shapes],
+          [False, False, True, True, True, True, True])
+    check("et le lecteur ne garde que ce que le normaliseur accepte",
+          len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
+    check("le refus de forme nomme exactement les autres",
+          len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
 
     # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
     # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1619,10 +1619,12 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
             # declaration would otherwise be dropped in silence by
             # duplicate_group_decls and read as "no declaration at all".
             for g in (head_c.get("duplicate_groups") or []):
+                _sep = g.get("separated_by") if isinstance(g, dict) else None
+                _seps = [_sep] if isinstance(_sep, str) else _sep
                 if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
                         or len(g.get("ids") or []) < 2 \
-                        or not isinstance(g.get("separated_by"), str) \
-                        or not g.get("separated_by"):
+                        or not isinstance(_seps, list) or not _seps \
+                        or not all(isinstance(m, str) and m for m in _seps):
                     corpus_problems.append(
                         "a `duplicate_groups` entry is malformed (%r) — it needs "
                         "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3262,9 +3264,15 @@ def duplicate_group_decls(corpus):
             continue
         ids = g.get("ids")
         sep = g.get("separated_by")
-        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+        # One separator or several: a class of two needs one mutant to split it,
+        # a class of four needs enough of them to tell all four apart. Written
+        # as a bare string for the common case, a list when resolution costs
+        # more than one.
+        seps = [sep] if isinstance(sep, str) else sep
+        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+                or not seps or not all(isinstance(m, str) and m for m in seps):
             continue
-        out[tuple(sorted(str(i) for i in ids))] = sep
+        out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
     return out
 
 
@@ -3273,18 +3281,28 @@ def separator_group_ids(corpus, mutant_id):
     if not mutant_id:
         return set()
     ids = set()
-    for group, sep in duplicate_group_decls(corpus).items():
-        if sep == mutant_id:
+    for group, seps in duplicate_group_decls(corpus).items():
+        if mutant_id in seps:
             ids.update(group)
     return ids
 
 
 def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
-    """Which byte-identical groups are NOT discharged by a measured separator.
+    """Which byte-identical classes are NOT discharged by measured separators.
 
-    Returns one record per group that fails, with the reason IN the record —
-    the gate turns them into its refusal, and the selftest calls this same
-    function, so what is tested is what runs.
+    `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
+    sha256 — so a class of three or more cannot be declared as a set of pairs:
+    the declaration is keyed on the class itself. What several separators buy is
+    RESOLUTION. A class is discharged when the members are pairwise
+    distinguishable: for each one, the pattern of which declared separators move
+    it must be unique. One separator over a pair reduces to "moves one, not the
+    other"; four members need enough separators to tell all four apart, which is
+    exactly what the campaign's own notes describe when they name `sep-04` for
+    one member and `sep-05` for two others.
+
+    Returns one record per class that fails, with the reason IN the record — the
+    gate turns them into its refusal, and the selftest calls this same function,
+    so what is tested is what runs.
     """
     decls = duplicate_group_decls(corpus)
     observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3292,48 +3310,54 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     # never `undetected_targets` nor `collateral` — score_mutant returns before
     # they are set — so crediting it would read "moved every declared target"
     # from a measurement that never ran. And that is exactly how a separator
-    # dies when a lot re-anchors it: its apply.sh stops working. The group would
+    # dies when a lot re-anchors it: its apply.sh stops working. The class would
     # have been reported PROVED by the failure it exists to catch.
     scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
     seen_ids = {v.get("id") for v in verdicts if v.get("id")}
     unproven = []
     for g in sorted(observed):
-        sep = decls.get(g)
-        if not sep:
+        seps = decls.get(g)
+        if not seps:
             unproven.append({"ids": list(g), "why":
-                             "no `duplicate_groups` entry declares this group. Either one "
+                             "no `duplicate_groups` entry declares this class. Either a "
                              "member is redundant — drop it — or the identity is a control, "
-                             "and then it must name the mutant that separates it."})
+                             "and then it must name the mutant(s) that tell them apart."})
             continue
-        v = scored.get(sep)
-        if v is None:
-            unproven.append({"ids": list(g), "separated_by": sep, "why":
-                             ("the declared separator ran but came back INVALID — it proves "
-                              "nothing, and a separator that stops applying is exactly how "
-                              "this group loses its proof")
-                             if sep in seen_ids else
-                             ("the declared separator was not scored in this pass (absent "
-                              "from the mutant set%s)" %
-                              (", or excluded by GM_MUTANTS" if restricted else ""))})
+        missing = [m for m in seps if m not in scored]
+        if missing:
+            unproven.append({"ids": list(g), "separated_by": list(seps), "why":
+                             "declared separator(s) %s %s" %
+                             (", ".join(sorted(missing)),
+                              "ran but came back INVALID — a separator that stops applying "
+                              "is exactly how this class loses its proof"
+                              if all(m in seen_ids for m in missing) else
+                              ("were not scored in this pass (absent from the mutant set%s)"
+                               % (", or excluded by GM_MUTANTS" if restricted else "")))})
             continue
-        moved = ((set(v.get("targets_declared") or [])
-                  - set(v.get("undetected_targets") or []))
-                 | set(v.get("collateral") or []))
-        inside = moved & set(g)
-        if not inside:
-            unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
-                             "the declared separator moves NO member of the group — it "
-                             "does not separate anything"})
-        elif inside == set(g):
-            unproven.append({"ids": list(g), "separated_by": sep,
-                             "moved": sorted(inside), "why":
-                             "the declared separator moves EVERY member together, so it no "
-                             "longer tells them apart. Draw one that moves a strict subset, "
-                             "or accept that the group is redundant."})
+        # One signature per member: which of the declared separators move it.
+        # Pairwise-distinct signatures IS "the references are distinguishable";
+        # anything less leaves two members that no declared mutant separates.
+        sig = {}
+        for m in g:
+            bits = []
+            for sep in seps:
+                v = scored[sep]
+                moved = ((set(v.get("targets_declared") or [])
+                          - set(v.get("undetected_targets") or []))
+                         | set(v.get("collateral") or []))
+                bits.append(m in moved)
+            sig.setdefault(tuple(bits), []).append(m)
+        collided = sorted(sorted(ms) for ms in sig.values() if len(ms) > 1)
+        if collided:
+            unproven.append({"ids": list(g), "separated_by": list(seps),
+                             "indistinguishable": collided, "why":
+                             "every declared separator treats these members identically, so "
+                             "none of them tells the references apart. Draw one that moves a "
+                             "strict subset, or accept that they are redundant."})
     for g in sorted(set(decls) - observed):
-        unproven.append({"ids": list(g), "separated_by": decls[g], "why":
-                         "declared, but these references are no longer byte-identical — the "
-                         "claim has nothing left to justify. Remove the declaration."})
+        unproven.append({"ids": list(g), "separated_by": list(decls[g]), "why":
+                         "declared, but these references are not a byte-identical class — the "
+                         "claim has nothing left to justify. Remove or re-key the declaration."})
     return unproven
 
 
@@ -5838,7 +5862,17 @@ def _selftest():
                      {"ids": ["019", "012"], "separated_by": ""},
                      "pas-un-dict"]}
     check("une declaration se lit triee, et les malformees sont ignorees",
-          duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+          duplicate_group_decls(corpus_dg), {("012", "013"): ("sep-01",)})
+    # Un separateur ou plusieurs : une classe de quatre demande assez de mutants
+    # pour distinguer les quatre, pas un seul qui coupe quelque part.
+    check("plusieurs separateurs se lisent, dedupliques et ordonnes",
+          duplicate_group_decls({"duplicate_groups": [
+              {"ids": ["a", "b", "c"], "separated_by": ["s2", "s1", "s2"]}]}),
+          {("a", "b", "c"): ("s2", "s1")})
+    check("une liste vide ou non-textuelle est ignoree",
+          duplicate_group_decls({"duplicate_groups": [
+              {"ids": ["a", "b"], "separated_by": []},
+              {"ids": ["c", "d"], "separated_by": [1]}]}), {})
     check("les ids d'un groupe sont epingles pour SON separateur",
           separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
     check("et pour aucun autre",
@@ -5897,6 +5931,69 @@ def _selftest():
         [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
     check("et le motif dit qu'il a tourne, pas qu'il est absent",
           [("INVALID" in x["why"]) for x in _inv], [True])
+
+    # Une CLASSE de quatre, le cas reel du corpus : `sep-04` deplace un membre,
+    # `sep-05` en deplace deux — ensemble ils donnent quatre signatures
+    # distinctes, donc les quatre references sont distinguables.
+    C4 = [{"ids": ["074", "075", "076", "110"],
+           "separated_by": ["sep-04", "sep-05"]}]
+    def _v(mid, moved):
+        return {"id": mid, "valid": True, "targets_declared": sorted(moved),
+                "undetected_targets": [], "collateral": []}
+    # Et le resultat est celui du corpus REEL, pas celui qu'on esperait :
+    # `sep-04` isole 074, `sep-05` deplace 076 ET 110 ensemble — donc ces deux-la
+    # partagent leur signature et rien ne les separe. Deux separateurs ne
+    # suffisent pas a distinguer quatre references ; le banc l'a appris du
+    # produit apres avoir affirme le contraire.
+    check("deux separateurs ne distinguent pas quatre membres",
+          [x.get("indistinguishable") for x in unproven_duplicate_groups(
+              [["074", "075", "076", "110"]],
+              {"entries": [], "duplicate_groups": C4},
+              [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"})])],
+          [[["076", "110"]]])
+    # Avec un troisieme qui ne bouge que 110, les quatre signatures deviennent
+    # distinctes et la classe est acquittee.
+    check("un separateur de plus les distingue toutes : acquittee",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["074", "075", "076", "110"]],
+              {"entries": [], "duplicate_groups": [
+                  {"ids": ["074", "075", "076", "110"],
+                   "separated_by": ["sep-04", "sep-05", "sep-06"]}]},
+              [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"}),
+               _v("sep-06", {"110"})])],
+          [])
+    # 076 et 110 partagent la meme signature : deux membres que rien ne separe.
+    check("deux membres de meme signature : la classe n'est PAS acquittee",
+          [x.get("indistinguishable") for x in unproven_duplicate_groups(
+              [["074", "075", "076", "110"]],
+              {"entries": [], "duplicate_groups": [
+                  {"ids": ["074", "075", "076", "110"], "separated_by": ["sep-04"]}]},
+              [_v("sep-04", {"074"})])],
+          [[["075", "076", "110"]]])
+    # Et une declaration en PAIRES sur une classe de trois ne la couvre pas :
+    # la cle est la classe maximale, pas un decoupage choisi par le lot.
+    check("des paires ne declarent pas une classe de trois",
+          sorted(x["ids"] for x in unproven_duplicate_groups(
+              [["a", "b", "c"]],
+              {"entries": [], "duplicate_groups": [
+                  {"ids": ["a", "b"], "separated_by": "s1"},
+                  {"ids": ["b", "c"], "separated_by": "s1"}]},
+              [_v("s1", {"a"})])),
+          [["a", "b"], ["a", "b", "c"], ["b", "c"]])
+
+    # Le CONTRAT que le site d'appel doit honorer : un separateur fourni parmi
+    # les verdicts du jeu tenu a l'ecart est reconnu comme les autres. La
+    # fonction est agnostique — c'est l'appelant qui doit composer les deux
+    # listes, et CE cablage-la n'est pas couvert par ce banc (le rejouer
+    # demanderait une porte complete). La limite est ecrite plutot que masquee.
+    check("un separateur venu du jeu tenu a l'ecart est reconnu",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]],
+              {"entries": [], "duplicate_groups": [
+                  {"ids": ["012", "013"], "separated_by": "held-sep"}]},
+              [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
+                "undetected_targets": [], "collateral": []}])],
+          [])
 
     D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
     check("separateur qui deplace UN membre : preuve acquittee",
@@ -6728,8 +6825,13 @@ def main():
         # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
         # separator to a lot's re-anchoring — the mutant now moves both members,
         # and the pair proves nothing at all.
+        # verdicts + held. A declared separator may live in the held-out set —
+        # score_mutant pins its group unconditionally, so the deciding
+        # measurement really IS taken — but it lands in `held`, not `verdicts`.
+        # Passing only the latter made the gate report a separator it had just
+        # scored as never scored, and refuse the group on its own blind spot.
         unproven = unproven_duplicate_groups(
-            report["duplicate_refs"], corpus, verdicts, bool(only))
+            report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
         report["duplicate_groups_unproven"] = unproven
         if unproven:
             # The headline counts what the payload lists. Interpolating the

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1596,11 +1596,38 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                 "not crashed")
             head_c = base_c = None
         if head_c is not None and base_c is not None:
-            if {k: v for k, v in head_c.items() if k != "entries"} != \
-                    {k: v for k, v in base_c.items() if k != "entries"}:
+            # `duplicate_groups` is the ONE key outside `entries` an extension
+            # may write, and the reason is not convenience: every other key here
+            # is frozen because it is TRUSTED, while this one is VERIFIED. A
+            # group declaration is discharged at the gate by a mutant that must
+            # really move part of the group and leave the rest still, so a lot
+            # gains nothing by writing one — a bogus separator refuses, and
+            # deleting a declaration turns its group back into an undeclared
+            # duplicate, which also refuses.
+            #
+            # Without this the gate named a remedy another judge forbade: the
+            # lot that ADDS an entry is the very lot that can create a new
+            # byte-identical pair, and it would have been told to declare a
+            # separator in a key it is refused permission to touch.
+            FREE_KEYS = {"entries", "duplicate_groups"}
+            if {k: v for k, v in head_c.items() if k not in FREE_KEYS} != \
+                    {k: v for k, v in base_c.items() if k not in FREE_KEYS}:
                 corpus_problems.append(
                     "corpus.json keys outside `entries` changed — an "
                     "extension adds entries and touches nothing else")
+            # Structure is judged HERE, truth at the gate. A malformed
+            # declaration would otherwise be dropped in silence by
+            # duplicate_group_decls and read as "no declaration at all".
+            for g in (head_c.get("duplicate_groups") or []):
+                if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
+                        or len(g.get("ids") or []) < 2 \
+                        or not isinstance(g.get("separated_by"), str) \
+                        or not g.get("separated_by"):
+                    corpus_problems.append(
+                        "a `duplicate_groups` entry is malformed (%r) — it needs "
+                        "at least two `ids` and a non-empty `separated_by`, or it "
+                        "is dropped in silence and reads as no declaration at all"
+                        % (g,))
             # An id names ONE observation. Duplicated ids collapse in every
             # by-id index (this one, the capture map, the refs map), so the
             # equality check would read the surviving twin while the capture
@@ -3261,7 +3288,14 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     """
     decls = duplicate_group_decls(corpus)
     observed = {tuple(sorted(g)) for g in duplicate_refs}
-    scored = {v.get("id"): v for v in verdicts if v.get("id")}
+    # VALID only. A failed or inert verdict carries `targets_declared` but
+    # never `undetected_targets` nor `collateral` — score_mutant returns before
+    # they are set — so crediting it would read "moved every declared target"
+    # from a measurement that never ran. And that is exactly how a separator
+    # dies when a lot re-anchors it: its apply.sh stops working. The group would
+    # have been reported PROVED by the failure it exists to catch.
+    scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
+    seen_ids = {v.get("id") for v in verdicts if v.get("id")}
     unproven = []
     for g in sorted(observed):
         sep = decls.get(g)
@@ -3274,9 +3308,13 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
         v = scored.get(sep)
         if v is None:
             unproven.append({"ids": list(g), "separated_by": sep, "why":
-                             "the declared separator was not scored in this pass (absent "
-                             "from the mutant set%s)" %
-                             (", or excluded by GM_MUTANTS" if restricted else "")})
+                             ("the declared separator ran but came back INVALID — it proves "
+                              "nothing, and a separator that stops applying is exactly how "
+                              "this group loses its proof")
+                             if sep in seen_ids else
+                             ("the declared separator was not scored in this pass (absent "
+                              "from the mutant set%s)" %
+                              (", or excluded by GM_MUTANTS" if restricted else ""))})
             continue
         moved = ((set(v.get("targets_declared") or [])
                   - set(v.get("undetected_targets") or []))
@@ -4869,6 +4907,49 @@ def _selftest():
         check("ref ajoutee non declaree par la demande -> refusee",
               xverdict(xbase)["acted"][0]["ok"], False)
 
+        # LE CANAL DE DECLARATION : le lot qui AJOUTE une entree est celui qui
+        # peut creer une nouvelle paire byte-identique, donc celui a qui la
+        # porte demande de declarer son separateur. Si le juge d'extension gelait
+        # cette cle, la porte nommerait un remede qu'un autre juge refuse — le
+        # defaut que le canal existe pour supprimer, simplement deplace.
+        xreset()
+        dup_entry = dict(base_entry, id="7", path="/dup")
+        xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                ("act", '{"id": "E-D", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, dup_entry],
+                       "duplicate_groups": [{"ids": ["1", "7"],
+                                             "separated_by": "sep-x"}]}, f)
+        xcommit()
+        _vd = xverdict(xbase)["acted"][0]
+        check("declarer un groupe de doublons n'est PAS un gel viole",
+              [pb for pb in _vd["problems"] if "keys outside" in pb], [])
+        # Et le gel tient pour tout le reste : une cle voisine refuse toujours.
+        xreset()
+        xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                ("act", '{"id": "E-D", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, dup_entry], "baseline": "reecrite"}, f)
+        xcommit()
+        check("mais toute AUTRE cle hors `entries` reste gelee",
+              any("keys outside" in pb
+                  for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+        # Une declaration malformee est refusee ICI plutot que jetee en silence
+        # par le lecteur, ou elle se lirait comme « aucune declaration ».
+        xreset()
+        xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                ("act", '{"id": "E-D", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, dup_entry],
+                       "duplicate_groups": [{"ids": ["1"], "separated_by": ""}]}, f)
+        xcommit()
+        check("une declaration malformee est refusee, pas ignoree",
+              any("malformed" in pb
+                  for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+
         # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
         xreset()
         xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "1"}]}'),
@@ -5774,7 +5855,7 @@ def _selftest():
     # rougit avec lui.
     def whys(group, decls, moved_by):
         corpus_ = {"entries": [], "duplicate_groups": decls}
-        verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+        verdicts_ = [{"id": mid, "valid": True, "targets_declared": sorted(mv),
                       "undetected_targets": [], "collateral": []}
                      for mid, mv in moved_by.items()]
         out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
@@ -5793,6 +5874,29 @@ def _selftest():
                     dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
     check("aucun epinglage pour un mutant qui ne separe rien",
           v_nopin["collateral"], [])
+
+    # Un separateur INVALIDE ne prouve rien. Son verdict porte
+    # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc
+    # le crediter revient a lire « toutes les cibles ont bouge » d'une mesure
+    # qui n'a pas eu lieu — et c'est precisement ainsi qu'un separateur meurt.
+    check("un separateur INVALIDE ne prouve pas le groupe",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]],
+              {"entries": [], "duplicate_groups": [
+                  {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+              [{"id": "sep-01", "valid": False,
+                "targets_declared": ["013"], "reason": "apply.sh a echoue"}])],
+          [["012", "013"]])
+    # Le motif, lu sans indexer a l'aveugle : si le groupe repassait "prouve",
+    # un `[0]` planterait au lieu de RAPPORTER, et un banc qui plante dit qu'il
+    # s'est passe quelque chose sans dire quoi.
+    _inv = unproven_duplicate_groups(
+        [["012", "013"]],
+        {"entries": [], "duplicate_groups": [
+            {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+        [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
+    check("et le motif dit qu'il a tourne, pas qu'il est absent",
+          [("INVALID" in x["why"]) for x in _inv], [True])
 
     D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
     check("separateur qui deplace UN membre : preuve acquittee",
@@ -5814,7 +5918,7 @@ def _selftest():
           [x["ids"] for x in unproven_duplicate_groups(
               [["012", "013"]],
               {"entries": [], "duplicate_groups": D},
-              [{"id": "sep-01", "targets_declared": ["013"],
+              [{"id": "sep-01", "valid": True, "targets_declared": ["013"],
                 "undetected_targets": [], "collateral": ["012"]}])],
           [["012", "013"]])
     # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
@@ -5822,7 +5926,7 @@ def _selftest():
           [x["ids"] for x in unproven_duplicate_groups(
               [["012", "013"]],
               {"entries": [], "duplicate_groups": D},
-              [{"id": "sep-01", "targets_declared": ["012", "013"],
+              [{"id": "sep-01", "valid": True, "targets_declared": ["012", "013"],
                 "undetected_targets": ["012", "013"], "collateral": []}])],
           [["012", "013"]])
 
@@ -6628,14 +6732,21 @@ def main():
             report["duplicate_refs"], corpus, verdicts, bool(only))
         report["duplicate_groups_unproven"] = unproven
         if unproven:
-            problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                            "so the corpus is %d observations wide, not %d — and their identity "
-                            "is NOT proved. A group may legitimately repeat (a refusal lane's "
-                            "second entry is a control), but the claim is discharged by a mutant "
-                            "that moves part of the group and leaves the rest still, declared in "
-                            "`duplicate_groups` and checked here. Unproved: %s"
-                            % (len(report["duplicate_refs"]), report["corpus_distinct"],
-                               report["corpus_total"],
+            # The headline counts what the payload lists. Interpolating the
+            # OBSERVED total while listing only the unproved ones told the
+            # operator "5 groups are not proved" beside a list of one — and the
+            # two do not even range over the same set: a stale declaration is
+            # unproved while its references are, by definition, no longer
+            # identical. On a gate whose whole point is precise adjudication,
+            # that gap is the defect.
+            problems.append("%d reference group(s) are not proved (out of %d byte-identical "
+                            "across DIFFERENT entries; the corpus is %d observations wide, "
+                            "not %d). A group may legitimately repeat — a refusal lane's "
+                            "second entry is a control — but the claim is discharged by a "
+                            "mutant that moves part of the group and leaves the rest still, "
+                            "declared in `duplicate_groups` and checked here: %s"
+                            % (len(unproven), len(report["duplicate_refs"]),
+                               report["corpus_distinct"], report["corpus_total"],
                                json.dumps(unproven, ensure_ascii=False)))
         if mode == "selfcheck":
             note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3213,6 +3213,92 @@ def diverged(refs, captured, ids):
     return sorted(i for i in ids if refs.get(i) != captured.get(i))
 
 
+def duplicate_group_decls(corpus):
+    """The corpus's `duplicate_groups` declarations, normalised.
+
+    Two entries whose references are byte-identical are not automatically a
+    defect: on a refusal lane the second is a CONTROL proving a mutant moved
+    only the first. But a note saying so is prose, and the gate cannot read
+    prose — so the claim is declared as data and DISCHARGED by measurement:
+    each group names the mutant that separates it, and the gate checks that the
+    mutant really moves some members and leaves the others still.
+
+    That is the difference between a waiver and a proof obligation. A waiver is
+    believed; this is executed, and it goes red by itself the day its separator
+    dies — which is exactly what happened to two of these groups when a lot
+    re-anchored their mutant, silently, while the notes still claimed the pair
+    was controlled.
+    """
+    out = {}
+    for g in (corpus.get("duplicate_groups") or []):
+        if not isinstance(g, dict):
+            continue
+        ids = g.get("ids")
+        sep = g.get("separated_by")
+        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+            continue
+        out[tuple(sorted(str(i) for i in ids))] = sep
+    return out
+
+
+def separator_group_ids(corpus, mutant_id):
+    """Every id of every group this mutant is declared to separate."""
+    if not mutant_id:
+        return set()
+    ids = set()
+    for group, sep in duplicate_group_decls(corpus).items():
+        if sep == mutant_id:
+            ids.update(group)
+    return ids
+
+
+def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+    """Which byte-identical groups are NOT discharged by a measured separator.
+
+    Returns one record per group that fails, with the reason IN the record —
+    the gate turns them into its refusal, and the selftest calls this same
+    function, so what is tested is what runs.
+    """
+    decls = duplicate_group_decls(corpus)
+    observed = {tuple(sorted(g)) for g in duplicate_refs}
+    scored = {v.get("id"): v for v in verdicts if v.get("id")}
+    unproven = []
+    for g in sorted(observed):
+        sep = decls.get(g)
+        if not sep:
+            unproven.append({"ids": list(g), "why":
+                             "no `duplicate_groups` entry declares this group. Either one "
+                             "member is redundant — drop it — or the identity is a control, "
+                             "and then it must name the mutant that separates it."})
+            continue
+        v = scored.get(sep)
+        if v is None:
+            unproven.append({"ids": list(g), "separated_by": sep, "why":
+                             "the declared separator was not scored in this pass (absent "
+                             "from the mutant set%s)" %
+                             (", or excluded by GM_MUTANTS" if restricted else "")})
+            continue
+        moved = ((set(v.get("targets_declared") or [])
+                  - set(v.get("undetected_targets") or []))
+                 | set(v.get("collateral") or []))
+        inside = moved & set(g)
+        if not inside:
+            unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
+                             "the declared separator moves NO member of the group — it "
+                             "does not separate anything"})
+        elif inside == set(g):
+            unproven.append({"ids": list(g), "separated_by": sep,
+                             "moved": sorted(inside), "why":
+                             "the declared separator moves EVERY member together, so it no "
+                             "longer tells them apart. Draw one that moves a strict subset, "
+                             "or accept that the group is redundant."})
+    for g in sorted(set(decls) - observed):
+        unproven.append({"ids": list(g), "separated_by": decls[g], "why":
+                         "declared, but these references are no longer byte-identical — the "
+                         "claim has nothing left to justify. Remove the declaration."})
+    return unproven
+
+
 def control_ids(corpus, targets, seed):
     """Deterministic sample of non-target entries, to measure collateral."""
     pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -3321,7 +3407,15 @@ def score_mutant(meta, config, corpus, canon, refs, ws, seed):
     if meta.get("needs_restart", True):
         app_restart(config, ws)
 
+    # An entry named in a duplicate-group declaration is ALWAYS controlled when
+    # the mutant that claims to separate it runs. The sample is otherwise a
+    # deterministic slice of the corpus, and a member that fell outside it could
+    # move unseen — which is precisely the claim the declaration makes, so the
+    # one measurement that decides it must not be left to the sampling stride.
     sample = control_ids(corpus, set(targets), seed)
+    pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+    if pinned:
+        sample = sorted(set(sample) | pinned)
     captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
     moved = diverged(refs, captured, targets)
     verdict["detected"] = bool(moved)
@@ -3693,10 +3787,12 @@ def _selftest():
                 (i in self.moved) if self.applied else (i in self.unstable)) else "")
                 for i in ids}
 
-    def score(targets, sample, moved, unstable=(), revert_code=0):
+    def score(targets, sample, moved, unstable=(), revert_code=0, dup_groups=None):
         ids = ["%03d" % n for n in range(1, 13)]
         refs = {i: "ref-" + i for i in ids}
         corpus = {"entries": [{"id": i, "surface": "http"} for i in ids]}
+        if dup_groups:
+            corpus["duplicate_groups"] = dup_groups
         meta = {"id": "t", "dir": "/dev/null", "class": "code", "surface": "http",
                 "archetype": "value_change", "targets": list(targets), "needs_restart": False}
         w = World(refs, moved, unstable)
@@ -5647,6 +5743,89 @@ def _selftest():
     check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
     check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
+    # ─── Groupes de references identiques : la preuve, pas la parole ──────────
+    #
+    # Deux entrees byte-identiques ne sont pas fautives en soi : sur une lane de
+    # refus, la seconde est un CONTROLE qui prouve qu'un mutant n'a deplace que
+    # la premiere. Ce que la porte ne pouvait pas faire, c'est distinguer ce cas
+    # d'un doublon — une note en prose ne se verifie pas. La declaration nomme
+    # le mutant separateur, et elle est ACQUITTEE par la mesure.
+    corpus_dg = {"entries": [{"id": "012"}, {"id": "013"}, {"id": "019"}],
+                 "duplicate_groups": [
+                     {"ids": ["013", "012"], "separated_by": "sep-01"},
+                     {"ids": ["019"], "separated_by": "trop-court"},
+                     {"ids": ["019", "012"], "separated_by": ""},
+                     "pas-un-dict"]}
+    check("une declaration se lit triee, et les malformees sont ignorees",
+          duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+    check("les ids d'un groupe sont epingles pour SON separateur",
+          separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
+    check("et pour aucun autre",
+          separator_group_ids(corpus_dg, "sep-02"), set())
+    check("un mutant sans id n'epingle rien",
+          separator_group_ids(corpus_dg, None), set())
+
+    # Le verdict lui-meme : ce que la porte conclut de ce qu'un separateur a
+    # REELLEMENT deplace. La forme qui compte est la derniere — un separateur
+    # qui deplace TOUT le groupe ne le separe plus, et c'est exactement ce qui
+    # est arrive a deux paires quand un lot a reancre leur mutant.
+    # Appelle la FONCTION QUE LA PORTE APPELLE — pas une reimplementation.
+    # Un banc qui rejoue la logique reste vert quand le produit derive ; celui-ci
+    # rougit avec lui.
+    def whys(group, decls, moved_by):
+        corpus_ = {"entries": [], "duplicate_groups": decls}
+        verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+                      "undetected_targets": [], "collateral": []}
+                     for mid, mv in moved_by.items()]
+        out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
+        return [x["ids"] for x in out]
+
+    # L'EPINGLAGE, et c'est la moitie porteuse : sans lui la mesure qui decide
+    # n'existe pas. Un membre du groupe hors de l'echantillon deterministe
+    # pourrait bouger sans etre vu, et la porte conclurait "sous-ensemble strict,
+    # groupe prouve" sur une separation qui n'a plus lieu.
+    v_pin = score(["001"], ["005"], ["001", "009"],
+                  dup_groups=[{"ids": ["001", "009"], "separated_by": "t"}])
+    check("un membre du groupe hors echantillon est quand meme controle",
+          v_pin["collateral"], ["009"])
+    # Et rien n'est epingle pour un mutant qui ne separe aucun groupe.
+    v_nopin = score(["001"], ["005"], ["001", "009"],
+                    dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
+    check("aucun epinglage pour un mutant qui ne separe rien",
+          v_nopin["collateral"], [])
+
+    D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
+    check("separateur qui deplace UN membre : preuve acquittee",
+          whys(["012", "013"], D, {"sep-01": {"013"}}), [])
+    check("separateur qui deplace TOUT le groupe : refuse",
+          whys(["012", "013"], D, {"sep-01": {"012", "013"}}), [["012", "013"]])
+    check("separateur qui ne deplace AUCUN membre : refuse",
+          whys(["012", "013"], D, {"sep-01": {"099"}}), [["012", "013"]])
+    check("separateur absent du jeu score : refuse",
+          whys(["012", "013"], D, {"autre": {"013"}}), [["012", "013"]])
+    check("groupe observe mais non declare : refuse",
+          whys(["012", "013"], [], {}), [["012", "013"]])
+    check("declaration devenue caduque : refuse",
+          whys(["012", "013"], D + [{"ids": ["019", "077"], "separated_by": "sep-02"}],
+               {"sep-01": {"013"}}), [["019", "077"]])
+    # Le collateral compte comme un deplacement : un membre que le separateur ne
+    # DECLARE pas mais deplace quand meme casse la separation aussi surement.
+    check("un membre deplace en collateral casse la separation",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]],
+              {"entries": [], "duplicate_groups": D},
+              [{"id": "sep-01", "targets_declared": ["013"],
+                "undetected_targets": [], "collateral": ["012"]}])],
+          [["012", "013"]])
+    # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
+    check("une cible declaree mais immobile ne prouve rien",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]],
+              {"entries": [], "duplicate_groups": D},
+              [{"id": "sep-01", "targets_declared": ["012", "013"],
+                "undetected_targets": ["012", "013"], "collateral": []}])],
+          [["012", "013"]])
+
     if failures:
         log("harnais : %d test(s) ECHOUENT" % len(failures))
         for f in failures:
@@ -5799,6 +5978,7 @@ def main():
               "holdout_detected": 0, "holdout_total": 0, "stable": False,
               "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
               "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
+              "duplicate_groups_unproven": [],
               "runner_replayable": False,
               "holdout_reused": [],
               "log_tail": ""}
@@ -6430,18 +6610,33 @@ def main():
         if report["score_pct"] < floor:
             problems.append("mutation score %d%% is under the %d%% floor"
                             % (report["score_pct"], floor))
-        if report["duplicate_refs"]:
+        # Byte-identical references are not automatically a defect — on a
+        # refusal lane the second entry is a CONTROL proving a mutant moved only
+        # the first. What was missing is the difference between that and a
+        # redundant pair, and it cannot be settled by a note: the gate reads
+        # data, not prose. So the corpus DECLARES the separating mutant per
+        # group, and the declaration is discharged by MEASUREMENT — the mutant
+        # must move some members and leave the others still, with every member
+        # pinned into its control sample so the answer exists.
+        #
+        # A proof obligation, not a waiver. It goes red by itself the day the
+        # separator dies, which is what a waiver could never do: measured 08/09,
+        # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
+        # separator to a lot's re-anchoring — the mutant now moves both members,
+        # and the pair proves nothing at all.
+        unproven = unproven_duplicate_groups(
+            report["duplicate_refs"], corpus, verdicts, bool(only))
+        report["duplicate_groups_unproven"] = unproven
+        if unproven:
             problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                            "so the corpus is %d observations wide, not %d. This is NOT always a "
-                            "defect: on a refusal lane two entries legitimately capture the same "
-                            "302, and the second is a control proving a mutant moved only the "
-                            "first. It IS a defect when the endpoints were meant to differ — then "
-                            "either one is redundant, or they differ on a path this fixture does "
-                            "not exercise and the difference is captured NOWHERE. Decide which, "
-                            "per group: %s"
+                            "so the corpus is %d observations wide, not %d — and their identity "
+                            "is NOT proved. A group may legitimately repeat (a refusal lane's "
+                            "second entry is a control), but the claim is discharged by a mutant "
+                            "that moves part of the group and leaves the rest still, declared in "
+                            "`duplicate_groups` and checked here. Unproved: %s"
                             % (len(report["duplicate_refs"]), report["corpus_distinct"],
                                report["corpus_total"],
-                               json.dumps(report["duplicate_refs"], ensure_ascii=False)))
+                               json.dumps(unproven, ensure_ascii=False)))
         if mode == "selfcheck":
             note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                          "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3540,6 +3540,38 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     return unproven
 
 
+def duplicate_groups_refusal(unproven, duplicate_refs, corpus_distinct, corpus_total):
+    """The gate's refusal, phrased over the TWO populations it actually has.
+
+    An OBSERVED byte-identical class that is not discharged is "N of M"; a STALE
+    declaration is unproved precisely BECAUSE its references are no longer
+    identical, so it is not one of the M and can never be. Counted into one
+    ratio the line read "4 reference group(s) are not proved (out of 1
+    byte-identical …)", which is arithmetic nobody can act on — on a gate whose
+    whole point is precise adjudication, a headline that cannot be read is
+    itself the defect.
+
+    Named rather than inline in main() so the self-test drives THIS text and not
+    a re-implementation of it.
+    """
+    observed = {tuple(sorted(g)) for g in duplicate_refs}
+    stale = [u for u in unproven if tuple(sorted(u["ids"])) not in observed]
+    head = []
+    if len(unproven) - len(stale):
+        head.append("%d of %d byte-identical reference group(s) across DIFFERENT entries "
+                    "are not proved (the corpus is %d observations wide, not %d)"
+                    % (len(unproven) - len(stale), len(duplicate_refs),
+                       corpus_distinct, corpus_total))
+    if stale:
+        head.append("%d `duplicate_groups` declaration(s) no longer describe a "
+                    "byte-identical class, so the claim has nothing left to justify"
+                    % len(stale))
+    return ("%s. A group may legitimately repeat — a refusal lane's second entry is a "
+            "control — but the claim is discharged by a mutant that moves part of the "
+            "group and leaves the rest still, declared in `duplicate_groups` and checked "
+            "here: %s" % ("; ".join(head), json.dumps(unproven, ensure_ascii=False)))
+
+
 def control_ids(corpus, targets, seed):
     """Deterministic sample of non-target entries, to measure collateral."""
     pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -6338,6 +6370,27 @@ def _selftest():
               [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
               False, [], ["held-sep"])], [True])
 
+    # LE TITRE, et il porte sur DEUX populations. Une classe OBSERVEE non
+    # acquittee se compte « N sur M » ; une declaration CADUQUE est non prouvee
+    # justement parce que ses references ne sont plus identiques, donc elle
+    # n'est pas l'un des M et ne peut pas l'etre. Comptees dans un seul rapport,
+    # la ligne annoncait « 4 reference group(s) are not proved (out of 1
+    # byte-identical …) » — une arithmetique sur laquelle personne n'agit.
+    _mixed = [{"ids": ["012", "013"], "why": "x"},
+              {"ids": ["019", "077"], "why": "caduque"},
+              {"ids": ["080", "081"], "why": "caduque aussi"}]
+    _head = duplicate_groups_refusal(_mixed, [["012", "013"]], 11, 14)
+    check("le titre separe les classes observees des declarations caduques",
+          [("1 of 1 byte-identical" in _head),
+           ("2 `duplicate_groups` declaration(s) no longer describe" in _head)],
+          [True, True])
+    check("et une seule population ne fait pas parler de l'autre",
+          [("no longer describe" in duplicate_groups_refusal(
+              [{"ids": ["012", "013"], "why": "x"}], [["012", "013"]], 11, 14)),
+           ("byte-identical reference group(s)" in duplicate_groups_refusal(
+               [{"ids": ["019", "077"], "why": "caduque"}], [], 14, 14))],
+          [False, False])
+
     D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
     check("separateur qui deplace UN membre : preuve acquittee",
           whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -7187,22 +7240,9 @@ def main():
             problems.append(shape)
         report["duplicate_groups_unproven"] = unproven
         if unproven:
-            # The headline counts what the payload lists. Interpolating the
-            # OBSERVED total while listing only the unproved ones told the
-            # operator "5 groups are not proved" beside a list of one — and the
-            # two do not even range over the same set: a stale declaration is
-            # unproved while its references are, by definition, no longer
-            # identical. On a gate whose whole point is precise adjudication,
-            # that gap is the defect.
-            problems.append("%d reference group(s) are not proved (out of %d byte-identical "
-                            "across DIFFERENT entries; the corpus is %d observations wide, "
-                            "not %d). A group may legitimately repeat — a refusal lane's "
-                            "second entry is a control — but the claim is discharged by a "
-                            "mutant that moves part of the group and leaves the rest still, "
-                            "declared in `duplicate_groups` and checked here: %s"
-                            % (len(unproven), len(report["duplicate_refs"]),
-                               report["corpus_distinct"], report["corpus_total"],
-                               json.dumps(unproven, ensure_ascii=False)))
+            problems.append(duplicate_groups_refusal(
+                unproven, report["duplicate_refs"],
+                report["corpus_distinct"], report["corpus_total"]))
         if mode == "selfcheck":
             note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                          "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -7313,11 +7313,16 @@ def main():
         # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
         # separator to a lot's re-anchoring — the mutant now moves both members,
         # and the pair proves nothing at all.
+        #
         # verdicts + held. A declared separator may live in the held-out set —
-        # score_mutant pins its group unconditionally, so the deciding
-        # measurement really IS taken — but it lands in `held`, not `verdicts`.
-        # Passing only the latter made the gate report a separator it had just
-        # scored as never scored, and refuse the group on its own blind spot.
+        # score_mutant pins its group into the control sample there too, so the
+        # deciding measurement really IS taken — but it lands in `held`, not
+        # `verdicts`. Passing only the latter made the gate report a separator it
+        # had just scored as never scored, and refuse the group on its own blind
+        # spot. What that held measurement finds reaches the gate's own hygiene
+        # terms through `measurement_hygiene`, so a class cannot be discharged
+        # through a channel the gate is forbidden to look at.
+        #
         # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
         # `held` est vide par construction, et un separateur qui en vient n'est
         # pas absent, il est retenu.
@@ -7331,8 +7336,7 @@ def main():
         unproven = unproven_duplicate_groups(
             report["duplicate_refs"], corpus, list(verdicts) + list(held),
             bool(only), withheld_ids, in_the_set)
-        for shape in duplicate_groups_shape_problems(corpus):
-            problems.append(shape)
+        problems.extend(duplicate_groups_shape_problems(corpus))
         report["duplicate_groups_unproven"] = unproven
         if unproven:
             problems.append(duplicate_groups_refusal(

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1678,6 +1678,48 @@ def extension_verdict(ws, gm_rel, base, acted_commits=None, acted_blobs=None,
                         "added entry id %r derives a reference path outside "
                         "refs/ — a write to an existing reference wearing an "
                         "addition's name" % (aid,))
+            # ADDITIONS-ONLY APPLIES INSIDE THE FREED KEY TOO.
+            #
+            # `duplicate_groups` was freed from the freeze because the lot that
+            # ADDS an entry is the one that can create a new byte-identical
+            # class, and telling it to declare a separator in a key another
+            # judge refuses it is a remedy nobody can apply. That argument frees
+            # ADDING a declaration — and adding is the half that is VERIFIED: a
+            # bogus separator is refused at the gate by measurement.
+            #
+            # Rewriting or deleting one is verified by nothing. Swapping a
+            # still-valid separator for another still-valid separator silently
+            # reassigns a class this lot never touched, and a deletion only
+            # re-opens the undeclared-duplicate refusal for whoever comes next.
+            # Exempting the whole key turned "an extension adds entries and
+            # touches nothing else" into a sentence with an exception nobody
+            # bounded.
+            base_decls = duplicate_group_decls(base_c)
+            head_decls = duplicate_group_decls(head_c)
+            added_str = {str(a) for a in added_ids}
+            for key, seps in sorted(base_decls.items()):
+                if key in head_decls:
+                    if set(head_decls[key]) != set(seps):
+                        corpus_problems.append(
+                            "`duplicate_groups` for class %s was RE-ADJUDICATED "
+                            "(%s -> %s) — an extension may declare a class it "
+                            "creates, never re-decide one it did not"
+                            % (json.dumps(list(key)), json.dumps(list(seps)),
+                               json.dumps(list(head_decls[key]))))
+                    continue
+                # A pre-existing class may only disappear into a SUPERSET that
+                # an added entry joined: a new entry landing on an existing
+                # byte-identical class re-keys it, and may need more separators
+                # to keep the members pairwise distinguishable. That is the
+                # legitimate case the exemption exists for; everything else is
+                # a withdrawal.
+                if not any(set(k) > set(key) and (set(k) - set(key)) & added_str
+                           for k in head_decls):
+                    corpus_problems.append(
+                        "`duplicate_groups` for class %s was WITHDRAWN — a "
+                        "deletion re-opens the undeclared-duplicate refusal for "
+                        "whoever comes next, and it is not this lot's "
+                        "adjudication to withdraw" % json.dumps(list(key)))
             claimed = set()
             for act in acts:
                 req = requests.get(act.get("id"))
@@ -5214,6 +5256,59 @@ def _selftest():
         check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
               [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
               ["", True])
+
+        # LE CANAL N'EST PAS UN DROIT DE REVISION. La cle est liberee du gel
+        # parce que le lot qui AJOUTE une entree est celui qui peut creer une
+        # nouvelle classe byte-identique. AJOUTER une declaration est verifie —
+        # un separateur bidon est refuse a la porte par la mesure. La REECRIRE
+        # ou la SUPPRIMER n'est verifie par rien : echanger un separateur
+        # valide contre un autre separateur valide rejuge en silence la classe
+        # d'un autre lot, et une suppression rouvre le refus « doublon non
+        # declare » pour le suivant.
+        xreset()
+        dg_a, dg_b = dict(base_entry, id="20"), dict(base_entry, id="21")
+        dg_c = dict(base_entry, id="22")
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, dg_a, dg_b],
+                       "duplicate_groups": [{"ids": ["20", "21"],
+                                             "separated_by": "sep-old"}]}, f)
+        xcommit()
+        xbase_dg = fixture_git(xroot, "rev-parse", "HEAD")
+
+        def xdg(groups):
+            """Un lot qui ajoute l'entree 22, sur une base qui PORTE deja une
+            declaration — et qui touche `duplicate_groups` comme indique."""
+            fixture_git(xroot, "reset", "-q", "--hard", xbase_dg)
+            fixture_git(xroot, "clean", "-qfd")
+            xledger(("request",
+                     '{"id": "E-G", "lot": "L", "corpus_entries": [{"id": "22"}]}'),
+                    ("act", '{"id": "E-G", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dg_a, dg_b, dg_c],
+                           "duplicate_groups": groups}, f)
+            xcommit()
+            return xverdict(xbase_dg)["acted"][0]["problems"]
+
+        check("echanger un separateur valide contre un autre : REFUSE",
+              any("RE-ADJUDICATED" in pb
+                  for pb in xdg([{"ids": ["20", "21"],
+                                  "separated_by": "sep-new"}])), True)
+        check("supprimer la declaration d'un autre lot : REFUSE",
+              any("WITHDRAWN" in pb for pb in xdg([])), True)
+        # Le cas legitime que l'exemption existe pour servir : l'entree ajoutee
+        # REJOINT la classe, qui se recle en sur-ensemble et peut demander un
+        # separateur de plus pour garder les membres distinguables deux a deux.
+        check("une entree ajoutee qui rejoint la classe la recle sans refus",
+              [pb for pb in xdg([{"ids": ["20", "21", "22"],
+                                  "separated_by": ["sep-old", "sep-2"]}])
+               if "duplicate_groups" in pb], [])
+        # Et DECLARER reste libre : ajouter une classe neuve ne touche a
+        # l'adjudication de personne.
+        check("declarer une classe neuve reste libre",
+              [pb for pb in xdg([{"ids": ["20", "21"], "separated_by": "sep-old"},
+                                 {"ids": ["1", "22"], "separated_by": "sep-3"}])
+               if "duplicate_groups" in pb], [])
 
         # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
         xreset()

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3259,7 +3259,15 @@ def duplicate_group_decls(corpus):
     was controlled.
     """
     out = {}
-    for g in (corpus.get("duplicate_groups") or []):
+    # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
+    # que le mutant est applique et AVANT le revert : une exception y tue le
+    # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
+    # fichier est explicite une vis plus haut — « refused, not crashed ». Le
+    # refus, lui, est prononce par duplicate_groups_shape_problems.
+    raw = corpus.get("duplicate_groups") or []
+    if not isinstance(raw, list):
+        return out
+    for g in raw:
         if not isinstance(g, dict):
             continue
         ids = g.get("ids")
@@ -3276,6 +3284,40 @@ def duplicate_group_decls(corpus):
     return out
 
 
+def duplicate_groups_shape_problems(corpus):
+    """Ce que le LECTEUR laisse tomber en silence, dit a voix haute.
+
+    duplicate_group_decls ignore ce qu'il ne sait pas lire — il le doit, il
+    tourne avec un mutant applique. Mais une declaration ignoree se lit comme
+    « aucune declaration », donc comme un groupe non declare : le message
+    envoie corriger une absence alors que le defaut est une faute de frappe.
+    """
+    raw = corpus.get("duplicate_groups")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
+                "every declared group then reads as undeclared"
+                % type(raw).__name__]
+    bad = []
+    for g in raw:
+        if not isinstance(g, dict):
+            bad.append(repr(g)[:80])
+            continue
+        sep = g.get("separated_by")
+        seps = [sep] if isinstance(sep, str) else sep
+        if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
+                or not isinstance(seps, list) or not seps \
+                or not all(isinstance(m, str) and m for m in seps):
+            bad.append(repr(g)[:80])
+    if bad:
+        return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
+                "each needs at least two `ids` and a non-empty `separated_by` "
+                "(a string, or a list of them): %s"
+                % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
+    return []
+
+
 def separator_group_ids(corpus, mutant_id):
     """Every id of every group this mutant is declared to separate."""
     if not mutant_id:
@@ -3287,7 +3329,8 @@ def separator_group_ids(corpus, mutant_id):
     return ids
 
 
-def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
+                              withheld=()):
     """Which byte-identical classes are NOT discharged by measured separators.
 
     `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3324,6 +3367,14 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
                              "and then it must name the mutant(s) that tell them apart."})
             continue
         missing = [m for m in seps if m not in scored]
+        # WITHHELD is not MISSING. In selfcheck the held-out set is deliberately
+        # not scored — `held` is empty by construction — so a separator drawn
+        # from it would be reported "absent from the mutant set", which is false
+        # and which the campaign cannot fix: the mutant IS in the set, its
+        # result is simply reserved for the final gate. Saying so is the whole
+        # difference between a work item and a dead end.
+        if missing and all(m in set(withheld) for m in missing):
+            continue
         if missing:
             unproven.append({"ids": list(g), "separated_by": list(seps), "why":
                              "declared separator(s) %s %s" %
@@ -5995,6 +6046,32 @@ def _selftest():
                 "undetected_targets": [], "collateral": []}])],
           [])
 
+    # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
+    # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
+    # sinon une faute de frappe se lit comme « groupe non declare » et envoie
+    # corriger une absence.
+    check("un `duplicate_groups` non-liste ne fait pas planter le lecteur",
+          duplicate_group_decls({"duplicate_groups": 5}), {})
+    check("et il est REFUSE, pas ignore",
+          len(duplicate_groups_shape_problems({"duplicate_groups": 5})), 1)
+    check("une entree malformee est refusee nommement",
+          len(duplicate_groups_shape_problems({"duplicate_groups": [
+              {"ids": ["a"], "separated_by": "s"}]})), 1)
+    check("et un corpus sans declaration ne dit rien",
+          duplicate_groups_shape_problems({"entries": []}), [])
+
+    # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
+    # n'est pas score, donc un separateur qui en vient est retenu, pas manquant
+    # — et le dire autrement produit un refus que la campagne ne peut pas lever.
+    _wd = {"entries": [], "duplicate_groups": [
+        {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+    check("un separateur RETENU ne produit pas de refus",
+          unproven_duplicate_groups([["012", "013"]], _wd, [], False,
+                                    ["held-sep"]), [])
+    check("mais un separateur simplement ABSENT en produit un",
+          [x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+
     D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
     check("separateur qui deplace UN membre : preuve acquittee",
           whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -6830,8 +6907,16 @@ def main():
         # measurement really IS taken — but it lands in `held`, not `verdicts`.
         # Passing only the latter made the gate report a separator it had just
         # scored as never scored, and refuse the group on its own blind spot.
+        # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
+        # `held` est vide par construction, et un separateur qui en vient n'est
+        # pas absent, il est retenu.
+        withheld_ids = ([m.get("id") for m in held_meta]
+                        if (mode == "selfcheck" and not held) else [])
         unproven = unproven_duplicate_groups(
-            report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
+            report["duplicate_refs"], corpus, list(verdicts) + list(held),
+            bool(only), withheld_ids)
+        for shape in duplicate_groups_shape_problems(corpus):
+            problems.append(shape)
         report["duplicate_groups_unproven"] = unproven
         if unproven:
             # The headline counts what the payload lists. Interpolating the

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3653,8 +3653,19 @@ def score_mutant(meta, config, corpus, canon, refs, ws, seed):
     # deterministic slice of the corpus, and a member that fell outside it could
     # move unseen — which is precisely the claim the declaration makes, so the
     # one measurement that decides it must not be left to the sampling stride.
+    #
+    # Pinned against the CORPUS, and that intersection is load-bearing.
+    # `control_covered` is `len(sample)`, and the gate refuses a mutant whose
+    # coverage is 0 — "collateral: 0" with nothing to control against is vacuous
+    # rather than earned. An id that no entry declares is never captured and
+    # never compared (capture() iterates entries; diverged() reads None on both
+    # sides and calls it equal), so pinning one would have raised the coverage
+    # with a control that does not exist and silenced that refusal. A
+    # declaration naming an id the corpus does not have is refused where it
+    # belongs — as a class nothing observes — not by inflating a count here.
     sample = control_ids(corpus, set(targets), seed)
-    pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+    corpus_ids = {e["id"] for e in corpus["entries"]}
+    pinned = (separator_group_ids(corpus, meta.get("id")) & corpus_ids) - set(targets)
     if pinned:
         sample = sorted(set(sample) | pinned)
     captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
@@ -6106,6 +6117,21 @@ def _selftest():
                     dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
     check("aucun epinglage pour un mutant qui ne separe rien",
           v_nopin["collateral"], [])
+    # Et JAMAIS un id que le corpus n'a pas. `control_covered` est len(sample),
+    # et la porte refuse un mutant dont la couverture est nulle — « collateral
+    # 0 » sans rien a controler est vide, pas merite. Un id qu'aucune entree ne
+    # declare n'est jamais capture ni compare : l'epingler aurait leve la
+    # couverture avec un temoin qui n'existe pas, et eteint ce refus-la.
+    # Lu sans planter : si l'epinglage repassait large, la capture serait
+    # interrogee sur un id qu'elle n'a pas — et un banc qui plante dit qu'il
+    # s'est passe quelque chose sans dire quoi.
+    try:
+        _vg = score(["001"], [], ["001"],
+                    dup_groups=[{"ids": ["001", "fantome"], "separated_by": "t"}])
+        _ghost = [_vg["control_covered"], _vg["collateral"]]
+    except Exception as e:                              # noqa: BLE001 - c'est le test
+        _ghost = "%s: %s" % (type(e).__name__, e)
+    check("un id absent du corpus n'est pas epingle comme temoin", _ghost, [0, []])
 
     # Un separateur INVALIDE ne prouve rien. Son verdict porte
     # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3304,13 +3304,43 @@ def duplicate_group_decls(corpus):
     re-anchored their mutant, silently, while the notes still claimed the pair
     was controlled.
     """
-    out = {}
+    # A class declared TWICE is REFUSED, not resolved. `out[key] = ...` let the
+    # later declaration win an ordering nobody audits: ["a","b"] and ["b","a"]
+    # normalise to one key, and which adjudication decided the class was decided
+    # by position in a JSON list. The second-order harm is worse than the
+    # overwrite — separator_group_ids reads THIS map, so the discarded
+    # declaration's separator never gets its group pinned into a control sample
+    # and the measurement that would decide the class is not taken at all.
+    #
+    # Dropping the key is FAIL-CLOSED: the class then reads as declared by
+    # nobody and the gate refuses it, with unproven_duplicate_groups naming the
+    # collision rather than an absence. A class declared twice with the SAME
+    # separators is merely repetitious, not ambiguous — order there decides
+    # nothing, so it is kept.
+    return {k: v[0] for k, v in duplicate_group_index(corpus).items()
+            if len({frozenset(s) for s in v}) == 1}
+
+
+def duplicate_group_index(corpus):
+    """Every well-formed declaration, grouped by the class it keys.
+
+    `{class_key: [separator tuples, one per declaration that named it]}` — the
+    shape that makes a collision VISIBLE instead of resolving it silently.
+    """
+    seen = {}
     for g in duplicate_group_raw(corpus):
         norm = duplicate_group_decl(g)
         if norm is None:
             continue
-        out[norm[0]] = norm[1]
-    return out
+        seen.setdefault(norm[0], []).append(norm[1])
+    return seen
+
+
+def duplicate_group_conflicts(corpus):
+    """Classes with two declarations that do NOT say the same thing."""
+    return {k: [list(s) for s in v]
+            for k, v in duplicate_group_index(corpus).items()
+            if len({frozenset(s) for s in v}) > 1}
 
 
 def duplicate_group_raw(corpus):
@@ -3374,13 +3404,21 @@ def duplicate_groups_shape_problems(corpus):
         return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                 "every declared group then reads as undeclared"
                 % type(raw).__name__]
+    out = []
     bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
     if bad:
-        return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
-                "each needs at least two `ids` and a non-empty `separated_by` "
-                "(a string, or a list of them): %s"
-                % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
-    return []
+        out.append("%d `duplicate_groups` entr%s malformed and silently ignored — "
+                   "each needs at least two `ids` and a non-empty `separated_by` "
+                   "(a string, or a list of them): %s"
+                   % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad)))
+    for key, seps in sorted(duplicate_group_conflicts(corpus).items()):
+        out.append(
+            "class %s is declared TWICE with different separators (%s) — the ids "
+            "are normalised, so ['a','b'] and ['b','a'] are ONE class and nothing "
+            "here can say which adjudication is meant. Both are dropped, and the "
+            "class is refused until one declaration remains."
+            % (json.dumps(list(key)), " vs ".join(json.dumps(s) for s in seps)))
+    return out
 
 
 def separator_group_ids(corpus, mutant_id):
@@ -3413,6 +3451,7 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     so what is tested is what runs.
     """
     decls = duplicate_group_decls(corpus)
+    conflicts = duplicate_group_conflicts(corpus)
     observed = {tuple(sorted(g)) for g in duplicate_refs}
     # VALID only. A failed or inert verdict carries `targets_declared` but
     # never `undetected_targets` nor `collateral` — score_mutant returns before
@@ -3426,6 +3465,15 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     for g in sorted(observed):
         seps = decls.get(g)
         if not seps:
+            # Declared twice is not declared once, but it is not UNDECLARED
+            # either — and sending the campaign to write a declaration it has
+            # already written twice is the dead end this file keeps removing.
+            if g in conflicts:
+                unproven.append({"ids": list(g), "conflicting": conflicts[g], "why":
+                                 "this class is declared TWICE with different separators, and "
+                                 "the ids normalise to ONE key — nothing here can say which "
+                                 "adjudication is meant, so neither is used. Keep one."})
+                continue
             unproven.append({"ids": list(g), "why":
                              "no `duplicate_groups` entry declares this class. Either a "
                              "member is redundant — drop it — or the identity is a control, "
@@ -6184,6 +6232,35 @@ def _selftest():
           len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
     check("le refus de forme nomme exactement les autres",
           len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
+
+    # DEUX declarations pour UNE classe : refusees, pas departagees. Les ids sont
+    # normalises, donc ["a","b"] et ["b","a"] sont la MEME classe et c'est la
+    # POSITION dans la liste qui tranchait. Le mal du second ordre est pire que
+    # l'ecrasement : separator_group_ids lit cette meme carte, donc le separateur
+    # perdant n'epingle jamais son groupe dans son echantillon de temoins — la
+    # mesure qui deciderait la classe n'est pas prise du tout.
+    _clash = {"duplicate_groups": [{"ids": ["a", "b"], "separated_by": "first"},
+                                   {"ids": ["b", "a"], "separated_by": "second"}]}
+    check("une classe declaree deux fois n'est pas departagee par l'ordre",
+          duplicate_group_decls(_clash), {})
+    check("et le perdant n'epingle plus rien en silence",
+          [separator_group_ids(_clash, "first"), separator_group_ids(_clash, "second")],
+          [set(), set()])
+    check("la collision est REFUSEE nommement",
+          [("declared TWICE" in p) for p in duplicate_groups_shape_problems(_clash)],
+          [True])
+    # Et le refus dit la collision, pas une absence : envoyer ecrire une
+    # declaration deja ecrite deux fois est le cul-de-sac que ce fichier retire.
+    check("le motif nomme la collision, pas une declaration manquante",
+          [[("declared TWICE" in x["why"]), x.get("conflicting")]
+           for x in unproven_duplicate_groups([["a", "b"]], _clash, [])],
+          [[True, [["first"], ["second"]]]])
+    # Repeter la MEME adjudication n'est pas ambigu : l'ordre n'y decide rien.
+    check("la meme adjudication ecrite deux fois reste lisible",
+          duplicate_group_decls({"duplicate_groups": [
+              {"ids": ["a", "b"], "separated_by": ["s1", "s2"]},
+              {"ids": ["b", "a"], "separated_by": ["s2", "s1"]}]}),
+          {("a", "b"): ("s1", "s2")})
 
     # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
     # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3433,7 +3433,7 @@ def separator_group_ids(corpus, mutant_id):
 
 
 def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                              withheld=()):
+                              withheld=(), in_the_set=()):
     """Which byte-identical classes are NOT discharged by measured separators.
 
     `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3489,14 +3489,29 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
         if missing and all(m in set(withheld) for m in missing):
             continue
         if missing:
-            unproven.append({"ids": list(g), "separated_by": list(seps), "why":
-                             "declared separator(s) %s %s" %
-                             (", ".join(sorted(missing)),
-                              "ran but came back INVALID — a separator that stops applying "
-                              "is exactly how this class loses its proof"
-                              if all(m in seen_ids for m in missing) else
-                              ("were not scored in this pass (absent from the mutant set%s)"
-                               % (", or excluded by GM_MUTANTS" if restricted else "")))})
+            # THREE reasons, and they send the campaign to three different
+            # places. It RAN and came back invalid — the separator is broken,
+            # fix it. It is IN the mutant set but was not reached — scoring
+            # stopped before it, or GM_MUTANTS excluded it; nothing here is the
+            # campaign's to fix, the class is simply not proved yet. It is
+            # genuinely ABSENT — the declaration names a mutant that does not
+            # exist. Collapsing the middle one into "absent from the mutant set"
+            # is a refusal nothing the campaign does can lift, which is the same
+            # dead end WITHHELD-is-not-ABSENT removed one commit earlier.
+            if all(m in seen_ids for m in missing):
+                why = ("ran but came back INVALID — a separator that stops applying "
+                       "is exactly how this class loses its proof")
+            elif all(m in set(in_the_set) for m in missing):
+                why = ("are IN the mutant set but were not scored in this pass — "
+                       "scoring stopped before them%s. The class is not proved yet; "
+                       "nothing in the corpus is wrong" %
+                       (", or GM_MUTANTS excluded them" if restricted else ""))
+            else:
+                why = ("were not scored in this pass (absent from the mutant set%s)"
+                       % (", or excluded by GM_MUTANTS" if restricted else ""))
+            unproven.append({"ids": list(g), "separated_by": list(seps),
+                             "why": "declared separator(s) %s %s"
+                                    % (", ".join(sorted(missing)), why)})
             continue
         # One signature per member: which of the declared separators move it.
         # Pairwise-distinct signatures IS "the references are distinguishable";
@@ -6273,6 +6288,29 @@ def _selftest():
     check("mais un separateur simplement ABSENT en produit un",
           [x["ids"] for x in unproven_duplicate_groups(
               [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+    # Et le TROISIEME cas, celui qui restait confondu avec le second : un
+    # separateur que le scan n'a pas ATTEINT (arret apres un revert sale,
+    # GM_MUTANTS restreint) existe bel et bien. Le refus doit rester — rien n'est
+    # prouve — mais dire « absent du jeu de mutants » envoyait la campagne
+    # corriger une absence qui n'en est pas une, exactement le cul-de-sac que
+    # RETENU-n'est-pas-ABSENT venait de retirer.
+    check("un separateur NON ATTEINT refuse en le disant, pas en criant l'absence",
+          [x["why"] for x in unproven_duplicate_groups(
+              [["012", "013"]], _wd, [], False, [], ["held-sep"])],
+          ["declared separator(s) held-sep are IN the mutant set but were not "
+           "scored in this pass — scoring stopped before them. The class is not "
+           "proved yet; nothing in the corpus is wrong"])
+    check("et un separateur vraiment absent garde son motif",
+          [("absent from the mutant set" in x["why"])
+           for x in unproven_duplicate_groups(
+               [["012", "013"]], _wd, [], False, [], ["un-autre"])], [True])
+    # Un separateur qui a TOURNE et qui est invalide garde le sien : le fait
+    # d'etre dans le jeu ne doit pas masquer qu'il a echoue.
+    check("un separateur INVALIDE reste un INVALIDE meme s'il est dans le jeu",
+          [("INVALID" in x["why"]) for x in unproven_duplicate_groups(
+              [["012", "013"]], _wd,
+              [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
+              False, [], ["held-sep"])], [True])
 
     D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
     check("separateur qui deplace UN membre : preuve acquittee",
@@ -7111,9 +7149,14 @@ def main():
         # pas absent, il est retenu.
         withheld_ids = ([m.get("id") for m in held_meta]
                         if (mode == "selfcheck" and not held) else [])
+        # Ce que le JEU DE MUTANTS contient, score ou non. Un separateur que le
+        # scan n'a pas atteint — l'arret apres un revert sale, un GM_MUTANTS
+        # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
+        # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
+        in_the_set = [m.get("id") for m in visible + held_meta]
         unproven = unproven_duplicate_groups(
             report["duplicate_refs"], corpus, list(verdicts) + list(held),
-            bool(only), withheld_ids)
+            bool(only), withheld_ids, in_the_set)
         for shape in duplicate_groups_shape_problems(corpus):
             problems.append(shape)
         report["duplicate_groups_unproven"] = unproven

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -3475,7 +3475,7 @@ def separator_group_ids(corpus, mutant_id):
 
 
 def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                              withheld=(), in_the_set=()):
+                              withheld=(), in_the_set=(), deferred=None):
     """Which byte-identical classes are NOT discharged by measured separators.
 
     `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3491,7 +3491,30 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
     Returns one record per class that fails, with the reason IN the record — the
     gate turns them into its refusal, and the selftest calls this same function,
     so what is tested is what runs.
+
+    A class whose every missing separator is WITHHELD lands in the caller's
+    `deferred` sink, never in the return value.
     """
+    # WITHHELD is neither ABSENT nor PROVED, and this used to discharge it.
+    # Skipping the class outright removed the false refusal at the cost of a
+    # false PROOF: with `seps = [held, visible]` where the visible one separates
+    # nothing, the class came back discharged without the scored separator ever
+    # being consulted. A term of convergence cannot be handed that.
+    #
+    # So it is DEFERRED — said out loud, in a sink the caller owns, never in the
+    # field the gate reads. A deferral is the absence of a verdict, not a
+    # verdict.
+    #
+    # No sink, no deferral — but the REASON must stay true. A withheld
+    # separator is IN the mutant set; folding it there makes the fallback say
+    # so, instead of shouting an absence that would send the campaign to fix a
+    # mutant that exists. Strictest AND honest: a caller that forgets the sink
+    # can only get a HARSHER verdict, never a softer one, and never a lying one.
+    if deferred is None:
+        in_the_set = list(in_the_set) + list(withheld)
+        withheld = set()
+    else:
+        withheld = set(withheld)
     decls = duplicate_group_decls(corpus)
     conflicts = duplicate_group_conflicts(corpus)
     observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3529,6 +3552,12 @@ def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False
         # result is simply reserved for the final gate. Saying so is the whole
         # difference between a work item and a dead end.
         if missing and all(m in set(withheld) for m in missing):
+            deferred.append({"ids": list(g), "separated_by": list(seps),
+                             "withheld": sorted(missing), "why":
+                             "every unscored separator belongs to the held-out set, whose "
+                             "verdicts this pass reserves — not scored here, and not scorable "
+                             "here. Neither proved nor refuted until the final gate scores "
+                             "them."})
             continue
         if missing:
             # THREE reasons, and they send the campaign to three different
@@ -6435,9 +6464,34 @@ def _selftest():
     # — et le dire autrement produit un refus que la campagne ne peut pas lever.
     _wd = {"entries": [], "duplicate_groups": [
         {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+    _sink = []
     check("un separateur RETENU ne produit pas de refus",
           unproven_duplicate_groups([["012", "013"]], _wd, [], False,
-                                    ["held-sep"]), [])
+                                    ["held-sep"], (), _sink), [])
+    # ...ET IL EST DIFFERE, PAS EFFACE. Sauter la classe retirait le faux refus
+    # au prix d'une fausse PREUVE : avec `seps = [retenu, visible]` ou le
+    # visible ne separe rien, la classe ressortait dechargee sans que le
+    # separateur score soit jamais consulte. Un terme de convergence ne peut pas
+    # recevoir ca.
+    check("... et la classe est DIFFEREE, pas effacee",
+          [(x["ids"], x["withheld"]) for x in _sink],
+          [(["012", "013"], ["held-sep"])])
+    # SANS PUITS, PAS DE REPORT — et le motif reste VRAI : un separateur retenu
+    # est dans le jeu, pas absent. Le defaut ne peut que RESSERRER, jamais
+    # mentir.
+    check("sans puits, RETENU redevient un refus, et un refus qui ne ment pas",
+          [x["why"] for x in unproven_duplicate_groups(
+              [["012", "013"]], _wd, [], False, ["held-sep"])],
+          ["declared separator(s) held-sep are IN the mutant set but were not "
+           "scored in this pass — scoring stopped before them. The class is not "
+           "proved yet; nothing in the corpus is wrong"])
+    # A LA PORTE FINALE RIEN N'EST RETENU : la voie du report y est
+    # inatteignable, donc elle ne peut pas adoucir le verdict qui decide.
+    _sink2 = []
+    check("porte finale : aucun report possible, le refus tient",
+          [[x["ids"] for x in unproven_duplicate_groups(
+              [["012", "013"]], _wd, [], False, (), (), _sink2)], _sink2],
+          [[["012", "013"]], []])
     check("mais un separateur simplement ABSENT en produit un",
           [x["ids"] for x in unproven_duplicate_groups(
               [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
@@ -6671,6 +6725,10 @@ def main():
               "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
               "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
               "duplicate_groups_unproven": [],
+              # Rapporte, jamais gate : un report est l'absence d'un verdict,
+              # pas un verdict. Il existe pour qu'un selfcheck ne lise pas
+              # PROUVE ce qu'il n'a fait que ne pas pouvoir mesurer.
+              "duplicate_groups_deferred": [],
               "runner_replayable": False,
               "holdout_reused": [],
               "log_tail": ""}
@@ -7333,11 +7391,17 @@ def main():
         # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
         # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
         in_the_set = [m.get("id") for m in visible + held_meta]
+        # Le puits des classes DIFFEREES. Il est fourni, donc `withheld` est
+        # honore ; sans lui la fonction retombe sur le refus le plus severe.
+        # Rien n'est retenu a la porte finale (`withheld_ids` y est vide), donc
+        # cette voie ne peut pas adoucir le verdict qui decide.
+        deferred = []
         unproven = unproven_duplicate_groups(
             report["duplicate_refs"], corpus, list(verdicts) + list(held),
-            bool(only), withheld_ids, in_the_set)
+            bool(only), withheld_ids, in_the_set, deferred)
         problems.extend(duplicate_groups_shape_problems(corpus))
         report["duplicate_groups_unproven"] = unproven
+        report["duplicate_groups_deferred"] = deferred
         if unproven:
             problems.append(duplicate_groups_refusal(
                 unproven, report["duplicate_refs"],

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2984,6 +2984,43 @@ def overall_revert_clean(verdicts, stopped, ws):
     return all(v.get("revert_clean", True) for v in verdicts)
 
 
+def measurement_hygiene(verdicts, held):
+    """`collateral`, `unstable_controls` and the line that NAMES them — over the
+    visible AND the held-out verdicts.
+
+    `score_pct` must stay visible-only: averaging a sealed set into the headline
+    is the resemblance this bot refuses. But these two are not a score, they are
+    HYGIENE OF MEASUREMENT — did a mutant move what it does not declare, does a
+    control reproduce itself — and `overall_revert_clean` already crosses both
+    sets for exactly that reason.
+
+    It became load-bearing the day a held verdict started DECIDING something:
+    `unproven_duplicate_groups` credits a separator's `collateral` as proof that
+    it moved a group member, and score_mutant PINS every group member into that
+    separator's control sample so the measurement exists. Read from `verdicts`
+    alone, the identical measurement was a hard red when the separator was
+    visible (`collateral == 0` is a gate term, in the graph AND in the standalone
+    runner) and a silent proof when it was held. A class cannot be discharged
+    through a channel the gate is forbidden to look at.
+
+    The detail ranges over the same set as the count — a headline that counts
+    what it does not list is the defect this file just removed from the
+    duplicate-group refusal — and each line says which set it came from, because
+    a held-out finding reads differently even though it is just as actionable.
+    """
+    held_ids = {v.get("id") for v in held}
+    both = list(verdicts) + list(held)
+    return {
+        "collateral": sum(len(v.get("collateral") or []) for v in both),
+        "unstable_controls": sorted({c for v in both
+                                     for c in (v.get("unstable_controls") or [])}),
+        "detail": "; ".join(
+            "%s moved %s%s" % (v.get("id"), v["collateral"],
+                               " (held-out)" if v.get("id") in held_ids else "")
+            for v in both if v.get("collateral")),
+    }
+
+
 def apply_mutant(meta, ws):
     # The marker goes down BEFORE apply.sh runs: an interruption between the
     # two leaves a tree that is mutated and a note that says by what. A marker
@@ -6045,6 +6082,27 @@ def _selftest():
               [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
                 "undetected_targets": [], "collateral": []}])],
           [])
+    # ...et l'AUTRE moitie de ce contrat : ce que ce separateur tenu a l'ecart a
+    # deplace doit atteindre les memes termes de porte qu'un separateur visible.
+    # Le meme verdict etait un rouge dur quand il etait visible (`collateral == 0`
+    # est un terme de la porte) et une preuve silencieuse quand il etait retenu :
+    # une classe ne peut pas etre acquittee par un canal que la porte n'a pas le
+    # droit de regarder.
+    _hy = measurement_hygiene(
+        [{"id": "vis", "collateral": ["005"]}],
+        [{"id": "held-sep", "collateral": ["009"], "unstable_controls": ["012"]}])
+    check("le collateral du jeu tenu a l'ecart compte dans le total",
+          _hy["collateral"], 2)
+    check("et ses temoins instables aussi",
+          _hy["unstable_controls"], ["012"])
+    # La liste couvre le meme ensemble que le compte — un titre qui compte ce
+    # qu'il ne nomme pas est le defaut que ce fichier vient de retirer au refus
+    # des doublons — et chaque ligne dit d'ou elle vient.
+    check("et chaque ligne nomme sa provenance",
+          _hy["detail"], "vis moved ['005']; held-sep moved ['009'] (held-out)")
+    check("un jeu tenu a l'ecart propre ne change rien",
+          measurement_hygiene([{"id": "vis", "collateral": ["005"]}], []),
+          {"collateral": 1, "unstable_controls": [], "detail": "vis moved ['005']"})
 
     # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
     # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
@@ -6758,6 +6816,7 @@ def main():
                 if scoring_must_stop(v, ws):
                     stopped = v
                     break
+        hygiene = measurement_hygiene(verdicts, held)
         if stopped is not None:
             note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
                  "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
@@ -6781,9 +6840,8 @@ def main():
             detected=len(detected),
             score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
             revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
-            collateral=sum(len(v.get("collateral") or []) for v in verdicts),
-        unstable_controls=sorted({c for v in verdicts
-                                  for c in (v.get("unstable_controls") or [])}),
+            collateral=hygiene["collateral"],
+            unstable_controls=hygiene["unstable_controls"],
             uncontrolled=[v["id"] for v in valid if not v.get("control_covered")],
             blind_lanes=blind,
             holdout_total=len([v for v in held if v.get("valid")]),
@@ -6860,10 +6918,7 @@ def main():
                             "cover. Not averaged away, not weighted: this list must be "
                             "empty. %s" % json.dumps(blind, ensure_ascii=False))
         if report["collateral"]:
-            detail = "; ".join(
-                "%s moved %s" % (v["id"], v["collateral"])
-                for v in verdicts if v.get("collateral")
-            )
+            detail = hygiene["detail"]
             problems.append("collateral drift on %d control entries — a mutant moves "
                             "responses it does not declare as targets. Either its "
                             "`targets` under-state its blast radius, or the capture is "

--- a/bots/golden-master/skills/deterministic-fixture.md
+++ b/bots/golden-master/skills/deterministic-fixture.md
@@ -87,7 +87,8 @@ reports success on the strength of the resemblance.
 | the gate passed | the runner exited 0 | the runner printed a red report and exited 0 anyway |
 | the held-out set was detected | `detected == total` | `0 == 0` holds when the set is absent |
 | the net is complete | the references are committed | the harness that replays them was gitignored |
-| the corpus is N wide | there are N entries | two entries shared one byte-identical reference |
+| the corpus is N wide | there are N entries | two entries shared one byte-identical reference — the remedy is `duplicate_groups`, which names the separating mutant and has the gate MEASURE the claim, see [[golden-master]] |
+| the identical pair is a deliberate control | a note in `REPORT.md` says so | the mutant that separated them was re-anchored by a later lot and now moves both; the note still read "settled, and proved" |
 
 The shape is always the same, and so is the consequence: **the failure mode is
 a false green, never a false red.** A check that under-claims annoys someone; a

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -254,6 +254,15 @@ non-list container) is **named**, never dropped in silence — a dropped
 declaration would read as "this class is undeclared" and send you to write one
 you had already written.
 
+**Proving a group does not buy back width, and that is deliberate.** The floor
+is applied to `corpus_distinct`, which counts distinct baseline observations. A
+separator proves the two references are *distinguishable under mutation*; it
+does not make them two observations of the application's behaviour at rest, and
+crediting them back would let a corpus reach its floor by padding with
+controls. So the two refusals are independent: discharge the class *and* widen
+the corpus. If the gate still says the corpus is too narrow after every group
+is proved, the answer is a new entry, never a new declaration.
+
 The extension channel may write this key: the lot that ADDS an entry is the one
 that can create a new byte-identical class, so it is also the one that must
 declare its separator. Every other key outside `entries` stays frozen.

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -201,6 +201,63 @@ a supervising process needs to see them:
 None of the three is a refusal: the judge publishes the state and the count, and the process that
 owns the campaign's cadence decides what a debt costs.
 
+## Two entries with the SAME reference — declare the mutant that tells them apart
+
+Two entries whose canonical references are byte-identical are one observation,
+not two. The corpus is then narrower than it claims, and the gate says so
+(`corpus_distinct` versus `corpus_total`).
+
+That is **not automatically a defect**. On a refusal lane the second entry is
+often a *control*: it exists to prove a mutant moved only the first. But a note
+in `REPORT.md` saying so is prose, and the gate reads data — so the claim is
+declared in `corpus.json` and **discharged by measurement**:
+
+```json
+{
+  "entries": [ ... ],
+  "duplicate_groups": [
+    {"ids": ["012", "013"], "separated_by": "sep-01"},
+    {"ids": ["074", "075", "076", "110"],
+     "separated_by": ["sep-04", "sep-05", "sep-06"]}
+  ]
+}
+```
+
+The rules, all of them enforced at the gate — `duplicate_groups_unproven` must
+be empty or the run does not converge, in the graph gate AND in
+`verify-oracle.sh`:
+
+- **The key is the CLASS, not a pairing you choose.** `duplicate_refs` reports
+  maximal equivalence classes — every id sharing one sha256 — so a class of
+  three cannot be declared as three pairs. `["a","b"]` and `["b","a"]` are the
+  same class; declaring one class **twice with different separators** is
+  refused, not resolved, because nothing can say which adjudication is meant.
+- **The separator must move a STRICT SUBSET.** A mutant that moves every member
+  no longer separates anything, and one that moves none never did. This is
+  measured: every member of a declared group is pinned into that mutant's
+  control sample, so the deciding observation always exists.
+- **Move the members you separate as DECLARED `targets`.** A member that moves
+  without being declared surfaces as `collateral`, which is its own hard gate
+  red — including for a separator drawn from the held-out set.
+- **A class of N needs enough separators for pairwise-distinct signatures.**
+  Two mutants do not tell four references apart: if `sep-05` moves 076 and 110
+  together, nothing separates those two and the class stays unproved. Add a
+  separator that moves a different subset.
+- **It is a proof obligation, not a waiver.** It goes red by itself the day a
+  lot re-anchors the separating mutant — which is exactly how two groups whose
+  notes read "settled, and proved" turned out to prove nothing at all.
+- **A declaration whose references are no longer identical is stale** and is
+  refused too: remove it or re-key it.
+
+A malformed declaration (fewer than two `ids`, an empty `separated_by`, a
+non-list container) is **named**, never dropped in silence — a dropped
+declaration would read as "this class is undeclared" and send you to write one
+you had already written.
+
+The extension channel may write this key: the lot that ADDS an entry is the one
+that can create a new byte-identical class, so it is also the one that must
+declare its separator. Every other key outside `entries` stays frozen.
+
 ## Re-baselining, and why it kills nets
 
 A golden master dies by re-baselining. Something breaks three screens, someone regenerates the

--- a/bots/golden-master/skills/oracle-mutation.md
+++ b/bots/golden-master/skills/oracle-mutation.md
@@ -39,6 +39,13 @@ You write the mutants. The harness decides whether they count. It will:
 - **refuse a mutant that targets everything.** With no control entries left, clean collateral is
   vacuous rather than earned. Keep mutants narrow: a blast radius covering the whole corpus tests
   nothing precise.
+- **hold a SEPARATOR to its claim.** A mutant a corpus names in `duplicate_groups` — the
+  declaration that two byte-identical references are a deliberate control rather than a redundant
+  pair — must be measured moving a *strict subset* of that class. Every member is pinned into its
+  control sample so the observation always exists, and the class stays unproved (gate red) if the
+  mutant moves all of them, none of them, or comes back invalid. Re-anchoring such a mutant
+  therefore breaks the pair it was quietly holding up: see [[golden-master]] for the declaration
+  shape and the discharge rule.
 
 ## Required archetypes
 

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3145,6 +3145,43 @@ tool sync_harness:
         return all(v.get("revert_clean", True) for v in verdicts)
 
 
+    def measurement_hygiene(verdicts, held):
+        """`collateral`, `unstable_controls` and the line that NAMES them — over the
+        visible AND the held-out verdicts.
+
+        `score_pct` must stay visible-only: averaging a sealed set into the headline
+        is the resemblance this bot refuses. But these two are not a score, they are
+        HYGIENE OF MEASUREMENT — did a mutant move what it does not declare, does a
+        control reproduce itself — and `overall_revert_clean` already crosses both
+        sets for exactly that reason.
+
+        It became load-bearing the day a held verdict started DECIDING something:
+        `unproven_duplicate_groups` credits a separator's `collateral` as proof that
+        it moved a group member, and score_mutant PINS every group member into that
+        separator's control sample so the measurement exists. Read from `verdicts`
+        alone, the identical measurement was a hard red when the separator was
+        visible (`collateral == 0` is a gate term, in the graph AND in the standalone
+        runner) and a silent proof when it was held. A class cannot be discharged
+        through a channel the gate is forbidden to look at.
+
+        The detail ranges over the same set as the count — a headline that counts
+        what it does not list is the defect this file just removed from the
+        duplicate-group refusal — and each line says which set it came from, because
+        a held-out finding reads differently even though it is just as actionable.
+        """
+        held_ids = {v.get("id") for v in held}
+        both = list(verdicts) + list(held)
+        return {
+            "collateral": sum(len(v.get("collateral") or []) for v in both),
+            "unstable_controls": sorted({c for v in both
+                                         for c in (v.get("unstable_controls") or [])}),
+            "detail": "; ".join(
+                "%s moved %s%s" % (v.get("id"), v["collateral"],
+                                   " (held-out)" if v.get("id") in held_ids else "")
+                for v in both if v.get("collateral")),
+        }
+
+
     def apply_mutant(meta, ws):
         # The marker goes down BEFORE apply.sh runs: an interruption between the
         # two leaves a tree that is mutated and a note that says by what. A marker
@@ -6206,6 +6243,27 @@ tool sync_harness:
                   [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
                     "undetected_targets": [], "collateral": []}])],
               [])
+        # ...et l'AUTRE moitie de ce contrat : ce que ce separateur tenu a l'ecart a
+        # deplace doit atteindre les memes termes de porte qu'un separateur visible.
+        # Le meme verdict etait un rouge dur quand il etait visible (`collateral == 0`
+        # est un terme de la porte) et une preuve silencieuse quand il etait retenu :
+        # une classe ne peut pas etre acquittee par un canal que la porte n'a pas le
+        # droit de regarder.
+        _hy = measurement_hygiene(
+            [{"id": "vis", "collateral": ["005"]}],
+            [{"id": "held-sep", "collateral": ["009"], "unstable_controls": ["012"]}])
+        check("le collateral du jeu tenu a l'ecart compte dans le total",
+              _hy["collateral"], 2)
+        check("et ses temoins instables aussi",
+              _hy["unstable_controls"], ["012"])
+        # La liste couvre le meme ensemble que le compte — un titre qui compte ce
+        # qu'il ne nomme pas est le defaut que ce fichier vient de retirer au refus
+        # des doublons — et chaque ligne dit d'ou elle vient.
+        check("et chaque ligne nomme sa provenance",
+              _hy["detail"], "vis moved ['005']; held-sep moved ['009'] (held-out)")
+        check("un jeu tenu a l'ecart propre ne change rien",
+              measurement_hygiene([{"id": "vis", "collateral": ["005"]}], []),
+              {"collateral": 1, "unstable_controls": [], "detail": "vis moved ['005']"})
 
         # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
         # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
@@ -6919,6 +6977,7 @@ tool sync_harness:
                     if scoring_must_stop(v, ws):
                         stopped = v
                         break
+            hygiene = measurement_hygiene(verdicts, held)
             if stopped is not None:
                 note(report, "scoring stopped after mutant %s: %s. The tree or the app is no longer "
                      "KNOWN to be at baseline, so the mutants after it were not scored and are absent "
@@ -6942,9 +7001,8 @@ tool sync_harness:
                 detected=len(detected),
                 score_pct=int(100 * len(detected) / len(valid)) if valid else 0,
                 revert_clean=overall_revert_clean(verdicts + held, stopped, ws),
-                collateral=sum(len(v.get("collateral") or []) for v in verdicts),
-            unstable_controls=sorted({c for v in verdicts
-                                      for c in (v.get("unstable_controls") or [])}),
+                collateral=hygiene["collateral"],
+                unstable_controls=hygiene["unstable_controls"],
                 uncontrolled=[v["id"] for v in valid if not v.get("control_covered")],
                 blind_lanes=blind,
                 holdout_total=len([v for v in held if v.get("valid")]),
@@ -7021,10 +7079,7 @@ tool sync_harness:
                                 "cover. Not averaged away, not weighted: this list must be "
                                 "empty. %s" % json.dumps(blind, ensure_ascii=False))
             if report["collateral"]:
-                detail = "; ".join(
-                    "%s moved %s" % (v["id"], v["collateral"])
-                    for v in verdicts if v.get("collateral")
-                )
+                detail = hygiene["detail"]
                 problems.append("collateral drift on %d control entries — a mutant moves "
                                 "responses it does not declare as targets. Either its "
                                 "`targets` under-state its blast radius, or the capture is "

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3465,13 +3465,43 @@ tool sync_harness:
         re-anchored their mutant, silently, while the notes still claimed the pair
         was controlled.
         """
-        out = {}
+        # A class declared TWICE is REFUSED, not resolved. `out[key] = ...` let the
+        # later declaration win an ordering nobody audits: ["a","b"] and ["b","a"]
+        # normalise to one key, and which adjudication decided the class was decided
+        # by position in a JSON list. The second-order harm is worse than the
+        # overwrite — separator_group_ids reads THIS map, so the discarded
+        # declaration's separator never gets its group pinned into a control sample
+        # and the measurement that would decide the class is not taken at all.
+        #
+        # Dropping the key is FAIL-CLOSED: the class then reads as declared by
+        # nobody and the gate refuses it, with unproven_duplicate_groups naming the
+        # collision rather than an absence. A class declared twice with the SAME
+        # separators is merely repetitious, not ambiguous — order there decides
+        # nothing, so it is kept.
+        return {k: v[0] for k, v in duplicate_group_index(corpus).items()
+                if len({frozenset(s) for s in v}) == 1}
+
+
+    def duplicate_group_index(corpus):
+        """Every well-formed declaration, grouped by the class it keys.
+
+        `{class_key: [separator tuples, one per declaration that named it]}` — the
+        shape that makes a collision VISIBLE instead of resolving it silently.
+        """
+        seen = {}
         for g in duplicate_group_raw(corpus):
             norm = duplicate_group_decl(g)
             if norm is None:
                 continue
-            out[norm[0]] = norm[1]
-        return out
+            seen.setdefault(norm[0], []).append(norm[1])
+        return seen
+
+
+    def duplicate_group_conflicts(corpus):
+        """Classes with two declarations that do NOT say the same thing."""
+        return {k: [list(s) for s in v]
+                for k, v in duplicate_group_index(corpus).items()
+                if len({frozenset(s) for s in v}) > 1}
 
 
     def duplicate_group_raw(corpus):
@@ -3535,13 +3565,21 @@ tool sync_harness:
             return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                     "every declared group then reads as undeclared"
                     % type(raw).__name__]
+        out = []
         bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
         if bad:
-            return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
-                    "each needs at least two `ids` and a non-empty `separated_by` "
-                    "(a string, or a list of them): %s"
-                    % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
-        return []
+            out.append("%d `duplicate_groups` entr%s malformed and silently ignored — "
+                       "each needs at least two `ids` and a non-empty `separated_by` "
+                       "(a string, or a list of them): %s"
+                       % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad)))
+        for key, seps in sorted(duplicate_group_conflicts(corpus).items()):
+            out.append(
+                "class %s is declared TWICE with different separators (%s) — the ids "
+                "are normalised, so ['a','b'] and ['b','a'] are ONE class and nothing "
+                "here can say which adjudication is meant. Both are dropped, and the "
+                "class is refused until one declaration remains."
+                % (json.dumps(list(key)), " vs ".join(json.dumps(s) for s in seps)))
+        return out
 
 
     def separator_group_ids(corpus, mutant_id):
@@ -3574,6 +3612,7 @@ tool sync_harness:
         so what is tested is what runs.
         """
         decls = duplicate_group_decls(corpus)
+        conflicts = duplicate_group_conflicts(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
         # VALID only. A failed or inert verdict carries `targets_declared` but
         # never `undetected_targets` nor `collateral` — score_mutant returns before
@@ -3587,6 +3626,15 @@ tool sync_harness:
         for g in sorted(observed):
             seps = decls.get(g)
             if not seps:
+                # Declared twice is not declared once, but it is not UNDECLARED
+                # either — and sending the campaign to write a declaration it has
+                # already written twice is the dead end this file keeps removing.
+                if g in conflicts:
+                    unproven.append({"ids": list(g), "conflicting": conflicts[g], "why":
+                                     "this class is declared TWICE with different separators, and "
+                                     "the ids normalise to ONE key — nothing here can say which "
+                                     "adjudication is meant, so neither is used. Keep one."})
+                    continue
                 unproven.append({"ids": list(g), "why":
                                  "no `duplicate_groups` entry declares this class. Either a "
                                  "member is redundant — drop it — or the identity is a control, "
@@ -6345,6 +6393,35 @@ tool sync_harness:
               len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
         check("le refus de forme nomme exactement les autres",
               len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
+
+        # DEUX declarations pour UNE classe : refusees, pas departagees. Les ids sont
+        # normalises, donc ["a","b"] et ["b","a"] sont la MEME classe et c'est la
+        # POSITION dans la liste qui tranchait. Le mal du second ordre est pire que
+        # l'ecrasement : separator_group_ids lit cette meme carte, donc le separateur
+        # perdant n'epingle jamais son groupe dans son echantillon de temoins — la
+        # mesure qui deciderait la classe n'est pas prise du tout.
+        _clash = {"duplicate_groups": [{"ids": ["a", "b"], "separated_by": "first"},
+                                       {"ids": ["b", "a"], "separated_by": "second"}]}
+        check("une classe declaree deux fois n'est pas departagee par l'ordre",
+              duplicate_group_decls(_clash), {})
+        check("et le perdant n'epingle plus rien en silence",
+              [separator_group_ids(_clash, "first"), separator_group_ids(_clash, "second")],
+              [set(), set()])
+        check("la collision est REFUSEE nommement",
+              [("declared TWICE" in p) for p in duplicate_groups_shape_problems(_clash)],
+              [True])
+        # Et le refus dit la collision, pas une absence : envoyer ecrire une
+        # declaration deja ecrite deux fois est le cul-de-sac que ce fichier retire.
+        check("le motif nomme la collision, pas une declaration manquante",
+              [[("declared TWICE" in x["why"]), x.get("conflicting")]
+               for x in unproven_duplicate_groups([["a", "b"]], _clash, [])],
+              [[True, [["first"], ["second"]]]])
+        # Repeter la MEME adjudication n'est pas ambigu : l'ordre n'y decide rien.
+        check("la meme adjudication ecrite deux fois reste lisible",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b"], "separated_by": ["s1", "s2"]},
+                  {"ids": ["b", "a"], "separated_by": ["s2", "s1"]}]}),
+              {("a", "b"): ("s1", "s2")})
 
         # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
         # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3636,7 +3636,7 @@ tool sync_harness:
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                                  withheld=(), in_the_set=()):
+                                  withheld=(), in_the_set=(), deferred=None):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3652,7 +3652,30 @@ tool sync_harness:
         Returns one record per class that fails, with the reason IN the record — the
         gate turns them into its refusal, and the selftest calls this same function,
         so what is tested is what runs.
+
+        A class whose every missing separator is WITHHELD lands in the caller's
+        `deferred` sink, never in the return value.
         """
+        # WITHHELD is neither ABSENT nor PROVED, and this used to discharge it.
+        # Skipping the class outright removed the false refusal at the cost of a
+        # false PROOF: with `seps = [held, visible]` where the visible one separates
+        # nothing, the class came back discharged without the scored separator ever
+        # being consulted. A term of convergence cannot be handed that.
+        #
+        # So it is DEFERRED — said out loud, in a sink the caller owns, never in the
+        # field the gate reads. A deferral is the absence of a verdict, not a
+        # verdict.
+        #
+        # No sink, no deferral — but the REASON must stay true. A withheld
+        # separator is IN the mutant set; folding it there makes the fallback say
+        # so, instead of shouting an absence that would send the campaign to fix a
+        # mutant that exists. Strictest AND honest: a caller that forgets the sink
+        # can only get a HARSHER verdict, never a softer one, and never a lying one.
+        if deferred is None:
+            in_the_set = list(in_the_set) + list(withheld)
+            withheld = set()
+        else:
+            withheld = set(withheld)
         decls = duplicate_group_decls(corpus)
         conflicts = duplicate_group_conflicts(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3690,6 +3713,12 @@ tool sync_harness:
             # result is simply reserved for the final gate. Saying so is the whole
             # difference between a work item and a dead end.
             if missing and all(m in set(withheld) for m in missing):
+                deferred.append({"ids": list(g), "separated_by": list(seps),
+                                 "withheld": sorted(missing), "why":
+                                 "every unscored separator belongs to the held-out set, whose "
+                                 "verdicts this pass reserves — not scored here, and not scorable "
+                                 "here. Neither proved nor refuted until the final gate scores "
+                                 "them."})
                 continue
             if missing:
                 # THREE reasons, and they send the campaign to three different
@@ -6596,9 +6625,34 @@ tool sync_harness:
         # — et le dire autrement produit un refus que la campagne ne peut pas lever.
         _wd = {"entries": [], "duplicate_groups": [
             {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+        _sink = []
         check("un separateur RETENU ne produit pas de refus",
               unproven_duplicate_groups([["012", "013"]], _wd, [], False,
-                                        ["held-sep"]), [])
+                                        ["held-sep"], (), _sink), [])
+        # ...ET IL EST DIFFERE, PAS EFFACE. Sauter la classe retirait le faux refus
+        # au prix d'une fausse PREUVE : avec `seps = [retenu, visible]` ou le
+        # visible ne separe rien, la classe ressortait dechargee sans que le
+        # separateur score soit jamais consulte. Un terme de convergence ne peut pas
+        # recevoir ca.
+        check("... et la classe est DIFFEREE, pas effacee",
+              [(x["ids"], x["withheld"]) for x in _sink],
+              [(["012", "013"], ["held-sep"])])
+        # SANS PUITS, PAS DE REPORT — et le motif reste VRAI : un separateur retenu
+        # est dans le jeu, pas absent. Le defaut ne peut que RESSERRER, jamais
+        # mentir.
+        check("sans puits, RETENU redevient un refus, et un refus qui ne ment pas",
+              [x["why"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, ["held-sep"])],
+              ["declared separator(s) held-sep are IN the mutant set but were not "
+               "scored in this pass — scoring stopped before them. The class is not "
+               "proved yet; nothing in the corpus is wrong"])
+        # A LA PORTE FINALE RIEN N'EST RETENU : la voie du report y est
+        # inatteignable, donc elle ne peut pas adoucir le verdict qui decide.
+        _sink2 = []
+        check("porte finale : aucun report possible, le refus tient",
+              [[x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, (), (), _sink2)], _sink2],
+              [[["012", "013"]], []])
         check("mais un separateur simplement ABSENT en produit un",
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
@@ -6832,6 +6886,10 @@ tool sync_harness:
                   "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
                   "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
                   "duplicate_groups_unproven": [],
+                  # Rapporte, jamais gate : un report est l'absence d'un verdict,
+                  # pas un verdict. Il existe pour qu'un selfcheck ne lise pas
+                  # PROUVE ce qu'il n'a fait que ne pas pouvoir mesurer.
+                  "duplicate_groups_deferred": [],
                   "runner_replayable": False,
                   "holdout_reused": [],
                   "log_tail": ""}
@@ -7494,11 +7552,17 @@ tool sync_harness:
             # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
             # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
             in_the_set = [m.get("id") for m in visible + held_meta]
+            # Le puits des classes DIFFEREES. Il est fourni, donc `withheld` est
+            # honore ; sans lui la fonction retombe sur le refus le plus severe.
+            # Rien n'est retenu a la porte finale (`withheld_ids` y est vide), donc
+            # cette voie ne peut pas adoucir le verdict qui decide.
+            deferred = []
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
-                bool(only), withheld_ids, in_the_set)
+                bool(only), withheld_ids, in_the_set, deferred)
             problems.extend(duplicate_groups_shape_problems(corpus))
             report["duplicate_groups_unproven"] = unproven
+            report["duplicate_groups_deferred"] = deferred
             if unproven:
                 problems.append(duplicate_groups_refusal(
                     unproven, report["duplicate_refs"],

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1757,11 +1757,38 @@ tool sync_harness:
                     "not crashed")
                 head_c = base_c = None
             if head_c is not None and base_c is not None:
-                if {k: v for k, v in head_c.items() if k != "entries"} != \
-                        {k: v for k, v in base_c.items() if k != "entries"}:
+                # `duplicate_groups` is the ONE key outside `entries` an extension
+                # may write, and the reason is not convenience: every other key here
+                # is frozen because it is TRUSTED, while this one is VERIFIED. A
+                # group declaration is discharged at the gate by a mutant that must
+                # really move part of the group and leave the rest still, so a lot
+                # gains nothing by writing one — a bogus separator refuses, and
+                # deleting a declaration turns its group back into an undeclared
+                # duplicate, which also refuses.
+                #
+                # Without this the gate named a remedy another judge forbade: the
+                # lot that ADDS an entry is the very lot that can create a new
+                # byte-identical pair, and it would have been told to declare a
+                # separator in a key it is refused permission to touch.
+                FREE_KEYS = {"entries", "duplicate_groups"}
+                if {k: v for k, v in head_c.items() if k not in FREE_KEYS} != \
+                        {k: v for k, v in base_c.items() if k not in FREE_KEYS}:
                     corpus_problems.append(
                         "corpus.json keys outside `entries` changed — an "
                         "extension adds entries and touches nothing else")
+                # Structure is judged HERE, truth at the gate. A malformed
+                # declaration would otherwise be dropped in silence by
+                # duplicate_group_decls and read as "no declaration at all".
+                for g in (head_c.get("duplicate_groups") or []):
+                    if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
+                            or len(g.get("ids") or []) < 2 \
+                            or not isinstance(g.get("separated_by"), str) \
+                            or not g.get("separated_by"):
+                        corpus_problems.append(
+                            "a `duplicate_groups` entry is malformed (%r) — it needs "
+                            "at least two `ids` and a non-empty `separated_by`, or it "
+                            "is dropped in silence and reads as no declaration at all"
+                            % (g,))
                 # An id names ONE observation. Duplicated ids collapse in every
                 # by-id index (this one, the capture map, the refs map), so the
                 # equality check would read the surviving twin while the capture
@@ -3422,7 +3449,14 @@ tool sync_harness:
         """
         decls = duplicate_group_decls(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
-        scored = {v.get("id"): v for v in verdicts if v.get("id")}
+        # VALID only. A failed or inert verdict carries `targets_declared` but
+        # never `undetected_targets` nor `collateral` — score_mutant returns before
+        # they are set — so crediting it would read "moved every declared target"
+        # from a measurement that never ran. And that is exactly how a separator
+        # dies when a lot re-anchors it: its apply.sh stops working. The group would
+        # have been reported PROVED by the failure it exists to catch.
+        scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
+        seen_ids = {v.get("id") for v in verdicts if v.get("id")}
         unproven = []
         for g in sorted(observed):
             sep = decls.get(g)
@@ -3435,9 +3469,13 @@ tool sync_harness:
             v = scored.get(sep)
             if v is None:
                 unproven.append({"ids": list(g), "separated_by": sep, "why":
-                                 "the declared separator was not scored in this pass (absent "
-                                 "from the mutant set%s)" %
-                                 (", or excluded by GM_MUTANTS" if restricted else "")})
+                                 ("the declared separator ran but came back INVALID — it proves "
+                                  "nothing, and a separator that stops applying is exactly how "
+                                  "this group loses its proof")
+                                 if sep in seen_ids else
+                                 ("the declared separator was not scored in this pass (absent "
+                                  "from the mutant set%s)" %
+                                  (", or excluded by GM_MUTANTS" if restricted else ""))})
                 continue
             moved = ((set(v.get("targets_declared") or [])
                       - set(v.get("undetected_targets") or []))
@@ -5030,6 +5068,49 @@ tool sync_harness:
             check("ref ajoutee non declaree par la demande -> refusee",
                   xverdict(xbase)["acted"][0]["ok"], False)
 
+            # LE CANAL DE DECLARATION : le lot qui AJOUTE une entree est celui qui
+            # peut creer une nouvelle paire byte-identique, donc celui a qui la
+            # porte demande de declarer son separateur. Si le juge d'extension gelait
+            # cette cle, la porte nommerait un remede qu'un autre juge refuse — le
+            # defaut que le canal existe pour supprimer, simplement deplace.
+            xreset()
+            dup_entry = dict(base_entry, id="7", path="/dup")
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": [{"ids": ["1", "7"],
+                                                 "separated_by": "sep-x"}]}, f)
+            xcommit()
+            _vd = xverdict(xbase)["acted"][0]
+            check("declarer un groupe de doublons n'est PAS un gel viole",
+                  [pb for pb in _vd["problems"] if "keys outside" in pb], [])
+            # Et le gel tient pour tout le reste : une cle voisine refuse toujours.
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry], "baseline": "reecrite"}, f)
+            xcommit()
+            check("mais toute AUTRE cle hors `entries` reste gelee",
+                  any("keys outside" in pb
+                      for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+            # Une declaration malformee est refusee ICI plutot que jetee en silence
+            # par le lecteur, ou elle se lirait comme « aucune declaration ».
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": [{"ids": ["1"], "separated_by": ""}]}, f)
+            xcommit()
+            check("une declaration malformee est refusee, pas ignoree",
+                  any("malformed" in pb
+                      for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
             xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "1"}]}'),
@@ -5935,7 +6016,7 @@ tool sync_harness:
         # rougit avec lui.
         def whys(group, decls, moved_by):
             corpus_ = {"entries": [], "duplicate_groups": decls}
-            verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+            verdicts_ = [{"id": mid, "valid": True, "targets_declared": sorted(mv),
                           "undetected_targets": [], "collateral": []}
                          for mid, mv in moved_by.items()]
             out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
@@ -5954,6 +6035,29 @@ tool sync_harness:
                         dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
         check("aucun epinglage pour un mutant qui ne separe rien",
               v_nopin["collateral"], [])
+
+        # Un separateur INVALIDE ne prouve rien. Son verdict porte
+        # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc
+        # le crediter revient a lire « toutes les cibles ont bouge » d'une mesure
+        # qui n'a pas eu lieu — et c'est precisement ainsi qu'un separateur meurt.
+        check("un separateur INVALIDE ne prouve pas le groupe",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+                  [{"id": "sep-01", "valid": False,
+                    "targets_declared": ["013"], "reason": "apply.sh a echoue"}])],
+              [["012", "013"]])
+        # Le motif, lu sans indexer a l'aveugle : si le groupe repassait "prouve",
+        # un `[0]` planterait au lieu de RAPPORTER, et un banc qui plante dit qu'il
+        # s'est passe quelque chose sans dire quoi.
+        _inv = unproven_duplicate_groups(
+            [["012", "013"]],
+            {"entries": [], "duplicate_groups": [
+                {"ids": ["012", "013"], "separated_by": "sep-01"}]},
+            [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
+        check("et le motif dit qu'il a tourne, pas qu'il est absent",
+              [("INVALID" in x["why"]) for x in _inv], [True])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -5975,7 +6079,7 @@ tool sync_harness:
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]],
                   {"entries": [], "duplicate_groups": D},
-                  [{"id": "sep-01", "targets_declared": ["013"],
+                  [{"id": "sep-01", "valid": True, "targets_declared": ["013"],
                     "undetected_targets": [], "collateral": ["012"]}])],
               [["012", "013"]])
         # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
@@ -5983,7 +6087,7 @@ tool sync_harness:
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]],
                   {"entries": [], "duplicate_groups": D},
-                  [{"id": "sep-01", "targets_declared": ["012", "013"],
+                  [{"id": "sep-01", "valid": True, "targets_declared": ["012", "013"],
                     "undetected_targets": ["012", "013"], "collateral": []}])],
               [["012", "013"]])
 
@@ -6789,14 +6893,21 @@ tool sync_harness:
                 report["duplicate_refs"], corpus, verdicts, bool(only))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
-                problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                                "so the corpus is %d observations wide, not %d — and their identity "
-                                "is NOT proved. A group may legitimately repeat (a refusal lane's "
-                                "second entry is a control), but the claim is discharged by a mutant "
-                                "that moves part of the group and leaves the rest still, declared in "
-                                "`duplicate_groups` and checked here. Unproved: %s"
-                                % (len(report["duplicate_refs"]), report["corpus_distinct"],
-                                   report["corpus_total"],
+                # The headline counts what the payload lists. Interpolating the
+                # OBSERVED total while listing only the unproved ones told the
+                # operator "5 groups are not proved" beside a list of one — and the
+                # two do not even range over the same set: a stale declaration is
+                # unproved while its references are, by definition, no longer
+                # identical. On a gate whose whole point is precise adjudication,
+                # that gap is the defect.
+                problems.append("%d reference group(s) are not proved (out of %d byte-identical "
+                                "across DIFFERENT entries; the corpus is %d observations wide, "
+                                "not %d). A group may legitimately repeat — a refusal lane's "
+                                "second entry is a control — but the claim is discharged by a "
+                                "mutant that moves part of the group and leaves the rest still, "
+                                "declared in `duplicate_groups` and checked here: %s"
+                                % (len(unproven), len(report["duplicate_refs"]),
+                                   report["corpus_distinct"], report["corpus_total"],
                                    json.dumps(unproven, ensure_ascii=False)))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1780,10 +1780,12 @@ tool sync_harness:
                 # declaration would otherwise be dropped in silence by
                 # duplicate_group_decls and read as "no declaration at all".
                 for g in (head_c.get("duplicate_groups") or []):
+                    _sep = g.get("separated_by") if isinstance(g, dict) else None
+                    _seps = [_sep] if isinstance(_sep, str) else _sep
                     if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
                             or len(g.get("ids") or []) < 2 \
-                            or not isinstance(g.get("separated_by"), str) \
-                            or not g.get("separated_by"):
+                            or not isinstance(_seps, list) or not _seps \
+                            or not all(isinstance(m, str) and m for m in _seps):
                         corpus_problems.append(
                             "a `duplicate_groups` entry is malformed (%r) — it needs "
                             "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3423,9 +3425,15 @@ tool sync_harness:
                 continue
             ids = g.get("ids")
             sep = g.get("separated_by")
-            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+            # One separator or several: a class of two needs one mutant to split it,
+            # a class of four needs enough of them to tell all four apart. Written
+            # as a bare string for the common case, a list when resolution costs
+            # more than one.
+            seps = [sep] if isinstance(sep, str) else sep
+            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+                    or not seps or not all(isinstance(m, str) and m for m in seps):
                 continue
-            out[tuple(sorted(str(i) for i in ids))] = sep
+            out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
         return out
 
 
@@ -3434,18 +3442,28 @@ tool sync_harness:
         if not mutant_id:
             return set()
         ids = set()
-        for group, sep in duplicate_group_decls(corpus).items():
-            if sep == mutant_id:
+        for group, seps in duplicate_group_decls(corpus).items():
+            if mutant_id in seps:
                 ids.update(group)
         return ids
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
-        """Which byte-identical groups are NOT discharged by a measured separator.
+        """Which byte-identical classes are NOT discharged by measured separators.
 
-        Returns one record per group that fails, with the reason IN the record —
-        the gate turns them into its refusal, and the selftest calls this same
-        function, so what is tested is what runs.
+        `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
+        sha256 — so a class of three or more cannot be declared as a set of pairs:
+        the declaration is keyed on the class itself. What several separators buy is
+        RESOLUTION. A class is discharged when the members are pairwise
+        distinguishable: for each one, the pattern of which declared separators move
+        it must be unique. One separator over a pair reduces to "moves one, not the
+        other"; four members need enough separators to tell all four apart, which is
+        exactly what the campaign's own notes describe when they name `sep-04` for
+        one member and `sep-05` for two others.
+
+        Returns one record per class that fails, with the reason IN the record — the
+        gate turns them into its refusal, and the selftest calls this same function,
+        so what is tested is what runs.
         """
         decls = duplicate_group_decls(corpus)
         observed = {tuple(sorted(g)) for g in duplicate_refs}
@@ -3453,48 +3471,54 @@ tool sync_harness:
         # never `undetected_targets` nor `collateral` — score_mutant returns before
         # they are set — so crediting it would read "moved every declared target"
         # from a measurement that never ran. And that is exactly how a separator
-        # dies when a lot re-anchors it: its apply.sh stops working. The group would
+        # dies when a lot re-anchors it: its apply.sh stops working. The class would
         # have been reported PROVED by the failure it exists to catch.
         scored = {v.get("id"): v for v in verdicts if v.get("id") and v.get("valid")}
         seen_ids = {v.get("id") for v in verdicts if v.get("id")}
         unproven = []
         for g in sorted(observed):
-            sep = decls.get(g)
-            if not sep:
+            seps = decls.get(g)
+            if not seps:
                 unproven.append({"ids": list(g), "why":
-                                 "no `duplicate_groups` entry declares this group. Either one "
+                                 "no `duplicate_groups` entry declares this class. Either a "
                                  "member is redundant — drop it — or the identity is a control, "
-                                 "and then it must name the mutant that separates it."})
+                                 "and then it must name the mutant(s) that tell them apart."})
                 continue
-            v = scored.get(sep)
-            if v is None:
-                unproven.append({"ids": list(g), "separated_by": sep, "why":
-                                 ("the declared separator ran but came back INVALID — it proves "
-                                  "nothing, and a separator that stops applying is exactly how "
-                                  "this group loses its proof")
-                                 if sep in seen_ids else
-                                 ("the declared separator was not scored in this pass (absent "
-                                  "from the mutant set%s)" %
-                                  (", or excluded by GM_MUTANTS" if restricted else ""))})
+            missing = [m for m in seps if m not in scored]
+            if missing:
+                unproven.append({"ids": list(g), "separated_by": list(seps), "why":
+                                 "declared separator(s) %s %s" %
+                                 (", ".join(sorted(missing)),
+                                  "ran but came back INVALID — a separator that stops applying "
+                                  "is exactly how this class loses its proof"
+                                  if all(m in seen_ids for m in missing) else
+                                  ("were not scored in this pass (absent from the mutant set%s)"
+                                   % (", or excluded by GM_MUTANTS" if restricted else "")))})
                 continue
-            moved = ((set(v.get("targets_declared") or [])
-                      - set(v.get("undetected_targets") or []))
-                     | set(v.get("collateral") or []))
-            inside = moved & set(g)
-            if not inside:
-                unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
-                                 "the declared separator moves NO member of the group — it "
-                                 "does not separate anything"})
-            elif inside == set(g):
-                unproven.append({"ids": list(g), "separated_by": sep,
-                                 "moved": sorted(inside), "why":
-                                 "the declared separator moves EVERY member together, so it no "
-                                 "longer tells them apart. Draw one that moves a strict subset, "
-                                 "or accept that the group is redundant."})
+            # One signature per member: which of the declared separators move it.
+            # Pairwise-distinct signatures IS "the references are distinguishable";
+            # anything less leaves two members that no declared mutant separates.
+            sig = {}
+            for m in g:
+                bits = []
+                for sep in seps:
+                    v = scored[sep]
+                    moved = ((set(v.get("targets_declared") or [])
+                              - set(v.get("undetected_targets") or []))
+                             | set(v.get("collateral") or []))
+                    bits.append(m in moved)
+                sig.setdefault(tuple(bits), []).append(m)
+            collided = sorted(sorted(ms) for ms in sig.values() if len(ms) > 1)
+            if collided:
+                unproven.append({"ids": list(g), "separated_by": list(seps),
+                                 "indistinguishable": collided, "why":
+                                 "every declared separator treats these members identically, so "
+                                 "none of them tells the references apart. Draw one that moves a "
+                                 "strict subset, or accept that they are redundant."})
         for g in sorted(set(decls) - observed):
-            unproven.append({"ids": list(g), "separated_by": decls[g], "why":
-                             "declared, but these references are no longer byte-identical — the "
-                             "claim has nothing left to justify. Remove the declaration."})
+            unproven.append({"ids": list(g), "separated_by": list(decls[g]), "why":
+                             "declared, but these references are not a byte-identical class — the "
+                             "claim has nothing left to justify. Remove or re-key the declaration."})
         return unproven
 
 
@@ -5999,7 +6023,17 @@ tool sync_harness:
                          {"ids": ["019", "012"], "separated_by": ""},
                          "pas-un-dict"]}
         check("une declaration se lit triee, et les malformees sont ignorees",
-              duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+              duplicate_group_decls(corpus_dg), {("012", "013"): ("sep-01",)})
+        # Un separateur ou plusieurs : une classe de quatre demande assez de mutants
+        # pour distinguer les quatre, pas un seul qui coupe quelque part.
+        check("plusieurs separateurs se lisent, dedupliques et ordonnes",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b", "c"], "separated_by": ["s2", "s1", "s2"]}]}),
+              {("a", "b", "c"): ("s2", "s1")})
+        check("une liste vide ou non-textuelle est ignoree",
+              duplicate_group_decls({"duplicate_groups": [
+                  {"ids": ["a", "b"], "separated_by": []},
+                  {"ids": ["c", "d"], "separated_by": [1]}]}), {})
         check("les ids d'un groupe sont epingles pour SON separateur",
               separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
         check("et pour aucun autre",
@@ -6058,6 +6092,69 @@ tool sync_harness:
             [{"id": "sep-01", "valid": False, "targets_declared": ["013"]}])
         check("et le motif dit qu'il a tourne, pas qu'il est absent",
               [("INVALID" in x["why"]) for x in _inv], [True])
+
+        # Une CLASSE de quatre, le cas reel du corpus : `sep-04` deplace un membre,
+        # `sep-05` en deplace deux — ensemble ils donnent quatre signatures
+        # distinctes, donc les quatre references sont distinguables.
+        C4 = [{"ids": ["074", "075", "076", "110"],
+               "separated_by": ["sep-04", "sep-05"]}]
+        def _v(mid, moved):
+            return {"id": mid, "valid": True, "targets_declared": sorted(moved),
+                    "undetected_targets": [], "collateral": []}
+        # Et le resultat est celui du corpus REEL, pas celui qu'on esperait :
+        # `sep-04` isole 074, `sep-05` deplace 076 ET 110 ensemble — donc ces deux-la
+        # partagent leur signature et rien ne les separe. Deux separateurs ne
+        # suffisent pas a distinguer quatre references ; le banc l'a appris du
+        # produit apres avoir affirme le contraire.
+        check("deux separateurs ne distinguent pas quatre membres",
+              [x.get("indistinguishable") for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": C4},
+                  [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"})])],
+              [[["076", "110"]]])
+        # Avec un troisieme qui ne bouge que 110, les quatre signatures deviennent
+        # distinctes et la classe est acquittee.
+        check("un separateur de plus les distingue toutes : acquittee",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["074", "075", "076", "110"],
+                       "separated_by": ["sep-04", "sep-05", "sep-06"]}]},
+                  [_v("sep-04", {"074"}), _v("sep-05", {"076", "110"}),
+                   _v("sep-06", {"110"})])],
+              [])
+        # 076 et 110 partagent la meme signature : deux membres que rien ne separe.
+        check("deux membres de meme signature : la classe n'est PAS acquittee",
+              [x.get("indistinguishable") for x in unproven_duplicate_groups(
+                  [["074", "075", "076", "110"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["074", "075", "076", "110"], "separated_by": ["sep-04"]}]},
+                  [_v("sep-04", {"074"})])],
+              [[["075", "076", "110"]]])
+        # Et une declaration en PAIRES sur une classe de trois ne la couvre pas :
+        # la cle est la classe maximale, pas un decoupage choisi par le lot.
+        check("des paires ne declarent pas une classe de trois",
+              sorted(x["ids"] for x in unproven_duplicate_groups(
+                  [["a", "b", "c"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["a", "b"], "separated_by": "s1"},
+                      {"ids": ["b", "c"], "separated_by": "s1"}]},
+                  [_v("s1", {"a"})])),
+              [["a", "b"], ["a", "b", "c"], ["b", "c"]])
+
+        # Le CONTRAT que le site d'appel doit honorer : un separateur fourni parmi
+        # les verdicts du jeu tenu a l'ecart est reconnu comme les autres. La
+        # fonction est agnostique — c'est l'appelant qui doit composer les deux
+        # listes, et CE cablage-la n'est pas couvert par ce banc (le rejouer
+        # demanderait une porte complete). La limite est ecrite plutot que masquee.
+        check("un separateur venu du jeu tenu a l'ecart est reconnu",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": [
+                      {"ids": ["012", "013"], "separated_by": "held-sep"}]},
+                  [{"id": "held-sep", "valid": True, "targets_declared": ["013"],
+                    "undetected_targets": [], "collateral": []}])],
+              [])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -6889,8 +6986,13 @@ tool sync_harness:
             # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
             # separator to a lot's re-anchoring — the mutant now moves both members,
             # and the pair proves nothing at all.
+            # verdicts + held. A declared separator may live in the held-out set —
+            # score_mutant pins its group unconditionally, so the deciding
+            # measurement really IS taken — but it lands in `held`, not `verdicts`.
+            # Passing only the latter made the gate report a separator it had just
+            # scored as never scored, and refuse the group on its own blind spot.
             unproven = unproven_duplicate_groups(
-                report["duplicate_refs"], corpus, verdicts, bool(only))
+                report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 # The headline counts what the payload lists. Interpolating the

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3374,6 +3374,92 @@ tool sync_harness:
         return sorted(i for i in ids if refs.get(i) != captured.get(i))
 
 
+    def duplicate_group_decls(corpus):
+        """The corpus's `duplicate_groups` declarations, normalised.
+
+        Two entries whose references are byte-identical are not automatically a
+        defect: on a refusal lane the second is a CONTROL proving a mutant moved
+        only the first. But a note saying so is prose, and the gate cannot read
+        prose — so the claim is declared as data and DISCHARGED by measurement:
+        each group names the mutant that separates it, and the gate checks that the
+        mutant really moves some members and leaves the others still.
+
+        That is the difference between a waiver and a proof obligation. A waiver is
+        believed; this is executed, and it goes red by itself the day its separator
+        dies — which is exactly what happened to two of these groups when a lot
+        re-anchored their mutant, silently, while the notes still claimed the pair
+        was controlled.
+        """
+        out = {}
+        for g in (corpus.get("duplicate_groups") or []):
+            if not isinstance(g, dict):
+                continue
+            ids = g.get("ids")
+            sep = g.get("separated_by")
+            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(sep, str) or not sep:
+                continue
+            out[tuple(sorted(str(i) for i in ids))] = sep
+        return out
+
+
+    def separator_group_ids(corpus, mutant_id):
+        """Every id of every group this mutant is declared to separate."""
+        if not mutant_id:
+            return set()
+        ids = set()
+        for group, sep in duplicate_group_decls(corpus).items():
+            if sep == mutant_id:
+                ids.update(group)
+        return ids
+
+
+    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+        """Which byte-identical groups are NOT discharged by a measured separator.
+
+        Returns one record per group that fails, with the reason IN the record —
+        the gate turns them into its refusal, and the selftest calls this same
+        function, so what is tested is what runs.
+        """
+        decls = duplicate_group_decls(corpus)
+        observed = {tuple(sorted(g)) for g in duplicate_refs}
+        scored = {v.get("id"): v for v in verdicts if v.get("id")}
+        unproven = []
+        for g in sorted(observed):
+            sep = decls.get(g)
+            if not sep:
+                unproven.append({"ids": list(g), "why":
+                                 "no `duplicate_groups` entry declares this group. Either one "
+                                 "member is redundant — drop it — or the identity is a control, "
+                                 "and then it must name the mutant that separates it."})
+                continue
+            v = scored.get(sep)
+            if v is None:
+                unproven.append({"ids": list(g), "separated_by": sep, "why":
+                                 "the declared separator was not scored in this pass (absent "
+                                 "from the mutant set%s)" %
+                                 (", or excluded by GM_MUTANTS" if restricted else "")})
+                continue
+            moved = ((set(v.get("targets_declared") or [])
+                      - set(v.get("undetected_targets") or []))
+                     | set(v.get("collateral") or []))
+            inside = moved & set(g)
+            if not inside:
+                unproven.append({"ids": list(g), "separated_by": sep, "moved": [], "why":
+                                 "the declared separator moves NO member of the group — it "
+                                 "does not separate anything"})
+            elif inside == set(g):
+                unproven.append({"ids": list(g), "separated_by": sep,
+                                 "moved": sorted(inside), "why":
+                                 "the declared separator moves EVERY member together, so it no "
+                                 "longer tells them apart. Draw one that moves a strict subset, "
+                                 "or accept that the group is redundant."})
+        for g in sorted(set(decls) - observed):
+            unproven.append({"ids": list(g), "separated_by": decls[g], "why":
+                             "declared, but these references are no longer byte-identical — the "
+                             "claim has nothing left to justify. Remove the declaration."})
+        return unproven
+
+
     def control_ids(corpus, targets, seed):
         """Deterministic sample of non-target entries, to measure collateral."""
         pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -3482,7 +3568,15 @@ tool sync_harness:
         if meta.get("needs_restart", True):
             app_restart(config, ws)
 
+        # An entry named in a duplicate-group declaration is ALWAYS controlled when
+        # the mutant that claims to separate it runs. The sample is otherwise a
+        # deterministic slice of the corpus, and a member that fell outside it could
+        # move unseen — which is precisely the claim the declaration makes, so the
+        # one measurement that decides it must not be left to the sampling stride.
         sample = control_ids(corpus, set(targets), seed)
+        pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+        if pinned:
+            sample = sorted(set(sample) | pinned)
         captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
         moved = diverged(refs, captured, targets)
         verdict["detected"] = bool(moved)
@@ -3854,10 +3948,12 @@ tool sync_harness:
                     (i in self.moved) if self.applied else (i in self.unstable)) else "")
                     for i in ids}
 
-        def score(targets, sample, moved, unstable=(), revert_code=0):
+        def score(targets, sample, moved, unstable=(), revert_code=0, dup_groups=None):
             ids = ["%03d" % n for n in range(1, 13)]
             refs = {i: "ref-" + i for i in ids}
             corpus = {"entries": [{"id": i, "surface": "http"} for i in ids]}
+            if dup_groups:
+                corpus["duplicate_groups"] = dup_groups
             meta = {"id": "t", "dir": "/dev/null", "class": "code", "surface": "http",
                     "archetype": "value_change", "targets": list(targets), "needs_restart": False}
             w = World(refs, moved, unstable)
@@ -5808,6 +5904,89 @@ tool sync_harness:
         check("l'audit voit les lancements de git", _git_audit["git"] > 0, True)
         check("l'audit voit les lancements du shell", _git_audit["sh"] > 0, True)
 
+        # ─── Groupes de references identiques : la preuve, pas la parole ──────────
+        #
+        # Deux entrees byte-identiques ne sont pas fautives en soi : sur une lane de
+        # refus, la seconde est un CONTROLE qui prouve qu'un mutant n'a deplace que
+        # la premiere. Ce que la porte ne pouvait pas faire, c'est distinguer ce cas
+        # d'un doublon — une note en prose ne se verifie pas. La declaration nomme
+        # le mutant separateur, et elle est ACQUITTEE par la mesure.
+        corpus_dg = {"entries": [{"id": "012"}, {"id": "013"}, {"id": "019"}],
+                     "duplicate_groups": [
+                         {"ids": ["013", "012"], "separated_by": "sep-01"},
+                         {"ids": ["019"], "separated_by": "trop-court"},
+                         {"ids": ["019", "012"], "separated_by": ""},
+                         "pas-un-dict"]}
+        check("une declaration se lit triee, et les malformees sont ignorees",
+              duplicate_group_decls(corpus_dg), {("012", "013"): "sep-01"})
+        check("les ids d'un groupe sont epingles pour SON separateur",
+              separator_group_ids(corpus_dg, "sep-01"), {"012", "013"})
+        check("et pour aucun autre",
+              separator_group_ids(corpus_dg, "sep-02"), set())
+        check("un mutant sans id n'epingle rien",
+              separator_group_ids(corpus_dg, None), set())
+
+        # Le verdict lui-meme : ce que la porte conclut de ce qu'un separateur a
+        # REELLEMENT deplace. La forme qui compte est la derniere — un separateur
+        # qui deplace TOUT le groupe ne le separe plus, et c'est exactement ce qui
+        # est arrive a deux paires quand un lot a reancre leur mutant.
+        # Appelle la FONCTION QUE LA PORTE APPELLE — pas une reimplementation.
+        # Un banc qui rejoue la logique reste vert quand le produit derive ; celui-ci
+        # rougit avec lui.
+        def whys(group, decls, moved_by):
+            corpus_ = {"entries": [], "duplicate_groups": decls}
+            verdicts_ = [{"id": mid, "targets_declared": sorted(mv),
+                          "undetected_targets": [], "collateral": []}
+                         for mid, mv in moved_by.items()]
+            out = unproven_duplicate_groups([sorted(group)], corpus_, verdicts_)
+            return [x["ids"] for x in out]
+
+        # L'EPINGLAGE, et c'est la moitie porteuse : sans lui la mesure qui decide
+        # n'existe pas. Un membre du groupe hors de l'echantillon deterministe
+        # pourrait bouger sans etre vu, et la porte conclurait "sous-ensemble strict,
+        # groupe prouve" sur une separation qui n'a plus lieu.
+        v_pin = score(["001"], ["005"], ["001", "009"],
+                      dup_groups=[{"ids": ["001", "009"], "separated_by": "t"}])
+        check("un membre du groupe hors echantillon est quand meme controle",
+              v_pin["collateral"], ["009"])
+        # Et rien n'est epingle pour un mutant qui ne separe aucun groupe.
+        v_nopin = score(["001"], ["005"], ["001", "009"],
+                        dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
+        check("aucun epinglage pour un mutant qui ne separe rien",
+              v_nopin["collateral"], [])
+
+        D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
+        check("separateur qui deplace UN membre : preuve acquittee",
+              whys(["012", "013"], D, {"sep-01": {"013"}}), [])
+        check("separateur qui deplace TOUT le groupe : refuse",
+              whys(["012", "013"], D, {"sep-01": {"012", "013"}}), [["012", "013"]])
+        check("separateur qui ne deplace AUCUN membre : refuse",
+              whys(["012", "013"], D, {"sep-01": {"099"}}), [["012", "013"]])
+        check("separateur absent du jeu score : refuse",
+              whys(["012", "013"], D, {"autre": {"013"}}), [["012", "013"]])
+        check("groupe observe mais non declare : refuse",
+              whys(["012", "013"], [], {}), [["012", "013"]])
+        check("declaration devenue caduque : refuse",
+              whys(["012", "013"], D + [{"ids": ["019", "077"], "separated_by": "sep-02"}],
+                   {"sep-01": {"013"}}), [["019", "077"]])
+        # Le collateral compte comme un deplacement : un membre que le separateur ne
+        # DECLARE pas mais deplace quand meme casse la separation aussi surement.
+        check("un membre deplace en collateral casse la separation",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": D},
+                  [{"id": "sep-01", "targets_declared": ["013"],
+                    "undetected_targets": [], "collateral": ["012"]}])],
+              [["012", "013"]])
+        # Et une cible DECLAREE qui n'a pas bouge ne compte pas comme deplacee.
+        check("une cible declaree mais immobile ne prouve rien",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]],
+                  {"entries": [], "duplicate_groups": D},
+                  [{"id": "sep-01", "targets_declared": ["012", "013"],
+                    "undetected_targets": ["012", "013"], "collateral": []}])],
+              [["012", "013"]])
+
         if failures:
             log("harnais : %d test(s) ECHOUENT" % len(failures))
             for f in failures:
@@ -5960,6 +6139,7 @@ tool sync_harness:
                   "holdout_detected": 0, "holdout_total": 0, "stable": False,
                   "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
                   "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
+                  "duplicate_groups_unproven": [],
                   "runner_replayable": False,
                   "holdout_reused": [],
                   "log_tail": ""}
@@ -6591,18 +6771,33 @@ tool sync_harness:
             if report["score_pct"] < floor:
                 problems.append("mutation score %d%% is under the %d%% floor"
                                 % (report["score_pct"], floor))
-            if report["duplicate_refs"]:
+            # Byte-identical references are not automatically a defect — on a
+            # refusal lane the second entry is a CONTROL proving a mutant moved only
+            # the first. What was missing is the difference between that and a
+            # redundant pair, and it cannot be settled by a note: the gate reads
+            # data, not prose. So the corpus DECLARES the separating mutant per
+            # group, and the declaration is discharged by MEASUREMENT — the mutant
+            # must move some members and leave the others still, with every member
+            # pinned into its control sample so the answer exists.
+            #
+            # A proof obligation, not a waiver. It goes red by itself the day the
+            # separator dies, which is what a waiver could never do: measured 08/09,
+            # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
+            # separator to a lot's re-anchoring — the mutant now moves both members,
+            # and the pair proves nothing at all.
+            unproven = unproven_duplicate_groups(
+                report["duplicate_refs"], corpus, verdicts, bool(only))
+            report["duplicate_groups_unproven"] = unproven
+            if unproven:
                 problems.append("%d reference group(s) are byte-identical across DIFFERENT entries, "
-                                "so the corpus is %d observations wide, not %d. This is NOT always a "
-                                "defect: on a refusal lane two entries legitimately capture the same "
-                                "302, and the second is a control proving a mutant moved only the "
-                                "first. It IS a defect when the endpoints were meant to differ — then "
-                                "either one is redundant, or they differ on a path this fixture does "
-                                "not exercise and the difference is captured NOWHERE. Decide which, "
-                                "per group: %s"
+                                "so the corpus is %d observations wide, not %d — and their identity "
+                                "is NOT proved. A group may legitimately repeat (a refusal lane's "
+                                "second entry is a control), but the claim is discharged by a mutant "
+                                "that moves part of the group and leaves the rest still, declared in "
+                                "`duplicate_groups` and checked here. Unproved: %s"
                                 % (len(report["duplicate_refs"]), report["corpus_distinct"],
                                    report["corpus_total"],
-                                   json.dumps(report["duplicate_refs"], ensure_ascii=False)))
+                                   json.dumps(unproven, ensure_ascii=False)))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                              "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1779,13 +1779,22 @@ tool sync_harness:
                 # Structure is judged HERE, truth at the gate. A malformed
                 # declaration would otherwise be dropped in silence by
                 # duplicate_group_decls and read as "no declaration at all".
-                for g in (head_c.get("duplicate_groups") or []):
-                    _sep = g.get("separated_by") if isinstance(g, dict) else None
-                    _seps = [_sep] if isinstance(_sep, str) else _sep
-                    if not isinstance(g, dict) or not isinstance(g.get("ids"), list) \
-                            or len(g.get("ids") or []) < 2 \
-                            or not isinstance(_seps, list) or not _seps \
-                            or not all(isinstance(m, str) and m for m in _seps):
+                #
+                # Through duplicate_group_raw / duplicate_group_decl, which is the
+                # SAME predicate the gate reads. Hand-written here, the container
+                # loop was `for g in (head_c.get("duplicate_groups") or [])` and
+                # `{"duplicate_groups": 5}` raised a TypeError — this judge runs
+                # outside the gate's try/finally, so no mutant is stranded, but the
+                # mode prints a stack trace where the campaign expects its verdict.
+                # The file's own doctrine, one screen up: refused, not crashed.
+                if head_c.get("duplicate_groups") is not None \
+                        and not isinstance(head_c.get("duplicate_groups"), list):
+                    corpus_problems.append(
+                        "`duplicate_groups` is %s, not a list — every declaration in "
+                        "it is ignored whole and reads as undeclared"
+                        % type(head_c.get("duplicate_groups")).__name__)
+                for g in duplicate_group_raw(head_c):
+                    if duplicate_group_decl(g) is None:
                         corpus_problems.append(
                             "a `duplicate_groups` entry is malformed (%r) — it needs "
                             "at least two `ids` and a non-empty `separated_by`, or it "
@@ -3457,29 +3466,58 @@ tool sync_harness:
         was controlled.
         """
         out = {}
-        # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
-        # que le mutant est applique et AVANT le revert : une exception y tue le
-        # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
-        # fichier est explicite une vis plus haut — « refused, not crashed ». Le
-        # refus, lui, est prononce par duplicate_groups_shape_problems.
-        raw = corpus.get("duplicate_groups") or []
-        if not isinstance(raw, list):
-            return out
-        for g in raw:
-            if not isinstance(g, dict):
+        for g in duplicate_group_raw(corpus):
+            norm = duplicate_group_decl(g)
+            if norm is None:
                 continue
-            ids = g.get("ids")
-            sep = g.get("separated_by")
-            # One separator or several: a class of two needs one mutant to split it,
-            # a class of four needs enough of them to tell all four apart. Written
-            # as a bare string for the common case, a list when resolution costs
-            # more than one.
-            seps = [sep] if isinstance(sep, str) else sep
-            if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
-                    or not seps or not all(isinstance(m, str) and m for m in seps):
-                continue
-            out[tuple(sorted(str(i) for i in ids))] = tuple(dict.fromkeys(seps))
+            out[norm[0]] = norm[1]
         return out
+
+
+    def duplicate_group_raw(corpus):
+        """The declarations as written — the list, or [] when the key is absent or
+        is not a list at all.
+
+        Ne LEVE JAMAIS, et c'est la moitie porteuse. Ce lecteur est atteint depuis
+        score_mutant, donc APRES que le mutant est applique et AVANT le revert : une
+        exception y tue le harnais sans imprimer son rapport et laisse l'arbre MUTE.
+        La doctrine du fichier est explicite quelques vis plus haut — « refused, not
+        crashed ». Le refus, lui, est prononce ailleurs : par
+        duplicate_groups_shape_problems a la porte, par le juge d'extension sur le
+        canal. Un `for g in (corpus.get("duplicate_groups") or [])` ecrit a la main
+        leve un TypeError sur `5` ou `true` — il y en avait trois copies, il n'y en
+        a plus qu'une.
+        """
+        raw = corpus.get("duplicate_groups")
+        return raw if isinstance(raw, list) else []
+
+
+    def duplicate_group_decl(g):
+        """ONE declaration, read once — the single shape predicate of this file.
+
+        Returns `(class_key, separators)` normalised, or None when the entry is
+        malformed. `class_key` is the sorted tuple of ids, which is what makes the
+        declaration keyed on the byte-identical CLASS rather than on an ordering the
+        lot chose; `separators` is deduplicated and order-preserving.
+
+        One separator or several: a class of two needs one mutant to split it, a
+        class of four needs enough of them to tell all four apart. Written as a bare
+        string for the common case, a list when resolution costs more than one.
+
+        It exists as one function because the predicate had been written three
+        times — the reader, the shape refusal, and the extension judge — and three
+        copies of a rule is three chances for a corpus to be well-formed for one
+        reader and malformed for another.
+        """
+        if not isinstance(g, dict):
+            return None
+        ids = g.get("ids")
+        sep = g.get("separated_by")
+        seps = [sep] if isinstance(sep, str) else sep
+        if not isinstance(ids, list) or len(ids) < 2 or not isinstance(seps, list) \
+                or not seps or not all(isinstance(m, str) and m for m in seps):
+            return None
+        return tuple(sorted(str(i) for i in ids)), tuple(dict.fromkeys(seps))
 
 
     def duplicate_groups_shape_problems(corpus):
@@ -3497,17 +3535,7 @@ tool sync_harness:
             return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
                     "every declared group then reads as undeclared"
                     % type(raw).__name__]
-        bad = []
-        for g in raw:
-            if not isinstance(g, dict):
-                bad.append(repr(g)[:80])
-                continue
-            sep = g.get("separated_by")
-            seps = [sep] if isinstance(sep, str) else sep
-            if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
-                    or not isinstance(seps, list) or not seps \
-                    or not all(isinstance(m, str) and m for m in seps):
-                bad.append(repr(g)[:80])
+        bad = [repr(g)[:80] for g in raw if duplicate_group_decl(g) is None]
         if bad:
             return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
                     "each needs at least two `ids` and a non-empty `separated_by` "
@@ -5222,6 +5250,25 @@ tool sync_harness:
             check("une declaration malformee est refusee, pas ignoree",
                   any("malformed" in pb
                       for pb in xverdict(xbase)["acted"][0]["problems"]), True)
+            # Et le CONTENEUR lui-meme : `duplicate_groups: 5` faisait lever un
+            # TypeError a la boucle ecrite a la main ici — ce juge tourne hors du
+            # try/finally de la porte, donc aucun mutant n'est abandonne, mais le
+            # mode imprimait une traceback la ou la campagne attend son verdict.
+            xreset()
+            xledger(("request", '{"id": "E-D", "lot": "L", "corpus_entries": [{"id": "7"}]}'),
+                    ("act", '{"id": "E-D", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dup_entry],
+                           "duplicate_groups": 5}, f)
+            xcommit()
+            try:
+                _cv, _craised = xverdict(xbase)["acted"][0], ""
+            except Exception as e:                          # noqa: BLE001 - c'est le test
+                _cv, _craised = {}, "%s: %s" % (type(e).__name__, e)
+            check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
+                  [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
+                  ["", True])
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()
@@ -6278,6 +6325,26 @@ tool sync_harness:
                   {"ids": ["a"], "separated_by": "s"}]})), 1)
         check("et un corpus sans declaration ne dit rien",
               duplicate_groups_shape_problems({"entries": []}), [])
+        # UN SEUL predicat de forme. Il en existait trois copies — le lecteur, le
+        # refus de forme, le juge d'extension — et trois copies d'une regle sont
+        # trois occasions qu'un corpus soit bien forme pour l'un et malforme pour
+        # l'autre. Ce banc pince l'accord plutot que chaque copie : ce que le
+        # normaliseur refuse est exactement ce que le lecteur laisse tomber et
+        # exactement ce que le refus nomme.
+        _shapes = [{"ids": ["a", "b"], "separated_by": "s"},          # bien forme
+                   {"ids": ["a", "b"], "separated_by": ["s", "s"]},   # bien forme
+                   {"ids": ["a"], "separated_by": "s"},               # trop court
+                   {"ids": ["a", "b"], "separated_by": []},           # sans separateur
+                   {"ids": ["a", "b"], "separated_by": [1]},          # non textuel
+                   {"ids": "ab", "separated_by": "s"},                # ids non-liste
+                   "pas-un-dict"]
+        check("le normaliseur et le refus de forme s'accordent entree par entree",
+              [duplicate_group_decl(g) is None for g in _shapes],
+              [False, False, True, True, True, True, True])
+        check("et le lecteur ne garde que ce que le normaliseur accepte",
+              len(duplicate_group_decls({"duplicate_groups": _shapes})), 1)
+        check("le refus de forme nomme exactement les autres",
+              len(duplicate_groups_shape_problems({"duplicate_groups": _shapes})), 1)
 
         # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
         # n'est pas score, donc un separateur qui en vient est retenu, pas manquant

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -7474,11 +7474,16 @@ tool sync_harness:
             # two groups whose notes still read "TRANCHÉ, ET PROUVÉ" had lost their
             # separator to a lot's re-anchoring — the mutant now moves both members,
             # and the pair proves nothing at all.
+            #
             # verdicts + held. A declared separator may live in the held-out set —
-            # score_mutant pins its group unconditionally, so the deciding
-            # measurement really IS taken — but it lands in `held`, not `verdicts`.
-            # Passing only the latter made the gate report a separator it had just
-            # scored as never scored, and refuse the group on its own blind spot.
+            # score_mutant pins its group into the control sample there too, so the
+            # deciding measurement really IS taken — but it lands in `held`, not
+            # `verdicts`. Passing only the latter made the gate report a separator it
+            # had just scored as never scored, and refuse the group on its own blind
+            # spot. What that held measurement finds reaches the gate's own hygiene
+            # terms through `measurement_hygiene`, so a class cannot be discharged
+            # through a channel the gate is forbidden to look at.
+            #
             # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
             # `held` est vide par construction, et un separateur qui en vient n'est
             # pas absent, il est retenu.
@@ -7492,8 +7497,7 @@ tool sync_harness:
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
                 bool(only), withheld_ids, in_the_set)
-            for shape in duplicate_groups_shape_problems(corpus):
-                problems.append(shape)
+            problems.extend(duplicate_groups_shape_problems(corpus))
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 problems.append(duplicate_groups_refusal(

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3701,6 +3701,38 @@ tool sync_harness:
         return unproven
 
 
+    def duplicate_groups_refusal(unproven, duplicate_refs, corpus_distinct, corpus_total):
+        """The gate's refusal, phrased over the TWO populations it actually has.
+
+        An OBSERVED byte-identical class that is not discharged is "N of M"; a STALE
+        declaration is unproved precisely BECAUSE its references are no longer
+        identical, so it is not one of the M and can never be. Counted into one
+        ratio the line read "4 reference group(s) are not proved (out of 1
+        byte-identical …)", which is arithmetic nobody can act on — on a gate whose
+        whole point is precise adjudication, a headline that cannot be read is
+        itself the defect.
+
+        Named rather than inline in main() so the self-test drives THIS text and not
+        a re-implementation of it.
+        """
+        observed = {tuple(sorted(g)) for g in duplicate_refs}
+        stale = [u for u in unproven if tuple(sorted(u["ids"])) not in observed]
+        head = []
+        if len(unproven) - len(stale):
+            head.append("%d of %d byte-identical reference group(s) across DIFFERENT entries "
+                        "are not proved (the corpus is %d observations wide, not %d)"
+                        % (len(unproven) - len(stale), len(duplicate_refs),
+                           corpus_distinct, corpus_total))
+        if stale:
+            head.append("%d `duplicate_groups` declaration(s) no longer describe a "
+                        "byte-identical class, so the claim has nothing left to justify"
+                        % len(stale))
+        return ("%s. A group may legitimately repeat — a refusal lane's second entry is a "
+                "control — but the claim is discharged by a mutant that moves part of the "
+                "group and leaves the rest still, declared in `duplicate_groups` and checked "
+                "here: %s" % ("; ".join(head), json.dumps(unproven, ensure_ascii=False)))
+
+
     def control_ids(corpus, targets, seed):
         """Deterministic sample of non-target entries, to measure collateral."""
         pool = [e["id"] for e in corpus["entries"] if e["id"] not in targets]
@@ -6499,6 +6531,27 @@ tool sync_harness:
                   [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
                   False, [], ["held-sep"])], [True])
 
+        # LE TITRE, et il porte sur DEUX populations. Une classe OBSERVEE non
+        # acquittee se compte « N sur M » ; une declaration CADUQUE est non prouvee
+        # justement parce que ses references ne sont plus identiques, donc elle
+        # n'est pas l'un des M et ne peut pas l'etre. Comptees dans un seul rapport,
+        # la ligne annoncait « 4 reference group(s) are not proved (out of 1
+        # byte-identical …) » — une arithmetique sur laquelle personne n'agit.
+        _mixed = [{"ids": ["012", "013"], "why": "x"},
+                  {"ids": ["019", "077"], "why": "caduque"},
+                  {"ids": ["080", "081"], "why": "caduque aussi"}]
+        _head = duplicate_groups_refusal(_mixed, [["012", "013"]], 11, 14)
+        check("le titre separe les classes observees des declarations caduques",
+              [("1 of 1 byte-identical" in _head),
+               ("2 `duplicate_groups` declaration(s) no longer describe" in _head)],
+              [True, True])
+        check("et une seule population ne fait pas parler de l'autre",
+              [("no longer describe" in duplicate_groups_refusal(
+                  [{"ids": ["012", "013"], "why": "x"}], [["012", "013"]], 11, 14)),
+               ("byte-identical reference group(s)" in duplicate_groups_refusal(
+                   [{"ids": ["019", "077"], "why": "caduque"}], [], 14, 14))],
+              [False, False])
+
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
               whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -7348,22 +7401,9 @@ tool sync_harness:
                 problems.append(shape)
             report["duplicate_groups_unproven"] = unproven
             if unproven:
-                # The headline counts what the payload lists. Interpolating the
-                # OBSERVED total while listing only the unproved ones told the
-                # operator "5 groups are not proved" beside a list of one — and the
-                # two do not even range over the same set: a stale declaration is
-                # unproved while its references are, by definition, no longer
-                # identical. On a gate whose whole point is precise adjudication,
-                # that gap is the defect.
-                problems.append("%d reference group(s) are not proved (out of %d byte-identical "
-                                "across DIFFERENT entries; the corpus is %d observations wide, "
-                                "not %d). A group may legitimately repeat — a refusal lane's "
-                                "second entry is a control — but the claim is discharged by a "
-                                "mutant that moves part of the group and leaves the rest still, "
-                                "declared in `duplicate_groups` and checked here: %s"
-                                % (len(unproven), len(report["duplicate_refs"]),
-                                   report["corpus_distinct"], report["corpus_total"],
-                                   json.dumps(unproven, ensure_ascii=False)))
+                problems.append(duplicate_groups_refusal(
+                    unproven, report["duplicate_refs"],
+                    report["corpus_distinct"], report["corpus_total"]))
             if mode == "selfcheck":
                 note(report, "MODE=selfcheck — the held-out set was sealed but NOT scored; "
                              "its result is withheld on purpose. Only the final gate scores "

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3594,7 +3594,7 @@ tool sync_harness:
 
 
     def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
-                                  withheld=()):
+                                  withheld=(), in_the_set=()):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3650,14 +3650,29 @@ tool sync_harness:
             if missing and all(m in set(withheld) for m in missing):
                 continue
             if missing:
-                unproven.append({"ids": list(g), "separated_by": list(seps), "why":
-                                 "declared separator(s) %s %s" %
-                                 (", ".join(sorted(missing)),
-                                  "ran but came back INVALID — a separator that stops applying "
-                                  "is exactly how this class loses its proof"
-                                  if all(m in seen_ids for m in missing) else
-                                  ("were not scored in this pass (absent from the mutant set%s)"
-                                   % (", or excluded by GM_MUTANTS" if restricted else "")))})
+                # THREE reasons, and they send the campaign to three different
+                # places. It RAN and came back invalid — the separator is broken,
+                # fix it. It is IN the mutant set but was not reached — scoring
+                # stopped before it, or GM_MUTANTS excluded it; nothing here is the
+                # campaign's to fix, the class is simply not proved yet. It is
+                # genuinely ABSENT — the declaration names a mutant that does not
+                # exist. Collapsing the middle one into "absent from the mutant set"
+                # is a refusal nothing the campaign does can lift, which is the same
+                # dead end WITHHELD-is-not-ABSENT removed one commit earlier.
+                if all(m in seen_ids for m in missing):
+                    why = ("ran but came back INVALID — a separator that stops applying "
+                           "is exactly how this class loses its proof")
+                elif all(m in set(in_the_set) for m in missing):
+                    why = ("are IN the mutant set but were not scored in this pass — "
+                           "scoring stopped before them%s. The class is not proved yet; "
+                           "nothing in the corpus is wrong" %
+                           (", or GM_MUTANTS excluded them" if restricted else ""))
+                else:
+                    why = ("were not scored in this pass (absent from the mutant set%s)"
+                           % (", or excluded by GM_MUTANTS" if restricted else ""))
+                unproven.append({"ids": list(g), "separated_by": list(seps),
+                                 "why": "declared separator(s) %s %s"
+                                        % (", ".join(sorted(missing)), why)})
                 continue
             # One signature per member: which of the declared separators move it.
             # Pairwise-distinct signatures IS "the references are distinguishable";
@@ -6434,6 +6449,29 @@ tool sync_harness:
         check("mais un separateur simplement ABSENT en produit un",
               [x["ids"] for x in unproven_duplicate_groups(
                   [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+        # Et le TROISIEME cas, celui qui restait confondu avec le second : un
+        # separateur que le scan n'a pas ATTEINT (arret apres un revert sale,
+        # GM_MUTANTS restreint) existe bel et bien. Le refus doit rester — rien n'est
+        # prouve — mais dire « absent du jeu de mutants » envoyait la campagne
+        # corriger une absence qui n'en est pas une, exactement le cul-de-sac que
+        # RETENU-n'est-pas-ABSENT venait de retirer.
+        check("un separateur NON ATTEINT refuse en le disant, pas en criant l'absence",
+              [x["why"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, [], ["held-sep"])],
+              ["declared separator(s) held-sep are IN the mutant set but were not "
+               "scored in this pass — scoring stopped before them. The class is not "
+               "proved yet; nothing in the corpus is wrong"])
+        check("et un separateur vraiment absent garde son motif",
+              [("absent from the mutant set" in x["why"])
+               for x in unproven_duplicate_groups(
+                   [["012", "013"]], _wd, [], False, [], ["un-autre"])], [True])
+        # Un separateur qui a TOURNE et qui est invalide garde le sien : le fait
+        # d'etre dans le jeu ne doit pas masquer qu'il a echoue.
+        check("un separateur INVALIDE reste un INVALIDE meme s'il est dans le jeu",
+              [("INVALID" in x["why"]) for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd,
+                  [{"id": "held-sep", "valid": False, "reason": "apply.sh a echoue"}],
+                  False, [], ["held-sep"])], [True])
 
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
@@ -7272,9 +7310,14 @@ tool sync_harness:
             # pas absent, il est retenu.
             withheld_ids = ([m.get("id") for m in held_meta]
                             if (mode == "selfcheck" and not held) else [])
+            # Ce que le JEU DE MUTANTS contient, score ou non. Un separateur que le
+            # scan n'a pas atteint — l'arret apres un revert sale, un GM_MUTANTS
+            # restreint — n'est pas absent : il existe, il n'a pas tourne. Le dire
+            # « absent du jeu » envoyait corriger une absence qui n'en est pas une.
+            in_the_set = [m.get("id") for m in visible + held_meta]
             unproven = unproven_duplicate_groups(
                 report["duplicate_refs"], corpus, list(verdicts) + list(held),
-                bool(only), withheld_ids)
+                bool(only), withheld_ids, in_the_set)
             for shape in duplicate_groups_shape_problems(corpus):
                 problems.append(shape)
             report["duplicate_groups_unproven"] = unproven

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3814,8 +3814,19 @@ tool sync_harness:
         # deterministic slice of the corpus, and a member that fell outside it could
         # move unseen — which is precisely the claim the declaration makes, so the
         # one measurement that decides it must not be left to the sampling stride.
+        #
+        # Pinned against the CORPUS, and that intersection is load-bearing.
+        # `control_covered` is `len(sample)`, and the gate refuses a mutant whose
+        # coverage is 0 — "collateral: 0" with nothing to control against is vacuous
+        # rather than earned. An id that no entry declares is never captured and
+        # never compared (capture() iterates entries; diverged() reads None on both
+        # sides and calls it equal), so pinning one would have raised the coverage
+        # with a control that does not exist and silenced that refusal. A
+        # declaration naming an id the corpus does not have is refused where it
+        # belongs — as a class nothing observes — not by inflating a count here.
         sample = control_ids(corpus, set(targets), seed)
-        pinned = separator_group_ids(corpus, meta.get("id")) - set(targets)
+        corpus_ids = {e["id"] for e in corpus["entries"]}
+        pinned = (separator_group_ids(corpus, meta.get("id")) & corpus_ids) - set(targets)
         if pinned:
             sample = sorted(set(sample) | pinned)
         captured = capture(config, corpus, canon, ids=set(targets) | set(sample))
@@ -6267,6 +6278,21 @@ tool sync_harness:
                         dup_groups=[{"ids": ["001", "009"], "separated_by": "un-autre"}])
         check("aucun epinglage pour un mutant qui ne separe rien",
               v_nopin["collateral"], [])
+        # Et JAMAIS un id que le corpus n'a pas. `control_covered` est len(sample),
+        # et la porte refuse un mutant dont la couverture est nulle — « collateral
+        # 0 » sans rien a controler est vide, pas merite. Un id qu'aucune entree ne
+        # declare n'est jamais capture ni compare : l'epingler aurait leve la
+        # couverture avec un temoin qui n'existe pas, et eteint ce refus-la.
+        # Lu sans planter : si l'epinglage repassait large, la capture serait
+        # interrogee sur un id qu'elle n'a pas — et un banc qui plante dit qu'il
+        # s'est passe quelque chose sans dire quoi.
+        try:
+            _vg = score(["001"], [], ["001"],
+                        dup_groups=[{"ids": ["001", "fantome"], "separated_by": "t"}])
+            _ghost = [_vg["control_covered"], _vg["collateral"]]
+        except Exception as e:                              # noqa: BLE001 - c'est le test
+            _ghost = "%s: %s" % (type(e).__name__, e)
+        check("un id absent du corpus n'est pas epingle comme temoin", _ghost, [0, []])
 
         # Un separateur INVALIDE ne prouve rien. Son verdict porte
         # `targets_declared` mais jamais `undetected_targets` ni `collateral`, donc

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -1839,6 +1839,48 @@ tool sync_harness:
                             "added entry id %r derives a reference path outside "
                             "refs/ — a write to an existing reference wearing an "
                             "addition's name" % (aid,))
+                # ADDITIONS-ONLY APPLIES INSIDE THE FREED KEY TOO.
+                #
+                # `duplicate_groups` was freed from the freeze because the lot that
+                # ADDS an entry is the one that can create a new byte-identical
+                # class, and telling it to declare a separator in a key another
+                # judge refuses it is a remedy nobody can apply. That argument frees
+                # ADDING a declaration — and adding is the half that is VERIFIED: a
+                # bogus separator is refused at the gate by measurement.
+                #
+                # Rewriting or deleting one is verified by nothing. Swapping a
+                # still-valid separator for another still-valid separator silently
+                # reassigns a class this lot never touched, and a deletion only
+                # re-opens the undeclared-duplicate refusal for whoever comes next.
+                # Exempting the whole key turned "an extension adds entries and
+                # touches nothing else" into a sentence with an exception nobody
+                # bounded.
+                base_decls = duplicate_group_decls(base_c)
+                head_decls = duplicate_group_decls(head_c)
+                added_str = {str(a) for a in added_ids}
+                for key, seps in sorted(base_decls.items()):
+                    if key in head_decls:
+                        if set(head_decls[key]) != set(seps):
+                            corpus_problems.append(
+                                "`duplicate_groups` for class %s was RE-ADJUDICATED "
+                                "(%s -> %s) — an extension may declare a class it "
+                                "creates, never re-decide one it did not"
+                                % (json.dumps(list(key)), json.dumps(list(seps)),
+                                   json.dumps(list(head_decls[key]))))
+                        continue
+                    # A pre-existing class may only disappear into a SUPERSET that
+                    # an added entry joined: a new entry landing on an existing
+                    # byte-identical class re-keys it, and may need more separators
+                    # to keep the members pairwise distinguishable. That is the
+                    # legitimate case the exemption exists for; everything else is
+                    # a withdrawal.
+                    if not any(set(k) > set(key) and (set(k) - set(key)) & added_str
+                               for k in head_decls):
+                        corpus_problems.append(
+                            "`duplicate_groups` for class %s was WITHDRAWN — a "
+                            "deletion re-opens the undeclared-duplicate refusal for "
+                            "whoever comes next, and it is not this lot's "
+                            "adjudication to withdraw" % json.dumps(list(key)))
                 claimed = set()
                 for act in acts:
                     req = requests.get(act.get("id"))
@@ -5375,6 +5417,59 @@ tool sync_harness:
             check("un `duplicate_groups` non-liste refuse, il ne fait pas planter le juge",
                   [_craised, any("not a list" in pb for pb in _cv.get("problems") or [])],
                   ["", True])
+
+            # LE CANAL N'EST PAS UN DROIT DE REVISION. La cle est liberee du gel
+            # parce que le lot qui AJOUTE une entree est celui qui peut creer une
+            # nouvelle classe byte-identique. AJOUTER une declaration est verifie —
+            # un separateur bidon est refuse a la porte par la mesure. La REECRIRE
+            # ou la SUPPRIMER n'est verifie par rien : echanger un separateur
+            # valide contre un autre separateur valide rejuge en silence la classe
+            # d'un autre lot, et une suppression rouvre le refus « doublon non
+            # declare » pour le suivant.
+            xreset()
+            dg_a, dg_b = dict(base_entry, id="20"), dict(base_entry, id="21")
+            dg_c = dict(base_entry, id="22")
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, dg_a, dg_b],
+                           "duplicate_groups": [{"ids": ["20", "21"],
+                                                 "separated_by": "sep-old"}]}, f)
+            xcommit()
+            xbase_dg = fixture_git(xroot, "rev-parse", "HEAD")
+
+            def xdg(groups):
+                """Un lot qui ajoute l'entree 22, sur une base qui PORTE deja une
+                declaration — et qui touche `duplicate_groups` comme indique."""
+                fixture_git(xroot, "reset", "-q", "--hard", xbase_dg)
+                fixture_git(xroot, "clean", "-qfd")
+                xledger(("request",
+                         '{"id": "E-G", "lot": "L", "corpus_entries": [{"id": "22"}]}'),
+                        ("act", '{"id": "E-G", "lot": "L",'
+                                ' "recorded_paths": [".golden-master/corpus.json"]}'))
+                with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                    json.dump({"entries": [base_entry, dg_a, dg_b, dg_c],
+                               "duplicate_groups": groups}, f)
+                xcommit()
+                return xverdict(xbase_dg)["acted"][0]["problems"]
+
+            check("echanger un separateur valide contre un autre : REFUSE",
+                  any("RE-ADJUDICATED" in pb
+                      for pb in xdg([{"ids": ["20", "21"],
+                                      "separated_by": "sep-new"}])), True)
+            check("supprimer la declaration d'un autre lot : REFUSE",
+                  any("WITHDRAWN" in pb for pb in xdg([])), True)
+            # Le cas legitime que l'exemption existe pour servir : l'entree ajoutee
+            # REJOINT la classe, qui se recle en sur-ensemble et peut demander un
+            # separateur de plus pour garder les membres distinguables deux a deux.
+            check("une entree ajoutee qui rejoint la classe la recle sans refus",
+                  [pb for pb in xdg([{"ids": ["20", "21", "22"],
+                                      "separated_by": ["sep-old", "sep-2"]}])
+                   if "duplicate_groups" in pb], [])
+            # Et DECLARER reste libre : ajouter une classe neuve ne touche a
+            # l'adjudication de personne.
+            check("declarer une classe neuve reste libre",
+                  [pb for pb in xdg([{"ids": ["20", "21"], "separated_by": "sep-old"},
+                                     {"ids": ["1", "22"], "separated_by": "sep-3"}])
+                   if "duplicate_groups" in pb], [])
 
             # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
             xreset()

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -3420,7 +3420,15 @@ tool sync_harness:
         was controlled.
         """
         out = {}
-        for g in (corpus.get("duplicate_groups") or []):
+        # Ne LEVE JAMAIS. Ce lecteur est atteint depuis score_mutant, donc APRES
+        # que le mutant est applique et AVANT le revert : une exception y tue le
+        # harnais sans imprimer son rapport et laisse l'arbre MUTE. La doctrine du
+        # fichier est explicite une vis plus haut — « refused, not crashed ». Le
+        # refus, lui, est prononce par duplicate_groups_shape_problems.
+        raw = corpus.get("duplicate_groups") or []
+        if not isinstance(raw, list):
+            return out
+        for g in raw:
             if not isinstance(g, dict):
                 continue
             ids = g.get("ids")
@@ -3437,6 +3445,40 @@ tool sync_harness:
         return out
 
 
+    def duplicate_groups_shape_problems(corpus):
+        """Ce que le LECTEUR laisse tomber en silence, dit a voix haute.
+
+        duplicate_group_decls ignore ce qu'il ne sait pas lire — il le doit, il
+        tourne avec un mutant applique. Mais une declaration ignoree se lit comme
+        « aucune declaration », donc comme un groupe non declare : le message
+        envoie corriger une absence alors que le defaut est une faute de frappe.
+        """
+        raw = corpus.get("duplicate_groups")
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            return ["`duplicate_groups` is %s, not a list — it is ignored whole, and "
+                    "every declared group then reads as undeclared"
+                    % type(raw).__name__]
+        bad = []
+        for g in raw:
+            if not isinstance(g, dict):
+                bad.append(repr(g)[:80])
+                continue
+            sep = g.get("separated_by")
+            seps = [sep] if isinstance(sep, str) else sep
+            if not isinstance(g.get("ids"), list) or len(g.get("ids") or []) < 2 \
+                    or not isinstance(seps, list) or not seps \
+                    or not all(isinstance(m, str) and m for m in seps):
+                bad.append(repr(g)[:80])
+        if bad:
+            return ["%d `duplicate_groups` entr%s malformed and silently ignored — "
+                    "each needs at least two `ids` and a non-empty `separated_by` "
+                    "(a string, or a list of them): %s"
+                    % (len(bad), "y is" if len(bad) == 1 else "ies are", "; ".join(bad))]
+        return []
+
+
     def separator_group_ids(corpus, mutant_id):
         """Every id of every group this mutant is declared to separate."""
         if not mutant_id:
@@ -3448,7 +3490,8 @@ tool sync_harness:
         return ids
 
 
-    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False):
+    def unproven_duplicate_groups(duplicate_refs, corpus, verdicts, restricted=False,
+                                  withheld=()):
         """Which byte-identical classes are NOT discharged by measured separators.
 
         `duplicate_refs` holds MAXIMAL equivalence classes — every id sharing one
@@ -3485,6 +3528,14 @@ tool sync_harness:
                                  "and then it must name the mutant(s) that tell them apart."})
                 continue
             missing = [m for m in seps if m not in scored]
+            # WITHHELD is not MISSING. In selfcheck the held-out set is deliberately
+            # not scored — `held` is empty by construction — so a separator drawn
+            # from it would be reported "absent from the mutant set", which is false
+            # and which the campaign cannot fix: the mutant IS in the set, its
+            # result is simply reserved for the final gate. Saying so is the whole
+            # difference between a work item and a dead end.
+            if missing and all(m in set(withheld) for m in missing):
+                continue
             if missing:
                 unproven.append({"ids": list(g), "separated_by": list(seps), "why":
                                  "declared separator(s) %s %s" %
@@ -6156,6 +6207,32 @@ tool sync_harness:
                     "undetected_targets": [], "collateral": []}])],
               [])
 
+        # R797693 : le lecteur ne LEVE jamais (il tourne avec un mutant applique),
+        # et ce qu'il laisse tomber est dit a voix haute par le controle de forme —
+        # sinon une faute de frappe se lit comme « groupe non declare » et envoie
+        # corriger une absence.
+        check("un `duplicate_groups` non-liste ne fait pas planter le lecteur",
+              duplicate_group_decls({"duplicate_groups": 5}), {})
+        check("et il est REFUSE, pas ignore",
+              len(duplicate_groups_shape_problems({"duplicate_groups": 5})), 1)
+        check("une entree malformee est refusee nommement",
+              len(duplicate_groups_shape_problems({"duplicate_groups": [
+                  {"ids": ["a"], "separated_by": "s"}]})), 1)
+        check("et un corpus sans declaration ne dit rien",
+              duplicate_groups_shape_problems({"entries": []}), [])
+
+        # R8bcd2c : RETENU n'est pas ABSENT. En selfcheck le jeu tenu a l'ecart
+        # n'est pas score, donc un separateur qui en vient est retenu, pas manquant
+        # — et le dire autrement produit un refus que la campagne ne peut pas lever.
+        _wd = {"entries": [], "duplicate_groups": [
+            {"ids": ["012", "013"], "separated_by": "held-sep"}]}
+        check("un separateur RETENU ne produit pas de refus",
+              unproven_duplicate_groups([["012", "013"]], _wd, [], False,
+                                        ["held-sep"]), [])
+        check("mais un separateur simplement ABSENT en produit un",
+              [x["ids"] for x in unproven_duplicate_groups(
+                  [["012", "013"]], _wd, [], False, [])], [["012", "013"]])
+
         D = [{"ids": ["012", "013"], "separated_by": "sep-01"}]
         check("separateur qui deplace UN membre : preuve acquittee",
               whys(["012", "013"], D, {"sep-01": {"013"}}), [])
@@ -6991,8 +7068,16 @@ tool sync_harness:
             # measurement really IS taken — but it lands in `held`, not `verdicts`.
             # Passing only the latter made the gate report a separator it had just
             # scored as never scored, and refuse the group on its own blind spot.
+            # Les ids TENUS A L'ECART quand leur resultat est reserve : en selfcheck
+            # `held` est vide par construction, et un separateur qui en vient n'est
+            # pas absent, il est retenu.
+            withheld_ids = ([m.get("id") for m in held_meta]
+                            if (mode == "selfcheck" and not held) else [])
             unproven = unproven_duplicate_groups(
-                report["duplicate_refs"], corpus, list(verdicts) + list(held), bool(only))
+                report["duplicate_refs"], corpus, list(verdicts) + list(held),
+                bool(only), withheld_ids)
+            for shape in duplicate_groups_shape_problems(corpus):
+                problems.append(shape)
             report["duplicate_groups_unproven"] = unproven
             if unproven:
                 # The headline counts what the payload lists. Interpolating the

--- a/bots/golden_master_runner_parity_test.go
+++ b/bots/golden_master_runner_parity_test.go
@@ -1,0 +1,99 @@
+package bots
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The golden-master gate is stated TWICE: once as the graph conjunction
+// (`compute oracle_gate.converged`) and once as `RUNNER_VERDICT_PY`'s `ok`,
+// the standalone `verify-oracle.sh` entry point that CI and humans run. The
+// runner's own comment says it must never be weaker than the graph gate.
+//
+// Nothing checked that. C031 makes a graph term reading an undeclared report
+// field a compile error, so leg one is guarded; the runner's `ok` is a Python
+// string inside a tool script and is invisible to every compiler in this repo.
+// That asymmetry is the structural reason the same defect happened twice — the
+// `holdout_reused` term, then `duplicate_groups_unproven`, each landed in the
+// graph conjunction while the entry point CI runs kept approving exactly the
+// tree the graph refuses.
+//
+// A verdict that establishes something NEAR what it claims and reports the
+// resemblance is the defect this bot exists to catch in other people's
+// deliveries; carrying it in its own two gates was not tenable.
+func TestGoldenMasterStandaloneRunnerCarriesTheGraphGatesTerms(t *testing.T) {
+	bot := readHarnessFile(t, "golden-master/main.bot")
+	graph := convergedExpr(t, bot)
+	runner := runnerVerdictOK(t, bot)
+
+	// The divergences that PRE-DATE this check, named so they stay visible
+	// instead of being silently re-created. The first two compare a report
+	// field against a graph `var`, which a runner reading only the report file
+	// structurally cannot reach — closing them means emitting the thresholds
+	// into the runner. The third is a plain report field and therefore the very
+	// class of weakness this test exists to prevent; it is tracked here rather
+	// than closed, because widening the standalone gate is its own change with
+	// its own blast radius.
+	knownGaps := map[string]string{
+		"score_pct":         "compared against vars.mutation_floor, which the report file does not carry",
+		"corpus_distinct":   "compared against vars.min_corpus, which the report file does not carry",
+		"unstable_controls": "a plain report field — a real gap, named rather than closed here",
+	}
+
+	seen := map[string]bool{}
+	for _, m := range regexp.MustCompile(`outputs\.oracle_run\.(\w+)`).FindAllStringSubmatch(graph, -1) {
+		field := m[1]
+		if seen[field] {
+			continue
+		}
+		seen[field] = true
+
+		carried := regexp.MustCompile(`r\.get\(\\"` + regexp.QuoteMeta(field) + `\\"\)`).MatchString(runner)
+		why, known := knownGaps[field]
+		switch {
+		case carried && known:
+			t.Errorf("the standalone runner now carries %s, but it is still listed as a known gap (%q): "+
+				"delete the entry, or the allowlist starts covering divergences nobody decided to accept", field, why)
+		case carried:
+		case known:
+			t.Logf("known divergence: the standalone runner does not read %s (%s)", field, why)
+		default:
+			t.Errorf("oracle_gate.converged refuses on outputs.oracle_run.%s but RUNNER_VERDICT_PY's `ok` never reads it: "+
+				"`verify-oracle.sh` — the entry point CI and humans run — would approve exactly the tree the graph gate "+
+				"refuses. Add `and not r.get(%q)` (or the comparison that fits) to `ok`, or, if the term genuinely cannot "+
+				"reach the standalone runner, add it to knownGaps in this test with the reason.", field, field)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("no outputs.oracle_run.* term found in the conjunction: it moved, fix this test")
+	}
+}
+
+// convergedExpr returns the one line that IS the graph conjunction. Pinned on
+// the expression, not on the `converged:` name — `schema gate_state` declares
+// the field too, and matching that would compare the gate against a type.
+func convergedExpr(t *testing.T, bot string) string {
+	t.Helper()
+	for _, l := range strings.Split(bot, "\n") {
+		if strings.Contains(l, `converged: "outputs.oracle_run.`) {
+			return l
+		}
+	}
+	t.Fatal("the `converged:` conjunction was not found in main.bot — the gate was restructured, fix this test")
+	return ""
+}
+
+// runnerVerdictOK returns the `ok=(...)` assignment of RUNNER_VERDICT_PY, and
+// only that: `mode=(r.get("mode") or "gate")` sits above it and the notice read
+// below, neither of which decides the verdict.
+func runnerVerdictOK(t *testing.T, bot string) string {
+	t.Helper()
+	const start, end = `ok=(r.get(`, `n=r.get(\"notice\")`
+	i := strings.Index(bot, start)
+	j := strings.Index(bot, end)
+	if i < 0 || j < 0 || j <= i {
+		t.Fatal("RUNNER_VERDICT_PY's `ok=(...)` assignment was not found between its markers — the runner verdict was restructured, fix this test")
+	}
+	return bot[i:j]
+}


### PR DESCRIPTION
The gate refused on **any** two byte-identical references, unconditionally. Its own message said the refusal is not always right — *"on a refusal lane two entries legitimately capture the same 302, and the second is a control proving a mutant moved only the first"* — and then offered no way to say so. The corpus answered in `note`, which is prose, and **the gate reads data**. A net whose duplicates were every one of them justified could therefore never converge.

Measured on a live campaign: five groups, each adjudicated in the notes with a named separator and a measured radius, and the gate refused all five. The rite had spent **7 hours** to be turned away by a clause nothing could satisfy.

### The claim becomes data, and is discharged by measurement

```json
"duplicate_groups": [
  {"ids": ["019", "077"], "separated_by": "sep-02-region-de-l-utilisateur-courant"}
]
```

The gate checks that the named mutant **moves some members and leaves the others still**:

| situation | verdict |
|---|---|
| group observed, no declaration | refuse — either one member is redundant, or name the separator |
| declared separator not scored in this pass | refuse (says so, and whether `GM_MUTANTS` restricted the traversal) |
| separator moves **no** member | refuse — it separates nothing |
| separator moves **every** member | refuse — it no longer tells them apart |
| declaration whose refs are no longer identical | refuse — a claim with nothing left to justify |

### Why a proof obligation and not a waiver

It goes red **by itself** the day the separator dies. That is not hypothetical: two of the five groups had lost theirs to a lot's re-anchoring — the mutant now moves both members and proves nothing — while the notes still read `TRANCHÉ, ET PROUVÉ`. A waiver would have carried those two forever.

### The pinning is the load-bearing half

A group member outside the deterministic control sample could move **unseen**, and the gate would then read a strict subset and call the group proved on a separation that no longer happens. Every member is now forced into its separator's control sample, so the measurement that decides exists by construction.

### Falsification

Against the function the gate itself calls, not a re-implementation of it — a bench that replays the logic stays green while the product drifts.

| sabotage | result |
|---|---|
| gate trusts the declaration (`inside = set(g)`) | **2 checks red** |
| pinning removed | **1 check red**, `obtenu: []` — the member that moved unseen |

274 selftest checks · `go test ./bots/...` green (96s) · `go vet` clean · copies re-inlined with `sync-harness.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)