### PR TITLE
fix(cost): an OpenAI turn was priced as if it had cost nothing to send

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260909122925-6caaec37ef7e
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba h1:J/EWLztoU3pmJ7YOUorC7Ic+Z+t5eyiu//BK4noG1bo=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260909122925-6caaec37ef7e h1:99LO7Q/5NSRbUvkBDNUEIQRcTQNgmj+CmmYupD/G9mA=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260909122925-6caaec37ef7e/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=

--- a/pkg/backend/model/generation_input_tokens_test.go
+++ b/pkg/backend/model/generation_input_tokens_test.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+)
+
+func drainAggregate(t *testing.T, events []api.StreamEvent) aggregatedResponse {
+	t.Helper()
+	ch := make(chan api.StreamEvent, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	agg := aggregateStream(context.Background(), ch)
+	if agg.err != nil {
+		t.Fatalf("aggregate: %v", agg.err)
+	}
+	return agg
+}
+
+// The OpenAI endpoints have no message_start-shaped frame to carry a
+// prompt count on: both learn it only in the terminal usage payload, so
+// claw reports it on message_delta. Reading output there and not input
+// priced every OpenAI turn as if it had cost nothing to send — which
+// matters beyond analysis, since a metered key's spend is computed
+// input×rate + output×rate and feeds an org's monthly cap.
+func TestAggregateStream_TakesInputTokensFromTheDeltaWhenThatIsWhereTheyAre(t *testing.T) {
+	agg := drainAggregate(t, []api.StreamEvent{
+		{Type: api.EventMessageStart},
+		{Type: api.EventContentBlockStart, Index: 0, ContentBlock: api.ContentBlockInfo{Type: "text", Index: 0}},
+		{Type: api.EventContentBlockDelta, Index: 0, Delta: api.Delta{Type: "text_delta", Text: "hi"}},
+		{Type: api.EventContentBlockStop, Index: 0},
+		{Type: api.EventMessageDelta, StopReason: "end_turn", Usage: api.UsageDelta{InputTokens: 4321, OutputTokens: 9}},
+		{Type: api.EventMessageStop},
+	})
+	if agg.usage.InputTokens != 4321 {
+		t.Errorf("InputTokens = %d, want 4321 — an OpenAI turn reads as free to send", agg.usage.InputTokens)
+	}
+	if agg.usage.OutputTokens != 9 {
+		t.Errorf("OutputTokens = %d, want 9", agg.usage.OutputTokens)
+	}
+}
+
+// The other direction, and the one a careless fix breaks: Anthropic and
+// bedrock answer on message_start and send a delta whose input count is
+// zero. Taking the delta unconditionally would erase the real number.
+func TestAggregateStream_DeltaZeroDoesNotEraseTheMessageStartCount(t *testing.T) {
+	agg := drainAggregate(t, []api.StreamEvent{
+		{Type: api.EventMessageStart, InputTokens: 100, CacheReadInputTokens: 7},
+		{Type: api.EventContentBlockStart, Index: 0, ContentBlock: api.ContentBlockInfo{Type: "text", Index: 0}},
+		{Type: api.EventContentBlockDelta, Index: 0, Delta: api.Delta{Type: "text_delta", Text: "hi"}},
+		{Type: api.EventContentBlockStop, Index: 0},
+		{Type: api.EventMessageDelta, StopReason: "end_turn", Usage: api.UsageDelta{OutputTokens: 20}},
+		{Type: api.EventMessageStop},
+	})
+	if agg.usage.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100 — a delta carrying nothing overwrote the message_start count", agg.usage.InputTokens)
+	}
+	if agg.usage.CacheReadTokens != 7 {
+		t.Errorf("CacheReadTokens = %d, want 7", agg.usage.CacheReadTokens)
+	}
+}

--- a/pkg/backend/model/generation_stream.go
+++ b/pkg/backend/model/generation_stream.go
@@ -210,6 +210,15 @@ func aggregateStream(ctx context.Context, ch <-chan api.StreamEvent) aggregatedR
 
 			case api.EventMessageDelta:
 				res.usage.OutputTokens = event.Usage.OutputTokens
+				// The OpenAI endpoints have no message_start-shaped frame
+				// to carry a prompt count on — both learn it only in the
+				// terminal usage payload — so claw reports it here. Taken
+				// only when non-zero: Anthropic and bedrock answer on
+				// message_start and send a delta carrying nothing, which
+				// an unconditional read would erase.
+				if event.Usage.InputTokens > 0 {
+					res.usage.InputTokens = event.Usage.InputTokens
+				}
 				// Exact billed thinking tokens (raw internal reasoning,
 				// independent of thinking.display); 0 when the provider
 				// omits the breakdown.

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/responses.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/responses.go
@@ -510,6 +510,7 @@ func (c *Client) streamResponsesEvents(ctx context.Context, resp *http.Response,
 		reasonOpenOrder []string
 		stopReason      = "end_turn"
 		outputTokens    int
+		inputTokens     int
 		reasoningTokens int
 	)
 
