### PR TITLE
feat(forge): a connection can pin the base its hook URLs are built from

### DIFF
--- a/cmd/iterion/remote_webhooks.go
+++ b/cmd/iterion/remote_webhooks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
@@ -117,20 +118,28 @@ var (
 	remoteForgeAvatarVariant string
 )
 
+var remoteForgeWebhookBase string
+
 var remoteForgeCmd = &cobra.Command{
 	Use:   "forge",
 	Short: "Forge connections and provisioning (team scope)",
 }
 
 var remoteForgeConnectionsCmd = &cobra.Command{
-	Use:   "connections [create|delete <conn-id>|repos <conn-id>|avatar <conn-id>]",
+	Use:   "connections [create|delete <conn-id>|repos <conn-id>|avatar <conn-id>|webhook-base <conn-id>]",
 	Short: "Forge connections",
 	Long: "List, create or delete the team's forge connections. `avatar <conn-id>` " +
 		"uploads the iterion-bot avatar onto the account behind a PAT connection " +
 		"(a GitLab group/project token's bot user, a Forgejo bot account); an " +
 		"account the forge does not flag as a bot needs --force. Refused on an " +
 		"OAuth connection (a person's account) and on GitHub, which has no avatar " +
-		"or App-logo API — the error names where to upload it by hand.",
+		"or App-logo API — the error names where to upload it by hand.\n\n" +
+		"`webhook-base <conn-id> --url <scheme://host>` pins the base this " +
+		"connection's inbound hook URLs are built from, for a forge that cannot " +
+		"reach the deployment's public URL — GitLab refuses an unlisted webhook " +
+		"host with \"Invalid url given\", and listing one is the forge admin's " +
+		"call, not ours. The pin is what makes the exception survive a " +
+		"re-provision; --url \"\" clears it. Takes effect at the next provision.",
 	Args: cobra.MaximumNArgs(2),
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		base, err := teamBase(cmd, c, "/forge/connections")
@@ -151,8 +160,17 @@ var remoteForgeConnectionsCmd = &cobra.Command{
 			return cli.RemoteGetPrint(cmd.Context(), c, p, base+"/"+args[1]+"/repos")
 		case args[0] == "avatar" && len(args) == 2:
 			return cli.RemoteForgeAvatar(cmd.Context(), c, p, base+"/"+args[1]+"/avatar", remoteForgeAvatarVariant, remoteForgeAvatarForce)
+		case args[0] == "webhook-base" && len(args) == 2:
+			if !cmd.Flags().Changed("url") {
+				return fmt.Errorf("--url is required (pass --url \"\" to clear the pin and follow the deployment's public URL)")
+			}
+			raw, err := json.Marshal(map[string]any{"webhook_base_url": remoteForgeWebhookBase})
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendData(cmd.Context(), c, p, "PATCH", base+"/"+args[1], string(raw), "connection patch JSON")
 		default:
-			return fmt.Errorf("usage: connections [create --data @f|delete <id>|repos <id>|avatar <id> [--force] [--variant plain|circle]]")
+			return fmt.Errorf("usage: connections [create --data @f|delete <id>|repos <id>|avatar <id> [--force] [--variant plain|circle]|webhook-base <id> --url <url>]")
 		}
 	}),
 }
