### PR TITLE
fix(pipelines): the control center served a team the origin of its own fork

### DIFF
--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -591,20 +591,46 @@ func (s *Server) teamBotManifest(ctx context.Context, tenantID, slug string) *bu
 // hold no tenant at all (see the contract at the top of this file).
 func (s *Server) effectiveFindByNameForTeam(ctx context.Context, teamID, name string) (botregistry.EntryWithSchema, bool, error) {
 	if teamID != "" && s.botSources != nil && strings.TrimSpace(name) != "" {
-		bs, found, err := s.teamBotRow(ctx, teamID, name)
+		entry, found, err := s.storedBotEntry(ctx, teamID, name)
 		switch {
 		case err != nil:
-			// A store blip is not "this team authored no such bot": say so,
-			// then fall through to the tiers that can still answer.
-			s.logger.Warn("bot source %s/%s: %v — reading the metadata fell through to the platform tier", teamID, name, err)
+			// A store blip — or a bundle whose own metadata will not parse —
+			// is not "this team authored no such bot": say so, then fall
+			// through to the tiers that can still answer.
+			s.logger.Warn("%v — reading the metadata fell through to the platform tier", err)
 		case found:
-			if entries := s.materializeBotEntries([]botsource.BotSource{bs}); len(entries) == 1 {
-				return entries[0], true, nil
-			}
-			s.logger.Warn("bot source %s/%s: metadata could not be materialized — falling through to the platform tier", teamID, bs.Slug)
+			return entry, true, nil
 		}
 	}
 	return s.effectiveFindByName(name)
+}
+
+// storedBotEntry is the metadata of ONE stored row — the tenant and slug a
+// launch resolution actually chose — read STRICTLY: a store failure or a
+// bundle whose metadata will not materialize is an error, never another
+// tier's entry for the same name.
+//
+// The strictness is the point, and it is why this is the single
+// implementation rather than effectiveFindByNameForTeam's inner half. A
+// caller that pairs this metadata with THAT row's bundle (resolvePipelineBot)
+// cannot accept a fall-through: it would launch a fork while reading the
+// origin's `enabled` and name — the divergence the chokepoint exists to
+// close, only quieter for arriving through a helper. A caller that merely
+// wants the best available answer (effectiveFindByNameForTeam) keeps its
+// fall-through, warning above.
+func (s *Server) storedBotEntry(ctx context.Context, tenantID, slug string) (botregistry.EntryWithSchema, bool, error) {
+	bs, found, err := s.teamBotRow(ctx, tenantID, slug)
+	if err != nil {
+		return botregistry.EntryWithSchema{}, false, fmt.Errorf("bot source %s/%s: %w", tenantID, slug, err)
+	}
+	if !found {
+		return botregistry.EntryWithSchema{}, false, nil
+	}
+	if entries := s.materializeBotEntries([]botsource.BotSource{bs}); len(entries) == 1 {
+		return entries[0], true, nil
+	}
+	return botregistry.EntryWithSchema{}, false, fmt.Errorf(
+		"bot source %s/%s: metadata could not be materialized (its manifest.yaml does not parse, or the bundle holds more than one workflow)", tenantID, bs.Slug)
 }
 
 // effectiveFindByName returns the effective (platform-overlaid) entry for a

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -644,20 +644,48 @@ func (s *Server) effectiveFindByName(name string) (botregistry.EntryWithSchema, 
 	if err != nil {
 		return botregistry.EntryWithSchema{}, false, err
 	}
+	entry, found := findEntryByName(entries, name)
+	return entry, found, nil
+}
+
+// bakedFindByName is effectiveFindByName WITHOUT the platform overlay: the
+// baked catalog answering for itself, workspace overlay composed as always.
+//
+// It is for the caller that already knows which tier served — a launch that
+// resolved the baked bundle — and must not read the entry of an override
+// that did not. The overlay is a 30s cache invalidated only on the replica
+// that wrote, so for that window after an override is DELETED it still
+// describes a bundle the live store no longer has, and effectiveFindByName
+// would hand back its `enabled` and name for the baked twin now running.
+// Every OTHER reader wants the effective answer and keeps it.
+func (s *Server) bakedFindByName(name string) (botregistry.EntryWithSchema, bool, error) {
+	entries, err := botregistry.ListWithSchema(s.botListOptions())
+	if err != nil {
+		return botregistry.EntryWithSchema{}, false, err
+	}
+	entry, found := findEntryByName(entries, name)
+	return entry, found, nil
+}
+
+// findEntryByName is the launcher's name match, one implementation for every
+// entry set: an exact match first, then the NormalizeName-folded spelling
+// (review_pr → review-pr), because the launcher accepts both and a run's
+// persisted BotID may carry either.
+func findEntryByName(entries []botregistry.EntryWithSchema, name string) (botregistry.EntryWithSchema, bool) {
 	for _, e := range entries {
 		if e.Name == name {
-			return e, true, nil
+			return e, true
 		}
 	}
 	// Tolerant match: normalised comparison after the exact pass.
 	nn := botregistry.NormalizeName(name)
 	if nn == "" {
-		return botregistry.EntryWithSchema{}, false, nil
+		return botregistry.EntryWithSchema{}, false
 	}
 	for _, e := range entries {
 		if botregistry.NormalizeName(e.Name) == nn {
-			return e, true, nil
+			return e, true
 		}
 	}
-	return botregistry.EntryWithSchema{}, false, nil
+	return botregistry.EntryWithSchema{}, false
 }

