### PR TITLE
feat(studio): redesign the cloud home around orchestration

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,82 +1,49 @@
 # Billy — branch-improvement validation
 
-## 2026-09-09 — #1028: a one-finding pass, measured rather than asserted (run 01a08605)
+## 2026-09-09 — #1028: lazy cloud home, bank recovered after quota stop
 
-- Status: **validated**. Narrow by construction: the operator scoped the pass
-  to Revi's single finding and disabled auto-merge for its duration, so this
-  exercises the scoped-pass path rather than a full campaign.
-- Versions: bot `branch-improve-loop` · iterion `82f881938` (the branch head
-  the review was anchored to). Backend claude_code.
-- Method: `/billy` on PR #1028 (`codex/cloud-home-redesign`, the cloud-home
-  redesign) after Revi run `01a085f9-871b-7aa9-85d6-e8724258c04c` left one
-  medium finding. Operator note narrowed the pass to `R8a91d4` only and
-  ruled the four open design questions out of scope. A plan phase ran and
-  was critiqued by a cross-model peer.
-- Result: converged in one pass, two commits, no loop. `f0c723e59` makes the
-  marketing page a lazy chunk; `54a2c24d3` adds the regression test.
-- Finding ledger: **R8a91d4 fixed**. `CloudLanding.tsx` is one of App.tsx's
-  few eager view imports — `PublicTopBar` lives in the same module and
-  renders on `/marketplace`, outside the lazy route tree — so the redesign's
-  static `import CloudHome` put the anonymous-only product page in the entry
-  chunk every authenticated operator downloads on first paint. `lazy()` plus
-  a `BootLoading` Suspense boundary (the same fallback as the ancestor
-  boundary, so the anonymous first paint is unchanged) moves it out.
-- Measured, not asserted: entry JS 461.25 → 289.78 kB (gzip 127.43 → 88.30),
-  entry CSS 119.68 → 98.21 kB (gzip 21.62 → 17.03). The page ships as its own
-  `CloudHome-*.js` (70.4 kB) + `CloudHome-*.css` (21.5 kB), and `index.html`
-  preloads neither. The check that mattered was the second one: none of the
-  54 chunks the entry HTML references still carries a `@lobehub` brand-icon
-  module, so the payload genuinely left the eager graph instead of moving
-  into a preloaded sibling — a chunk-size delta alone would not have
-  distinguished those two outcomes.
-- Value: a regression invisible to every gate the repo runs. A static import
-  of an anonymous-only page compiles, typechecks, passes 1351 tests and only
-  shows up as bytes in the entry chunk. Revi caught it by reading the import
-  convention, not by measuring.
-- Ratchet: the acceptance gate was content-based on purpose (unique page
-  strings absent from the entry JS, `.ch-orbit` absent from the entry CSS) —
-  rolldown chunk names are not a contract, and a filename assertion would
-  have been the fragile half. That gate lives in the run, so the durable
-  guard is `studio/src/views/CloudLanding.test.tsx`: CloudLanding must
-  suspend on first paint rather than mount the page synchronously. It was
-  **falsified before landing** — restoring the static import fails it with
-  `expected <main></main> to be null` — so it cannot pass on the code it
-  exists to reject. One case on purpose: `lazy()` memoises its resolved
-  module, so a sibling case that awaited the chunk first would leave this one
-  blind to the pending state and the guard would pass on test order alone.
-- Friction worth knowing: the real `CloudHome` cannot be mounted under
-  vitest at all — `@lobehub/icons` resolves through `@lobehub/ui` to a
-  malformed `es/node_modules/@base-ui/react/merge-props` path that the
-  runner's ESM externalization rejects, though the vite build resolves it
-  fine. The test mocks the far side of the boundary, which is sound here
-  (the split is what is under test), but a future spec that needs the real
-  page rendered will have to inline that dep in the vitest config first.
-- Surfaced, not fixed — a real behavioural regression outside the pass's
-  scope: `studio/src/views/CloudHome/index.tsx:94-108`. The new one-button
-  theme control derives its action from `resolved` and calls
-  `setMode(resolved === "dark" ? "light" : "dark")`, so it can only ever
-  write `"light"` or `"dark"`. `ThemeMode` is `"system" | "light" | "dark"`,
-  `"system"` is the default, `setMode` persists to localStorage, and
-  `initializeTheme()`'s `matchMedia` listener only fires while
-  `mode === "system"`. One click therefore severs OS-theme-following
-  permanently, with no way to restore it from this public page. The shared
-  `ThemeToggle` is a three-state radiogroup whose doc comment names this
-  exact surface, and the store already ships `cycleMode()`. Left alone
-  because both candidate fixes change an operator-approved nav appearance,
-  which this pass was explicitly told to preserve; it needs its own change
-  and an appearance decision. It is a defect, not one of the four settled
-  design questions.
-- Validation: `task studio:check` green — eslint 0 errors (563 warnings,
-  unchanged from the branch baseline), `tsc -b`, and vitest 152 files /
-  1352 tests, up from the 151 / 1351 baseline by exactly the new case.
-  `vite build` exit 0. Three files changed: `CloudLanding.tsx`, its new
-  test, and this bilan — the plan predicted two, before the ratchet test was
-  added. **No CI or merge result is claimed for the changed head; neither
-  had happened when this was written.**
-- Lessons for next run: when a finding is about payload rather than
-  behaviour, make the acceptance gate answer "did it leave the eager graph",
-  not "did the number go down" — the two come apart exactly when a bundler
-  reshuffles chunks, which is the case worth catching.
+- Status: **bank recovered; delivery review interrupted by provider quota**.
+  This was not a completed end-to-end Billy run.
+- Method: `/billy` on PR #1028, scoped to Revi finding `R8a91d4` after
+  review `01a085f9-871b-7aa9-85d6-e8724258c04c`. Run
+  `01a08605-1dd6-7907-9baa-86fae51f3e0b` started at 11:54:37Z from
+  `82f881938`; auto-merge was disabled during the pass. The owner made no
+  concurrent edits to its branch.
+- Result: `f0c723e59` defers CloudHome with React.lazy and the existing
+  BootLoading fallback while keeping PublicTopBar eager; `54a2c24d3` adds
+  a regression test; `8fe07161f` records the initial bilan. The approved
+  page content, appearance, local login fallback and marketplace flag stay
+  intact. **R8a91d4 is fixed.**
+- Evidence: the bot measured entry JS 461.25 → 289.78 kB (gzip 127.43 →
+  88.30) and entry CSS 119.68 → 98.21 kB (gzip 21.62 → 17.03). Neither
+  CloudHome nor its brand-icon payload remained in the eager preload graph.
+  The new test was falsified by temporarily restoring the static import.
+  Studio lint had zero errors, TypeScript and Vite passed, and all 1,352
+  tests in 152 files passed. The generated delivery script also passed,
+  including the OpenAPI/client drift check.
+- Stop and recovery: the final `review` node hit the Claude five-hour limit
+  at 12:41:07Z (`USAGE_LIMIT_BLOCKED`, reset advertised for 13:50Z), before
+  publishing a ledger or pushing the PR. The owner cancelled the parked run
+  and confirmed `cancelled`, with no running execution, before recovering
+  checkpoint `iterion/run-01a08605-1dd6-7907-9baa-86fae51f3e0b-checkpoint`.
+  FETCH_HEAD matched the recorded `8fe07161f6a92587a3dc34c3bb6bf155365ccd06`;
+  its three commits were preserved by fast-forward rather than replaying
+  the completed campaign after the reset.
+- Recovery validation: the owner reran Studio lint (0 errors), TypeScript,
+  all 1,352 tests and the production build successfully. Browser checks on
+  the built SPA confirm that `/login` neither requests nor preloads the
+  CloudHome JS/CSS, while `/` loads both and still navigates to login. Local
+  bundle sizes match the measurements above. GitHub CI and Revi must validate
+  the published head before queue entry.
+- Frictions: planning and peer review took about 25 minutes for one
+  import-boundary correction. A 30-second shell timeout cut off the peer's
+  baseline lint; the owner supplied the already-green baseline and advised
+  a longer timeout. Vitest cannot resolve the real page's lobehub UI import
+  in this environment, so the boundary test mocks its far side; the
+  production bundle check covers the actual dependency graph. Soft usage
+  readings (`stopped=false`, including 0%) did not predict the hard denial.
+- Lesson: validate the eager dependency graph, not just a chunk-size drop,
+  and preserve banked work when the delivery review cannot obtain a model.
 
 ## 2026-09-08 — #964: quota stop after useful fixes, bank delivered locally
 

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,83 @@
 # Billy — branch-improvement validation
 