@@ -259,6 +277,7 @@ func init() {
 		if c == remoteForgeConnectionsCmd {
 			c.Flags().BoolVar(&remoteForgeAvatarForce, "force", false, "avatar: apply even when the forge does not flag the account as a bot (a dedicated account, never a person's)")
 			c.Flags().StringVar(&remoteForgeAvatarVariant, "variant", "", "avatar: mascot rendering to upload, plain (default) or circle")
+			c.Flags().StringVar(&remoteForgeWebhookBase, "url", "", "webhook-base: scheme+host the forge should deliver to; \"\" clears the pin")
 		}
 	}
 	remoteWebhooksCmd.AddCommand(

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -74,6 +74,19 @@ unparseable or path-carrying value is refused with 422 at the PATCH, on
 purpose: a wrong base does not fail when it is set — it fails as hooks that
 register successfully and never arrive.
 
+Two more properties of that endpoint worth knowing:
+
+- **It refuses a body carrying `webhook_base_url` *and*
+  `security_read_enabled` together (400).** They act on different systems —
+  one pins a URL, the other mints or withdraws a live org token on GitHub —
+  and nothing makes them atomic. Sent together, a failure of the
+  security-read half would drop the URL change while the error named only
+  security-read. Send them as separate requests.
+- **An `http://` base on a non-loopback host is accepted but warned**: the
+  forge then delivers the payload *and* the signature header in the clear.
+  An internal-network endpoint is a legitimate thing to pin, so this is a
+  log line, not a refusal.
+
 **Declaring the pin is what makes the exception durable.** A hook URL that
 merely predates a public-URL change is one re-provision away from being
 silently rewritten to an address the forge is not allowed to call — and

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -46,6 +46,45 @@ Rotate or revoke at any time: `POST /api/teams/{id}/webhooks/{webhook_id}/rotate
 returns a fresh plaintext (also shown once) and updates the forge's
 "secret" field is then a manual step.
 
+## When a forge cannot reach the deployment's public URL
+
+Provisioned hook URLs are built from the deployment's public URL
+(`auth.publicUrl` → `forge.Orchestrator.PublicURL`), which is what every
+connection wants: move the deployment and the next provision moves its
+hooks with it.
+
+A forge may refuse that host outright. **GitLab** rejects any webhook URL
+outside its instance-wide outbound allowlist with `Invalid url given`
+(HTTP 422, surfaced as `create hook: HTTP 422`), and getting a host listed
+is an administrative act on the forge's side — Admin area → Settings →
+Network → Outbound requests. A deployment that serves two names, or that is
+migrating between them, then has one connection that cannot follow.
+
+`Connection.WebhookBaseURL` pins the base for **that connection only**:
+
+```sh
+iterion remote forge connections webhook-base <conn-id> \
+  --url https://iterion.old-and-allowlisted.example
+iterion remote forge connections webhook-base <conn-id> --url ""   # clear
+```
+
+It takes effect at the next provision, and the value must be scheme+host
+(the `/api/webhooks/<provider>/<id>` route is appended to it). An
+unparseable or path-carrying value is refused with 422 at the PATCH, on
+purpose: a wrong base does not fail when it is set — it fails as hooks that
+register successfully and never arrive.
+
+**Declaring the pin is what makes the exception durable.** A hook URL that
+merely predates a public-URL change is one re-provision away from being
+silently rewritten to an address the forge is not allowed to call — and
+enabling one more bot, or moving the repo to another team, is a
+re-provision. The write succeeds; only the deliveries stop.
+
+Prefer getting the canonical host allowlisted and clearing the pin. It is
+an escape hatch for the interval where that is out of your hands, not a
+target state — the pinned host has to keep resolving and serving for as
+long as the pin is there.
+
 ## Auth modes — token vs HMAC
 
 Iterion's middleware has two authentication modes, picked per provider

--- a/openapi.json
+++ b/openapi.json
@@ -613,6 +613,9 @@
           "updated_at": {
             "format": "date-time",
             "type": "string"
+          },
+          "webhook_base_url": {
+            "type": "string"
           }
         },
         "required": [

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -598,7 +598,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		o.rollbackConfig(ctx, createdConfig, webhookID)
 		return ProvisionResult{}, fmt.Errorf("forge: build admin client: %w", err)
 	}
-	hookURL := o.inboundURL(conn.Provider, webhookID)
+	hookURL := o.inboundURL(conn, webhookID)
 	spec := HookSpec{URL: hookURL, Secret: plaintext, Events: nativeEvents, Active: true}
 
 	// existing is the zero RepoIntegration when !hasExisting, so its HookID
@@ -1021,8 +1021,17 @@ func (o *Orchestrator) DeprovisionConnection(ctx context.Context, tenantID, conn
 	return o.Connections.Delete(ctx, connID)
 }
 
-func (o *Orchestrator) inboundURL(p Provider, webhookID string) string {
-	return strings.TrimRight(o.PublicURL, "/") + "/api/webhooks/" + string(p) + "/" + webhookID
+// inboundURL builds the hook URL the forge will call back on. The single
+// place a hook address is decided, so the per-connection override needs to
+// exist in exactly one spot: a connection that pins WebhookBaseURL keeps
+// its own base, everyone else follows the deployment's public URL and moves
+// with it.
+func (o *Orchestrator) inboundURL(conn Connection, webhookID string) string {
+	base := conn.WebhookBaseURL
+	if base == "" {
+		base = o.PublicURL
+	}
+	return strings.TrimRight(base, "/") + "/api/webhooks/" + string(conn.Provider) + "/" + webhookID
 }
 
 // ---- small helpers ----

--- a/pkg/forge/orchestrator_webhook_base_test.go
+++ b/pkg/forge/orchestrator_webhook_base_test.go
@@ -1,0 +1,142 @@
+package forge
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// hookURLFor returns the URL the fake forge recorded for repo.
+func hookURLFor(t *testing.T, fa *fakeAdmin, repo string) string {
+	t.Helper()
+	h, ok := fa.hooks[repo]
+	if !ok {
+		t.Fatalf("no hook registered for %s", repo)
+	}
+	return h.URL
+}
+
+// TestHookURLFollowsThePublicURLByDefault: the ordinary connection has no
+// opinion about its hook address and must move with the deployment.
+func TestHookURLFollowsThePublicURLByDefault(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+
+	if _, err := o.Provision(context.Background(), ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(got, "https://iterion.example.com/api/webhooks/") {
+		t.Fatalf("hook URL = %q, want it built from the deployment's public URL", got)
+	}
+}
+
+// TestPinnedConnectionKeepsItsOwnHookBase: a forge that cannot reach the
+// deployment's public URL pins its own. GitLab refuses any webhook URL
+// outside its outbound allowlist with "Invalid url given" (HTTP 422), and
+// listing a host is an administrative act on the forge's side — so without
+// this, one such forge pins the public URL of the WHOLE deployment.
+func TestPinnedConnectionKeepsItsOwnHookBase(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	conn := seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	conn.WebhookBaseURL = "https://iterion.allowlisted.example"
+	if err := o.Connections.Update(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(got, "https://iterion.allowlisted.example/api/webhooks/") {
+		t.Fatalf("hook URL = %q, want the connection's pinned base — the deployment's "+
+			"public URL is one the forge is not allowed to call", got)
+	}
+}
+
+// TestPinSurvivesAReprovision is the assertion the feature exists for.
+// Leaving an old hook URL in place "because nobody re-provisions it" is not
+// a state, it is a delay: enabling one more bot, splitting a team, or any
+// bots-enable call rewrites the hook from the CURRENT public URL. The pin
+// is what makes the exception durable rather than merely un-disturbed.
+func TestPinSurvivesAReprovision(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	conn := seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	conn.WebhookBaseURL = "https://iterion.allowlisted.example"
+	if err := o.Connections.Update(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The deployment moves to its new domain while this connection cannot.
+	o.PublicURL = "https://iterion.cloud"
+
+	// One more bot on the same repo — the full re-provision path.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"revi-converse"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := hookURLFor(t, fa, "group/api")
+	if strings.Contains(got, "iterion.cloud") {
+		t.Fatalf("the re-provision rewrote the hook to the new public URL (%q). The forge "+
+			"refuses that host, so deliveries stop — and the write SUCCEEDS, so nothing "+
+			"reports it.", got)
+	}
+	if !strings.HasPrefix(got, "https://iterion.allowlisted.example/api/webhooks/") {
+		t.Fatalf("hook URL = %q, want the pinned base preserved across the re-provision", got)
+	}
+}
+
+// TestClearingThePinHandsTheConnectionBack: the override is not a one-way
+// door — once the forge lists the canonical host, clearing the pin must put
+// the connection back on the deployment's public URL at the next provision.
+func TestClearingThePinHandsTheConnectionBack(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	conn := seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	conn.WebhookBaseURL = "https://iterion.allowlisted.example"
+	if err := o.Connections.Update(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	conn.WebhookBaseURL = ""
+	if err := o.Connections.Update(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"revi-converse"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(got, "https://iterion.example.com/api/webhooks/") {
+		t.Fatalf("hook URL = %q, want the public URL again once the pin is cleared", got)
+	}
+}

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -129,6 +129,26 @@ type Connection struct {
 	// SSRF host-pin keeps applying.
 	ForgeBaseURL string `bson:"forge_base_url,omitempty" json:"forge_base_url,omitempty"`
 
+	// WebhookBaseURL overrides, for this connection only, the base the
+	// INBOUND hook URL is built from — the reverse direction of
+	// ForgeBaseURL, which names the host we call OUT to. Empty = the
+	// deployment's public URL, which is what every connection wants until
+	// one of them cannot reach it.
+	//
+	// It exists because a forge may refuse the deployment's canonical host
+	// outright: GitLab's outbound allowlist rejects any unlisted webhook
+	// URL with "Invalid url given" (HTTP 422), and getting a host listed is
+	// an administrative act on the forge's side, not ours. Without a
+	// per-connection escape hatch, one such forge pins the whole
+	// deployment's public URL — a re-provision would rewrite its hook to an
+	// address it is not allowed to call, and the failure would only surface
+	// as a provisioning error much later.
+	//
+	// Declaring it is what makes the exception survive: a hook URL that
+	// merely predates a public-URL change is one re-provision away from
+	// being silently replaced.
+	WebhookBaseURL string `bson:"webhook_base_url,omitempty" json:"webhook_base_url,omitempty"`
+
 	// Connected identity / namespace, populated from WhoAmI at connect time.
 	AccountLogin string `bson:"account_login,omitempty" json:"account_login,omitempty"`
 	AccountID    string `bson:"account_id,omitempty" json:"account_id,omitempty"`

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/forge"
 	forgegithub "github.com/SocialGouv/iterion/pkg/forge/github"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/secure/httpdial"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -445,19 +447,35 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 		httpError(w, http.StatusBadRequest, "nothing to update: patchable fields are security_read_enabled and webhook_base_url")
 		return
 	}
+	// Refused rather than half-applied. The two fields are unrelated
+	// operations against different systems — one pins a URL, the other mints
+	// or withdraws a live org token on GitHub — and there is no transaction
+	// spanning them. Accepting both would mean that when the security-read
+	// half fails (wrong kind, an org clash, a mint that 502s), the URL change
+	// is dropped while the error names only security-read: the caller reads a
+	// single failure and cannot tell that half its intent was discarded.
+	if req.SecurityReadEnabled != nil && req.WebhookBaseURL != nil {
+		httpError(w, http.StatusBadRequest, "send security_read_enabled and webhook_base_url in separate requests: they are independent operations and nothing makes them atomic, so a failure of one would silently drop the other")
+		return
+	}
 	ctx := store.WithTenant(r.Context(), teamID)
-	// Applied before the security-read flow and independent of it: pinning a
-	// hook base mints and withdraws nothing, and a request that carries only
-	// this field must not walk a token path at all.
+	// Its own path, reached only when the request carries this field alone:
+	// pinning a hook base mints and withdraws nothing, and must not walk a
+	// token path at all.
 	if req.WebhookBaseURL != nil {
 		base, err := canonicalWebhookBaseURL(*req.WebhookBaseURL)
 		if err != nil {
 			httpError(w, http.StatusUnprocessableEntity, "%v", err)
 			return
 		}
+		// A non-loopback http base means the forge delivers the payload AND
+		// the signature header in the clear. Warned rather than refused: an
+		// internal-network endpoint is a legitimate thing to pin, and the
+		// operator is the one who knows the network.
+		if u, perr := url.Parse(base); perr == nil && u.Scheme == "http" && !httpdial.IsLoopbackBind(u.Hostname()) && s.logger != nil {
+			s.logger.Warn("forge: connection %s pins a plaintext webhook base (%s) — the forge will deliver payloads and the signature header unencrypted", conn.ID, base)
+		}
 		conn.WebhookBaseURL = base
-	}
-	if req.SecurityReadEnabled == nil {
 		conn.UpdatedAt = time.Now().UTC()
 		if err := s.forgeConnections.Update(ctx, conn); err != nil {
 			httpError(w, http.StatusInternalServerError, "persist connection: %v", err)

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -408,6 +408,12 @@ type forgeConnectionPatchReq struct {
 	// SecurityReadEnabled toggles the org-wide Dependabot-alerts token flow
 	// for this github_app connection (see forge.SecurityReadSecretName).
 	SecurityReadEnabled *bool `json:"security_read_enabled,omitempty"`
+	// WebhookBaseURL pins the base this connection's inbound hook URLs are
+	// built from, for a forge that cannot reach the deployment's public URL
+	// (see forge.Connection.WebhookBaseURL). An explicit "" clears it and
+	// hands the connection back to the public URL — which is why it is a
+	// pointer: absent and "cleared" are different intents.
+	WebhookBaseURL *string `json:"webhook_base_url,omitempty"`
 }
 
 // handlePatchForgeConnection updates a connection's operator-tunable flags.
@@ -435,12 +441,35 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+	if req.SecurityReadEnabled == nil && req.WebhookBaseURL == nil {
+		httpError(w, http.StatusBadRequest, "nothing to update: patchable fields are security_read_enabled and webhook_base_url")
+		return
+	}
+	ctx := store.WithTenant(r.Context(), teamID)
+	// Applied before the security-read flow and independent of it: pinning a
+	// hook base mints and withdraws nothing, and a request that carries only
+	// this field must not walk a token path at all.
+	if req.WebhookBaseURL != nil {
+		base, err := canonicalWebhookBaseURL(*req.WebhookBaseURL)
+		if err != nil {
+			httpError(w, http.StatusUnprocessableEntity, "%v", err)
+			return
+		}
+		conn.WebhookBaseURL = base
+	}
 	if req.SecurityReadEnabled == nil {
-		httpError(w, http.StatusBadRequest, "nothing to update: security_read_enabled is the only patchable field")
+		conn.UpdatedAt = time.Now().UTC()
+		if err := s.forgeConnections.Update(ctx, conn); err != nil {
+			httpError(w, http.StatusInternalServerError, "persist connection: %v", err)
+			return
+		}
+		s.auditTenant(r, teamID, "forge.connection.webhook_base_url", "forge_connection", conn.ID, map[string]any{
+			"webhook_base_url": conn.WebhookBaseURL,
+		})
+		writeJSON(w, conn)
 		return
 	}
 	enable := *req.SecurityReadEnabled
-	ctx := store.WithTenant(r.Context(), teamID)
 	if enable {
 		if conn.Kind != forge.KindGitHubApp {
 			httpError(w, http.StatusUnprocessableEntity, "security-read requires a github_app connection (this one is %s); a non-App deployment can set the %q team secret by hand instead", conn.Kind, forge.SecurityReadSecretName)

--- a/pkg/server/forge_state.go
+++ b/pkg/server/forge_state.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -150,4 +151,42 @@ func canonicalForgeBaseURL(raw string, provider forge.Provider) string {
 	}
 	s = strings.TrimRight(s, "/")
 	return s
+}
+
+// canonicalWebhookBaseURL normalises the base a connection's inbound hook
+// URLs are built from. Empty means "clear the pin", handing the connection
+// back to the deployment's public URL.
+//
+// Unlike canonicalForgeBaseURL it REFUSES what it cannot make sense of
+// rather than guessing: this value is handed to a forge as the address to
+// deliver to, so a wrong one does not fail here — it fails much later, as
+// hooks that were registered successfully and never arrive. A scheme is
+// required for the same reason (assuming https for a host that only speaks
+// http would produce exactly that silent shape), and a path is refused
+// because the route is appended to it.
+func canonicalWebhookBaseURL(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return "", nil
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("webhook_base_url is not a URL: %v", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("webhook_base_url must be an absolute http(s) URL (got %q) — the forge dials this address, so the scheme cannot be inferred", s)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("webhook_base_url has no host: %q", s)
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("webhook_base_url must not carry credentials")
+	}
+	if p := strings.Trim(u.Path, "/"); p != "" {
+		return "", fmt.Errorf("webhook_base_url must be scheme+host only (got path %q) — the /api/webhooks/... route is appended to it", u.Path)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("webhook_base_url must not carry a query or fragment: %q", s)
+	}
+	return u.Scheme + "://" + u.Host, nil
 }

--- a/pkg/server/forge_webhook_base_routes_test.go
+++ b/pkg/server/forge_webhook_base_routes_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// patchWebhookBase drives the real handler with a webhook-base-only body.
+func patchWebhookBase(t *testing.T, s *Server, connID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := forgeReq(superAdminCtx(), "PATCH", "/api/teams/t1/forge/connections/"+connID, body, "t1")
+	req.SetPathValue("conn_id", connID)
+	w := httptest.NewRecorder()
+	s.handlePatchForgeConnection(w, req)
+	return w
+}
+
+// TestWebhookBasePatch_PersistsAndDoesNotTouchTheTokenPath: pinning a hook
+// base mints and withdraws nothing. If it shared the security-read path, a
+// deployment-topology change would move a live org token as a side effect.
+func TestWebhookBasePatch_PersistsAndDoesNotTouchTheTokenPath(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+	minted := 0
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		minted++
+		return "ghs_minted", time.Time{}, nil
+	}
+
+	w := patchWebhookBase(t, s, "c1", `{"webhook_base_url":"https://iterion.fabrique.social.gouv.fr"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if minted != 0 {
+		t.Fatalf("mint calls = %d, want 0 — pinning a hook base is not a token operation", minted)
+	}
+	conn, err := s.forgeConnections.Get(context.Background(), "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn.WebhookBaseURL != "https://iterion.fabrique.social.gouv.fr" {
+		t.Fatalf("WebhookBaseURL = %q, want it persisted", conn.WebhookBaseURL)
+	}
+	if conn.SecurityReadEnabled {
+		t.Fatal("a webhook-base patch must not flip the security-read flag")
+	}
+}
+
+// TestWebhookBasePatch_ClearsWithAnExplicitEmptyString: absent and cleared
+// are different intents, which is why the field is a pointer.
+func TestWebhookBasePatch_ClearsWithAnExplicitEmptyString(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+
+	if w := patchWebhookBase(t, s, "c1", `{"webhook_base_url":"https://pinned.example"}`); w.Code != http.StatusOK {
+		t.Fatalf("set: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if w := patchWebhookBase(t, s, "c1", `{"webhook_base_url":""}`); w.Code != http.StatusOK {
+		t.Fatalf("clear: code=%d body=%s", w.Code, w.Body.String())
+	}
+	conn, _ := s.forgeConnections.Get(context.Background(), "c1")
+	if conn.WebhookBaseURL != "" {
+		t.Fatalf("WebhookBaseURL = %q, want cleared", conn.WebhookBaseURL)
+	}
+}
+
+// TestWebhookBasePatch_RefusesWhatCannotBeDialed: a bad base does not fail
+// here — it fails as hooks that register fine and never arrive. Refuse it
+// at the only moment an operator is watching.
+func TestWebhookBasePatch_RefusesWhatCannotBeDialed(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"no scheme", `{"webhook_base_url":"iterion.example.com"}`},
+		{"not http", `{"webhook_base_url":"ftp://iterion.example.com"}`},
+		{"carries a path", `{"webhook_base_url":"https://iterion.example.com/hooks"}`},
+		{"carries credentials", `{"webhook_base_url":"https://u:p@iterion.example.com"}`},
+		{"carries a query", `{"webhook_base_url":"https://iterion.example.com?a=1"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newForgeTestServer(t)
+			seedAppConn(t, s, "c1", "SocialGouv", "", false)
+			w := patchWebhookBase(t, s, "c1", tc.body)
+			if w.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("code=%d body=%s, want 422", w.Code, w.Body.String())
+			}
+			conn, _ := s.forgeConnections.Get(context.Background(), "c1")
+			if conn.WebhookBaseURL != "" {
+				t.Fatalf("a refused value was still persisted: %q", conn.WebhookBaseURL)
+			}
+		})
+	}
+}
+
+// TestConnectionPatch_StillRefusesAnEmptyBody: adding a second patchable
+// field must not turn "nothing to update" into a silent 200.
+func TestConnectionPatch_StillRefusesAnEmptyBody(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+	if w := patchWebhookBase(t, s, "c1", `{}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s, want 400", w.Code, w.Body.String())
+	}
+}
+
+func TestCanonicalWebhookBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"  ", "", false},
+		{"https://iterion.cloud", "https://iterion.cloud", false},
+		{"https://iterion.cloud/", "https://iterion.cloud", false},
+		{"http://localhost:8080", "http://localhost:8080", false},
+		{"iterion.cloud", "", true},
+		{"https://", "", true},
+	} {
+		got, err := canonicalWebhookBaseURL(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("canonicalWebhookBaseURL(%q) = %q, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("canonicalWebhookBaseURL(%q): %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("canonicalWebhookBaseURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/server/forge_webhook_base_routes_test.go
+++ b/pkg/server/forge_webhook_base_routes_test.go
@@ -105,6 +105,36 @@ func TestConnectionPatch_StillRefusesAnEmptyBody(t *testing.T) {
 	}
 }
 
+// TestConnectionPatch_RefusesACombinedBody: the two fields act on different
+// systems — one pins a URL, the other mints or withdraws a live org token on
+// GitHub — and nothing makes them atomic. Accepted together, a failure of
+// the security-read half returns before the persist: the URL change is
+// dropped while the error names only security-read, so the caller reads one
+// failure and cannot tell half its intent was discarded.
+func TestConnectionPatch_RefusesACombinedBody(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+	minted := 0
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		minted++
+		return "ghs_minted", time.Time{}, nil
+	}
+
+	body := `{"security_read_enabled":true,"webhook_base_url":"https://pinned.example"}`
+	w := patchWebhookBase(t, s, "c1", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d body=%s, want 400", w.Code, w.Body.String())
+	}
+	if minted != 0 {
+		t.Fatalf("mint calls = %d, want 0 — the refusal must happen before either side acts", minted)
+	}
+	conn, _ := s.forgeConnections.Get(context.Background(), "c1")
+	if conn.WebhookBaseURL != "" || conn.SecurityReadEnabled {
+		t.Fatalf("a refused combined patch applied something: base=%q security_read=%v",
+			conn.WebhookBaseURL, conn.SecurityReadEnabled)
+	}
+}
+
 func TestCanonicalWebhookBaseURL(t *testing.T) {
 	for _, tc := range []struct {
 		in      string

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5607,6 +5607,7 @@ export interface components {
             tenant_id: string;
             /** Format: date-time */
             updated_at: string;
+            webhook_base_url?: string;
         };
         DependencyGraphEdge: {
             from: string;


### PR DESCRIPTION
## Why

Hook URLs are derived from the deployment's public URL — right for every
connection, until one of them cannot reach that host.

GitLab refuses any webhook URL outside its instance-wide outbound allowlist
with `Invalid url given` (HTTP 422), and getting a host listed is an
administrative act on the forge's side. So a single such forge pinned the
public URL of the **whole** deployment: moving to a new domain meant either
leaving that forge behind, or not moving.

Concretely, on our own instance: the GitLab PIC allowlist cannot currently
be extended, so those repos must keep the old host while the sixteen GitHub
ones migrate.

## What

`Connection.WebhookBaseURL`, scoped to one connection. Empty keeps today's
behaviour exactly — the field is absent from every existing document and
reads as "follow the public URL" — so a deployment that never sets it cannot
tell this shipped.

```sh
iterion remote forge connections webhook-base <conn-id> --url https://old.example
iterion remote forge connections webhook-base <conn-id> --url ""   # clear
```

**The point is that the exception survives.** Leaving an old hook URL in
place because nobody re-provisions it is not a state, it is a delay:
enabling one more bot or moving a repo to another team rewrites the hook
from the current public URL, the write succeeds, and only the deliveries
stop. A declared pin is what makes it durable — and clearing it hands the
connection back, so the door opens both ways.

The value is validated at the PATCH rather than canonicalised generously
like its sibling `ForgeBaseURL`: this address is handed to a forge to dial,
so a wrong one does not fail where it is typed. A missing scheme is refused
instead of assumed, for that exact reason.

Pinning is kept off the security-read path entirely — it mints and withdraws
no token, and a body carrying only this field walks none of that code.

## Shape

`inboundURL` has a single call site, so the override needed exactly one
decision point.

## Verification

Nine tests, `task lint` clean, OpenAPI + studio schema regenerated.

Verified to bite rather than merely pass: with the override ignored, the two
tests asserting a pin is honoured fail, and the two describing the default
path stay green.

The load-bearing one is `TestPinSurvivesAReprovision` — it moves the
deployment's public URL mid-test and re-provisions, which is the failure this
exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)