@@ -791,6 +792,7 @@ func (c *Client) streamResponsesEvents(ctx context.Context, resp *http.Response,
 		case "response.completed":
 			if ev.Response != nil && ev.Response.Usage != nil {
 				outputTokens = ev.Response.Usage.OutputTokens
+				inputTokens = ev.Response.Usage.InputTokens
 				reasoningTokens = ev.Response.Usage.OutputTokensDetails.ReasoningTokens
 			}
 			// Reconcile any function_call accumulator that landed
@@ -840,6 +842,7 @@ func (c *Client) streamResponsesEvents(ctx context.Context, resp *http.Response,
 			// a successful empty turn.
 			if ev.Response != nil && ev.Response.Usage != nil {
 				outputTokens = ev.Response.Usage.OutputTokens
+				inputTokens = ev.Response.Usage.InputTokens
 				reasoningTokens = ev.Response.Usage.OutputTokensDetails.ReasoningTokens
 			}
 			reason := "unknown"
@@ -899,7 +902,7 @@ func (c *Client) streamResponsesEvents(ctx context.Context, resp *http.Response,
 		}
 	}
 
-	usage := api.UsageDelta{OutputTokens: outputTokens}
+	usage := api.UsageDelta{OutputTokens: outputTokens, InputTokens: inputTokens}
 	usage.OutputTokensDetails.ThinkingTokens = reasoningTokens
 	if !send(api.StreamEvent{
 		Type:       api.EventMessageDelta,

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openaiwire/stream.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openaiwire/stream.go
@@ -77,6 +77,7 @@ func StreamEvents(ctx context.Context, resp *http.Response, ch chan<- api.Stream
 		toolCalls    = make(map[int]*sseutil.ToolCallAccumulator)
 		finishReason string
 		outputTokens int
+		inputTokens  int
 		sawDone      bool
 	)
 
@@ -105,11 +106,12 @@ func StreamEvents(ctx context.Context, resp *http.Response, ch chan<- api.Stream
 		}
 
 		// Capture usage from the final usage chunk (choices will be empty
-		// there). Only output tokens are surfaced via UsageDelta; input
-		// tokens travel via the provider's own request bookkeeping and are
-		// intentionally discarded here.
+		// there). Both directions ride UsageDelta: this endpoint has no
+		// message_start-shaped frame to carry the prompt count on, so the
+		// terminal chunk is the only place it is ever reported.
 		if chunk.Usage != nil {
 			outputTokens = chunk.Usage.CompletionTokens
+			inputTokens = chunk.Usage.PromptTokens
 		}
 
 		for _, choice := range chunk.Choices {
@@ -222,7 +224,7 @@ func StreamEvents(ctx context.Context, resp *http.Response, ch chan<- api.Stream
 	send(api.StreamEvent{
 		Type:       api.EventMessageDelta,
 		StopReason: stopReason,
-		Usage:      api.UsageDelta{OutputTokens: outputTokens},
+		Usage:      api.UsageDelta{OutputTokens: outputTokens, InputTokens: inputTokens},
 	})
 	send(api.StreamEvent{Type: api.EventMessageStop})
 }

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/types.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/types.go
@@ -369,6 +369,14 @@ type MessageDelta struct {
 // UsageDelta contains token usage info.
 type UsageDelta struct {
 	OutputTokens int `json:"output_tokens"`
+	// InputTokens is the prompt count for providers that only learn it
+	// once the turn is over. Anthropic and Bedrock report theirs on
+	// message_start (StreamEvent.InputTokens) and leave this at 0; the
+	// OpenAI endpoints have no equivalent frame, since both put the
+	// prompt count in the terminal usage payload. A consumer therefore
+	// takes whichever of the two is non-zero — never the later one
+	// unconditionally, which would zero the Anthropic count.
+	InputTokens int `json:"input_tokens"`
 	// OutputTokensDetails carries Anthropic's exact billed breakdown.
 	// ThinkingTokens counts the raw internal reasoning (always the full
 	// amount regardless of thinking.display); 0 when the API omits it.

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/conversation.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/conversation.go
@@ -790,6 +790,14 @@ func (loop *ConversationLoop) runOneTurnStreaming(ctx context.Context, events ch
 		case api.EventMessageDelta:
 			stopReason = event.StopReason
 			outputTokens = event.Usage.OutputTokens
+			// Providers that only learn the prompt count once the turn is
+			// over report it here instead of on message_start (the OpenAI
+			// endpoints). Taken only when non-zero, so a provider that
+			// already answered on message_start is not zeroed by a delta
+			// that carries nothing.
+			if event.Usage.InputTokens > 0 {
+				inputTokens = event.Usage.InputTokens
+			}
 
 		case api.EventMessageStop:
 			// stream complete

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
 # github.com/SherClockHolmes/webpush-go v1.4.0
 ## explicit; go 1.13
 github.com/SherClockHolmes/webpush-go
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260908131953-dd630c6c76ba
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260909122925-6caaec37ef7e
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
Closes the codex half of #992 — the half that had to be **measured before being fixed**, because the ticket rightly refused to assume it mirrored the `claude_code` one. It does not; the two have nothing in common.

## What was actually wrong

**Every OpenAI-family call through claw reported zero input tokens** — not just the ChatGPT-Codex thread this issue started from. Both endpoints report the count, and both translations dropped it:

- `openaiwire` (chat/completions) parsed `prompt_tokens` and never read it, on the stated premise that input tokens *"travel via the provider's own request bookkeeping"*. **There is no such bookkeeping**: the only other carrier is `StreamEvent.InputTokens`, read from `message_start`, which neither OpenAI path ever sets. A confident false derivation, and it is why nobody looked again.
- `/v1/responses` sends `message_start` **bare** and built its `UsageDelta` from the output half alone, at both the completed and the incomplete arm; `oaiResponsesUsage.InputTokens` was declared and never read.

Sweeping claw for any assignment of input tokens returned exactly two hits before this change — the Anthropic SSE client and bedrock. Those two were right; openai and openaiwire were not.

Why codex and not the others: `shouldUseResponsesAPI` routes to `/v1/responses` when `ReasoningEffort != "" && len(Tools) > 0`, which is every agent node on that fil.

## The consequence the ticket did not have

#992 concluded the accounting was right and only the analysis was wrong. That holds for `claude_code`, whose delegate carries its own `cost_usd`. It does **not** hold here — `pkg/runner/loop_metrics.go` prices a claw step from tokens:

    c := inputT*rate.inputUSDPerToken + outputT*rate.outputUSDPerToken

With `inputT` structurally zero, the input half was charged at **zero for every OpenAI call**. On a subscription that is a cosmetic estimate; on a **metered OpenAI API key** the org monthly cost cap, a credential-pool donor's remaining allowance and the run's own `max_cost_usd` all under-counted real money — and input is usually the bulk of a coding turn. Measured on ovh-prod: the codex credential shows 641 516 output tokens against **0** input.

## The fix, and the trap inside it

In **claw** ([SocialGouv/claw-code-go@6caaec3](https://github.com/SocialGouv/claw-code-go/commit/6caaec37ef7e)): `UsageDelta` gains `InputTokens` and both endpoints fill it. The prompt count cannot ride `message_start` here — both endpoints only learn it in the terminal usage payload, long after that frame is gone — so the delta is the only place it can travel. claw's own conversation loop reads it too, so `claw status` stops reporting zero.

Here: `aggregateStream` takes it **only when non-zero**. Anthropic and bedrock answer on `message_start` and then send a delta carrying nothing; an unconditional read would erase the real count. That is the regression a careless version of this fix introduces, and it has its own test.

## Red first

    --- FAIL: TestStreamEvents_SurfacesPromptTokens (openaiwire)
        input tokens = 0, want 4321 — the chunk reported them and the
        translation dropped them
    --- FAIL: TestStreamResponses_SurfacesInputTokens (openai)
        input tokens = 0, want 1234 — the endpoint reported them and the
        translation dropped them
    --- FAIL: TestAggregateStream_TakesInputTokensFromTheDeltaWhenThatIsWhereTheyAre
        InputTokens = 0, want 4321 — an OpenAI turn reads as free to send

`TestAggregateStream_DeltaZeroDoesNotEraseTheMessageStartCount` was green before and stays green — it is a regression guard on the trap above, not evidence, and is labelled so.

The existing `/v1/responses` fixture already carried `"input_tokens":10` and asserted only the output side, which is how the drop survived its own test suite.

## Verification

`task check` **EXIT=0** — 142 packages `ok`, zero `FAIL`. claw's own suite green (44 packages) with the change; the one `plugin/` failure seen on a first full run (`text file busy`) is a load-dependent flake in a package this change cannot reach — it passes 3/3 in isolation both with and without the change, and the full suite passes on a re-run.

The pin moves via `scripts/bump-claw.sh` (never hand-written), `go mod verify` clean.

## What #992 keeps

Point 1 of its Fix stands and is untouched here: a CLI delegate reports one aggregated token count, still booked entirely as **input**, so a consumer reading that field alone is told something the code knows is false. That is a naming decision — a third field, or a flag saying the split is unknown — not a plumbing one, and it deserves its own change.