+## 2026-09-09 — #1028: a one-finding pass, measured rather than asserted (run 01a08605)
+
+- Status: **validated**. Narrow by construction: the operator scoped the pass
+  to Revi's single finding and disabled auto-merge for its duration, so this
+  exercises the scoped-pass path rather than a full campaign.
+- Versions: bot `branch-improve-loop` · iterion `82f881938` (the branch head
+  the review was anchored to). Backend claude_code.
+- Method: `/billy` on PR #1028 (`codex/cloud-home-redesign`, the cloud-home
+  redesign) after Revi run `01a085f9-871b-7aa9-85d6-e8724258c04c` left one
+  medium finding. Operator note narrowed the pass to `R8a91d4` only and
+  ruled the four open design questions out of scope. A plan phase ran and
+  was critiqued by a cross-model peer.
+- Result: converged in one pass, two commits, no loop. `f0c723e59` makes the
+  marketing page a lazy chunk; `54a2c24d3` adds the regression test.
+- Finding ledger: **R8a91d4 fixed**. `CloudLanding.tsx` is one of App.tsx's
+  few eager view imports — `PublicTopBar` lives in the same module and
+  renders on `/marketplace`, outside the lazy route tree — so the redesign's
+  static `import CloudHome` put the anonymous-only product page in the entry
+  chunk every authenticated operator downloads on first paint. `lazy()` plus
+  a `BootLoading` Suspense boundary (the same fallback as the ancestor
+  boundary, so the anonymous first paint is unchanged) moves it out.
+- Measured, not asserted: entry JS 461.25 → 289.78 kB (gzip 127.43 → 88.30),
+  entry CSS 119.68 → 98.21 kB (gzip 21.62 → 17.03). The page ships as its own
+  `CloudHome-*.js` (70.4 kB) + `CloudHome-*.css` (21.5 kB), and `index.html`
+  preloads neither. The check that mattered was the second one: none of the
+  54 chunks the entry HTML references still carries a `@lobehub` brand-icon
+  module, so the payload genuinely left the eager graph instead of moving
+  into a preloaded sibling — a chunk-size delta alone would not have
+  distinguished those two outcomes.
+- Value: a regression invisible to every gate the repo runs. A static import
+  of an anonymous-only page compiles, typechecks, passes 1351 tests and only
+  shows up as bytes in the entry chunk. Revi caught it by reading the import
+  convention, not by measuring.
+- Ratchet: the acceptance gate was content-based on purpose (unique page
+  strings absent from the entry JS, `.ch-orbit` absent from the entry CSS) —
+  rolldown chunk names are not a contract, and a filename assertion would
+  have been the fragile half. That gate lives in the run, so the durable
+  guard is `studio/src/views/CloudLanding.test.tsx`: CloudLanding must
+  suspend on first paint rather than mount the page synchronously. It was
+  **falsified before landing** — restoring the static import fails it with
+  `expected <main></main> to be null` — so it cannot pass on the code it
+  exists to reject. One case on purpose: `lazy()` memoises its resolved
+  module, so a sibling case that awaited the chunk first would leave this one
+  blind to the pending state and the guard would pass on test order alone.
+- Friction worth knowing: the real `CloudHome` cannot be mounted under
+  vitest at all — `@lobehub/icons` resolves through `@lobehub/ui` to a
+  malformed `es/node_modules/@base-ui/react/merge-props` path that the
+  runner's ESM externalization rejects, though the vite build resolves it
+  fine. The test mocks the far side of the boundary, which is sound here
+  (the split is what is under test), but a future spec that needs the real
+  page rendered will have to inline that dep in the vitest config first.
+- Surfaced, not fixed — a real behavioural regression outside the pass's
+  scope: `studio/src/views/CloudHome/index.tsx:94-108`. The new one-button
+  theme control derives its action from `resolved` and calls
+  `setMode(resolved === "dark" ? "light" : "dark")`, so it can only ever
+  write `"light"` or `"dark"`. `ThemeMode` is `"system" | "light" | "dark"`,
+  `"system"` is the default, `setMode` persists to localStorage, and
+  `initializeTheme()`'s `matchMedia` listener only fires while
+  `mode === "system"`. One click therefore severs OS-theme-following
+  permanently, with no way to restore it from this public page. The shared
+  `ThemeToggle` is a three-state radiogroup whose doc comment names this
+  exact surface, and the store already ships `cycleMode()`. Left alone
+  because both candidate fixes change an operator-approved nav appearance,
+  which this pass was explicitly told to preserve; it needs its own change
+  and an appearance decision. It is a defect, not one of the four settled
+  design questions.
+- Validation: `task studio:check` green — eslint 0 errors (563 warnings,
+  unchanged from the branch baseline), `tsc -b`, and vitest 152 files /
+  1352 tests, up from the 151 / 1351 baseline by exactly the new case.
+  `vite build` exit 0. Three files changed: `CloudLanding.tsx`, its new
+  test, and this bilan — the plan predicted two, before the ratchet test was
+  added. **No CI or merge result is claimed for the changed head; neither
+  had happened when this was written.**
+- Lessons for next run: when a finding is about payload rather than
+  behaviour, make the acceptance gate answer "did it leave the eager graph",
+  not "did the number go down" — the two come apart exactly when a bundler
+  reshuffles chunks, which is the case worth catching.
+
 ## 2026-09-08 — #964: quota stop after useful fixes, bank delivered locally
 
 - Status: **banked commits recovered and locally validated**. The campaign

