### PR TITLE
fix(server): a tenant the store says is GONE is not a blip to launch past

### DIFF
--- a/pkg/server/launch_gate.go
+++ b/pkg/server/launch_gate.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -129,9 +130,12 @@ func (a *launchAdmission) rollback(logger interface{ Warn(string, ...any) }) {
 // On allow it returns the admission handle for the metered increment
 // (nil when nothing was metered).
 //
-// Fail-open on store errors, mirroring the suspend check: quotas are an
-// operator policy, not a hard security boundary — a transient Mongo
-// blip must not wedge every launch. Super-admins bypass entirely.
+// Fail-open on a DEGRADED store read, mirroring the suspend check:
+// quotas are an operator policy, not a hard security boundary — a
+// transient Mongo blip must not wedge every launch. A team the store
+// answers is GONE is not that case and is denied, since no later check
+// can bound a run whose tenant does not exist. Super-admins bypass
+// entirely.
 // The run-quota increment is the one exception to fail-open being
 // "free": when AllowRun errors the launch proceeds unmetered (logged).
 func (s *Server) gateLaunch(ctx context.Context) (*launchAdmission, *launchDenial) {
@@ -159,8 +163,27 @@ func (s *Server) gateLaunch(ctx context.Context) (*launchAdmission, *launchDenia
 	if !ok || t.ID != id.TeamID {
 		var err error
 		t, err = st.GetTeam(ctx, id.TeamID)
-		if err != nil {
-			return nil, nil // fail-open (see doc comment)
+		switch {
+		case errors.Is(err, identity.ErrNotFound):
+			// Not a blip — a definite answer. The token names a team that
+			// no longer exists, so admitting it runs work under a tenant
+			// nobody can suspend, bill or see. The teamless arm above
+			// refuses that situation when the claim is empty; this is the
+			// same situation arriving later. The webhook middleware draws
+			// the same line one layer up (middleware_webhook.go).
+			return nil, &launchDenial{
+				status: http.StatusForbidden,
+				reason: denyNoWorkspace,
+				detail: "the workspace this session points at no longer exists — sign in again, or ask an admin to add you to a team",
+			}
+		case err != nil:
+			// A degraded read keeps the fail-open of the doc comment, but
+			// says so: what follows is a launch with no suspend check and
+			// no metering, which is invisible from the outside otherwise.
+			if s.logger != nil {
+				s.logger.Warn("launch gate: team %s unreadable (%v) — launching UNGATED: suspend unchecked, run unmetered", id.TeamID, err)
+			}
+			return nil, nil
 		}
 	}
 	// The team's parent org owns the monthly budget + the top-level

--- a/pkg/server/launch_gate_test.go
+++ b/pkg/server/launch_gate_test.go
@@ -236,10 +236,15 @@ func TestGateLaunch_Bypasses(t *testing.T) {
 	// A teamless non-admin is now DENIED (no workspace) — see
 	// TestGateLaunch_TeamlessDenied. Local mode (no auth store) still bypasses
 	// via the st == nil branch.
-	// Missing team fails open.
+	// A team the store answers is GONE is denied for the same reason: it is
+	// an answer, not a blip, and no later check can bound a run whose tenant
+	// does not exist. A DEGRADED read still fails open — the two are told
+	// apart in TestGateLaunch_VanishedTeamIsDeniedNotFailedOpen and
+	// TestGateLaunch_DegradedTeamReadFailsOpenLoudly.
 	ghost := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "ghost"})
-	if _, d := s.gateLaunch(ghost); d != nil {
-		t.Fatalf("ghost team denied: %+v", d)
+	_, d := s.gateLaunch(ghost)
+	if d == nil || d.status != 403 || d.reason != denyNoWorkspace {
+		t.Fatalf("ghost team denial = %+v, want 403 %s", d, denyNoWorkspace)
 	}
 }
 

--- a/pkg/server/launch_gate_vanished_tenant_test.go
+++ b/pkg/server/launch_gate_vanished_tenant_test.go
@@ -1,0 +1,129 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/identity"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/pat"
+)
+
+// degradedTeamRead is an identity store whose team read can be switched to
+// fail with something that is NOT ErrNotFound — a store outage rather than
+// an answer. Switchable so a test can seed through the real store first and
+// degrade only the read under test.
+type degradedTeamRead struct {
+	identity.Store
+	err error
+	on  *atomic.Bool
+}
+
+func (d degradedTeamRead) GetTeam(ctx context.Context, id string) (identity.Team, error) {
+	if d.on.Load() {
+		return identity.Team{}, d.err
+	}
+	return d.Store.GetTeam(ctx, id)
+}
+
+// newDegradableServer is newOrgTestServer with a capturable log sink and a
+// team read that can be broken mid-test, so the two arms of a failed
+// identity read can be told apart by what the server DOES and by what it
+// SAYS.
+func newDegradableServer(t *testing.T) (*Server, *atomic.Bool, *bytes.Buffer) {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	signer, err := auth.NewJWTSigner(base64.RawStdEncoding.EncodeToString(key), 15*time.Minute)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	degrade := &atomic.Bool{}
+	st := degradedTeamRead{Store: identity.NewMemoryStore(), err: context.DeadlineExceeded, on: degrade}
+	svc, err := auth.NewService(auth.Config{
+		Store:      st,
+		Sessions:   auth.NewMemorySessionStore(),
+		Signer:     signer,
+		SignupMode: auth.SignupOpen,
+		RefreshTTL: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("auth service: %v", err)
+	}
+	logs := &bytes.Buffer{}
+	s := New(Config{}, iterlog.New(iterlog.LevelWarn, logs))
+	s.authSvc = svc
+	return s, degrade, logs
+}
+
+// A JWT naming a team that no longer exists is a DEFINITE answer, not a
+// blip: failing open let a stale token keep launching work under a tenant
+// nobody can suspend, bill or see. The teamless arm already refuses that
+// situation when the claim is empty; a vanished team is the same situation
+// arriving later.
+func TestGateLaunch_VanishedTeamIsDeniedNotFailedOpen(t *testing.T) {
+	s, _, _ := newDegradableServer(t)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "team-that-was-deleted"})
+	adm, d := s.gateLaunch(ctx)
+	if d == nil {
+		t.Fatalf("a vanished tenant was admitted (admission=%+v) — the launch runs unmetered under a team nobody owns", adm)
+	}
+	if d.status != 403 || d.reason != denyNoWorkspace {
+		t.Fatalf("denial = %+v, want 403 %s", d, denyNoWorkspace)
+	}
+}
+
+// A degraded read keeps the documented fail-open — quotas are operator
+// policy and a transient store failure must not wedge every launch — but it
+// may no longer be SILENT: the launch that follows is unmetered and
+// un-suspendable, which is invisible from the outside otherwise.
+func TestGateLaunch_DegradedTeamReadFailsOpenLoudly(t *testing.T) {
+	s, degrade, logs := newDegradableServer(t)
+	degrade.Store(true)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "t1"})
+	if _, d := s.gateLaunch(ctx); d != nil {
+		t.Fatalf("degraded read denied the launch (%+v) — the documented policy for a transient failure is fail-open", d)
+	}
+	got := logs.String()
+	if !strings.Contains(got, "t1") || !strings.Contains(strings.ToLower(got), "ungated") {
+		t.Fatalf("a launch admitted past a failed identity read logged nothing usable; logs = %q", got)
+	}
+}
+
+// The same class one layer down: a PAT identity is FIXED for the token's
+// whole life, so an org scope dropped because the store blipped is a lie it
+// then carries everywhere. The membership read four lines above already
+// refuses on error; the team read must not disagree with it.
+func TestPATIdentity_DegradedTeamReadRefusesInsteadOfDroppingOrgScope(t *testing.T) {
+	s, degrade, _ := newDegradableServer(t)
+	s.pats = pat.NewMemoryStore()
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{
+		ID: "u1", Email: "u1@x", Status: identity.UserStatusActive, DefaultTeamID: "t1",
+	}); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{
+		UserID: "u1", TeamID: "t1", Role: identity.RoleMember,
+	}); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	authed := auth.WithIdentity(ctx, auth.Identity{UserID: "u1", Email: "u1@x", TeamID: "t1", Role: identity.RoleMember})
+	_, plaintext := createPAT(t, s, authed, `{"name":"ci"}`)
+
+	degrade.Store(true)
+	id, err := s.identityFromPAT(ctx, plaintext)
+	if err == nil {
+		t.Fatalf("a degraded team read minted identity %+v with org %q — an org-less PAT silently fails every org-scoped lookup that has no team fallback", id, id.OrgID)
+	}
+}

