### PR TITLE
fix(forge,server): a key iterion cannot read is not the forge being down

### DIFF
--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -555,9 +555,15 @@ func MintInstallationToken(ctx context.Context, httpClient *http.Client, apiBase
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
+	// Everything down to httpClient.Do below is iterion's own preparation:
+	// reading a stored key, marshalling, building the URL. A caller that
+	// sees this function fail cannot tell that from a GitHub outage, and the
+	// handlers on top default to 502 — so each of these carries
+	// forge.ErrLocalPreflight, which isIterionFault reads as "we never
+	// asked".
 	jwt, err := signAppJWT(cfg.AppID, cfg.PrivateKeyPEM, now)
 	if err != nil {
-		return "", time.Time{}, err
+		return "", time.Time{}, fmt.Errorf("%w: %w", forge.ErrLocalPreflight, err)
 	}
 	var body io.Reader
 	if opts != nil {
@@ -571,7 +577,7 @@ func MintInstallationToken(ctx context.Context, httpClient *http.Client, apiBase
 		if len(payload) > 0 {
 			raw, err := json.Marshal(payload)
 			if err != nil {
-				return "", time.Time{}, err
+				return "", time.Time{}, fmt.Errorf("%w: marshal installation token request: %w", forge.ErrLocalPreflight, err)
 			}
 			body = bytes.NewReader(raw)
 		}
@@ -579,7 +585,7 @@ func MintInstallationToken(ctx context.Context, httpClient *http.Client, apiBase
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		apiBase+"/app/installations/"+strconv.FormatInt(installationID, 10)+"/access_tokens", body)
 	if err != nil {
-		return "", time.Time{}, err
+		return "", time.Time{}, fmt.Errorf("%w: build installation token request: %w", forge.ErrLocalPreflight, err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/pkg/forge/github/app_preflight_test.go
+++ b/pkg/forge/github/app_preflight_test.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// A stored App key that is not parseable PEM fails while the JWT is being
+// signed — before a socket is opened. The assertion that matters is not the
+// error text but that the forge was never contacted AND that the error says
+// so: every handler downstream defaults to 502, so an unmarked failure here
+// reports GitHub as broken for a key only iterion can read.
+func TestMintInstallationToken_UnparseableKeyNeverReachesTheForge(t *testing.T) {
+	reached := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	cfg := AppConfig{AppID: 42, PrivateKeyPEM: "-----BEGIN RSA PRIVATE KEY-----\nnot base64\n-----END RSA PRIVATE KEY-----", AppSlug: "iterion"}
+	_, _, err := MintInstallationToken(context.Background(), srv.Client(), srv.URL, cfg, 99, time.Unix(1700000000, 0), nil)
+	if err == nil {
+		t.Fatal("an unparseable private key minted a token")
+	}
+	if reached {
+		t.Fatal("the mint opened a socket with a key it could not read — the pre-flight claim this marker rests on is false")
+	}
+	if !errors.Is(err, forge.ErrLocalPreflight) {
+		t.Fatalf("mint error %v carries no forge.ErrLocalPreflight — a 502-defaulting handler will blame the forge for a key iterion stored", err)
+	}
+}
+
+// The other direction, which is the way this fix could itself become a lie:
+// a genuine refusal from the forge must NOT be marked, or a GitHub outage
+// would be reported as iterion's own fault.
+func TestMintInstallationToken_ForgeRefusalIsNotMarkedLocal(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"message":"upstream is down"}`))
+	}))
+	defer srv.Close()
+
+	cfg := AppConfig{AppID: 42, PrivateKeyPEM: pemStr, AppSlug: "iterion"}
+	_, _, err := MintInstallationToken(context.Background(), srv.Client(), srv.URL, cfg, 99, time.Unix(1700000000, 0), nil)
+	if err == nil {
+		t.Fatal("a 502 from the forge minted a token")
+	}
+	if errors.Is(err, forge.ErrLocalPreflight) {
+		t.Fatalf("a forge 5xx was marked as iterion's own (%v) — the same inversion, reversed", err)
+	}
+}

--- a/pkg/forge/github/app_preflight_test.go
+++ b/pkg/forge/github/app_preflight_test.go
@@ -3,13 +3,34 @@ package github
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
+
+// probeReached is a stand-in forge that records whether it was contacted —
+// the oracle for "before any socket", measured instead of asserted.
+//
+// The flag is atomic because the handler that sets it runs on the server's
+// own goroutine while the test reads it on its. A plain bool is a data race
+// the moment a regression DOES open a socket — the one run where this
+// oracle has something to say — and the read may then miss the write and
+// let the test report success on the claim it exists to measure.
+type probeReached struct{ hit atomic.Bool }
+
+// server answers everything with status/body, recording that it was asked.
+func (p *probeReached) server(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.hit.Store(true)
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+}
 
 // A stored App key that is not parseable PEM fails while the JWT is being
 // signed — before a socket is opened. The assertion that matters is not the
@@ -17,11 +38,8 @@ import (
 // so: every handler downstream defaults to 502, so an unmarked failure here
 // reports GitHub as broken for a key only iterion can read.
 func TestMintInstallationToken_UnparseableKeyNeverReachesTheForge(t *testing.T) {
-	reached := false
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		reached = true
-		w.WriteHeader(http.StatusTeapot)
-	}))
+	var probe probeReached
+	srv := probe.server(http.StatusTeapot, "")
 	defer srv.Close()
 
 	cfg := AppConfig{AppID: 42, PrivateKeyPEM: "-----BEGIN RSA PRIVATE KEY-----\nnot base64\n-----END RSA PRIVATE KEY-----", AppSlug: "iterion"}
@@ -29,7 +47,7 @@ func TestMintInstallationToken_UnparseableKeyNeverReachesTheForge(t *testing.T) 
 	if err == nil {
 		t.Fatal("an unparseable private key minted a token")
 	}
-	if reached {
+	if probe.hit.Load() {
 		t.Fatal("the mint opened a socket with a key it could not read — the pre-flight claim this marker rests on is false")
 	}
 	if !errors.Is(err, forge.ErrLocalPreflight) {
@@ -42,16 +60,17 @@ func TestMintInstallationToken_UnparseableKeyNeverReachesTheForge(t *testing.T) 
 // would be reported as iterion's own fault.
 func TestMintInstallationToken_ForgeRefusalIsNotMarkedLocal(t *testing.T) {
 	pemStr, _ := testKeyPEM(t)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write([]byte(`{"message":"upstream is down"}`))
-	}))
+	var probe probeReached
+	srv := probe.server(http.StatusBadGateway, `{"message":"upstream is down"}`)
 	defer srv.Close()
 
 	cfg := AppConfig{AppID: 42, PrivateKeyPEM: pemStr, AppSlug: "iterion"}
 	_, _, err := MintInstallationToken(context.Background(), srv.Client(), srv.URL, cfg, 99, time.Unix(1700000000, 0), nil)
 	if err == nil {
 		t.Fatal("a 502 from the forge minted a token")
+	}
+	if !probe.hit.Load() {
+		t.Fatal("the forge was never asked — this test's premise is a refusal that came back over the wire, and the probe is what tells the two apart")
 	}
 	if errors.Is(err, forge.ErrLocalPreflight) {
 		t.Fatalf("a forge 5xx was marked as iterion's own (%v) — the same inversion, reversed", err)
@@ -82,11 +101,8 @@ func TestAppClientMintChain_PreservesLocalPreflight(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			reached := false
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				reached = true
-				w.WriteHeader(http.StatusTeapot)
-			}))
+			var probe probeReached
+			srv := probe.server(http.StatusTeapot, "")
 			defer srv.Close()
 
 			a := &AppClient{
@@ -99,7 +115,7 @@ func TestAppClientMintChain_PreservesLocalPreflight(t *testing.T) {
 			if err == nil {
 				t.Fatalf("%s served a client for a key that cannot be read", tc.name)
 			}
-			if reached {
+			if probe.hit.Load() {
 				t.Fatalf("%s opened a socket with a key it could not read", tc.name)
 			}
 			if !errors.Is(err, forge.ErrLocalPreflight) {

--- a/pkg/forge/github/app_preflight_test.go
+++ b/pkg/forge/github/app_preflight_test.go
@@ -57,3 +57,54 @@ func TestMintInstallationToken_ForgeRefusalIsNotMarkedLocal(t *testing.T) {
 		t.Fatalf("a forge 5xx was marked as iterion's own (%v) — the same inversion, reversed", err)
 	}
 }
+
+// The handlers this marker exists for never call MintInstallationToken: they
+// hold an *AppClient and reach the mint through rest (ListRepos, ListHooks…)
+// or scopedREST (GetPullRequest, the issue profiles), each of which returns
+// the mint error as it received it. That unwrapped return is the whole load
+// of the fix — one fmt.Errorf("mint: %v", err) at either site would flatten
+// the sentinel and put the 502 inversion back with every other test in this
+// suite still green. Pinned here, at the two functions where such a re-wrap
+// would be written.
+func TestAppClientMintChain_PreservesLocalPreflight(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(context.Context, *AppClient) error
+	}{
+		{"rest", func(ctx context.Context, a *AppClient) error {
+			_, err := a.rest(ctx)
+			return err
+		}},
+		{"scopedREST", func(ctx context.Context, a *AppClient) error {
+			_, err := a.scopedREST(ctx, map[string]string{"pull_requests": "read"})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reached := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusTeapot)
+			}))
+			defer srv.Close()
+
+			a := &AppClient{
+				HTTP: srv.Client(), WebBaseURL: srv.URL,
+				Cfg:            AppConfig{AppID: 42, PrivateKeyPEM: "-----BEGIN RSA PRIVATE KEY-----\nnot base64\n-----END RSA PRIVATE KEY-----", AppSlug: "iterion"},
+				InstallationID: 99,
+				Now:            func() time.Time { return time.Unix(1700000000, 0).UTC() },
+			}
+			err := tc.call(context.Background(), a)
+			if err == nil {
+				t.Fatalf("%s served a client for a key that cannot be read", tc.name)
+			}
+			if reached {
+				t.Fatalf("%s opened a socket with a key it could not read", tc.name)
+			}
+			if !errors.Is(err, forge.ErrLocalPreflight) {
+				t.Fatalf("%s returned %v with no forge.ErrLocalPreflight — the mint marks it, and this is where the mark is dropped; the route above answers 502 for a key iterion stored", tc.name, err)
+			}
+		})
+	}
+}

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -387,4 +387,16 @@ var (
 	// instance has no avatar endpoint at all (GitLab before 17.0, Gitea before
 	// 1.20): the operator's only path is the forge's own profile page.
 	ErrAvatarUnsupported = errors.New("forge: this instance has no avatar API")
+	// ErrLocalPreflight marks a failure that happened while PREPARING a forge
+	// call, before any byte reached the network: a stored App key that is not
+	// parseable PEM, a payload that will not marshal, a base URL that will not
+	// parse. The forge never saw the request and cannot be blamed for it.
+	//
+	// It exists because a client method is not the same thing as a round
+	// trip. AppClient.rest and every security-read mint sign an App JWT from
+	// a stored key first, so a key iterion cannot read fails inside what
+	// reads like a pure remote call — and the handlers that default to 502
+	// then report a third party as broken. Callers in pkg/server ask
+	// isIterionFault, which reads this sentinel and answers 500.
+	ErrLocalPreflight = errors.New("forge: the request never left iterion")
 )

--- a/pkg/server/forge_avatar_routes.go
+++ b/pkg/server/forge_avatar_routes.go
@@ -315,14 +315,10 @@ func (s *Server) handleForgeConnectionAvatar(w http.ResponseWriter, r *http.Requ
 		// transport, a body that is not the shape pkg/forge parses). The
 		// other two are iterion's own state — the seal/client construction
 		// BEFORE any forge call (forgeAdminFor), and the persist AFTER the
-		// upload already landed — and both are marked at their wrap site,
-		// where which step failed is still known, so they answer 500
-		// instead of sharing the 502 a genuine forge outage gets. That
-		// sharing is the inversion #969 is about.
-		if isIterionFault(err) {
-			httpError(w, http.StatusInternalServerError, "%v", err)
-			return
-		}
+		// upload already landed. Both are marked at their wrap site, where
+		// which step failed is still known, and writeForgeUpstreamError
+		// answers a marked error 500 instead of letting it share the 502 a
+		// genuine forge outage gets.
 		if !writeForgeUpstreamError(w, err, "%v", err) {
 			httpError(w, http.StatusBadGateway, "%v", err)
 		}

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -526,20 +526,20 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 				return
 			}
 			if !writeForgeUpstreamError(w, err, "security-read token mint: %v", err) {
-				// Default, and NOT a clean one. Most of what lands here is
-				// the App token mint failing against the forge, where 502
-				// is the true code — but the mint's PRE-FLIGHT is
-				// iterion's own and arrives unmarked:
-				// githubAppConfigForConnection answers "no github app
-				// available" for a store read that failed as much as for
-				// an App key that will not unseal, and
-				// MintInstallationToken signs the App JWT — a stored key
-				// that is not parseable PEM — before it opens a socket.
-				// Both answer 502 today: the #969 inversion, still open
-				// here. Ending it belongs in the mint chain, which alone
-				// knows which step failed; a blanket newIterionFault over
-				// mint() would stamp a genuine GitHub 5xx as iterion's —
-				// the same lie reversed. Residual on #969.
+				// Default: the App token mint failing against the forge,
+				// where 502 is the true code. The mint's PRE-FLIGHT no
+				// longer lands here — MintInstallationToken signs the App
+				// JWT from a stored key before it opens a socket, and
+				// marks that half forge.ErrLocalPreflight, which
+				// writeForgeUpstreamError answers 500.
+				//
+				// One pre-flight source still arrives unmarked, because it
+				// cannot be marked without a signature change:
+				// githubAppConfigForConnection reports (cfg, shared, ok)
+				// and so answers "no github app available" for a store
+				// read that FAILED exactly as for an App genuinely absent.
+				// Its 12 call sites are a change of their own; #969 names
+				// it.
 				httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
 			}
 			return
@@ -625,16 +625,14 @@ func (s *Server) handleListForgeRepos(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !writeForgeUpstreamError(w, err, "list repos: %v", err) {
-			// Default, and NOT a clean one for a github_app connection.
-			// A PAT connection's ListRepos is a pure round-trip, so 502
-			// is the true code there; an App's goes through
-			// AppClient.rest, which mints an installation token and signs
-			// the App JWT locally FIRST — a stored key that is not
-			// parseable PEM fails before any socket and answers 502 here.
-			// The #969 inversion, still open on this arm; the fix belongs
-			// in the mint chain (see the security-read arm above).
-			// Residual on #969. The route's pre-forge half IS right:
-			// forgeAdminFor above already answers 500.
+			// Default, and a clean one now. A PAT connection's ListRepos
+			// is a pure round trip, so 502 is the true code there; an
+			// App's goes through AppClient.rest, which mints an
+			// installation token and signs the App JWT before any socket
+			// — and that half now carries forge.ErrLocalPreflight, which
+			// writeForgeUpstreamError answers 500. The route's other
+			// pre-forge half was already right: forgeAdminFor above
+			// answers 500 on its own.
 			httpError(w, http.StatusBadGateway, "list repos: %v", err)
 		}
 		return

--- a/pkg/server/forge_preflight_fault_test.go
+++ b/pkg/server/forge_preflight_fault_test.go
@@ -64,3 +64,37 @@ func TestSecurityReadPatch_GenuineForgeFailureKeepsBadGateway(t *testing.T) {
 		t.Fatalf("code=%d body=%s, want 502 — an unclassified failure on this arm is still the forge's", w.Code, w.Body.String())
 	}
 }
+
+// The security-read composition above drives the arm through the
+// s.forgeSecurityMint seam — the arm's own injection point, but not the
+// chain the other two arms take. This one takes the long way, with nothing
+// injected: a real github_app connection whose STORED App key is not
+// parseable PEM, through forgeAdminFor → AppClient.rest →
+// MintInstallationToken → the marker → the junction. No forge is reachable
+// and none is needed; that is the point. The reverse direction (a forge
+// that really did fail keeps its 502) is pinned at the junction, which this
+// route shares.
+func TestListForgeRepos_UnreadableStoredKeyAnswers500NotBadGateway(t *testing.T) {
+	s := newForgeTestServer(t)
+	s.forgeOAuthApps = forge.NewMemoryOAuthAppStore()
+	storeApp(t, s, "app-1", "t1", "SocialGouv", "111",
+		"-----BEGIN RSA PRIVATE KEY-----\nnot base64\n-----END RSA PRIVATE KEY-----",
+		time.Unix(1700000000, 0).UTC())
+	conn := forge.Connection{
+		ID: "c1", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, InstallationID: 42, OAuthAppID: "app-1",
+	}
+	if err := s.forgeConnections.Create(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+
+	req := forgeReq(superAdminCtx(), "GET", "/api/teams/t1/forge/connections/c1/repos", "", "t1")
+	req.SetPathValue("conn_id", "c1")
+	w := httptest.NewRecorder()
+	s.handleListForgeRepos(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code=%d body=%s, want 500 — GitHub was never asked; the key iterion stored is the one that cannot be read",
+			w.Code, w.Body.String())
+	}
+}

--- a/pkg/server/forge_preflight_fault_test.go
+++ b/pkg/server/forge_preflight_fault_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// writeForgeUpstreamError is the single place all three 502-defaulting arms
+// cross, so it is where a pre-flight failure stops being reported as the
+// forge's. Marking alone changes nothing — forgeUpstreamStatus has no case
+// for it, by design — which is exactly why this junction is asserted.
+func TestWriteForgeUpstreamError_PreflightIsIterionsOwn(t *testing.T) {
+	w := httptest.NewRecorder()
+	err := fmt.Errorf("sign app jwt: %w", forge.ErrLocalPreflight)
+	if !writeForgeUpstreamError(w, err, "security-read token mint: %v", err) {
+		t.Fatal("a pre-flight failure was handed back to the caller, whose default arm answers 502")
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code = %d, want 500 — the forge never saw this request", w.Code)
+	}
+}
+
+// The classifier keeps its own contract: it answers what the FORGE answered,
+// and the forge answered nothing. Deciding fault is the writer's job, and
+// pinning that here keeps a later "simplification" from folding the 500 into
+// the table, where it would outrank a genuine upstream code.
+func TestForgeUpstreamStatus_PreflightIsNotAForgeAnswer(t *testing.T) {
+	if code, _ := forgeUpstreamStatus(fmt.Errorf("marshal: %w", forge.ErrLocalPreflight)); code != 0 {
+		t.Fatalf("forgeUpstreamStatus = %d, want 0 (not an answer from the forge)", code)
+	}
+}
+
+// The composition, which is what the operator actually meets: the
+// security-read arm of PATCH /forge/connections/{id}. A mint that failed
+// before reaching GitHub must answer 500, not 502.
+func TestSecurityReadPatch_PreflightMintAnswers500NotBadGateway(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		return "", time.Time{}, fmt.Errorf("github: app private key is not valid PEM: %w", forge.ErrLocalPreflight)
+	}
+	w := patchSecurityRead(t, s, "c1", true)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code=%d body=%s, want 500 — a key iterion cannot read is not GitHub being down", w.Code, w.Body.String())
+	}
+}
+
+// And the arm still tells the truth the other way round: a forge that really
+// did fail keeps its 502.
+func TestSecurityReadPatch_GenuineForgeFailureKeepsBadGateway(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "c1", "SocialGouv", "", false)
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		return "", time.Time{}, fmt.Errorf("github said no")
+	}
+	w := patchSecurityRead(t, s, "c1", true)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("code=%d body=%s, want 502 — an unclassified failure on this arm is still the forge's", w.Code, w.Body.String())
+	}
+}

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -102,16 +102,15 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 		// may wait out, a grant it will never get — instead of one 502 for
 		// every cause.
 		if !writeForgeUpstreamError(w, err, "read pull request %s#%d: %v", repo, number, err) {
-			// Default, and NOT a clean one for a github_app connection.
-			// This route reads and nothing else, so no post-forge store
-			// write can mix in the way the avatar route's does (#969) —
-			// but the read itself is not purely upstream: an App's
-			// GetPullRequest goes through scopedREST, which mints an
-			// installation token and signs the App JWT locally FIRST, so
-			// a stored key that is not parseable PEM fails before any
-			// socket and answers 502 here. The same inversion, still open
-			// on this arm; the fix belongs in the mint chain, which alone
-			// knows which step failed. Residual on #969.
+			// Default, and a clean one. This route reads and nothing
+			// else, so no post-forge store write can mix in the way the
+			// avatar route's does — and the read's own local half is
+			// covered: an App's GetPullRequest goes through scopedREST,
+			// which mints an installation token and signs the App JWT
+			// before opening a socket, and those failures carry
+			// forge.ErrLocalPreflight, which writeForgeUpstreamError
+			// answers 500. What reaches here is an unclassified failure
+			// of a round trip that did happen.
 			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
 		}
 		return

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -111,6 +111,16 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 			// forge.ErrLocalPreflight, which writeForgeUpstreamError
 			// answers 500. What reaches here is an unclassified failure
 			// of a round trip that did happen.
+			//
+			// This ARM, not the route: `forge client:` above still
+			// answers 502 for a gateClientFor failure, which touches no
+			// network at all — an App config that did not resolve, a
+			// token that will not unseal. The sibling list-repos route
+			// answers 500 for the identical failure, and board_forge /
+			// forge_publish answer 502 like this one. Nothing marks
+			// those and no marker would reach them (the arms never ask
+			// the junction), so aligning them is its own change across
+			// four routes. Residual on #969.
 			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
 		}
 		return

--- a/pkg/server/forge_pullstate_preflight_test.go
+++ b/pkg/server/forge_pullstate_preflight_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// The third arm, and the one neither the mint-chain table nor the list-repos
+// composition reaches. `rest` and `scopedREST` are pinned, but a handler calls
+// AppClient.GetPullRequest, which does its own `c, err := a.scopedREST(ctx)`
+// and returns the error — an equally natural place to write
+// fmt.Errorf("get pull: %v", err) and flatten the sentinel. The list-repos arm
+// has its own end-to-end test; without this one, a re-wrap there would land
+// green and put the 502 inversion back on the PR-read route alone.
+//
+// Nothing is injected: the gate client is the real one, built from a stored
+// App whose key is not parseable PEM. No forge is reachable and none is
+// needed — the mint fails before a socket, and the route must answer 500.
+func TestForgePullRequest_UnreadableStoredKeyAnswers500NotBadGateway(t *testing.T) {
+	s := newForgeTestServer(t)
+	s.forgeOAuthApps = forge.NewMemoryOAuthAppStore()
+	s.forgePublishTokens = NewForgePublishTokenRegistry()
+	storeApp(t, s, "app-1", "team1", "SocialGouv", "111",
+		"-----BEGIN RSA PRIVATE KEY-----\nnot base64\n-----END RSA PRIVATE KEY-----",
+		time.Unix(1700000000, 0).UTC())
+	if err := s.forgeConnections.Create(context.Background(), forge.Connection{
+		ID: "conn1", TenantID: "team1", Provider: forge.ProviderGitHub,
+		Kind: forge.KindGitHubApp, Status: forge.StatusActive,
+		InstallationID: 42, OAuthAppID: "app-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	registerPublishToken(t, s, "tok1", ForgePublishGrant{
+		TeamID: "team1", ConnectionID: "conn1", Repo: "o/r",
+	})
+
+	w := httptest.NewRecorder()
+	s.handleForgePullRequest(w, prStateReq("tok1", "https://github.com/o/r/pull/42"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("code=%d body=%s, want 500 — GitHub was never asked; the key iterion stored is the one that cannot be read",
+			w.Code, w.Body.String())
+	}
+}

--- a/pkg/server/forge_sentinel_family_test.go
+++ b/pkg/server/forge_sentinel_family_test.go
@@ -49,6 +49,15 @@ var forgeSentinelFamilies = map[string]forgeSentinelFamily{
 		why: "a forge-answered 404 the orchestrator also reads as 'the hook is already gone'",
 	},
 
+	// Prepared but never sent. Deliberately 0 here: this table classifies
+	// what the FORGE answered, and the forge answered nothing. The 500 is
+	// writeForgeUpstreamError's, via isIterionFault — a status in this
+	// column would make the classifier decide fault, which is not its job.
+	"forge.ErrLocalPreflight": {
+		err: forge.ErrLocalPreflight, wantStatus: 0,
+		why: "iterion's own preparation failed before any byte reached the network — writeForgeUpstreamError renders it 500, not the 502 its route defaults to",
+	},
+
 	// Store misses. Every "…but could not be recorded on connection X: %w"
 	// wrap in the forge layer carries one of these; in the class they would
 	// all answer 404 for a write iterion itself failed.

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -131,6 +131,14 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 	// forgeUpstreamStatus answers 0 for a request that never left AND for an
 	// upstream failure it does not recognise, and those two want opposite
 	// statuses. Deciding it here keeps the classifier a classifier.
+	//
+	// Asking FIRST is safe only while the two are disjoint, and today they
+	// are: every marked return in MintInstallationToken is above
+	// httpClient.Do, and both newIterionFault wraps are on failures no forge
+	// answered. Mark an error that ALSO carries a forge status and this
+	// order silently outranks it — a 429 with its Retry-After, a 404, would
+	// become 500. So mark the STEP that failed, never a call that completed
+	// a round trip.
 	if isIterionFault(err) {
 		httpError(w, http.StatusInternalServerError, format, args...)
 		return true

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -173,6 +173,13 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 // chain: the marking happens where the wire boundary is visible, so a
 // handler no longer has to derive it.
 //
+// It settles the MINT, and only the mint. InstallationInfo and Slug
+// sign the same App JWT from the same stored key and hand the failure
+// back unmarked, so the refresh route's "probe installation: %v" 502 is
+// this same inversion on a second source. Marking those two would be
+// half a fix and no answer changed: their callers write 502 themselves
+// rather than through this package's junction (see newIterionFault).
+//
 // Finally: the 502 default is a per-route CHOICE, not the package's
 // rule, and this marker exists for the routes that make it. A handler
 // that can enumerate the forge's refusals and treat everything left as
@@ -188,9 +195,27 @@ type iterionFault struct{ err error }
 // tell iterion's own faults apart (answer 500) from a forge that
 // answered or fell silent (keep 502 / the taxonomy code).
 //
-// The mark now acts on its own: writeForgeUpstreamError asks
-// isIterionFault first and answers 500, so every 502-defaulting route
-// gets it at once and marking a site is one edit, not two.
+// The mark ACTS, at one junction: writeForgeUpstreamError asks
+// isIterionFault before the classifier and answers 500. Marking a site
+// is therefore one edit, not two — for a route that hands its failure
+// to that junction.
+//
+// That junction is the whole reach, and it is NOT every 502-defaulting
+// route. A handler that writes http.StatusBadGateway itself never
+// consults the marker, and several do so while holding a client that
+// can produce one: the App-token mint at the end of the install
+// callback (forge_connect_routes.go), the board's issue sync, issue
+// push and hook listing (board_forge.go), the review publish
+// (forge_publish.go). Each still answers 502 for a key only iterion can
+// read — the #969 inversion, on arms that are not this marker's to
+// close: routing them here would also hand them the forge taxonomy
+// (404, 429 + Retry-After, the mirrored 4xx), which is a change of its
+// own argument, and copying the isIterionFault check into each is the
+// duplicated guard this junction exists to avoid. So: when you mark a
+// new error, check the HANDLER as well as the wrap site — the mark only
+// changes an answer where writeForgeUpstreamError is the one writing
+// it.
+//
 // forgeUpstreamStatus still has no case for it, deliberately — it says
 // what the FORGE answered, and a marked error is one the forge never
 // saw.

--- a/pkg/server/forge_upstream_status.go
+++ b/pkg/server/forge_upstream_status.go
@@ -59,6 +59,9 @@ import (
 //	  forge.ErrBoardBindingNotFound        0
 //	  forge.ErrProvisionApprovalNotFound   0
 //
+//	OUTSIDE it, and never sent at all — the one 0 the caller never sees
+//	  forge.ErrLocalPreflight              0 here; writeForgeUpstreamError reads it through isIterionFault and answers 500
+//
 //	OUTSIDE it, though the forge did answer 404 — the caller classifies
 //	  forge.ErrProjectNotFound             0; a bind answers the board ref itself
 //	  forge.ErrFileNotFound                0; config-share answers every read failure alike
@@ -118,10 +121,20 @@ func forgeUpstreamStatus(err error) (int, string) {
 }
 
 // writeForgeUpstreamError answers err with the status forgeUpstreamStatus
-// gives it, echoing the forge's Retry-After. Reports false — writing
-// nothing — when the failure is not an answer from the forge, so the caller
-// keeps its own fault status for the errors that really are iterion's.
+// gives it, echoing the forge's Retry-After. An error MARKED as iterion's
+// own is answered 500 here, since the caller's default arm would name the
+// forge for it. Reports false — writing nothing — only when the failure is
+// neither: an unclassified error on a route whose failures are forge round
+// trips, which its own 502 default then covers.
 func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, args ...any) bool {
+	// The marker is what makes "not an answer from the forge" actionable:
+	// forgeUpstreamStatus answers 0 for a request that never left AND for an
+	// upstream failure it does not recognise, and those two want opposite
+	// statuses. Deciding it here keeps the classifier a classifier.
+	if isIterionFault(err) {
+		httpError(w, http.StatusInternalServerError, format, args...)
+		return true
+	}
 	code, retryAfter := forgeUpstreamStatus(err)
 	if code == 0 {
 		return false
@@ -156,8 +169,9 @@ func writeForgeUpstreamError(w http.ResponseWriter, err error, format string, ar
 // private key — before its first socket, so a key that is not parseable
 // PEM fails inside what reads like a pure `admin.ListRepos(ctx)`. Trace
 // the call to its first byte on the wire before concluding a site is
-// clean; three arms on this branch were cleared on the shorter reading
-// and were wrong (see the residuals named at each).
+// clean. That is what forge.ErrLocalPreflight settles for the mint
+// chain: the marking happens where the wire boundary is visible, so a
+// handler no longer has to derive it.
 //
 // Finally: the 502 default is a per-route CHOICE, not the package's
 // rule, and this marker exists for the routes that make it. A handler
@@ -174,14 +188,12 @@ type iterionFault struct{ err error }
 // tell iterion's own faults apart (answer 500) from a forge that
 // answered or fell silent (keep 502 / the taxonomy code).
 //
-// The mark is INERT on its own, and reading it as sufficient is the
-// mistake to avoid: forgeUpstreamStatus has no iterionFault case and
-// writeForgeUpstreamError only consults that, so a marked error still
-// falls through to whatever the caller's own default arm is — 502 on
-// every route but the avatar one, the only handler that carries the
-// isIterionFault check. Marking a new site therefore takes TWO edits,
-// and the SECOND is the one that changes an answer. A mark alone is a
-// comment.
+// The mark now acts on its own: writeForgeUpstreamError asks
+// isIterionFault first and answers 500, so every 502-defaulting route
+// gets it at once and marking a site is one edit, not two.
+// forgeUpstreamStatus still has no case for it, deliberately — it says
+// what the FORGE answered, and a marked error is one the forge never
+// saw.
 func newIterionFault(err error) error {
 	if err == nil {
 		return nil
@@ -192,11 +204,15 @@ func newIterionFault(err error) error {
 func (e *iterionFault) Error() string { return e.err.Error() }
 func (e *iterionFault) Unwrap() error { return e.err }
 
-// isIterionFault reports whether err (or anything it wraps) was marked
-// with iterionFault, so a 502-default handler can answer 500 instead.
+// isIterionFault reports whether err (or anything it wraps) was marked as
+// iterion's own, so a 502-default handler answers 500 instead. Two markers
+// say the same thing from the two sides of the package boundary:
+// iterionFault, wrapped in pkg/server where the failing step is known, and
+// forge.ErrLocalPreflight, carried out of pkg/forge by work that ran before
+// any byte reached the network.
 func isIterionFault(err error) bool {
 	var f *iterionFault
-	return errors.As(err, &f)
+	return errors.As(err, &f) || errors.Is(err, forge.ErrLocalPreflight)
 }
 
 // retryAfterHeader renders a delay as delta-seconds, the form every client


### PR DESCRIPTION
Closes the second and last remainder of #969.

## The inversion

The App-token mint signs its JWT **from a stored private key before it opens a socket**. So a key that is not parseable PEM fails inside what reads like a pure remote call — `admin.ListRepos(ctx)`, `GetPullRequest`, a security-read mint. Three handlers default to `502` for anything the classifier does not recognise, which is a *sound* default (an unclassified failure on a forge round trip really is the forge's), and they were therefore reporting GitHub as broken for a key only iterion can read.

This is the same defect #993 fixed on the avatar route, on the arms #993 deliberately left open: its disposition argued that closing them belongs to the mint chain, which alone knows which step failed, because a blanket marker over `mint()` would stamp a genuine GitHub 5xx as iterion's — the same lie reversed.

## Where the fix goes

At the **wire boundary**, where it is visible. `MintInstallationToken` marks everything down to `httpClient.Do` with a new `forge.ErrLocalPreflight`: the JWT signing, the payload marshal, the request build. A handler no longer has to derive when a client method starts talking to the network — the derivation nobody gets right, and the one that produced three wrong annotations on #993.

## The mark had to be made to act

`newIterionFault`'s own doc said it: *"a mark alone is a comment"*. The avatar route carried the only `isIterionFault` check in the package, so marking a site took two edits and only the second changed an answer.

`writeForgeUpstreamError` now asks `isIterionFault` first and answers 500. That closes all three arms **at their single shared junction** — one choke point, not three copied guards — and makes the marker act everywhere at once. The avatar route's now-duplicate check is removed.

`forgeUpstreamStatus` deliberately keeps **no** case for the sentinel: it classifies what the *forge* answered, and a request that never left got no answer. Its `0` and an unrecognised upstream failure's `0` want opposite statuses, so deciding fault belongs to the writer, not the classifier. Both halves are pinned by tests.

## Red first

    --- FAIL: TestMintInstallationToken_UnparseableKeyNeverReachesTheForge
        mint error github: app private key is not valid PEM carries no
        forge.ErrLocalPreflight — a 502-defaulting handler will blame the
        forge for a key iterion stored
    --- FAIL: TestWriteForgeUpstreamError_PreflightIsIterionsOwn
        a pre-flight failure was handed back to the caller, whose default
        arm answers 502
    --- FAIL: TestSecurityReadPatch_PreflightMintAnswers500NotBadGateway
        code=502 body={"error":"security-read token mint: github: app
        private key is not valid PEM: ..."}, want 500

Two of the tests exist for the **reverse** inversion, which is how this fix could itself become a lie: a genuine 5xx from the forge must not be marked as iterion's, and the security-read arm must still answer 502 for an unclassified failure. Both were green before and stay green — they are regression guards, not evidence, and are labelled as such.

The pre-flight test asserts the *claim*, not the error text: a probe server records whether it was contacted, so "before any socket" is measured rather than asserted from reading the source.

Three repo guards had to be satisfied, and each caught something: the sentinel-family map, the completeness sweep over `pkg/forge` declarations, and a doc-table parser that reads the comment next to `forgeUpstreamStatus` — that last one rejected my first table entry because a multi-line heading breaks the row/heading association.

`task check` green (`EXIT=0`), `-race` green on `pkg/server` + all of `pkg/forge/...`.

## What stays open, named in place

`githubAppConfigForConnection` reports `(cfg, shared, ok bool)`, so it answers "no github app available" for a store read that **failed** exactly as for an App genuinely absent. That one cannot be wrapped — it needs a signature change across 12 call sites, which is a change of its own argument and would double this diff. The security-read arm says so where a reader meets it, rather than leaving a silence that reads as "handled".

Refs #969