--- a/studio/src/views/CloudHome/PlatformFeatures.tsx
+++ b/studio/src/views/CloudHome/PlatformFeatures.tsx
@@ -1,0 +1,134 @@
+import {
+  ArrowUpRight, BookOpen, Box, BrainCircuit, CalendarClock, ChartNoAxesCombined,
+  ClipboardCheck, FileText, Gauge, GitBranch, GitPullRequest, KeyRound, Layers3,
+  MessageSquare, Network, PanelsTopLeft, Puzzle, RotateCcw, ScanEye, ScrollText,
+  ShieldCheck, SlidersHorizontal, SquarePen, Terminal, Users, Workflow,
+} from "lucide-react";
+
+const highlights = [
+  {
+    label: "LIVE AGENT SUPERVISION",
+    title: "Agents can have a coach, too.",
+    description: "Attach a supervisor that watches live activity and sends course corrections during a run. Define when it should step in, with its own evaluation budget.",
+    icon: ScanEye,
+    href: "supervisors.html",
+    link: "Meet the supervisors",
+  },
+  {
+    label: "MEMORY ACROSS RUNS",
+    title: "Give the next run a head start.",
+    description: "Let bots save decisions, findings and handover notes in persistent knowledge spaces. Reuse that context across runs, bots or projects, with scoped access.",
+    icon: BookOpen,
+    href: "memory-and-knowledge.html",
+    link: "Explore shared memory",
+  },
+  {
+    label: "WORKFLOW BENCHMARKS",
+    title: "Put your workflow to the test.",
+    description: "Compare judge verdicts across repeated runs and recipe variants. Measure approval rates and how review loops converge before extending your automation.",
+    icon: ChartNoAxesCombined,
+    href: "asymptote-bench.html",
+    link: "Explore quality benchmarks",
+  },
+];
+
+const capabilities = [
+  {
+    label: "01 / ORCHESTRATE",
+    title: "Define how agents work.",
+    icon: Workflow,
+    features: [
+      { name: "Multi-agent, multi-model", description: "Mix specialist agents and model families in one workflow. Let one model implement and another review.", icon: Workflow },
+      { name: "Visual + code authoring", description: "Build workflows on a canvas or edit the source. Both stay in sync, with validation as you work.", icon: SquarePen },
+      { name: "Reusable, versioned bots", description: "Keep workflows in Git. Review changes, share bot bundles and reuse what works across projects.", icon: GitBranch },
+      { name: "Model choice & fallback", description: "Choose models for each task, including sovereign endpoints. Set fallback routes for provider outages or usage limits.", icon: BrainCircuit },
+      { name: "Skills, plugins & MCP", description: "Give agents your team's knowledge, connect tools and extend their capabilities.", icon: Puzzle },
+      { name: "CLI, API & SDK", description: "Start workflows from your terminal, your applications or an existing delivery pipeline.", icon: Terminal },
+    ],
+  },
+  {
+    label: "02 / OPERATE",
+    title: "Connect work to action.",
+    icon: Layers3,
+    features: [
+      { name: "Repositories & events", description: "Trigger bots from pull requests, board changes and webhooks. Chain workflows when a run completes.", icon: GitPullRequest },
+      { name: "Recurring automation", description: "Schedule maintenance, documentation and monitoring. Set the cadence and let the workflow run.", icon: CalendarClock },
+      { name: "Dependencies between pipelines", description: "Chain tasks across bots and hold downstream work until its prerequisites succeed.", icon: Network },
+      { name: "One place to follow work", description: "Track repositories, boards, pipelines and runs in the Studio. Inspect progress and generated artifacts.", icon: PanelsTopLeft },
+      { name: "Ask questions. Keep working.", description: "Let agents ask for input while independent work continues, and wait when an answer is needed. Keep approvals and live steering available.", icon: MessageSquare },
+      { name: "Checkpoint & resume", description: "Resume interrupted workflows from saved progress, without repeating completed steps.", icon: RotateCcw },
+    ],
+  },
+  {
+    label: "03 / GOVERN",
+    title: "Keep control of execution.",
+    icon: ShieldCheck,
+    features: [
+      { name: "Budgets & limits", description: "Set limits on cost, tokens, time and iterations. Adjust a running workflow's budget when needed.", icon: Gauge },
+      { name: "Tests & review gates", description: "Require tests, checks or a reviewer's approval before progressing. Bound review-and-fix loops with explicit limits.", icon: ClipboardCheck },
+      { name: "Isolated workspaces", description: "Run work in dedicated Git worktrees and sandboxes. Configure tool permissions and network access.", icon: Box },
+      { name: "Your keys & secrets", description: "Bring your own provider credentials and bind secrets to the workflows that need them.", icon: KeyRound },
+      { name: "Teams & access", description: "Organize shared work across teams, manage membership and connect your organization's SSO.", icon: Users },
+      { name: "Traceable execution", description: "Follow run events, inspect outputs and review audit records to understand what happened.", icon: ScrollText },
+    ],
+  },
+];
+
+export default function PlatformFeatures() {
+  return (
+    <section className="ch-section ch-control" id="control" aria-labelledby="ch-control-heading">
+      <div className="ch-section-heading">
+        <div>
+          <p className="ch-eyebrow">THE AGENT CONTROL PLANE.</p>
+          <h2 id="ch-control-heading">Let it run.<br /><span>Keep the reins.</span></h2>
+        </div>
+        <p>Supervise the work. Carry context forward.<br />Measure results and keep control.</p>
+      </div>
+      <div className="ch-highlight-grid">
+        {highlights.map(({ label, title, description, icon: Icon, href, link }) => (
+          <article className="ch-highlight" key={label}>
+            <p className="ch-highlight-label"><Icon size={21} strokeWidth={1.5} aria-hidden="true" />{label}</p>
+            <h3>{title}</h3>
+            <p>{description}</p>
+            <a href={`https://socialgouv.github.io/iterion/${href}`} target="_blank" rel="noreferrer">{link} <ArrowUpRight size={13} /></a>
+          </article>
+        ))}
+      </div>
+      <div className="ch-experience-grid">
+        <article className="ch-experience-card">
+          <p className="ch-experience-label"><FileText size={19} strokeWidth={1.5} aria-hidden="true" /> TAILORED OUTPUT</p>
+          <h3>The right information, up front.</h3>
+          <p>Each bot defines what to highlight in its final output: key findings, a summary, or links to deliverables. Shape the result around what people need to understand and act on.</p>
+          <p className="ch-experience-example">A review's findings. A published digest. A pull request.</p>
+        </article>
+        <article className="ch-experience-card">
+          <p className="ch-experience-label"><SlidersHorizontal size={19} strokeWidth={1.5} aria-hidden="true" /> FOCUSED CONFIGURATION</p>
+          <h3>Settings your whole team can use.</h3>
+          <p>Bots can expose custom configuration fields in a dedicated editor. Choose exactly what users can see and change, so non-technical teammates get only the settings relevant to their work.</p>
+          <p className="ch-experience-example">For Vigie: choose feed sources and adjust the editorial brief.</p>
+          <a href="https://socialgouv.github.io/iterion/config-share.html" target="_blank" rel="noreferrer">Explore scoped configuration <ArrowUpRight size={13} /></a>
+        </article>
+      </div>
+      <div className="ch-capability-grid">
+        {capabilities.map(({ label, title, icon: Icon, features }) => (
+          <article className="ch-capability-group" key={label}>
+            <p className="ch-capability-label">{label}</p>
+            <Icon className="ch-capability-icon" size={28} strokeWidth={1.3} aria-hidden="true" />
+            <h3>{title}</h3>
+            <ul>
+              {features.map(({ name, description, icon: FeatureIcon }) => (
+                <li key={name}>
+                  <h4><FeatureIcon size={16} strokeWidth={1.6} aria-hidden="true" /><span>{name}</span></h4>
+                  <p>{description}</p>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+      <a className="ch-capability-docs" href="https://socialgouv.github.io/iterion/current-state.html" target="_blank" rel="noreferrer">
+        Explore the platform documentation <ArrowUpRight size={14} />
+      </a>
+    </section>
+  );
+}

--- a/studio/src/views/CloudHome/StackCompatibility.tsx
+++ b/studio/src/views/CloudHome/StackCompatibility.tsx
@@ -1,0 +1,94 @@
+import type { ComponentType } from "react";
+import { Container, GitBranch, GitMerge, Search, ShieldCheck, ShipWheel, Webhook } from "lucide-react";
+import Claude from "@lobehub/icons/es/Claude";
+import OpenAI from "@lobehub/icons/es/OpenAI";
+import Gemini from "@lobehub/icons/es/Gemini";
+import Mistral from "@lobehub/icons/es/Mistral";
+import Ollama from "@lobehub/icons/es/Ollama";
+import Vllm from "@lobehub/icons/es/Vllm";
+import OpenRouter from "@lobehub/icons/es/OpenRouter";
+import Azure from "@lobehub/icons/es/Azure";
+import Bedrock from "@lobehub/icons/es/Bedrock";
+import Github from "@lobehub/icons/es/Github";
+import MCP from "@lobehub/icons/es/MCP";
+
+type StackItem = { name: string; Icon: ComponentType<{ size?: number }> };
+
+// Compatibility surfaces, not an exhaustive catalog of accepted model IDs.
+// Custom model endpoints use the engine's OpenAI-compatible API support.
+const models: StackItem[] = [
+  { name: "Mistral", Icon: Mistral },
+  { name: "Ollama", Icon: Ollama },
+  { name: "vLLM", Icon: Vllm },
+  { name: "Claude", Icon: Claude },
+  { name: "OpenAI", Icon: OpenAI },
+  { name: "Gemini", Icon: Gemini },
+  { name: "OpenRouter", Icon: OpenRouter },
+  { name: "Azure OpenAI", Icon: Azure },
+  { name: "AWS Bedrock", Icon: Bedrock },
+];
+
+const tools: StackItem[] = [
+  { name: "GitHub", Icon: Github },
+  { name: "GitLab", Icon: GitBranch },
+  { name: "Forgejo", Icon: GitMerge },
+  { name: "MCP", Icon: MCP },
+  { name: "Docker", Icon: Container },
+  { name: "Kubernetes", Icon: ShipWheel },
+  { name: "SearXNG", Icon: Search },
+  { name: "Webhooks", Icon: Webhook },
+];
+
+function StackRow({ label, items, reverse = false }: {
+  label: string;
+  items: StackItem[];
+  reverse?: boolean;
+}) {
+  return (
+    <div className="ch-stack-row">
+      <p className="ch-stack-row-label">{label}</p>
+      <div className="ch-stack-window" tabIndex={0} role="group" aria-label={label}>
+        <div className={`ch-stack-track${reverse ? " ch-stack-reverse" : ""}`}>
+          {[false, true].map(duplicate => (
+            <ul
+              className={`ch-stack-list${duplicate ? " ch-stack-duplicate" : ""}`}
+              key={String(duplicate)}
+              aria-label={duplicate ? undefined : label}
+              aria-hidden={duplicate || undefined}
+            >
+              {items.map(({ name, Icon }) => (
+                <li key={name}>
+                  <span aria-hidden="true"><Icon size={24} /></span>
+                  <span>{name}</span>
+                </li>
+              ))}
+            </ul>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function StackCompatibility() {
+  return (
+    <section
+      id="stack"
+      className="ch-stack ch-container"
+      aria-labelledby="ch-stack-heading"
+    >
+      <h2 id="ch-stack-heading" className="ch-eyebrow ch-stack-heading">YOUR STACK. ALREADY INVITED.</h2>
+      <div className="ch-stack-rows">
+        <StackRow label="Models & inference" items={models} />
+        <StackRow label="Tools & infrastructure" items={tools} reverse />
+      </div>
+      <div className="ch-sovereign-note">
+        <ShieldCheck size={20} strokeWidth={1.5} aria-hidden="true" />
+        <p>
+          <strong>Bring any sovereign model through an OpenAI-compatible API.</strong>
+          <span> Choose your hosting, run on your own infrastructure, and keep control of where your models run.</span>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/studio/src/views/CloudHome/cloud-home.css
+++ b/studio/src/views/CloudHome/cloud-home.css
@@ -1,0 +1,348 @@
+.cloud-home {
+  /* Brand and surface colors follow the published Iterion documentation. */
+  --ch-bg: #1b1b1f;
+  --ch-panel: #202127;
+  --ch-panel-raised: #292a31;
+  --ch-text: #dfdfd6;
+  --ch-muted: #98989f;
+  --ch-faint: #909098;
+  --ch-line: #2e2e32;
+  --ch-accent: #a8b1ff;
+  --ch-accent-soft: rgba(100, 108, 255, .16);
+  --ch-button-bg: #3e63dd;
+  --ch-button-hover: #3a5ccc;
+  --ch-accent-ink: #fff;
+  --ch-mint: #a5d7be;
+  background: var(--ch-bg);
+  color: var(--ch-text);
+  font-family: "Geist Variable", sans-serif;
+  font-size: 14px;
+  line-height: 1.55;
+  overflow: clip;
+}
+:root[data-theme="light"] .cloud-home {
+  --ch-bg: #fff;
+  --ch-panel: #f6f6f7;
+  --ch-panel-raised: #ebebef;
+  --ch-text: #3c3c43;
+  --ch-muted: #67676c;
+  --ch-faint: #67676c;
+  --ch-line: #e2e2e3;
+  --ch-accent: #3451b2;
+  --ch-accent-soft: rgba(100, 108, 255, .14);
+  --ch-button-bg: #3a5ccc;
+  --ch-button-hover: #3451b2;
+  --ch-accent-ink: #fff;
+  --ch-mint: #30745b;
+}
+.cloud-home a { text-decoration: none; }
+.cloud-home button { cursor: pointer; font: inherit; }
+.cloud-home a, .cloud-home button { -webkit-tap-highlight-color: transparent; }
+.cloud-home :focus-visible { outline: 2px solid var(--ch-accent); outline-offset: 5px; }
+.cloud-home svg { flex-shrink: 0; }
+.ch-container { width: min(1200px, calc(100% - 96px)); margin-inline: auto; }
+.ch-skip { position: fixed; left: 16px; top: -100px; padding: 12px 20px; z-index: 100; background: var(--ch-button-bg); color: var(--ch-accent-ink); border-radius: 6px; }
+.ch-skip:focus { top: 10px; }
+.ch-nav-wrap { position: sticky; top: 0; z-index: 30; background: color-mix(in srgb, var(--ch-bg) 90%, transparent); backdrop-filter: blur(18px); border-bottom: 1px solid var(--ch-line); }
+.ch-nav { display: flex; height: 84px; align-items: center; justify-content: space-between; gap: 25px; }
+.ch-brand { display: inline-flex; align-items: center; gap: 10px; color: var(--ch-text); flex-shrink: 0; }
+.ch-brand-mark { width: 33px; height: 33px; }
+.ch-brand > span { display: flex; align-items: center; gap: 10px; font-size: 24px; letter-spacing: -1px; font-weight: 620; }
+.ch-cloud-label { padding: 3px 7px; font-size: 10px; font-weight: 450; letter-spacing: .2px; line-height: 1.3; border: 1px solid var(--ch-line); border-radius: 4px; color: var(--ch-muted); }
+.ch-nav-links, .ch-nav-actions { display: flex; align-items: center; gap: 29px; }
+.ch-nav-links a { color: var(--ch-muted); font-size: 13px; display: inline-flex; align-items: center; gap: 4px; }
+.ch-nav-links a:hover, .ch-footer a:hover { color: var(--ch-accent); }
+.ch-nav-actions { gap: 20px; }
+.ch-theme, .ch-github-icon { border: 0; background: transparent; color: var(--ch-muted); display: grid; place-items: center; width: 28px; height: 32px; }
+.ch-theme:hover, .ch-github-icon:hover { color: var(--ch-text); }
+.ch-nav-signin { border: 1px solid var(--ch-line); border-radius: 6px; padding: 8px 14px; display: inline-flex; align-items: center; gap: 17px; font-size: 12px; color: var(--ch-text); }
+.ch-nav-signin:hover { background: var(--ch-panel-raised); }
+.ch-mobile-toggle, .ch-mobile-nav { display: none; }
+.ch-hero { display: grid; grid-template-columns: 1.02fr 1fr; align-items: center; min-height: 615px; padding-block: 80px 76px; gap: 20px; }
+.ch-open-source { display: inline-flex; align-items: center; gap: 9px; font-family: var(--font-mono); font-size: 9px; letter-spacing: 1.15px; color: var(--ch-muted); }
+.ch-open-source > svg { margin-left: 6px; }
+.ch-open-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--ch-accent); box-shadow: 0 0 12px color-mix(in srgb, var(--ch-accent) 35%, transparent); }
+.ch-hero h1 { font-size: clamp(42px, 4.7vw, 66px); letter-spacing: -.045em; font-weight: 520; line-height: 1.07; margin: 28px 0 25px; }
+.ch-hero h1 > span { color: var(--ch-accent); }
+.ch-hero-description strong { color: var(--ch-text); font-weight: 450; }
+.ch-hero-description { font-size: 16px; color: var(--ch-muted); line-height: 1.8; letter-spacing: -.15px; margin: 0; }
+.ch-hero-ctas { display: flex; gap: 17px; align-items: center; margin-top: 31px; }
+.ch-button { display: inline-flex; align-items: center; justify-content: center; gap: 17px; min-height: 46px; padding: 12px 18px; border: 1px solid transparent; border-radius: 6px; font-size: 12px; font-weight: 550; white-space: nowrap; transition: background .18s, transform .18s; }
+.ch-button:hover { transform: translateY(-2px); }
+.ch-button-primary { background: var(--ch-button-bg); color: var(--ch-accent-ink); box-shadow: 0 3px 20px color-mix(in srgb, var(--ch-accent) 7%, transparent); }
+.ch-button-primary:hover { background: var(--ch-button-hover); }
+.ch-button-text { gap: 9px; padding-inline: 3px; color: var(--ch-text); }
+.ch-hero-footnote { display: flex; align-items: center; gap: 19px; margin-top: 24px; font-size: 10px; color: var(--ch-faint); }
+.ch-hero-footnote > span { display: inline-flex; gap: 6px; align-items: center; }
+.ch-hero-footnote svg { color: var(--ch-faint); }
+.ch-orbit { position: relative; aspect-ratio: 560 / 450; width: 100%; color: var(--ch-line); isolation: isolate; background: radial-gradient(ellipse at 50% 48%, color-mix(in srgb, var(--ch-accent) 7%, transparent), transparent 60%); }
+.ch-orbit-caption, .ch-orbit-bottom { position: absolute; inset: 0 12px auto; display: flex; align-items: center; gap: 12px; font-family: var(--font-mono); font-size: 8px; letter-spacing: 1.4px; color: var(--ch-faint); }
+.ch-orbit-caption > :last-child { margin-left: auto; }
+.ch-tiny-cross { font-size: 20px; font-weight: 200; color: var(--ch-faint); }
+.ch-orbit-ring { position: absolute; border: 1px solid color-mix(in srgb, var(--ch-line) 65%, transparent); border-radius: 50%; left: 50%; top: 49%; transform: translate(-50%, -50%); z-index: -1; }
+.ch-ring-one { width: 64%; aspect-ratio: 1; }
+.ch-ring-two { width: 80%; aspect-ratio: 1; border-style: dashed; opacity: .6; }
+.ch-ring-three { width: 94%; aspect-ratio: 1; opacity: .35; }
+.ch-orbit-paths { width: 100%; height: 100%; position: absolute; inset: 0; }
+.ch-flow-path { stroke-dasharray: 65 390; stroke-dashoffset: -100; opacity: .7; }
+.ch-core { position: absolute; left: 49.8%; top: 48.4%; transform: translate(-50%, -50%); display: flex; align-items: center; justify-content: center; flex-direction: column; width: 126px; height: 126px; border-radius: 30px; color: var(--ch-accent); background: linear-gradient(145deg, var(--ch-panel-raised), var(--ch-bg)); border: 1px solid color-mix(in srgb, var(--ch-accent) 40%, var(--ch-line)); box-shadow: 0 15px 40px #0002, inset 0 1px 0 #ffffff12; }
+.ch-core-mark { width: 52px; height: 52px; object-fit: contain; flex-shrink: 0; }
+.ch-core > span { font-size: 20px; color: var(--ch-text); letter-spacing: -.6px; font-weight: 600; margin-top: 2px; }
+.ch-core > small { font-family: var(--font-mono); letter-spacing: 1.8px; font-size: 6px; color: var(--ch-muted); margin-top: 3px; }
+.ch-orbit-node { position: absolute; display: flex; align-items: center; gap: 10px; background: linear-gradient(125deg, var(--ch-panel-raised), var(--ch-panel)); border: 1px solid var(--ch-line); border-radius: 8px; padding: 12px; box-shadow: 0 10px 26px #0002; color: var(--ch-muted); min-width: 161px; }
+.ch-orbit-node > div { display: flex; flex-direction: column; gap: 4px; }
+.ch-orbit-node small { font-size: 6px; letter-spacing: 1px; font-family: var(--font-mono); color: var(--ch-faint); }
+.ch-orbit-node strong { font-size: 10px; font-weight: 520; color: var(--ch-text); }
+.ch-node-icon { display: grid; place-items: center; width: 29px; height: 29px; border: 1px solid var(--ch-line); border-radius: 6px; color: var(--ch-accent); }
+.ch-node-plan { left: 0; top: 19%; transform: rotate(-4deg); }
+.ch-node-build { right: -1%; top: 15%; transform: rotate(4deg); border-color: color-mix(in srgb, var(--ch-accent) 38%, var(--ch-line)); }
+.ch-node-review { left: -1%; top: 69%; transform: rotate(-3deg); }
+.ch-node-ship { right: -1%; top: 67%; transform: rotate(3deg); }
+.ch-mint { color: var(--ch-mint); }
+.ch-live-dot { width: 5px; height: 5px; background: var(--ch-accent); border-radius: 50%; flex-shrink: 0; }
+.ch-orbit-bottom { top: auto; bottom: 0; letter-spacing: 0; font-size: 8px; }
+.ch-orbit-bottom .ch-tiny-cross { margin-left: auto; }
+.ch-section { padding-block: 110px; scroll-margin-top: 100px; }
+.ch-eyebrow { font-family: var(--font-mono); font-size: 9px; font-weight: 400; letter-spacing: 1.5px; line-height: 1.7; color: var(--ch-accent); margin: 0 0 20px; }
+.cloud-home h2 { font-weight: 500; font-size: 42px; letter-spacing: -1.8px; line-height: 1.15; margin: 0; }
+
+.ch-trigger-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 64px; }
+.ch-trigger-story { display: flex; flex-direction: column; min-width: 0; border-top: 1px solid var(--ch-line); padding-top: 27px; }
+.ch-trigger-label { display: flex; align-items: center; gap: 9px; font-family: var(--font-mono); font-size: 9px; letter-spacing: 1.1px; color: var(--ch-accent); margin: 0 0 18px; }
+.ch-trigger-story h3 { font-size: 25px; font-weight: 500; line-height: 1.3; letter-spacing: -.7px; margin: 0 0 13px; }
+.ch-trigger-description { margin: 0; max-width: 475px; font-size: 14px; line-height: 1.8; color: var(--ch-muted); }
+.ch-bot-stories { margin-block: 28px; flex: 1; }
+.ch-bot-story + .ch-bot-story { margin-top: 25px; }
+.ch-bot-story h4 { display: flex; flex-wrap: wrap; align-items: baseline; gap: 11px; margin: 0 0 9px; font-size: 18px; font-weight: 550; }
+.ch-bot-story h4 a { display: inline-flex; align-items: center; gap: 5px; }
+.ch-bot-story h4 a:hover { color: var(--ch-accent); }
+.ch-bot-story h4 a > svg { color: var(--ch-faint); }
+.ch-bot-story h4 > span { font-size: 11px; font-weight: 400; color: var(--ch-faint); }
+.ch-bot-story > p { margin: 0; max-width: 475px; font-size: 13px; line-height: 1.8; color: var(--ch-muted); }
+.ch-trigger-summary { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; border-top: 1px solid var(--ch-line); padding-top: 20px; margin: 0; font-family: var(--font-mono); font-size: 10px; color: var(--ch-faint); }
+.ch-trigger-summary > svg { color: var(--ch-accent); }
+.ch-control { padding-top: 18px; }
+.ch-section-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 25px; margin-bottom: 37px; }
+.ch-section-heading h2 > span { color: var(--ch-muted); }
+.ch-section-heading > p { color: var(--ch-muted); font-size: 13px; line-height: 1.8; margin: 0 0 4px; }
+.ch-highlight-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 32px; margin-bottom: 42px; }
+.ch-highlight { display: flex; flex-direction: column; padding-top: 26px; border-top: 1px solid var(--ch-line); }
+.ch-highlight .ch-highlight-label { display: flex; align-items: center; gap: 10px; margin: 0 0 22px; font-family: var(--font-mono); font-size: 8px; letter-spacing: 1px; color: var(--ch-accent); }
+.ch-highlight h3 { margin: 0 0 15px; max-width: 330px; font-size: 26px; font-weight: 500; line-height: 1.3; letter-spacing: -.7px; text-wrap: balance; }
+.ch-highlight > p { margin: 0 0 22px; font-size: 13px; line-height: 1.85; color: var(--ch-muted); }
+.ch-highlight > a { display: inline-flex; align-items: center; gap: 7px; align-self: flex-start; margin-top: auto; color: var(--ch-accent); font-size: 11px; }
+.ch-highlight > a:hover { text-decoration: underline; }
+.ch-experience-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; margin-bottom: 24px; }
+.ch-experience-card { padding: 30px; border: 1px solid var(--ch-line); border-radius: 9px; background: linear-gradient(135deg, var(--ch-panel), var(--ch-bg)); }
+.ch-experience-card .ch-experience-label { display: flex; align-items: center; gap: 10px; margin: 0 0 22px; font-family: var(--font-mono); font-size: 8px; letter-spacing: 1.2px; color: var(--ch-accent); }
+.ch-experience-card h3 { margin: 0 0 15px; font-size: 25px; font-weight: 500; line-height: 1.3; letter-spacing: -.7px; }
+.ch-experience-card > p { margin: 0; font-size: 13px; line-height: 1.85; color: var(--ch-muted); }
+.ch-experience-card .ch-experience-example { margin-top: 20px; font-size: 12px; color: var(--ch-text); }
+.ch-experience-card > a { display: inline-flex; align-items: center; gap: 7px; margin-top: 15px; color: var(--ch-accent); font-size: 11px; }
+.ch-experience-card > a:hover { text-decoration: underline; }
+.ch-capability-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border: 1px solid var(--ch-line); border-radius: 9px; overflow: hidden; background: var(--ch-panel); }
+.ch-capability-group { padding: 30px; }
+.ch-capability-group + .ch-capability-group { border-left: 1px solid var(--ch-line); }
+.ch-capability-label { margin: 0 0 24px; font-size: 8px; font-family: var(--font-mono); letter-spacing: 1.2px; color: var(--ch-faint); }
+.ch-capability-icon { color: var(--ch-accent); margin-bottom: 19px; }
+.ch-capability-group h3 { max-width: 235px; font-size: 26px; line-height: 1.25; letter-spacing: -.8px; font-weight: 500; margin: 0 0 30px; }
+.ch-capability-group ul { list-style: none; padding: 0; margin: 0; }
+.ch-capability-group li + li { margin-top: 24px; }
+.ch-capability-group h4 { display: flex; align-items: flex-start; gap: 9px; font-size: 14px; font-weight: 500; line-height: 1.4; margin: 0 0 7px; }
+.ch-capability-group h4 > svg { color: var(--ch-accent); margin-top: 2px; }
+.ch-capability-group li p { font-size: 12px; line-height: 1.8; color: var(--ch-muted); margin: 0; }
+.ch-capability-docs { display: inline-flex; align-items: center; gap: 8px; margin-top: 22px; color: var(--ch-muted); font-size: 12px; }
+.ch-capability-docs:hover { color: var(--ch-accent); }
+.ch-no-wrap { white-space: nowrap; }
+.ch-final-cta { position: relative; text-align: center; padding: 60px 20px 100px; }
+.ch-final-cta .ch-eyebrow { font-size: 8px; color: var(--ch-faint); margin-bottom: 15px; }
+.ch-final-cta h2 { font-size: 46px; letter-spacing: -2px; }
+.ch-final-cta > p:not(.ch-eyebrow) { color: var(--ch-muted); margin: 17px 0 28px; font-size: 13px; }
+.ch-final-cta > div { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 12px; }
+.ch-button-secondary { background: var(--ch-panel); color: var(--ch-text); border-color: var(--ch-line); gap: 9px; }
+.ch-button-secondary:hover { background: var(--ch-panel-raised); }
+.ch-footer { display: flex; align-items: center; justify-content: space-between; gap: 25px; border-top: 1px solid var(--ch-line); padding-block: 33px; }
+.ch-footer .ch-brand-mark { width: 25px; height: 25px; }
+.ch-footer .ch-brand > span { font-size: 20px; }
+.ch-footer p { color: var(--ch-faint); font-size: 9px; margin: 9px 0 0; }
+.ch-footer nav { display: flex; flex-wrap: wrap; align-items: center; gap: 24px; font-size: 10px; color: var(--ch-muted); }
+.ch-footer nav > a { display: flex; align-items: center; gap: 3px; }
+.ch-footer nav > span { color: var(--ch-faint); font-size: 8px; }
+@media (min-width: 1500px) { .ch-hero { min-height: 670px; } }
+@media (max-width: 1100px) {
+  .ch-highlight-grid { gap: 24px; }
+  .ch-highlight h3 { font-size: 24px; }
+  .ch-experience-card { padding: 24px; }
+  .ch-capability-group { padding: 24px; }
+  .ch-trigger-columns { gap: 36px; }
+
+  .ch-container { width: calc(100% - 64px); }
+  .ch-nav-links { gap: 20px; }
+  .ch-nav-actions { gap: 10px; }
+  .ch-hero { gap: 10px; min-height: 590px; }
+  .ch-orbit-node { min-width: 140px; padding: 9px; gap: 7px; }
+  .ch-orbit-node strong { font-size: 9px; }
+  .ch-core { width: 100px; height: 100px; border-radius: 23px; }
+  .ch-core-mark { width: 40px; height: 40px; }
+  .cloud-home h2 { font-size: 36px; }
+}
+@media (max-width: 850px) {
+  .ch-highlight-grid { grid-template-columns: 1fr; gap: 30px; }
+  .ch-highlight h3 { max-width: none; }
+  .ch-highlight > p { max-width: 600px; }
+  .ch-experience-grid { grid-template-columns: 1fr; }
+  .ch-experience-card { padding: 28px; }
+  .ch-capability-grid { grid-template-columns: 1fr; }
+  .ch-capability-group { padding: 28px; }
+  .ch-capability-group + .ch-capability-group { border-left: 0; border-top: 1px solid var(--ch-line); }
+  .ch-capability-group h3 { max-width: none; margin-bottom: 25px; }
+  .ch-capability-group ul { display: grid; grid-template-columns: 1fr 1fr; gap: 24px 32px; }
+  .ch-capability-group li + li { margin: 0; }
+  .ch-trigger-columns { grid-template-columns: 1fr; gap: 45px; }
+  .ch-trigger-description, .ch-bot-story > p { max-width: 580px; }
+
+  .ch-use-cases .ch-section-heading { flex-direction: column; gap: 20px; }
+  .ch-use-cases .ch-section-heading > p { max-width: none; }
+
+  .ch-nav-links { display: none; }
+  .ch-mobile-toggle { display: grid; place-items: center; border: 0; background: transparent; color: var(--ch-text); width: 32px; height: 36px; }
+  .ch-mobile-nav { display: flex; flex-direction: column; gap: 18px; padding: 20px 32px 26px; border-top: 1px solid var(--ch-line); font-size: 13px; }
+  .ch-mobile-nav > a { display: flex; align-items: center; gap: 5px; }
+  .ch-hero { grid-template-columns: 1fr; padding-top: 65px; padding-bottom: 40px; gap: 40px; }
+  .ch-hero-copy { text-align: center; }
+  .ch-hero h1 { font-size: clamp(40px, 8vw, 64px); }
+  .ch-hero-ctas, .ch-hero-footnote { justify-content: center; }
+  .ch-orbit { width: min(540px, 100%); margin: auto; }
+  .ch-orbit-node { padding: 12px; min-width: 165px; }
+  .ch-orbit-node strong { font-size: 11px; }
+  .ch-core { width: 126px; height: 126px; }
+  .ch-core-mark { width: 52px; height: 52px; }
+  .ch-section { padding-block: 70px; }
+  .ch-control { padding-top: 15px; }
+  .ch-section-heading { align-items: flex-start; }
+  .ch-section-heading > p { max-width: 230px; }
+  .ch-section-heading > p > br { display: none; }
+  .ch-footer { align-items: flex-start; }
+  .ch-footer nav { justify-content: flex-end; gap: 18px; }
+  .ch-footer nav > span { width: 100%; text-align: right; }
+}
+@media (max-width: 520px) {
+  .ch-highlight-grid { margin-bottom: 30px; }
+  .ch-highlight > p { font-size: 12px; }
+  .ch-highlight h3 { font-size: 23px; text-wrap: initial; }
+  .ch-experience-card { padding: 26px; }
+  .ch-experience-card h3 { font-size: 23px; }
+  .ch-experience-card > p { font-size: 12px; }
+  .ch-capability-group { padding: 26px; }
+  .ch-capability-group ul { grid-template-columns: 1fr; gap: 22px; }
+  .ch-capability-group h3 { font-size: 24px; }
+  .ch-capability-docs { font-size: 11px; }
+  .ch-trigger-story h3 { font-size: 23px; }
+  .ch-trigger-label { font-size: 8px; }
+  .ch-trigger-description { font-size: 13px; }
+  .ch-trigger-summary { font-size: 9px; gap: 8px; }
+
+  .ch-container { width: calc(100% - 40px); }
+  .ch-nav { height: 70px; gap: 10px; }
+  .ch-brand > span { font-size: 23px; gap: 7px; }
+  .ch-brand { gap: 7px; }
+  .ch-brand-mark { width: 29px; height: 29px; }
+  .ch-cloud-label { font-size: 8px; padding: 3px 5px; }
+  .ch-nav-actions { gap: 7px; }
+  .ch-github-icon { display: none; }
+  .ch-nav-signin { padding: 7px 9px; gap: 7px; font-size: 10px; }
+  .ch-theme { width: 23px; }
+  .ch-mobile-toggle { width: 24px; }
+  .ch-hero { padding-top: 47px; gap: 46px; }
+  .ch-open-source { font-size: 7px; letter-spacing: .8px; }
+  .ch-hero h1 { font-size: clamp(34px, 10.2vw, 48px); margin-block: 25px 22px; }
+  .ch-hero-description { font-size: 13px; line-height: 1.85; }
+  .ch-hero-ctas { gap: 14px; margin-top: 27px; }
+  .ch-button { font-size: 10px; padding: 11px 12px; gap: 10px; min-height: 44px; }
+  .ch-button-text { padding-inline: 0; gap: 6px; }
+  .ch-hero-footnote { gap: 14px; font-size: 8px; margin-top: 22px; }
+  .ch-hero-footnote > span { gap: 4px; }
+  .ch-hero-footnote svg { width: 10px; }
+  .ch-orbit { aspect-ratio: 560/490; }
+  .ch-orbit-caption { font-size: 6px; letter-spacing: .8px; inset-inline: 0; }
+  .ch-orbit-node { min-width: 125px; padding: 9px 7px; gap: 6px; border-radius: 6px; }
+  .ch-orbit-node strong { font-size: 8px; }
+  .ch-orbit-node small { font-size: 4.5px; letter-spacing: .6px; }
+  .ch-orbit-node > svg:last-child { width: 10px; }
+  .ch-node-icon { width: 24px; height: 24px; }
+  .ch-node-icon svg { width: 13px; }
+  .ch-node-plan { top: 20%; }
+  .ch-node-build { top: 16%; }
+  .ch-node-review { top: 73%; }
+  .ch-node-ship { top: 71%; }
+  .ch-core { width: 86px; height: 86px; border-radius: 21px; top: 49%; }
+  .ch-core-mark { width: 34px; height: 34px; }
+  .ch-core > span { font-size: 16px; }
+  .ch-core > small { font-size: 4px; letter-spacing: 1px; }
+  .ch-orbit-bottom { inset-inline: 0; font-size: 6px; gap: 6px; }
+  .ch-orbit-bottom > svg { width: 11px; }
+  .ch-section { padding-block: 57px; }
+  .ch-eyebrow { font-size: 7px; letter-spacing: 1.2px; margin-bottom: 16px; }
+  .cloud-home h2 { font-size: 34px; letter-spacing: -1.3px; }
+  .ch-control { padding-top: 5px; }
+  .ch-section-heading { flex-direction: column; gap: 20px; margin-bottom: 26px; }
+  .ch-section-heading > p { max-width: 300px; font-size: 12px; }
+  .ch-final-cta { padding: 30px 0 70px; }
+  .ch-final-cta h2 { font-size: 36px; }
+  .ch-final-cta > p:not(.ch-eyebrow) { font-size: 12px; }
+  .ch-final-cta > div { gap: 9px; }
+  .ch-footer { flex-direction: column; gap: 27px; padding-block: 26px; }
+  .ch-footer nav { justify-content: flex-start; gap: 23px; }
+  .ch-footer nav > span { text-align: left; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .ch-hero-copy, .ch-orbit { animation: ch-arrive .7s ease-out both; }
+  .ch-orbit { animation-delay: .12s; }
+  @keyframes ch-arrive { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+}
+@media (prefers-reduced-motion: reduce) { .cloud-home *, .cloud-home *::before { transition: none !important; animation: none !important; scroll-behavior: auto !important; } }
+
+.ch-stack { padding-block: 35px 27px; border-block: 1px solid var(--ch-line); scroll-margin-top: 105px; }
+.cloud-home .ch-stack-heading { font-size: 8px; font-weight: 400; letter-spacing: 1.5px; line-height: 1.7; margin: 0; color: var(--ch-faint); }
+.ch-stack-rows { margin-block: 12px 23px; }
+.ch-stack-row { display: grid; grid-template-columns: 160px minmax(0, 1fr); align-items: center; gap: 25px; }
+.ch-stack-row + .ch-stack-row { border-top: 1px solid var(--ch-line); }
+.ch-stack-row-label { margin: 0; color: var(--ch-faint); font-family: var(--font-mono); font-size: 8px; text-transform: uppercase; letter-spacing: 1px; line-height: 1.6; }
+.ch-stack-window { min-width: 0; overflow: hidden; mask-image: linear-gradient(to right, transparent, black 4%, black 96%, transparent); }
+.ch-stack-track { display: flex; width: max-content; animation: ch-stack-scroll 42s linear infinite; will-change: transform; }
+.ch-stack-reverse { animation-direction: reverse; animation-duration: 46s; }
+.ch-stack-list { display: flex; align-items: center; flex-shrink: 0; list-style: none; margin: 0; padding: 21px 42px 21px 0; gap: 42px; }
+.ch-stack-list li { display: inline-flex; align-items: center; flex-shrink: 0; gap: 10px; color: var(--ch-muted); font-size: 18px; font-weight: 500; letter-spacing: -.4px; white-space: nowrap; }
+.ch-stack-list li > span:first-child { display: flex; color: var(--ch-text); opacity: .8; }
+.ch-stack-list svg { width: 24px; height: 24px; }
+.ch-stack-rows:hover .ch-stack-track, .ch-stack-rows:focus-within .ch-stack-track { animation-play-state: paused; }
+.ch-sovereign-note { display: flex; align-items: flex-start; gap: 11px; padding: 16px 19px; border-left: 2px solid var(--ch-accent); background: linear-gradient(90deg, var(--ch-accent-soft), transparent); }
+.ch-sovereign-note > svg { color: var(--ch-accent); margin-top: 1px; }
+.ch-sovereign-note p { margin: 0; font-size: 12px; line-height: 1.8; color: var(--ch-muted); }
+.ch-sovereign-note strong { font-weight: 500; color: var(--ch-text); }
+@keyframes ch-stack-scroll { to { transform: translateX(-50%); } }
+@media (max-width: 850px) {
+  .ch-stack-row { grid-template-columns: 130px minmax(0, 1fr); gap: 17px; }
+  .ch-stack-list { gap: 32px; padding-right: 32px; }
+  .ch-stack-list li { font-size: 16px; }
+}
+@media (max-width: 520px) {
+  .ch-stack { padding-block: 29px 24px; }
+  .ch-stack-rows { margin-block: 20px 16px; }
+  .ch-stack-row { grid-template-columns: minmax(0, 1fr); gap: 0; }
+  .ch-stack-row + .ch-stack-row { padding-top: 15px; }
+  .ch-stack-row-label { font-size: 7px; }
+  .ch-stack-list { padding-block: 17px; gap: 28px; padding-right: 28px; }
+  .ch-stack-list li { gap: 8px; font-size: 16px; }
+  .ch-stack-list svg { width: 22px; height: 22px; }
+  .ch-sovereign-note { padding: 12px; gap: 9px; }
+  .ch-sovereign-note p { font-size: 11px; }
+  .ch-sovereign-note p > span { display: block; margin-top: 5px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ch-stack-duplicate { display: none; }
+  .ch-stack-track { width: 100%; transform: none; will-change: auto; animation: none; }
+  .ch-stack-window { mask-image: none; }
+  .ch-stack-list { flex-wrap: wrap; flex-shrink: 1; gap: 20px 26px; padding-right: 0; }
+  .ch-stack-list li { font-size: 14px; }
+}

--- a/studio/src/views/CloudHome/index.tsx
+++ b/studio/src/views/CloudHome/index.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+import { ArrowRight, ArrowUpRight, Check, ChevronRight, Clock3, Code2, GitBranch, GitPullRequest, ListChecks, Menu, Moon, ShieldCheck, Sun, X } from "lucide-react";
+import { GitHubLogoIcon } from "@radix-ui/react-icons";
+import { BrandMark } from "@/components/ui/BrandMark";
+import { useThemeStore } from "@/store/theme";
+import StackCompatibility from "./StackCompatibility";
+import PlatformFeatures from "./PlatformFeatures";
+import "./cloud-home.css";
+
+const GITHUB = "https://github.com/SocialGouv/iterion";
+const DOCS = "https://socialgouv.github.io/iterion/";
+
+function Brand() {
+  return <Link href="/" className="ch-brand" aria-label="Iterion Cloud home"><BrandMark className="ch-brand-mark" /><span>iterion<span className="ch-cloud-label">cloud</span></span></Link>;
+}
+
+function HeroVisual() {
+  return (
+    <div className="ch-orbit" role="img" aria-label="Iterion coordinates a mission through planning, execution, review and delivery.">
+      <div className="ch-orbit-caption"><span className="ch-tiny-cross">+</span> COMPLEXITY, COORDINATED <span>01—04</span></div>
+      <div className="ch-orbit-ring ch-ring-one" /><div className="ch-orbit-ring ch-ring-two" /><div className="ch-orbit-ring ch-ring-three" />
+      <svg className="ch-orbit-paths" viewBox="0 0 560 450" fill="none" aria-hidden="true">
+        <path d="M112 125 C180 125 180 218 279 218 S380 108 447 108 M279 218 C370 218 379 340 446 340 M279 218 C192 218 198 349 98 349" stroke="currentColor" strokeWidth="1" />
+        <path className="ch-flow-path" d="M112 125 C180 125 180 218 279 218 S380 108 447 108" stroke="var(--ch-accent)" strokeWidth="2" />
+        <circle cx="279" cy="218" r="97" stroke="currentColor" strokeDasharray="2 8" />
+      </svg>
+      <div className="ch-core"><BrandMark className="ch-core-mark" /><span>iterion</span><small>ORCHESTRATE</small></div>
+      <div className="ch-orbit-node ch-node-plan"><span className="ch-node-icon"><ListChecks size={17} /></span><div><small>01 / UNDERSTAND</small><strong>A clear plan</strong></div><Check size={13} className="ch-mint" /></div>
+      <div className="ch-orbit-node ch-node-build"><span className="ch-node-icon"><Code2 size={17} /></span><div><small>02 / EXECUTE</small><strong>Agents at work</strong></div><span className="ch-live-dot" /></div>
+      <div className="ch-orbit-node ch-node-review"><span className="ch-node-icon"><ShieldCheck size={17} /></span><div><small>03 / VERIFY</small><strong>Review & refine</strong></div></div>
+      <div className="ch-orbit-node ch-node-ship"><span className="ch-node-icon"><GitPullRequest size={17} /></span><div><small>04 / DELIVER</small><strong>Ready to ship</strong></div><ArrowUpRight size={14} /></div>
+      <div className="ch-orbit-bottom"><GitBranch size={13} /><span>One workflow. Every step connected.</span><span className="ch-tiny-cross">+</span></div>
+    </div>
+  );
+}
+
+function UseCases() {
+  return (
+    <section className="ch-section ch-use-cases" id="workflows" aria-labelledby="ch-use-cases-heading">
+      <div className="ch-section-heading">
+        <div>
+          <p className="ch-eyebrow">CONNECTED TO YOUR WORK.</p>
+          <h2 id="ch-use-cases-heading">Connect your repos.<br />React to events.<br />Run on schedule.</h2>
+        </div>
+        <p>A pull request, a webhook, or a recurring task.<br />Get the results where your team works.</p>
+      </div>
+      <div className="ch-trigger-columns">
+        <article className="ch-trigger-story" aria-labelledby="ch-repo-heading">
+          <p className="ch-trigger-label"><GitBranch size={17} /> REPOSITORY EVENTS</p>
+          <h3 id="ch-repo-heading">Put bots on your repositories.</h3>
+          <p className="ch-trigger-description">
+            Connect a GitHub, GitLab or Forgejo repository and enable the bots
+            you need. Pull requests trigger their work automatically.
+          </p>
+          <div className="ch-bot-stories">
+            <div className="ch-bot-story">
+              <h4><a href={`${GITHUB}/tree/main/bots/review-pr`} target="_blank" rel="noreferrer">Revi <ArrowUpRight size={13} /></a><span>Code review</span></h4>
+              <p>Reviews pull requests and posts findings directly on the changed lines, so the discussion stays with the code.</p>
+            </div>
+            <div className="ch-bot-story">
+              <h4><a href={`${GITHUB}/tree/main/bots/dep-update-guard`} target="_blank" rel="noreferrer">Vetty <ArrowUpRight size={13} /></a><span>Dependency maintenance</span></h4>
+              <p>Checks Dependabot and Renovate updates, adapts the code when needed, and runs the build and tests before reporting back on the PR.</p>
+            </div>
+          </div>
+          <p className="ch-trigger-summary">Repository event <ArrowRight size={13} /> Bot <ArrowRight size={13} /> PR feedback</p>
+        </article>
+        <article className="ch-trigger-story" aria-labelledby="ch-schedule-heading">
+          <p className="ch-trigger-label"><Clock3 size={17} /> RECURRING SCHEDULES</p>
+          <h3 id="ch-schedule-heading">Give recurring work a rhythm.</h3>
+          <p className="ch-trigger-description">
+            Choose a cadence and configure your bot. Iterion runs it on
+            schedule, whether the work is about your code or the world outside it.
+          </p>
+          <div className="ch-bot-stories">
+            <div className="ch-bot-story">
+              <h4><a href={`${GITHUB}/tree/main/bots/feed-watch`} target="_blank" rel="noreferrer">Vigie <ArrowUpRight size={13} /></a><span>News & technology watch</span></h4>
+              <p>Collects RSS/Atom feeds, removes duplicates and writes a sourced digest. Publishes it to your Slack or Mattermost channel at the cadence you choose.</p>
+            </div>
+            <div className="ch-bot-story">
+              <h4><a href={`${GITHUB}/tree/main/bots/docs-refresh`} target="_blank" rel="noreferrer">Doki <ArrowUpRight size={13} /></a><span>Documentation maintenance</span></h4>
+              <p>Aligns your documentation with the code, then keeps it current with scheduled incremental updates based on what changed. Delivers the changes as reviewable pull requests.</p>
+            </div>
+          </div>
+          <p className="ch-trigger-summary">Schedule <ArrowRight size={13} /> Bot <ArrowRight size={13} /> Published results</p>
+        </article>
+      </div>
+    </section>
+  );
+}
+
+export default function CloudHome({ marketplaceEnabled = false }: { marketplaceEnabled?: boolean }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const resolved = useThemeStore(s => s.resolved);
+  const setTheme = useThemeStore(s => s.setMode);
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = "Iterion Cloud — The control plane for AI agents";
+    return () => { document.title = previousTitle; };
+  }, []);
+  return (
+    <div className="cloud-home">
+      <a href="#ch-main" className="ch-skip">Skip to content</a>
+      <header className="ch-nav-wrap">
+        <div className="ch-nav ch-container">
+          <Brand />
+          <nav className="ch-nav-links" aria-label="Main navigation"><a href="#workflows">Use cases</a><a href="#control">Platform</a><a href={DOCS} target="_blank" rel="noreferrer">Documentation <ArrowUpRight size={12} /></a></nav>
+          <div className="ch-nav-actions"><button className="ch-theme" type="button" onClick={() => setTheme(resolved === "dark" ? "light" : "dark")} aria-label={`Switch to ${resolved === "dark" ? "light" : "dark"} theme`}>{resolved === "dark" ? <Sun size={17} /> : <Moon size={17} />}</button><a className="ch-github-icon" href={GITHUB} target="_blank" rel="noreferrer" aria-label="Iterion on GitHub"><GitHubLogoIcon width={19} height={19} /></a><Link href="/login" className="ch-nav-signin">Sign in <ArrowUpRight size={14} /></Link><button className="ch-mobile-toggle" type="button" onClick={() => setMenuOpen(!menuOpen)} aria-expanded={menuOpen} aria-controls="ch-mobile-nav" aria-label={menuOpen ? "Close navigation" : "Open navigation"}>{menuOpen ? <X size={21} /> : <Menu size={21} />}</button></div>
+        </div>
+        {menuOpen && <nav id="ch-mobile-nav" className="ch-mobile-nav" aria-label="Mobile navigation"><a href="#workflows" onClick={() => setMenuOpen(false)}>Use cases</a><a href="#control" onClick={() => setMenuOpen(false)}>Platform</a><a href={DOCS} target="_blank" rel="noreferrer">Documentation <ArrowUpRight size={13} /></a></nav>}
+      </header>
+      <main id="ch-main">
+        <section className="ch-hero ch-container" aria-labelledby="ch-title">
+          <div className="ch-hero-copy"><a className="ch-open-source" href={GITHUB} target="_blank" rel="noreferrer"><span className="ch-open-dot" /> OPEN SOURCE. OPEN POSSIBILITIES. <ChevronRight size={13} /></a><h1 id="ch-title">Your agents called.<br /><span>They need an<br />orchestrator.</span></h1><p className="ch-hero-description">Linux runs apps. Kubernetes orchestrates containers.<br /><strong>Iterion orchestrates agents.</strong></p><div className="ch-hero-ctas"><Link href="/login" className="ch-button ch-button-primary">Open Iterion Cloud <ArrowUpRight size={17} /></Link><a href="#workflows" className="ch-button ch-button-text"><ArrowRight size={15} /> Explore use cases</a></div><div className="ch-hero-footnote"><span><Check size={13} /> Git native</span><span><Check size={13} /> Model agnostic</span><span><Check size={13} /> MIT licensed</span></div></div>
+          <HeroVisual />
+        </section>
+        <StackCompatibility />
+        <div className="ch-container"><UseCases />
+          <PlatformFeatures />
+          <section className="ch-final-cta" aria-labelledby="ch-deployment-heading">
+            <p className="ch-eyebrow">DEPLOYMENT OPTIONS</p>
+            <h2 id="ch-deployment-heading">Cloud, local or <span className="ch-no-wrap">self-hosted.</span></h2>
+            <p>The same workflow engine, wherever you run it.<br />Use Iterion Cloud, work locally, or deploy on your own infrastructure.</p>
+            <div><Link href="/login" className="ch-button ch-button-primary">Open Iterion Cloud <ArrowUpRight size={17} /></Link><a href={`${DOCS}quickstart.html`} target="_blank" rel="noreferrer" className="ch-button ch-button-secondary">Run locally <ArrowUpRight size={14} /></a><a href={`${DOCS}cloud-deployment.html`} target="_blank" rel="noreferrer" className="ch-button ch-button-text">Self-host Iterion <ArrowUpRight size={14} /></a></div>
+          </section>
+        </div>
+      </main>
+      <footer className="ch-footer ch-container"><div><Brand /><p>Complex work. Beautifully orchestrated.</p></div><nav aria-label="Footer navigation"><a href={DOCS} target="_blank" rel="noreferrer">Docs <ArrowUpRight size={12} /></a><a href={GITHUB} target="_blank" rel="noreferrer">GitHub <ArrowUpRight size={12} /></a>{marketplaceEnabled && <Link href="/marketplace">Marketplace <ArrowRight size={12} /></Link>}<span>Open source · MIT license</span></nav></footer>
+    </div>
+  );
+}

--- a/studio/src/views/CloudLanding.test.tsx
+++ b/studio/src/views/CloudLanding.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import CloudLanding from "@/views/CloudLanding";
+import { useServerInfoStore } from "@/store/serverInfo";
+import type { ServerInfo } from "@/api/types";
+
+// Stand in for the real product page. What is under test is the split
+// itself — whether CloudLanding reaches CloudHome through a chunk boundary
+// or inlines it — so the far side only has to be identifiable. Mounting the
+// real one here would also drag in @lobehub/icons, which vitest's ESM
+// externalization cannot resolve (the vite build resolves it fine).
+vi.mock("@/views/CloudHome", async () => {
+  const { createElement } = await import("react");
+  return { default: () => createElement("main", null, "product page") };
+});
+
+describe("CloudLanding", () => {
+  afterEach(() => cleanup());
+
+  // App.tsx imports this module EAGERLY — PublicTopBar renders on
+  // /marketplace, outside the lazy route tree — so a static
+  // `import CloudHome` ships the anonymous-only marketing page (its own
+  // stylesheet plus ~50 icon modules) inside the entry chunk that every
+  // authenticated operator downloads on first paint. `lazy()` is what keeps
+  // it out, and a revert to a static import mounts the page synchronously,
+  // failing the first assertion below.
+  //
+  // Deliberately ONE case: `lazy()` memoises the resolved module on the
+  // object built at import time, so a sibling case that awaited the chunk
+  // first would leave this one unable to observe the pending state — and the
+  // guard would then pass on a static import purely from test order.
+  it("defers the product page to its own chunk instead of rendering it on first paint", async () => {
+    useServerInfoStore.setState({ info: { mode: "cloud" } as ServerInfo });
+
+    render(<CloudLanding />);
+
+    // The page owns the <main> landmark, and none of it is mounted yet —
+    // only the Suspense fallback's spinner.
+    expect(screen.queryByRole("main")).toBeNull();
+    expect(screen.getByRole("status")).toBeTruthy();
+
+    // ...and it arrives once the chunk resolves.
+    expect(await screen.findByRole("main")).toBeTruthy();
+  });
+});

--- a/studio/src/views/CloudLanding.tsx
+++ b/studio/src/views/CloudLanding.tsx
@@ -1,12 +1,20 @@
-import { useEffect } from "react";
+import { Suspense, lazy, useEffect } from "react";
 import { useLocation } from "wouter";
 import { Button } from "@/components/ui/Button";
 import { BrandWordmark } from "@/components/ui/BrandWordmark";
 import { BrandMark } from "@/components/ui/BrandMark";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import BootLoading from "@/components/shared/BootLoading";
 import { useServerInfoStore } from "@/store/serverInfo";
 import { SignInCard } from "./Login";
-import CloudHome from "./CloudHome";
+
+// This module is one of App.tsx's few EAGER view imports, because
+// PublicTopBar (below) renders on /marketplace outside the lazy route tree.
+// So the product page — its own stylesheet plus ~50 icon modules — is
+// lazy()'d here rather than statically imported: it is shown to anonymous
+// visitors only, and a static import would put it in the entry chunk every
+// authenticated operator downloads on first paint.
+const CloudHome = lazy(() => import("./CloudHome"));
 
 // PublicTopBar is the slim header shown above the public Marketplace view
 // when an anonymous visitor browses it (that route lives outside the
@@ -49,5 +57,9 @@ export default function CloudLanding() {
       </div>
     );
   }
-  return <CloudHome marketplaceEnabled={serverInfo.marketplace_enabled} />;
+  return (
+    <Suspense fallback={<BootLoading />}>
+      <CloudHome marketplaceEnabled={serverInfo.marketplace_enabled} />
+    </Suspense>
+  );
 }

--- a/studio/src/views/CloudLanding.tsx
+++ b/studio/src/views/CloudLanding.tsx
@@ -1,155 +1,12 @@
 import { useEffect } from "react";
 import { useLocation } from "wouter";
-import { useQuery } from "@tanstack/react-query";
-import { GitHubLogoIcon, ArrowRightIcon } from "@radix-ui/react-icons";
-
 import { Button } from "@/components/ui/Button";
 import { BrandWordmark } from "@/components/ui/BrandWordmark";
 import { BrandMark } from "@/components/ui/BrandMark";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { useServerInfoStore } from "@/store/serverInfo";
-import { listMarketplace, type MarketplaceEntry } from "@/api/marketplace";
-
 import { SignInCard } from "./Login";
-
-const GITHUB_URL = "https://github.com/SocialGouv/iterion";
-const DOCS_URL = "https://socialgouv.github.io/iterion/";
-
-// FALLBACK_BOTS is the curated agent set shown when the marketplace is empty
-// or unreachable, so the hero never collapses to a blank showcase. Mirrors
-// the named personas shipped in bots/ (kept short — the live marketplace is
-// the real source once seeded).
-const FALLBACK_BOTS: { name: string; blurb: string }[] = [
-  { name: "Featurly", blurb: "Ships a feature end to end, review-gated." },
-  { name: "Revi", blurb: "Reviews pull requests and replies in-thread." },
-  { name: "Willy", blurb: "Whole-codebase improvement loop, converging." },
-  { name: "Seki", blurb: "Source security audit (SAST) with a real floor." },
-  { name: "Nexie", blurb: "Your co-CTO: surveys the repo, plans what's next." },
-  { name: "Testy", blurb: "Adds real test coverage, anti-façade." },
-];
-
-type ShowcaseBot = { name: string; blurb: string; installs?: number };
-
-// gridGlowStyle layers a faint accent grid under a radial indigo glow — a
-// restrained cyberpunk backdrop (see studio/docs/visual-identity.md), masked
-// to fade out before it reaches the content. Token-driven, so it tracks the
-// active theme.
-const gridGlowStyle: React.CSSProperties = {
-  backgroundImage:
-    "radial-gradient(48rem 26rem at 50% -8%, var(--color-accent-soft), transparent 70%)," +
-    "linear-gradient(to right, color-mix(in srgb, var(--color-accent) 8%, transparent) 1px, transparent 1px)," +
-    "linear-gradient(to bottom, color-mix(in srgb, var(--color-accent) 8%, transparent) 1px, transparent 1px)",
-  backgroundSize: "100% 100%, 44px 44px, 44px 44px",
-  WebkitMaskImage: "radial-gradient(80% 60% at 50% 0%, black, transparent 78%)",
-  maskImage: "radial-gradient(80% 60% at 50% 0%, black, transparent 78%)",
-};
-
-// LandingTopBar is the sticky header of the marketing landing: brand on the
-// left, theme toggle + GitHub + Sign-in on the right.
-function LandingTopBar() {
-  const [, navigate] = useLocation();
-  return (
-    <div className="sticky top-0 z-20 border-b border-border-subtle bg-surface-0/80 backdrop-blur">
-      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
-        <div className="flex items-center gap-2.5">
-          <BrandMark className="h-7 w-7" />
-          <BrandWordmark />
-        </div>
-        <div className="flex items-center gap-2 sm:gap-3">
-          <ThemeToggle />
-          <a
-            href={GITHUB_URL}
-            target="_blank"
-            rel="noreferrer"
-            aria-label="iterion on GitHub"
-            title="iterion on GitHub"
-            className="hidden h-8 w-8 items-center justify-center rounded-full text-fg-muted transition-colors hover:bg-surface-2 hover:text-fg-default sm:flex"
-          >
-            <GitHubLogoIcon className="h-4 w-4" />
-          </a>
-          <Button variant="primary" size="sm" onClick={() => navigate("/login")}>
-            Sign in
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// PersonaAvatar is the accent-tinted monogram tile fronting each showcase
-// card — gives the agent grid a face without shipping per-bot artwork.
-function PersonaAvatar({ name }: { name: string }) {
-  return (
-    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft text-sm font-semibold text-accent-text">
-      {name.slice(0, 1).toUpperCase()}
-    </span>
-  );
-}
-
-// BotShowcase renders the marketplace's featured bots (public browse), with
-// a graceful static fallback. Read-only and best-effort: a failed fetch
-// just shows the curated roster.
-function BotShowcase() {
-  // Same key + request as the Marketplace view's default unfiltered
-  // browse, so landing → marketplace navigation shares the cache. No
-  // error surface by design: failed just means the curated roster.
-  const query = useQuery<MarketplaceEntry[]>({
-    queryKey: ["marketplace", "", "", "", "popular"],
-    queryFn: () => listMarketplace("", "", "", "popular"),
-  });
-  const bots = query.data ?? null;
-  const failed = query.isError;
-
-  const cards: ShowcaseBot[] | null =
-    bots && bots.length > 0
-      ? bots.slice(0, 6).map((b) => ({
-          name: b.display_name || b.name,
-          blurb: b.description || "",
-          installs: b.installs,
-        }))
-      : failed || bots // resolved empty or errored → curated roster
-        ? FALLBACK_BOTS
-        : null; // still loading
-
-  if (!cards) {
-    return (
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" aria-hidden>
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div
-            key={i}
-            className="h-24 animate-pulse rounded-xl border border-border-subtle bg-surface-1"
-          />
-        ))}
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {cards.map((b) => (
-        <div
-          key={b.name}
-          className="group flex items-start gap-3 rounded-xl border border-border-subtle bg-surface-1 p-4 text-left transition-all hover:-translate-y-0.5 hover:border-accent hover:shadow-[var(--shadow-md)]"
-        >
-          <PersonaAvatar name={b.name} />
-          <div className="min-w-0">
-            <div className="flex items-baseline gap-2">
-              <span className="truncate font-semibold text-fg-default">{b.name}</span>
-              {typeof b.installs === "number" && b.installs > 0 && (
-                <span className="shrink-0 font-mono text-micro text-fg-subtle">
-                  {b.installs}↓
-                </span>
-              )}
-            </div>
-            {b.blurb && (
-              <div className="mt-1 line-clamp-2 text-sm text-fg-muted">{b.blurb}</div>
-            )}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+import CloudHome from "./CloudHome";
 
 // PublicTopBar is the slim header shown above the public Marketplace view
 // when an anonymous visitor browses it (that route lives outside the
@@ -178,124 +35,19 @@ export function PublicTopBar() {
   );
 }
 
-// LandingHero is the full-width marketing pitch above the sign-in card.
-// Dark/light theme-aware, electric-indigo, a restrained cyberpunk nod —
-// deliberately NOT a pastel SaaS hero. The infrastructure/control-plane brand
-// voice is paired with a live agent showcase and links out to the public
-// marketplace, GitHub, and docs.
-function LandingHero() {
-  const [, navigate] = useLocation();
-  const marketplaceEnabled = useServerInfoStore((s) => s.info?.marketplace_enabled);
-
-  return (
-    <header className="relative overflow-hidden border-b border-border-subtle">
-      <div aria-hidden className="pointer-events-none absolute inset-0" style={gridGlowStyle} />
-      <div className="relative mx-auto max-w-5xl px-6 py-16 text-center sm:py-24">
-        <div className="mb-6 flex justify-center">
-          <BrandMark className="h-16 w-16 drop-shadow-[0_4px_24px_var(--color-accent-soft)]" />
-        </div>
-
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-border-subtle bg-surface-1/60 px-3 py-1 text-xs text-fg-muted backdrop-blur">
-          <span className="h-1.5 w-1.5 rounded-full bg-accent" />
-          Open-source control plane for AI agents
-        </span>
-
-        <h1
-          className="mt-5 bg-clip-text text-4xl font-bold tracking-tight text-transparent sm:text-6xl"
-          style={{
-            backgroundImage:
-              "linear-gradient(92deg, var(--color-fg-default) 30%, var(--color-accent-text))",
-          }}
-        >
-          The control plane for AI agents.
-        </h1>
-        <p className="mt-4 text-lg font-medium text-accent-text sm:text-2xl">
-          Apps have Linux. The cloud has Kubernetes. AI agents have Iterion.
-        </p>
-        <p className="mx-auto mt-5 max-w-2xl text-base text-fg-muted">
-          Define agent workflows as code. Iterion schedules, coordinates, and
-          governs agents across parallel branches, review gates, tools, and
-          budgets — from one auditable control plane.
-        </p>
-
-        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-          {marketplaceEnabled && (
-            <Button variant="primary" size="md" onClick={() => navigate("/marketplace")}>
-              <span className="flex items-center gap-1.5">
-                Explore the marketplace
-                <ArrowRightIcon className="h-4 w-4" />
-              </span>
-            </Button>
-          )}
-          <a href={GITHUB_URL} target="_blank" rel="noreferrer">
-            <Button variant="secondary" size="md">
-              <span className="flex items-center gap-1.5">
-                <GitHubLogoIcon className="h-4 w-4" />
-                View on GitHub
-              </span>
-            </Button>
-          </a>
-          <a href={DOCS_URL} target="_blank" rel="noreferrer">
-            <Button variant="ghost" size="md">
-              Read the docs
-            </Button>
-          </a>
-        </div>
-
-        <div className="mt-16">
-          <div className="mb-4 text-xs uppercase tracking-[0.2em] text-fg-subtle">
-            Featured agent workflows
-          </div>
-          <BotShowcase />
-        </div>
-      </div>
-    </header>
-  );
-}
-
-// CloudLanding is the anonymous root in cloud mode: a marketing hero above
-// the existing sign-in card. In any other mode (or before server-info
-// resolves) it degrades to the plain centred sign-in card, so desktop/local
-// never sees the hero.
+// The public product page is cloud-only. Keep the existing sign-in fallback
+// for deployments that do not run in cloud mode.
 export default function CloudLanding() {
   const serverInfo = useServerInfoStore((s) => s.info);
   useEffect(() => {
     if (!serverInfo) void useServerInfoStore.getState().refresh();
   }, [serverInfo]);
-
-  const isCloud = serverInfo?.mode === "cloud";
-
-  if (!isCloud) {
+  if (serverInfo?.mode !== "cloud") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-surface-0 text-fg-default px-4">
         <SignInCard />
       </div>
     );
   }
-
-  return (
-    <div className="min-h-screen bg-surface-0 text-fg-default">
-      <LandingTopBar />
-      <LandingHero />
-      <section className="relative flex items-center justify-center px-4 py-14 sm:py-20">
-        <div className="w-full max-w-md">
-          <div className="mb-4 text-center text-xs uppercase tracking-[0.2em] text-fg-subtle">
-            Get started
-          </div>
-          <SignInCard />
-        </div>
-      </section>
-      <footer className="border-t border-border-subtle px-6 py-8 text-center text-xs text-fg-subtle">
-        <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-center gap-x-4 gap-y-2">
-          <span>© iterion — MIT-licensed</span>
-          <a href={GITHUB_URL} target="_blank" rel="noreferrer" className="text-accent-text hover:underline">
-            GitHub
-          </a>
-          <a href={DOCS_URL} target="_blank" rel="noreferrer" className="text-accent-text hover:underline">
-            Docs
-          </a>
-        </div>
-      </footer>
-    </div>
-  );
+  return <CloudHome marketplaceEnabled={serverInfo.marketplace_enabled} />;
 }


### PR DESCRIPTION
The anonymous cloud home currently leads with an agent catalog and does not explain how Iterion connects agents to real work. Replace it with the locally reviewed product page: repository events and recurring schedules illustrated by Revi, Vetty, Vigie and Doki, followed by model/tool compatibility and documented orchestration, operation and governance capabilities.

The page uses the documentation palette and existing brand mark, with light/dark themes, mobile navigation and reduced-motion support. It highlights live supervision, persistent knowledge, workflow benchmarks, bot-defined outputs and focused configuration for non-technical users. The hero is a conceptual workflow graphic, with no fabricated application screenshot.

Load the product page lazily so its CSS and brand icons do not enter the authenticated app's initial bundle. Cloud calls to action retain the login route; the public Marketplace header, marketplace feature flag and non-cloud sign-in fallback are preserved. No preview fixtures or dependency changes are included.

Validation:
- Studio ESLint: zero errors (563 existing warnings); TypeScript and production Vite build passed.
- Full Studio Vitest suite: 152 files, 1,352 tests passed. The new chunk-boundary regression test was checked against the pre-fix static import.
- Built-SPA browser checks with anonymous API fixtures: login navigation, marketplace enabled/disabled, local-mode fallback, mobile navigation and reduced motion passed. `/login` requests/preloads no CloudHome assets; `/` loads the separate JS and CSS.
- Entry JS drops from 461.25 to 289.78 kB (gzip 127.43 to 88.30); entry CSS from 119.68 to 98.21 kB (gzip 21.62 to 17.03).
- Light/dark layouts at 320, 390, 768, 1024 and 1440px: no horizontal overflow. Reviewed-proposal axe checks found no WCAG A/AA violations in the validated layouts.
- The Billy run's quota stop and recovery evidence are recorded in docs/bot-runs/branch-improve-loop.md. Required GitHub CI and Revi validate the published head before merge.

Closes #1026.
