### PR TITLE
fix(forge): a deployment that moved could never repair its own hooks

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -68,11 +68,27 @@ iterion remote forge connections webhook-base <conn-id> \
 iterion remote forge connections webhook-base <conn-id> --url ""   # clear
 ```
 
-It takes effect at the next provision, and the value must be scheme+host
-(the `/api/webhooks/<provider>/<id>` route is appended to it). An
-unparseable or path-carrying value is refused with 422 at the PATCH, on
-purpose: a wrong base does not fail when it is set — it fails as hooks that
-register successfully and never arrive.
+It takes effect at the next provision of each repo on that connection, and
+the value must be scheme+host (the `/api/webhooks/<provider>/<id>` route is
+appended to it). An unparseable or path-carrying value is refused with 422 at
+the PATCH, on purpose: a wrong base does not fail when it is set — it fails
+as hooks that register successfully and never arrive.
+
+Re-provisioning a repo is the gesture that applies it, and it is a
+**reconcile**: `POST /api/teams/{id}/forge/repo-bots` with the repo's current
+`bot_ids` and nothing else (`launch_vars`, `overlap`,
+`auto_fix_on_gate_failure` and `hold_labels` all mean "leave the stored one
+alone" when omitted, so re-sending them is a chance to mistype
+`gate_context`, not a safety). It compares the address the forge *should* be
+calling against the one it is, and rewrites the hook in place when they
+differ — same hook id, same webhook id, and the fresh `iwh_` reaches both
+ends together. Where nothing has moved it touches the forge not at all, so
+it is safe to re-run across a whole fleet.
+
+That comparison is what makes a public-URL change reachable at all: the
+idempotence test used to look at bots and events only, so an instance that
+moved could never repair its own hooks — provisioning answered 200, changed
+nothing, and the deliveries kept going to an address it no longer served.
 
 Two more properties of that endpoint worth knowing:
 

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -336,12 +336,25 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		return ProvisionResult{}, fmt.Errorf("forge: bots %v declare no forge events to subscribe to", desiredBots)
 	}
 
-	// Idempotent no-op: same bots + same events already provisioned. Still
-	// reconcile the per-bot token bindings before returning — an integration
-	// provisioned before the binding fix landed has none, so the board-launch
-	// path can't authenticate until a re-provision backfills them. Cheap and
-	// idempotent (ensureBotBinding no-ops when the binding already matches).
-	if hasExisting && equalStringSet(existing.BotIDs, desiredBots) && equalStringSet(existing.EventsNormalized, eventsNormalized) {
+	// The address the forge SHOULD be calling, which is not a property of the
+	// request: it moves when the deployment's public URL moves, or when a
+	// connection starts (or stops) pinning its own base. Comparing it here is
+	// what makes the no-op below an actual reconcile — a hook left on the old
+	// host is a repo whose deliveries stop, and re-running provisioning is the
+	// gesture an operator reaches for to repair exactly that.
+	desiredHookURL := ""
+	if hasExisting {
+		desiredHookURL = o.inboundURL(conn, existing.WebhookID)
+	}
+
+	// Idempotent no-op: same bots, same events AND the hook already points
+	// where it should. Still reconcile the per-bot token bindings before
+	// returning — an integration provisioned before the binding fix landed
+	// has none, so the board-launch path can't authenticate until a
+	// re-provision backfills them. Cheap and idempotent (ensureBotBinding
+	// no-ops when the binding already matches).
+	if hasExisting && equalStringSet(existing.BotIDs, desiredBots) && equalStringSet(existing.EventsNormalized, eventsNormalized) &&
+		existing.HookURL == desiredHookURL {
 		for _, b := range desiredBots {
 			if err := o.ensureBotBinding(ctx, req.TenantID, b, frByBot[b].SecretName(), existing.ManagedSecretID); err != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: bind %s for bot %s: %w", frByBot[b].SecretName(), b, err)

--- a/pkg/forge/orchestrator_hook_url_drift_test.go
+++ b/pkg/forge/orchestrator_hook_url_drift_test.go
@@ -1,0 +1,155 @@
+package forge
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// TestReprovisionRepairsAHookLeftOnTheOldHost: the deployment's public URL is
+// not a property of the request, so an already-provisioned repo can end up
+// with a hook pointing at an address the forge still calls and iterion no
+// longer answers on. Re-running provisioning is the gesture an operator
+// reaches for to repair that, and it has to actually do it: the idempotent
+// no-op compared bots and events only, so it returned 200 having changed
+// nothing while every delivery kept going to the old host.
+func TestReprovisionRepairsAHookLeftOnTheOldHost(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+	req := ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	before := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(before, "https://iterion.example.com/") {
+		t.Fatalf("setup: hook = %q", before)
+	}
+
+	// The deployment moves. Nothing about the repo or its bots changes.
+	o.PublicURL = "https://iterion.cloud"
+
+	// EXACTLY the same request an operator would re-send.
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	got := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(got, "https://iterion.cloud/api/webhooks/") {
+		t.Fatalf("the hook was left on the old host (%q). Re-provisioning reported success "+
+			"and changed nothing, so the repo's deliveries keep going somewhere iterion "+
+			"no longer serves — and no error says so anywhere.", got)
+	}
+}
+
+// TestReprovisionRewritesInPlace: the repair must not strand the old hook or
+// leave the two ends disagreeing. It DOES mint a fresh iwh_ — that is the
+// documented design (a mutating provision never needs the prior plaintext,
+// and iterion holds both ends) — so what matters is not that the secret is
+// stable but that the token handed to the forge is the one the stored config
+// will accept. A rotation that reached only one end would authenticate
+// nothing, and the symptom would be deliveries rejected at the door.
+func TestReprovisionRewritesInPlace(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+	req := ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}
+	res, err := o.Provision(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstHook := fa.hooks["group/api"].ID
+	createsBefore := fa.creates
+
+	o.PublicURL = "https://iterion.cloud"
+	res2, err := o.Provision(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fa.hooks["group/api"].ID != firstHook {
+		t.Errorf("hook id changed (%s → %s): the old hook is stranded on the forge and the "+
+			"new one carries a different secret", firstHook, fa.hooks["group/api"].ID)
+	}
+	if fa.creates != createsBefore {
+		t.Errorf("CreateHook was called again (%d → %d); the repair must UPDATE the hook it owns",
+			createsBefore, fa.creates)
+	}
+	if res2.WebhookID != res.WebhookID {
+		t.Errorf("webhook id changed (%s → %s)", res.WebhookID, res2.WebhookID)
+	}
+	// The lockstep: whatever token went to the forge must be the one the
+	// stored config accepts. Both ends move together or neither does.
+	cfg, err := o.Webhooks.Get(ctx, res2.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !webhooks.VerifyToken(fa.lastSecret, cfg.TokenHash) {
+		t.Error("the token registered on the forge does not verify against the stored config: " +
+			"a rotation reached one end only, and every delivery would be refused at the door")
+	}
+}
+
+// TestReprovisionStillNoOpsWhenNothingMoved: the comparison must not turn
+// every re-provision into a forge write. A fleet-wide reconcile is only safe
+// to re-run if it is silent where there is nothing to repair.
+func TestReprovisionStillNoOpsWhenNothingMoved(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+	req := ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	updatesBefore, createsBefore := fa.updates, fa.creates
+
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	if fa.updates != updatesBefore || fa.creates != createsBefore {
+		t.Errorf("an unchanged re-provision touched the forge (updates %d→%d, creates %d→%d)",
+			updatesBefore, fa.updates, createsBefore, fa.creates)
+	}
+}
+
+// TestReprovisionFollowsAConnectionPin: the desired address is the connection's
+// when it pins one, so pinning a base AFTER a repo was provisioned repairs that
+// repo too. Without it the pin would only apply to repos provisioned later —
+// the half-applied shape this whole mechanism exists to avoid.
+func TestReprovisionFollowsAConnectionPin(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	conn := seedConn(t, o, sealer)
+	ctx := context.Background()
+	req := ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	conn.WebhookBaseURL = "https://iterion.allowlisted.example"
+	if err := o.Connections.Update(ctx, conn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Provision(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+
+	got := hookURLFor(t, fa, "group/api")
+	if !strings.HasPrefix(got, "https://iterion.allowlisted.example/api/webhooks/") {
+		t.Fatalf("hook = %q, want the connection's newly pinned base — a pin set after "+
+			"provisioning must reach the repos already provisioned", got)
+	}
+}


### PR DESCRIPTION
## The defect

Provisioning short-circuits when the bot set and the event set already match.
That test never looked at the address the forge is actually calling — but the
hook URL is not a property of the request. It moves when the deployment's
public URL moves, and when a connection starts or stops pinning a base of its
own (#1011).

So the one gesture an operator reaches for — re-run provisioning on the repo —
reported success and changed nothing, while every delivery kept going to a host
iterion no longer answers on. Nothing failed anywhere: not the call, not the
forge, not a log line. The repo simply went quiet.

Found live, migrating this deployment to `iterion.cloud`: the documented step
"re-provision the repos so their hooks follow" turned out to be inert on all
sixteen of them. `upsertHook` would have rewritten the URL in place — it just
was never reached.

## The fix

The idempotence test includes the address, so a re-provision becomes a
**reconcile**:

- drifted → rewrites the hook in place: same hook id, same webhook id, and the
  fresh `iwh_` reaches both ends together;
- unchanged → touches the forge not at all, which is what makes it safe to
  re-run across a whole fleet.

An integration predating the stored `hook_url` reads as drifted once and
repairs itself — the same `UpdateHook` with the address it already had.

## Verification

Four tests, canary-verified: with the address removed from the comparison, the
two that assert the repair fail and the two that describe the unchanged path
stay green. `task lint` clean.

One of the four started red for a reason that was **mine, not the code's**: I
had asserted the webhook secret must survive a URL repair. It must not —
minting a fresh `iwh_` on every mutating provision is deliberate and
documented, so the prior plaintext is never needed and iterion holds both ends.
The assertion now pins the invariant that does exist: the token handed to the
forge verifies against the stored config, so a rotation cannot reach one end
only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)