--- a/pkg/server/pat_routes.go
+++ b/pkg/server/pat_routes.go
@@ -120,9 +120,17 @@ func (s *Server) handleCreatePAT(w http.ResponseWriter, r *http.Request) {
 	// A team-pinned token binds the caller's future org scope too — the
 	// server owns the team→org fact, so state it in the response instead
 	// of leaving clients to re-derive it from the org tree.
+	// The token is already minted and its plaintext exists only in the
+	// response below, so a failed lookup here cannot abort the request
+	// without stranding a token the caller will never see. It reports the
+	// scope it could not resolve instead of letting an empty org_id read
+	// as "this token has no org".
 	orgID := ""
 	if req.TeamID != "" {
-		if team, terr := s.authStore().GetTeam(r.Context(), req.TeamID); terr == nil {
+		team, terr := s.authStore().GetTeam(r.Context(), req.TeamID)
+		if terr != nil {
+			s.logger.Warn("pat create: token %s is pinned to team %s but its org is unresolved (%v) — org_id omitted from the response", t.ID, req.TeamID, terr)
+		} else {
 			orgID = team.OrgID
 		}
 	}
@@ -207,11 +215,17 @@ func (s *Server) identityFromPAT(ctx context.Context, presented string) (auth.Id
 		}
 		role = mb.Role
 		// The parent org, which the browser path carries on the JWT. A PAT
-		// identity without it silently fails every org-scoped lookup that
-		// has no team fallback of its own.
-		if t, err := st.GetTeam(ctx, teamID); err == nil {
-			orgID = t.OrgID
+		// identity is FIXED for the token's whole life — there is no
+		// session to switch scope on — so an org dropped because the read
+		// failed is a lie the token then carries everywhere, silently
+		// failing every org-scoped lookup that has no team fallback. Refuse
+		// like the membership read above rather than mint a narrower
+		// identity than the token was granted.
+		team, err := st.GetTeam(ctx, teamID)
+		if err != nil {
+			return auth.Identity{}, fmt.Errorf("token org scope unavailable: %w", err)
 		}
+		orgID = team.OrgID
 	}
 	// last_used_at is observability — detached write off the hot path.
 	tokenID := t.ID


### PR DESCRIPTION
Closes the first of the two remainders on #969: an iterion store failure rendered as a fact about the world.

## The bug

`gateLaunch` is the choke point every cloud launch surface crosses — REST launch and resume, the inbound webhooks, the retry sweeper, the board dispatcher. It read the caller's team and, **on any error, admitted the launch**. The rationale is sound and documented: quotas are operator policy, not a security boundary, and a transient Mongo blip must not wedge a deployment.

But it collapsed two different answers into one. `ErrNotFound` is not a blip — it is the store *answering*: the token names a team that no longer exists. Admitting it ran work under a tenant nobody can suspend, bill or see, for as long as that token lived. The arm immediately above already refuses precisely that situation when the team claim is empty.

Two things made it hard to see. The webhook middleware had **already** drawn the line correctly one layer up (403 gone / 503 degraded), so the two sites disagreed about the same fact — and the webhook path never reached the bug only because it stashes its loaded team on the context, so `gateLaunch`'s own read is skipped there. And the existing test pinned the behaviour with a bare `// Missing team fails open.`, no rationale, directly beneath a denial that does carry one.

## What changed

- **`ErrNotFound` → 403** `no_workspace`, matching the teamless arm and the webhook middleware.
- **A degraded read keeps the fail-open**, and stops being silent. What follows is a launch with no suspend check and no metering; that was invisible from the outside.
- The doc comment now describes the two arms instead of one.

## The class, not the site

Grepping every `GetTeam` in `pkg/server` rather than the one the report named turned up two more:

- **`identityFromPAT`** dropped the org scope on a failed read — four lines below a membership read that refuses on error. A PAT identity is *fixed* for the token's whole life, so the lie travelled with it, silently failing every org-scoped lookup with no team fallback. Its own comment predicted exactly that consequence and the code swallowed anyway. Now refused.
- **PAT creation** reported `org_id: ""` for the same reason. This one cannot propagate — the token is already minted and its plaintext exists only in that response, so failing would strand a token the caller never sees. It logs the unresolved scope instead of letting an empty field read as "this token has no org".

Honest account of the remaining sites: of the sixteen `GetTeam` calls in `pkg/server`, **none now fails open or downgrades in silence**. Four still conflate a degraded read with a definite fact (`auth_authz`, `credpool` ×2, `orgs_routes` ×2) but every one of them fails **closed**; turning those into 503s is a wider behaviour change than this argument carries, and is not in scope here.

## Red first

All three tests were watched failing before the fix, each for its own reason:

    --- FAIL: TestGateLaunch_VanishedTeamIsDeniedNotFailedOpen
        a vanished tenant was admitted (admission=<nil>) — the launch runs
        unmetered under a team nobody owns
    --- FAIL: TestGateLaunch_DegradedTeamReadFailsOpenLoudly
        a launch admitted past a failed identity read logged nothing usable;
        logs = ""
    --- FAIL: TestPATIdentity_DegradedTeamReadRefusesInsteadOfDroppingOrgScope
        a degraded team read minted identity {UserID:u1 ... OrgID: TeamID:t1}
        with org "" — an org-less PAT silently fails every org-scoped lookup

The degraded arm is pinned by its own test, so a later change cannot quietly close the fail-open either.

`task check` green (`EXIT=0`), `-race` green on `pkg/server` + `pkg/identity`.

## Still open on #969

The GitHub App **mint chain** — three arms where a stored key that fails to parse is answered `502 Bad Gateway`, documented in #993 but not closed. Same class, different choke point: only the mint chain knows which step failed, so a blanket marker there would be the same lie in the other direction.

Refs #969