--- a/pkg/server/bot_resolver.go
+++ b/pkg/server/bot_resolver.go
@@ -630,7 +630,7 @@ func (s *Server) storedBotEntry(ctx context.Context, tenantID, slug string) (bot
 		return entries[0], true, nil
 	}
 	return botregistry.EntryWithSchema{}, false, fmt.Errorf(
-		"bot source %s/%s: metadata could not be materialized (its manifest.yaml does not parse, or the bundle holds more than one workflow)", tenantID, bs.Slug)
+		"bot source %s/%s: metadata could not be materialized — discovery describes the row with nothing (no manifest.yaml alongside more than one workflow, or a manifest this build cannot parse)", tenantID, bs.Slug)
 }
 
 // effectiveFindByName returns the effective (platform-overlaid) entry for a

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -96,11 +96,16 @@ var tenantFreeMetadataAllowed = map[string]string{
 	"config_shares_routes.go":    "botManifest is botManifestFor's platform + baked fall-through",
 	"forge_gate_pause_notice.go": "effectiveFindByName is teamBotManifest's fall-through, reached only when the run records no team row",
 	"webhooks_handoff.go":        "the deployment-wide producer FLOOR; teamHandoffProducers is the team half, and the scan picks per run by Run.BotSourceTenant",
+	// bakedFindByName, and only after the LAUNCH already resolved the baked
+	// tier: the tenant tiers were consulted and served nothing, so the entry
+	// must come from the bundle that will run and not from the platform
+	// overlay, whose 30s cache may still hold a deleted override.
+	"pipeline_admission.go": "the metadata of a launch that already resolved BAKED — each tier answers for itself (storedBotEntry serves the other two)",
 }
 
 func TestBotResolutionSweep_TenantFreeMetadataIsDeclared(t *testing.T) {
 	tenantFree := regexp.MustCompile(
-		`s\.(?:effectiveEntries\(\)|effectiveEntriesWithSchema\(\)|effectiveFindByName\(|botExists\(|botManifest\(|entryOrigin\(|findBot\()`)
+		`s\.(?:effectiveEntries\(\)|effectiveEntriesWithSchema\(\)|effectiveFindByName\(|bakedFindByName\(|botExists\(|botManifest\(|entryOrigin\(|findBot\()`)
 	sweepServerFiles(t, func(name, body string) {
 		if !tenantFree.MatchString(body) {
 			return

--- a/pkg/server/bot_resolver_sweep_test.go
+++ b/pkg/server/bot_resolver_sweep_test.go
@@ -55,6 +55,12 @@ func TestBotResolutionSweep_NoRawRegistryReads(t *testing.T) {
 var teamlessResolveAllowed = map[string]string{
 	"resume_source.go": "the no-persisted-origin branch: a run whose BotSourceTenant is empty did NOT launch from a team row (the team branch above re-resolves that row by its own tenant)",
 	"board_comment.go": "the native board is a single local store with no tenancy — the launch its comment dispatcher triggers resolves platform-over-baked too",
+	// The LOOP only: pipelineAdmissionEnabled refuses cloud mode, so it
+	// drives cfg.NativeTrackerStore, a single local store whose tenant is
+	// "" by construction. The two request-scoped callers of the same
+	// launchTicketNow (the board's "launch now" and the task create/update
+	// checks) hold an authenticated identity and pass its team.
+	"pipeline_admission.go": "the admission loop is local-only; its board has no tenancy, so the launch it drives resolves platform-over-baked",
 }
 
 func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
@@ -66,7 +72,7 @@ func TestBotResolutionSweep_NoLiteralTeamlessResolution(t *testing.T) {
 	// Only a LITERAL "" is decidable statically; a variable that happens to
 	// be empty at run time is the caller's own contract to keep.
 	teamless := regexp.MustCompile(
-		`(?:resolveBot(?:Source|Tiered(?:Raw)?)?|resolveRunRetryPolicy|handoffConsumersFor|botVarDefault|botManifestFor|effectiveFindByNameForTeam|effectiveEntriesFor(?:Team)?|botExistsForTeam|botConfigShareSpec|boardRouteForLabel|cmdDiscoveryFor|entryOriginFor|teamHandoffProducers|forgeBot(?:Forge|Invocations))\([^,]+,\s*""`)
+		`(?:resolveBot(?:Source|Tiered(?:Raw)?)?|resolvePipelineBot|launchTicketNow|resolveRunRetryPolicy|handoffConsumersFor|botVarDefault|botManifestFor|effectiveFindByNameForTeam|effectiveEntriesFor(?:Team)?|botExistsForTeam|botConfigShareSpec|boardRouteForLabel|cmdDiscoveryFor|entryOriginFor|teamHandoffProducers|forgeBot(?:Forge|Invocations))\([^,]+,\s*""`)
 	sweepServerFiles(t, func(name, body string) {
 		if !teamless.MatchString(body) {
 			return
@@ -90,13 +96,6 @@ var tenantFreeMetadataAllowed = map[string]string{
 	"config_shares_routes.go":    "botManifest is botManifestFor's platform + baked fall-through",
 	"forge_gate_pause_notice.go": "effectiveFindByName is teamBotManifest's fall-through, reached only when the run records no team row",
 	"webhooks_handoff.go":        "the deployment-wide producer FLOOR; teamHandoffProducers is the team half, and the scan picks per run by Run.BotSourceTenant",
-	// The pipelines control center launches by FILESYSTEM PATH
-	// (entry.MainFile()) instead of through resolveBotSource, so a stored
-	// bundle has no path to launch from and its admission check must match.
-	// Making the check tenant-aware alone would create cards that can never
-	// launch; both halves move together, in the #871 launch-surface class.
-	"pipeline_boards_tasks.go": "admission check for a lane whose launch is itself FS-path-based (tracked with the launch half)",
-	"pipeline_admission.go":    "same lane: launchTicketNow launches entry.MainFile(), not a resolved bundle",
 }
 
 func TestBotResolutionSweep_TenantFreeMetadataIsDeclared(t *testing.T) {

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -573,7 +573,7 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 	// through a helper instead of a tier choice. Here it is an error naming
 	// the row the operator has to fix. (A hand-broken manifest is NOT on that
 	// list: botsource.Validate decodes it at write time.)
-	entry, found, err := s.pipelineBotEntry(ctx, teamID, botID, lb)
+	entry, found, err := s.pipelineBotEntry(ctx, botID, lb)
 	if err != nil {
 		lb.Cleanup()
 		return pipelineBot{}, false, err
@@ -606,7 +606,10 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 // deleted override's `enabled` and name: a disabled override making an
 // enabled bot unlaunchable, or worse the reverse. Each tier answering for
 // itself is the whole shape of this chokepoint; this is its third leg.
-func (s *Server) pipelineBotEntry(ctx context.Context, teamID, botID string, lb *launchBot) (botregistry.EntryWithSchema, bool, error) {
+//
+// It takes no team: `lb` already names the tier that won, and a team id here
+// could only be used to consult a tier that did not.
+func (s *Server) pipelineBotEntry(ctx context.Context, botID string, lb *launchBot) (botregistry.EntryWithSchema, bool, error) {
 	if lb.Ref != nil && lb.Ref.TenantID != "" {
 		return s.storedBotEntry(ctx, lb.Ref.TenantID, lb.Ref.Slug)
 	}

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -565,11 +565,14 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 	// tier and a bundle from another is the divergence it exists to close.
 	//
 	// A stored tier reads STRICTLY for the same reason. effectiveFindByNameForTeam
-	// falls THROUGH when the row it found will not materialize — a fork whose
-	// manifest.yaml does not parse, a store blip on the second read — and its
-	// fall-through lands on the origin this fork replaces: exactly the pairing
-	// the paragraph above forbids, arriving through a helper instead of a tier
-	// choice. Here it is an error the operator can act on.
+	// falls THROUGH when the row it found will not materialize — a store blip
+	// on the second read, a bundle discovery cannot describe (no manifest.yaml
+	// and more than one workflow), a manifest whose schema_version this build
+	// no longer accepts — and its fall-through lands on the origin the fork
+	// replaces: exactly the pairing the paragraph above forbids, arriving
+	// through a helper instead of a tier choice. Here it is an error naming
+	// the row the operator has to fix. (A hand-broken manifest is NOT on that
+	// list: botsource.Validate decodes it at write time.)
 	entry, found, err := s.pipelineBotEntry(ctx, teamID, botID, lb)
 	if err != nil {
 		lb.Cleanup()

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -530,6 +530,22 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 		return pipelineBot{}, false, err
 	}
 	if lb == nil {
+		// "Nothing resolved" is not always "no such bot": the baked tier
+		// reports an UNREADABLE catalog as an absence — resolveBotTieredRaw
+		// collapses every ResolveBotPath failure into (nil, nil), and one
+		// malformed manifest.yaml anywhere under the discovery roots fails
+		// the whole walk, for every bot. The metadata read crosses the same
+		// catalog and propagates that error, so ask it before answering
+		// "absent": the operator is then told his catalog will not parse
+		// (what findBot used to say, before this lane went through the
+		// tiers) instead of being told the bot he just typed does not exist.
+		// A genuine absence stays a genuine absence. It is the SAME read the
+		// found path makes (the sweep's tenant-aware form, so this probe
+		// cannot answer from a tier the launch would not have served); only
+		// its error is used here, since nothing resolved to describe.
+		if _, _, catErr := s.effectiveFindByNameForTeam(ctx, teamID, botID); catErr != nil {
+			return pipelineBot{}, false, catErr
+		}
 		return pipelineBot{}, false, nil
 	}
 	// The metadata half of the SAME resolution. It must describe the

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -531,11 +531,26 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 	if lb == nil {
 		return pipelineBot{}, false, nil
 	}
-	// The metadata half of the SAME resolution: both reads go through
-	// teamBotRow, so they land on one row and the enabled flag describes
-	// the bundle that will actually run — not the origin a fork was made
-	// from.
-	entry, found, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
+	// The metadata half of the SAME resolution. It must describe the
+	// artifact the launch SELECTED, so a STORED tier answers for itself:
+	// the row that served, read by its own tenant and canonical slug, which
+	// is the same live teamBotRow read the launch made.
+	//
+	// The platform tier is why this is not just `teamID`. Its launch read is
+	// live (botSources.GetBySlug), while effectiveFindByName's overlay comes
+	// from the 30s platformBotSetCached set, invalidated only on the replica
+	// that served the write. Asking for the platform tenant by name lands on
+	// teamBotRow — live — instead, so the two halves cannot straddle that
+	// window: a freshly pushed override no longer reads as "a launchable
+	// bundle nothing describes" (a 500 on card create), and an override with
+	// its own `enabled:` no longer inherits the flag of the baked twin it
+	// shadows. Which is this chokepoint's whole point: metadata from one
+	// tier and a bundle from another is the divergence it exists to close.
+	metaTeam, metaName := teamID, botID
+	if lb.Ref != nil && lb.Ref.TenantID != "" {
+		metaTeam, metaName = lb.Ref.TenantID, lb.Ref.Slug
+	}
+	entry, found, err := s.effectiveFindByNameForTeam(ctx, metaTeam, metaName)
 	if err != nil {
 		lb.Cleanup()
 		return pipelineBot{}, false, err

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -594,15 +594,23 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 }
 
 // pipelineBotEntry reads the catalog metadata describing the bundle `lb`
-// selected — from the tier that selected it. A stored row (team or platform)
-// answers for itself, strictly: no other tier may stand in for it. Only the
-// baked tier falls through the ordinary team → platform → baked metadata
-// path, which is what it resolved through in the first place.
+// selected — from the tier that selected it, and from no other. A stored row
+// (team or platform) answers through its own live row; the baked tier answers
+// from the baked catalog with the platform overlay OFF.
+//
+// That last part is the leg the tier order cannot close by itself. Reaching
+// the baked tier means the live store served neither a team row nor a
+// platform one, while platformBotSetCached — a 30s TTL invalidated only on
+// the replica that wrote — may still carry an override that was just DELETED.
+// The overlaid read would then describe the running baked bundle with the
+// deleted override's `enabled` and name: a disabled override making an
+// enabled bot unlaunchable, or worse the reverse. Each tier answering for
+// itself is the whole shape of this chokepoint; this is its third leg.
 func (s *Server) pipelineBotEntry(ctx context.Context, teamID, botID string, lb *launchBot) (botregistry.EntryWithSchema, bool, error) {
 	if lb.Ref != nil && lb.Ref.TenantID != "" {
 		return s.storedBotEntry(ctx, lb.Ref.TenantID, lb.Ref.Slug)
 	}
-	return s.effectiveFindByNameForTeam(ctx, teamID, botID)
+	return s.bakedFindByName(botID)
 }
 
 // launchTicketNow claims a ticket and launches its bot, returning the run

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -411,7 +411,10 @@ func (s *Server) launchReadyTicket(runs *runview.Service, board native.BoardStor
 			return
 		}
 	}
-	if _, err := s.launchTicketNow(runs, board, iss); err != nil {
+	// The loop is local-only (pipelineAdmissionEnabled refuses cloud), so
+	// the board it drives carries no tenant: the bot resolves
+	// platform-over-baked with an empty team, and there is none to invent.
+	if _, err := s.launchTicketNow(context.Background(), "", runs, board, iss); err != nil {
 		// launchTicketNow already logged the specifics; the loop is
 		// best-effort and simply retries on the next tick.
 		return
@@ -483,13 +486,86 @@ var _ interface {
 	ServerNow(context.Context) (time.Time, error)
 } = (*boardmongo.Store)(nil)
 
+// pipelineBot is one bot resolution serving BOTH halves of the pipelines
+// lane: the metadata its admission checks read — the canonical name a card
+// is stamped with, and whether the bot is enabled — and the bundle its
+// launch runs. Resolving the two separately is what let the control center
+// admit a card on the baked catalog's metadata and then launch the baked
+// catalog's bundle for a team that had forked that very bot.
+type pipelineBot struct {
+	// Name is the canonical bot id: what the card records and what the
+	// upsert key is built from. A card may carry a tolerated spelling
+	// (`feature_dev` for a `feature-dev` bundle) — every tier resolves it,
+	// and the board keeps the canonical one.
+	Name string
+	// Enabled is the catalog-visibility decision: the manifest `enabled:`
+	// default, composed with the workspace overlay for baked entries.
+	Enabled bool
+	// Launch is the launch-ready bundle. The caller OWNS it and must
+	// Cleanup() it — including the check-only callers, which pay the
+	// resolution so that a card that cannot be launched is never created
+	// (the admitBoardCard bargain).
+	Launch *launchBot
+}
+
+// resolvePipelineBot resolves the bot a pipeline ticket names through the
+// full tier order — teamID's own botsource row, then a platform override,
+// then the baked catalog — and answers with what BOTH halves of the lane
+// need. (zero, false, nil) is a genuine absence each caller maps to its own
+// refusal; an error is a resolver failure, never a fall-through to a bundle
+// nobody chose.
+//
+// teamID is the tenant the CARD belongs to. The cloud pipeline board is
+// selected from the request's active team (cloudBoardResolve), so a card
+// carried by a team that forked its bot must run that fork, and a bot only
+// that team authored must be cardable at all — a stored row has no
+// filesystem path to launch from. It is a parameter and not a ctx read for
+// bot_resolver.go's reason: the tier must follow "who is this launch for",
+// not whichever tenant the ctx happens to carry. Empty is legitimate for
+// the local studio, whose board has no tenancy.
+func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (pipelineBot, bool, error) {
+	lb, err := s.resolveBotTiered(ctx, teamID, botID, "")
+	if err != nil {
+		return pipelineBot{}, false, err
+	}
+	if lb == nil {
+		return pipelineBot{}, false, nil
+	}
+	// The metadata half of the SAME resolution: both reads go through
+	// teamBotRow, so they land on one row and the enabled flag describes
+	// the bundle that will actually run — not the origin a fork was made
+	// from.
+	entry, found, err := s.effectiveFindByNameForTeam(ctx, teamID, botID)
+	if err != nil {
+		lb.Cleanup()
+		return pipelineBot{}, false, err
+	}
+	if !found {
+		// The two halves disagree: a launchable bundle nothing describes.
+		// Say so. Guessing "enabled" is how a disabled bot launches;
+		// guessing "absent" is how a launchable bot becomes uncardable.
+		lb.Cleanup()
+		return pipelineBot{}, false, fmt.Errorf(
+			"bot %q resolves to a launchable bundle on the %s tier but no catalog metadata describes it", botID, lb.Origin)
+	}
+	// The catalog tier answers to a tolerated spelling and hands back the
+	// REQUESTED one; the canonical name is the metadata's. Carry it into
+	// the launch too, so the card, the upsert key and the run all agree.
+	lb.BotID = entry.Name
+	return pipelineBot{Name: entry.Name, Enabled: entry.Enabled, Launch: lb}, true, nil
+}
+
 // launchTicketNow claims a ticket and launches its bot, returning the run
 // id. It is the shared body of the admission loop (which ignores the error
 // and retries next tick) and of the operator's explicit "launch now" drag,
 // which needs the failure reported back over HTTP. The bot-not-in-catalog
 // case is a *skip*, not a failure, for the loop — hence the dedicated
 // error the caller can distinguish.
-func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore, iss *native.Issue) (string, error) {
+//
+// ctx scopes the bot RESOLUTION (a store read in cloud, where this endpoint
+// is reachable); the launch itself keeps its own background context, so a
+// client that hangs up mid-request cannot cancel a run already in flight.
+func (s *Server) launchTicketNow(ctx context.Context, teamID string, runs *runview.Service, board native.BoardStore, iss *native.Issue) (string, error) {
 	// A ticket held under a LIVE claim already has a launcher — the
 	// dispatcher wins with the CLAIM, and its move out of Ready is
 	// offloaded, so the state alone cannot say the ticket is free. This is
@@ -526,12 +602,12 @@ func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore,
 	if cur.Claim != "" && !cur.ClaimLeaseUntil.IsZero() && cur.ClaimLeaseUntil.After(s.boardNow(board)) {
 		return "", fmt.Errorf("ticket %s is claimed by %q under a live lease — its launcher is already on it; wait for the lease to lapse (or for the watchdog to reclaim it)", iss.ID, cur.Claim)
 	}
-	entry, found, err := s.findBot(iss.Bot)
+	bot, found, err := s.resolvePipelineBot(ctx, teamID, iss.Bot)
 	if err != nil {
 		s.logger.Warn("pipeline admission: resolve bot %q: %v", iss.Bot, err)
 		return "", fmt.Errorf("resolve bot %q: %w", iss.Bot, err)
 	}
-	if !found || !entry.Enabled {
+	if !found || !bot.Enabled {
 		// Unknown/disabled bot: leave the ticket in Ready, surfaced as-is.
 		// Say so (once per ticket+bot, not every tick) — after a studio
 		// project switch the boot-scoped board can reference bots the
@@ -540,6 +616,9 @@ func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore,
 		s.warnAdmissionSkipOnce(iss.ID, iss.Bot, found)
 		return "", fmt.Errorf("bot %q is not in this workspace's catalog (or is disabled)", iss.Bot)
 	}
+	// The materialized bundle dir belongs to this call: the launch consumes
+	// it while compiling, and nothing downstream reads it afterwards.
+	defer bot.Launch.Cleanup()
 	// Leave the launch column BEFORE launching so the next tick won't
 	// re-pick this ticket while Launch is in flight. StateInProgress is not
 	// StateReady, so admitReadyPipelines skips it; the run's status then
@@ -572,10 +651,8 @@ func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore,
 			return "", fmt.Errorf("ticket %s moved out of %q while it was being launched — nothing was started; re-read the board and retry", iss.ID, sourceState)
 		}
 	}
-	res, err := runs.Launch(context.Background(), runview.LaunchSpec{
-		FilePath: entry.MainFile(),
-		BotID:    entry.Name,
-		Vars:     iss.BotArgs,
+	spec := runview.LaunchSpec{
+		Vars: iss.BotArgs,
 		// Stamp the ticket onto the run IMMEDIATELY. Without this the run is
 		// undiscoverable from its ticket until SetLastRun lands below — and
 		// between the SetState above and that stamp sit compileForLaunch,
@@ -594,7 +671,12 @@ func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore,
 		// reserved slot, and this is what lets its own relaunch spend that
 		// reservation instead of being refused by it.
 		PipelineTicketID: iss.ID,
-	})
+	}
+	// The resolved bundle carries the source, the compile dir, the runner
+	// ref and the tier that served it — so a run says which tier it came
+	// from here exactly as on the other launch surfaces.
+	bot.Launch.Stamp(&spec)
+	res, err := runs.Launch(context.Background(), spec)
 	if err != nil {
 		s.logger.Warn("pipeline admission: launch ticket %s: %v", iss.ID, err)
 		// Put the ticket back where it came FROM, not in a fixed column: a
@@ -618,6 +700,6 @@ func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore,
 	if err := board.SetLastRun(iss.ID, res.RunID, ""); err != nil {
 		s.logger.Warn("pipeline admission: link run %s to ticket %s: %v", res.RunID, iss.ID, err)
 	}
-	s.logger.Info("pipeline admission: started ticket %s as run %s (bot %s)", iss.ID, res.RunID, entry.Name)
+	s.logger.Info("pipeline admission: started ticket %s as run %s (bot %s, %s tier)", iss.ID, res.RunID, bot.Name, bot.Launch.Tier())
 	return res.RunID, nil
 }

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/dispatcher"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
@@ -546,11 +547,14 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 	// its own `enabled:` no longer inherits the flag of the baked twin it
 	// shadows. Which is this chokepoint's whole point: metadata from one
 	// tier and a bundle from another is the divergence it exists to close.
-	metaTeam, metaName := teamID, botID
-	if lb.Ref != nil && lb.Ref.TenantID != "" {
-		metaTeam, metaName = lb.Ref.TenantID, lb.Ref.Slug
-	}
-	entry, found, err := s.effectiveFindByNameForTeam(ctx, metaTeam, metaName)
+	//
+	// A stored tier reads STRICTLY for the same reason. effectiveFindByNameForTeam
+	// falls THROUGH when the row it found will not materialize — a fork whose
+	// manifest.yaml does not parse, a store blip on the second read — and its
+	// fall-through lands on the origin this fork replaces: exactly the pairing
+	// the paragraph above forbids, arriving through a helper instead of a tier
+	// choice. Here it is an error the operator can act on.
+	entry, found, err := s.pipelineBotEntry(ctx, teamID, botID, lb)
 	if err != nil {
 		lb.Cleanup()
 		return pipelineBot{}, false, err
@@ -568,6 +572,18 @@ func (s *Server) resolvePipelineBot(ctx context.Context, teamID, botID string) (
 	// the launch too, so the card, the upsert key and the run all agree.
 	lb.BotID = entry.Name
 	return pipelineBot{Name: entry.Name, Enabled: entry.Enabled, Launch: lb}, true, nil
+}
+
+// pipelineBotEntry reads the catalog metadata describing the bundle `lb`
+// selected — from the tier that selected it. A stored row (team or platform)
+// answers for itself, strictly: no other tier may stand in for it. Only the
+// baked tier falls through the ordinary team → platform → baked metadata
+// path, which is what it resolved through in the first place.
+func (s *Server) pipelineBotEntry(ctx context.Context, teamID, botID string, lb *launchBot) (botregistry.EntryWithSchema, bool, error) {
+	if lb.Ref != nil && lb.Ref.TenantID != "" {
+		return s.storedBotEntry(ctx, lb.Ref.TenantID, lb.Ref.Slug)
+	}
+	return s.effectiveFindByNameForTeam(ctx, teamID, botID)
 }
 
 // launchTicketNow claims a ticket and launches its bot, returning the run

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -607,6 +607,14 @@ func (s *Server) launchTicketNow(ctx context.Context, teamID string, runs *runvi
 		s.logger.Warn("pipeline admission: resolve bot %q: %v", iss.Bot, err)
 		return "", fmt.Errorf("resolve bot %q: %w", iss.Bot, err)
 	}
+	// The materialized bundle dir belongs to this call: the launch consumes
+	// it while compiling, and nothing downstream reads it afterwards. The
+	// defer sits ABOVE the skip so a DISABLED bot's bundle is reclaimed too
+	// — a resolution that FOUND the bot materialized it (and in cloud
+	// snapshotted the whole collection to a second temp dir), and nothing
+	// ever comes back for it. Cleanup is nil-safe, so the not-found branch
+	// costs nothing.
+	defer bot.Launch.Cleanup()
 	if !found || !bot.Enabled {
 		// Unknown/disabled bot: leave the ticket in Ready, surfaced as-is.
 		// Say so (once per ticket+bot, not every tick) — after a studio
@@ -616,9 +624,6 @@ func (s *Server) launchTicketNow(ctx context.Context, teamID string, runs *runvi
 		s.warnAdmissionSkipOnce(iss.ID, iss.Bot, found)
 		return "", fmt.Errorf("bot %q is not in this workspace's catalog (or is disabled)", iss.Bot)
 	}
-	// The materialized bundle dir belongs to this call: the launch consumes
-	// it while compiling, and nothing downstream reads it afterwards.
-	defer bot.Launch.Cleanup()
 	// Leave the launch column BEFORE launching so the next tick won't
 	// re-pick this ticket while Launch is in flight. StateInProgress is not
 	// StateReady, so admitReadyPipelines skips it; the run's status then

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -622,13 +622,24 @@ func (s *Server) launchTicketNow(ctx context.Context, teamID string, runs *runvi
 		s.logger.Warn("pipeline admission: resolve bot %q: %v", iss.Bot, err)
 		return "", fmt.Errorf("resolve bot %q: %w", iss.Bot, err)
 	}
-	// The materialized bundle dir belongs to this call: the launch consumes
-	// it while compiling, and nothing downstream reads it afterwards. The
-	// defer sits ABOVE the skip so a DISABLED bot's bundle is reclaimed too
-	// — a resolution that FOUND the bot materialized it (and in cloud
-	// snapshotted the whole collection to a second temp dir), and nothing
-	// ever comes back for it. Cleanup is nil-safe, so the not-found branch
-	// costs nothing.
+	// The materialized bundle dir belongs to this call: Launch compiles from
+	// it synchronously (compileForLaunch, on both the cloud-publisher and
+	// the in-process path) before returning, and nothing downstream reads
+	// it. The defer sits ABOVE the skip so a DISABLED bot's bundle is
+	// reclaimed too — a resolution that FOUND the bot materialized it (and
+	// in cloud snapshotted the whole collection to a second temp dir), and
+	// nothing ever comes back for it. Cleanup is nil-safe, so the not-found
+	// branch costs nothing.
+	//
+	// The one path where "synchronously" does not hold is runview's LOCAL
+	// pipeline-concurrency queue: over the cap, admitOrEnqueue keeps the
+	// whole LaunchSpec and startQueuedRun compiles from it later, after this
+	// defer has run. That borrow predates this lane (every caller of
+	// Launch defers Cleanup the same way) and the fix belongs to the queue,
+	// which must own what it retains — not here, where the alternative is
+	// leaking the dir forever. Cloud is unaffected: the publisher path
+	// returns before the queue branch, and s.pipelineQueue is nil whenever
+	// a publisher is wired.
 	defer bot.Launch.Cleanup()
 	if !found || !bot.Enabled {
 		// Unknown/disabled bot: leave the ticket in Ready, surfaced as-is.
@@ -637,7 +648,15 @@ func (s *Server) launchTicketNow(ctx context.Context, teamID string, runs *runvi
 		// current workspace's catalog no longer resolves, and a silent
 		// skip reads as a stuck pipeline.
 		s.warnAdmissionSkipOnce(iss.ID, iss.Bot, found)
-		return "", fmt.Errorf("bot %q is not in this workspace's catalog (or is disabled)", iss.Bot)
+		// The two cases are not the same fix, and this string is what the
+		// operator reads: launch-now returns it over HTTP. It must also name
+		// the tiers the resolution actually covers now — "this workspace's
+		// catalog" describes the loop's local board, but a cloud card that
+		// resolves nowhere failed on its TEAM's bots too.
+		if !found {
+			return "", fmt.Errorf("bot %q resolves on none of the tiers this card can launch from — the team's own bots, a platform override, or the baked catalog", iss.Bot)
+		}
+		return "", fmt.Errorf("bot %q is disabled", iss.Bot)
 	}
 	// Leave the launch column BEFORE launching so the next tick won't
 	// re-pick this ticket while Launch is in flight. StateInProgress is not

--- a/pkg/server/pipeline_admission_sweep_test.go
+++ b/pkg/server/pipeline_admission_sweep_test.go
@@ -313,7 +313,7 @@ func TestLaunchTicketNow_RefusesAClaimedTicket(t *testing.T) {
 		t.Fatalf("Claim: %v", err)
 	}
 	s := newSweepTestServer()
-	_, err = s.launchTicketNow(nil, board, iss)
+	_, err = s.launchTicketNow(context.Background(), "", nil, board, iss)
 	if err == nil {
 		t.Fatal("launchTicketNow accepted a ticket held under a live claim — a second run was minted while its launcher was mid-launch")
 	}
@@ -414,7 +414,7 @@ func TestLaunchTicketNow_ParkedClaimWithALapsedLeaseStaysRelaunchable(t *testing
 	}
 
 	s := newSweepTestServer()
-	_, err = s.launchTicketNow(nil, board2, cur)
+	_, err = s.launchTicketNow(context.Background(), "", nil, board2, cur)
 	if err != nil && strings.Contains(err.Error(), "claimed by") {
 		t.Fatalf("the operator's relaunch of a parked, claim-retained card is refused: %v — nothing else ever frees that claim", err)
 	}
@@ -472,7 +472,7 @@ func TestLaunchTicketNow_LegacyUnleasedClaimIsRelaunchable(t *testing.T) {
 	}
 
 	s := newSweepTestServer()
-	_, err = s.launchTicketNow(nil, board2, cur)
+	_, err = s.launchTicketNow(context.Background(), "", nil, board2, cur)
 	if err != nil && strings.Contains(err.Error(), "claimed by") {
 		t.Fatalf("a legacy no-lease claim was refused by the guard: %v — no lease will ever lapse and no watchdog lists this card", err)
 	}
@@ -570,7 +570,7 @@ func TestLaunchTicketNow_LeaseIsMeasuredWithTheBoardClock(t *testing.T) {
 	cb := clockedBoard{BoardStore: board2, now: time.Now().UTC().Add(-30 * time.Minute)}
 
 	s := newSweepTestServer()
-	_, lerr := s.launchTicketNow(nil, cb, func() *native.Issue { c, _ := board2.Get(iss.ID); return c }())
+	_, lerr := s.launchTicketNow(context.Background(), "", nil, cb, func() *native.Issue { c, _ := board2.Get(iss.ID); return c }())
 	if lerr == nil || !strings.Contains(lerr.Error(), "claimed by") {
 		t.Fatalf("a lease LIVE on the board's clock was admitted because the pod's clock ran fast: err=%v", lerr)
 	}
@@ -671,7 +671,7 @@ func TestLaunchTicketNow_MovesANonReadyTicket(t *testing.T) {
 
 	// The launch itself may fail (no backend credential here); what is
 	// under test is the board move that precedes it.
-	_, _ = s.launchTicketNow(svc, board, iss)
+	_, _ = s.launchTicketNow(context.Background(), "", svc, board, iss)
 
 	var moved bool
 	if err := board.ScanEvents(func(e *native.Event) bool {
@@ -716,7 +716,7 @@ func TestLaunchTicketNow_RefusesConcurrentDrift(t *testing.T) {
 	}
 	drifting := &driftingBoard{BoardStore: board, onceTo: native.StateReady, id: iss.ID}
 
-	_, err = s.launchTicketNow(svc, drifting, iss)
+	_, err = s.launchTicketNow(context.Background(), "", svc, drifting, iss)
 	if err == nil {
 		t.Fatal("a ticket that moved under the CAS was accepted — the silent no-op reports success for a card that never moved")
 	}

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -686,7 +687,11 @@ func (s *Server) handlePipelineBoardTaskLaunch(w http.ResponseWriter, r *http.Re
 			return
 		}
 	}
-	runID, err := s.launchTicketNow(runs, boardStore, issue)
+	// The bot resolves for the team the board itself was selected from
+	// (cloudBoardResolve), so a team's fork — or a bot only it authored —
+	// serves its own cards.
+	caller, _ := auth.FromContext(r.Context())
+	runID, err := s.launchTicketNow(r.Context(), caller.TeamID, runs, boardStore, issue)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board launch: %v", err)
 		return

--- a/pkg/server/pipeline_boards_tasks.go
+++ b/pkg/server/pipeline_boards_tasks.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/SocialGouv/iterion/internal/httpx"
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 )
 
@@ -116,7 +117,12 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: bot is required")
 		return
 	}
-	entry, found, err := s.findBot(req.Bot)
+	// The card's bot resolves through the tier that will SERVE its launch —
+	// the same team the board itself was selected from. A check answering
+	// from the baked catalog alone refuses a bot only this team authored
+	// (no path exists for it) and admits a fork's origin in its place.
+	caller, _ := auth.FromContext(r.Context())
+	bot, found, err := s.resolvePipelineBot(r.Context(), caller.TeamID, req.Bot)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board task: discover bot: %v", err)
 		return
@@ -125,8 +131,11 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board task: bot %q not found", req.Bot)
 		return
 	}
-	if req.Start && !entry.Enabled {
-		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: bot %q is disabled", entry.Name)
+	// The bundle was materialized to prove the card is launchable; nothing
+	// past this point runs it.
+	defer bot.Launch.Cleanup()
+	if req.Start && !bot.Enabled {
+		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: bot %q is disabled", bot.Name)
 		return
 	}
 	board, err := boardStore.Board()
@@ -144,14 +153,14 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 
 	// Upsert: planners re-run without duplicating tickets for the same request file.
 	if req.Upsert {
-		if bot, inputPath, ok := native.UpsertKey(entry.Name, botArgs); ok {
-			existing, ferr := native.FindByBotInputPath(boardStore, bot, inputPath)
+		if upsertBot, inputPath, ok := native.UpsertKey(bot.Name, botArgs); ok {
+			existing, ferr := native.FindByBotInputPath(boardStore, upsertBot, inputPath)
 			if ferr != nil {
 				s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board task: upsert lookup: %v", ferr)
 				return
 			}
 			if existing != nil {
-				issue, uerr := s.upsertPipelineTask(boardStore, board, existing, req, entry.Name, botArgs, blockers)
+				issue, uerr := s.upsertPipelineTask(boardStore, board, existing, req, bot.Name, botArgs, blockers)
 				if uerr != nil {
 					if strings.Contains(uerr.Error(), "cycle") {
 						s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: %v", uerr)
@@ -227,7 +236,7 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		State:    state,
 		Labels:   append([]string(nil), req.Labels...),
 		Priority: req.Priority,
-		Bot:      entry.Name,
+		Bot:      bot.Name,
 		BotArgs:  cloneStringMap(req.BotArgs),
 		External: req.External,
 	}
@@ -355,23 +364,32 @@ func (s *Server) handlePipelineBoardTaskUpdate(w http.ResponseWriter, r *http.Re
 		patch.Title = &title
 	}
 	if req.Bot != nil {
-		bot := strings.TrimSpace(*req.Bot)
+		name := strings.TrimSpace(*req.Bot)
 		// An empty bot would silently unbind the ticket — it then never
 		// launches and folds into Backlog with no UX to recover. Creation
 		// already rejects a missing bot; the patch must too (unbinding, if
 		// ever wanted, should be an explicit operation, not a blank field).
-		if bot == "" {
+		if name == "" {
 			s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board update: bot cannot be empty")
 			return
 		}
-		if _, found, ferr := s.findBot(bot); ferr != nil {
+		// Same tier order as the create check and the launch: a re-binding
+		// this lane refuses is one the launch would have served.
+		caller, _ := auth.FromContext(r.Context())
+		bot, found, ferr := s.resolvePipelineBot(r.Context(), caller.TeamID, name)
+		if ferr != nil {
 			s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board update: discover bot: %v", ferr)
 			return
-		} else if !found {
-			s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board update: bot %q not found", bot)
+		}
+		if !found {
+			s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board update: bot %q not found", name)
 			return
 		}
-		patch.Bot = &bot
+		bot.Launch.Cleanup()
+		// Record the canonical name, as creation does: the two write the
+		// same field and a card must not read differently for having been
+		// re-bound rather than created.
+		patch.Bot = &bot.Name
 	}
 	if req.Blockers != nil {
 		normalized := native.NormalizeBlockers(*req.Blockers)

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/botsource"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The pipelines control center is the FIFTH launch surface of the #871
+// class: its board is selected from the request's active team
+// (cloudBoardResolve), so the bot a card names must resolve through the
+// same team → platform → baked order every other surface uses. Resolving
+// it tenant-free serves a team the ORIGIN of the bot it forked, and makes
+// a bot only that team authored impossible to card at all.
+
+// bakeProbeBundle writes the baked catalog's `probe` as a real bundle
+// directory (manifest + main.bot) and returns the discovery root. A bundle
+// and not a loose .bot: a cloud launch freezes the bot's collection before
+// compiling, and that snapshot is rooted at the bundle's main.bot.
+func bakeProbeBundle(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "probe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: probe\nversion: 1.0.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.bot"), []byte(tierBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// pipelineTierEnv is a cloud-shaped pipelines control center for team t1:
+// its own board behind CloudBoardFor, a catalog baked with `probe`, and a
+// bot-source store the test seeds rows into.
+type pipelineTierEnv struct {
+	srv   *Server
+	board *native.Store
+	pub   *tierPublisher
+}
+
+func newPipelineTierEnv(t *testing.T) *pipelineTierEnv {
+	t.Helper()
+	s := newOrgTestServer(t)
+	s.cfg.Mode = "cloud"
+	seedGate(t, s, gateSpec{id: "t1"})
+
+	s.cfg.Bots.Paths = []string{bakeProbeBundle(t)}
+	s.botSources = botsource.NewMemoryStore()
+
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = board.Close() })
+	s.cfg.CloudBoardFor = func(teamID string) native.BoardStore {
+		if teamID == "t1" {
+			return board
+		}
+		return nil
+	}
+
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = rs
+	pub := &tierPublisher{}
+	s.runs = newTestRunviewService(t, "", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+	return &pipelineTierEnv{srv: s, board: board, pub: pub}
+}
+
+// seedRow stores one bot bundle for a tenant.
+func (e *pipelineTierEnv) seedRow(t *testing.T, tenant, slug, body string) {
+	t.Helper()
+	if _, err := e.srv.botSources.Create(store.WithTenant(context.Background(), tenant), botsource.BotSource{
+		TenantID: tenant, Slug: slug,
+		Files: map[string]string{botsource.MainBotFile: body},
+	}); err != nil {
+		t.Fatalf("seed %s/%s: %v", tenant, slug, err)
+	}
+}
+
+// req builds a request authenticated as a member of t1 — the identity the
+// board itself is resolved from.
+func (e *pipelineTierEnv) req(method, path, body string) *http.Request {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	return r.WithContext(auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", TeamID: "t1", OrgID: "t1"}))
+}
+
+// createCard posts a task and returns the created card.
+func (e *pipelineTierEnv) createCard(t *testing.T, body string) native.Issue {
+	t.Helper()
+	w := httptest.NewRecorder()
+	e.srv.handlePipelineBoardTaskCreate(w, e.req(http.MethodPost, "/api/v1/pipeline-board/tasks", body))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create card = %d %s, want 201", w.Code, w.Body.String())
+	}
+	var card native.Issue
+	if err := json.Unmarshal(w.Body.Bytes(), &card); err != nil {
+		t.Fatalf("decode card: %v", err)
+	}
+	return card
+}
+
+// launchCard drives the operator's explicit "launch now".
+func (e *pipelineTierEnv) launchCard(t *testing.T, id string) {
+	t.Helper()
+	r := e.req(http.MethodPost, "/api/v1/pipeline-board/tasks/"+id+"/launch", "")
+	r.SetPathValue("id", id)
+	w := httptest.NewRecorder()
+	e.srv.handlePipelineBoardTaskLaunch(w, r)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("launch card = %d %s, want 202", w.Code, w.Body.String())
+	}
+}
+
+// Half 1 — a team that forked a catalog bot must run ITS fork from the
+// pipelines board. The card is the team's (the board resolves per team);
+// serving it the catalog bundle is a silent substitution.
+func TestPipelineBoardLaunchServesTheTeamsFork(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	env.seedRow(t, "t1", "probe", tierForkBot)
+
+	card := env.createCard(t, `{"bot":"probe","title":"fork me"}`)
+	env.launchCard(t, card.ID)
+
+	assertServedByTheFork(t, "pipelines control center", env.pub.only(t))
+}
+
+// Half 2 — a bot ONLY the team authored has no filesystem path at all
+// (materializeBotEntries blanks it), so a lane that cards and launches by
+// path cannot serve it: the card is refused at create, and there is no
+// second way in.
+func TestPipelineBoardCardsAndLaunchesATeamAuthoredBot(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	env.seedRow(t, "t1", "teamonly", tierForkBot)
+
+	card := env.createCard(t, `{"bot":"teamonly","title":"authored here"}`)
+	if card.Bot != "teamonly" {
+		t.Fatalf("card bot = %q, want teamonly", card.Bot)
+	}
+	env.launchCard(t, card.ID)
+
+	spec := env.pub.only(t)
+	if !strings.Contains(spec.Source, "TEAMFORK") {
+		t.Errorf("the launch ran a bundle that is not the team's own (source: %q)", spec.Source)
+	}
+	if spec.BotSourceTier != store.BotSourceTierTeam {
+		t.Errorf("bot_source_tier = %q, want %q", spec.BotSourceTier, store.BotSourceTierTeam)
+	}
+	if spec.BotBundle == nil || spec.BotBundle.TenantID != "t1" || spec.BotBundle.Slug != "teamonly" {
+		t.Errorf("bundle ref = %+v, want the team's own row so the runner rebuilds it", spec.BotBundle)
+	}
+}
+
+// Half 2b — the update handler's admission check must reach the same tier
+// as the launch: a bot only the team authored is a legal re-binding.
+func TestPipelineBoardUpdateAcceptsATeamAuthoredBot(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	env.seedRow(t, "t1", "teamonly", tierForkBot)
+
+	card := env.createCard(t, `{"bot":"probe","title":"rebind me"}`)
+	r := env.req(http.MethodPatch, "/api/v1/pipeline-board/tasks/"+card.ID, `{"bot":"teamonly"}`)
+	r.SetPathValue("id", card.ID)
+	w := httptest.NewRecorder()
+	env.srv.handlePipelineBoardTaskUpdate(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update bot = %d %s, want 200 — the team's own bot is not in the catalog and must still bind", w.Code, w.Body.String())
+	}
+	got, err := env.board.Get(card.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Bot != "teamonly" {
+		t.Fatalf("card bot = %q, want teamonly", got.Bot)
+	}
+}
+
+// Half 3 — the admission LOOP is local-only (pipelineAdmissionEnabled
+// refuses cloud), so its board carries no tenant: it must keep resolving
+// platform-over-baked with an empty team, and must never be handed some
+// team's row.
+func TestPipelineAdmissionLoopResolvesWithNoTeam(t *testing.T) {
+	s := newOrgTestServer(t)
+	seedGate(t, s, gateSpec{id: "t1"})
+	botsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(botsDir, "probe.bot"), []byte(tierBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Bots.Paths = []string{botsDir}
+	// A team row exists for the same slug — the loop has no team, so it
+	// must not be reachable from here.
+	s.botSources = botsource.NewMemoryStore()
+	if _, err := s.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
+		TenantID: "t1", Slug: "probe",
+		Files: map[string]string{botsource.MainBotFile: tierForkBot},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = board.Close() })
+	s.cfg.NativeTrackerStore = board
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cfg.Store = rs
+	pub := &tierPublisher{}
+	s.runs = newTestRunviewService(t, "", runview.WithStore(rs), runview.WithLaunchPublisher(pub))
+
+	if !s.pipelineAdmissionEnabled() {
+		t.Fatal("precondition: the local admission loop must be enabled here")
+	}
+	iss, err := board.Create(native.Issue{Title: "local ticket", State: native.StateReady, Bot: "probe"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.admitReadyPipelines()
+
+	spec := pub.only(t)
+	if !strings.Contains(spec.Source, "BAKED") {
+		t.Errorf("the loop launched %q — with no team it must serve the baked catalog, never a team's row", spec.Source)
+	}
+	if spec.BotSourceTier != store.BotSourceTierBaked {
+		t.Errorf("bot_source_tier = %q, want %q", spec.BotSourceTier, store.BotSourceTierBaked)
+	}
+	got, err := board.Get(iss.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != native.StateInProgress {
+		t.Fatalf("ticket state = %q, want in_progress — the loop did not launch it", got.State)
+	}
+}

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -237,8 +237,14 @@ func TestPipelineBoardDisabledBotLeavesNoBundleBehind(t *testing.T) {
 }
 
 // Half 2b — the update handler's admission check must reach the same tier
-// as the launch: a bot only the team authored is a legal re-binding.
+// as the launch: a bot only the team authored is a legal re-binding. It is
+// also the THIRD site paying for a materialization it does not run, so it
+// carries the same ownership assertion as create and launch: three sites,
+// one contract, and the ordering slip that shipped at one of them is only
+// caught if every one is checked.
 func TestPipelineBoardUpdateAcceptsATeamAuthoredBot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
 	env := newPipelineTierEnv(t)
 	env.seedRow(t, "t1", "teamonly", tierForkBot)
 
@@ -256,6 +262,9 @@ func TestPipelineBoardUpdateAcceptsATeamAuthoredBot(t *testing.T) {
 	}
 	if got.Bot != "teamonly" {
 		t.Fatalf("card bot = %q, want teamonly", got.Bot)
+	}
+	if n := countBundleTempDirs(t, tmp); n != 0 {
+		t.Errorf("the re-binding check left %d materialized bundle dir(s) behind — it resolves a bundle only to answer whether the bot exists", n)
 	}
 }
 

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -332,6 +332,41 @@ func TestPipelineBoardPlatformMetadataDescribesTheBundleThatRuns(t *testing.T) {
 	})
 }
 
+// A catalog that will not PARSE is not a catalog without this bot in it.
+// The baked tier reports both the same way — resolveBotTieredRaw turns any
+// ResolveBotPath failure into "nothing resolved", and one malformed
+// manifest.yaml under the discovery roots fails the walk for every bot — so
+// the lane has to ask before it answers "not found". Before this lane went
+// through the tiers, findBot propagated that error and the operator was told
+// what to fix.
+func TestPipelineBoardSaysWhenTheCatalogItselfWillNotParse(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	// A second bundle, alongside the healthy `probe`, whose manifest is not
+	// YAML. Discovery walks the whole root, so `probe` stops resolving too.
+	broken := filepath.Join(env.srv.cfg.Bots.Paths[0], "broken")
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "manifest.yaml"), []byte("name: broken\nversion: [1.0.0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, "main.bot"), []byte(tierBakedBot), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	env.srv.handlePipelineBoardTaskCreate(w, env.req(http.MethodPost, "/api/v1/pipeline-board/tasks", `{"bot":"probe","title":"catalog is broken"}`))
+	if w.Code == http.StatusNotFound {
+		t.Fatalf("create = 404 %s — the catalog could not be READ, and the operator is being sent to look for a bot that is there", w.Body.String())
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("create = %d %s, want 500 carrying the parse failure", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "manifest") {
+		t.Errorf("refusal = %s, want the manifest parse failure that actually blocked the resolution", body)
+	}
+}
+
 // blipStore fails the Nth GetBySlug of one tenant and serves every other
 // read normally — the transient store failure that lands BETWEEN the two
 // reads a single resolution makes.

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -441,6 +441,47 @@ func assertUnreadableMetadataRefusal(t *testing.T, env *pipelineTierEnv) {
 	}
 }
 
+// The third leg: a platform override DELETED inside the overlay's 30s
+// window. The live store no longer has it, so the launch resolves the BAKED
+// bundle — while the cached overlay still describes the override on every
+// replica that did not serve the delete. Reading `enabled` there refuses a
+// card whose bundle is enabled and would run.
+func TestPipelineBoardIgnoresADeletedOverrideStillInTheOverlay(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	created, err := env.srv.botSources.Create(store.WithTenant(context.Background(), botsource.PlatformTenantID), botsource.BotSource{
+		TenantID: botsource.PlatformTenantID, Slug: "probe",
+		Files: map[string]string{
+			botsource.MainBotFile: strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1),
+			"manifest.yaml":       "name: probe\nversion: 2.0.0\nenabled: false\n",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed the override: %v", err)
+	}
+	// Warm the overlay WITH the override present, then delete it: this is
+	// the state of every replica that did not serve the delete.
+	if _, _, err := env.srv.effectiveFindByNameForTeam(context.Background(), "t1", "probe"); err != nil {
+		t.Fatalf("warm the overlay: %v", err)
+	}
+	if err := env.srv.botSources.Delete(store.WithTenant(context.Background(), botsource.PlatformTenantID), created.ID); err != nil {
+		t.Fatalf("delete the override: %v", err)
+	}
+
+	// The baked `probe` is enabled, and it is what the launch now resolves.
+	card := env.createCard(t, `{"bot":"probe","title":"override withdrawn"}`)
+	r := env.req(http.MethodPost, "/api/v1/pipeline-board/tasks/"+card.ID+"/launch", "")
+	r.SetPathValue("id", card.ID)
+	w := httptest.NewRecorder()
+	env.srv.handlePipelineBoardTaskLaunch(w, r)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("launch = %d %s, want 202 — the bundle that runs is the ENABLED baked `probe`, "+
+			"and `enabled` was read off an override the store no longer has", w.Code, w.Body.String())
+	}
+	if spec := env.pub.only(t); !strings.Contains(spec.Source, "BAKED") {
+		t.Errorf("the launch ran %q, want the baked bundle the deleted override no longer shadows", spec.Source)
+	}
+}
+
 // Half 3 — the admission LOOP is local-only (pipelineAdmissionEnabled
 // refuses cloud), so its board carries no tenant: it must keep resolving
 // platform-over-baked with an empty team, and must never be handed some

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -259,6 +259,69 @@ func TestPipelineBoardUpdateAcceptsATeamAuthoredBot(t *testing.T) {
 	}
 }
 
+// The MIDDLE tier the lane never reached either: a stored platform row has
+// no filesystem path, so before the tiered resolution a card bound to a
+// deployment-wide override compiled from an empty FilePath. This is the
+// same class as the team fork, one tier down.
+func TestPipelineBoardServesAPlatformOverride(t *testing.T) {
+	env := newPipelineTierEnv(t)
+	env.seedRow(t, botsource.PlatformTenantID, "probe", strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1))
+
+	card := env.createCard(t, `{"bot":"probe","title":"override me"}`)
+	env.launchCard(t, card.ID)
+
+	spec := env.pub.only(t)
+	if !strings.Contains(spec.Source, "PLATFORM") {
+		t.Errorf("the launch ran a bundle that is not the deployment's override (source: %q)", spec.Source)
+	}
+	if spec.BotSourceTier != store.BotSourceTierPlatform {
+		t.Errorf("bot_source_tier = %q, want %q", spec.BotSourceTier, store.BotSourceTierPlatform)
+	}
+}
+
+// The metadata half must describe the artifact the LAUNCH selected. The
+// platform tier is where the two can be read through different mechanisms:
+// the launch reads the store live, while the catalog overlay is served from
+// a 30s cache invalidated only on the replica that wrote. Both cases below
+// warm that cache BEFORE the push, which is every other replica's state for
+// the window after `iterion remote admin bots push`.
+func TestPipelineBoardPlatformMetadataDescribesTheBundleThatRuns(t *testing.T) {
+	t.Run("a freshly pushed override is not a launchable bundle nothing describes", func(t *testing.T) {
+		env := newPipelineTierEnv(t)
+		// Warm the overlay while the platform tenant holds nothing.
+		if _, found, err := env.srv.effectiveFindByNameForTeam(context.Background(), "t1", "newbot"); err != nil || found {
+			t.Fatalf("precondition: found=%v err=%v, want a cold miss", found, err)
+		}
+		env.seedRow(t, botsource.PlatformTenantID, "newbot", strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1))
+
+		// Launchable on the live store; a stale overlay makes it uncardable.
+		card := env.createCard(t, `{"bot":"newbot","title":"pushed just now"}`)
+		env.launchCard(t, card.ID)
+		if spec := env.pub.only(t); !strings.Contains(spec.Source, "PLATFORM") {
+			t.Errorf("the launch ran %q, want the override that was just pushed", spec.Source)
+		}
+	})
+
+	t.Run("an override's own enabled flag wins over the baked twin it shadows", func(t *testing.T) {
+		env := newPipelineTierEnv(t)
+		// The card is created (and the overlay warmed) against the ENABLED
+		// baked `probe`; the override lands after.
+		card := env.createCard(t, `{"bot":"probe","title":"shadowed"}`)
+		env.seedRowWithManifest(t, botsource.PlatformTenantID, "probe",
+			strings.Replace(tierBakedBot, "BAKED", "PLATFORM", 1),
+			"name: probe\nversion: 2.0.0\nenabled: false\n")
+
+		r := env.req(http.MethodPost, "/api/v1/pipeline-board/tasks/"+card.ID+"/launch", "")
+		r.SetPathValue("id", card.ID)
+		w := httptest.NewRecorder()
+		env.srv.handlePipelineBoardTaskLaunch(w, r)
+		if w.Code != http.StatusConflict {
+			t.Fatalf("launch = %d %s, want 409 — the bundle that would run is the DISABLED override, "+
+				"and reading `enabled` off the baked twin it shadows launches it anyway", w.Code, w.Body.String())
+		}
+	})
+}
+
 // Half 3 — the admission LOOP is local-only (pipelineAdmissionEnabled
 // refuses cloud), so its board carries no tenant: it must keep resolving
 // platform-over-baked with an empty team, and must never be handed some

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -95,6 +95,38 @@ func (e *pipelineTierEnv) seedRow(t *testing.T, tenant, slug, body string) {
 	}
 }
 
+// seedRowWithManifest is seedRow for a row that must carry catalog
+// metadata — the `enabled:` flag being the only way to produce a
+// (found=true, Enabled=false) resolution, which is the disabled-bot path.
+func (e *pipelineTierEnv) seedRowWithManifest(t *testing.T, tenant, slug, body, manifest string) {
+	t.Helper()
+	if _, err := e.srv.botSources.Create(store.WithTenant(context.Background(), tenant), botsource.BotSource{
+		TenantID: tenant, Slug: slug,
+		Files: map[string]string{botsource.MainBotFile: body, "manifest.yaml": manifest},
+	}); err != nil {
+		t.Fatalf("seed %s/%s: %v", tenant, slug, err)
+	}
+}
+
+// countBundleTempDirs counts the materializations a bot resolution leaves
+// under the test's private TMPDIR: `storedLaunchBot`'s own dir, and the
+// frozen collection `snapshotLaunchBot` writes in cloud mode. Both are
+// owned by the resolving call and must be gone when it returns.
+func countBundleTempDirs(t *testing.T, tmp string) int {
+	t.Helper()
+	ents, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("read TMPDIR %s: %v", tmp, err)
+	}
+	n := 0
+	for _, e := range ents {
+		if strings.HasPrefix(e.Name(), "iterion-launch-bot-") || strings.HasPrefix(e.Name(), "iterion-bundle-snapshot-") {
+			n++
+		}
+	}
+	return n
+}
+
 // req builds a request authenticated as a member of t1 — the identity the
 // board itself is resolved from.
 func (e *pipelineTierEnv) req(method, path, body string) *http.Request {
@@ -170,6 +202,37 @@ func TestPipelineBoardCardsAndLaunchesATeamAuthoredBot(t *testing.T) {
 	}
 	if spec.BotBundle == nil || spec.BotBundle.TenantID != "t1" || spec.BotBundle.Slug != "teamonly" {
 		t.Errorf("bundle ref = %+v, want the team's own row so the runner rebuilds it", spec.BotBundle)
+	}
+}
+
+// Paying for a resolution means owning what it materialized. A DISABLED bot
+// is the path where the two diverge: the resolution succeeded — a temp
+// bundle dir on disk, and in cloud a second one holding the frozen
+// collection — and the caller then refuses the launch. Every operator click
+// of "launch now" on such a card leaves one full bundle tree under the
+// server pod's TMPDIR, and nothing ever comes back for it.
+func TestPipelineBoardDisabledBotLeavesNoBundleBehind(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	env := newPipelineTierEnv(t)
+	env.seedRowWithManifest(t, "t1", "parked", tierForkBot, "name: parked\nversion: 1.0.0\nenabled: false\n")
+
+	// Creation admits the card (only `start: true` is refused on a disabled
+	// bot) and already reclaims its own materialization.
+	card := env.createCard(t, `{"bot":"parked","title":"disabled bot"}`)
+	if n := countBundleTempDirs(t, tmp); n != 0 {
+		t.Fatalf("card creation left %d materialized bundle dir(s) behind", n)
+	}
+
+	r := env.req(http.MethodPost, "/api/v1/pipeline-board/tasks/"+card.ID+"/launch", "")
+	r.SetPathValue("id", card.ID)
+	w := httptest.NewRecorder()
+	env.srv.handlePipelineBoardTaskLaunch(w, r)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("launch of a card bound to a disabled bot = %d %s, want 409", w.Code, w.Body.String())
+	}
+	if n := countBundleTempDirs(t, tmp); n != 0 {
+		t.Errorf("the refused launch left %d materialized bundle dir(s) behind — one per operator click, with no reaper", n)
 	}
 }
 

--- a/pkg/server/pipeline_bot_tier_test.go
+++ b/pkg/server/pipeline_bot_tier_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -329,6 +330,80 @@ func TestPipelineBoardPlatformMetadataDescribesTheBundleThatRuns(t *testing.T) {
 				"and reading `enabled` off the baked twin it shadows launches it anyway", w.Code, w.Body.String())
 		}
 	})
+}
+
+// blipStore fails the Nth GetBySlug of one tenant and serves every other
+// read normally — the transient store failure that lands BETWEEN the two
+// reads a single resolution makes.
+type blipStore struct {
+	botsource.Store
+	tenant string
+	failOn int // 1-based index of the GetBySlug call to fail
+	seen   int
+}
+
+func (b *blipStore) GetBySlug(ctx context.Context, tenantID, slug string) (botsource.BotSource, error) {
+	if tenantID == b.tenant {
+		b.seen++
+		if b.seen == b.failOn {
+			return botsource.BotSource{}, errors.New("mongo: connection reset by peer")
+		}
+	}
+	return b.Store.GetBySlug(ctx, tenantID, slug)
+}
+
+// A row whose OWN metadata cannot be read is the other way the two halves
+// come apart: the launch resolves the fork (a non-empty main.bot is all it
+// asks for), while the metadata read falls THROUGH to the tier below and
+// lands on the ORIGIN this fork replaces. Pairing the fork's bundle with the
+// origin's `enabled` and canonical name is the substitution the chokepoint
+// exists to refuse — and refusing it explicitly is the same contract the
+// launch half already keeps, where only ErrNotFound may fall through.
+func TestPipelineBoardRefusesAForkWhoseOwnMetadataIsUnreadable(t *testing.T) {
+	// Both cases card the slug of an ENABLED baked `probe` — the entry a
+	// fall-through hands back, and the reason silence here is not neutral.
+	t.Run("a store blip between the two reads", func(t *testing.T) {
+		env := newPipelineTierEnv(t)
+		env.seedRow(t, "t1", "probe", tierForkBot)
+		// The launch half reads the row (call 1) and materializes the fork;
+		// the metadata read (call 2) is the one that blips.
+		env.srv.botSources = &blipStore{Store: env.srv.botSources, tenant: "t1", failOn: 2}
+
+		assertUnreadableMetadataRefusal(t, env)
+	})
+
+	t.Run("a bundle whose metadata does not materialize", func(t *testing.T) {
+		env := newPipelineTierEnv(t)
+		// No manifest.yaml and two workflows: discovery cannot say which one
+		// the row IS, so it describes the row with neither.
+		if _, err := env.srv.botSources.Create(store.WithTenant(context.Background(), "t1"), botsource.BotSource{
+			TenantID: "t1", Slug: "probe",
+			Files: map[string]string{botsource.MainBotFile: tierForkBot, "child.bot": tierForkBot},
+		}); err != nil {
+			t.Fatalf("seed t1/probe: %v", err)
+		}
+
+		assertUnreadableMetadataRefusal(t, env)
+	})
+}
+
+// assertUnreadableMetadataRefusal drives a card create for `probe` and
+// requires an explicit refusal naming the row — never a card admitted on the
+// baked twin's metadata, and never a launch of the fork behind it.
+func assertUnreadableMetadataRefusal(t *testing.T, env *pipelineTierEnv) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	env.srv.handlePipelineBoardTaskCreate(w, env.req(http.MethodPost, "/api/v1/pipeline-board/tasks", `{"bot":"probe","title":"unreadable fork"}`))
+	if w.Code == http.StatusCreated {
+		t.Fatalf("the card was created (%d) — the team's fork was admitted on the ORIGIN's metadata, "+
+			"which is not the bundle that would run", w.Code)
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("create = %d %s, want 500 naming the row whose metadata cannot be read", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "t1/probe") {
+		t.Errorf("refusal = %s, want the tenant/slug of the row the operator has to fix", body)
+	}
 }
 
 // Half 3 — the admission LOOP is local-only (pipelineAdmissionEnabled


### PR DESCRIPTION
Closes #970.

## The bug

The pipelines control center resolved its bot on the **platform + baked** tiers and launched **by filesystem path** (`entry.MainFile()`), bypassing the tiered resolver #871 threaded through the other four automated launch surfaces. Two silent consequences:

1. **A team that forked a catalog bot got the ORIGIN.** The card is the team's — `resolvePipelineBoardStore` resolves per team in cloud — and the run was served by the catalog bundle, while board, triggers, schedules and webhooks all served the fork.
2. **A bot only the team authored could not be carded at all.** A stored entry has `Path == ""` (blanked by `materializeBotEntries`), so `MainFile()` had nothing to launch from.

## One choke point, not two parallel edits

The issue notes the two halves are inseparable: making the admission check tenant-aware alone would let an operator create cards that can never launch, and fixing the launch alone leaves the check refusing cards it should accept.

The board lane already solved that exact problem with a single shared helper (`boardLaunchPreconditions`, used by both `admitBoardCard` and `processBoardCard`). This mirrors it: `resolvePipelineBot(ctx, teamID, botID)` resolves once and returns both halves — the canonical name and enabled flag the checks read, and the `*launchBot` the launch runs and stamps. Three call sites, one resolution path; after the change no other site in the lane selects a bot.

When the two halves disagree — a launchable bundle no metadata describes — it **errors explicitly** rather than guessing: guessing "enabled" is how a disabled bot launches, guessing "absent" is how a launchable bot becomes uncardable.

## Scope, deliberately bounded

`pipelineAdmissionEnabled()` requires `s.cfg.Mode != "cloud"`, so the background admission loop **never runs in cloud** — it drives the local `NativeTrackerStore` only, where the tenant is `""` by construction. No tenant was invented for it; it passes `""` and falls through platform → baked exactly as before. The complement was checked too: the launch/create/update handlers *are* reachable in cloud (`resolvePipelineBoardStore` → `cloudBoardResolve` → `cfg.CloudBoardFor(id.TeamID)`), which is precisely why they must pass the team.

Both `tenantFreeMetadataAllowed` entries are removed — leaving them would let the next sweep pass on a hole that is closed. `pipeline_admission.go` is added to `teamlessResolveAllowed` for the loop's single literal `""`, and **that guard was verified to bite**: deleting the allowlist line fails the sweep naming the file.

## Red first

Obtained against unmodified `origin/main` production code, with the final tests in place:

    --- FAIL: TestPipelineBoardLaunchServesTheTeamsFork
        launched a bundle that is not the team's fork of `probe` (source: "")
        bundle ref = <nil>, want the team's row (tenant t1) so the runner
        rebuilds the fork, not the baked twin
        bot_source_tier = "", want "team"
    --- FAIL: TestPipelineBoardCardsAndLaunchesATeamAuthoredBot
        create card = 404 {"error":"pipeline board task: bot \"teamonly\" not found"}, want 201
    --- FAIL: TestPipelineBoardUpdateAcceptsATeamAuthoredBot
        update bot = 404 ..., want 200
    --- FAIL: TestPipelineAdmissionLoopResolvesWithNoTeam
        the loop launched "" — with no team it must serve the baked catalog

**Honest note on the fourth test**: its load-bearing half — the loop launches, and launches the *baked* bundle — was already true before. It is red above only because the pre-fix loop stamped neither `Source` nor `BotSourceTier`. Its real value is as a regression guard on the ticket-state assertion, which passed both before and after.

## Deviation from the plan, and why

The brief said to route through `resolveBotSource`; this calls `resolveBotTiered` directly. `resolveBotSource` is a two-line wrapper that turns "not found" into an `error`, and all three sites need a `found bool` to keep their 404-vs-500 and skip-vs-fail distinctions — string-matching an error message to recover that would be worse.

Local mode is unchanged byte-for-byte for a baked bot: with `bundleDir == ""`, `compileForLaunch` takes the same `compileWith(path, …, true, nil)` path and `lb.Source` is the exact file bytes, so the resume hash is identical, and bundle skill/preset mirroring still runs.

One small behaviour change, made deliberately: the update handler now stores the **canonical** bot name, as create already did. The two writing the same field differently was an inconsistency, and every downstream resolver tolerates both spellings.

## Verification

`task check` **EXIT=0** (142 packages, lint + go + e2e + goldens + studio vitest 1351/1351 + pi-ext + brand). `go test -race ./pkg/server/...` **EXIT=0**. `task openapi:gen` shows no drift — nothing persisted or serialized changed.

## Flagged, not touched

`pkg/dispatcher/routing_runner.go` and `engine_runner.go` also resolve and launch by path, but they are the standalone `iterion dispatch` daemon: local-only, no server tiers, no tenancy. Outside this class.
