### PR TITLE
feat(dsl): authoring lot 0 — `#` comments, positioned diagnostics with fix lines, every doc fence compiled (#1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,10 +407,14 @@ this file uses below). All Go and node tooling come from `devbox.json`;
 A `.devcontainer/devcontainer.json` provides the same environment for VS
 Code / GitHub Codespaces.
 
-**Cross-shell note:** `.bot` tool nodes invoke commands via `sh -c`,
-which on Linux Mint/Ubuntu hosts is **dash**, but inside devbox is
-**bash 5.x**. Author tool commands as POSIX-compatible (no brace
-expansion, no `[[ ]]`, no `<<<`). See
+**Cross-shell note:** a `.bot` tool node's `command:` runs through
+**`bash -c`**, on the host and inside a sandbox alike
+([`executor_tool.go`](pkg/backend/model/executor_tool.go), `toolNodeCommand`
+— bash is pinned precisely because `/bin/sh` is **dash** on Debian-derived
+images). A `script:` node runs the interpreter its `language:` names, and
+`language: sh` is whatever `sh` is on PATH (dash on Linux Mint/Ubuntu, bash
+5.x inside devbox), so author scripts POSIX-compatible (no brace expansion,
+no `[[ ]]`, no `<<<`). See
 [docs/workflow_authoring_pitfalls.md](docs/workflow_authoring_pitfalls.md#shell-portability-for-tool-nodes).
 
 **pnpm via corepack:** the `studio/` workspace is locked to a specific

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1554,7 +1554,7 @@ it **on** — they build what they change. See
 Two things to know when writing one:
 
 - **Non-interactive PATH is the trap.** `tool` nodes run through a
-  non-interactive `sh -c` that never sources a shell profile, so a tool that
+  non-interactive `bash -c` that never sources a shell profile, so a tool that
   is installed but not on `PATH` is a tool that does not exist. The engine
   prepends the devbox profile's bin dir for this reason — don't hand-roll it
   per bot.

--- a/SKILL-run-and-refine.md
+++ b/SKILL-run-and-refine.md
@@ -140,8 +140,9 @@ inspect Git history and external side effects so retries remain idempotent.
 - Run `iterion validate` after every structural edit.
 - Check schemas, prompt references, edge exhaustiveness, declared cycles,
   router-mode properties, convergence, resources, and workspace safety.
-- Add an exit edge for loop exhaustion. Do not make a loop unbounded merely to
-  silence `LOOP_EXHAUSTED`.
+- Add an exit edge for loop exhaustion (a spent loop with no other edge fails
+  the run `NO_OUTGOING_EDGE`). Do not make a loop unbounded merely to silence
+  that failure.
 - Keep decisions that can be computed or tested out of LLM prompts.
 
 ### Structured LLM output

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,8 +44,9 @@ agent, judge, router, human, tool, compute, emit, wait, await_answers, subbot,
 group, use, workflow
 ```
 
-Keep exactly one compiled workflow per file. Use `##` comments. Strings may be
-quoted, backtick-delimited raw strings, or block scalars where accepted.
+Keep exactly one compiled workflow per file. `#` starts a comment (`##` is the
+same comment). Strings may be quoted, backtick-delimited raw strings, or block
+scalars where accepted.
 
 ## Select node kinds deliberately
 
@@ -92,7 +93,7 @@ sync on demand via `await_answers`.
 
 Iterion has five router modes:
 
-```iter
+```iter fragment
 router dispatch:
   mode: fan_out_each
   over: "{{outputs.plan.items}}"
@@ -122,7 +123,7 @@ provide separate workspaces.
 
 Use edge clauses in any order, at most once each:
 
-```iter
+```iter fragment:edges
 src -> dst
 src -> dst when approved
 src -> dst when not approved
@@ -147,6 +148,44 @@ Runtime templates include `vars`, `input`, `outputs`, `artifacts`,
 `{{params.name}}` at compile time. In tool commands, ordinary
 `{{input.field}}` is shell-escaped; `{{!input.field}}` is deliberately raw and
 must receive only trusted executable syntax.
+
+## Rules the grammar does not show
+
+Every one of these is enforced by the compiler or the runtime, and none of
+them can be read off the syntax tables — authors reverse-engineer them from
+shipped bots, so they are written here:
+
+- **A tool node's stdout is its output.** With `output:` declared, the
+  command must print a JSON object matching the schema; other stdout is
+  wrapped as `{"result": "…"}` and the fields downstream expect are absent. A
+  non-zero exit fails the node — wrap a command whose failure is a *result*
+  (a failing test suite) so it exits 0 and reports `passed: false`.
+- **A loop needs an exhaustion exit.** `src -> body as name(N)` next to a bare
+  `src -> exit` is the one legal pair of unconditional edges (the back-edge is
+  exempt from C010); without the bare edge a spent loop dies `LOOP_EXHAUSTED`.
+- **`outputs.*` needs no threading.** `{{outputs.<node>.<field>}}` is
+  readable from any node that runs after the producer; `{{input.<field>}}`
+  only carries the node's declared input and what an edge `with` mapped.
+- **Never quote a `{{ref}}` in a `command:`.** The runtime shell-escapes it as
+  one word; your own quotes close its quoting (C137).
+- **`expr:` values and quoted `when` are expressions, not templates**: write
+  `input.x`, never `{{input.x}}` (C040).
+- **A `#` never means anything else outside a string, a prompt body or a
+  block scalar** — it is a comment, so a literal `{{…}}` example belongs in
+  prose, not in a prompt (every reference in a prompt is validated).
+- **A typed refusal is `fail <name>:`** with an UPPER_SNAKE `code:` — the bare
+  `-> fail` target carries no code.
+
+## Validate in a loop, against the right build
+
+Write, then `iterion validate --json <file>`: every finding carries its
+source position and a `fix:` line, so correct the file at the position
+given, never by guessing. Loop until `valid` is true, then `iterion diagram`
+to check the shape, and only then run. From Claude Code the MCP
+`local_validate` tool returns the same JSON. Validate with the build the bot
+will run on (the `requires.iterion` floor in its manifest): a builtin or a
+property a newer engine added compiles on that engine and dies on an older
+one at its first evaluation (C138).
 
 ## Prefer deterministic controls
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -187,7 +187,8 @@ to check the shape, and only then run. From Claude Code the MCP
 `local_validate` tool returns the same JSON. Validate with the build the bot
 will run on (the `requires.iterion` floor in its manifest): a builtin or a
 property a newer engine added compiles on that engine and dies on an older
-one at its first evaluation (C138).
+one at validation or at its first evaluation — an unknown builtin name is
+C040, an argument count the older evaluator cannot satisfy is C138.
 
 ## Prefer deterministic controls
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -162,7 +162,9 @@ shipped bots, so they are written here:
   (a failing test suite) so it exits 0 and reports `passed: false`.
 - **A loop needs an exhaustion exit.** `src -> body as name(N)` next to a bare
   `src -> exit` is the one legal pair of unconditional edges (the back-edge is
-  exempt from C010); without the bare edge a spent loop dies `LOOP_EXHAUSTED`.
+  exempt from C010); without the bare edge a spent loop leaves the node with
+  no edge to take and the run fails `NO_OUTGOING_EDGE` (the log names the
+  exhausted loop).
 - **`outputs.*` needs no threading.** `{{outputs.<node>.<field>}}` is
   readable from any node that runs after the producer; `{{input.<field>}}`
   only carries the node's declared input and what an edge `with` mapped.

--- a/bots/sec-audit-source/skills/vuln-matchers-guide.md
+++ b/bots/sec-audit-source/skills/vuln-matchers-guide.md
@@ -91,7 +91,7 @@ attachments:
 
 Then reference it in the relevant scanner tool node command:
 
-```iter
+```iter fragment
 tool run_js_scanners:
   command: |
     semgrep \

--- a/bots/whats-next/skills/iterion-dsl-quickref.md
+++ b/bots/whats-next/skills/iterion-dsl-quickref.md
@@ -376,7 +376,7 @@ commits when approved. Reference: `examples/review-merge-gate.bot`,
 
 ```iter fragment
 tool commit_changes:
-  command: `git add -A && git commit -m {{input.msg}}`   # one string, run through `sh -c`
+  command: `git add -A && git commit -m {{input.msg}}`   # one string, run through `bash -c`
   input:   commit_request         # schema declaring `msg: string`
   output:  commit_result          # the command prints JSON matching this schema on stdout
   await:   wait_all               # only when the node has multiple incoming edges
@@ -386,10 +386,13 @@ A tool node has ONE `command:` string (or a `script:` + `language:`). A
 `command:` runs through `bash -c`, host and sandbox alike; a `script:` runs the
 interpreter its `language:` names (`sh` is dash on Debian-derived images —
 keep scripts POSIX). There is no `args:` list and no `readonly:` on a tool. Every `{{ref}}` is shell-escaped as one word by the
-runtime — never wrap it in quotes of your own (C137). **A tool that declares
-`output:` must print a JSON object matching that schema on stdout**; anything
-else fails the node. A `json`-typed input renders as one JSON token; an
-output list referenced directly space-joins into several words.
+runtime — never wrap it in quotes of your own (C137). **A tool's stdout IS its
+output**: print a JSON object matching the `output:` schema; any other stdout is
+silently wrapped as `{"result": "…"}` and the declared fields are absent
+downstream, while a non-zero exit fails the node (wrap a command whose failure
+is a result — a failing test suite — so it exits 0 and reports `passed: false`).
+A `json`-typed input renders as one JSON token; an output list referenced
+directly space-joins into several words.
 
 Add `publish: <name>` to a `tool` (or `compute`, or agent/human)
 node to persist its output as a versioned artifact — surfaced in the

--- a/bots/whats-next/skills/iterion-dsl-quickref.md
+++ b/bots/whats-next/skills/iterion-dsl-quickref.md
@@ -382,9 +382,10 @@ tool commit_changes:
   await:   wait_all               # only when the node has multiple incoming edges
 ```
 
-A tool node has ONE `command:` string (or a `script:` + `language:`), run
-through `sh -c` (POSIX — assume dash). There is no `args:` list and no
-`readonly:` on a tool. Every `{{ref}}` is shell-escaped as one word by the
+A tool node has ONE `command:` string (or a `script:` + `language:`). A
+`command:` runs through `bash -c`, host and sandbox alike; a `script:` runs the
+interpreter its `language:` names (`sh` is dash on Debian-derived images —
+keep scripts POSIX). There is no `args:` list and no `readonly:` on a tool. Every `{{ref}}` is shell-escaped as one word by the
 runtime — never wrap it in quotes of your own (C137). **A tool that declares
 `output:` must print a JSON object matching that schema on stdout**; anything
 else fails the node. A `json`-typed input renders as one JSON token; an

--- a/bots/whats-next/skills/iterion-dsl-quickref.md
+++ b/bots/whats-next/skills/iterion-dsl-quickref.md
@@ -45,8 +45,10 @@ schema verdict:
   confidence: string
 
 prompt my_system:
-  Imperative-voice instructions. Reference {{vars.feature_prompt}}
-  or {{input.field}} or {{outputs.upstream_node.field}}.
+  Imperative-voice instructions. Reference a var as {{vars.feature_prompt}};
+  the node's own input lives under the input namespace and an upstream
+  node's output under outputs.<node>.<field> (every reference is checked
+  at validate time, so a prompt may only name what exists).
 
 cursor ambition:                  # optional prompt-engineering dial (see docs/cursors.md)
   values:
@@ -56,7 +58,8 @@ cursor ambition:                  # optional prompt-engineering dial (see docs/c
 agent worker:
   backend: "claw"
   model:   "openai/gpt-5.5"
-  ...
+  system:  my_system
+  output:  verdict
 
 workflow my_workflow:
   entry: worker
@@ -92,13 +95,15 @@ A bot-declared refusal (a budget guard, a precondition, a non-actionable lot)
 should end the run with a code the operator, `iterion remote runs list`, the
 gate notice and the alert sinks can act on — not "workflow reached fail node":
 
-```iter
+```iter fragment
 fail plan_exhausted:
   code: PLAN_BUDGET_EXHAUSTED         ## UPPER_SNAKE identifier (C247 otherwise)
   message: "planning used {{outputs.plan_budget_gate.pct}}% of max_duration"
   resumable: true                     ## default false = intentional, non-resumable end
 
-plan_budget_gate -> plan_exhausted when over_budget
+workflow w:
+  entry: plan_budget_gate
+  plan_budget_gate -> plan_exhausted when over_budget
 ```
 
 The engine stamps `code` as the run's `failure_code` and the rendered
@@ -127,7 +132,7 @@ deliberate refusal only changes verdict when an operator changes something.
 
 ## Agent/judge properties
 
-```iter
+```iter fragment
 agent w:
   backend: "claw"               # or claude_code / codex / pi / kimi / grok
   model:   "openai/gpt-5.5"     # claw with openai/* prefix
@@ -244,7 +249,7 @@ Session-mode notes:
 
 ## Edges
 
-```iter
+```iter fragment:edges
 src -> dst                                        # unconditional
 src -> dst when approved                          # bool field on src.output
 src -> dst when not approved
@@ -275,7 +280,7 @@ Rules:
 
 ## Human node
 
-```iter
+```iter fragment
 human ask_priorities:
   input:  ask_schema
   output: ask_schema
@@ -304,7 +309,7 @@ A `file`-typed schema field renders a drop zone at the gate; the
 operator's upload becomes a run attachment and the answer is a
 descriptor (`path` / `filename` / `mime` / `size` / `sha256`).
 
-```iter
+```iter fragment
 schema music_gate:
   approved: bool
   music: file
@@ -314,7 +319,7 @@ human pick_soundtrack:
   output: music_gate
 ```
 
-```iter
+```iter fragment
 prompt mix:
   Master the track at {{outputs.pick_soundtrack.music.path}}
 ```
@@ -339,7 +344,7 @@ prompt mix:
 
 ### Review-&-merge gate (`interaction: review`)
 
-```iter
+```iter fragment
 human ship_review:
   interaction: review
   model: "anthropic/claude-sonnet-4-6"   # the companion (writes test steps + verdict)
@@ -352,7 +357,7 @@ human ship_review:
   max_turns: 8                           # dialogue asymptote backstop
 ```
 
-```iter
+```iter fragment:edges
 ship_review -> done   when "decision == 'approved'"
 ship_review -> implement when "decision == 'changes_requested'" as fix_loop(5)
 ship_review -> fail    # default fallback
@@ -369,18 +374,21 @@ commits when approved. Reference: `examples/review-merge-gate.bot`,
 
 ## Tool node
 
-```iter
+```iter fragment
 tool commit_changes:
-  command: sh
-  args: ["-c", "git add -A && git commit -m {{input.msg}}"]
-  readonly: false                # opt-out of workspace-safety read-only mode
-  await: wait_all                # only when the node has multiple incoming edges
+  command: `git add -A && git commit -m {{input.msg}}`   # one string, run through `sh -c`
+  input:   commit_request         # schema declaring `msg: string`
+  output:  commit_result          # the command prints JSON matching this schema on stdout
+  await:   wait_all               # only when the node has multiple incoming edges
 ```
 
-Tool commands run via `sh -c` (POSIX). Template substitutions
-auto-escape strings, but `string[]` substitutions split into
-multiple argv tokens — use positional argv + `--` sentinels
-when passing multi-element arrays.
+A tool node has ONE `command:` string (or a `script:` + `language:`), run
+through `sh -c` (POSIX — assume dash). There is no `args:` list and no
+`readonly:` on a tool. Every `{{ref}}` is shell-escaped as one word by the
+runtime — never wrap it in quotes of your own (C137). **A tool that declares
+`output:` must print a JSON object matching that schema on stdout**; anything
+else fails the node. A `json`-typed input renders as one JSON token; an
+output list referenced directly space-joins into several words.
 
 Add `publish: <name>` to a `tool` (or `compute`, or agent/human)
 node to persist its output as a versioned artifact — surfaced in the
@@ -402,7 +410,7 @@ opt into a recovery ladder so a brittle recipe self-heals instead of
 hard-blocking. Add the optional quad — `goal` + recipe (`command`/`script`)
 + `postcondition` + `policy`:
 
-```iter
+```iter fragment
 tool commit_changes:
   command: `git add -A && git commit -F - <<< {{input.msg}}`
   goal: "Commit the upgrade; working tree clean except known caches."
@@ -473,7 +481,7 @@ instead.
 When you need to thread a value through a human node or
 across a loop boundary:
 
-```iter
+```iter fragment
 schema carry:
   payload: json
 
@@ -489,7 +497,7 @@ Reference `input.x`, `outputs.x.y`, `loop.<name>.previous_output.x`
 directly without `{{...}}`. The same `run.*` members are readable bare — the
 **phase-budget guard** is one `compute`:
 
-```iter
+```iter fragment
 compute plan_budget_gate:
   output: gate
   expr:
@@ -515,7 +523,7 @@ compute plan_budget_gate:
 
 ## Workflow block
 
-```iter
+```iter fragment
 workflow my_wf:
   entry: first_node
   default_backend: "claude_code"      # default backend for every node
@@ -533,23 +541,24 @@ workflow my_wf:
     threshold: 0.9
     preserve_recent: 8
 
-  mcp:                                # workflow-wide MCP server registry
-    servers:
-      - name: my_server
-        transport: stdio
-        command: my-mcp-server
-        args: []
+  mcp:                                # workflow-wide MCP servers, by name
+    servers: [my_server]              # each one a top-level `mcp_server` declaration
 
   worktree: auto                      # see "Worktree and sandbox" below
   sandbox:  auto
 
   ## Edges go here
   first_node -> done
+
+mcp_server my_server:                 # declared at top level, referenced above
+  transport: stdio
+  command: "my-mcp-server"
+  args: []
 ```
 
 ## Worktree and sandbox
 
-```iter
+```iter fragment
 workflow safe:
   worktree: auto                      # fresh git worktree per run
   sandbox:  auto                      # reads .devcontainer/devcontainer.json
@@ -558,7 +567,7 @@ workflow safe:
 
 Block-form sandbox:
 
-```iter
+```iter fragment
 workflow isolated:
   sandbox:
     image: "ghcr.io/socialgouv/iterion-sandbox-slim:v0.13"
@@ -568,12 +577,10 @@ workflow isolated:
     #   args: { BASE: "alpine:3.20" }
     user: "1000:1000"
     network:
-      mode: allowlist                 # allowlist | inherit | none
+      mode: allowlist                 # open (default) | allowlist | denylist
       preset: default                 # LLM + npm/pypi/golang + git hosts
       inherit: false                  # add to (not replace) the preset
-      rules:
-        - host: "registry.example.com"
-          port: 443
+      rules: ["registry.example.com", "!evil.site"]   # host globs, inline; `!` denies
 ```
 
 Sandbox top-level modes: `auto`, `none`, or the block form

--- a/cmd/iterion/main.go
+++ b/cmd/iterion/main.go
@@ -83,6 +83,11 @@ func main() {
 	defer cancel()
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
+		// The command already wrote its diagnosis (a --json result with
+		// valid:false): exit non-zero without a second JSON document.
+		if errors.Is(err, cli.ErrReported) {
+			os.Exit(1)
+		}
 		if jsonOutput {
 			newPrinter().JSON(map[string]string{"error": err.Error()})
 		} else {

--- a/cmd/iterion/main.go
+++ b/cmd/iterion/main.go
@@ -84,8 +84,11 @@ func main() {
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		// The command already wrote its diagnosis (a --json result with
-		// valid:false): exit non-zero without a second JSON document.
+		// valid:false): exit non-zero without a second JSON document. Not an
+		// incident either, so nothing is captured — but whatever the run
+		// captured before is flushed, as on every other exit.
 		if errors.Is(err, cli.ErrReported) {
+			errtrack.Flush()
 			os.Exit(1)
 		}
 		if jsonOutput {

--- a/docs/adr/001-round-robin-router-mode.md
+++ b/docs/adr/001-round-robin-router-mode.md
@@ -45,7 +45,7 @@ Add a `round_robin` mode to the `router` node in the v1 DSL.
 
 ### Syntax
 
-```iter
+```iter fragment
 router refine_selector:
   mode: round_robin
 ```
@@ -61,28 +61,28 @@ router refine_selector:
 
 ### Usage example
 
-```iter
+```iter fragment
 router refine_selector:
   mode: round_robin
 
 agent claude_refine:
   backend: "claude_code"
-  ...
+  # …
 
 agent codex_refine:
   backend: "codex"
-  ...
+  # …
 
 workflow example:
-  ...
+  # …
   val_judge -> refine_selector when not ready as refine_loop(4)
 
-  refine_selector -> claude_refine with { ... }
-  refine_selector -> codex_refine with { ... }
+  refine_selector -> claude_refine
+  refine_selector -> codex_refine
 
-  claude_refine -> val_fanout with { ... }
-  codex_refine -> val_fanout with { ... }
-  ...
+  claude_refine -> val_fanout
+  codex_refine -> val_fanout
+  # …
 ```
 
 On the first pass: `claude_refine` is selected.

--- a/docs/adr/081-async-human-interaction.md
+++ b/docs/adr/081-async-human-interaction.md
@@ -57,7 +57,7 @@ become answered, the service auto-resumes.
 **Deterministic sync point.** A new special node kind **`await_answers`**
 (sibling of `emit`/`wait`):
 
-```iter
+```iter fragment
 await_answers gate:
   from: gatherer      ## optional: only questions posted by this node
   timeout: "30m"      ## mandatory (no-silent-infinity invariant)

--- a/docs/async-interaction.md
+++ b/docs/async-interaction.md
@@ -11,7 +11,7 @@ LLM's discretion (the `await_answers` tool).
 
 ## DSL
 
-```iter
+```iter fragment
 agent draft:
   interaction: async        # grants ask_user_async + await_answers (+ blocking ask_user)
   system: draft_sys

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -20,7 +20,7 @@ local / desktop / cloud, the upload protocol, and the security model.
 
 ## DSL
 
-```iter
+```iter fragment
 attachments:
   logo: image
   spec: file

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -718,7 +718,7 @@ auto-resolution. `OPENAI_API_KEY` alone routes to `claw`.
 A Codex node receives OpenAI's hosted native Web search only when it declares
 the canonical DSL tool:
 
-```iter
+```iter fragment
 agent researcher:
   backend: "codex"
   model: "gpt-5.6-terra"
@@ -1288,19 +1288,22 @@ To pin a backend across an entire workflow (e.g. force `claude_code`
 even when OAuth is missing, expecting CI to inject it later):
 
 ```iter
-default_backend: claude_code
+workflow review:
+  entry: reviewer
+  default_backend: "claude_code"   # every node without its own backend: uses it
+  reviewer -> done
 
 agent reviewer:
   # inherits backend: claude_code
-  ...
+  model: "anthropic/claude-sonnet-4-6"
 ```
 
 Per-node overrides take precedence:
 
-```iter
+```iter fragment
 agent reviewer:
-  backend: claw
-  model: anthropic/claude-haiku-4-5-20251001
+  backend: "claw"
+  model: "anthropic/claude-haiku-4-5-20251001"
 ```
 
 ## Using a non-Anthropic provider via the Anthropic wire format (z.ai / GLM)

--- a/docs/bundles.md
+++ b/docs/bundles.md
@@ -68,7 +68,7 @@ my-bot/
 | `main.bot`        | The workflow source. Must live at the bundle root. |
 | `manifest.yaml`   | Bundle metadata (name, version, schema_version, optional `attachments:` map). Optional. |
 | `skills/`         | Claude Code skills. Mirrored into `<workDir>/.claude/skills/` at run time. Workspace files always win on collision (warn-logged). |
-| `prompts/`        | Reusable `.md` prompts. Each file is auto-registered with name equal to the filename stem — `prompts/helper.md` makes `system: helper` resolvable from `main.bot`. Workflow-declared prompts always win on collision. |
+| `prompts/`        | Reusable `.md` prompts. Each file is auto-registered with name equal to the filename stem — `prompts/helper.md` makes `system: helper` resolvable from `main.bot`. Workflow-declared prompts always win on collision. An `{{include "x.md"}}` inside one resolves next to that file, inside `prompts/`. |
 | `attachments/`    | Default binary inputs the manifest can map to declared `attachments:` entries. Runtime uploads (Launch modal, cloud) override these. |
 | `presets/`        | File-based presets ("sous-bots"): each `presets/<name>.md` (YAML frontmatter + markdown body) is a named launch-time specialization selected with `--preset <name>`, layering variable overrides + a system-prompt bias + skill hints onto the bot. |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -55,7 +55,9 @@ iterion validate workflow.bot
 iterion validate bundle.botz --json
 ```
 
-Accepted inputs are `.bot`, `.botz`, and bundle directories. Validation reports sparse DSL diagnostics in C001–C199 plus the async-interaction and structural band C240–C244, and bundle checks in C200–C234; the [diagnostic catalogue](references/diagnostics.md) is authoritative.
+Accepted inputs are `.bot`, `.botz`, and bundle directories. Validation reports sparse DSL diagnostics in C001–C199 plus the async-interaction and structural band C240–C249, and bundle checks in C200–C234; the [diagnostic catalogue](references/diagnostics.md) is authoritative.
+
+Every finding is printed with its source position when the stage could attribute one — `file:line:column: error [C019]: …`, the node's or edge's own line for a compile diagnostic — and a `fix:` line beneath it, the one-line remedy from the compiler's catalogue. `--json` carries the same findings as `diagnostics`, one object each: `source` (`parse` | `compile` | `bundle`), `code`, `severity`, `file` / `line` / `column`, `message`, `hint`, `node_id`, `edge_id`. The older `parse_diagnostics` / `compile_diagnostics` / `bundle_diagnostics` string lists remain. The MCP `local_validate` tool returns this same JSON, so an agent's write → validate → fix loop reads positions and fixes, not prose.
 
 ### `iterion diagram`
 

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -7,7 +7,7 @@ environment, and credential resolution chain chooses one — `model:` alone does
 direct API call. Delegated coding-agent backends are the richest choice for
 editing files, running shell, and driving git:
 
-```iter
+```iter fragment
 agent implementer:
   backend: "codex"                # or claude_code / pi / kimi / grok
   input: plan_schema
@@ -32,7 +32,7 @@ review, judge, or plan that should call a provider API in-process, pin both the
 `claw` backend and the model; `readonly: true` constrains the node independently
 of that selection:
 
-```iter
+```iter fragment
 agent reviewer:
   backend: "claw"                      # Force an in-process provider call
   model: "anthropic/claude-sonnet-5"

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -29,13 +29,13 @@ agent, judge, router, human, tool, compute, emit, wait, await_answers, subbot,
 group, use, workflow
 ```
 
-Declarations may appear in any order subject to validation. `##` starts a comment. Values accept quoted strings, backtick-delimited raw strings, and `|` block scalars where the grammar expects a string.
+Declarations may appear in any order subject to validation. `#` starts a comment that runs to the end of the line (`##` is the same comment; both forms are accepted everywhere except inside a string, a prompt body or a `|` block scalar, where a `#` is text). Values accept quoted strings, backtick-delimited raw strings, and `|` block scalars where the grammar expects a string.
 
 ## Inputs and reusable values
 
 ### Variables and presets
 
-```iter
+```iter fragment
 vars:
   project: string
   mode: string [enum: "autonomous", "interview"] = "autonomous"
@@ -57,7 +57,7 @@ A workflow may declare an additional `vars:` block. Top-level and workflow varia
 
 ### Attachments
 
-```iter
+```iter fragment
 attachments:
   specification: file
     description: "Product specification"
@@ -70,7 +70,7 @@ Attachments are uploaded/persisted inputs, not scalar vars. They are available a
 
 ### Secrets
 
-```iter
+```iter fragment
 secrets:
   forge_token: "${FORGE_TOKEN}"
   deploy_key:
@@ -89,7 +89,7 @@ Value secrets render as opaque placeholders and are materialised only at executi
 
 ### Prompts
 
-```iter
+```iter fragment
 prompt review_system:
   You are a reviewer for {{vars.project}}.
 
@@ -103,7 +103,7 @@ prompt review_user:
 
 ### Schemas
 
-```iter
+```iter fragment
 schema review_request:
   code: string
 
@@ -136,6 +136,8 @@ Schemas define structured node inputs/outputs. Field types match variable types 
 | `{{run.max_duration_seconds}}` / `.max_cost_usd` / `.max_tokens` / `.max_iterations` | The run's **effective** budget caps. |
 | `{{params.name}}` | `group` parameter during compile-time expansion. |
 
+`{{outputs.<node>.<field>}}` is readable from **any** node that runs after the producer — in a prompt, a command, an expression or a fail message — with no `with` threading; `{{input.<field>}}` only carries what the node's own `input:` schema declares and the incoming edge `with` mapped. Thread through `with` when a value must travel under a chosen name (a loop feedback field, a fan-out item); read `outputs.*` directly otherwise.
+
 `fan_out_each` also exposes the current item as `{{outputs.<router>.<as-name>}}`. Environment expressions use `${NAME}` (and supported default forms) before execution. In a tool `command` or `script`, `{{!input.field}}` is the explicit raw-substitution form; ordinary `{{input.field}}` is shell-escaped. Use the raw form only when the value is intentionally executable shell syntax, because it crosses the command-injection boundary.
 
 **Inside a fan-out branch**, every namespace above resolves exactly as it does on the trunk — a node renders the same whether it was reached by a plain edge or by a `fan_out_all` / `fan_out_each` router. `{{outputs.*}}` resolves against the BRANCH's own view: its upstream trunk outputs plus what this branch has produced, plus the per-item binding a `fan_out_each` stamped. Sibling branches are invisible to each other, which is what makes the render deterministic; their outputs only become readable at the convergence node. `{{run.*}}` is the run's, not the branch's — the whole run's consumption and caps, shared by every branch.
@@ -146,7 +148,7 @@ A tool `command:` / `script:` / `postcondition:` resolves `{{input.*}}`, `{{vars
 
 `agent` performs work; `judge` is the semantically evaluative twin. They accept the same properties.
 
-```iter
+```iter fragment
 agent reviewer:
   description: "Read-only branch reviewer"
   backend: "claude_code"
@@ -187,7 +189,7 @@ Important property groups:
 
 Node-level nested blocks include:
 
-```iter
+```iter fragment
 agent worker:
   # ...model/prompts...
   compaction:
@@ -217,7 +219,7 @@ See [memory and knowledge](memory-and-knowledge.md), [cursors](cursors.md), [per
 
 Iterion has five router modes:
 
-```iter
+```iter fragment
 router all_reviews:
   mode: fan_out_all
 
@@ -249,7 +251,7 @@ router smart:
 
 Parallel branches converge at an `agent`, `judge`, `human`, `tool`, or `compute` node:
 
-```iter
+```iter fragment
 compute collect:
   output: collection_result
   await: wait_all       # or best_effort
@@ -263,7 +265,7 @@ Routers are fan-out sources and never declare `await`. See [routers](routers.md)
 
 ## Human interaction
 
-```iter
+```iter fragment
 human approval:
   description: "Release approval"
   input: approval_request
@@ -283,7 +285,7 @@ Resume a pause with `iterion resume --run-id <id> --file workflow.bot --answer k
 
 A tool executes either a shell command or a script; it does not call an LLM.
 
-```iter
+```iter fragment
 tool run_tests:
   description: "Run the repository test suite"
   command: `make test`
@@ -295,9 +297,19 @@ tool run_tests:
 
 `command` and `script` are mutually exclusive. A script adds `language: js|py|sh|bash` (default `sh`). Tools also accept `input`, `output`, `publish`, `artifact_labels`, `await`, `sandbox`, `compress`, `permission`, and `needs`.
 
+**The output contract.** A tool node's **stdout is its output**: the runtime parses it as a JSON object, and that object is what `{{outputs.<tool>.<field>}}`, an edge `when`, and the declared `output:` schema see. Stdout that is not a JSON object is wrapped as `{"result": "<text>"}` — a downstream `{{outputs.run_tests.passed}}` then finds nothing. A non-zero exit code **fails the node** (resumable), stdout and stderr attached; when the failure is a *result* rather than an error — a test suite that fails, a scanner that finds something — wrap the command so it exits 0 and reports the verdict as a field:
+
+```iter fragment
+tool run_tests:
+  command: `if make test >/tmp/test.log 2>&1; then ok=true; else ok=false; fi; printf '{"passed":%s,"log":%s}' "$ok" "$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()[-20000:]))' </tmp/test.log)"`
+  output: test_result        # schema: passed: bool, log: string
+```
+
+(`printf` with a JSON-quoted payload is the portable idiom; `python3 -c "…json.dumps…"` reads well but assumes `python3` in the sandbox image — declare it in the bot's `devbox.json` if you rely on it.) Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
+
 Verified Actions add a deterministic outcome check and bounded recovery:
 
-```iter
+```iter fragment
 tool deploy:
   command: `./deploy.sh`
   goal: "The service is deployed and healthy"
@@ -316,7 +328,7 @@ tool deploy:
 
 `compute` evaluates bounded expressions without an LLM or shell:
 
-```iter
+```iter fragment
 schema stats:
   count: int
   ready: bool
@@ -333,7 +345,7 @@ Expressions support field/index access, arithmetic/comparison/boolean operators,
 
 **The output is typed by its schema.** A compute output is conformed to the declared field types where it is produced, on the trunk and inside a fan-out branch alike: an integral number under `int` is stored as the integer it reads as, an integer under `float` as a float, and a value that cannot be conformed fails the node with the field named — a fractional float under `int` (`10.58` from a division), a string under `bool`, a number under `string`. The engine never picks a rounding for you: write it, with `floor(x)` (towards negative infinity) or `round(x)` (half away from zero), both of which return an integer.
 
-```iter
+```iter fragment
 schema gauge:
   used_pct: int
 
@@ -403,7 +415,7 @@ to the `_tokens` / `_cost_usd` keys the backends write — the per-node
 timing counterpart, stamped by the engine so tool and compute nodes get
 it too.
 
-```iter
+```iter fragment
 schema gauge:
   used_pct: int
   exhausted: bool
@@ -424,7 +436,7 @@ float with an integer's label.
 
 These nodes coordinate concurrent branches through immutable run-scoped events:
 
-```iter
+```iter fragment
 emit publish_ready:
   event: "ready"
   with {
@@ -449,7 +461,7 @@ operator sees whichever of a bot's refusals fired.
 A workflow that refuses for a **reason** declares a named fail node
 instead. One per reason; the bare `fail` keeps its untyped behaviour.
 
-```iter
+```iter fragment
 fail plan_exhausted:
   description: "the plan phase outgrew its share of the budget"
   code: PLAN_BUDGET_EXHAUSTED
@@ -507,6 +519,9 @@ naming the node. Put a guard whose refusal must be resumable on the trunk.
 Groups are compile-time macros containing agents, judges, routers, humans, tools, computes, and internal edges. Each use prefixes cloned node ids and substitutes `{{params.*}}`.
 
 ```iter
+prompt inspect_prompt:
+  Inspect the change and report material defects only.
+
 group check(rule):
   agent inspect:
     model: "anthropic/claude-sonnet-4-6"
@@ -525,7 +540,7 @@ External workflow edges address expanded nodes as `<prefix>.<node>`.
 
 ### `subbot`
 
-```iter
+```iter fragment
 subbot run_ticket:
   description: "Implement one planned ticket"
   source: "child.bot"
@@ -545,7 +560,7 @@ See [groups, iteration, resources, and sub-bots](groups-iteration-subbots.md) fo
 
 A cursor declares reusable prompt calibration; a supervisor is a concurrent watcher, not a graph node:
 
-```iter
+```iter fragment
 cursor rigor:
   description: "Review strictness"
   values:
@@ -564,7 +579,7 @@ Cursor declarations use either `values:` or numeric `bands:`, never both. Superv
 
 ## MCP servers
 
-```iter
+```iter fragment
 mcp_server code_tools:
   transport: stdio
   command: "npx"
@@ -596,7 +611,7 @@ connects declared servers, claw registers in-process tools.)
 
 A workflow selects the entry node, configures run-wide controls, and declares edges:
 
-```iter
+```iter fragment
 workflow review:
   entry: prepare
   default_backend: "claude_code"
@@ -667,10 +682,10 @@ same threshold then refuses. The run instead leaves through its own exit
 path with room to walk it — for the campaign shape below, the
 `gate -> publish` fall-through that also serves loop exhaustion.
 
-```iter
-  gate -> publish when converged
-  gate -> work as passes(4)
-  gate -> publish            # exhausted, or unaffordable: ship what is banked
+```iter fragment:edges
+gate -> publish when converged
+gate -> work as passes(4)
+gate -> publish            # exhausted, or unaffordable: ship what is banked
 ```
 
 This matters for any loop that banks work as it goes (commits in stride, a
@@ -759,7 +774,7 @@ ever apply. The counter-intuitive consequence is real — a run refused at
 its terminal node. Raise the cap and resume for the former; the latter is
 the case the grace was built for.
 
-```iter
+```iter fragment
 workflow campaign:
   entry: work
   loop_budget_guard: off    # this loop must burn its cap, not stop short
@@ -834,7 +849,7 @@ needs is the *workflow's* declaration, which rides the `.bot` itself. So a
 bot's `repo_devbox: off` holds in cloud, while `--repo-devbox` is a local
 run's override.
 
-```iter
+```iter fragment
 workflow review_pr:
   entry: review
   repo_devbox: off    # this run reads the repo, it does not build it
@@ -842,7 +857,7 @@ workflow review_pr:
 
 ### Edge forms
 
-```iter
+```iter fragment:edges
 src -> dst
 src -> dst when approved
 src -> dst when not approved
@@ -864,6 +879,15 @@ Optional `when`/`else`, `as`, and `with` clauses may appear in any order, once e
 Quoted `when` expressions are evaluated in parallel branch bodies as well as on the trunk, against that branch's private outputs, artifacts, loop state, and shared run variables. Migration note: older runtimes skipped expression-form edges inside `fan_out_all`, `fan_out_each`, and `llm multi: true` branches, so an existing workflow may now take a guarded route that previously fell through to `else` or an unconditional edge.
 
 Every cycle must carry an `as <loop>(...)` clause. A cap may be a literal, a runtime template, or `unbounded` with a fuel ceiling. If an unbounded loop omits its local fuel, `budget.max_iterations` must supply it; the runtime also applies a no-progress liveness monitor. `as foreach` is different: it walks a finite array sequentially and binds the `each.<name>` namespace.
+
+**Leaving an exhausted loop.** Once a bounded loop has spent its iterations the back-edge is declined, and a node left with no other edge ends the run with `LOOP_EXHAUSTED`. The exit is written as a second, bare edge from the same node — the **loop-exhaustion exit**:
+
+```iter fragment:edges
+fixer -> run_tests as fix_passes(3)   # the back-edge, taken while iterations remain
+fixer -> fix_passes_exhausted         # fires once they are spent (or when the budget cannot fund another)
+```
+
+A loop back-edge does not count toward [C010](references/diagnostics.md) (one unconditional edge per node), so this pair is the one legal shape with two unconditional edges; the bare edge also serves a conditional back-edge (`… when not approved as fix(3)`) once its cap is reached. Route it to a typed `fail <name>:` when exhaustion is a refusal, or onward when the work banked so far should still be delivered.
 
 A bounded loop or foreach may live wholly inside one `fan_out_all`, `fan_out_each`, or `llm` `multi: true` branch. Every branch/item owns independent counters, loop snapshots, outputs, artifact allocations, and a durable cursor; siblings may therefore finish after different numbers of iterations, and a restart or human pause resumes the same local scope without replaying completed iterations. The collector becomes ready only after those local lifecycles terminate, under the existing `wait_all` / `best_effort` policy.
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -142,7 +142,7 @@ Schemas define structured node inputs/outputs. Field types match variable types 
 
 **Inside a fan-out branch**, every namespace above resolves exactly as it does on the trunk — a node renders the same whether it was reached by a plain edge or by a `fan_out_all` / `fan_out_each` router. `{{outputs.*}}` resolves against the BRANCH's own view: its upstream trunk outputs plus what this branch has produced, plus the per-item binding a `fan_out_each` stamped. Sibling branches are invisible to each other, which is what makes the render deterministic; their outputs only become readable at the convergence node. `{{run.*}}` is the run's, not the branch's — the whole run's consumption and caps, shared by every branch.
 
-A tool `command:` / `script:` / `postcondition:` resolves `{{input.*}}`, `{{vars.*}}`, `{{secrets.*}}`, `{{run.*}}` and `{{outputs.<node>.<field>}}` — the last from the same template snapshot a prompt renders from, on the trunk and in a branch alike (inside a branch, the branch's own view, per-item binding included). An output is substituted exactly like an input: shell-escaped as one word in a `command:` / `postcondition:`, as a JSON literal in a `script:`; the `{{!outputs.…}}` raw form crosses the command-injection boundary like `{{!input.…}}` does. An output the referenced node has not produced yet takes the missing-input rule too — the `{{…}}` placeholder stays in a shell body so `sh -c` fails on it visibly, and renders as `null` in a script body. The output arrives with the shape its producer gave it: a `json`-declared **input** field is pre-encoded into one JSON token for the shell, an output referenced directly is not, so a list of strings space-joins into several words. To keep the pre-encoding, thread the value through an edge `with` mapping into a `json` input field and read `{{input.<key>}}`.
+A tool `command:` / `script:` / `postcondition:` resolves `{{input.*}}`, `{{vars.*}}`, `{{secrets.*}}`, `{{run.*}}` and `{{outputs.<node>.<field>}}` — the last from the same template snapshot a prompt renders from, on the trunk and in a branch alike (inside a branch, the branch's own view, per-item binding included). An output is substituted exactly like an input: shell-escaped as one word in a `command:` / `postcondition:`, as a JSON literal in a `script:`; the `{{!outputs.…}}` raw form crosses the command-injection boundary like `{{!input.…}}` does. An output the referenced node has not produced yet takes the missing-input rule too — the `{{…}}` placeholder stays in a shell body so `bash -c` fails on it visibly, and renders as `null` in a script body. The output arrives with the shape its producer gave it: a `json`-declared **input** field is pre-encoded into one JSON token for the shell, an output referenced directly is not, so a list of strings space-joins into several words. To keep the pre-encoding, thread the value through an edge `with` mapping into a `json` input field and read `{{input.<key>}}`.
 
 ## LLM nodes: `agent` and `judge`
 
@@ -397,7 +397,7 @@ value. In an expression it is nil — the same silence as
 `vars.<unknown>` — and comparing it is what fails, loudly, at the node.
 In a rendered body it takes the missing-ref rule every namespace
 follows: the `{{…}}` placeholder stays in a prompt and in a shell
-`command:` / `postcondition:`, so `sh -c` fails on visible braces
+`command:` / `postcondition:`, so `bash -c` fails on visible braces
 instead of running one argument short, and it renders as `null` in a
 `script:` body so the interpreter still parses.
 
@@ -880,7 +880,7 @@ Quoted `when` expressions are evaluated in parallel branch bodies as well as on 
 
 Every cycle must carry an `as <loop>(...)` clause. A cap may be a literal, a runtime template, or `unbounded` with a fuel ceiling. If an unbounded loop omits its local fuel, `budget.max_iterations` must supply it; the runtime also applies a no-progress liveness monitor. `as foreach` is different: it walks a finite array sequentially and binds the `each.<name>` namespace.
 
-**Leaving an exhausted loop.** Once a bounded loop has spent its iterations the back-edge is declined, and a node left with no other edge ends the run with `LOOP_EXHAUSTED`. The exit is written as a second, bare edge from the same node — the **loop-exhaustion exit**:
+**Leaving an exhausted loop.** Once a bounded loop has spent its iterations the back-edge is declined (the log says `edge to "…" skipped — loop "…" exhausted`), and a node left with no other edge ends the run with `NO_OUTGOING_EDGE`. The exit is written as a second, bare edge from the same node — the **loop-exhaustion exit**:
 
 ```iter fragment:edges
 fixer -> run_tests as fix_passes(3)   # the back-edge, taken while iterations remain

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -301,11 +301,11 @@ tool run_tests:
 
 ```iter fragment
 tool run_tests:
-  command: `if make test >/tmp/test.log 2>&1; then ok=true; else ok=false; fi; printf '{"passed":%s,"log":%s}' "$ok" "$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()[-20000:]))' </tmp/test.log)"`
+  command: `if make test >/tmp/test.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, log: .}' </tmp/test.log`
   output: test_result        # schema: passed: bool, log: string
 ```
 
-(`printf` with a JSON-quoted payload is the portable idiom; `python3 -c "…json.dumps…"` reads well but assumes `python3` in the sandbox image — declare it in the bot's `devbox.json` if you rely on it.) A `command:` runs through **`bash -c`**, on the host and inside a sandbox alike ([`executor_tool.go`](../pkg/backend/model/executor_tool.go), `toolNodeCommand`); a `script:` runs the interpreter its `language:` names, and `language: sh` is whatever `sh` is on PATH — dash on Debian-derived images, so keep scripts POSIX. Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
+(`jq -Rs` reads the whole log as one JSON string and ships in the default sandbox image; a `python3 -c "…json.dumps…"` wrapper reads well but `python3` is NOT in that image, and a missing interpreter turns the payload into invalid JSON that the runtime then wraps as `{"result": …}` in silence — declare any interpreter you rely on in the bot's `devbox.json`.) A `command:` runs through **`bash -c`**, on the host and inside a sandbox alike ([`executor_tool.go`](../pkg/backend/model/executor_tool.go), `toolNodeCommand`); a `script:` runs the interpreter its `language:` names, and `language: sh` is whatever `sh` is on PATH — dash on Debian-derived images, so keep scripts POSIX. Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
 
 Verified Actions add a deterministic outcome check and bounded recovery:
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -99,7 +99,7 @@ prompt review_user:
   Previous result: {{outputs.prior.summary}}
 ```
 
-`{{include "relative/path.md"}}` inlines a file at compile time. Paths are relative to the `.bot`, may not escape its directory (including through symlinks), and are capped at 256 KiB. Included content may contain normal runtime templates.
+`{{include "relative/path.md"}}` inlines a file at compile time. Paths are relative to the file that contains the include — the `.bot` for a prompt declared in it, a bundle's `prompts/` directory for a `prompts/*.md` — may not escape that directory (including through symlinks), and are capped at 256 KiB. Included content may contain normal runtime templates.
 
 ### Schemas
 
@@ -202,7 +202,6 @@ agent worker:
     read: true
     write: true
     pre_compact_inject: true
-    project_root: true
     visibility: "bot"
   cursors:
     enabled: true

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -305,7 +305,7 @@ tool run_tests:
   output: test_result        # schema: passed: bool, log: string
 ```
 
-(`printf` with a JSON-quoted payload is the portable idiom; `python3 -c "…json.dumps…"` reads well but assumes `python3` in the sandbox image — declare it in the bot's `devbox.json` if you rely on it.) Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
+(`printf` with a JSON-quoted payload is the portable idiom; `python3 -c "…json.dumps…"` reads well but assumes `python3` in the sandbox image — declare it in the bot's `devbox.json` if you rely on it.) A `command:` runs through **`bash -c`**, on the host and inside a sandbox alike ([`executor_tool.go`](../pkg/backend/model/executor_tool.go), `toolNodeCommand`); a `script:` runs the interpreter its `language:` names, and `language: sh` is whatever `sh` is on PATH — dash on Debian-derived images, so keep scripts POSIX. Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
 
 Verified Actions add a deterministic outcome check and bounded recovery:
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -301,11 +301,11 @@ tool run_tests:
 
 ```iter fragment
 tool run_tests:
-  command: `if make test >/tmp/test.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, log: .}' </tmp/test.log`
+  command: `if make test >/tmp/test.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, log: .[-20000:]}' </tmp/test.log`
   output: test_result        # schema: passed: bool, log: string
 ```
 
-(`jq -Rs` reads the whole log as one JSON string and ships in the default sandbox image; a `python3 -c "…json.dumps…"` wrapper reads well but `python3` is NOT in that image, and a missing interpreter turns the payload into invalid JSON that the runtime then wraps as `{"result": …}` in silence — declare any interpreter you rely on in the bot's `devbox.json`.) A `command:` runs through **`bash -c`**, on the host and inside a sandbox alike ([`executor_tool.go`](../pkg/backend/model/executor_tool.go), `toolNodeCommand`); a `script:` runs the interpreter its `language:` names, and `language: sh` is whatever `sh` is on PATH — dash on Debian-derived images, so keep scripts POSIX. Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
+(`jq -Rs` reads the whole log as one JSON string and ships in the default sandbox image; the `.[-20000:]` tail bounds what reaches the schema field — and every downstream prompt that reads it — because nothing else does: a 50 MB log would land in the judge's context whole; a `python3 -c "…json.dumps…"` wrapper reads well but `python3` is NOT in that image, and a missing interpreter turns the payload into invalid JSON that the runtime then wraps as `{"result": …}` in silence — declare any interpreter you rely on in the bot's `devbox.json`.) A `command:` runs through **`bash -c`**, on the host and inside a sandbox alike ([`executor_tool.go`](../pkg/backend/model/executor_tool.go), `toolNodeCommand`); a `script:` runs the interpreter its `language:` names, and `language: sh` is whatever `sh` is on PATH — dash on Debian-derived images, so keep scripts POSIX. Every `{{ref}}` in a `command:` is shell-escaped as one word; do not wrap it in quotes of your own ([C137](references/diagnostics.md)).
 
 Verified Actions add a deterministic outcome check and bounded recovery:
 

--- a/docs/grammar/iterion_v1.ebnf
+++ b/docs/grammar/iterion_v1.ebnf
@@ -5,7 +5,9 @@
    reachability, exhaustive routing, cycle declarations, budgets, and so on.
 
    INDENT/DEDENT are virtual tokens emitted by the indentation-aware lexer.
-   Comments beginning with ## and blank lines are ignored between constructs.
+   Comments open with # (## is the same comment) and, like blank lines, are
+   ignored between constructs; inside a string, a prompt body or a block
+   scalar a # is text.
 *)
 
 file = { top_level_decl } ;

--- a/docs/grammar/iterion_v1.ebnf
+++ b/docs/grammar/iterion_v1.ebnf
@@ -16,7 +16,8 @@ top_level_decl = vars_decl | presets_decl | attachments_decl | secrets_decl
                | mcp_server_decl | prompt_decl | schema_decl
                | cursor_decl | supervisor_decl
                | agent_decl | judge_decl | router_decl | human_decl
-               | tool_decl | compute_decl | emit_decl | wait_decl | subbot_decl
+               | tool_decl | compute_decl | emit_decl | wait_decl
+               | await_answers_decl | subbot_decl
                | fail_decl
                | group_decl | use_decl | workflow_decl ;
 
@@ -274,6 +275,16 @@ wait_prop = "description" ":" STRING_LIT NEWLINE
           | "event" ":" STRING_LIT NEWLINE
           | "timeout" ":" STRING_LIT NEWLINE
           | "output" ":" IDENT NEWLINE ;
+
+(* The deterministic sync point for async human questions (ADR-081): parks
+   its branch until every pending ask_user_async question of the `from:`
+   node (or the whole run) is answered. The timeout is mandatory. *)
+await_answers_decl = "await_answers" IDENT ":" NEWLINE INDENT
+                       { await_answers_prop }
+                     DEDENT ;
+await_answers_prop = "description" ":" STRING_LIT NEWLINE
+                   | "from" ":" ( IDENT | STRING_LIT ) NEWLINE
+                   | "timeout" ":" STRING_LIT NEWLINE ;
 
 (* A NAMED terminal failure node. The bare "fail" target stays reserved and
    untyped; a declaration is how a workflow carries its own diagnosis onto

--- a/docs/groups-iteration-subbots.md
+++ b/docs/groups-iteration-subbots.md
@@ -282,6 +282,7 @@ workflow tickets:
   plan -> dispatch
   dispatch -> run_ticket
   run_ticket -> collect when validated   # collect declares await: best_effort
+  run_ticket -> escalate else            # a rejected ticket reaches a human (C012 without it)
   collect -> done
 ```
 

--- a/docs/groups-iteration-subbots.md
+++ b/docs/groups-iteration-subbots.md
@@ -257,7 +257,7 @@ boundaries are worth knowing before a heavy fan-out:
 The headline pattern — *map a sub-bot over a dependency DAG of work items, each
 in its own worktree slot* — combines all of these:
 
-```iter
+```iter fragment
 router dispatch:
   mode: fan_out_each
   over: "{{outputs.plan.tickets}}"

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -199,7 +199,7 @@ Two shapes, matching the two things an operator actually does.
 
 ### A declared `file` field — the workflow knows it needs one
 
-```iter
+```iter fragment
 schema music_gate:
   approved: bool
   music: file
@@ -212,7 +212,7 @@ human pick_soundtrack:
 The studio renders a drop zone for `music`. Downstream nodes read a
 descriptor:
 
-```iter
+```iter fragment
 prompt mix:
   Master the track at {{outputs.pick_soundtrack.music.path}}
   ({{outputs.pick_soundtrack.music.mime}},
@@ -271,7 +271,7 @@ files.
 Those land on the reserved `_attachments` answer key as a list of the
 same descriptors:
 
-```iter
+```iter fragment
 prompt apply_feedback:
   {{outputs.review._attachments}}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,21 +75,33 @@ schema verdict:
   approved: bool
   notes: string
 
+prompt plan_system:
+  Turn the request into a concrete plan: files, steps, constraints.
+
+prompt implement_system:
+  Implement the plan, then run the tests.
+
+prompt review_system:
+  Approve only if the change is complete and the tests pass.
+
 agent plan:
-  system: "Turn the request into a concrete plan: files, steps, constraints."
+  model: "anthropic/claude-sonnet-4-6"
+  system: plan_system
 
 agent implement:
   backend: "claude_code"
-  system: "Implement the plan, then run the tests."
+  system: implement_system
 
 judge review:
+  model: "anthropic/claude-sonnet-4-6"
   output: verdict
-  system: "Approve only if the change is complete and the tests pass."
+  system: review_system
 
 workflow ship_it:
   entry: plan
-  plan -> implement -> review
-  review -> implement as fix(3) when not approved
+  plan -> implement
+  implement -> review
+  review -> implement when not approved as fix(3)
   review -> done when approved
 ```
 

--- a/docs/privacy_filter.md
+++ b/docs/privacy_filter.md
@@ -99,7 +99,7 @@ needed.
 
 ### 1. Anti-secret commit gate (flagship)
 
-```iter
+```iter fragment
 tool generate_diff:
   command: "git diff --cached"
   output: diff_text
@@ -119,7 +119,10 @@ judge review:
   output: review_verdict
 
 workflow main:
-  start -> generate_diff -> scan_secrets -> gate
+  entry: start
+  start -> generate_diff
+  generate_diff -> scan_secrets
+  scan_secrets -> gate
   gate -> review when not has_secret
   gate -> fail_node when has_secret
   review -> done
@@ -133,7 +136,7 @@ PEM, etc.) plus generic high-entropy detection.
 
 ### 2. Triage tickets without exposing PII to the LLM
 
-```iter
+```iter fragment
 schema ticket_in:
   raw: string
 schema redacted:
@@ -158,7 +161,10 @@ agent classify:
   user: triage_prompt
 
 workflow main:
-  start -> sanitize -> classify -> done
+  entry: start
+  start -> sanitize
+  sanitize -> classify
+  classify -> done
 ```
 
 The LLM only ever sees `PII_xxx` tokens for emails and phone numbers by default.
@@ -167,7 +173,7 @@ PII either, so the entire run trace is publishable / auditable as-is.
 
 ### 3. Web-fetch summarization with sanitization
 
-```iter
+```iter fragment
 tool fetch_doc:
   command: "web_fetch"
   input: url_in
@@ -184,7 +190,11 @@ agent summarize:
   output: summary
 
 workflow main:
-  start -> fetch_doc -> sanitize -> summarize -> done
+  entry: start
+  start -> fetch_doc
+  fetch_doc -> sanitize
+  sanitize -> summarize
+  summarize -> done
 ```
 
 Useful for scheduled scraping workflows where the input domain is
@@ -193,7 +203,7 @@ public pages in your `events.jsonl`.
 
 ### 4. Two-stage customer support (redact → draft → unredact)
 
-```iter
+```iter fragment
 schema email_in:
   body: string
 
@@ -223,7 +233,12 @@ human approve:
   output: approval
 
 workflow main:
-  start -> redact_email -> draft_reply -> restore_pii -> approve -> done
+  entry: start
+  start -> redact_email
+  redact_email -> draft_reply
+  draft_reply -> restore_pii
+  restore_pii -> approve
+  approve -> done
 ```
 
 The agent is structurally prevented from seeing emails, phone numbers,
@@ -237,7 +252,7 @@ the placeholder format is overridable if needed.
 
 ### 5. Anonymized dataset / example export
 
-```iter
+```iter fragment
 tool list_artifacts:
   command: "ls .iterion/runs/$RUN_ID/artifacts/*.json"
   output: file_list
@@ -250,8 +265,11 @@ tool redact_artifact:
   output: clean_artifact
 
 workflow main:
-  start -> list_artifacts -> fan
-  fan -> redact_artifact -> done
+  entry: start
+  start -> list_artifacts
+  list_artifacts -> fan
+  fan -> redact_artifact
+  redact_artifact -> done
 ```
 
 Convert real-data run traces into shareable demo material. Combine with
@@ -259,7 +277,7 @@ Convert real-data run traces into shareable demo material. Combine with
 
 ### 6. Sanitization after a Human node
 
-```iter
+```iter fragment
 human collect_context:
   interaction: human
   output: raw_context
@@ -274,7 +292,11 @@ agent investigate:
   output: report
 
 workflow main:
-  start -> collect_context -> sanitize -> investigate -> done
+  entry: start
+  start -> collect_context
+  collect_context -> sanitize
+  sanitize -> investigate
+  investigate -> done
 ```
 
 Belt-and-braces: the raw answer lives only in `interactions/<id>.json`
@@ -283,7 +305,7 @@ artifacts.
 
 ### 7. Pure detect-mode audit / compliance scan
 
-```iter
+```iter fragment
 prompt report_prompt:
   Produce a markdown report listing: spans per category, highest-risk
   documents, recommended actions. Use the `rule` field to identify
@@ -301,7 +323,10 @@ agent report:
   user: report_prompt
 
 workflow main:
-  start -> scan -> report -> done
+  entry: start
+  start -> scan
+  scan -> report
+  report -> done
 ```
 
 No mutation of source data — produces an inventory. Combine with

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -2,6 +2,8 @@
 
 All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`ir.Validate`), plus the bundle-consistency codes (`C2xx`) that `iterion validate` reports for a packaged bot. Diagnostics are either **errors** (block execution) or **warnings** (informational).
 
+The compiler carries its own copy of each row's *Fix* ([`pkg/dsl/ir/diag_catalog.go`](../../pkg/dsl/ir/diag_catalog.go)): `iterion validate` prints it as the `fix:` line under every finding, the studio shows it in the diagnostic badge, and the MCP `local_validate` result carries it as `hint`. A code the compiler can emit that has no catalogue entry fails `TestDiagCatalogCoversEveryCode`, so a finding never arrives without a next step. Parse-stage codes (`E0xx`, [`pkg/dsl/parser/diagnostic.go`](../../pkg/dsl/parser/diagnostic.go)) carry a fix line the same way.
+
 ## Compilation Diagnostics
 
 | Code | Severity | Description | Cause | Fix |
@@ -30,7 +32,7 @@ All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`
 | Code | Severity | Description | Cause | Fix |
 |------|----------|-------------|-------|-----|
 | **C009** | error | Session at convergence point | A node with `await:` (or multiple incoming sources) uses `session: inherit` or `session: fork` | Change to `session: fresh`, `session: artifacts_only`, or `session: persist` |
-| **C010** | error | Multiple unconditional edges | A non-router node has more than one unconditional outgoing edge | Keep only one default edge, or use a router for fan-out |
+| **C010** | error | Multiple unconditional edges | A non-router node has more than one unconditional outgoing edge. A loop back-edge (`as name(N)`) does not count: `src -> body as name(N)` next to a bare `src -> exit` is the **loop-exhaustion exit** — the bare edge fires once the loop has spent its iterations — and is the one allowed shape with two unconditional edges from a node | Keep only one default edge (plus a loop back-edge and its exhaustion exit), or use a router for fan-out |
 | **C011** | error | Ambiguous conditions | Same condition field appears twice with same polarity from the same source | Remove the duplicate edge or use different conditions |
 | **C012** | error | Missing fallback | A node has conditional edges but no unconditional fallback and conditions aren't exhaustive | Add `when not X` to complement `when X`, or add an unconditional edge |
 | **C013** | error | Condition field not boolean | A `when` clause references a field that isn't `bool` in the source output schema | Change the schema field to `bool` |
@@ -83,7 +85,7 @@ All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`
 | **C091** | error | Secret / var name collision | A secret name collides with a declared `vars:` entry | Rename one — secrets and vars share a template namespace |
 | **C092** | error | Invalid secret host | A secret's egress host scoping (Layer 2 `hosts:`) is ill-formed | Use valid host entries (hostnames / domains) |
 | **C093** | error | Unknown secret reference | `{{secrets.X}}` references a secret not declared in the `secrets:` block | Declare the secret, or fix the name |
-| **C094** | error | Malformed file secret | An `as: file` secret declaration is malformed | Provide a valid `value:`/`env:` and file-mount form |
+| **C094** | error | Malformed file secret | An `as: file` secret declaration is malformed (a bad `mount_path:`, an `env:` that is not an identifier) | Fix the offending property. A bare `as: file` (optionally `optional: true`) is complete on its own — it resolves the stored secret by name and mounts it; `value:`/`env:`/`mount_path:` are additions, not requirements |
 | **C095** | error | Unsupported secret sub-field | `{{secrets.X.<subfield>}}` uses a sub-field the runtime does not expose | Drop the sub-field, or reference `{{secrets.X}}` directly |
 | **C097** | error | Unbounded loop without fuel | An `as name(unbounded)` loop has no fuel ceiling (neither a per-loop `unbounded <N>` nor a workflow `budget.max_iterations`) — the "no silent infinity" invariant | Add a per-loop fuel (`as name(unbounded 200)`) or a workflow `budget.max_iterations` |
 | **C098** | warning | Unbounded loop without exit | An `unbounded` loop's body has no edge leaving the loop — only fuel/liveness can stop it | Add a `when`-exit (convergence condition) so the loop terminates by its own logic |
@@ -207,8 +209,8 @@ phrasing template and are all warnings, so a skill gap never fails validation.
 
 **"I get C019 (undeclared cycle)"**
 Every back-edge (edge that creates a cycle) needs `as loop_name(N)`. Example:
-```iter
-judge -> agent when not approved as retry(3) with { ... }
+```iter fragment:edges
+evaluator -> worker when not approved as retry(3) with { feedback: "{{outputs.evaluator.summary}}" }
 ```
 
 **"I get C009 (session at convergence)"**

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -208,7 +208,28 @@ phrasing template and are all warnings, so a skill gap never fails validation.
 ## Quick Troubleshooting
 
 **"I get C019 (undeclared cycle)"**
-Every back-edge (edge that creates a cycle) needs `as loop_name(N)`. Example:
+Every back-edge (edge that creates a cycle) needs `as loop_name(N)`. This is the shape that fails:
+
+```iter invalid
+schema verdict:
+  approved: bool
+
+agent worker:
+  model: "anthropic/claude-sonnet-4-6"
+  output: verdict
+
+judge evaluator:
+  model: "anthropic/claude-sonnet-4-6"
+  output: verdict
+
+workflow w:
+  entry: worker
+  worker -> evaluator
+  evaluator -> done when approved
+  evaluator -> worker when not approved     # C019: a cycle with no declared loop
+```
+
+And the fix, on the back-edge:
 ```iter fragment:edges
 evaluator -> worker when not approved as retry(3) with { feedback: "{{outputs.evaluator.summary}}" }
 ```

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -210,7 +210,7 @@ phrasing template and are all warnings, so a skill gap never fails validation.
 **"I get C019 (undeclared cycle)"**
 Every back-edge (edge that creates a cycle) needs `as loop_name(N)`. This is the shape that fails:
 
-```iter invalid
+```iter invalid:C019
 schema verdict:
   approved: bool
 

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -29,7 +29,7 @@ key: |
   with preserved newlines
 ```
 
-Raw strings have no backtick escape. `## strict-escape: on` in the leading file comments opts quoted strings into standard escape interpretation. Lists are bracketed and comma-separated. Depending on the property, elements are identifiers, strings, tool refs (`mcp.server.*`), or either.
+Raw strings have no backtick escape. A `# strict-escape: on` line (or `## strict-escape: on`) among the leading comment lines of the file opts quoted strings into standard escape interpretation. Lists are bracketed and comma-separated. Depending on the property, elements are identifiers, strings, tool refs (`mcp.server.*`), or either.
 
 Scalar declaration literals are strings, integers, floats, or booleans. JSON and `string[]` defaults/preset values therefore use a quoted JSON representation.
 

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -2,7 +2,7 @@
 
 This is the readable inventory of the syntax accepted by the current parser. The machine-oriented counterpart is [`grammar/iterion_v1.ebnf`](../grammar/iterion_v1.ebnf). Parsing success is only the first stage: the IR compiler then checks declarations, types, references, graph structure, mode-specific properties, loops, resources, and capabilities.
 
-Notation: `{x}` means zero or more, `[x]` is optional, and `a | b` is an alternative. Indentation is significant; examples use two spaces. `##` comments and blank lines are ignored between constructs.
+Notation: `{x}` means zero or more, `[x]` is optional, and `a | b` is an alternative. Indentation is significant; examples use two spaces. `#` comments (`##` is the same comment) and blank lines are ignored between constructs.
 
 ## File declarations
 
@@ -21,7 +21,7 @@ At most one top-level `vars`, `presets`, `attachments`, and `secrets` block is r
 
 Identifiers match `[A-Za-z_][A-Za-z0-9_]*`; quote kebab-case skill names and other values containing punctuation. A DSL string can use:
 
-```iter
+```text
 key: "escaped string"
 key: `raw string: $SHELL and "quotes" stay literal`
 key: |
@@ -296,7 +296,7 @@ Budget fields are `max_parallel_branches: INT`, `max_duration: STRING`, `max_cos
 
 Resources are either counting semaphores or named-member pools:
 
-```iter
+```iter fragment:workflow
 resources:
   browser: 2
   worktree: ["slot-a", "slot-b"]
@@ -308,7 +308,7 @@ Nodes acquire them with `needs: browser` or `needs: [browser, worktree]`.
 
 Short form:
 
-```iter
+```iter fragment:workflow
 sandbox: auto   # or none / inline
 ```
 

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -12,7 +12,7 @@ file = { top_level_decl } ;
 top_level_decl = vars | presets | attachments | secrets | mcp_server
                | prompt | schema | cursor | supervisor
                | agent | judge | router | human | tool | compute
-               | emit | wait | await_answers | subbot | group | use | workflow ;
+               | emit | wait | await_answers | fail | subbot | group | use | workflow ;
 ```
 
 At most one top-level `vars`, `presets`, `attachments`, and `secrets` block is retained. Named declarations may repeat only when their names remain unique after compilation.

--- a/docs/references/patterns.md
+++ b/docs/references/patterns.md
@@ -1,6 +1,9 @@
 # Iterion DSL — Common Workflow Patterns
 
-Reusable patterns for building `.bot` workflows. Each pattern includes a skeleton snippet and explanation.
+Reusable patterns for building `.bot` workflows. Each pattern is a complete
+workflow that compiles as written (the repository's tests compile every
+snippet on this page), so it can be copied into a `.bot` and adapted. A
+`${MODEL:-…}` model spec keeps the model overridable from the environment.
 
 ---
 
@@ -9,20 +12,32 @@ Reusable patterns for building `.bot` workflows. Each pattern includes a skeleto
 The simplest pattern: nodes execute sequentially.
 
 ```iter
+schema request:
+  request: string
+
+schema step_a_output:
+  data: string
+
+schema step_b_input:
+  data: string
+
+schema step_b_output:
+  result: string
+
 agent step_a:
-  model: "${MODEL}"
-  input: input_schema
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  input: request
   output: step_a_output
 
 agent step_b:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: step_b_input
   output: step_b_output
 
 workflow pipeline:
   entry: step_a
   step_a -> step_b with {
-    data: "{{outputs.step_a}}"
+    data: "{{outputs.step_a.data}}"
   }
   step_b -> done
 ```
@@ -34,14 +49,28 @@ workflow pipeline:
 An agent produces work, a judge evaluates it. If rejected, loop back with feedback. Bounded to prevent infinite execution.
 
 ```iter
+schema task_input:
+  task: string
+  feedback: string
+
+schema task_output:
+  result: string
+
+schema eval_input:
+  submission: json
+
+schema eval_output:
+  approved: bool
+  summary: string
+
 agent worker:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: task_input
   output: task_output
   session: fresh
 
 judge evaluator:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: eval_input
   output: eval_output
   session: fresh
@@ -65,6 +94,10 @@ workflow review_loop:
 - The loop is declared with `as refine_loop(5)` — max 5 iterations
 - `{{outputs.worker.history}}` gives the agent all its previous attempts
 - The `when` condition field (`approved`) must be `bool` in `eval_output`
+- When the loop's five iterations are spent, the back-edge is declined and
+  the run fails with `LOOP_EXHAUSTED`; add a bare `evaluator -> <exit>` edge
+  (the loop-exhaustion exit, exempt from C010) to route the exhausted case
+  somewhere useful instead
 
 ---
 
@@ -73,21 +106,34 @@ workflow review_loop:
 A router sends work to multiple agents in parallel. A downstream node waits for all results.
 
 ```iter
+schema analysis_input:
+  data: string
+
+schema analysis_output:
+  findings: string
+
+schema synthesis_input:
+  result_a: json
+  result_b: json
+
+schema synthesis_output:
+  summary: string
+
 router distribute:
   mode: fan_out_all
 
 agent analyzer_a:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: analysis_input
   output: analysis_output
 
 agent analyzer_b:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: analysis_input
   output: analysis_output
 
 judge synthesizer:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   await: wait_all
   input: synthesis_input
   output: synthesis_output
@@ -125,8 +171,26 @@ workflow parallel_analysis:
 A router forwards to different agents based on conditions from upstream output.
 
 ```iter
+schema classification:
+  is_complex: bool
+
+schema handled:
+  result: string
+
+agent classifier:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: classification
+
 router dispatch:
   mode: condition
+
+agent simple_handler:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: handled
+
+agent complex_handler:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: handled
 
 workflow conditional:
   entry: classifier
@@ -151,6 +215,9 @@ workflow conditional:
 An LLM decides which target to route to. No `when` conditions on edges.
 
 ```iter
+schema handled:
+  result: string
+
 prompt router_system:
   Given the input, decide which specialist to route to.
   - code_agent: for code-level issues
@@ -158,8 +225,16 @@ prompt router_system:
 
 router smart_router:
   mode: llm
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   system: router_system
+
+agent code_agent:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: handled
+
+agent design_agent:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: handled
 
 workflow llm_routed:
   entry: smart_router
@@ -183,6 +258,23 @@ workflow llm_routed:
 Pause execution for human approval before proceeding.
 
 ```iter
+schema work_output:
+  summary: string
+
+schema approval_input:
+  submission: json
+
+schema approval_output:
+  approved: bool
+  notes: string
+
+prompt approval_instructions:
+  Review the submission below and approve it, or reject it with a note.
+
+agent worker:
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
+  output: work_output
+
 human approval_gate:
   input: approval_input
   output: approval_output
@@ -215,7 +307,7 @@ leaving executor selection to credential detection. `claude_code`, `codex`,
 explicit opt-ins. A separate `model:` pin is optional and does not select the
 backend.
 
-```iter
+```iter fragment
 agent implementer:
   backend: "claude_code"
   input: task_input
@@ -223,7 +315,7 @@ agent implementer:
   system: impl_system
   user: impl_user
   session: fresh
-  tools: [Read, Edit, Write, Bash, Glob, Grep]
+  tools: [read_file, file_edit, write_file, bash, glob, grep]
   tool_max_steps: 25
 ```
 
@@ -232,6 +324,8 @@ agent implementer:
 - Delegation supports `interaction` (forwarding human input to the subprocess)
 - `readonly: true` marks the node as non-mutating for workspace safety
 - Multiple mutating delegates cannot run in parallel (workspace safety constraint)
+- A `tools:` list uses the snake_case built-in names; it constrains `claw`
+  and is inert on CLI backends, which keep their full native toolset
 
 ---
 
@@ -240,12 +334,31 @@ agent implementer:
 Use a `tool` node to run shell commands directly (no LLM), combined with a judge for feedback loops.
 
 ```iter
+schema ci_result:
+  passed: bool
+  logs: string
+
+schema verify_input:
+  results: json
+  changes: json
+
+schema verify_output:
+  passed: bool
+  summary: string
+
+schema fix_input:
+  feedback: string
+  ci_logs: string
+
+schema fix_output:
+  changes: string
+
 tool run_ci:
-  command: "${CI_COMMAND}"
+  command: "${CI_COMMAND:-make test}"
   output: ci_result
 
 judge verify:
-  model: "${MODEL}"
+  model: "${MODEL:-anthropic/claude-sonnet-4-6}"
   input: verify_input
   output: verify_output
 
@@ -253,7 +366,6 @@ agent fixer:
   backend: "claude_code"
   input: fix_input
   output: fix_output
-  tools: [Read, Edit, Write, Bash]
 
 workflow ci_fix:
   entry: fixer
@@ -273,6 +385,11 @@ workflow ci_fix:
   }
 ```
 
+**Key points:**
+- A tool node with `output:` must print a JSON object matching that schema
+  on stdout (`{"passed": true, "logs": "…"}`); wrap the real command so the
+  exit code becomes a field rather than a node failure
+
 ---
 
 ## 9. Session Fork for Read-Only Extraction
@@ -283,7 +400,7 @@ Fork a session to let multiple readonly agents extract information without consu
 agent worker:
   backend: "claude_code"
   session: fresh
-  tools: [Read, Edit, Write, Bash]
+  tools: [read_file, file_edit, write_file, bash]
 
 router extract_router:
   mode: fan_out_all
@@ -292,13 +409,13 @@ agent summarizer:
   backend: "claude_code"
   session: fork
   readonly: true
-  tools: [Read, Glob, Grep]
+  tools: [read_file, glob, grep]
 
 agent commit_namer:
   backend: "claude_code"
   session: fork
   readonly: true
-  tools: [Read, Bash]
+  tools: [read_file, bash]
 
 workflow fork_extract:
   entry: worker
@@ -327,18 +444,32 @@ workflow fork_extract:
 Cycle through agents one at a time, useful for dual-model approaches.
 
 ```iter
+schema task_input:
+  task: string
+
+schema task_output:
+  result: string
+
+schema verdict:
+  accepted: bool
+
 router alternator:
   mode: round_robin
 
 agent model_a:
-  model: "claude-sonnet-4-20250514"
+  model: "anthropic/claude-sonnet-4-6"
   input: task_input
   output: task_output
 
 agent model_b:
-  model: "gpt-4o"
+  backend: "claw"
+  model: "openai/gpt-5.5"
   input: task_input
   output: task_output
+
+judge evaluator:
+  model: "anthropic/claude-sonnet-4-6"
+  output: verdict
 
 workflow dual_model:
   entry: alternator

--- a/docs/references/patterns.md
+++ b/docs/references/patterns.md
@@ -356,7 +356,7 @@ schema fix_output:
 tool run_ci:
   ## The exit code becomes a field: a failing suite is a RESULT the judge
   ## reads, not a node failure — and stdout is the JSON the schema declares.
-  command: `if ${CI_COMMAND:-make test} >/tmp/ci.log 2>&1; then ok=true; else ok=false; fi; printf '{"passed":%s,"logs":%s}' "$ok" "$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()[-20000:]))' </tmp/ci.log)"`
+  command: `if ${CI_COMMAND:-make test} >/tmp/ci.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, logs: .}' </tmp/ci.log`
   output: ci_result
 
 judge verify:

--- a/docs/references/patterns.md
+++ b/docs/references/patterns.md
@@ -95,9 +95,9 @@ workflow review_loop:
 - `{{outputs.worker.history}}` gives the agent all its previous attempts
 - The `when` condition field (`approved`) must be `bool` in `eval_output`
 - When the loop's five iterations are spent, the back-edge is declined and
-  the run fails with `LOOP_EXHAUSTED`; add a bare `evaluator -> <exit>` edge
-  (the loop-exhaustion exit, exempt from C010) to route the exhausted case
-  somewhere useful instead
+  the evaluator has no edge left, so the run fails `NO_OUTGOING_EDGE`; add a
+  bare `evaluator -> <exit>` edge (the loop-exhaustion exit, exempt from
+  C010) to route the exhausted case somewhere useful instead
 
 ---
 
@@ -354,7 +354,9 @@ schema fix_output:
   changes: string
 
 tool run_ci:
-  command: "${CI_COMMAND:-make test}"
+  ## The exit code becomes a field: a failing suite is a RESULT the judge
+  ## reads, not a node failure — and stdout is the JSON the schema declares.
+  command: `if ${CI_COMMAND:-make test} >/tmp/ci.log 2>&1; then ok=true; else ok=false; fi; printf '{"passed":%s,"logs":%s}' "$ok" "$(python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()[-20000:]))' </tmp/ci.log)"`
   output: ci_result
 
 judge verify:
@@ -386,9 +388,11 @@ workflow ci_fix:
 ```
 
 **Key points:**
-- A tool node with `output:` must print a JSON object matching that schema
-  on stdout (`{"passed": true, "logs": "…"}`); wrap the real command so the
-  exit code becomes a field rather than a node failure
+- A tool node's stdout is its output: print a JSON object matching the
+  `output:` schema (`{"passed": true, "logs": "…"}`). Any other stdout is
+  silently wrapped as `{"result": "…"}` and the declared fields are absent
+  downstream, and a non-zero exit fails the node — hence the wrapper, which
+  turns the exit code into a field
 
 ---
 

--- a/docs/references/patterns.md
+++ b/docs/references/patterns.md
@@ -356,7 +356,7 @@ schema fix_output:
 tool run_ci:
   ## The exit code becomes a field: a failing suite is a RESULT the judge
   ## reads, not a node failure — and stdout is the JSON the schema declares.
-  command: `if ${CI_COMMAND:-make test} >/tmp/ci.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, logs: .}' </tmp/ci.log`
+  command: `if ${CI_COMMAND:-make test} >/tmp/ci.log 2>&1; then ok=true; else ok=false; fi; jq -Rs --argjson passed "$ok" '{passed: $passed, logs: .[-20000:]}' </tmp/ci.log`
   output: ci_result
 
 judge verify:
@@ -392,7 +392,8 @@ workflow ci_fix:
   `output:` schema (`{"passed": true, "logs": "…"}`). Any other stdout is
   silently wrapped as `{"result": "…"}` and the declared fields are absent
   downstream, and a non-zero exit fails the node — hence the wrapper, which
-  turns the exit code into a field
+  turns the exit code into a field and keeps only the log's last 20 000
+  characters (the judge reads that field; nothing else bounds it)
 
 ---
 

--- a/docs/review-merge-gate.md
+++ b/docs/review-merge-gate.md
@@ -12,7 +12,7 @@ It is a fourth `interaction:` mode on `human` nodes, alongside `human`,
 
 ## At a glance
 
-```iter
+```iter fragment
 human ship_review:
   interaction: review
   model: "anthropic/claude-sonnet-4-6"   # the companion (writes test steps + verdict)

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -22,14 +22,14 @@ flowchart LR
 
 ## Syntax
 
-```iter
+```text
 router <name>:
   mode: fan_out_all | fan_out_each | condition | round_robin | llm
 ```
 
 LLM routers accept additional properties:
 
-```iter
+```iter fragment
 router fix_router:
   mode: llm
   model: "anthropic/claude-sonnet-4-6"   # or backend: "claude_code"
@@ -54,7 +54,7 @@ router uses its built-in fallback model.
 
 This is the default mode. The router sends execution to **every** outgoing edge simultaneously. Each target runs in its own branch, and branches converge at a downstream node that declares `await: wait_all` or `await: best_effort` — executed once, after every branch has settled (see [Convergence with `await`](#convergence-with-await)).
 
-```iter
+```iter fragment
 router review_fanout:
   mode: fan_out_all
 
@@ -64,7 +64,7 @@ agent synthesize_reviews:
   await: wait_all
 
 workflow example:
-  ...
+  # …
   review_fanout -> claude_review
   review_fanout -> gpt_review
   claude_review -> synthesize_reviews
@@ -86,7 +86,7 @@ An `llm multi: true` router is checked more tightly than the other two. `fan_out
 
 `fan_out_each` resolves `over:` to an array at runtime and replays its single outgoing template branch once per item. The current item is exposed on the router output under the binding named by `as:` (default `item`).
 
-```iter
+```iter fragment
 router dispatch:
   mode: fan_out_each
   over: "{{outputs.plan.tickets}}"
@@ -116,7 +116,7 @@ The router must have exactly one unconditional outgoing edge: it is the head of 
 
 Optional `key:` and `depends_on:` fields turn the array into a dependency DAG. `key` names the unique-id field on each item; `depends_on` names an array field containing prerequisite ids. Independent items run concurrently, dependants wait, failed prerequisites skip their dependants, and a dependency cycle fails the run.
 
-```iter
+```iter fragment
 router dispatch:
   mode: fan_out_each
   over: "{{outputs.plan.tickets}}"
@@ -141,12 +141,12 @@ When item paths reconverge into one collector, declare `await: wait_all` or `awa
 
 A condition router picks a single target based on boolean fields in the upstream node's output. The routing logic is expressed on the edges, not in the router itself.
 
-```iter
+```iter fragment
 router decision:
   mode: condition
 
 workflow example:
-  ...
+  # …
   judge -> decision
   decision -> fix_agent when not approved
   decision -> done when approved
@@ -162,12 +162,12 @@ When the `judge` node produces `{ "approved": true }`, the edge `decision -> don
 
 Each time the router is traversed, it selects the **next** outgoing edge in declaration order, wrapping around after the last one.
 
-```iter
+```iter fragment
 router refine_selector:
   mode: round_robin
 
 workflow example:
-  ...
+  # …
   val_judge -> refine_selector when not ready as refine_loop(4)
   refine_selector -> claude_refine
   refine_selector -> gpt_refine
@@ -199,7 +199,7 @@ An LLM reads the workflow context and decides which route to take. This is the o
 
 ### Single route example
 
-```iter
+```iter fragment
 prompt routing_prompt:
   Based on the review findings, decide whether
   the code, the docs, or the tests need fixing.
@@ -210,7 +210,7 @@ router fix_router:
   system: routing_prompt
 
 workflow example:
-  ...
+  # …
   fix_router -> fix_code
   fix_router -> fix_docs
   fix_router -> fix_tests
@@ -220,7 +220,7 @@ workflow example:
 
 With `multi: true`, the LLM can select several routes at once. Selected targets run in parallel and converge at a downstream node that declares `await: wait_all` or `await: best_effort`. Those parallel bodies use the same branch-local bounded-loop semantics as `fan_out_all`; on restart the persisted route selection and branch cursors are reused instead of asking the model to route again.
 
-```iter
+```iter fragment
 router fix_router:
   mode: llm
   backend: "claude_code"
@@ -228,7 +228,7 @@ router fix_router:
   multi: true
 
 workflow example:
-  ...
+  # …
   fix_router -> fix_code
   fix_router -> fix_docs
   fix_router -> fix_tests

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -363,7 +363,7 @@ Blocked requests surface to the run as a `network_blocked` event in
 
 The DSL accepts both short-form modes and block-form inline specs:
 
-```iter
+```iter fragment
 workflow x:
   # Short form: read .devcontainer/devcontainer.json, or fall back to
   # the default image when no devcontainer is present.
@@ -414,7 +414,7 @@ and auto-mode fallback cases.
 Per-node overrides accept the same short or block form on `agent`,
 `judge`, and `tool`:
 
-```iter
+```iter fragment
 agent shell_helper:
   sandbox: none      # this node runs on the host even though the
                      # workflow has sandbox: auto
@@ -1181,7 +1181,7 @@ service is deployed; the resulting image lands in the local Docker
 image store and the sibling container of the run consumes it via
 `docker run` like any pre-built ref.
 
-```iter
+```iter fragment:workflow
 sandbox:
   build:
     dockerfile: "examples/sandbox_build.dockerfile"

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -26,7 +26,7 @@ The shortest path to a sandboxed run:
 1. Add (or reuse) a `.devcontainer/devcontainer.json` in your repo.
 2. Set `sandbox: auto` on your workflow:
 
-   ```iter
+   ```iter fragment
    workflow review:
      worktree: auto
      sandbox: auto
@@ -664,7 +664,7 @@ your repo root and `sandbox: auto` will pick them up.
 | `kimi` / `grok` | **fully sandboxed** (CLI runs inside the container) |
 | `codex`       | **unsupported by the outer sandbox** — the pinned SDK cannot use Iterion's command builder, so the node fails explicitly |
 | `claw`        | **sandboxed via runner sub-process** (Phase 4 V1) — see below |
-| Tool nodes    | **fully sandboxed** (`sh -c` runs inside the container) |
+| Tool nodes    | **fully sandboxed** (`bash -c` runs inside the container) |
 | MCP servers   | Built-in board tools reach sandboxed `claude_code` and pi RPC over per-run HTTP; ask-user uses HTTP for Claude Code and pi's embedded control channel. Declared stdio servers remain host-side for Claude Code, but pi RPC starts them beside pi (inside the sandbox). See [MCP tools in a sandbox](#mcp-tools-in-a-sandbox). |
 
 ### Claw backend in sandbox
@@ -1227,7 +1227,7 @@ already cover via CI:
 - Build the workflow's image in CI (GitHub Actions, GitLab CI…),
   push to a registry, pin by digest.
 - Reference the digest from the workflow:
-  ```iter
+  ```iter fragment:workflow
   sandbox:
     image: "ghcr.io/myorg/myimage@sha256:<digest>"
   ```

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -53,7 +53,7 @@ Declare secrets in the DSL; the agent only ever sees an opaque
 placeholder `__ITERION_SECRET_<name>__`; iterion swaps in the real value
 at the moment of execution.
 
-```iter
+```iter fragment
 secrets:
   github_token: "${GITHUB_TOKEN}"          # short form
   deploy_key:
@@ -88,7 +88,7 @@ materialization above.
 Some credentials are safer and more ergonomic as files (`kubeconfig`,
 cloud SDK config, deploy certs). Declare them with `as: file`:
 
-```iter
+```iter fragment
 secrets:
   kubeconfig:
     as: file
@@ -132,7 +132,7 @@ records the failure as `StatusLaunchError` on its delivery trail.
 Mark a secret `optional: true` to skip it silently instead — for a bot
 that only needs the credential on *some* runs:
 
-```iter
+```iter fragment
 secrets:
   forge_token:
     as: file
@@ -286,10 +286,10 @@ A declared secret with **no inline `value:`** resolves *by name* from this
 store — so a bot declares what it needs, and the operator supplies it out of
 band:
 
-```iter
+```iter fragment
 secrets:
   GITHUB_TOKEN:            # no value: → resolved by name from the local store
-    hosts: [github.com]    # egress lock still applies (Layer 2)
+    hosts: ["github.com"]    # egress lock still applies (Layer 2)
 ```
 
 ### Storage, master key, scope

--- a/docs/security-bots-distributed.md
+++ b/docs/security-bots-distributed.md
@@ -134,7 +134,7 @@ Behavior:
 `scan_join` and `triage`, gated by `--var shard_size=<N>` (default
 `0` = no sharding):
 
-```iter
+```iter fragment
 compute plan_shards:
   ## Lists every source file the scanners touched. If shard_size > 0,
   ## emits a shards plan; otherwise emits a single-shard plan (no fan-out).
@@ -142,18 +142,19 @@ compute plan_shards:
   output: plan_output
   expr:
     enabled: "vars.shard_size > 0"
-    ...
+    # … the shard plan fields
 
 tool dispatch_shards:
   ## Calls `iterion __scan-shards`. Skipped when plan_shards.enabled is false.
   command: `iterion __scan-shards --parent-run-id={{run.id}} ...`
-  ...
+  # … output schema, publish
 
-# Edges:
-scan_join -> plan_shards
-plan_shards -> dispatch_shards when enabled
-plan_shards -> triage when not enabled
-dispatch_shards -> done  # children emit their own issues + FileRecords
+workflow sharded:
+  entry: scan_join
+  scan_join -> plan_shards
+  plan_shards -> dispatch_shards when enabled
+  plan_shards -> triage when not enabled
+  dispatch_shards -> done  # children emit their own issues + FileRecords
 ```
 
 When sharding is enabled, the parent doesn't run triage / revalidate

--- a/docs/ultracode.md
+++ b/docs/ultracode.md
@@ -47,7 +47,7 @@ extra configuration.
 
 ## Usage
 
-```iter
+```iter fragment
 agent implementer:
   backend: "claude_code"
   model: "anthropic/claude-opus-4-8"
@@ -63,13 +63,13 @@ small model such as `anthropic/claude-sonnet-4-6`.
 
 The value is also settable dynamically from an upstream node:
 
-```iter
-router -> implementer with {_reasoning_effort: "ultracode"}
+```iter fragment:edges
+plan_router -> implementer with { _reasoning_effort: "ultracode" }
 ```
 
 and via env substitution, which is resolved (and re-validated) at runtime:
 
-```iter
+```iter fragment:agent
   reasoning_effort: "${ITERION_EFFORT:-ultracode}"
 ```
 

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -85,9 +85,9 @@ iterion plugin config firecrawl api_url=http://localhost:3002
 The plugin contributes an `mcp.firecrawl.*` server to the workflow MCP
 catalog. A claw node uses it like any MCP tool:
 
-```iter
+```iter fragment
 agent researcher:
-  backend: claw
+  backend: "claw"
   tools: [mcp.firecrawl.search, mcp.firecrawl.scrape, web_fetch]
   mcp:
     servers: [firecrawl]

--- a/docs/workflow_authoring_pitfalls.md
+++ b/docs/workflow_authoring_pitfalls.md
@@ -585,9 +585,10 @@ echo {"count":3,"done":false}
 ```
 
 This worked under devbox (bash interpreting). On a Linux Mint host the
-same workflow piped through `sh -c` ran under dash — *which has no
-brace expansion*. The output landed unchanged, JSON parsed, run
-succeeded.
+same workflow piped through `sh -c` (what the executor invoked at the
+time; a `command:` now runs `bash -c`, and a `language: sh` script still
+hits exactly this) ran under dash — *which has no brace expansion*. The
+output landed unchanged, JSON parsed, run succeeded.
 
 But on a host where the user's `sh` *was* bash (e.g. Ubuntu with
 `dash` reconfigured to `bash`, or any rebuilt image where bash is
@@ -620,7 +621,7 @@ echo \{\"count\":$(wc -c < /tmp/counter),\"done\":false\}
 
 Every `{`, `}`, and `"` is backslash-escaped. The braces are escaped
 to defeat brace expansion under bash; the quotes are escaped to
-survive the outer YAML/`.bot` string-literal layer plus `sh -c`.
+survive the outer YAML/`.bot` string-literal layer plus `bash -c`.
 
 Alternative: produce JSON via `printf '{"count":%d,"done":false}\n' N`.
 `printf` is POSIX, has no brace expansion semantics, and reads as
@@ -671,8 +672,9 @@ If a downstream node fails with "expected object, got string" or
 
 1. Run the command manually under `dash` *and* under `bash` — they
    should produce identical output.
-2. Run it under devbox (`devbox run -- sh -c '…'`) since that's what
-   the engine inherits from PATH.
+2. Run it under devbox (`devbox run -- bash -c '…'` for a `command:`,
+   `devbox run -- sh -c '…'` for a `language: sh` script) since that's
+   the PATH the engine inherits.
 3. Inspect the run's `events.jsonl` for the `tool_called` event — it
    records the resolved command string and raw stdout.
 

--- a/docs/workflow_authoring_pitfalls.md
+++ b/docs/workflow_authoring_pitfalls.md
@@ -556,13 +556,17 @@ Sharper prompts up front would have cut that in half.
 
 ## Shell portability for tool nodes
 
-`.bot` `tool` nodes execute their `command:` string via
-`exec.Command("sh", "-c", …)` (see `pkg/backend/model/executor.go`,
-`executeToolNodeShell`). The crucial detail: **`sh` resolves to whatever
-binary `sh` points at in the runtime PATH.** It is *not* a fixed
-interpreter.
+A `.bot` `tool` node's `command:` string runs via `bash -c`
+(`pkg/backend/model/executor_tool.go`, `toolNodeCommand`), on the host and
+inside a sandbox alike — bash is pinned precisely because `/bin/sh` is dash
+on Debian-derived images. A `script:` node is different: it runs the
+interpreter its `language:` names, and `language: sh` (the default) is
+whatever binary `sh` points at in the runtime PATH — *not* a fixed
+interpreter. The rules below bind every `script:` in `sh`, and every
+`command:` that may also run where bash is absent (a minimal image: install
+bash via `post_create`, or write POSIX).
 
-This means the same workflow can behave differently across hosts:
+A `sh` script can therefore behave differently across hosts:
 
 | Environment              | What `sh` actually is |
 | ------------------------ | --------------------- |
@@ -672,16 +676,14 @@ If a downstream node fails with "expected object, got string" or
 3. Inspect the run's `events.jsonl` for the `tool_called` event — it
    records the resolved command string and raw stdout.
 
-### Why the engine doesn't pin `bash`
+### Why `command:` pins `bash` and `script:` does not
 
-We stayed with `sh` because:
-
-- Alpine / busybox images don't ship bash by default; pinning to
-  `bash` would break minimal containers.
-- macOS bash is 3.2 (GPL-3 avoidance); pinning would silently invoke
-  a 17-year-old bash with different defaults.
-- POSIX is a small, well-documented target. Authoring to it scales.
-
-**If you genuinely need bash**, invoke it explicitly:
-`bash -c '…bash-only syntax…'`. That's a contract the workflow
-declares, not an assumption.
+A `command:` is a one-line recipe that authors reach for with bash
+idioms (`[[ ]]`, arrays, `pipefail`), and `/bin/sh` is dash on the
+Debian-derived images the sandbox ships — so the executor runs `bash -c`
+and treats a missing bash as the image's problem (install it via
+`post_create`, or rewrite the body in POSIX). A `script:` names its own
+interpreter through `language:`, which is the contract to reach for when
+the shell matters: `language: bash` for bash-only syntax, `language: sh`
+when the script must also run on Alpine/busybox or macOS's bash 3.2 — a
+small, well-documented POSIX target that authoring to scales.

--- a/pkg/botregistry/description_hash_test.go
+++ b/pkg/botregistry/description_hash_test.go
@@ -33,4 +33,16 @@ func TestLeadingCommentDescription_StopsAtTheFirstLineOfCode(t *testing.T) {
 	if got := leadingCommentDescription([]byte(raw), "x.bot"); got != "A simple bot." {
 		t.Errorf("description = %q, want the paragraph after the frontmatter", got)
 	}
+	// A BOM is not a line of code (the lexer strips it too), and CR / CRLF
+	// line endings terminate lines — neither may cost the description or
+	// leak the code that follows it.
+	for name, raw := range map[string]string{
+		"BOM":     "\ufeff## A simple bot.\n## Does one thing.\n\nagent a:\n",
+		"CRLF":    "## A simple bot.\r\n## Does one thing.\r\n\r\nagent a:\r\n",
+		"lone CR": "## A simple bot.\r## Does one thing.\ragent a:\r",
+	} {
+		if got := leadingCommentDescription([]byte(raw), "x.bot"); got != "A simple bot. Does one thing." {
+			t.Errorf("%s: description = %q, want the two comment lines joined", name, got)
+		}
+	}
 }

--- a/pkg/botregistry/description_hash_test.go
+++ b/pkg/botregistry/description_hash_test.go
@@ -1,0 +1,14 @@
+package botregistry
+
+import "testing"
+
+// The description reader follows the lexer's definition of a comment line
+// (`#` or `##`) and of the frontmatter fence (`# ---` or `## ---`): a bot
+// whose leading comments use a single hash keeps its catalogue description,
+// and a single-hash frontmatter block is skipped like a double-hash one.
+func TestLeadingCommentDescription_SingleHashComments(t *testing.T) {
+	raw := []byte("# ---\n# name: Alpha\n# ---\n# A simple bot.\n## Does one thing.\n\nagent a:\n")
+	if got := leadingCommentDescription(raw, "simple.bot"); got != "A simple bot. Does one thing." {
+		t.Fatalf("description = %q, want the two comment lines joined", got)
+	}
+}

--- a/pkg/botregistry/description_hash_test.go
+++ b/pkg/botregistry/description_hash_test.go
@@ -12,3 +12,25 @@ func TestLeadingCommentDescription_SingleHashComments(t *testing.T) {
 		t.Fatalf("description = %q, want the two comment lines joined", got)
 	}
 }
+
+// The description is the LEADING comment paragraph, before the first line of
+// code. A file with no header comment has no description: a `# shell comment`
+// inside a `command: |` block, or a prompt body's `# Heading` (text for the
+// lexer), must never be published as the bot's catalogue description.
+func TestLeadingCommentDescription_StopsAtTheFirstLineOfCode(t *testing.T) {
+	cases := map[string]string{
+		"shell comment in a block scalar": "tool t:\n  command: |\n    # shell comment\n    echo hi\nworkflow w:\n  entry: t\n  t -> done\n",
+		"heading in a prompt body":        "prompt p:\n  # Internal reviewer notes — do not ship\n  You are a reviewer.\n",
+		"comment after the first decl":    "agent a:\n  model: \"m\"\n\n# Not a description: it follows code.\n",
+	}
+	for name, raw := range cases {
+		if got := leadingCommentDescription([]byte(raw), "x.bot"); got != "" {
+			t.Errorf("%s: description = %q, want none", name, got)
+		}
+	}
+	// A blank line between the frontmatter and the paragraph is still fine.
+	raw := "## ---\n## name: Alpha\n## ---\n\n## A simple bot.\n\nagent a:\n"
+	if got := leadingCommentDescription([]byte(raw), "x.bot"); got != "A simple bot." {
+		t.Errorf("description = %q, want the paragraph after the frontmatter", got)
+	}
+}

--- a/pkg/botregistry/registry.go
+++ b/pkg/botregistry/registry.go
@@ -503,21 +503,24 @@ func leadingCommentDescription(raw []byte, filename string) string {
 	var out []string
 	skippingFM := false
 	for _, ln := range lines {
-		trim := strings.TrimSpace(ln)
-		if trim == "## ---" {
+		// A comment line is `#` or `##`, the lexer's own rule
+		// (workflowfile.CommentText); the frontmatter fence is the `---`
+		// comment whichever hash count it uses.
+		text, isComment := workflowfile.CommentText(ln)
+		if isComment && strings.TrimSpace(text) == workflowfile.FrontmatterFence {
 			skippingFM = !skippingFM
 			continue
 		}
 		if skippingFM {
 			continue
 		}
-		if !strings.HasPrefix(trim, "##") {
+		if !isComment {
 			if len(out) > 0 {
 				break
 			}
 			continue
 		}
-		body := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(trim, "##"), " "))
+		body := strings.TrimSpace(text)
 		if body == "" || isDecorationLine(body) || body == filename {
 			if len(out) > 0 {
 				break

--- a/pkg/botregistry/registry.go
+++ b/pkg/botregistry/registry.go
@@ -500,7 +500,12 @@ func parseBotFile(path string) (*Entry, error) {
 // rules like `## ────`) and a header line repeating the file's own name
 // are skipped — they are framing, not description.
 func leadingCommentDescription(raw []byte, filename string) string {
-	lines := strings.Split(string(raw), "\n")
+	// The same normalisation the lexer applies before it reads the file:
+	// a BOM is not a line of code, and a CR or CRLF terminates a line.
+	src := strings.TrimPrefix(string(raw), "\ufeff")
+	src = strings.ReplaceAll(src, "\r\n", "\n")
+	src = strings.ReplaceAll(src, "\r", "\n")
+	lines := strings.Split(src, "\n")
 	var out []string
 	skippingFM := false
 	for _, ln := range lines {

--- a/pkg/botregistry/registry.go
+++ b/pkg/botregistry/registry.go
@@ -493,9 +493,10 @@ func parseBotFile(path string) (*Entry, error) {
 	return e, nil
 }
 
-// leadingCommentDescription returns the first paragraph of `## ` lines
-// at the top of the file (excluding any `## ---` framing). Stops at the
-// first blank line or non-comment line. Decoration-only lines (banner
+// leadingCommentDescription returns the first paragraph of comment lines
+// (`#` or `##`) at the top of the file (excluding any `## ---` framing),
+// before the first line of code. Stops at the first blank line after the
+// paragraph or at the first non-comment line. Decoration-only lines (banner
 // rules like `## ────`) and a header line repeating the file's own name
 // are skipped — they are framing, not description.
 func leadingCommentDescription(raw []byte, filename string) string {
@@ -515,10 +516,17 @@ func leadingCommentDescription(raw []byte, filename string) string {
 			continue
 		}
 		if !isComment {
-			if len(out) > 0 {
-				break
+			// A blank line ends a paragraph already collected and is
+			// skipped before one; the first line of CODE ends the scan —
+			// a `# shell comment` inside a `command: |` or a prompt
+			// body's `# Heading` is text of the bot, not its description.
+			if strings.TrimSpace(ln) == "" {
+				if len(out) > 0 {
+					break
+				}
+				continue
 			}
-			continue
+			break
 		}
 		body := strings.TrimSpace(text)
 		if body == "" || isDecorationLine(body) || body == filename {

--- a/pkg/bundle/frontmatter.go
+++ b/pkg/bundle/frontmatter.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"go.yaml.in/yaml/v2"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/workflowfile"
 )
 
 // Frontmatter is the optional `## ---` … `## ---` YAML block at the top of a
@@ -34,19 +36,25 @@ func ReadFrontmatter(path string) *Frontmatter {
 // and YAML-decodes the inner content. The block is allowed only at the very
 // top of the file, optionally after blank lines. Returns nil when the block
 // is absent or malformed.
+//
+// The fence and the inner lines are comment lines of the workflow source, so
+// they follow the lexer's definition of a comment (workflowfile.CommentText):
+// `# ---` and `## ---` are the same fence, `# name: x` and `## name: x` the
+// same line. A reader that only knew `##` would silently drop the whole
+// catalogue identity of a file the parser accepts.
 func ParseFrontmatter(raw []byte) *Frontmatter {
 	lines := strings.Split(string(raw), "\n")
 	i := 0
 	for i < len(lines) && strings.TrimSpace(lines[i]) == "" {
 		i++
 	}
-	if i >= len(lines) || strings.TrimSpace(lines[i]) != "## ---" {
+	if i >= len(lines) || !isFrontmatterFence(lines[i]) {
 		return nil
 	}
 	start := i + 1
 	end := -1
 	for j := start; j < len(lines); j++ {
-		if strings.TrimSpace(lines[j]) == "## ---" {
+		if isFrontmatterFence(lines[j]) {
 			end = j
 			break
 		}
@@ -56,13 +64,22 @@ func ParseFrontmatter(raw []byte) *Frontmatter {
 	}
 	var yamlLines []string
 	for _, ln := range lines[start:end] {
-		stripped := strings.TrimPrefix(ln, "## ")
-		stripped = strings.TrimPrefix(stripped, "##")
-		yamlLines = append(yamlLines, stripped)
+		if text, ok := workflowfile.CommentText(ln); ok {
+			yamlLines = append(yamlLines, text)
+		} else {
+			yamlLines = append(yamlLines, ln)
+		}
 	}
 	var fm Frontmatter
 	if err := yaml.Unmarshal([]byte(strings.Join(yamlLines, "\n")), &fm); err != nil {
 		return nil
 	}
 	return &fm
+}
+
+// isFrontmatterFence reports whether line is the `---` comment line that
+// opens or closes a frontmatter block, whichever hash count it uses.
+func isFrontmatterFence(line string) bool {
+	text, ok := workflowfile.CommentText(line)
+	return ok && strings.TrimSpace(text) == workflowfile.FrontmatterFence
 }

--- a/pkg/bundle/frontmatter_hash_test.go
+++ b/pkg/bundle/frontmatter_hash_test.go
@@ -1,0 +1,39 @@
+package bundle
+
+import "testing"
+
+// The frontmatter block is made of comment lines, so it follows the lexer's
+// definition of a comment: `# ---` is the same fence as `## ---`, a `# note`
+// above the block is a comment like any other, and `# name: x` inside it is
+// the same line as `## name: x`. Before this held, a valid `.bot` lost its
+// name, description and triggers to a single-hash comment.
+func TestParseFrontmatterAcceptsSingleHashComments(t *testing.T) {
+	cases := map[string]string{
+		"double-hash block": "## ---\n## name: Alpha Bot\n## description: the catalog description\n## triggers:\n##   - nightly\n## ---\n\nworkflow w:\n  entry: a\n",
+		"single-hash block": "# ---\n# name: Alpha Bot\n# description: the catalog description\n# triggers:\n#   - nightly\n# ---\n\nworkflow w:\n  entry: a\n",
+		"mixed hashes":      "## ---\n# name: Alpha Bot\n## description: the catalog description\n# triggers:\n##   - nightly\n# ---\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			fm := ParseFrontmatter([]byte(src))
+			if fm == nil {
+				t.Fatal("no frontmatter parsed")
+			}
+			if fm.Name != "Alpha Bot" || fm.Description != "the catalog description" {
+				t.Errorf("name/description = %q / %q", fm.Name, fm.Description)
+			}
+			if len(fm.Triggers) != 1 || fm.Triggers[0] != "nightly" {
+				t.Errorf("triggers = %v, want [nightly]", fm.Triggers)
+			}
+		})
+	}
+	if ParseFrontmatter([]byte("workflow w:\n  entry: a\n")) != nil {
+		t.Error("a file without a fence has no frontmatter")
+	}
+	// The block still has to be the first thing in the file: a comment above
+	// the fence, of either hash count, means "no frontmatter" — the same rule
+	// as before, now applied evenly.
+	if ParseFrontmatter([]byte("# a note\n## ---\n## name: Alpha Bot\n## ---\n")) != nil {
+		t.Error("a comment above the fence must not be read as a frontmatter block")
+	}
+}

--- a/pkg/cli/errors.go
+++ b/pkg/cli/errors.go
@@ -23,6 +23,13 @@ import (
 // chain marked it as a user-input failure.
 var ErrUserInput = errors.New("user input")
 
+// ErrReported marks a failure whose diagnosis the command has ALREADY
+// written to its output — a `--json` result carrying `valid: false` and
+// its diagnostics. The CLI exits non-zero on it without printing a second
+// JSON document after the first, which would break every parser reading
+// the stream.
+var ErrReported = errors.New("already reported")
+
 // UserInputError wraps err with ErrUserInput so the CLI exits with
 // status 2. Returns nil when err is nil so the caller can chain
 // `return cli.UserInputError(maybeErr)` without a nil check.

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -172,7 +172,7 @@ func RunValidate(path string, p *Printer) error {
 			printDiagnostics(p, result.Diagnostics)
 			p.Line("  result: INVALID (no workflow found)")
 		}
-		return fmt.Errorf("validation failed")
+		return validationFailed(p)
 	}
 
 	// Compile (includes static validation).
@@ -267,9 +267,19 @@ func RunValidate(path string, p *Printer) error {
 	}
 
 	if !result.Valid {
-		return fmt.Errorf("validation failed")
+		return validationFailed(p)
 	}
 	return nil
+}
+
+// validationFailed is the non-zero exit of an invalid workflow. In --json mode
+// the result already carries the verdict and every finding, so the error is
+// marked ErrReported and the CLI prints nothing more.
+func validationFailed(p *Printer) error {
+	if p.Format == OutputJSON {
+		return fmt.Errorf("validation failed: %w", ErrReported)
+	}
+	return fmt.Errorf("validation failed")
 }
 
 // scanBundleSkills reads a bundle's skills/*.md frontmatter (name +

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -78,14 +78,20 @@ func formatDiagnostic(d ValidateDiagnostic) []string {
 }
 
 // sortValidateDiagnostics orders the findings the way a reader edits: by
-// source position — the global ones, which have none, first — then code,
-// node, edge and message. The compiler already orders its own list this
+// source position, then code, node, edge and message. A finding with no
+// position (a global compile check, a bundle check) goes LAST: it is
+// usually a consequence of a positioned one — `entry node "a" not found`
+// because a tab on line 2 broke the declaration — and must not be the first
+// line the operator reads. The compiler already orders its own list this
 // way; RunValidate concatenates the parse, compile and bundle stages, so the
 // same key is applied once more across them, otherwise a parse finding on
 // line 12 precedes a compile finding on line 7.
 func sortValidateDiagnostics(ds []ValidateDiagnostic) {
 	sort.SliceStable(ds, func(i, j int) bool {
 		a, b := ds[i], ds[j]
+		if (a.Line == 0) != (b.Line == 0) {
+			return a.Line != 0
+		}
 		if a.File != b.File {
 			return a.File < b.File
 		}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
@@ -74,6 +75,37 @@ func formatDiagnostic(d ValidateDiagnostic) []string {
 		lines = append(lines, "    fix: "+d.Hint)
 	}
 	return lines
+}
+
+// sortValidateDiagnostics orders the findings the way a reader edits: by
+// source position — the global ones, which have none, first — then code,
+// node, edge and message. The compiler already orders its own list this
+// way; RunValidate concatenates the parse, compile and bundle stages, so the
+// same key is applied once more across them, otherwise a parse finding on
+// line 12 precedes a compile finding on line 7.
+func sortValidateDiagnostics(ds []ValidateDiagnostic) {
+	sort.SliceStable(ds, func(i, j int) bool {
+		a, b := ds[i], ds[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		if a.Code != b.Code {
+			return a.Code < b.Code
+		}
+		if a.NodeID != b.NodeID {
+			return a.NodeID < b.NodeID
+		}
+		if a.EdgeID != b.EdgeID {
+			return a.EdgeID < b.EdgeID
+		}
+		return a.Message < b.Message
+	})
 }
 
 // printDiagnostics writes the structured findings under a heading.
@@ -165,6 +197,7 @@ func RunValidate(path string, p *Printer) error {
 
 	if pr.File == nil || len(pr.File.Workflows) == 0 {
 		result.Valid = false
+		sortValidateDiagnostics(result.Diagnostics)
 		if p.Format == OutputJSON {
 			p.JSON(result)
 		} else {
@@ -245,6 +278,7 @@ func RunValidate(path string, p *Printer) error {
 		}
 	}
 
+	sortValidateDiagnostics(result.Diagnostics)
 	if p.Format == OutputJSON {
 		p.JSON(result)
 	} else {

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -31,6 +31,63 @@ type ValidateResult struct {
 	// (bundlelint, C2xx). Kept separate from CompileDiagnostics so the
 	// studio can distinguish DSL-level from manifest-level issues.
 	BundleDiagnostics []string `json:"bundle_diagnostics,omitempty"`
+	// Diagnostics is the structured form of the three lists above: one
+	// object per finding with its stage, code, severity, source position,
+	// message and fix line — what a validate loop (an agent, an editor, the
+	// MCP local_validate tool) acts on. The string lists stay for readers
+	// that only print.
+	Diagnostics []ValidateDiagnostic `json:"diagnostics,omitempty"`
+}
+
+// ValidateDiagnostic is one finding of `iterion validate` in the shape a
+// tool can act on: where (file:line:column when the stage could attribute
+// one), what (code + message) and the one-line fix.
+type ValidateDiagnostic struct {
+	Source   string `json:"source"` // parse | compile | bundle
+	Code     string `json:"code,omitempty"`
+	Severity string `json:"severity"` // error | warning
+	File     string `json:"file,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Column   int    `json:"column,omitempty"`
+	Message  string `json:"message"`
+	Hint     string `json:"hint,omitempty"`
+	NodeID   string `json:"node_id,omitempty"`
+	EdgeID   string `json:"edge_id,omitempty"`
+}
+
+// formatDiagnostic renders one finding for the human output: the
+// position when known, then severity, code and message on one line, and
+// the fix line indented beneath it.
+func formatDiagnostic(d ValidateDiagnostic) []string {
+	var b strings.Builder
+	if d.Line > 0 {
+		fmt.Fprintf(&b, "%s:%d:%d: ", d.File, d.Line, d.Column)
+	}
+	b.WriteString(d.Severity)
+	if d.Code != "" {
+		fmt.Fprintf(&b, " [%s]", d.Code)
+	}
+	b.WriteString(": ")
+	b.WriteString(d.Message)
+	lines := []string{b.String()}
+	if d.Hint != "" {
+		lines = append(lines, "    fix: "+d.Hint)
+	}
+	return lines
+}
+
+// printDiagnostics writes the structured findings under a heading.
+func printDiagnostics(p *Printer, diags []ValidateDiagnostic) {
+	if len(diags) == 0 {
+		return
+	}
+	p.Blank()
+	p.Line("  Diagnostics:")
+	for _, d := range diags {
+		for _, l := range formatDiagnostic(d) {
+			p.Line("    %s", l)
+		}
+	}
 }
 
 // RunValidate parses, compiles, and validates a .bot file or `.botz`
@@ -83,6 +140,16 @@ func RunValidate(path string, p *Printer) error {
 	pr := parser.Parse(path, string(src))
 	for _, d := range pr.Diagnostics {
 		result.ParseDiagnostics = append(result.ParseDiagnostics, d.Error())
+		result.Diagnostics = append(result.Diagnostics, ValidateDiagnostic{
+			Source:   "parse",
+			Code:     string(d.Code),
+			Severity: d.Severity.String(),
+			File:     d.File,
+			Line:     d.Line,
+			Column:   d.Column,
+			Message:  d.Message,
+			Hint:     d.Hint,
+		})
 		if d.Severity == parser.SeverityError {
 			result.Valid = false
 		}
@@ -102,9 +169,7 @@ func RunValidate(path string, p *Printer) error {
 			p.JSON(result)
 		} else {
 			p.Header("Validate: " + path)
-			for _, d := range result.ParseDiagnostics {
-				p.Line("  %s", d)
-			}
+			printDiagnostics(p, result.Diagnostics)
 			p.Line("  result: INVALID (no workflow found)")
 		}
 		return fmt.Errorf("validation failed")
@@ -114,6 +179,18 @@ func RunValidate(path string, p *Printer) error {
 	cr := ir.Compile(pr.File)
 	for _, d := range cr.Diagnostics {
 		result.CompileDiagnostics = append(result.CompileDiagnostics, d.Error())
+		result.Diagnostics = append(result.Diagnostics, ValidateDiagnostic{
+			Source:   "compile",
+			Code:     string(d.Code),
+			Severity: d.Severity.String(),
+			File:     d.File,
+			Line:     d.Line,
+			Column:   d.Column,
+			Message:  d.Message,
+			Hint:     d.Hint,
+			NodeID:   d.NodeID,
+			EdgeID:   d.EdgeID,
+		})
 		if d.Severity == ir.SeverityError {
 			result.Valid = false
 		}
@@ -122,6 +199,11 @@ func RunValidate(path string, p *Printer) error {
 	if cr.Workflow != nil {
 		if err := mcp.PrepareWorkflow(cr.Workflow, filepath.Dir(path)); err != nil {
 			result.CompileDiagnostics = append(result.CompileDiagnostics, err.Error())
+			result.Diagnostics = append(result.Diagnostics, ValidateDiagnostic{
+				Source:   "compile",
+				Severity: "error",
+				Message:  err.Error(),
+			})
 			result.Valid = false
 		}
 		result.WorkflowName = cr.Workflow.Name
@@ -146,6 +228,17 @@ func RunValidate(path string, p *Printer) error {
 		})
 		for _, d := range diags {
 			result.BundleDiagnostics = append(result.BundleDiagnostics, d.Error())
+			msg := d.Message
+			if d.Field != "" {
+				msg = d.Field + ": " + msg
+			}
+			result.Diagnostics = append(result.Diagnostics, ValidateDiagnostic{
+				Source:   "bundle",
+				Code:     string(d.Code),
+				Severity: d.Severity.String(),
+				Message:  msg,
+				Hint:     d.Hint,
+			})
 			if d.Severity == bundlelint.SeverityError {
 				result.Valid = false
 			}
@@ -164,15 +257,7 @@ func RunValidate(path string, p *Printer) error {
 			p.KV("Nodes", fmt.Sprintf("%d", result.NodeCount))
 			p.KV("Edges", fmt.Sprintf("%d", result.EdgeCount))
 		}
-		allDiags := append(result.ParseDiagnostics, result.CompileDiagnostics...)
-		allDiags = append(allDiags, result.BundleDiagnostics...)
-		if len(allDiags) > 0 {
-			p.Blank()
-			p.Line("  Diagnostics:")
-			for _, d := range allDiags {
-				p.Line("    %s", d)
-			}
-		}
+		printDiagnostics(p, result.Diagnostics)
 		p.Blank()
 		if result.Valid {
 			p.Line("  result: OK")

--- a/pkg/cli/validate_diagnostics_test.go
+++ b/pkg/cli/validate_diagnostics_test.go
@@ -27,6 +27,35 @@ workflow w:
   b -> a
 `
 
+// The parse, compile and bundle stages are concatenated; the reader still
+// gets one list in source order, global findings first — a compile finding on
+// line 7 is listed before a parse finding on line 12.
+func TestValidate_DiagnosticsAreInSourceOrderAcrossStages(t *testing.T) {
+	dir := t.TempDir()
+	src := "schema out:\n  ok: bool\n\nagent a:\n  model: \"m\"\n  output: out\n\nworkflow w:\n  entry: a\n  a -> zzz\n\nagent b:\n  model: \"m\"\n  temperature: 0.2\n"
+	path := writeFixture(t, dir, "order.bot", src)
+	p, buf := newTestPrinter(cli.OutputJSON)
+	_ = cli.RunValidate(path, p)
+	var result cli.ValidateResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("cannot parse JSON output: %v\n%s", err, buf.String())
+	}
+	var lines []int
+	for _, d := range result.Diagnostics {
+		if d.Severity == "error" {
+			lines = append(lines, d.Line)
+		}
+	}
+	for i := 1; i < len(lines); i++ {
+		if lines[i] < lines[i-1] {
+			t.Fatalf("diagnostics not in source order: lines %v\n%+v", lines, result.Diagnostics)
+		}
+	}
+	if len(lines) < 2 {
+		t.Fatalf("expected a compile finding (line 10) and a parse finding (line 14), got %+v", result.Diagnostics)
+	}
+}
+
 // TestValidate_DiagnosticsCarryPositionAndFix checks what an author (or an
 // agent in a validate loop) receives: in --json, one structured object per
 // finding with its stage, code, source position and fix line; in the human

--- a/pkg/cli/validate_diagnostics_test.go
+++ b/pkg/cli/validate_diagnostics_test.go
@@ -28,7 +28,7 @@ workflow w:
 `
 
 // The parse, compile and bundle stages are concatenated; the reader still
-// gets one list in source order, global findings first — a compile finding on
+// gets one list in source order, global findings last — a compile finding on
 // line 7 is listed before a parse finding on line 12.
 func TestValidate_DiagnosticsAreInSourceOrderAcrossStages(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/cli/validate_diagnostics_test.go
+++ b/pkg/cli/validate_diagnostics_test.go
@@ -1,0 +1,102 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/cli"
+)
+
+// A workflow with one graph defect (an undeclared cycle) and one parse
+// defect in a second fixture: the two stages a validate loop has to read.
+const undeclaredCycleWorkflow = `schema out:
+  ok: bool
+
+agent a:
+  model: "test-model"
+  output: out
+
+agent b:
+  model: "test-model"
+  output: out
+
+workflow w:
+  entry: a
+  a -> b
+  b -> a
+`
+
+// TestValidate_DiagnosticsCarryPositionAndFix checks what an author (or an
+// agent in a validate loop) receives: in --json, one structured object per
+// finding with its stage, code, source position and fix line; in the human
+// output, the same position and a `fix:` line under the message.
+func TestValidate_DiagnosticsCarryPositionAndFix(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFixture(t, dir, "cycle.bot", undeclaredCycleWorkflow)
+
+	p, buf := newTestPrinter(cli.OutputJSON)
+	if err := cli.RunValidate(path, p); err == nil {
+		t.Fatal("expected validation to fail on the undeclared cycle")
+	}
+	var result cli.ValidateResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("cannot parse JSON output: %v\n%s", err, buf.String())
+	}
+	var cycle *cli.ValidateDiagnostic
+	for i := range result.Diagnostics {
+		if result.Diagnostics[i].Code == "C019" {
+			cycle = &result.Diagnostics[i]
+		}
+	}
+	if cycle == nil {
+		t.Fatalf("expected a C019 diagnostic, got %+v", result.Diagnostics)
+	}
+	if cycle.Source != "compile" || cycle.Severity != "error" {
+		t.Errorf("C019 source/severity = %q/%q", cycle.Source, cycle.Severity)
+	}
+	if cycle.Hint == "" {
+		t.Error("C019 carries no fix line")
+	}
+	if cycle.Line == 0 || cycle.File == "" {
+		t.Errorf("C019 carries no source position: %+v", *cycle)
+	}
+	if !strings.Contains(strings.Join(result.CompileDiagnostics, "\n"), "C019") {
+		t.Error("the legacy compile_diagnostics string list lost the finding")
+	}
+
+	p, buf = newTestPrinter(cli.OutputHuman)
+	_ = cli.RunValidate(path, p)
+	out := buf.String()
+	if !strings.Contains(out, "error [C019]") {
+		t.Errorf("human output lost the code:\n%s", out)
+	}
+	if !strings.Contains(out, "fix: ") {
+		t.Errorf("human output has no fix line:\n%s", out)
+	}
+	if !strings.Contains(out, "cycle.bot:") {
+		t.Errorf("human output has no source position:\n%s", out)
+	}
+
+	// Parse-stage findings ride the same structure, with the parser's own
+	// position and fix line.
+	bad := writeFixture(t, dir, "bad.bot", "agent a:\n  temperature: 0.2\n")
+	p, buf = newTestPrinter(cli.OutputJSON)
+	_ = cli.RunValidate(bad, p)
+	result = cli.ValidateResult{}
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("cannot parse JSON output: %v\n%s", err, buf.String())
+	}
+	var unknown *cli.ValidateDiagnostic
+	for i := range result.Diagnostics {
+		if result.Diagnostics[i].Code == "E012" {
+			unknown = &result.Diagnostics[i]
+		}
+	}
+	if unknown == nil {
+		t.Fatalf("expected an E012 diagnostic, got %+v", result.Diagnostics)
+	}
+	if unknown.Source != "parse" || unknown.Line != 2 || unknown.Hint == "" {
+		t.Errorf("E012 = %+v, want source=parse line=2 and a fix line", *unknown)
+	}
+}

--- a/pkg/cli/validate_order_test.go
+++ b/pkg/cli/validate_order_test.go
@@ -1,0 +1,40 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/cli"
+)
+
+// A finding with no position is usually the CONSEQUENCE of a positioned one:
+// a tab on the `model:` line drops the agent declaration, so the entry node
+// no longer exists (a global C008). Listed first, the consequence is what the
+// reader — an agent in a validate loop — acts on; it must come last.
+func TestValidate_GlobalFindingsSortAfterPositionedOnes(t *testing.T) {
+	dir := t.TempDir()
+	src := "schema out:\n  ok: bool\n\nagent a:\n\tmodel: \"m\"\n  output: out\n\nworkflow w:\n  entry: a\n  a -> done\n"
+	path := writeFixture(t, dir, "tab.bot", src)
+	p, buf := newTestPrinter(cli.OutputJSON)
+	_ = cli.RunValidate(path, p)
+	var result cli.ValidateResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("cannot parse JSON output: %v\n%s", err, buf.String())
+	}
+	positioned, global := 0, 0
+	seenGlobal := false
+	for _, d := range result.Diagnostics {
+		if d.Line == 0 {
+			global++
+			seenGlobal = true
+			continue
+		}
+		positioned++
+		if seenGlobal {
+			t.Fatalf("a positioned finding follows a global one:\n%+v", result.Diagnostics)
+		}
+	}
+	if positioned == 0 || global == 0 {
+		t.Fatalf("fixture must yield both a positioned and a global finding, got %d/%d:\n%+v", positioned, global, result.Diagnostics)
+	}
+}

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -766,9 +766,11 @@ func (c *compiler) compilePrompts() {
 		// Expand {{include "..."}} markers once, at compile time, before
 		// ParseRefs sees the body — the injected file content becomes part
 		// of the resolved prompt (auditable, no runtime file reads).
-		// Resolve relative to the .bot source directory, carried on the
-		// declaration's span (like MergeBundlePrompts reads bundle files
-		// relative to the bundle dir).
+		// Resolve relative to the directory of the file that declares the
+		// prompt, carried on the declaration's span: the .bot source, or
+		// the bundle's prompts/ for a merged prompts/*.md. A prompt with no
+		// span would resolve against the process working directory — on a
+		// server, nobody's — so every constructor stamps one.
 		body, incErrs := expandPromptIncludes(p.Body, filepath.Dir(p.Span.Start.File))
 		for _, e := range incErrs {
 			c.errorfAtSpan(DiagBadPromptInclude, p.Span, "prompt %q: %v", p.Name, e)

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -129,6 +129,10 @@ type compiler struct {
 	schemas map[string]*Schema
 	prompts map[string]*Prompt
 	mcp     map[string]*MCPServer
+	// edgeSpans remembers where each compiled edge was declared, so a
+	// diagnostic on an edge lands on ITS line even when another edge shares
+	// its endpoints (the canonical "<from>-><to>" id cannot tell them apart).
+	edgeSpans map[*Edge]ast.Span
 
 	autoBackendOnce   sync.Once
 	autoBackendCached bool
@@ -146,63 +150,66 @@ func (c *compiler) workflowInteractionDefault() InteractionMode {
 	return InteractionNone
 }
 
-func (c *compiler) errorf(code DiagCode, format string, args ...any) {
+// emit appends one diagnostic. Every emit helper below is a view over it, so
+// whatever attribution a site can offer — a node, an edge, a source span, a
+// site-specific fix line — travels the same way whichever helper it used,
+// and the catalogue fix line is the default hint for every code.
+func (c *compiler) emit(sev Severity, code DiagCode, nodeID, edgeID string, sp ast.Span, hint string, format string, args ...any) {
+	if hint == "" {
+		hint = HintFor(code)
+	}
 	c.diags = append(c.diags, Diagnostic{
 		Code:     code,
-		Severity: SeverityError,
+		Severity: sev,
 		Message:  fmt.Sprintf(format, args...),
-		Hint:     HintFor(code),
+		NodeID:   nodeID,
+		EdgeID:   edgeID,
+		Hint:     hint,
+		File:     sp.Start.File,
+		Line:     sp.Start.Line,
+		Column:   sp.Start.Column,
 	})
 }
 
+func (c *compiler) errorf(code DiagCode, format string, args ...any) {
+	c.emit(SeverityError, code, "", "", ast.Span{}, "", format, args...)
+}
+
 func (c *compiler) warnf(code DiagCode, format string, args ...any) {
-	c.diags = append(c.diags, Diagnostic{
-		Code:     code,
-		Severity: SeverityWarning,
-		Message:  fmt.Sprintf(format, args...),
-		Hint:     HintFor(code),
-	})
+	c.emit(SeverityWarning, code, "", "", ast.Span{}, "", format, args...)
 }
 
 // errorfAt is a variant of errorf that attaches authoritative attribution
 // (nodeID and/or edgeID) so downstream tooling can render the diagnostic on
-// the precise node or edge instead of guessing from the message text.
+// the precise node or edge instead of guessing from the message text; the
+// source position is resolved from those ids by attachPositions.
 func (c *compiler) errorfAt(code DiagCode, nodeID, edgeID string, format string, args ...any) {
-	c.diags = append(c.diags, Diagnostic{
-		Code:     code,
-		Severity: SeverityError,
-		Message:  fmt.Sprintf(format, args...),
-		NodeID:   nodeID,
-		EdgeID:   edgeID,
-		Hint:     HintFor(code),
-	})
+	c.emit(SeverityError, code, nodeID, edgeID, ast.Span{}, "", format, args...)
 }
 
 // warnfAt is the warning counterpart to errorfAt.
 func (c *compiler) warnfAt(code DiagCode, nodeID, edgeID string, format string, args ...any) {
-	c.diags = append(c.diags, Diagnostic{
-		Code:     code,
-		Severity: SeverityWarning,
-		Message:  fmt.Sprintf(format, args...),
-		NodeID:   nodeID,
-		EdgeID:   edgeID,
-		Hint:     HintFor(code),
-	})
+	c.emit(SeverityWarning, code, nodeID, edgeID, ast.Span{}, "", format, args...)
+}
+
+// errorfOnEdge attributes a diagnostic to one specific AST edge — its own
+// line, which is what tells two edges sharing endpoints apart — with the
+// canonical edge id alongside.
+func (c *compiler) errorfOnEdge(code DiagCode, ae *ast.Edge, format string, args ...any) {
+	c.emit(SeverityError, code, "", edgeID(ae.From, ae.To), ae.Span, "", format, args...)
+}
+
+// errorfAtEdge is errorfOnEdge for a compiled edge, through the span
+// compileEdges recorded for it.
+func (c *compiler) errorfAtEdge(code DiagCode, e *Edge, format string, args ...any) {
+	c.emit(SeverityError, code, e.From, edgeID(e.From, e.To), c.edgeSpans[e], "", format, args...)
 }
 
 // errorfAtSpan attributes a diagnostic to a source span directly — for a
 // declaration that is not a graph node (a prompt, a schema) and so has no
 // NodeID for attachPositions to look up.
 func (c *compiler) errorfAtSpan(code DiagCode, sp ast.Span, format string, args ...any) {
-	c.diags = append(c.diags, Diagnostic{
-		Code:     code,
-		Severity: SeverityError,
-		Message:  fmt.Sprintf(format, args...),
-		Hint:     HintFor(code),
-		File:     sp.Start.File,
-		Line:     sp.Start.Line,
-		Column:   sp.Start.Column,
-	})
+	c.emit(SeverityError, code, "", "", sp, "", format, args...)
 }
 
 // edgeID builds the canonical "<from>-><to>" identifier the studio uses so
@@ -1485,10 +1492,10 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 	for _, ae := range astEdges {
 		// Validate node references.
 		if _, ok := c.nodes[ae.From]; !ok {
-			c.errorfAt(DiagUnknownNode, "", edgeID(ae.From, ae.To), "edge source %q not found", ae.From)
+			c.errorfOnEdge(DiagUnknownNode, ae, "edge source %q not found", ae.From)
 		}
 		if _, ok := c.nodes[ae.To]; !ok {
-			c.errorfAt(DiagUnknownNode, "", edgeID(ae.From, ae.To), "edge target %q not found", ae.To)
+			c.errorfOnEdge(DiagUnknownNode, ae, "edge target %q not found", ae.To)
 		}
 
 		e := &Edge{
@@ -1496,6 +1503,10 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 			To:     ae.To,
 			IsElse: ae.IsElse,
 		}
+		if c.edgeSpans == nil {
+			c.edgeSpans = map[*Edge]ast.Span{}
+		}
+		c.edgeSpans[e] = ae.Span
 
 		// Condition: either a simple field name (legacy) or a parsed expression.
 		if ae.When != nil {
@@ -1542,7 +1553,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 				if ae.Loop.MaxIterationsExpr != "" {
 					refs, err := ParseRefs(ae.Loop.MaxIterationsExpr)
 					if err != nil {
-						c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To),
+						c.errorfOnEdge(DiagBadTemplateRef, ae,
 							"loop %q: template cap %q: %v",
 							ae.Loop.Name, ae.Loop.MaxIterationsExpr, err)
 					}
@@ -1558,7 +1569,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 							loop.MaxIterations = n
 							loop.MaxIterationsExpr = ""
 						} else {
-							c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To),
+							c.errorfOnEdge(DiagBadTemplateRef, ae,
 								"loop %q: cap %q has no template refs and is not an integer — a static non-numeric cap would silently limit the loop to 0 iterations",
 								ae.Loop.Name, ae.Loop.MaxIterationsExpr)
 						}
@@ -1583,7 +1594,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 				}
 				refs, err := ParseRefs(ae.Foreach.Collection)
 				if err != nil {
-					c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To), "foreach %q: collection %q: %v", ae.Foreach.Name, ae.Foreach.Collection, err)
+					c.errorfOnEdge(DiagBadTemplateRef, ae, "foreach %q: collection %q: %v", ae.Foreach.Name, ae.Foreach.Collection, err)
 				}
 				fe.CollectionRefs = refs
 				foreaches[ae.Foreach.Name] = fe
@@ -1596,7 +1607,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 			for i, w := range ae.With {
 				refs, err := ParseRefs(w.Value)
 				if err != nil {
-					c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To), "edge %s -> %s, with key %q: %v",
+					c.errorfOnEdge(DiagBadTemplateRef, ae, "edge %s -> %s, with key %q: %v",
 						ae.From, ae.To, w.Key, err)
 				}
 				e.With[i] = &DataMapping{
@@ -2235,7 +2246,7 @@ func refInQuotes(command string) []string {
 // being cleaned up. The fix is always the same — drop the author's quotes.
 func (c *compiler) checkQuotedCommandRefs(node, command string) {
 	for _, ref := range refInQuotes(command) {
-		c.warnf(DiagQuotedCommandRef,
+		c.warnfAt(DiagQuotedCommandRef, node, "",
 			"tool %q command: %s sits inside quotes you wrote — the runtime already shell-quotes a ref, and the two CANCEL "+
 				"(the value then lands as shell syntax; on a forge-controlled value that is command execution). Remove the surrounding quotes.",
 			node, ref)

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -82,6 +82,15 @@ type Diagnostic struct {
 	NodeID   string
 	EdgeID   string
 	Hint     string
+	// File, Line and Column locate the declaration the diagnostic is
+	// attributed to — the node named by NodeID, or the edge named by
+	// EdgeID — in the source that was compiled. Best-effort: a global
+	// diagnostic (no workflow, duplicate loop) has no position and keeps
+	// the zero values, and a group-expanded node points at the group
+	// member it was cloned from.
+	File   string
+	Line   int // 1-based; 0 = no position
+	Column int // 1-based
 }
 
 func (d Diagnostic) Error() string {
@@ -142,6 +151,7 @@ func (c *compiler) errorf(code DiagCode, format string, args ...any) {
 		Code:     code,
 		Severity: SeverityError,
 		Message:  fmt.Sprintf(format, args...),
+		Hint:     HintFor(code),
 	})
 }
 
@@ -150,6 +160,7 @@ func (c *compiler) warnf(code DiagCode, format string, args ...any) {
 		Code:     code,
 		Severity: SeverityWarning,
 		Message:  fmt.Sprintf(format, args...),
+		Hint:     HintFor(code),
 	})
 }
 
@@ -163,6 +174,7 @@ func (c *compiler) errorfAt(code DiagCode, nodeID, edgeID string, format string,
 		Message:  fmt.Sprintf(format, args...),
 		NodeID:   nodeID,
 		EdgeID:   edgeID,
+		Hint:     HintFor(code),
 	})
 }
 
@@ -174,6 +186,22 @@ func (c *compiler) warnfAt(code DiagCode, nodeID, edgeID string, format string, 
 		Message:  fmt.Sprintf(format, args...),
 		NodeID:   nodeID,
 		EdgeID:   edgeID,
+		Hint:     HintFor(code),
+	})
+}
+
+// errorfAtSpan attributes a diagnostic to a source span directly — for a
+// declaration that is not a graph node (a prompt, a schema) and so has no
+// NodeID for attachPositions to look up.
+func (c *compiler) errorfAtSpan(code DiagCode, sp ast.Span, format string, args ...any) {
+	c.diags = append(c.diags, Diagnostic{
+		Code:     code,
+		Severity: SeverityError,
+		Message:  fmt.Sprintf(format, args...),
+		Hint:     HintFor(code),
+		File:     sp.Start.File,
+		Line:     sp.Start.Line,
+		Column:   sp.Start.Column,
 	})
 }
 
@@ -369,6 +397,7 @@ func Compile(file *ast.File) *CompileResult {
 		mcp:     make(map[string]*MCPServer),
 	}
 	w := c.compile()
+	c.attachPositions()
 	return &CompileResult{
 		Workflow:    w,
 		Diagnostics: c.diags,
@@ -611,7 +640,7 @@ func (c *compiler) compileSchemas() {
 			// validation then only saw the survivor, so an attacker
 			// could slip an unaudited schema past a review pipeline
 			// that inspected only the first occurrence.
-			c.errorf(DiagDuplicateNodeID,
+			c.errorfAtSpan(DiagDuplicateNodeID, s.Span,
 				"duplicate schema name %q: schemas must be unique within a file", s.Name)
 			continue
 		}
@@ -707,7 +736,7 @@ func (c *compiler) compilePrompts() {
 			// Mirror compileSchemas: a second `prompt foo:` used to
 			// silently overwrite the first in c.prompts, leaving the
 			// audit-relevant earlier body invisible.
-			c.errorf(DiagDuplicateNodeID,
+			c.errorfAtSpan(DiagDuplicateNodeID, p.Span,
 				"duplicate prompt name %q: prompts must be unique within a file", p.Name)
 			continue
 		}
@@ -720,11 +749,11 @@ func (c *compiler) compilePrompts() {
 		// relative to the bundle dir).
 		body, incErrs := expandPromptIncludes(p.Body, filepath.Dir(p.Span.Start.File))
 		for _, e := range incErrs {
-			c.errorf(DiagBadPromptInclude, "prompt %q: %v", p.Name, e)
+			c.errorfAtSpan(DiagBadPromptInclude, p.Span, "prompt %q: %v", p.Name, e)
 		}
 		refs, err := ParseRefs(body)
 		if err != nil {
-			c.errorf(DiagBadTemplateRef, "prompt %q: %v", p.Name, err)
+			c.errorfAtSpan(DiagBadTemplateRef, p.Span, "prompt %q: %v", p.Name, err)
 		}
 		c.prompts[p.Name] = &Prompt{
 			Name:         p.Name,
@@ -1024,10 +1053,10 @@ func (c *compiler) compileHumans() {
 				model = h.Model
 			}
 			if model == "" {
-				c.errorf(DiagMissingModelOrBackend, "human %q with interaction %s must set 'model' or 'interaction_model'", h.Name, interaction)
+				c.errorfAt(DiagMissingModelOrBackend, h.Name, "", "human %q with interaction %s must set 'model' or 'interaction_model'", h.Name, interaction)
 			}
 			if h.Output == "" {
-				c.errorf(DiagMissingModelOrBackend, "human %q with interaction %s must set 'output'", h.Name, interaction)
+				c.errorfAt(DiagMissingModelOrBackend, h.Name, "", "human %q with interaction %s must set 'output'", h.Name, interaction)
 			}
 			node.Model = h.Model
 			if h.InteractionModel != "" {
@@ -1061,7 +1090,7 @@ func (c *compiler) compileHumans() {
 			if h.ReviewURL != "" {
 				refs, err := ParseRefs(h.ReviewURL)
 				if err != nil {
-					c.errorf(DiagBadTemplateRef, "human %q review_url: %v", h.Name, err)
+					c.errorfAt(DiagBadTemplateRef, h.Name, "", "human %q review_url: %v", h.Name, err)
 				} else {
 					node.ReviewURLRefs = refs
 				}
@@ -1092,18 +1121,18 @@ func (c *compiler) compileTools() {
 		// command and script are mutually exclusive; exactly one must be set.
 		switch {
 		case t.Command == "" && t.Script == "":
-			c.errorf(DiagBadTemplateRef, "tool %q: must declare either `command:` or `script:`", t.Name)
+			c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q: must declare either `command:` or `script:`", t.Name)
 		case t.Command != "" && t.Script != "":
-			c.errorf(DiagBadTemplateRef, "tool %q: `command:` and `script:` are mutually exclusive", t.Name)
+			c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q: `command:` and `script:` are mutually exclusive", t.Name)
 		case t.Script == "" && t.Language != "":
 			// language without script makes no sense.
-			c.errorf(DiagBadTemplateRef, "tool %q: `language:` is only valid alongside `script:`", t.Name)
+			c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q: `language:` is only valid alongside `script:`", t.Name)
 		}
 
 		var cmdRefs []*Ref
 		if t.Command != "" {
 			if refs, err := ParseRefs(t.Command); err != nil {
-				c.errorf(DiagBadTemplateRef, "tool %q command: %v", t.Name, err)
+				c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q command: %v", t.Name, err)
 			} else {
 				cmdRefs = refs
 			}
@@ -1113,7 +1142,7 @@ func (c *compiler) compileTools() {
 		var scriptRefs []*Ref
 		if t.Script != "" {
 			if refs, err := ParseRefs(t.Script); err != nil {
-				c.errorf(DiagBadTemplateRef, "tool %q script: %v", t.Name, err)
+				c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q script: %v", t.Name, err)
 			} else {
 				scriptRefs = refs
 			}
@@ -1125,7 +1154,7 @@ func (c *compiler) compileTools() {
 			case "js", "node", "py", "python", "python3", "sh", "bash":
 				// known
 			default:
-				c.errorf(DiagBadTemplateRef, "tool %q: unsupported language %q (want one of: js, node, py, python, python3, sh, bash)", t.Name, t.Language)
+				c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q: unsupported language %q (want one of: js, node, py, python, python3, sh, bash)", t.Name, t.Language)
 			}
 		}
 
@@ -1135,7 +1164,7 @@ func (c *compiler) compileTools() {
 		var postcondRefs []*Ref
 		if t.Postcondition != "" {
 			if refs, err := ParseRefs(t.Postcondition); err != nil {
-				c.errorf(DiagBadTemplateRef, "tool %q postcondition: %v", t.Name, err)
+				c.errorfAt(DiagBadTemplateRef, t.Name, "", "tool %q postcondition: %v", t.Name, err)
 			} else {
 				postcondRefs = refs
 			}
@@ -1456,10 +1485,10 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 	for _, ae := range astEdges {
 		// Validate node references.
 		if _, ok := c.nodes[ae.From]; !ok {
-			c.errorf(DiagUnknownNode, "edge source %q not found", ae.From)
+			c.errorfAt(DiagUnknownNode, "", edgeID(ae.From, ae.To), "edge source %q not found", ae.From)
 		}
 		if _, ok := c.nodes[ae.To]; !ok {
-			c.errorf(DiagUnknownNode, "edge target %q not found", ae.To)
+			c.errorfAt(DiagUnknownNode, "", edgeID(ae.From, ae.To), "edge target %q not found", ae.To)
 		}
 
 		e := &Edge{
@@ -1513,7 +1542,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 				if ae.Loop.MaxIterationsExpr != "" {
 					refs, err := ParseRefs(ae.Loop.MaxIterationsExpr)
 					if err != nil {
-						c.errorf(DiagBadTemplateRef,
+						c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To),
 							"loop %q: template cap %q: %v",
 							ae.Loop.Name, ae.Loop.MaxIterationsExpr, err)
 					}
@@ -1529,7 +1558,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 							loop.MaxIterations = n
 							loop.MaxIterationsExpr = ""
 						} else {
-							c.errorf(DiagBadTemplateRef,
+							c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To),
 								"loop %q: cap %q has no template refs and is not an integer — a static non-numeric cap would silently limit the loop to 0 iterations",
 								ae.Loop.Name, ae.Loop.MaxIterationsExpr)
 						}
@@ -1554,7 +1583,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 				}
 				refs, err := ParseRefs(ae.Foreach.Collection)
 				if err != nil {
-					c.errorf(DiagBadTemplateRef, "foreach %q: collection %q: %v", ae.Foreach.Name, ae.Foreach.Collection, err)
+					c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To), "foreach %q: collection %q: %v", ae.Foreach.Name, ae.Foreach.Collection, err)
 				}
 				fe.CollectionRefs = refs
 				foreaches[ae.Foreach.Name] = fe
@@ -1567,7 +1596,7 @@ func (c *compiler) compileEdges(astEdges []*ast.Edge) ([]*Edge, map[string]*Loop
 			for i, w := range ae.With {
 				refs, err := ParseRefs(w.Value)
 				if err != nil {
-					c.errorf(DiagBadTemplateRef, "edge %s -> %s, with key %q: %v",
+					c.errorfAt(DiagBadTemplateRef, "", edgeID(ae.From, ae.To), "edge %s -> %s, with key %q: %v",
 						ae.From, ae.To, w.Key, err)
 				}
 				e.With[i] = &DataMapping{
@@ -2002,7 +2031,7 @@ func (c *compiler) validateSchemaRef(node, prop, ref string) {
 		return
 	}
 	if _, ok := c.schemas[ref]; !ok {
-		c.errorf(DiagUnknownSchema, "node %q property %q references unknown schema %q", node, prop, ref)
+		c.errorfAt(DiagUnknownSchema, node, "", "node %q property %q references unknown schema %q", node, prop, ref)
 	}
 }
 
@@ -2011,7 +2040,7 @@ func (c *compiler) validatePromptRef(node, prop, ref string) {
 		return
 	}
 	if _, ok := c.prompts[ref]; !ok {
-		c.errorf(DiagUnknownPrompt, "node %q property %q references unknown prompt %q", node, prop, ref)
+		c.errorfAt(DiagUnknownPrompt, node, "", "node %q property %q references unknown prompt %q", node, prop, ref)
 	}
 }
 

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -205,11 +205,23 @@ func (c *compiler) errorfAtEdge(code DiagCode, e *Edge, format string, args ...a
 	c.emit(SeverityError, code, e.From, edgeID(e.From, e.To), c.edgeSpans[e], "", format, args...)
 }
 
+// warnfAtEdge is the warning counterpart to errorfAtEdge.
+func (c *compiler) warnfAtEdge(code DiagCode, e *Edge, format string, args ...any) {
+	c.emit(SeverityWarning, code, e.From, edgeID(e.From, e.To), c.edgeSpans[e], "", format, args...)
+}
+
 // errorfAtSpan attributes a diagnostic to a source span directly — for a
 // declaration that is not a graph node (a prompt, a schema) and so has no
 // NodeID for attachPositions to look up.
 func (c *compiler) errorfAtSpan(code DiagCode, sp ast.Span, format string, args ...any) {
 	c.emit(SeverityError, code, "", "", sp, "", format, args...)
+}
+
+// errorfAtNodeSpan attributes a diagnostic to a node AND to a specific span —
+// for a node that has more than one declaration, where the id alone would
+// resolve to the first one while the line to edit is the other.
+func (c *compiler) errorfAtNodeSpan(code DiagCode, nodeID string, sp ast.Span, format string, args ...any) {
+	c.emit(SeverityError, code, nodeID, "", sp, "", format, args...)
 }
 
 // edgeID builds the canonical "<from>-><to>" identifier the studio uses so
@@ -342,33 +354,34 @@ func (c *compiler) validateNodeNames() {
 	type decl struct {
 		kind string
 		name string
+		span ast.Span
 	}
 	all := make([]decl, 0,
 		len(c.file.Agents)+len(c.file.Judges)+len(c.file.Routers)+
 			len(c.file.Humans)+len(c.file.Tools)+len(c.file.Computes))
 	for _, d := range c.file.Agents {
-		all = append(all, decl{"agent", d.Name})
+		all = append(all, decl{"agent", d.Name, d.Span})
 	}
 	for _, d := range c.file.Judges {
-		all = append(all, decl{"judge", d.Name})
+		all = append(all, decl{"judge", d.Name, d.Span})
 	}
 	for _, d := range c.file.Routers {
-		all = append(all, decl{"router", d.Name})
+		all = append(all, decl{"router", d.Name, d.Span})
 	}
 	for _, d := range c.file.Humans {
-		all = append(all, decl{"human", d.Name})
+		all = append(all, decl{"human", d.Name, d.Span})
 	}
 	for _, d := range c.file.Tools {
-		all = append(all, decl{"tool", d.Name})
+		all = append(all, decl{"tool", d.Name, d.Span})
 	}
 	for _, d := range c.file.Computes {
-		all = append(all, decl{"compute", d.Name})
+		all = append(all, decl{"compute", d.Name, d.Span})
 	}
 	for _, d := range c.file.Subbots {
-		all = append(all, decl{"subbot", d.Name})
+		all = append(all, decl{"subbot", d.Name, d.Span})
 	}
 	for _, d := range c.file.Fails {
-		all = append(all, decl{"fail", d.Name})
+		all = append(all, decl{"fail", d.Name, d.Span})
 	}
 
 	seen := make(map[string]string, len(all)) // name → first kind to claim it
@@ -384,7 +397,9 @@ func (c *compiler) validateNodeNames() {
 			continue
 		}
 		if firstKind, dup := seen[d.name]; dup {
-			c.errorfAt(DiagDuplicateNodeID, d.name, "",
+			// Point at the REDECLARATION — the line to delete — not at the
+			// first declaration the node id alone would resolve to.
+			c.errorfAtNodeSpan(DiagDuplicateNodeID, d.name, d.span,
 				"duplicate node ID %q: already declared as %s, redeclared as %s — node IDs must be unique across all kinds",
 				d.name, firstKind, d.kind)
 			continue

--- a/pkg/dsl/ir/diag_catalog.go
+++ b/pkg/dsl/ir/diag_catalog.go
@@ -75,7 +75,7 @@ var Catalog = map[DiagCode]DiagInfo{
 	DiagArtifactLabelsNoPublish:  {"Artifact labels without publish", "Add `publish: <name>` so the labels have an artifact to attach to, or remove `artifact_labels:`."},
 	DiagMemoryInvalidVisibility:  {"Invalid memory visibility", "Use one of `bot`, `project`, `cross_project`, `user`, `org`, `global`."},
 	DiagMemoryVisibilityConflict: {"Memory visibility conflict", "Use `visibility:` alone; drop the legacy `project_root:`."},
-	DiagBadPromptInclude:         {"Bad prompt include", "Point `{{include \"...\"}}` at an existing file inside the .bot's directory, under 256 KiB, with a relative path."},
+	DiagBadPromptInclude:         {"Bad prompt include", "Point `{{include \"...\"}}` at an existing file, with a path relative to the file that contains the include (the `.bot`'s directory for a prompt declared in it, a bundle's `prompts/` for a `prompts/*.md`), never escaping it, under 256 KiB."},
 
 	// Attachments.
 	DiagDuplicateAttachment:       {"Duplicate attachment", "Rename or merge the duplicate `attachments:` entry."},

--- a/pkg/dsl/ir/diag_catalog.go
+++ b/pkg/dsl/ir/diag_catalog.go
@@ -1,0 +1,198 @@
+package ir
+
+// DiagInfo is the catalogue entry of one diagnostic code: what the check is
+// and the one-line fix an author can act on without opening the reference.
+// The Fix line is what `Diagnostic.Hint` carries when the emitting site did
+// not set a more specific one, so every diagnostic the compiler produces
+// arrives with an actionable next step — in `iterion validate`, in the
+// studio's inline badge and in the MCP `local_validate` result alike.
+//
+// docs/references/diagnostics.md remains the long-form reference (cause,
+// context, examples); TestDiagCatalogCoversEveryCode keeps the two in step
+// by refusing a code that exists in the compiler but not here.
+type DiagInfo struct {
+	Title string // the check, as a short noun phrase
+	Fix   string // the imperative one-line remedy
+}
+
+// Catalog maps every compile/validation diagnostic code the ir package can
+// emit to its title and fix line. Bundle-consistency codes (C2xx, pkg/bundlelint)
+// carry their own hints and are not listed here.
+var Catalog = map[DiagCode]DiagInfo{
+	// Compilation.
+	DiagUnknownNode:           {"Unknown node reference", "Declare the node or fix the name — an edge, `entry:` or `watches:` may only name a declared node."},
+	DiagUnknownSchema:         {"Unknown schema reference", "Declare `schema <name>:` or fix the name in `input:` / `output:`."},
+	DiagUnknownPrompt:         {"Unknown prompt reference", "Declare `prompt <name>:` (or drop a `prompts/<name>.md` in the bundle) or fix the name in `system:` / `user:`."},
+	DiagBadTemplateRef:        {"Bad template reference", "Use `{{vars.X}}`, `{{input.X}}`, `{{outputs.node.field}}`, `{{artifacts.X}}`, `{{attachments.X}}`, `{{loop.name.iteration}}` or `{{run.id}}`; a literal example needs prose, not braces."},
+	DiagDuplicateLoop:         {"Conflicting loop definitions", "Edges sharing a loop name must agree on the cap; use one cap or two loop names."},
+	DiagNoWorkflow:            {"No workflow found", "Add a `workflow <name>:` block with an `entry:` and the edges."},
+	DiagMultipleWorkflow:      {"Multiple workflows", "Keep one `workflow` block per file; split the others into their own `.bot` (a `subbot` can run them)."},
+	DiagMissingEntry:          {"Missing entry node", "Point `entry:` at a declared node."},
+	DiagMissingModelOrBackend: {"Missing model or backend", "Add `model: \"...\"` or `backend: \"...\"` to the node (an LLM-backed human node needs `interaction_model:` and `output:`)."},
+	DiagDuplicateMCPServer:    {"Duplicate MCP server", "Give each `mcp_server` declaration a unique name."},
+	DiagInvalidMCPServer:      {"Invalid MCP server config", "stdio servers need `command:`; http/sse servers need `url:` and must not set `command:`/`args:`."},
+	DiagComputeNoExpr:         {"Compute node has no expressions", "Add an `expr:` block mapping each output field to an expression, or remove the node."},
+	DiagBadExpr:               {"Expression failed to parse", "`expr:` values and quoted `when` clauses are expressions, not templates: write `input.x`, not `{{input.x}}`; check operators, parentheses and builtin names."},
+	DiagDuplicateNodeID:       {"Duplicate node id", "Rename one of the declarations — node ids share one global namespace across all kinds."},
+	DiagReservedNodeName:      {"Reserved node name", "`done` and `fail` are the reserved terminal targets; pick another name."},
+	DiagInvalidSandboxMode:    {"Invalid sandbox mode", "Use `sandbox: auto`, `sandbox: none`, or a block with exactly one of `image:` / `build:`."},
+	DiagSandboxAutoNoConfig:   {"Sandbox auto without config", "Add a `.devcontainer/devcontainer.json`, a default image, or an inline `sandbox:` block with `image:`/`build:`."},
+	DiagBudgetCostInvalid:     {"Invalid budget cost", "Use a non-negative finite USD amount for `max_cost_usd`, or omit it."},
+
+	// Validation — edges, sessions and reachability.
+	DiagSessionAfterConvergence:  {"Session at convergence point", "A node with several incoming branches cannot `session: inherit` or `fork`; use `fresh`, `artifacts_only` or `persist`."},
+	DiagMultipleDefaultEdges:     {"Multiple unconditional edges", "Keep one default edge per node (a loop back-edge `as name(N)` plus one exhaustion fall-through is the allowed pair); fan out with a router."},
+	DiagAmbiguousCondition:       {"Ambiguous conditions", "Two edges from one node test the same field with the same polarity; remove the duplicate or change the condition."},
+	DiagMissingFallback:          {"Missing fallback", "Complete `when X` with `when not X`, an `else` edge, or an unconditional edge from the same node."},
+	DiagConditionNotBool:         {"Condition field not boolean", "A bare `when field` needs a `bool` field in the source's `output:` schema; use a quoted expression (`when \"count > 0\"`) for other types."},
+	DiagConditionFieldNotFound:   {"Condition field not found", "Add the field to the source node's `output:` schema, or fix the name."},
+	DiagElseWithoutConditional:   {"Else without conditional sibling", "`else` needs a `when` sibling from the same node; otherwise write a plain `src -> dst` edge."},
+	DiagMultipleElseEdges:        {"Multiple else edges", "Keep exactly one `else` edge per source node."},
+	DiagElseWithUnconditional:    {"Else alongside unconditional", "`else` IS the fallback: remove the bare unconditional edge, or drop the `else` keyword."},
+	DiagSandboxOptOut:            {"Sandbox opt-out", "Remove `sandbox: none` to run sandboxed; keep the opt-out only when the flow genuinely needs the host environment."},
+	DiagUnreachableNode:          {"Unreachable node", "Wire an edge from a reachable node, or remove the declaration."},
+	DiagHistoryRefNotInLoop:      {"History ref not in loop", "`{{outputs.node.history}}` only exists inside a declared loop (`as name(N)` on the back-edge); add the loop or drop `.history`."},
+	DiagUndeclaredCycle:          {"Undeclared cycle", "Declare the back-edge as a bounded loop: `src -> dst as name(N)` (or `as name(unbounded N)`), and give the loop an exhaustion exit edge."},
+	DiagRoundRobinTooFewEdges:    {"Round-robin too few edges", "A `round_robin` router needs at least two unconditional outgoing edges."},
+	DiagLLMRouterTooFewEdges:     {"LLM router too few edges", "An `llm` router needs at least two outgoing edges to choose from."},
+	DiagLLMRouterConditionEdge:   {"LLM router edge has condition", "Remove `when` from the edges of an `llm` router; the model selects the target."},
+	DiagRouterLLMOnlyProperty:    {"LLM-only property on non-LLM router", "`model`, `backend`, `system`, `user`, `multi` and `reasoning_effort` belong to `mode: llm`; remove them or change the mode."},
+	DiagInvalidLoopIterations:    {"Invalid loop iterations", "A loop cap must be at least 1."},
+	DiagInvalidReasoningEffort:   {"Invalid reasoning effort", "Use `low`, `medium`, `high`, `xhigh`, `max` or `ultracode` (or a quoted `${VAR}` string)."},
+	DiagDuplicateWithKey:         {"Duplicate with-mapping key", "The same `with` key reaches one target from several unconditional edges; use distinct keys or make the edges conditional."},
+	DiagUnknownRefNode:           {"Unknown outputs node reference", "`{{outputs.<node>}}` names a node that is not declared; declare it or fix the typo."},
+	DiagRefFieldNotInSchema:      {"Outputs ref field not in output schema", "Reference a field the node's `output:` schema declares, or add it to the schema."},
+	DiagRefNodeNoSchema:          {"Outputs ref on schemaless node", "Add an `output:` schema to the referenced node so the field can be verified, or use `{{vars.x}}` for a launch-time value."},
+	DiagUndeclaredVar:            {"Undeclared variable", "Declare the variable in `vars:` (top level or workflow), or fix the name."},
+	DiagInputFieldNotInSchema:    {"Input ref field not in the validated namespace", "In a prompt/command/expr, `{{input.x}}` must be in the node's `input:` schema; in an edge `with`, it is the SOURCE node's `output:` — use `{{outputs.<node>.x}}` or `{{vars.x}}` otherwise."},
+	DiagUnknownArtifact:          {"Unknown artifact", "Add `publish: <name>` on an earlier node, or fix the artifact name."},
+	DiagRefNodeNotReachable:      {"Reference to non-reachable node", "`{{outputs.<node>}}` must name a node that runs before the consumer; wire the graph so the producer comes first."},
+	DiagNodeMaxTokensVsBudget:    {"Node max_tokens exceeds workflow budget", "Lower the node's `max_tokens` or raise `budget.max_tokens`."},
+	DiagUnsupportedMCPAuth:       {"Unsupported MCP auth type", "Only `oauth2` is wired; drop the `auth:` block or set `type: \"oauth2\"`."},
+	DiagInvalidCompaction:        {"Invalid compaction values", "`threshold` is a fraction in (0, 1] and `preserve_recent` an integer >= 1."},
+	DiagMemoryNotSupported:       {"Memory enabled on unsupported backend", "Only `backend: \"claw\"` wires the memory tools today; switch the backend or drop the `memory:` block."},
+	DiagMemoryMissingScope:       {"Memory missing scope", "Add `scope: <name>` to the `memory:` block."},
+	DiagArtifactLabelsNoPublish:  {"Artifact labels without publish", "Add `publish: <name>` so the labels have an artifact to attach to, or remove `artifact_labels:`."},
+	DiagMemoryInvalidVisibility:  {"Invalid memory visibility", "Use one of `bot`, `project`, `cross_project`, `user`, `org`, `global`."},
+	DiagMemoryVisibilityConflict: {"Memory visibility conflict", "Use `visibility:` alone; drop the legacy `project_root:`."},
+	DiagBadPromptInclude:         {"Bad prompt include", "Point `{{include \"...\"}}` at an existing file inside the .bot's directory, under 256 KiB, with a relative path."},
+
+	// Attachments.
+	DiagDuplicateAttachment:       {"Duplicate attachment", "Rename or merge the duplicate `attachments:` entry."},
+	DiagAttachmentVarConflict:     {"Attachment / var name collision", "Rename one of them — attachments and vars share a template namespace."},
+	DiagInvalidAttachmentMIME:     {"Invalid attachment MIME", "Use `type/subtype` MIME values (`image/png`, `application/pdf`, `image/*`)."},
+	DiagUnknownAttachment:         {"Unknown attachment reference", "Declare the attachment in an `attachments:` block, or fix the name."},
+	DiagAttachmentSubfieldUnknown: {"Unknown attachment sub-field", "Use `.path`, `.url`, `.mime`, `.size` or `.sha256`, or drop the sub-field."},
+
+	// Browser pane.
+	DiagPlaywrightNeedsBrowserImage: {"Playwright MCP server requires a browser-capable sandbox image", "Use a browser-capable image (e.g. `ghcr.io/socialgouv/iterion-sandbox-browser`) or remove the Playwright MCP server."},
+
+	// Presets.
+	DiagPresetUnknownVar:   {"Preset references unknown variable", "Declare the variable in `vars:`, or fix/remove the preset key."},
+	DiagPresetTypeMismatch: {"Preset value type mismatch", "Match the preset value to the variable's declared type."},
+	DiagDuplicatePreset:    {"Duplicate preset name", "Rename or merge the duplicate preset."},
+
+	// Capabilities, cursors, providers, ultracode.
+	DiagUnknownCapability:    {"Unknown capability", "Use a registered capability (`board.read`, `board.create`, `board.move`, `board.assign`, `board.label`, `board.close`, `board.comment`, `watch.subscribe`, `watch.unsubscribe`) or accept the warning for an extension."},
+	DiagMalformedCapability:  {"Malformed capability", "Use the lowercase `domain.action` shape, e.g. `board.create`."},
+	DiagBoardCapInSandbox:    {"Board capability inside sandbox", "No action if the iterion HTTP server is reachable from the sandbox; otherwise drop the capability or disable the sandbox for the node."},
+	DiagUnknownCursor:        {"Unknown cursor reference", "Declare `cursor <name>:` at top level, or drop the setting."},
+	DiagInvalidCursorVal:     {"Invalid cursor value", "Use a declared enum value, or a number in [0, 1] that falls in a declared band."},
+	DiagMalformedCursor:      {"Malformed cursor declaration", "Declare exactly one of `values:` or `bands:`; bands must be disjoint sub-ranges of [0, 1]."},
+	DiagDuplicateCursor:      {"Duplicate cursor name", "Rename or merge the duplicate `cursor` declaration."},
+	DiagUnknownProvider:      {"Unknown provider", "Fix the provider name, or accept the warning for a newly added provider."},
+	DiagProviderChainIgnored: {"Provider chain ignored", "Only `claude_code` honours a multi-element `provider:` chain; drop the extra elements or switch the backend."},
+	DiagUltracodeModelGate:   {"Ultracode model gate", "Use an Opus 4.8 / Claude 5 model for full `ultracode`, or accept the degrade to `xhigh`."},
+
+	// Secrets.
+	DiagDuplicateSecret:   {"Duplicate secret", "Rename or merge the duplicate `secrets:` entry."},
+	DiagSecretVarConflict: {"Secret / var name collision", "Rename one of them — secrets and vars share a template namespace."},
+	DiagInvalidSecretHost: {"Invalid secret host", "Use hostnames or domains in `hosts:` (quoted strings)."},
+	DiagUnknownSecret:     {"Unknown secret reference", "Declare the secret in the `secrets:` block, or fix the name."},
+	DiagInvalidSecretFile: {"Malformed file secret", "An `as: file` secret takes an optional `value:`/`env:`/`mount_path:`; a bare `as: file` (+ `optional: true`) resolves the stored secret by name."},
+	DiagSecretSubfield:    {"Unsupported secret sub-field", "Use `{{secrets.X}}` or `{{secrets.X.path}}` (file secrets only)."},
+
+	// Unbounded loops.
+	DiagUnboundedNoFuel: {"Unbounded loop without fuel", "Give the loop a fuel ceiling: `as name(unbounded 200)` or a workflow `budget.max_iterations`."},
+	DiagUnboundedNoExit: {"Unbounded loop without exit", "Add a `when` exit edge so the loop can terminate by its own logic, not only by fuel."},
+
+	// Review gate, compress, memory switch, guards.
+	DiagReviewNeedsWorktree:    {"Review without worktree", "Add `worktree: auto` to the workflow (the review gate merges the run's worktree), or drop `interaction: review`."},
+	DiagReviewURLUnknownRef:    {"Review URL unknown ref", "Point `review_url` at a declared node's output, or remove it."},
+	DiagInvalidCompress:        {"Invalid compress value", "Use `on`, `off` or `ultra`."},
+	DiagQuotedCommandRef:       {"Tool command quotes a ref the runtime already quotes", "Remove the quotes around `{{ref}}` in the command — the runtime shell-escapes every ref; build optional flags with `${VAR:+--flag \"$VAR\"}` from a bare `VAR={{ref}}`."},
+	DiagInvalidAutoMemory:      {"Invalid auto_memory value", "Use `on` or `off`, or drop the field to inherit."},
+	DiagAutoMemoryNotSupported: {"auto_memory on an unsupported backend", "Use `claude_code`, `claw` or `pi`, or drop `auto_memory:`."},
+	DiagInvalidLoopBudgetGuard: {"Invalid loop_budget_guard value", "Use `on` or `off`, or drop the field to inherit."},
+	DiagInvalidRepoDevbox:      {"Invalid repo_devbox value", "Use `on` or `off`, or drop the field to inherit."},
+
+	// Verified actions (ADR-044).
+	DiagInvalidPolicy:        {"Invalid policy", "Use `required`, `recover` or `best_effort`."},
+	DiagRecoveryNoPostcond:   {"Recovery without postcondition", "Add a `postcondition:` (the deterministic oracle) or drop the recovery."},
+	DiagRecoveryOnGate:       {"Recovery on a gate", "Remove `recovery:` — a node whose recipe IS its postcondition is a gate and stays deterministic."},
+	DiagRecoveryWithoutRecov: {"Recovery without recover policy", "Set `policy: recover`, or remove the `recovery:` bounds."},
+
+	// Typing.
+	DiagEnumLiteralMismatch:     {"Enum literal never matches", "Compare against one of the field's declared `enum:` values, or extend the enum."},
+	DiagExprOperandTypeMismatch: {"Expression operand type mismatch", "Compare operands of compatible types (a `string[]` is not an `int`)."},
+	DiagWhenExprNotBoolish:      {"when-expression not boolean", "Write a comparison (`when \"count > 0\"`) instead of a bare number."},
+	DiagVarDefaultTypeMismatch:  {"Var default type mismatch", "Make the default literal match the declared type (`count: int = 3`)."},
+	DiagInvalidPermission:       {"Invalid permission", "Use `off`, `ask` or `deny`."},
+	DiagPermissionRulesNoGate:   {"Permission rules without gate", "Set `permission: ask` or `deny` on the workflow so `allow`/`ask`/`deny` rules apply, or remove the lists."},
+	DiagToolNodePermissionInert: {"Tool-node permission inert", "Remove `permission:` from the tool node; gate the agent nodes instead."},
+	DiagGatedCLIBackendSandbox:  {"Gated backend needs a host-side run", "Declare `sandbox: none` (workflow or node), launch with `--sandbox none`, or use a deny-shaped policy on claw."},
+	DiagIndexOnScalar:           {"Index on scalar", "Index an array or map; drop the subscript on a string/bool/number."},
+	DiagInvalidNodeTimeout:      {"Invalid node timeout", "Use a positive Go duration string, e.g. `timeout: \"20m\"`."},
+	DiagFileFieldNotHuman:       {"file field outside a human pause", "Move the `file` field to a human node's `output:` with `interaction: human` (or `llm_or_human`), or use `string` for a path the node computes."},
+	DiagReservedAnswerKey:       {"Reserved answer key", "Rename the field — `_attachments` is written by the engine on resume."},
+	DiagVarEnumNonString:        {"Var enum on non-string type", "Declare the var as `string`, or drop the `[enum: ...]` constraint."},
+	DiagVarDefaultNotInEnum:     {"Var default not in enum", "Use one of the enum values as the default, or extend the list."},
+	DiagVarEnumDuplicate:        {"Duplicate var enum value", "Remove the duplicate value."},
+	DiagBuiltinArity:            {"Builtin call the evaluator cannot satisfy", "Fix the argument count (`length`/`sort`/`floor`/`round` take 1; `contains`/`join`/`tail` take 2; `if`/`slice` take 3; `concat`/`min`/`max` take 1+), or run on an engine that accepts this shape (`requires.iterion`)."},
+	DiagFanOutEachMissingOver:   {"fan_out_each without over", "Add `over: \"{{...array...}}\"` to the router."},
+	DiagFanOutEachOnlyProperty:  {"fan_out_each property on non-fan_out_each", "Remove `over`/`as`/`key`/`depends_on`, or set `mode: fan_out_each`."},
+	DiagFanOutEachEdges:         {"fan_out_each edge count", "Keep exactly one unconditional template edge from the router."},
+	DiagUseUnknownGroup:         {"Use references unknown group", "Declare `group <name>(...)`, or fix the name."},
+	DiagUseParamMismatch:        {"Use param mismatch", "Bind exactly the group's declared params in `with { ... }`."},
+	DiagForeachConflictsLoop:    {"foreach conflicts with loop", "Use one iteration form per edge: `as foreach` OR `as <loop>(N)`."},
+	DiagSubbotNoSource:          {"subbot without source", "Add `source: \"<child>.bot\"` (relative to this file)."},
+
+	// Fallback chains (ADR-087).
+	DiagMalformedProviderStep: {"Malformed provider step", "Write both parts of a `provider:model` element, e.g. `anthropic:claude-sonnet-4-6`."},
+	DiagFallbackMalformed:     {"Malformed fallback route", "Give the route a distinct name and target; a route that changes `backend:` must also pin its own `model:`."},
+	DiagCommandIgnored:        {"Command ignored", "Only `claude_code` honours a per-node `command:` override; switch the backend or drop it."},
+	DiagFallbackUnknownOn:     {"Unknown fallback trigger", "Use `usage_window`, `auth`, `unavailable`, `transient_exhausted` or `any` in `on:`."},
+	DiagFallbackUnsafeCross:   {"Unsafe fallback crossing", "Route to a gate-enforcing backend (`claude_code`/`claw`/`pi`), declare an explicit `tools:` list, or drop session continuity when crossing backends."},
+	DiagFallbackDrift:         {"Fallback capability drift", "Accept the degradation, or pin the route to a backend that honours the setting."},
+
+	// Supervisors, resources, events, skills.
+	DiagUnknownWatchedNode:      {"Supervisor watches non-agent", "Watch an agent node, or fix the node id."},
+	DiagMalformedSupervisor:     {"Malformed supervisor", "Use a valid Go duration for `cooldown:`."},
+	DiagDuplicateSupervisor:     {"Duplicate supervisor", "Rename or merge the duplicate `supervisor` declaration."},
+	DiagUnknownSupervisorPrompt: {"Unknown supervisor prompt", "Declare the prompt named by `system:`, or fix the name."},
+	DiagResourceCapInvalid:      {"Invalid resource capacity", "Use a capacity >= 1 (or a non-empty list of named members)."},
+	DiagUnknownResourceInNeeds:  {"Unknown resource in needs", "Declare the resource in the workflow's `resources:` block, or fix the name."},
+	DiagEventNoName:             {"Event node without name", "Add `event: \"<name>\"` to the emit/wait node."},
+	DiagWaitNoTimeout:           {"Wait without timeout", "Add `timeout: \"30s\"` (a positive Go duration) — no silent infinity."},
+	DiagEventNoListener:         {"Dangling event", "Pair each `wait` with an `emit` of the same event name (and vice versa)."},
+	DiagInvalidSkillRef:         {"Invalid skill reference", "Use a single path segment of letters/digits/`.`/`-`/`_`; quote kebab-case names (`skills: [\"changelog-writer\"]`)."},
+	DiagUnknownTool:             {"Unknown tool name", "Use a claw built-in (`read_file`, `write_file`, `file_edit`, `glob`, `grep`, `bash`, `web_fetch`, ...) or an MCP tool by its `mcp.<server>.<tool>` name; the message names the nearest match."},
+
+	// Async interaction, parallel branches, typed fails (C24x band).
+	DiagAsyncOnHuman:          {"Async interaction on human node", "Move `interaction: async` to the asking agent/judge and add an `await_answers` node as the sync point."},
+	DiagAwaitAnswersNoTimeout: {"await_answers without timeout", "Add `timeout: \"30m\"` (a positive Go duration) — no silent infinity."},
+	DiagAwaitAnswersBadFrom:   {"await_answers with dead from", "Point `from:` at an `interaction: async` agent/judge, or drop it to await the whole run."},
+	DiagPersistInFanOut:       {"Persist in fan-out body", "Move the `session: persist` node to the trunk after the join, or use `session: fresh` inside the branch."},
+	DiagLoopInExecBranch:      {"Bounded iteration crosses a parallel-branch boundary", "Keep every node of the cycle inside one branch with its own loop name, move the loop to the trunk (wrap the router from the join), or use a `subbot`."},
+	DiagHumanModeInExecBranch: {"Trunk-only human mode in parallel branch", "Use a plain `interaction: human` gate inside the branch, or move the review / llm_or_human gate after the collector."},
+	DiagImplicitCollectorMove: {"Implicit fan-out collector execution moved into branches", "Add `await: wait_all` or `await: best_effort` to the intended collector, or keep it unmarked when per-branch execution is intended."},
+	DiagInvalidFailCode:       {"Malformed fail code", "Use an UPPER_SNAKE identifier: `code: PLAN_BUDGET_EXHAUSTED`."},
+	DiagReservedFailCode:      {"Fail code collides with an engine code", "Pick a code of the bot's own (`BUDGET_EXCEEDED`, `TIMEOUT`, `USAGE_LIMIT_BLOCKED`, ... are the engine's)."},
+	DiagDuplicateFanOutTarget: {"Duplicate fan-out target", "Remove the duplicate edge; use a `fan_out_each` router when the intent is N executions of one node."},
+}
+
+// HintFor returns the catalogue fix line for code, or "" when the code has
+// no entry (the emitting site is then expected to have set its own hint).
+func HintFor(code DiagCode) string {
+	return Catalog[code].Fix
+}

--- a/pkg/dsl/ir/diag_catalog_test.go
+++ b/pkg/dsl/ir/diag_catalog_test.go
@@ -1,0 +1,125 @@
+package ir
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// irDiagConstRe matches a diagnostic-code const declared in THIS package.
+var irDiagConstRe = regexp.MustCompile(`(Diag[A-Za-z0-9_]+)\s+DiagCode\s*=\s*"(C[0-9]{3})"`)
+
+// TestDiagCatalogCoversEveryCode refuses a diagnostic code the compiler can
+// emit that has no catalogue entry: every diagnostic must arrive with a fix
+// line, in `iterion validate`, in the studio badge and in the MCP result
+// alike. It scans source rather than reflecting, like diag_codes_test.go,
+// because Go consts are not enumerable at runtime.
+func TestDiagCatalogCoversEveryCode(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byCode := map[DiagCode]string{}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range irDiagConstRe.FindAllStringSubmatch(string(data), -1) {
+			byCode[DiagCode(m[2])] = m[1]
+		}
+	}
+	if len(byCode) == 0 {
+		t.Fatal("scanned no diagnostic-code consts — the scanner regex is stale")
+	}
+	var missing []string
+	for code, name := range byCode {
+		info, ok := Catalog[code]
+		if !ok || strings.TrimSpace(info.Fix) == "" || strings.TrimSpace(info.Title) == "" {
+			missing = append(missing, string(code)+" ("+name+")")
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%d diagnostic code(s) have no catalogue entry (title + fix line) in diag_catalog.go: %s",
+			len(missing), strings.Join(missing, ", "))
+	}
+}
+
+// TestDiagnosticsCarryHintAndPosition compiles a source with one node-level
+// and one edge-level defect and checks that each diagnostic reaches the
+// caller with the catalogue hint and the position of the declaration it
+// names — the two fields a validate loop acts on.
+func TestDiagnosticsCarryHintAndPosition(t *testing.T) {
+	src := `schema out:
+  ok: bool
+
+agent a:
+  model: "m"
+  output: out
+
+agent b:
+  model: "m"
+  output: out
+  session: inherit
+
+workflow w:
+  entry: a
+  a -> b when ok
+  b -> a
+`
+	pr := parser.Parse("hint.bot", src)
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	res := Compile(pr.File)
+	var seen []string
+	for _, d := range res.Diagnostics {
+		if d.Severity != SeverityError {
+			continue
+		}
+		seen = append(seen, string(d.Code))
+		if d.Hint == "" {
+			t.Errorf("%s: no hint", d.Code)
+		}
+		if d.Hint != HintFor(d.Code) {
+			t.Errorf("%s: hint %q is not the catalogue's %q", d.Code, d.Hint, HintFor(d.Code))
+		}
+		if d.NodeID == "" && d.EdgeID == "" {
+			continue
+		}
+		if d.File != "hint.bot" || d.Line == 0 {
+			t.Errorf("%s (node %q, edge %q): no source position, got %s:%d:%d", d.Code, d.NodeID, d.EdgeID, d.File, d.Line, d.Column)
+		}
+	}
+	joined := strings.Join(seen, ",")
+	if !strings.Contains(joined, string(DiagMissingFallback)) {
+		t.Errorf("expected C012 (missing fallback) among %v", seen)
+	}
+	if !strings.Contains(joined, string(DiagUndeclaredCycle)) {
+		t.Errorf("expected C019 (undeclared cycle) among %v", seen)
+	}
+}
+
+// TestParseDiagnosticsCarryHint checks the parser side of the same contract.
+func TestParseDiagnosticsCarryHint(t *testing.T) {
+	pr := parser.Parse("hint.bot", "agent a:\n  temperature: 0.2\n")
+	if len(pr.Diagnostics) == 0 {
+		t.Fatal("expected an unknown-property diagnostic")
+	}
+	d := pr.Diagnostics[0]
+	if d.Code != parser.DiagUnknownProperty {
+		t.Fatalf("code = %s, want %s", d.Code, parser.DiagUnknownProperty)
+	}
+	if d.Hint == "" || d.Hint != parser.HintFor(d.Code) {
+		t.Errorf("hint = %q, want the catalogued one", d.Hint)
+	}
+}

--- a/pkg/dsl/ir/diag_duplicate_positions_test.go
+++ b/pkg/dsl/ir/diag_duplicate_positions_test.go
@@ -1,0 +1,57 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// A "duplicate" finding must point at the REPEAT — the line the author
+// deletes — not at the first occurrence, which the node id alone resolves to
+// and which is the declaration they keep.
+func TestDuplicateFindingsPointAtTheRepeat(t *testing.T) {
+	lines := []string{
+		/* 1 */ "schema out:",
+		/* 2 */ "  ok: bool",
+		/* 3 */ "",
+		/* 4 */ "agent b:",
+		/* 5 */ "  model: \"m\"",
+		/* 6 */ "  output: out",
+		/* 7 */ "",
+		/* 8 */ "router r:",
+		/* 9 */ "  mode: fan_out_all",
+		/* 10 */ "",
+		/* 11 */ "agent b:",
+		/* 12 */ "  model: \"m\"",
+		/* 13 */ "  output: out",
+		/* 14 */ "",
+		/* 15 */ "agent c:",
+		/* 16 */ "  model: \"m\"",
+		/* 17 */ "  output: out",
+		/* 18 */ "  await: wait_all",
+		/* 19 */ "",
+		/* 20 */ "workflow w:",
+		/* 21 */ "  entry: r",
+		/* 22 */ "  r -> b",
+		/* 23 */ "  r -> c",
+		/* 24 */ "  r -> b",
+		/* 25 */ "  b -> c",
+		/* 26 */ "  c -> done",
+	}
+	pr := parser.Parse("dup.bot", strings.Join(lines, "\n")+"\n")
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	res := Compile(pr.File)
+	at := map[DiagCode][]int{}
+	for _, d := range res.Diagnostics {
+		at[d.Code] = append(at[d.Code], d.Line)
+	}
+	if got := at[DiagDuplicateNodeID]; len(got) != 1 || got[0] != 11 {
+		t.Errorf("C041 at lines %v, want [11] (the redeclaration)\n%v", got, res.Diagnostics)
+	}
+	if got := at[DiagDuplicateFanOutTarget]; len(got) != 1 || got[0] != 24 {
+		t.Errorf("C249 at lines %v, want [24] (the repeated edge)\n%v", got, res.Diagnostics)
+	}
+}

--- a/pkg/dsl/ir/diag_duplicate_positions_test.go
+++ b/pkg/dsl/ir/diag_duplicate_positions_test.go
@@ -55,3 +55,39 @@ func TestDuplicateFindingsPointAtTheRepeat(t *testing.T) {
 		t.Errorf("C249 at lines %v, want [24] (the repeated edge)\n%v", got, res.Diagnostics)
 	}
 }
+
+// Two `use` blocks with one prefix expand to the same node ids. The finding
+// points at the repeated `use` line — the line to change — not at the group
+// body both instances are copied from, and it is reported once.
+func TestDuplicateUsePrefixPointsAtTheRepeatedUse(t *testing.T) {
+	lines := []string{
+		/* 1 */ "schema pout:",
+		/* 2 */ "  ok: bool",
+		/* 3 */ "",
+		/* 4 */ "group gate_block(label):",
+		/* 5 */ "  tool gate:",
+		/* 6 */ "    command: `printf '{\"ok\":true}'`",
+		/* 7 */ "    output: pout",
+		/* 8 */ "",
+		/* 9 */ "use gate_block as r1 with { label: \"A\" }",
+		/* 10 */ "use gate_block as r1 with { label: \"B\" }",
+		/* 11 */ "",
+		/* 12 */ "workflow w:",
+		/* 13 */ "  entry: r1.gate",
+		/* 14 */ "  r1.gate -> done",
+	}
+	pr := parser.Parse("use.bot", strings.Join(lines, "\n")+"\n")
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	res := Compile(pr.File)
+	var got []int
+	for _, d := range res.Diagnostics {
+		if d.Code == DiagDuplicateNodeID {
+			got = append(got, d.Line)
+		}
+	}
+	if len(got) != 1 || got[0] != 10 {
+		t.Errorf("C041 at lines %v, want [10] (the repeated use)\n%v", got, res.Diagnostics)
+	}
+}

--- a/pkg/dsl/ir/diag_order_test.go
+++ b/pkg/dsl/ir/diag_order_test.go
@@ -1,0 +1,35 @@
+package ir
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// The compiler's own list puts a finding without a position AFTER the
+// positioned ones: `entry node "ghost" not found` (global) is read after the
+// edge that names an unknown node, not before it.
+func TestGlobalFindingsSortAfterPositionedOnes(t *testing.T) {
+	src := "schema out:\n  ok: bool\n\nagent a:\n  model: \"m\"\n  output: out\n\nworkflow w:\n  entry: ghost\n  a -> zzz\n"
+	pr := parser.Parse("order.bot", src)
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	res := Compile(pr.File)
+	seenGlobal := false
+	var positioned, global int
+	for _, d := range res.Diagnostics {
+		if d.Line == 0 {
+			global++
+			seenGlobal = true
+			continue
+		}
+		positioned++
+		if seenGlobal {
+			t.Fatalf("positioned finding %s [%s] listed after a global one:\n%v", d.Message, d.Code, res.Diagnostics)
+		}
+	}
+	if positioned == 0 || global == 0 {
+		t.Fatalf("fixture must yield both kinds, got %d positioned / %d global:\n%v", positioned, global, res.Diagnostics)
+	}
+}

--- a/pkg/dsl/ir/diag_positions.go
+++ b/pkg/dsl/ir/diag_positions.go
@@ -1,6 +1,10 @@
 package ir
 
-import "github.com/SocialGouv/iterion/pkg/dsl/ast"
+import (
+	"sort"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+)
 
 // attachPositions stamps a source position onto every diagnostic that names
 // a node or an edge: the declaration's own `<kind> <name>:` line for a node,
@@ -114,4 +118,33 @@ func (c *compiler) attachPositions() {
 			d.File, d.Line, d.Column = p.File, p.Line, p.Column
 		}
 	}
+
+	// Several validators walk maps, so two compilations of one file used to
+	// list the same findings in a different order. Positioned findings read
+	// in source order, the global ones (no position) first; a tie on the
+	// position is broken by code, node, edge and message — every field a
+	// finding has — so the order never depends on map iteration and a
+	// `--json` diff of two runs is quiet.
+	sort.SliceStable(c.diags, func(i, j int) bool {
+		a, b := c.diags[i], c.diags[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		if a.Code != b.Code {
+			return a.Code < b.Code
+		}
+		if a.NodeID != b.NodeID {
+			return a.NodeID < b.NodeID
+		}
+		if a.EdgeID != b.EdgeID {
+			return a.EdgeID < b.EdgeID
+		}
+		return a.Message < b.Message
+	})
 }

--- a/pkg/dsl/ir/diag_positions.go
+++ b/pkg/dsl/ir/diag_positions.go
@@ -1,0 +1,117 @@
+package ir
+
+import "github.com/SocialGouv/iterion/pkg/dsl/ast"
+
+// attachPositions stamps a source position onto every diagnostic that names
+// a node or an edge: the declaration's own `<kind> <name>:` line for a node,
+// the edge's line for an edge. Compile diagnostics are produced from the
+// AST, whose spans the parser already records, so the position costs one
+// lookup — and it is what turns "error [C019]" into a location an editor,
+// an agent or `iterion validate` can jump to.
+//
+// Best-effort by design: a diagnostic that already carries a position keeps
+// it, a global one (no workflow, duplicate loop name) has none, and a
+// group-expanded node (`<prefix>.<name>`) points at the group member it was
+// cloned from.
+func (c *compiler) attachPositions() {
+	if c.file == nil {
+		return
+	}
+	nodePos := map[string]ast.Pos{}
+	add := func(name string, sp ast.Span) {
+		if name == "" || sp.Start.Line == 0 {
+			return
+		}
+		if _, seen := nodePos[name]; !seen {
+			nodePos[name] = sp.Start
+		}
+	}
+	f := c.file
+	for _, d := range f.Agents {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Judges {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Routers {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Humans {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Tools {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Computes {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Emits {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Waits {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.AwaitAnswers {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Fails {
+		add(d.Name, d.Span)
+	}
+	for _, d := range f.Subbots {
+		add(d.Name, d.Span)
+	}
+	for _, u := range f.Uses {
+		for _, g := range f.Groups {
+			if g.Name != u.Group {
+				continue
+			}
+			for _, d := range g.Agents {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+			for _, d := range g.Judges {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+			for _, d := range g.Routers {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+			for _, d := range g.Humans {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+			for _, d := range g.Tools {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+			for _, d := range g.Computes {
+				add(u.Prefix+"."+d.Name, d.Span)
+			}
+		}
+	}
+
+	edgePos := map[string]ast.Pos{}
+	for _, w := range f.Workflows {
+		for _, e := range w.Edges {
+			if e.Span.Start.Line == 0 {
+				continue
+			}
+			id := e.From + "->" + e.To
+			if _, seen := edgePos[id]; !seen {
+				edgePos[id] = e.Span.Start
+			}
+		}
+	}
+
+	for i := range c.diags {
+		d := &c.diags[i]
+		if d.Line != 0 {
+			continue
+		}
+		if d.EdgeID != "" {
+			if p, ok := edgePos[d.EdgeID]; ok {
+				d.File, d.Line, d.Column = p.File, p.Line, p.Column
+				continue
+			}
+		}
+		if p, ok := nodePos[d.NodeID]; ok {
+			d.File, d.Line, d.Column = p.File, p.Line, p.Column
+		}
+	}
+}

--- a/pkg/dsl/ir/diag_positions.go
+++ b/pkg/dsl/ir/diag_positions.go
@@ -121,12 +121,17 @@ func (c *compiler) attachPositions() {
 
 	// Several validators walk maps, so two compilations of one file used to
 	// list the same findings in a different order. Positioned findings read
-	// in source order, the global ones (no position) first; a tie on the
-	// position is broken by code, node, edge and message — every field a
-	// finding has — so the order never depends on map iteration and a
-	// `--json` diff of two runs is quiet.
+	// in source order; the global ones (no position) go LAST, since they are
+	// usually consequences of a positioned one (`entry node not found`
+	// because the declaration above failed); a tie on the position is broken
+	// by code, node, edge and message — every field a finding has — so the
+	// order never depends on map iteration and a `--json` diff of two runs
+	// is quiet.
 	sort.SliceStable(c.diags, func(i, j int) bool {
 		a, b := c.diags[i], c.diags[j]
+		if (a.Line == 0) != (b.Line == 0) {
+			return a.Line != 0
+		}
 		if a.File != b.File {
 			return a.File < b.File
 		}

--- a/pkg/dsl/ir/diag_positions_test.go
+++ b/pkg/dsl/ir/diag_positions_test.go
@@ -1,0 +1,136 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// A finding must point at the line the author has to EDIT: the edge line for
+// an edge-scoped check (each edge its own line, even when several share
+// endpoints), the prompt declaration for a reference inside a prompt body —
+// never the header of the node that merely consumes the text.
+func TestDiagnosticsPointAtTheEdgeAndPromptLines(t *testing.T) {
+	lines := []string{
+		/* 1 */ "schema out:",
+		/* 2 */ "  ok: bool",
+		/* 3 */ "",
+		/* 4 */ "prompt shared:",
+		/* 5 */ "  Uses {{outputs.ghost.field}} here.",
+		/* 6 */ "",
+		/* 7 */ "agent a:",
+		/* 8 */ "  model: \"m\"",
+		/* 9 */ "  output: out",
+		/* 10 */ "  system: shared",
+		/* 11 */ "",
+		/* 12 */ "router r:",
+		/* 13 */ "  mode: llm",
+		/* 14 */ "  model: \"m\"",
+		/* 15 */ "",
+		/* 16 */ "agent b:",
+		/* 17 */ "  model: \"m\"",
+		/* 18 */ "  output: out",
+		/* 19 */ "  system: shared",
+		/* 20 */ "",
+		/* 21 */ "agent c:",
+		/* 22 */ "  model: \"m\"",
+		/* 23 */ "  output: out",
+		/* 24 */ "",
+		/* 25 */ "workflow w:",
+		/* 26 */ "  entry: a",
+		/* 27 */ "  a -> r",
+		/* 28 */ "  r -> b when ok",
+		/* 29 */ "  r -> b when not ok",
+		/* 30 */ "  r -> c",
+		/* 31 */ "  b -> done with { taken: \"{{input.nosuchfield}}\" }",
+		/* 32 */ "  c -> done",
+	}
+	src := strings.Join(lines, "\n") + "\n"
+	pr := parser.Parse("pos.bot", src)
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	res := Compile(pr.File)
+
+	at := map[string][]int{}
+	for _, d := range res.Diagnostics {
+		at[string(d.Code)] = append(at[string(d.Code)], d.Line)
+	}
+	// C022 fires once per conditional edge of the llm router: lines 28 and 29,
+	// not 28 twice.
+	if got := fmt.Sprint(at["C022"]); got != "[28 29]" {
+		t.Errorf("C022 lines = %s, want [28 29] (each edge its own line)", got)
+	}
+	// The unknown-node reference lives in the prompt body: line 4 is where
+	// to edit, once per consuming node.
+	for _, l := range at["C029"] {
+		if l != 4 {
+			t.Errorf("C029 at line %d, want 4 (the prompt declaration)", l)
+		}
+	}
+	if len(at["C029"]) == 0 {
+		t.Errorf("expected C029 for the ghost reference, got %v", at)
+	}
+	// The with-mapping reference lives on the edge line.
+	if got := fmt.Sprint(at["C034"]); got != "[31]" {
+		t.Errorf("C034 lines = %s, want [31] (the edge line)", got)
+	}
+
+	// Determinism: the same file compiles to the same ordered list.
+	first := diagSignature(res.Diagnostics)
+	for i := 0; i < 5; i++ {
+		again := Compile(parser.Parse("pos.bot", src).File)
+		if s := diagSignature(again.Diagnostics); s != first {
+			t.Fatalf("diagnostic order changed between two compilations:\n%s\nvs\n%s", first, s)
+		}
+	}
+}
+
+func diagSignature(ds []Diagnostic) string {
+	var b strings.Builder
+	for _, d := range ds {
+		fmt.Fprintf(&b, "%s@%d:%d %s\n", d.Code, d.Line, d.Column, d.NodeID)
+	}
+	return b.String()
+}
+
+// The catalogue fix for C032 ("add an output: schema") cannot be followed on
+// a router, which has no output of its own; that site carries its own fix.
+func TestRouterPassThroughWarningCarriesItsOwnFix(t *testing.T) {
+	src := `schema out:
+  ok: bool
+
+agent a:
+  model: "m"
+  output: out
+
+router r:
+  mode: condition
+
+agent b:
+  model: "m"
+  output: out
+
+workflow w:
+  entry: a
+  a -> r
+  r -> b with { taken: "{{input.zzz}}" }
+  b -> done
+`
+	res := Compile(parser.Parse("r.bot", src).File)
+	var seen bool
+	for _, d := range res.Diagnostics {
+		if d.Code != DiagRefNodeNoSchema {
+			continue
+		}
+		seen = true
+		if strings.Contains(d.Hint, "output:` schema") || !strings.Contains(d.Hint, "map the field onto it") {
+			t.Errorf("router C032 hint = %q — must tell the author to map the field onto the router, not to add an output schema a router cannot have", d.Hint)
+		}
+	}
+	if !seen {
+		t.Fatalf("expected a C032 warning on the router pass-through, got %+v", res.Diagnostics)
+	}
+}

--- a/pkg/dsl/ir/docs_snippets_extract_test.go
+++ b/pkg/dsl/ir/docs_snippets_extract_test.go
@@ -1,0 +1,54 @@
+package ir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The extractor must see a fence wherever markdown allows one — indented
+// inside a list item, with its indentation stripped from the body — and must
+// surface a malformed tag instead of dropping the fence. Both were blind
+// spots of the first version: two indented fences in docs/sandbox.md were
+// never checked, and a tag with a space would have vanished silently.
+func TestDocSnippetExtractorSeesIndentedFencesAndBadTags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	md := "Intro\n\n" +
+		"1. Step one:\n\n" +
+		"   ```iter fragment:workflow\n" +
+		"   entry: plan\n" +
+		"   sandbox: auto\n" +
+		"   ```\n\n" +
+		"- bullet:\n" +
+		"  ```iter\n" +
+		"  schema out:\n" +
+		"    ok: bool\n" +
+		"  ```\n\n" +
+		"```iter fragment edges\n" +
+		"a -> b\n" +
+		"```\n"
+	if err := os.WriteFile(path, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snips := extractDocSnippets(t, path)
+	if len(snips) != 3 {
+		t.Fatalf("expected 3 fences (two indented, one with a bad tag), got %d: %+v", len(snips), snips)
+	}
+	if snips[0].tag != "fragment:workflow" || snips[0].body != "entry: plan\nsandbox: auto\n" {
+		t.Errorf("indented fence 1 = tag %q body %q — indentation not stripped or tag lost", snips[0].tag, snips[0].body)
+	}
+	if snips[1].tag != "" || snips[1].body != "schema out:\n  ok: bool\n" {
+		t.Errorf("indented fence 2 = tag %q body %q — nested indentation must survive, list indent must not", snips[1].tag, snips[1].body)
+	}
+	if snips[2].tag != "fragment edges" {
+		t.Fatalf("bad tag = %q, want it captured verbatim so compileSnippet can refuse it", snips[2].tag)
+	}
+	if _, _, err := compileSnippet(snips[2]); err == nil {
+		t.Error("a tag with a space must be refused, not treated as a policy")
+	}
+	// The de-indented fragment wraps and parses like a column-0 one.
+	if pe, _, err := compileSnippet(snips[0]); err != nil || len(pe) > 0 {
+		t.Errorf("indented fragment:workflow should parse once de-indented: err=%v parseErrs=%v", err, pe)
+	}
+}

--- a/pkg/dsl/ir/docs_snippets_extract_test.go
+++ b/pkg/dsl/ir/docs_snippets_extract_test.go
@@ -3,6 +3,7 @@ package ir
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +51,41 @@ func TestDocSnippetExtractorSeesIndentedFencesAndBadTags(t *testing.T) {
 	// The de-indented fragment wraps and parses like a column-0 one.
 	if pe, _, err := compileSnippet(snips[0]); err != nil || len(pe) > 0 {
 		t.Errorf("indented fragment:workflow should parse once de-indented: err=%v parseErrs=%v", err, pe)
+	}
+}
+
+// A closing fence sits at exactly the opening indent: a deeper ``` inside the
+// body is text (a prompt teaching an agent to emit a code block), and a body
+// line indented less than the fence is reported rather than silently kept.
+func TestDocSnippetExtractorClosesOnlyAtTheFenceIndent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.md")
+	md := "- item:\n" +
+		"  ```iter fragment\n" +
+		"  prompt p:\n" +
+		"    Reply inside a code block:\n" +
+		"    ```\n" +
+		"    text\n" +
+		"    ```\n" +
+		"  ```\n\n" +
+		"  ```iter fragment\n" +
+		"  schema out:\n" +
+		" ok: bool\n" +
+		"  ```\n"
+	if err := os.WriteFile(path, []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snips := extractDocSnippets(t, path)
+	if len(snips) != 2 {
+		t.Fatalf("expected 2 fences, got %d: %+v", len(snips), snips)
+	}
+	if !strings.Contains(snips[0].body, "  ```\n  text\n  ```\n") {
+		t.Errorf("the deeper ``` lines must stay in the body, got %q", snips[0].body)
+	}
+	if snips[0].malformed != "" {
+		t.Errorf("first fence wrongly reported malformed: %s", snips[0].malformed)
+	}
+	if snips[1].malformed == "" {
+		t.Errorf("a body line indented less than its fence must be reported, got body %q", snips[1].body)
 	}
 }

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -37,9 +37,13 @@ import (
 // Markdown renderers read only the first word, so the tags are invisible
 // to readers and only this test sees them.
 
+// A fence may be indented (inside a list item); the same indentation is
+// stripped from its body. The info string after `iter` is captured whole so a
+// tag with a space in it (```iter fragment edges) is reported instead of
+// being silently dropped.
 var (
-	fenceOpenRe = regexp.MustCompile("^```iter(?:\\s+(\\S+))?\\s*$")
-	fenceEndRe  = regexp.MustCompile("^```\\s*$")
+	fenceOpenRe = regexp.MustCompile("^(\\s*)```iter\\b(.*)$")
+	fenceEndRe  = regexp.MustCompile("^\\s*```\\s*$")
 )
 
 // snippetFragmentKinds are the declaration kinds a `fragment:<kind>` fence
@@ -103,6 +107,7 @@ func extractDocSnippets(t *testing.T, path string) []docSnippet {
 	var out []docSnippet
 	var cur *docSnippet
 	var body []string
+	indent := ""
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 1024*1024), 4*1024*1024)
 	lineNo := 0
@@ -111,7 +116,8 @@ func extractDocSnippets(t *testing.T, path string) []docSnippet {
 		line := sc.Text()
 		if cur == nil {
 			if m := fenceOpenRe.FindStringSubmatch(line); m != nil {
-				cur = &docSnippet{file: path, line: lineNo, tag: m[1]}
+				indent = m[1]
+				cur = &docSnippet{file: path, line: lineNo, tag: strings.TrimSpace(m[2])}
 				body = body[:0]
 			}
 			continue
@@ -122,7 +128,7 @@ func extractDocSnippets(t *testing.T, path string) []docSnippet {
 			cur = nil
 			continue
 		}
-		body = append(body, line)
+		body = append(body, strings.TrimPrefix(line, indent))
 	}
 	if err := sc.Err(); err != nil {
 		t.Fatalf("read %s: %v", path, err)
@@ -183,7 +189,7 @@ func compileSnippet(s docSnippet) (parseErrs, compileErrs []string, err error) {
 		}
 		src = indentSnippet(kind+" _snippet:", s.body)
 	default:
-		return nil, nil, fmt.Errorf("unknown fence tag %q — use `iter`, `iter fragment`, `iter fragment:edges`, `iter fragment:workflow`, `iter fragment:<kind>` or `iter invalid`", tag)
+		return nil, nil, fmt.Errorf("unknown fence tag %q — use `iter`, `iter fragment`, `iter fragment:edges`, `iter fragment:workflow`, `iter fragment:<kind>` or `iter invalid` (one word, no spaces)", tag)
 	}
 	pr := parser.Parse(filepath.Base(s.file), src)
 	for _, d := range pr.Diagnostics {

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -64,6 +64,11 @@ var fragmentElsewhereCodes = map[DiagCode]bool{
 	DiagHistoryRefNotInLoop: true, DiagUnknownRefNode: true, DiagUndeclaredVar: true,
 	DiagUnknownArtifact: true, DiagRefNodeNotReachable: true, DiagUnknownAttachment: true,
 	DiagUnknownSecret: true, DiagUnknownCursor: true, DiagUseUnknownGroup: true,
+	// A router's edge-count checks and a node's resource lease read the
+	// workflow's edges and `resources:` block — the part a node-only
+	// fragment omits (the synthetic workflow appended for it has neither).
+	DiagRoundRobinTooFewEdges: true, DiagLLMRouterTooFewEdges: true,
+	DiagFanOutEachEdges: true, DiagUnknownResourceInNeeds: true,
 }
 
 var diagCodeRe = regexp.MustCompile(`\[(C\d{3})\]`)
@@ -178,6 +183,26 @@ func extractDocSnippets(t *testing.T, path string) []docSnippet {
 	return out
 }
 
+// withSyntheticWorkflow appends a minimal workflow to a fragment that declares
+// nodes but no workflow, so the compiler runs its node-level passes on them.
+// Without it the compiler returns at "no workflow" (C006) before expanding
+// groups, resolving prompts or checking any node — 52 of the 79 `fragment`
+// fences — and the "compile" half of the fragment policy checked nothing.
+// The synthetic workflow only names an entry: the nodes stay unreachable
+// (C016, excused) and unwired (excused), which is what a fragment is.
+var firstNodeDeclRe = regexp.MustCompile(`(?m)^(?:agent|judge|router|human|tool|compute|subbot|emit|wait|await_answers|fail)\s+([A-Za-z_]\w*)\s*:`)
+
+func withSyntheticWorkflow(body string) string {
+	if regexp.MustCompile(`(?m)^workflow\s`).MatchString(body) {
+		return body
+	}
+	m := firstNodeDeclRe.FindStringSubmatch(body)
+	if m == nil {
+		return body
+	}
+	return body + "\nworkflow _snippet:\n  entry: " + m[1] + "\n"
+}
+
 // indentSnippet nests a fragment under a synthetic declaration header.
 func indentSnippet(header, body string) string {
 	var b strings.Builder
@@ -216,7 +241,9 @@ func compileSnippet(s docSnippet) (parseErrs, compileErrs []string, err error) {
 	src := s.body
 	tag := s.tag
 	switch {
-	case tag == "" || tag == "fragment" || tag == "invalid" || strings.HasPrefix(tag, "invalid:"):
+	case tag == "" || tag == "invalid" || strings.HasPrefix(tag, "invalid:"):
+	case tag == "fragment":
+		src = withSyntheticWorkflow(s.body)
 	case tag == "fragment:edges":
 		src = indentSnippet("workflow _snippet:\n  entry: "+firstEdgeSource(s.body), s.body)
 	case tag == "fragment:workflow":

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -268,9 +268,19 @@ func compileSnippet(s docSnippet) (parseErrs, compileErrs []string, err error) {
 	}
 	cr := Compile(pr.File)
 	for _, d := range cr.Diagnostics {
-		if d.Severity == SeverityError {
-			compileErrs = append(compileErrs, d.Error())
+		if d.Severity != SeverityError {
+			continue
 		}
+		// C018 (`model:`/`backend:` missing) is waived when the HOST can
+		// auto-detect a credential (compile.go canAutoResolveBackend), so
+		// its verdict differs between a laptop with a Claude login and CI
+		// with none — the one compile check that reads the environment.
+		// The guard cannot judge auto-detection, and an example that
+		// relies on it is legitimate, so it never counts here.
+		if d.Code == DiagMissingModelOrBackend {
+			continue
+		}
+		compileErrs = append(compileErrs, d.Error())
 	}
 	return parseErrs, compileErrs, nil
 }

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -1,0 +1,249 @@
+package ir
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// Every ```iter fence in the repository's documentation is a program the
+// reader — a human or an agent given the authoring skill — will copy. This
+// test compiles each of them with the real parser and compiler, so a
+// snippet can no longer teach a syntax the language does not have.
+//
+// Measured before the guard existed (2026-09-09): of 91 fences across the
+// authoring docs, 2 compiled, 48 did not even parse, and the three
+// canonical examples of the DSL quickref skill (tool node, workflow block,
+// sandbox block) all failed — with exactly the mistakes an agent then
+// reproduces (YAML-style lists, `#` comments, a plausible property that
+// does not exist).
+//
+// The fence's info string carries the policy, after the language tag:
+//
+//	```iter                     standalone — must parse AND compile clean
+//	```iter fragment            top-level declarations — must parse
+//	```iter fragment:edges      edge lines — wrapped in a workflow, must parse
+//	```iter fragment:workflow   workflow members — wrapped, must parse
+//	```iter fragment:<kind>     node properties — wrapped in `<kind> _:`, must parse
+//	```iter invalid             a documented anti-example — must NOT be clean
+//
+// Markdown renderers read only the first word, so the tags are invisible
+// to readers and only this test sees them.
+
+var (
+	fenceOpenRe = regexp.MustCompile("^```iter(?:\\s+(\\S+))?\\s*$")
+	fenceEndRe  = regexp.MustCompile("^```\\s*$")
+)
+
+// snippetFragmentKinds are the declaration kinds a `fragment:<kind>` fence
+// may be wrapped in.
+var snippetFragmentKinds = map[string]bool{
+	"agent": true, "judge": true, "router": true, "human": true, "tool": true,
+	"compute": true, "subbot": true, "emit": true, "wait": true, "await_answers": true,
+	"fail": true, "supervisor": true, "cursor": true, "mcp_server": true,
+	"schema": true, "prompt": true, "group": true,
+}
+
+type docSnippet struct {
+	file string
+	line int // line of the opening fence, 1-based
+	tag  string
+	body string
+}
+
+// docSnippetFiles lists the markdown a reader may take DSL from: the docs
+// tree, the two root skills, the README, and every bot/example README and
+// skill.
+func docSnippetFiles(t *testing.T) []string {
+	t.Helper()
+	root := filepath.Join("..", "..", "..")
+	var files []string
+	for _, p := range []string{"README.md", "SKILL.md", "SKILL-run-and-refine.md"} {
+		if _, err := os.Stat(filepath.Join(root, p)); err == nil {
+			files = append(files, filepath.Join(root, p))
+		}
+	}
+	walk := func(dir string) {
+		_ = filepath.WalkDir(filepath.Join(root, dir), func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(path, ".md") {
+				files = append(files, path)
+			}
+			return nil
+		})
+	}
+	walk("docs")
+	for _, g := range []string{"bots/*/skills/*.md", "bots/*/README.md", "examples/*/README.md", "examples/*/skills/*.md"} {
+		m, _ := filepath.Glob(filepath.Join(root, g))
+		files = append(files, m...)
+	}
+	sort.Strings(files)
+	if len(files) == 0 {
+		t.Fatal("no documentation files found — is the test running from pkg/dsl/ir?")
+	}
+	return files
+}
+
+func extractDocSnippets(t *testing.T, path string) []docSnippet {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var out []docSnippet
+	var cur *docSnippet
+	var body []string
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 4*1024*1024)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		line := sc.Text()
+		if cur == nil {
+			if m := fenceOpenRe.FindStringSubmatch(line); m != nil {
+				cur = &docSnippet{file: path, line: lineNo, tag: m[1]}
+				body = body[:0]
+			}
+			continue
+		}
+		if fenceEndRe.MatchString(line) {
+			cur.body = strings.Join(body, "\n") + "\n"
+			out = append(out, *cur)
+			cur = nil
+			continue
+		}
+		body = append(body, line)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if cur != nil {
+		t.Errorf("%s:%d: ```iter fence is never closed", path, cur.line)
+	}
+	return out
+}
+
+// indentSnippet nests a fragment under a synthetic declaration header.
+func indentSnippet(header, body string) string {
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n")
+	for _, l := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		if strings.TrimSpace(l) == "" {
+			b.WriteString("\n")
+			continue
+		}
+		b.WriteString("  ")
+		b.WriteString(l)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// firstEdgeSource returns the source node of the first edge line, for the
+// synthetic `entry:` of an edges fragment.
+func firstEdgeSource(body string) string {
+	for _, l := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(l)
+		if s == "" || strings.HasPrefix(s, "#") {
+			continue
+		}
+		if i := strings.Index(s, "->"); i > 0 {
+			return strings.TrimSpace(s[:i])
+		}
+	}
+	return "_entry"
+}
+
+// compileSnippet returns the parse errors and the compile errors of a
+// snippet assembled per its tag.
+func compileSnippet(s docSnippet) (parseErrs, compileErrs []string, err error) {
+	src := s.body
+	tag := s.tag
+	switch {
+	case tag == "" || tag == "fragment" || tag == "invalid":
+	case tag == "fragment:edges":
+		src = indentSnippet("workflow _snippet:\n  entry: "+firstEdgeSource(s.body), s.body)
+	case tag == "fragment:workflow":
+		src = indentSnippet("workflow _snippet:", s.body)
+	case strings.HasPrefix(tag, "fragment:"):
+		kind := strings.TrimPrefix(tag, "fragment:")
+		if !snippetFragmentKinds[kind] {
+			return nil, nil, fmt.Errorf("unknown fragment kind %q", kind)
+		}
+		src = indentSnippet(kind+" _snippet:", s.body)
+	default:
+		return nil, nil, fmt.Errorf("unknown fence tag %q — use `iter`, `iter fragment`, `iter fragment:edges`, `iter fragment:workflow`, `iter fragment:<kind>` or `iter invalid`", tag)
+	}
+	pr := parser.Parse(filepath.Base(s.file), src)
+	for _, d := range pr.Diagnostics {
+		if d.Severity == parser.SeverityError {
+			parseErrs = append(parseErrs, d.Error())
+		}
+	}
+	if pr.File == nil {
+		return parseErrs, nil, nil
+	}
+	cr := Compile(pr.File)
+	for _, d := range cr.Diagnostics {
+		if d.Severity == SeverityError {
+			compileErrs = append(compileErrs, d.Error())
+		}
+	}
+	return parseErrs, compileErrs, nil
+}
+
+func firstN(items []string, n int) string {
+	if len(items) > n {
+		items = append(items[:n:n], fmt.Sprintf("… and %d more", len(items)-n))
+	}
+	return strings.Join(items, "\n      ")
+}
+
+// TestDocsIterFencesCompile is the guard: every ```iter fence in the docs
+// honours the policy its tag declares.
+func TestDocsIterFencesCompile(t *testing.T) {
+	total := 0
+	for _, path := range docSnippetFiles(t) {
+		for _, s := range extractDocSnippets(t, path) {
+			total++
+			rel := strings.TrimPrefix(s.file, filepath.Join("..", "..", "..")+string(filepath.Separator))
+			where := fmt.Sprintf("%s:%d fence `iter %s`", rel, s.line, s.tag)
+			parseErrs, compileErrs, err := compileSnippet(s)
+			if err != nil {
+				t.Errorf("%s: %v", where, err)
+				continue
+			}
+			switch s.tag {
+			case "invalid":
+				if len(parseErrs)+len(compileErrs) == 0 {
+					t.Errorf("%s: is tagged as an anti-example but compiles clean — drop the tag or make it invalid again", where)
+				}
+			case "":
+				if len(parseErrs) > 0 {
+					t.Errorf("%s: does not parse:\n      %s\n    (a standalone fence must parse and compile; tag it `iter fragment…` if it is deliberately partial)", where, firstN(parseErrs, 3))
+				} else if len(compileErrs) > 0 {
+					t.Errorf("%s: does not compile:\n      %s\n    (declare what it references, or tag it `iter fragment` if it is deliberately partial)", where, firstN(compileErrs, 3))
+				}
+			default: // fragment*
+				if len(parseErrs) > 0 {
+					t.Errorf("%s: does not parse:\n      %s", where, firstN(parseErrs, 3))
+				}
+			}
+		}
+	}
+	if total == 0 {
+		t.Fatal("found no ```iter fences at all — the extractor is broken")
+	}
+	t.Logf("checked %d ```iter fences", total)
+}

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -28,7 +28,8 @@ import (
 // The fence's info string carries the policy, after the language tag:
 //
 //	```iter                     standalone — must parse AND compile clean
-//	```iter fragment            top-level declarations — must parse
+//	```iter fragment            top-level declarations — must parse, and compile
+//	                            except for what it may omit (see fragmentElsewhereCodes)
 //	```iter fragment:edges      edge lines — wrapped in a workflow, must parse
 //	```iter fragment:workflow   workflow members — wrapped, must parse
 //	```iter fragment:<kind>     node properties — wrapped in `<kind> _:`, must parse
@@ -46,6 +47,39 @@ import (
 // with a space in it (```iter fragment edges) is reported instead of being
 // silently dropped.
 var fenceOpenRe = regexp.MustCompile("^(\\s*)```iter\\b(.*)$")
+
+// fragmentElsewhereCodes are the compile errors a `fragment` fence may raise
+// only because it omits what it references — declared elsewhere on the page:
+// an unknown node, schema, prompt, var, artifact, attachment, secret, cursor
+// or group; no workflow, no entry; a node the missing workflow cannot reach;
+// a history ref whose loop is outside. Every OTHER compile error is a shape
+// error of the fragment itself (a conditional edge with no fallback, an
+// undeclared cycle, a bad expression) and fails the guard: with 79 of the
+// 108 fences tagged `fragment`, a parse-only policy would leave most of the
+// documentation semantically unchecked — and did, until the headline pattern
+// of groups-iteration-subbots.md was found to fail C012.
+var fragmentElsewhereCodes = map[DiagCode]bool{
+	DiagUnknownNode: true, DiagUnknownSchema: true, DiagUnknownPrompt: true,
+	DiagNoWorkflow: true, DiagMissingEntry: true, DiagUnreachableNode: true,
+	DiagHistoryRefNotInLoop: true, DiagUnknownRefNode: true, DiagUndeclaredVar: true,
+	DiagUnknownArtifact: true, DiagRefNodeNotReachable: true, DiagUnknownAttachment: true,
+	DiagUnknownSecret: true, DiagUnknownCursor: true, DiagUseUnknownGroup: true,
+}
+
+var diagCodeRe = regexp.MustCompile(`\[(C\d{3})\]`)
+
+// fragmentShapeErrors keeps the compile errors a fragment cannot excuse.
+func fragmentShapeErrors(compileErrs []string) []string {
+	var out []string
+	for _, e := range compileErrs {
+		m := diagCodeRe.FindStringSubmatch(e)
+		if m != nil && fragmentElsewhereCodes[DiagCode(m[1])] {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
 
 // snippetFragmentKinds are the declaration kinds a `fragment:<kind>` fence
 // may be wrapped in.
@@ -256,7 +290,13 @@ func TestDocsIterFencesCompile(t *testing.T) {
 				} else if len(compileErrs) > 0 {
 					t.Errorf("%s: does not compile:\n      %s\n    (declare what it references, or tag it `iter fragment` if it is deliberately partial)", where, firstN(compileErrs, 3))
 				}
-			default: // fragment*
+			case s.tag == "fragment":
+				if len(parseErrs) > 0 {
+					t.Errorf("%s: does not parse:\n      %s", where, firstN(parseErrs, 3))
+				} else if shape := fragmentShapeErrors(compileErrs); len(shape) > 0 {
+					t.Errorf("%s: has a shape error a fragment cannot excuse:\n      %s\n    (a fragment may omit what it references; it may not be wrong about what it shows)", where, firstN(shape, 3))
+				}
+			default: // fragment:edges, fragment:workflow, fragment:<kind> — wrapped, parse only
 				if len(parseErrs) > 0 {
 					t.Errorf("%s: does not parse:\n      %s", where, firstN(parseErrs, 3))
 				}

--- a/pkg/dsl/ir/docs_snippets_test.go
+++ b/pkg/dsl/ir/docs_snippets_test.go
@@ -32,19 +32,20 @@ import (
 //	```iter fragment:edges      edge lines — wrapped in a workflow, must parse
 //	```iter fragment:workflow   workflow members — wrapped, must parse
 //	```iter fragment:<kind>     node properties — wrapped in `<kind> _:`, must parse
-//	```iter invalid             a documented anti-example — must NOT be clean
+//	```iter invalid:C019        a documented anti-example — must fail with THAT code
+//	```iter invalid             an anti-example — must not be clean (any error)
 //
 // Markdown renderers read only the first word, so the tags are invisible
 // to readers and only this test sees them.
 
 // A fence may be indented (inside a list item); the same indentation is
-// stripped from its body. The info string after `iter` is captured whole so a
-// tag with a space in it (```iter fragment edges) is reported instead of
-// being silently dropped.
-var (
-	fenceOpenRe = regexp.MustCompile("^(\\s*)```iter\\b(.*)$")
-	fenceEndRe  = regexp.MustCompile("^\\s*```\\s*$")
-)
+// stripped from its body, its closing fence must sit at exactly that indent
+// (a deeper ``` is body text — a prompt teaching an agent to emit a code
+// fence), and a body line indented less than the fence is reported rather
+// than silently kept. The info string after `iter` is captured whole so a tag
+// with a space in it (```iter fragment edges) is reported instead of being
+// silently dropped.
+var fenceOpenRe = regexp.MustCompile("^(\\s*)```iter\\b(.*)$")
 
 // snippetFragmentKinds are the declaration kinds a `fragment:<kind>` fence
 // may be wrapped in.
@@ -56,10 +57,11 @@ var snippetFragmentKinds = map[string]bool{
 }
 
 type docSnippet struct {
-	file string
-	line int // line of the opening fence, 1-based
-	tag  string
-	body string
+	file      string
+	line      int // line of the opening fence, 1-based
+	tag       string
+	body      string
+	malformed string // non-empty when the fence's own shape is wrong (a body line less indented than the fence)
 }
 
 // docSnippetFiles lists the markdown a reader may take DSL from: the docs
@@ -122,11 +124,14 @@ func extractDocSnippets(t *testing.T, path string) []docSnippet {
 			}
 			continue
 		}
-		if fenceEndRe.MatchString(line) {
+		if strings.TrimRight(line, " \t") == indent+"```" {
 			cur.body = strings.Join(body, "\n") + "\n"
 			out = append(out, *cur)
 			cur = nil
 			continue
+		}
+		if strings.TrimSpace(line) != "" && !strings.HasPrefix(line, indent) && cur.malformed == "" {
+			cur.malformed = fmt.Sprintf("line %d is indented less than its fence", lineNo)
 		}
 		body = append(body, strings.TrimPrefix(line, indent))
 	}
@@ -177,7 +182,7 @@ func compileSnippet(s docSnippet) (parseErrs, compileErrs []string, err error) {
 	src := s.body
 	tag := s.tag
 	switch {
-	case tag == "" || tag == "fragment" || tag == "invalid":
+	case tag == "" || tag == "fragment" || tag == "invalid" || strings.HasPrefix(tag, "invalid:"):
 	case tag == "fragment:edges":
 		src = indentSnippet("workflow _snippet:\n  entry: "+firstEdgeSource(s.body), s.body)
 	case tag == "fragment:workflow":
@@ -225,17 +230,27 @@ func TestDocsIterFencesCompile(t *testing.T) {
 			total++
 			rel := strings.TrimPrefix(s.file, filepath.Join("..", "..", "..")+string(filepath.Separator))
 			where := fmt.Sprintf("%s:%d fence `iter %s`", rel, s.line, s.tag)
+			if s.malformed != "" {
+				t.Errorf("%s: %s", where, s.malformed)
+				continue
+			}
 			parseErrs, compileErrs, err := compileSnippet(s)
 			if err != nil {
 				t.Errorf("%s: %v", where, err)
 				continue
 			}
-			switch s.tag {
-			case "invalid":
+			switch {
+			case strings.HasPrefix(s.tag, "invalid:"):
+				code := strings.TrimPrefix(s.tag, "invalid:")
+				all := strings.Join(append(parseErrs, compileErrs...), "\n")
+				if !strings.Contains(all, "["+code+"]") {
+					t.Errorf("%s: is tagged as the %s anti-example but does not fail with it:\n      %s", where, code, firstN(append(parseErrs, compileErrs...), 3))
+				}
+			case s.tag == "invalid":
 				if len(parseErrs)+len(compileErrs) == 0 {
 					t.Errorf("%s: is tagged as an anti-example but compiles clean — drop the tag or make it invalid again", where)
 				}
-			case "":
+			case s.tag == "":
 				if len(parseErrs) > 0 {
 					t.Errorf("%s: does not parse:\n      %s\n    (a standalone fence must parse and compile; tag it `iter fragment…` if it is deliberately partial)", where, firstN(parseErrs, 3))
 				} else if len(compileErrs) > 0 {

--- a/pkg/dsl/ir/expand_groups.go
+++ b/pkg/dsl/ir/expand_groups.go
@@ -27,12 +27,24 @@ func (c *compiler) expandGroups() {
 	if len(c.file.Workflows) > 0 {
 		wf = c.file.Workflows[0]
 	}
+	prefixes := make(map[string]bool, len(c.file.Uses))
 	for _, use := range c.file.Uses {
 		g, ok := groups[use.Group]
 		if !ok {
 			c.errorf(DiagUseUnknownGroup, "use references unknown group %q", use.Group)
 			continue
 		}
+		// Two `use` blocks with one prefix would expand to the same node
+		// ids; reported HERE, on the repeated `use` line — the line to
+		// change — rather than as duplicate ids positioned on the group
+		// body, which both instances share and which is not the mistake.
+		if prefixes[use.Prefix] {
+			c.errorfAtSpan(DiagDuplicateNodeID, use.Span,
+				"use %q as %q: prefix %q is already used by an earlier `use` — every instantiation needs its own prefix",
+				use.Group, use.Prefix, use.Prefix)
+			continue
+		}
+		prefixes[use.Prefix] = true
 		binds := c.bindGroupParams(g, use)
 		c.instantiateGroup(g, names[use.Group], use.Prefix, binds, wf)
 	}

--- a/pkg/dsl/ir/prompt_include.go
+++ b/pkg/dsl/ir/prompt_include.go
@@ -26,7 +26,9 @@ var promptIncludeRe = regexp.MustCompile(`\{\{\s*include\s+"([^"]*)"\s*\}\}`)
 
 // expandPromptIncludes replaces every {{include "..."}} marker in a
 // prompt body with the verbatim contents of the referenced file,
-// resolved relative to baseDir (the directory of the .bot source).
+// resolved relative to baseDir — the directory of the file that declares
+// the prompt: the .bot source, or a bundle's prompts/ for a prompts/*.md
+// (never the process working directory, which on a server is nobody's).
 //
 // Expansion happens at compile time, once, before ParseRefs runs — so
 // the injected text becomes part of the resolved prompt body in the IR
@@ -63,7 +65,7 @@ func readPromptInclude(baseDir, rel string) (string, error) {
 		return "", fmt.Errorf("include: empty path")
 	}
 	if filepath.IsAbs(rel) {
-		return "", fmt.Errorf("include %q: absolute paths are not allowed (use a path relative to the .bot file)", rel)
+		return "", fmt.Errorf("include %q: absolute paths are not allowed (use a path relative to the file that contains the include)", rel)
 	}
 	if baseDir == "" {
 		baseDir = "."

--- a/pkg/dsl/ir/validate_edges.go
+++ b/pkg/dsl/ir/validate_edges.go
@@ -31,7 +31,7 @@ func (c *compiler) validateInheritAtConvergence(w *Workflow) {
 			continue
 		}
 		if session == SessionInherit || session == SessionInheritIfAvailable || session == SessionFork {
-			c.errorf(DiagSessionAfterConvergence,
+			c.errorfAt(DiagSessionAfterConvergence, nodeID, "",
 				"node %q has session: %s but has await: %s (convergence point); only fresh, artifacts_only, or persist are allowed",
 				nodeID, session, awaitMode)
 		}
@@ -48,7 +48,7 @@ func (c *compiler) validatePersistNotInFanOut(w *Workflow) {
 		if !ok || llm.GetSession() != SessionPersist || !body[id] {
 			continue
 		}
-		c.errorf(DiagPersistInFanOut,
+		c.errorfAt(DiagPersistInFanOut, id, "",
 			"node %q has session: persist but sits in a fan_out_all/fan_out_each/llm-multi body; persist is trunk-only in v1 (C243)",
 			id)
 	}
@@ -172,7 +172,7 @@ func (c *compiler) validateEdgeRouting(w *Workflow) {
 			for i, e := range g.unconditional {
 				targets[i] = e.To
 			}
-			c.errorf(DiagMultipleDefaultEdges,
+			c.errorfAt(DiagMultipleDefaultEdges, nodeID, "",
 				"node %q has %d unconditional edges (targets: %v); only one default edge is allowed",
 				nodeID, len(g.unconditional), targets)
 		}
@@ -184,14 +184,14 @@ func (c *compiler) validateEdgeRouting(w *Workflow) {
 			for i, e := range g.elseEdges {
 				targets[i] = e.To
 			}
-			c.errorf(DiagMultipleElseEdges,
+			c.errorfAt(DiagMultipleElseEdges, nodeID, "",
 				"node %q has %d `else` edges (targets: %v); only one else fallback is allowed",
 				nodeID, len(g.elseEdges), targets)
 		}
 		// C040: `else` REPLACES the bare unconditional fallback — having
 		// both is two competing defaults, pick one form.
 		if len(g.elseEdges) > 0 && len(g.unconditional) > 0 {
-			c.errorf(DiagElseWithUnconditional,
+			c.errorfAt(DiagElseWithUnconditional, nodeID, "",
 				"node %q has both an `else` edge (-> %s) and an unconditional edge (-> %s); `else` IS the fallback — remove one",
 				nodeID, g.elseEdges[0].To, g.unconditional[0].To)
 		}
@@ -199,7 +199,7 @@ func (c *compiler) validateEdgeRouting(w *Workflow) {
 		// mean anything — it would just be an unconditional edge wearing
 		// a misleading keyword.
 		if len(g.elseEdges) > 0 && len(g.conditional) == 0 {
-			c.errorf(DiagElseWithoutConditional,
+			c.errorfAt(DiagElseWithoutConditional, nodeID, "",
 				"node %q has an `else` edge (-> %s) but no conditional (`when`) sibling; use a plain edge",
 				nodeID, g.elseEdges[0].To)
 		}
@@ -214,7 +214,7 @@ func (c *compiler) validateEdgeRouting(w *Workflow) {
 		// edge (it is the explicit fallback form).
 		if len(g.unconditional) == 0 && len(g.loopBearing) == 0 && len(g.elseEdges) == 0 {
 			if !isExhaustive(g.conditional) {
-				c.errorf(DiagMissingFallback,
+				c.errorfAt(DiagMissingFallback, nodeID, "",
 					"node %q has conditional edges but no default (unconditional) fallback edge",
 					nodeID)
 			}
@@ -242,7 +242,7 @@ func (c *compiler) validateRoundRobinEdges(w *Workflow) {
 			}
 		}
 		if count < 2 {
-			c.errorf(DiagRoundRobinTooFewEdges,
+			c.errorfAt(DiagRoundRobinTooFewEdges, r.ID, "",
 				"round_robin router %q has %d unconditional outgoing edge(s); at least 2 are needed for alternation",
 				r.ID, count)
 		}
@@ -264,14 +264,14 @@ func (c *compiler) validateLLMRouterEdges(w *Workflow) {
 			if e.From == r.ID {
 				count++
 				if e.IsConditional() {
-					c.errorf(DiagLLMRouterConditionEdge,
+					c.errorfAt(DiagLLMRouterConditionEdge, r.ID, edgeID(e.From, e.To),
 						"llm router %q edge to %q has a 'when' condition; LLM routers select targets directly",
 						r.ID, e.To)
 				}
 			}
 		}
 		if count < 2 {
-			c.errorf(DiagLLMRouterTooFewEdges,
+			c.errorfAt(DiagLLMRouterTooFewEdges, r.ID, "",
 				"llm router %q has %d outgoing edge(s); at least 2 are needed",
 				r.ID, count)
 		}
@@ -298,14 +298,14 @@ func (c *compiler) validateFanOutEachEdges(w *Workflow) {
 			if e.From == r.ID {
 				count++
 				if e.IsConditional() {
-					c.errorf(DiagFanOutEachEdges,
+					c.errorfAt(DiagFanOutEachEdges, r.ID, edgeID(e.From, e.To),
 						"fan_out_each router %q edge to %q has a 'when' condition; the single template edge must be unconditional",
 						r.ID, e.To)
 				}
 			}
 		}
 		if count != 1 {
-			c.errorf(DiagFanOutEachEdges,
+			c.errorfAt(DiagFanOutEachEdges, r.ID, "",
 				"fan_out_each router %q has %d outgoing edge(s); exactly one (the per-item template head) is required",
 				r.ID, count)
 		}
@@ -705,10 +705,10 @@ func routerSpawnsExecBranch(r *RouterNode) bool {
 // is a silent no-op and the intended bound (e.g. on Godot sessions) never
 // applies — exactly the failure mode the feature exists to prevent.
 func (c *compiler) validateResources(w *Workflow) {
-	for _, node := range w.Nodes {
+	for id, node := range w.Nodes {
 		for _, r := range NodeNeeds(node) {
 			if _, ok := w.Resources[r]; !ok {
-				c.errorf(DiagUnknownResourceInNeeds,
+				c.errorfAt(DiagUnknownResourceInNeeds, id, "",
 					"node %q needs resource %q, which is not declared in the workflow's resources: block",
 					node.NodeID(), r)
 			}
@@ -772,7 +772,7 @@ func (c *compiler) checkAmbiguousConditions(nodeID string, edges []*Edge) {
 			default:
 				label = e.Condition
 			}
-			c.errorf(DiagAmbiguousCondition,
+			c.errorfAt(DiagAmbiguousCondition, nodeID, "",
 				"node %q has ambiguous edges: both %s->%s and %s->%s trigger on %s",
 				nodeID, prev.From, prev.To, e.From, e.To, label)
 		} else {
@@ -909,7 +909,7 @@ func (c *compiler) validateDuplicateWithKeys(w *Workflow) {
 		seen := make(map[string]string) // key -> first source
 		for _, ks := range keys {
 			if prevFrom, ok := seen[ks.key]; ok && prevFrom != ks.from {
-				c.errorf(DiagDuplicateWithKey,
+				c.errorfAt(DiagDuplicateWithKey, targetID, "",
 					"node %q receives with-mapping key %q from both %q and %q; keys must be unique across incoming edges",
 					targetID, ks.key, prevFrom, ks.from)
 			} else if !ok {

--- a/pkg/dsl/ir/validate_edges.go
+++ b/pkg/dsl/ir/validate_edges.go
@@ -341,6 +341,7 @@ func (c *compiler) validateDuplicateFanOutTargets(w *Workflow) {
 			continue
 		}
 		counts := make(map[string]int)
+		second := make(map[string]*Edge) // the first REPEAT of a target: the edge to remove
 		var order []string
 		for _, e := range w.Edges {
 			if e.From != r.ID {
@@ -348,6 +349,8 @@ func (c *compiler) validateDuplicateFanOutTargets(w *Workflow) {
 			}
 			if counts[e.To] == 0 {
 				order = append(order, e.To)
+			} else if second[e.To] == nil {
+				second[e.To] = e
 			}
 			counts[e.To]++
 		}
@@ -355,7 +358,7 @@ func (c *compiler) validateDuplicateFanOutTargets(w *Workflow) {
 			if counts[target] < 2 {
 				continue
 			}
-			c.warnfAt(DiagDuplicateFanOutTarget, r.ID, edgeID(r.ID, target),
+			c.warnfAtEdge(DiagDuplicateFanOutTarget, second[target],
 				"%s declares %d edges to %q; every branch is identified by branch_<router>_<target>, so those executions share one branch id, one output slot and one durable checkpoint — a resume can restart one at the other's position (C249). %s",
 				describeBranchRouter(r), counts[target], target, duplicateFanOutRemedy(r))
 		}

--- a/pkg/dsl/ir/validate_edges.go
+++ b/pkg/dsl/ir/validate_edges.go
@@ -264,7 +264,7 @@ func (c *compiler) validateLLMRouterEdges(w *Workflow) {
 			if e.From == r.ID {
 				count++
 				if e.IsConditional() {
-					c.errorfAt(DiagLLMRouterConditionEdge, r.ID, edgeID(e.From, e.To),
+					c.errorfAtEdge(DiagLLMRouterConditionEdge, e,
 						"llm router %q edge to %q has a 'when' condition; LLM routers select targets directly",
 						r.ID, e.To)
 				}
@@ -298,7 +298,7 @@ func (c *compiler) validateFanOutEachEdges(w *Workflow) {
 			if e.From == r.ID {
 				count++
 				if e.IsConditional() {
-					c.errorfAt(DiagFanOutEachEdges, r.ID, edgeID(e.From, e.To),
+					c.errorfAtEdge(DiagFanOutEachEdges, e,
 						"fan_out_each router %q edge to %q has a 'when' condition; the single template edge must be unconditional",
 						r.ID, e.To)
 				}

--- a/pkg/dsl/ir/validate_reachability.go
+++ b/pkg/dsl/ir/validate_reachability.go
@@ -77,7 +77,7 @@ func (c *compiler) validateHistoryRefs(w *Workflow) {
 				return // unknown node already reported by other checks
 			}
 			if !loopNodes[nodeID] {
-				c.errorf(DiagHistoryRefNotInLoop,
+				c.errorfAt(DiagHistoryRefNotInLoop, nodeID, "",
 					"%s: reference %s uses .history but node %q is not in any loop",
 					ctx, ref.Raw, nodeID)
 			}
@@ -145,7 +145,7 @@ func (c *compiler) validateUndeclaredCycles(w *Workflow) {
 				// Back-edge found — cycle. Only report if neither endpoint
 				// participates in a declared loop (which bounds the cycle).
 				if !loopNodes[node] && !loopNodes[to] {
-					c.errorf(DiagUndeclaredCycle,
+					c.errorfAt(DiagUndeclaredCycle, "", edgeID(node, to),
 						"cycle detected: edge %s -> %s forms a cycle without a declared loop; add a loop with max_iterations to bound it",
 						node, to)
 				}

--- a/pkg/dsl/ir/validate_refs.go
+++ b/pkg/dsl/ir/validate_refs.go
@@ -373,7 +373,7 @@ func (c *compiler) validateSecretsRef(w *Workflow, rc refContext) {
 	name := rc.Ref.Path[0]
 	secret, ok := w.Secrets[name]
 	if !ok {
-		c.errorf(DiagUnknownSecret,
+		c.errorfAt(DiagUnknownSecret, rc.NodeID, "",
 			"%s: reference %s targets undeclared secret %q",
 			rc.Location, rc.Ref.Raw, name)
 		return
@@ -383,13 +383,13 @@ func (c *compiler) validateSecretsRef(w *Workflow, rc refContext) {
 	}
 	sub := rc.Ref.Path[1]
 	if sub != "path" {
-		c.errorf(DiagSecretSubfield,
+		c.errorfAt(DiagSecretSubfield, rc.NodeID, "",
 			"%s: reference %s uses unknown secret sub-field %q (expected: path)",
 			rc.Location, rc.Ref.Raw, sub)
 		return
 	}
 	if !secret.IsFile() {
-		c.errorf(DiagSecretSubfield,
+		c.errorfAt(DiagSecretSubfield, rc.NodeID, "",
 			"%s: reference %s uses .path on non-file secret %q",
 			rc.Location, rc.Ref.Raw, name)
 	}
@@ -401,7 +401,7 @@ func (c *compiler) validateAttachmentsRef(w *Workflow, rc refContext) {
 	}
 	name := rc.Ref.Path[0]
 	if _, ok := w.Attachments[name]; !ok {
-		c.errorf(DiagUnknownAttachment,
+		c.errorfAt(DiagUnknownAttachment, rc.NodeID, "",
 			"%s: reference %s targets undeclared attachment %q",
 			rc.Location, rc.Ref.Raw, name)
 		return
@@ -409,7 +409,7 @@ func (c *compiler) validateAttachmentsRef(w *Workflow, rc refContext) {
 	if len(rc.Ref.Path) >= 2 {
 		sub := rc.Ref.Path[1]
 		if _, ok := AttachmentSubFields[sub]; !ok {
-			c.errorf(DiagAttachmentSubfieldUnknown,
+			c.errorfAt(DiagAttachmentSubfieldUnknown, rc.NodeID, "",
 				"%s: reference %s uses unknown sub-field %q (expected one of: path, url, mime, size, sha256)",
 				rc.Location, rc.Ref.Raw, sub)
 		}
@@ -425,7 +425,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// C029: referenced node must exist.
 	targetNode, ok := w.Nodes[targetNodeID]
 	if !ok {
-		c.errorf(DiagUnknownRefNode,
+		c.errorfAt(DiagUnknownRefNode, rc.NodeID, "",
 			"%s: reference %s targets unknown node %q",
 			rc.Location, rc.Ref.Raw, targetNodeID)
 		return
@@ -433,7 +433,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 
 	// C036: referenced node must be reachable before consumer.
 	if !checkReachable(rc, predecessors, targetNodeID) {
-		c.errorf(DiagRefNodeNotReachable,
+		c.errorfAt(DiagRefNodeNotReachable, rc.NodeID, "",
 			"%s: reference %s targets node %q which is not reachable before %q",
 			rc.Location, rc.Ref.Raw, targetNodeID, rc.NodeID)
 		return
@@ -459,7 +459,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// exactly those fields are valid, anything else is a hard error.
 	if implicit := NodeImplicitOutputFields(targetNode); implicit != nil {
 		if !slices.Contains(implicit, fieldName) {
-			c.errorf(DiagRefFieldNotInSchema,
+			c.errorfAt(DiagRefFieldNotInSchema, rc.NodeID, "",
 				"%s: reference %s accesses field %q on %s node %q — its only output field(s): %s",
 				rc.Location, rc.Ref.Raw, fieldName, targetNode.NodeKind(), targetNodeID, strings.Join(implicit, ", "))
 		}
@@ -469,7 +469,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// C032: node has no output schema — warn that field access can't be verified.
 	outSchema := NodeOutputSchema(targetNode)
 	if outSchema == "" {
-		c.warnf(DiagRefNodeNoSchema,
+		c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "",
 			"%s: reference %s accesses field %q on node %q which has no output schema; cannot verify",
 			rc.Location, rc.Ref.Raw, fieldName, targetNodeID)
 		return
@@ -481,7 +481,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 		return // already reported by C002
 	}
 	if findField(schema, fieldName) == nil {
-		c.errorf(DiagRefFieldNotInSchema,
+		c.errorfAt(DiagRefFieldNotInSchema, rc.NodeID, "",
 			"%s: reference %s accesses field %q not found in output schema %q of node %q",
 			rc.Location, rc.Ref.Raw, fieldName, outSchema, targetNodeID)
 	}
@@ -493,7 +493,7 @@ func (c *compiler) validateVarsRef(w *Workflow, rc refContext) {
 	}
 	varName := rc.Ref.Path[0]
 	if _, ok := w.Vars[varName]; !ok {
-		c.errorf(DiagUndeclaredVar,
+		c.errorfAt(DiagUndeclaredVar, rc.NodeID, "",
 			"%s: reference %s targets undeclared variable %q",
 			rc.Location, rc.Ref.Raw, varName)
 	}
@@ -531,7 +531,7 @@ func (c *compiler) validateNodeInputRef(w *Workflow, rc refContext, node Node, f
 	}
 
 	if findField(schema, fieldName) == nil {
-		c.errorf(DiagInputFieldNotInSchema,
+		c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "",
 			"%s: reference %s accesses field %q not found in input schema %q of node %q",
 			rc.Location, rc.Ref.Raw, fieldName, inSchema, rc.NodeID)
 	}
@@ -553,7 +553,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 	}
 	if implicit := NodeImplicitOutputFields(node); implicit != nil {
 		if !slices.Contains(implicit, fieldName) {
-			c.errorf(DiagInputFieldNotInSchema,
+			c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "",
 				"%s: reference %s accesses field %q on %s node %q — its only output field(s): %s (edge with-mappings resolve {{input.*}} against the source node's output)",
 				rc.Location, rc.Ref.Raw, fieldName, node.NodeKind(), rc.NodeID, strings.Join(implicit, ", "))
 		}
@@ -571,7 +571,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 		if _, isVar := w.Vars[fieldName]; isVar {
 			msg += fmt.Sprintf("; use {{vars.%s}} for a workflow variable", fieldName)
 		}
-		c.warnf(DiagRefNodeNoSchema, "%s", msg)
+		c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "", "%s", msg)
 		return
 	}
 	schema, ok := w.Schemas[outSchema]
@@ -592,7 +592,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 			msg += fmt.Sprintf("; field %q is on the source node's input schema, not its output", fieldName)
 		}
 	}
-	c.errorf(DiagInputFieldNotInSchema, "%s", msg)
+	c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "", "%s", msg)
 }
 
 // validateRouterEdgeInput is C032 for a mid-graph router whose outgoing
@@ -612,7 +612,7 @@ func (c *compiler) validateRouterEdgeInput(w *Workflow, rc refContext, r *Router
 	if _, isVar := w.Vars[fieldName]; isVar {
 		msg += fmt.Sprintf("; use {{vars.%s}} for a workflow variable", fieldName)
 	}
-	c.warnf(DiagRefNodeNoSchema, "%s", msg)
+	c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "", "%s", msg)
 }
 
 // routerPassThroughKeys is the set of keys a mid-graph router will have
@@ -662,7 +662,7 @@ func (c *compiler) validateArtifactsRef(w *Workflow, rc refContext, predecessors
 	// C035: artifact must be published by some node.
 	producerID, ok := producers[artifactName]
 	if !ok {
-		c.errorf(DiagUnknownArtifact,
+		c.errorfAt(DiagUnknownArtifact, rc.NodeID, "",
 			"%s: reference %s targets artifact %q which is not published by any node",
 			rc.Location, rc.Ref.Raw, artifactName)
 		return
@@ -670,7 +670,7 @@ func (c *compiler) validateArtifactsRef(w *Workflow, rc refContext, predecessors
 
 	// C036: producer must be reachable before consumer.
 	if !checkReachable(rc, predecessors, producerID) {
-		c.errorf(DiagRefNodeNotReachable,
+		c.errorfAt(DiagRefNodeNotReachable, rc.NodeID, "",
 			"%s: reference %s targets artifact %q published by node %q which is not reachable before %q",
 			rc.Location, rc.Ref.Raw, artifactName, producerID, rc.NodeID)
 	}

--- a/pkg/dsl/ir/validate_refs.go
+++ b/pkg/dsl/ir/validate_refs.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/dsl/ast"
 	"github.com/SocialGouv/iterion/pkg/dsl/expr"
 )
 
@@ -22,11 +23,30 @@ type refContext struct {
 	Location    string // e.g. "prompt 'sys' (node 'a')"
 	IncludeSelf bool   // true for edge with-mappings: the source node itself is available
 	EdgeTo      string // destination of an edge with-mapping; empty otherwise
+	// EdgeID and Span locate the TEXT that holds the reference — the edge
+	// line for a with-mapping, the prompt declaration for a prompt body —
+	// so a diagnostic lands where the author has to edit, not on the
+	// consuming node's header. Zero when the reference lives in the node
+	// itself (a command, a script, an expression), where the node's own
+	// declaration is the right place.
+	EdgeID string
+	Span   ast.Span
+}
+
+// refErrorf / refWarnf emit a template-reference diagnostic with the
+// context's full attribution: node, edge and the span of the text that
+// carries the reference.
+func (c *compiler) refErrorf(rc refContext, code DiagCode, format string, args ...any) {
+	c.emit(SeverityError, code, rc.NodeID, rc.EdgeID, rc.Span, "", format, args...)
+}
+
+func (c *compiler) refWarnf(rc refContext, code DiagCode, format string, args ...any) {
+	c.emit(SeverityWarning, code, rc.NodeID, rc.EdgeID, rc.Span, "", format, args...)
 }
 
 // collectAllRefs gathers every template reference in the workflow together
 // with the node that consumes it.
-func collectAllRefs(w *Workflow) []refContext {
+func collectAllRefs(w *Workflow, promptSpans map[string]ast.Span, edgeSpans map[*Edge]ast.Span) []refContext {
 	// Build reverse map: prompt name → list of consuming node IDs.
 	promptUsers := make(map[string][]string)
 	for _, n := range w.Nodes {
@@ -37,7 +57,9 @@ func collectAllRefs(w *Workflow) []refContext {
 
 	var out []refContext
 
-	// Prompt template refs.
+	// Prompt template refs. The reference sits in the prompt's text, so the
+	// prompt declaration is where the diagnostic points; the consuming node
+	// stays the attribution (what the reference resolves against).
 	for _, p := range w.Prompts {
 		consumers := promptUsers[p.Name]
 		for _, ref := range p.TemplateRefs {
@@ -46,6 +68,7 @@ func collectAllRefs(w *Workflow) []refContext {
 					Ref:      ref,
 					NodeID:   nodeID,
 					Location: fmt.Sprintf("prompt %q (node %q)", p.Name, nodeID),
+					Span:     promptSpans[p.Name],
 				})
 			}
 		}
@@ -70,6 +93,8 @@ func collectAllRefs(w *Workflow) []refContext {
 					Location:    fmt.Sprintf("edge %s -> %s, with %q", e.From, e.To, dm.Key),
 					IncludeSelf: true,
 					EdgeTo:      e.To,
+					EdgeID:      edgeID(e.From, e.To),
+					Span:        edgeSpans[e],
 				})
 			}
 		}
@@ -338,7 +363,15 @@ func validEnvName(s string) bool {
 }
 
 func (c *compiler) validateTemplateRefs(w *Workflow) {
-	refs := collectAllRefs(w)
+	promptSpans := map[string]ast.Span{}
+	if c.file != nil {
+		for _, p := range c.file.Prompts {
+			if _, seen := promptSpans[p.Name]; !seen {
+				promptSpans[p.Name] = p.Span
+			}
+		}
+	}
+	refs := collectAllRefs(w, promptSpans, c.edgeSpans)
 	if len(refs) == 0 {
 		return
 	}
@@ -373,7 +406,7 @@ func (c *compiler) validateSecretsRef(w *Workflow, rc refContext) {
 	name := rc.Ref.Path[0]
 	secret, ok := w.Secrets[name]
 	if !ok {
-		c.errorfAt(DiagUnknownSecret, rc.NodeID, "",
+		c.refErrorf(rc, DiagUnknownSecret,
 			"%s: reference %s targets undeclared secret %q",
 			rc.Location, rc.Ref.Raw, name)
 		return
@@ -383,13 +416,13 @@ func (c *compiler) validateSecretsRef(w *Workflow, rc refContext) {
 	}
 	sub := rc.Ref.Path[1]
 	if sub != "path" {
-		c.errorfAt(DiagSecretSubfield, rc.NodeID, "",
+		c.refErrorf(rc, DiagSecretSubfield,
 			"%s: reference %s uses unknown secret sub-field %q (expected: path)",
 			rc.Location, rc.Ref.Raw, sub)
 		return
 	}
 	if !secret.IsFile() {
-		c.errorfAt(DiagSecretSubfield, rc.NodeID, "",
+		c.refErrorf(rc, DiagSecretSubfield,
 			"%s: reference %s uses .path on non-file secret %q",
 			rc.Location, rc.Ref.Raw, name)
 	}
@@ -401,7 +434,7 @@ func (c *compiler) validateAttachmentsRef(w *Workflow, rc refContext) {
 	}
 	name := rc.Ref.Path[0]
 	if _, ok := w.Attachments[name]; !ok {
-		c.errorfAt(DiagUnknownAttachment, rc.NodeID, "",
+		c.refErrorf(rc, DiagUnknownAttachment,
 			"%s: reference %s targets undeclared attachment %q",
 			rc.Location, rc.Ref.Raw, name)
 		return
@@ -409,7 +442,7 @@ func (c *compiler) validateAttachmentsRef(w *Workflow, rc refContext) {
 	if len(rc.Ref.Path) >= 2 {
 		sub := rc.Ref.Path[1]
 		if _, ok := AttachmentSubFields[sub]; !ok {
-			c.errorfAt(DiagAttachmentSubfieldUnknown, rc.NodeID, "",
+			c.refErrorf(rc, DiagAttachmentSubfieldUnknown,
 				"%s: reference %s uses unknown sub-field %q (expected one of: path, url, mime, size, sha256)",
 				rc.Location, rc.Ref.Raw, sub)
 		}
@@ -425,7 +458,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// C029: referenced node must exist.
 	targetNode, ok := w.Nodes[targetNodeID]
 	if !ok {
-		c.errorfAt(DiagUnknownRefNode, rc.NodeID, "",
+		c.refErrorf(rc, DiagUnknownRefNode,
 			"%s: reference %s targets unknown node %q",
 			rc.Location, rc.Ref.Raw, targetNodeID)
 		return
@@ -433,7 +466,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 
 	// C036: referenced node must be reachable before consumer.
 	if !checkReachable(rc, predecessors, targetNodeID) {
-		c.errorfAt(DiagRefNodeNotReachable, rc.NodeID, "",
+		c.refErrorf(rc, DiagRefNodeNotReachable,
 			"%s: reference %s targets node %q which is not reachable before %q",
 			rc.Location, rc.Ref.Raw, targetNodeID, rc.NodeID)
 		return
@@ -459,7 +492,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// exactly those fields are valid, anything else is a hard error.
 	if implicit := NodeImplicitOutputFields(targetNode); implicit != nil {
 		if !slices.Contains(implicit, fieldName) {
-			c.errorfAt(DiagRefFieldNotInSchema, rc.NodeID, "",
+			c.refErrorf(rc, DiagRefFieldNotInSchema,
 				"%s: reference %s accesses field %q on %s node %q — its only output field(s): %s",
 				rc.Location, rc.Ref.Raw, fieldName, targetNode.NodeKind(), targetNodeID, strings.Join(implicit, ", "))
 		}
@@ -469,7 +502,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 	// C032: node has no output schema — warn that field access can't be verified.
 	outSchema := NodeOutputSchema(targetNode)
 	if outSchema == "" {
-		c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "",
+		c.refWarnf(rc, DiagRefNodeNoSchema,
 			"%s: reference %s accesses field %q on node %q which has no output schema; cannot verify",
 			rc.Location, rc.Ref.Raw, fieldName, targetNodeID)
 		return
@@ -481,7 +514,7 @@ func (c *compiler) validateOutputsRef(w *Workflow, rc refContext, predecessors m
 		return // already reported by C002
 	}
 	if findField(schema, fieldName) == nil {
-		c.errorfAt(DiagRefFieldNotInSchema, rc.NodeID, "",
+		c.refErrorf(rc, DiagRefFieldNotInSchema,
 			"%s: reference %s accesses field %q not found in output schema %q of node %q",
 			rc.Location, rc.Ref.Raw, fieldName, outSchema, targetNodeID)
 	}
@@ -493,7 +526,7 @@ func (c *compiler) validateVarsRef(w *Workflow, rc refContext) {
 	}
 	varName := rc.Ref.Path[0]
 	if _, ok := w.Vars[varName]; !ok {
-		c.errorfAt(DiagUndeclaredVar, rc.NodeID, "",
+		c.refErrorf(rc, DiagUndeclaredVar,
 			"%s: reference %s targets undeclared variable %q",
 			rc.Location, rc.Ref.Raw, varName)
 	}
@@ -531,7 +564,7 @@ func (c *compiler) validateNodeInputRef(w *Workflow, rc refContext, node Node, f
 	}
 
 	if findField(schema, fieldName) == nil {
-		c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "",
+		c.refErrorf(rc, DiagInputFieldNotInSchema,
 			"%s: reference %s accesses field %q not found in input schema %q of node %q",
 			rc.Location, rc.Ref.Raw, fieldName, inSchema, rc.NodeID)
 	}
@@ -553,7 +586,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 	}
 	if implicit := NodeImplicitOutputFields(node); implicit != nil {
 		if !slices.Contains(implicit, fieldName) {
-			c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "",
+			c.refErrorf(rc, DiagInputFieldNotInSchema,
 				"%s: reference %s accesses field %q on %s node %q — its only output field(s): %s (edge with-mappings resolve {{input.*}} against the source node's output)",
 				rc.Location, rc.Ref.Raw, fieldName, node.NodeKind(), rc.NodeID, strings.Join(implicit, ", "))
 		}
@@ -571,7 +604,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 		if _, isVar := w.Vars[fieldName]; isVar {
 			msg += fmt.Sprintf("; use {{vars.%s}} for a workflow variable", fieldName)
 		}
-		c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "", "%s", msg)
+		c.refWarnf(rc, DiagRefNodeNoSchema, "%s", msg)
 		return
 	}
 	schema, ok := w.Schemas[outSchema]
@@ -592,7 +625,7 @@ func (c *compiler) validateEdgeInputRef(w *Workflow, rc refContext, node Node, f
 			msg += fmt.Sprintf("; field %q is on the source node's input schema, not its output", fieldName)
 		}
 	}
-	c.errorfAt(DiagInputFieldNotInSchema, rc.NodeID, "", "%s", msg)
+	c.refErrorf(rc, DiagInputFieldNotInSchema, "%s", msg)
 }
 
 // validateRouterEdgeInput is C032 for a mid-graph router whose outgoing
@@ -612,7 +645,12 @@ func (c *compiler) validateRouterEdgeInput(w *Workflow, rc refContext, r *Router
 	if _, isVar := w.Vars[fieldName]; isVar {
 		msg += fmt.Sprintf("; use {{vars.%s}} for a workflow variable", fieldName)
 	}
-	c.warnfAt(DiagRefNodeNoSchema, rc.NodeID, "", "%s", msg)
+	// The catalogue fix for C032 ("add an output: schema") cannot be
+	// followed on a router, which has no output of its own: the remedy
+	// here is to map the field onto the router or read a var.
+	c.emit(SeverityWarning, DiagRefNodeNoSchema, rc.NodeID, rc.EdgeID, rc.Span,
+		fmt.Sprintf("A router has no `output:` of its own — map the field onto it through an incoming edge (`… -> %s with { %s: \"…\" }`), or read `{{vars.%s}}` for a launch-time value.", rc.NodeID, fieldName, fieldName),
+		"%s", msg)
 }
 
 // routerPassThroughKeys is the set of keys a mid-graph router will have
@@ -662,7 +700,7 @@ func (c *compiler) validateArtifactsRef(w *Workflow, rc refContext, predecessors
 	// C035: artifact must be published by some node.
 	producerID, ok := producers[artifactName]
 	if !ok {
-		c.errorfAt(DiagUnknownArtifact, rc.NodeID, "",
+		c.refErrorf(rc, DiagUnknownArtifact,
 			"%s: reference %s targets artifact %q which is not published by any node",
 			rc.Location, rc.Ref.Raw, artifactName)
 		return
@@ -670,7 +708,7 @@ func (c *compiler) validateArtifactsRef(w *Workflow, rc refContext, predecessors
 
 	// C036: producer must be reachable before consumer.
 	if !checkReachable(rc, predecessors, producerID) {
-		c.errorfAt(DiagRefNodeNotReachable, rc.NodeID, "",
+		c.refErrorf(rc, DiagRefNodeNotReachable,
 			"%s: reference %s targets artifact %q published by node %q which is not reachable before %q",
 			rc.Location, rc.Ref.Raw, artifactName, producerID, rc.NodeID)
 	}

--- a/pkg/dsl/parser/comment_contract_test.go
+++ b/pkg/dsl/parser/comment_contract_test.go
@@ -1,0 +1,93 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/dsl/workflowfile"
+)
+
+// The lexer is one of four readers of "what a comment line looks like" (the
+// strict-escape pre-scan, the bundle frontmatter reader and the catalogue's
+// description reader are the others). Accepting `#` at the lexer alone left
+// the other three reading `##` only — silently: a `# note` above
+// `## strict-escape: on` disarmed the directive, and a `# ---` frontmatter
+// lost the bot's catalogue identity. workflowfile.CommentText is the shared
+// definition; this test holds the lexer to it.
+func TestLexerCommentTextMatchesSharedDefinition(t *testing.T) {
+	for _, line := range []string{"# note", "## note", "#note", "##   indented", "   # leading spaces", "#", "##"} {
+		want, ok := workflowfile.CommentText(line)
+		if !ok {
+			t.Fatalf("%q must be a comment line for the shared definition", line)
+		}
+		lx := parser.NewLexer("c.bot", line+"\n")
+		var got string
+		var found bool
+		for _, tok := range lx.All() {
+			if tok.Type == parser.TokenComment {
+				got, found = tok.Value, true
+			}
+		}
+		if !found {
+			t.Errorf("%q: the lexer emitted no comment token", line)
+			continue
+		}
+		if got != strings.TrimSpace(want) {
+			t.Errorf("%q: lexer text %q, shared definition %q", line, got, want)
+		}
+	}
+	if _, ok := workflowfile.CommentText("key: value"); ok {
+		t.Error("a property line is not a comment")
+	}
+}
+
+// `## strict-escape: on` is read by a pre-scan of the leading comment lines.
+// That scan must accept the same comment forms as the lexer, or a valid file's
+// string semantics depend on the hash count of an unrelated comment.
+func TestStrictEscapeDirectiveSurvivesSingleHashComments(t *testing.T) {
+	body := "\nschema out:\n  ok: bool\n  note: string\n\nagent a:\n  model: \"m\\tx\"\n  output: out\n\nworkflow w:\n  entry: a\n  a -> done\n"
+	cases := []struct {
+		name   string
+		header string
+		strict bool
+	}{
+		{"double-hash directive", "## strict-escape: on\n", true},
+		{"single-hash directive", "# strict-escape: on\n", true},
+		{"single-hash comment above the directive", "# plain comment\n## strict-escape: on\n", true},
+		{"no directive", "# plain comment\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := parser.Parse("se.bot", tc.header+body)
+			for _, d := range pr.Diagnostics {
+				t.Fatalf("unexpected diagnostic: %s", d.Error())
+			}
+			model := pr.File.Agents[0].Model
+			if tc.strict && model != "m\tx" {
+				t.Errorf("strict mode expected: model = %q, want a real tab", model)
+			}
+			if !tc.strict && model != `m\tx` {
+				t.Errorf("legacy mode expected: model = %q, want the literal backslash-t", model)
+			}
+		})
+	}
+}
+
+// A comment on the prompt header line is not part of the header: the body
+// that follows still opens as prompt text, first line included.
+func TestPromptHeaderTrailingCommentKeepsTheBody(t *testing.T) {
+	for _, header := range []string{"prompt p: # why", "prompt p: ## why", "prompt p:"} {
+		src := "schema out:\n  ok: bool\n\n" + header + "\n  # Heading of the body\n  Body text.\n\nagent a:\n  model: \"m\"\n  output: out\n  system: p\n\nworkflow w:\n  entry: a\n  a -> done\n"
+		pr := parser.Parse("ph.bot", src)
+		for _, d := range pr.Diagnostics {
+			t.Errorf("%q: unexpected diagnostic: %s", header, d.Error())
+		}
+		if pr.File == nil || len(pr.File.Prompts) != 1 {
+			t.Fatalf("%q: expected one prompt", header)
+		}
+		if b := pr.File.Prompts[0].Body; !strings.Contains(b, "# Heading of the body") || !strings.Contains(b, "Body text.") {
+			t.Errorf("%q: prompt body lost a line: %q", header, b)
+		}
+	}
+}

--- a/pkg/dsl/parser/comment_contract_test.go
+++ b/pkg/dsl/parser/comment_contract_test.go
@@ -40,6 +40,12 @@ func TestLexerCommentTextMatchesSharedDefinition(t *testing.T) {
 	if _, ok := workflowfile.CommentText("key: value"); ok {
 		t.Error("a property line is not a comment")
 	}
+	// The lexer refuses a tab as indentation, so a tab-indented `#` line is
+	// not a comment line for the shared definition either — otherwise a
+	// file the parser rejects would still be read for its frontmatter.
+	if _, ok := workflowfile.CommentText("\t# tabbed"); ok {
+		t.Error("a tab-indented hash line must not be a comment line")
+	}
 }
 
 // `## strict-escape: on` is read by a pre-scan of the leading comment lines.

--- a/pkg/dsl/parser/comment_hash_test.go
+++ b/pkg/dsl/parser/comment_hash_test.go
@@ -1,0 +1,119 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// A comment opens with `#`; `##` is the same comment with one more hash.
+// The single form is what a YAML-trained author (human or model) writes
+// first: measured on the repo's own documentation, 25 of the 48 `iter`
+// fences that failed to parse did so on a `# note` the lexer used to read
+// as an unknown property named '#'. The places where `#` stays text —
+// inside a string, a prompt body, a block scalar — are asserted here so
+// the relaxation can never eat data.
+func TestHashCommentsAreComments(t *testing.T) {
+	src := `# leading single-hash comment
+## leading double-hash comment
+vars:
+  count: int = 3 # trailing after a literal
+  mode: string [enum: "a", "b"] = "a"  # trailing after an enum default
+
+schema out:
+  ok: bool # trailing after a type
+  # a comment line inside a block
+  note: string
+
+prompt p:
+  # this line is prompt text, not a comment
+  Keep the "#hashtag" and the trailing # in prose.
+
+agent a: # trailing after the header
+  model: "m#1" # the hash inside the string is data
+  tools: [bash, grep] # after a list
+  output: out
+  system: p
+  # a comment line between properties
+  reasoning_effort: high
+
+tool t:
+  command: |
+    echo '# not a comment inside a block scalar'
+  output: out
+
+workflow w: # header comment
+  entry: a
+  # comment line among edges
+  a -> t # trailing after an edge
+  t -> done
+`
+	res := parser.Parse("hash.bot", src)
+	for _, d := range res.Diagnostics {
+		t.Errorf("unexpected diagnostic: %s", d.Error())
+	}
+	f := res.File
+	if f == nil {
+		t.Fatal("parsed file is nil")
+	}
+
+	// Both leading comment forms are captured as top-level comments, with
+	// the same text extraction.
+	if len(f.Comments) < 2 {
+		t.Fatalf("expected the two leading comments to be captured, got %d", len(f.Comments))
+	}
+	if f.Comments[0].Text != "leading single-hash comment" {
+		t.Errorf("single-hash comment text = %q", f.Comments[0].Text)
+	}
+	if f.Comments[1].Text != "leading double-hash comment" {
+		t.Errorf("double-hash comment text = %q", f.Comments[1].Text)
+	}
+
+	if f.Vars == nil || len(f.Vars.Fields) != 2 {
+		t.Fatalf("vars: expected 2 fields, got %+v", f.Vars)
+	}
+	if len(f.Schemas) != 1 || len(f.Schemas[0].Fields) != 2 {
+		t.Fatalf("schema: expected 2 fields, got %+v", f.Schemas)
+	}
+
+	// A `#` inside a prompt body is prompt text.
+	if len(f.Prompts) != 1 {
+		t.Fatalf("expected 1 prompt, got %d", len(f.Prompts))
+	}
+	body := f.Prompts[0].Body
+	if !strings.Contains(body, "# this line is prompt text, not a comment") {
+		t.Errorf("prompt body lost a leading-hash line: %q", body)
+	}
+	if !strings.Contains(body, `"#hashtag"`) || !strings.Contains(body, "trailing # in prose") {
+		t.Errorf("prompt body lost inline hashes: %q", body)
+	}
+
+	// A `#` inside a string is data; the list and the properties after a
+	// comment line are intact.
+	if len(f.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(f.Agents))
+	}
+	a := f.Agents[0]
+	if a.Model != "m#1" {
+		t.Errorf("agent model = %q, want %q", a.Model, "m#1")
+	}
+	if len(a.Tools) != 2 {
+		t.Errorf("agent tools = %v, want 2 entries", a.Tools)
+	}
+	if a.ReasoningEffort != "high" {
+		t.Errorf("property after a comment line was lost: reasoning_effort = %q", a.ReasoningEffort)
+	}
+
+	// A `#` inside a block scalar is data.
+	if len(f.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(f.Tools))
+	}
+	if !strings.Contains(f.Tools[0].Command, "# not a comment inside a block scalar") {
+		t.Errorf("block scalar lost its hash: %q", f.Tools[0].Command)
+	}
+
+	if len(f.Workflows) != 1 || len(f.Workflows[0].Edges) != 2 {
+		t.Fatalf("workflow: expected 2 edges, got %+v", f.Workflows)
+	}
+}

--- a/pkg/dsl/parser/diagnostic.go
+++ b/pkg/dsl/parser/diagnostic.go
@@ -33,7 +33,7 @@ const (
 // there rather than repeating the message.
 var hints = map[DiagCode]string{
 	DiagUnexpectedToken:     "Inside a block every line is `key: value` (or `src -> dst` inside `workflow:`); check this line's indentation and that its block is still open.",
-	DiagExpectedToken:       "Quote string values (`backend: \"claw\"`), write lists inline as `[a, b]`, and open every declaration as `<kind> <name>:` above an indented block.",
+	DiagExpectedToken:       "Give this position the shape the parser wanted: a bare name for a prompt/schema/node reference, a quoted string for a value, an indented block under a header, an inline `[a, b]` list.",
 	DiagBadIndentation:      "Indent with spaces only, by the same width at every level, and align the line with an enclosing block.",
 	DiagUnterminatedStr:     "Close the quote, or use a backtick raw string / a `|` block scalar for multi-line content.",
 	DiagDuplicateDecl:       "Rename one of the two declarations.",
@@ -51,6 +51,41 @@ var hints = map[DiagCode]string{
 // catalogued.
 func HintFor(code DiagCode) string {
 	return hints[code]
+}
+
+// expectedTokenHint names the shape the parser wanted at a token, so an
+// "expected X, got Y" arrives with the remedy for THAT shape rather than the
+// generic E002 line. The most common miss is the inverse of the generic
+// advice: a quoted string where a bare reference name belongs
+// (`system: "Review the diff"` — the author meant to declare a prompt).
+func expectedTokenHint(want, got TokenType) string {
+	switch want {
+	case TokenIdent:
+		if got == TokenString {
+			return "This property takes a bare name — a declared `prompt`, `schema` or node — not a quoted string: declare `prompt my_prompt:` with the text, then write `system: my_prompt`."
+		}
+		return "This property takes a bare name (letters, digits, `_`), such as a declared prompt, schema or node."
+	case TokenString:
+		if got == TokenIdent || got == TokenInt || got == TokenFloat {
+			return "Quote this value (`backend: \"claw\"`, `timeout: \"20m\"`) — an unquoted word is read as an identifier."
+		}
+		return "This property takes a quoted string (or a backtick raw string, or a `|` block scalar)."
+	case TokenInt:
+		return "This property takes an unquoted integer literal."
+	case TokenIndent:
+		return "Open an indented block under this header: its properties (or edges) go on the following lines, indented by two spaces."
+	case TokenColon:
+		return "Write `key: value` — a colon right after the property name — or `src -> dst` for an edge."
+	case TokenLBrack:
+		return "This property takes an inline list on one line: `[a, b]`."
+	case TokenRBrack:
+		return "Close the list with `]`: comma-separated elements on ONE line, no `- item` lines."
+	case TokenArrow:
+		return "An edge is `src -> dst`, optionally followed by `when …`, `else`, `as name(N)` or `with { … }`."
+	case TokenNewline:
+		return "One property or edge per line; nothing may follow the value on the same line except a comment."
+	}
+	return ""
 }
 
 // Severity indicates the severity of a diagnostic.

--- a/pkg/dsl/parser/diagnostic.go
+++ b/pkg/dsl/parser/diagnostic.go
@@ -62,7 +62,7 @@ func expectedTokenHint(want, got TokenType) string {
 	switch want {
 	case TokenIdent:
 		if got == TokenString {
-			return "This property takes a bare name — a declared `prompt`, `schema` or node — not a quoted string: declare `prompt my_prompt:` with the text, then write `system: my_prompt`."
+			return "This property takes a bare name — a declared `prompt`, `schema` or node — not a quoted string: remove the quotes (`entry: a`, `output: my_schema`); for `system:`/`user:` the name is a `prompt` declared with the text."
 		}
 		return "This property takes a bare name (letters, digits, `_`), such as a declared prompt, schema or node."
 	case TokenString:

--- a/pkg/dsl/parser/diagnostic.go
+++ b/pkg/dsl/parser/diagnostic.go
@@ -9,8 +9,9 @@ const (
 	// Structural errors
 	DiagUnexpectedToken DiagCode = "E001" // unexpected token
 	DiagExpectedToken   DiagCode = "E002" // expected specific token
-	DiagBadIndentation  DiagCode = "E003" // indentation mismatch
+	DiagBadIndentation  DiagCode = "E003" // indentation mismatch (tabs, misaligned dedent, nesting depth)
 	DiagUnterminatedStr DiagCode = "E004" // unterminated string literal
+	DiagBadEscape       DiagCode = "E005" // unknown escape sequence in a quoted string (strict-escape mode)
 
 	// Declaration errors
 	DiagDuplicateDecl   DiagCode = "E010" // duplicate declaration name
@@ -36,6 +37,7 @@ var hints = map[DiagCode]string{
 	DiagExpectedToken:       "Give this position the shape the parser wanted: a bare name for a prompt/schema/node reference, a quoted string for a value, an indented block under a header, an inline `[a, b]` list.",
 	DiagBadIndentation:      "Indent with spaces only, by the same width at every level, and align the line with an enclosing block.",
 	DiagUnterminatedStr:     "Close the quote, or use a backtick raw string / a `|` block scalar for multi-line content.",
+	DiagBadEscape:           "In strict-escape mode a backslash only escapes `\\\"`, `\\\\`, `\\n`, `\\t`, `\\r` and `\\0`: double the backslash for a literal one, or move the text to a backtick raw string / a `|` block scalar.",
 	DiagDuplicateDecl:       "Rename one of the two declarations.",
 	DiagReservedName:        "`done` and `fail` are the reserved terminal targets; pick another name.",
 	DiagUnknownProperty:     "Check the property table for this node kind in docs/references/dsl-grammar.md — a property another kind accepts is not accepted here.",

--- a/pkg/dsl/parser/diagnostic.go
+++ b/pkg/dsl/parser/diagnostic.go
@@ -28,6 +28,31 @@ const (
 	DiagElseWithWhen        DiagCode = "E031" // an edge cannot carry both when and else
 )
 
+// hints is the one-line remedy each parse code arrives with. A parse error
+// is positioned to the token, so the hint names the shape the parser wanted
+// there rather than repeating the message.
+var hints = map[DiagCode]string{
+	DiagUnexpectedToken:     "Inside a block every line is `key: value` (or `src -> dst` inside `workflow:`); check this line's indentation and that its block is still open.",
+	DiagExpectedToken:       "Quote string values (`backend: \"claw\"`), write lists inline as `[a, b]`, and open every declaration as `<kind> <name>:` above an indented block.",
+	DiagBadIndentation:      "Indent with spaces only, by the same width at every level, and align the line with an enclosing block.",
+	DiagUnterminatedStr:     "Close the quote, or use a backtick raw string / a `|` block scalar for multi-line content.",
+	DiagDuplicateDecl:       "Rename one of the two declarations.",
+	DiagReservedName:        "`done` and `fail` are the reserved terminal targets; pick another name.",
+	DiagUnknownProperty:     "Check the property table for this node kind in docs/references/dsl-grammar.md — a property another kind accepts is not accepted here.",
+	DiagMissingProperty:     "Add the property the message names.",
+	DiagDuplicateBlock:      "Keep one `vars:` / `presets:` / `attachments:` / `secrets:` block per file and merge the entries into it.",
+	DiagInvalidValue:        "Use one of the accepted values the message lists.",
+	DiagInvalidType:         "Types are `string`, `bool`, `int`, `float`, `json` and `string[]` (a schema field may also be `file`).",
+	DiagDuplicateEdgeClause: "Each of `when`/`else`, `as` and `with` may appear once per edge.",
+	DiagElseWithWhen:        "An edge is either guarded (`when`) or the fallback (`else`), never both.",
+}
+
+// HintFor returns the one-line remedy for a parse code, or "" when none is
+// catalogued.
+func HintFor(code DiagCode) string {
+	return hints[code]
+}
+
 // Severity indicates the severity of a diagnostic.
 type Severity int
 
@@ -49,8 +74,9 @@ type Diagnostic struct {
 	Severity Severity
 	Message  string
 	File     string
-	Line     int // 1-based
-	Column   int // 1-based
+	Line     int    // 1-based
+	Column   int    // 1-based
+	Hint     string // one-line remedy, from HintFor unless the site set a more specific one
 }
 
 func (d Diagnostic) Error() string {

--- a/pkg/dsl/parser/diagnostic.go
+++ b/pkg/dsl/parser/diagnostic.go
@@ -62,7 +62,7 @@ func expectedTokenHint(want, got TokenType) string {
 	switch want {
 	case TokenIdent:
 		if got == TokenString {
-			return "This property takes a bare name — a declared `prompt`, `schema` or node — not a quoted string: remove the quotes (`entry: a`, `output: my_schema`); for `system:`/`user:` the name is a `prompt` declared with the text."
+			return "This property takes a bare name — a declared `prompt`, `schema` or node — not a quoted string. For `system:`/`user:` declare the text as a prompt (`prompt my_prompt:` with the text below it, then `system: my_prompt`); for `entry:`/`input:`/`output:` just remove the quotes (`entry: a`)."
 		}
 		return "This property takes a bare name (letters, digits, `_`), such as a declared prompt, schema or node."
 	case TokenString:

--- a/pkg/dsl/parser/expect_hints_test.go
+++ b/pkg/dsl/parser/expect_hints_test.go
@@ -1,0 +1,40 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// An "expected X, got Y" must arrive with the remedy for the shape the
+// parser wanted at that token — the generic E002 line ("quote string
+// values") told the author of `system: "…"` to do the opposite of the fix.
+func TestExpectedTokenHintsNameTheWantedShape(t *testing.T) {
+	cases := []struct {
+		name, src, want string
+	}{
+		{"quoted string where a prompt name belongs", "agent a:\n  system: \"Review the diff\"\n", "bare name"},
+		{"bare word where a string belongs", "agent a:\n  backend: claw\n", "Quote this value"},
+		{"header without its block", "agent a:\nworkflow w:\n  entry: a\n", "indented block"},
+		{"YAML list where an inline list belongs", "agent a:\n  tools:\n    - bash\n", "inline list"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := parser.Parse("h.bot", tc.src)
+			var found bool
+			for _, d := range pr.Diagnostics {
+				if d.Code == parser.DiagExpectedToken && strings.Contains(d.Hint, tc.want) {
+					found = true
+				}
+			}
+			if !found {
+				var got []string
+				for _, d := range pr.Diagnostics {
+					got = append(got, d.Error()+" | fix: "+d.Hint)
+				}
+				t.Errorf("no E002 hint containing %q; diagnostics:\n%s", tc.want, strings.Join(got, "\n"))
+			}
+		})
+	}
+}

--- a/pkg/dsl/parser/grammar_docs_completeness_test.go
+++ b/pkg/dsl/parser/grammar_docs_completeness_test.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// topLevelDeclKeywords is every keyword parseFile dispatches on as a
+// top-level declaration. It is the parser's own list — the test below
+// holds the two human-readable grammars to it, so a declaration kind
+// added to the parser cannot stay absent from the reference an author
+// reads (the way `fail` was missing from dsl-grammar.md and
+// `await_answers` from the EBNF until 2026-09-09).
+var topLevelDeclKeywords = []string{
+	"vars", "presets", "attachments", "secrets", "mcp_server",
+	"prompt", "schema", "cursor", "supervisor",
+	"agent", "judge", "router", "human", "tool", "compute",
+	"emit", "wait", "await_answers", "fail", "subbot",
+	"group", "use", "workflow",
+}
+
+// topLevelProduction extracts the body of the `top_level_decl = … ;`
+// production from a grammar document.
+func topLevelProduction(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	m := regexp.MustCompile(`(?s)top_level_decl\s*=(.*?);`).FindStringSubmatch(string(data))
+	if m == nil {
+		t.Fatalf("%s: no `top_level_decl = … ;` production found", path)
+	}
+	return m[1]
+}
+
+// TestTopLevelDeclarationsAreDocumented fails when a declaration keyword the
+// parser accepts at top level is missing from the readable grammar or the
+// EBNF's top_level_decl production. The EBNF names productions
+// `<keyword>_decl`; the readable grammar names the keyword itself.
+func TestTopLevelDeclarationsAreDocumented(t *testing.T) {
+	ebnf := topLevelProduction(t, "../../../docs/grammar/iterion_v1.ebnf")
+	readable := topLevelProduction(t, "../../../docs/references/dsl-grammar.md")
+	for _, kw := range topLevelDeclKeywords {
+		if !regexp.MustCompile(`\b` + kw + `_decl\b`).MatchString(ebnf) {
+			t.Errorf("docs/grammar/iterion_v1.ebnf: top_level_decl lacks %s_decl", kw)
+		}
+		if !regexp.MustCompile(`\b` + kw + `\b`).MatchString(readable) {
+			t.Errorf("docs/references/dsl-grammar.md: top_level_decl lacks %s", kw)
+		}
+	}
+	// The parser side of the same contract: every keyword listed here is a
+	// declaration keyword the lexer knows (a typo in the list above would
+	// otherwise pass silently).
+	for _, kw := range topLevelDeclKeywords {
+		if _, ok := keywords[kw]; !ok {
+			t.Errorf("%q is not a lexer keyword — the list in this test is stale", kw)
+		}
+	}
+	_ = strings.TrimSpace
+}

--- a/pkg/dsl/parser/lexer.go
+++ b/pkg/dsl/parser/lexer.go
@@ -53,7 +53,7 @@ type Lexer struct {
 func NewLexer(filename, src string) *Lexer {
 	if len(src) > maxSourceSize {
 		l := &Lexer{file: filename, line: 1, col: 1}
-		l.tokens = []Token{{Type: TokenError, Value: fmt.Sprintf("source file exceeds maximum size (%d bytes > %d)", len(src), maxSourceSize), Line: 1, Column: 1}}
+		l.tokens = []Token{{Type: TokenError, Code: DiagUnexpectedToken, Value: fmt.Sprintf("source file exceeds maximum size (%d bytes > %d)", len(src), maxSourceSize), Line: 1, Column: 1}}
 		return l
 	}
 	// Normalize the source before tokenising:
@@ -181,7 +181,7 @@ func (l *Lexer) handleLineStart() {
 	// scalar mode (heredocs preserve tab content verbatim) and in
 	// prompt body lines (handled below the dispatch).
 	if !l.blockScalarMode && !l.promptMode && l.pos < len(l.src) && l.src[l.pos] == '\t' {
-		l.emit(TokenError, "tabs are not allowed for indentation; use spaces", startLine, spaces+1)
+		l.emitError(DiagBadIndentation, "tabs are not allowed for indentation; use spaces", startLine, spaces+1)
 		// Consume the rest of the line so we don't loop on the same tab.
 		for l.pos < len(l.src) && l.src[l.pos] != '\n' {
 			l.advance()
@@ -240,7 +240,7 @@ func (l *Lexer) handleLineStart() {
 	currentLevel := l.indentStack[len(l.indentStack)-1]
 	if spaces > currentLevel {
 		if len(l.indentStack) >= maxNestingDepth {
-			l.emit(TokenError, fmt.Sprintf("maximum nesting depth exceeded (%d levels)", maxNestingDepth), startLine, 1)
+			l.emitError(DiagBadIndentation, fmt.Sprintf("maximum nesting depth exceeded (%d levels)", maxNestingDepth), startLine, 1)
 			return
 		}
 		l.indentStack = append(l.indentStack, spaces)
@@ -260,7 +260,7 @@ func (l *Lexer) handleLineStart() {
 		}
 		// Verify alignment
 		if l.indentStack[len(l.indentStack)-1] != spaces {
-			l.emit(TokenError, "indentation does not match any outer level", startLine, 1)
+			l.emitError(DiagBadIndentation, "indentation does not match any outer level", startLine, 1)
 		}
 	}
 
@@ -452,7 +452,7 @@ func (l *Lexer) scanToken() {
 			l.scanBlockScalar(startLine, startCol)
 		} else {
 			l.advance()
-			l.emit(TokenError, string(ch), startLine, startCol)
+			l.emitError(DiagUnexpectedToken, "unexpected '|': a block scalar opener is only valid right after `key:`", startLine, startCol)
 		}
 
 	case unicode.IsDigit(ch):
@@ -463,7 +463,7 @@ func (l *Lexer) scanToken() {
 
 	default:
 		l.advance()
-		l.emit(TokenError, string(ch), startLine, startCol)
+		l.emitError(DiagUnexpectedToken, fmt.Sprintf("unexpected character %q", string(ch)), startLine, startCol)
 	}
 }
 
@@ -488,7 +488,11 @@ func (l *Lexer) scanString(startLine, startCol int) {
 				case '0':
 					buf = append(buf, 0)
 				default:
-					l.emit(TokenError, fmt.Sprintf("unknown escape sequence \\%c in strict-escape mode", next), startLine, startCol)
+					l.emitError(DiagBadEscape, fmt.Sprintf("unknown escape sequence \\%c in strict-escape mode", next), startLine, startCol)
+					// Consume the rest of the literal: one bad escape is one
+					// diagnostic, not one plus an "unexpected character" for
+					// every byte the string still holds.
+					l.skipRestOfString()
 					return
 				}
 				l.advance()
@@ -501,7 +505,7 @@ func (l *Lexer) scanString(startLine, startCol int) {
 			continue
 		}
 		if l.src[l.pos] == '\n' {
-			l.emit(TokenError, "unterminated string literal", startLine, startCol)
+			l.emitError(DiagUnterminatedStr, "unterminated string literal", startLine, startCol)
 			return
 		}
 		buf = append(buf, l.src[l.pos])
@@ -510,7 +514,7 @@ func (l *Lexer) scanString(startLine, startCol int) {
 	if l.pos < len(l.src) {
 		l.advance() // skip closing "
 	} else {
-		l.emit(TokenError, "unterminated string literal", startLine, startCol)
+		l.emitError(DiagUnterminatedStr, "unterminated string literal", startLine, startCol)
 		return
 	}
 	l.emit(TokenString, string(buf), startLine, startCol)
@@ -532,7 +536,7 @@ func (l *Lexer) scanRawString(startLine, startCol int) {
 		l.advance()
 	}
 	if l.pos >= len(l.src) {
-		l.emit(TokenError, "unterminated raw string literal (missing closing backtick)", startLine, startCol)
+		l.emitError(DiagUnterminatedStr, "unterminated raw string literal (missing closing backtick)", startLine, startCol)
 		return
 	}
 	l.advance() // skip closing `
@@ -582,7 +586,7 @@ func (l *Lexer) scanBlockScalar(startLine, startCol int) {
 		}
 	}
 	if l.pos < len(l.src) && l.src[l.pos] != '\n' {
-		l.emit(TokenError, "expected newline after '|' (block scalar opener)", startLine, startCol)
+		l.emitError(DiagExpectedToken, "expected newline after '|' (block scalar opener)", startLine, startCol)
 		return
 	}
 	if l.pos < len(l.src) {
@@ -663,7 +667,7 @@ func (l *Lexer) handleIndentation(spaces, startLine int) {
 	currentLevel := l.indentStack[len(l.indentStack)-1]
 	if spaces > currentLevel {
 		if len(l.indentStack) >= maxNestingDepth {
-			l.emit(TokenError, fmt.Sprintf("maximum nesting depth exceeded (%d levels)", maxNestingDepth), startLine, 1)
+			l.emitError(DiagBadIndentation, fmt.Sprintf("maximum nesting depth exceeded (%d levels)", maxNestingDepth), startLine, 1)
 			return
 		}
 		l.indentStack = append(l.indentStack, spaces)
@@ -674,7 +678,7 @@ func (l *Lexer) handleIndentation(spaces, startLine int) {
 			l.emit(TokenDedent, "", startLine, 1)
 		}
 		if l.indentStack[len(l.indentStack)-1] != spaces {
-			l.emit(TokenError, "indentation does not match any outer level", startLine, 1)
+			l.emitError(DiagBadIndentation, "indentation does not match any outer level", startLine, 1)
 		}
 	}
 	l.atLineStart = false
@@ -736,6 +740,30 @@ func (l *Lexer) advance() {
 
 func (l *Lexer) emit(tt TokenType, value string, line, col int) {
 	l.tokens = append(l.tokens, Token{Type: tt, Value: value, Line: line, Column: col})
+}
+
+// skipRestOfString advances past the remainder of a quoted literal after an
+// error inside it — through the closing quote, or to the end of the line —
+// so the error is reported once instead of cascading.
+func (l *Lexer) skipRestOfString() {
+	for l.pos < len(l.src) && l.src[l.pos] != '\n' {
+		ch := l.src[l.pos]
+		l.advance()
+		if ch == '\\' && l.pos < len(l.src) && l.src[l.pos] != '\n' {
+			l.advance()
+			continue
+		}
+		if ch == '"' {
+			return
+		}
+	}
+}
+
+// emitError records a lexer diagnosis as an error token that carries its
+// own diagnostic code, so the parser can report the cause wherever the token
+// surfaces — inside a block as well as at the top level.
+func (l *Lexer) emitError(code DiagCode, msg string, line, col int) {
+	l.tokens = append(l.tokens, Token{Type: TokenError, Code: code, Value: msg, Line: line, Column: col})
 }
 
 func isIdentStart(r rune) bool {

--- a/pkg/dsl/parser/lexer.go
+++ b/pkg/dsl/parser/lexer.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/workflowfile"
 )
 
 // Safety limits to prevent DoS from malicious .bot files.
@@ -85,14 +87,17 @@ func NewLexer(filename, src string) *Lexer {
 func detectStrictEscape(src string) bool {
 	lines := strings.SplitN(src, "\n", 32)
 	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		if !strings.HasPrefix(trimmed, "##") {
+		// A comment is a `#` or `##` line — the same rule the lexer applies
+		// (workflowfile.CommentText is the shared definition), so a plain
+		// `# note` above the directive neither hides it nor ends the scan.
+		body, ok := workflowfile.CommentText(line)
+		if !ok {
 			return false
 		}
-		body := strings.TrimSpace(strings.TrimPrefix(trimmed, "##"))
+		body = strings.TrimSpace(body)
 		// Accept `strict-escape: on` (with optional surrounding whitespace
 		// already trimmed) and a few cosmetic variants.
 		if body == "strict-escape: on" || body == "strict-escape:on" || body == "strict-escape = on" {
@@ -271,41 +276,46 @@ func (l *Lexer) promptBodyOpensHere(spaces int) bool {
 	if spaces <= l.indentStack[len(l.indentStack)-1] {
 		return false
 	}
-	idx := len(l.tokens) - 1
-	if idx >= 0 && l.tokens[idx].Type == TokenNewline {
-		idx--
-	}
-	if idx >= 0 && l.tokens[idx].Type == TokenColon {
-		idx--
-	}
-	if idx >= 0 && (l.tokens[idx].Type == TokenIdent || isKeywordToken(l.tokens[idx].Type)) {
-		idx--
-	}
-	return idx >= 0 && l.tokens[idx].Type == TokenPrompt
+	return l.promptHeaderEndsAt(len(l.tokens) - 1)
 }
 
 // isPromptIndent checks if the last emitted tokens before the INDENT are: prompt IDENT : NEWLINE INDENT
 func (l *Lexer) isPromptIndent() bool {
-	n := len(l.tokens)
-	if n < 4 {
-		return false
-	}
-	// tokens: ..., TokenPrompt, TokenIdent(name), TokenColon, TokenNewline, TokenIndent(just emitted)
-	// The INDENT we just emitted is at n-1
-	idx := n - 2 // should be Newline
+	// The INDENT just emitted sits at len-1; the header ends before it.
+	return l.promptHeaderEndsAt(len(l.tokens) - 2)
+}
+
+// promptHeaderEndsAt reports whether the significant tokens ending at index
+// idx are the suffix of a prompt header, `prompt <name>:` followed by an
+// optional NEWLINE. Comment tokens are skipped: a trailing `# why` on the
+// header line is a comment, not a token of the header, and must not hide the
+// body that follows (scanComment consumes the newline, so the Newline token
+// may be absent after one).
+func (l *Lexer) promptHeaderEndsAt(idx int) bool {
+	idx = l.significantIndexAt(idx)
 	if idx >= 0 && l.tokens[idx].Type == TokenNewline {
-		idx--
+		idx = l.significantIndexAt(idx - 1)
 	}
 	if idx >= 0 && l.tokens[idx].Type == TokenColon {
-		idx--
+		idx = l.significantIndexAt(idx - 1)
+	} else {
+		return false
 	}
 	if idx >= 0 && (l.tokens[idx].Type == TokenIdent || isKeywordToken(l.tokens[idx].Type)) {
+		idx = l.significantIndexAt(idx - 1)
+	} else {
+		return false
+	}
+	return idx >= 0 && l.tokens[idx].Type == TokenPrompt
+}
+
+// significantIndexAt returns the index of the last non-comment token at or
+// before idx, or -1.
+func (l *Lexer) significantIndexAt(idx int) int {
+	for idx >= 0 && l.tokens[idx].Type == TokenComment {
 		idx--
 	}
-	if idx >= 0 && l.tokens[idx].Type == TokenPrompt {
-		return true
-	}
-	return false
+	return idx
 }
 
 // emitPromptLine captures the rest of the current line as a prompt text line.

--- a/pkg/dsl/parser/lexer.go
+++ b/pkg/dsl/parser/lexer.go
@@ -220,8 +220,12 @@ func (l *Lexer) handleLineStart() {
 		}
 	}
 
-	// Comment lines at line start
-	if l.pos+1 < len(l.src) && l.src[l.pos] == '#' && l.src[l.pos+1] == '#' {
+	// Comment lines at line start: `#` or `##` (see scanComment). The one
+	// exception is the first line of a prompt body: prompt mode only starts
+	// when the INDENT below is emitted, so a `# Heading` opening the body
+	// (the ordinary markdown shape of a human node's instructions) must
+	// reach that INDENT as text rather than vanish as a comment.
+	if l.pos < len(l.src) && l.src[l.pos] == '#' && !l.promptBodyOpensHere(spaces) {
 		l.scanComment(startLine)
 		l.atLineStart = true
 		return
@@ -256,6 +260,28 @@ func (l *Lexer) handleLineStart() {
 	}
 
 	l.atLineStart = false
+}
+
+// promptBodyOpensHere reports whether a line indented by `spaces` is the
+// first line of a prompt body: it is deeper than the current level and the
+// tokens emitted so far end with the `prompt <name>:` header. It is the
+// pre-INDENT twin of isPromptIndent, consulted before a `#` on such a line
+// could be scanned as a comment.
+func (l *Lexer) promptBodyOpensHere(spaces int) bool {
+	if spaces <= l.indentStack[len(l.indentStack)-1] {
+		return false
+	}
+	idx := len(l.tokens) - 1
+	if idx >= 0 && l.tokens[idx].Type == TokenNewline {
+		idx--
+	}
+	if idx >= 0 && l.tokens[idx].Type == TokenColon {
+		idx--
+	}
+	if idx >= 0 && (l.tokens[idx].Type == TokenIdent || isKeywordToken(l.tokens[idx].Type)) {
+		idx--
+	}
+	return idx >= 0 && l.tokens[idx].Type == TokenPrompt
 }
 
 // isPromptIndent checks if the last emitted tokens before the INDENT are: prompt IDENT : NEWLINE INDENT
@@ -305,10 +331,18 @@ func (l *Lexer) emitPromptLine(leadingSpaces int) {
 	l.atLineStart = true
 }
 
+// scanComment consumes a comment to the end of its line. A comment opens
+// with `#`; the traditional `##` form is the same comment with one more
+// hash, so both `# note` and `## note` carry the text "note". Outside a
+// string, a prompt body or a block scalar a `#` never means anything else
+// in the language, so accepting the single form costs no ambiguity — and
+// it is the form every YAML-trained author (human or model) reaches for.
 func (l *Lexer) scanComment(startLine int) {
 	startCol := l.col
-	l.advance() // skip first #
-	l.advance() // skip second #
+	l.advance() // skip the opening #
+	if l.pos < len(l.src) && l.src[l.pos] == '#' {
+		l.advance() // the `##` form: skip the second #
+	}
 	var buf []rune
 	for l.pos < len(l.src) && l.src[l.pos] != '\n' {
 		buf = append(buf, l.src[l.pos])
@@ -341,8 +375,8 @@ func (l *Lexer) scanToken() {
 		l.emit(TokenNewline, "", startLine, startCol)
 		l.atLineStart = true
 
-	case ch == '#' && l.pos+1 < len(l.src) && l.src[l.pos+1] == '#':
-		// Inline comment — consume rest of line
+	case ch == '#':
+		// Inline comment (`#` or `##`) — consume rest of line
 		l.scanComment(startLine)
 
 	case ch == ':':
@@ -527,12 +561,12 @@ func (l *Lexer) lastSignificantToken() TokenType {
 // `key: "..."` followed by a newline.
 func (l *Lexer) scanBlockScalar(startLine, startCol int) {
 	l.advance() // skip opening |
-	// Skip trailing inline whitespace and an optional ## comment on the
+	// Skip trailing inline whitespace and an optional comment on the
 	// opener line, then consume the newline that introduces the block.
 	for l.pos < len(l.src) && (l.src[l.pos] == ' ' || l.src[l.pos] == '\t') {
 		l.advance()
 	}
-	if l.pos+1 < len(l.src) && l.src[l.pos] == '#' && l.src[l.pos+1] == '#' {
+	if l.pos < len(l.src) && l.src[l.pos] == '#' {
 		for l.pos < len(l.src) && l.src[l.pos] != '\n' {
 			l.advance()
 		}
@@ -610,7 +644,7 @@ func (l *Lexer) handleBlockScalarLine(spaces, startLine int) {
 // the dedenting line back through the regular indent state machine).
 func (l *Lexer) handleIndentation(spaces, startLine int) {
 	// Comment-only line at this indentation: scan it and stay at line start.
-	if l.pos+1 < len(l.src) && l.src[l.pos] == '#' && l.src[l.pos+1] == '#' {
+	if l.pos < len(l.src) && l.src[l.pos] == '#' && !l.promptBodyOpensHere(spaces) {
 		l.scanComment(startLine)
 		l.atLineStart = true
 		return

--- a/pkg/dsl/parser/lexer_error_diagnosis_test.go
+++ b/pkg/dsl/parser/lexer_error_diagnosis_test.go
@@ -1,0 +1,94 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// One bad escape is ONE diagnostic: the lexer consumes the rest of the
+// literal, so the bytes it still held do not each become an "unexpected
+// character" the body loop then reads as a property name.
+func TestBadEscapeIsReportedOnce(t *testing.T) {
+	pr := parser.Parse("esc.bot", "# strict-escape: on\nagent a:\n  model: \"a\\db\"\n  output: out\n")
+	if len(pr.Diagnostics) != 1 || pr.Diagnostics[0].Code != parser.DiagBadEscape {
+		var got []string
+		for _, d := range pr.Diagnostics {
+			got = append(got, d.Error())
+		}
+		t.Fatalf("want exactly one E005, got:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// An indented line with no open block above it (its header failed) used to
+// read "unexpected token '' at top level" — an indent token has no text.
+func TestIndentOutsideAnyBlockIsNamed(t *testing.T) {
+	pr := parser.Parse("ind.bot", "agent a:\n\tmodel: \"m\"\n  output: out\n")
+	var named bool
+	for _, d := range pr.Diagnostics {
+		if strings.Contains(d.Message, "unexpected token ''") {
+			t.Errorf("opaque message survived: %s", d.Error())
+		}
+		if d.Code == parser.DiagBadIndentation && strings.Contains(d.Message, "indented line outside any block") && d.Line == 3 {
+			named = true
+		}
+	}
+	if !named {
+		var got []string
+		for _, d := range pr.Diagnostics {
+			got = append(got, d.Error())
+		}
+		t.Errorf("line 3 not reported as an indented line outside any block:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// A diagnosis the lexer makes (a tab, an unterminated string, a bad escape)
+// must reach the author as what it is — its own code, message and fix line —
+// wherever the error token surfaces. Inside a declaration body it used to
+// arrive as "expected INDENT, got Error" with a hint about opening a block
+// the author had opened: a hint that produces a WORSE file.
+func TestLexerDiagnosisSurvivesInsideBlocks(t *testing.T) {
+	cases := []struct {
+		name, src string
+		code      parser.DiagCode
+		message   string
+	}{
+		{"tab inside a node body", "agent a:\n\tmodel: \"m\"\n", parser.DiagBadIndentation, "tabs are not allowed"},
+		{"tab at top level", "\tagent a:\n", parser.DiagBadIndentation, "tabs are not allowed"},
+		{"unterminated string in a property", "agent a:\n  model: \"m\n  output: out\n", parser.DiagUnterminatedStr, "unterminated string literal"},
+		{"unterminated raw string", "tool t:\n  command: `echo hi\n", parser.DiagUnterminatedStr, "unterminated raw string"},
+		{"unknown escape under strict-escape", "# strict-escape: on\nagent a:\n  model: \"a\\db\"\n", parser.DiagBadEscape, "unknown escape sequence"},
+		{"stray character in a node body", "agent a:\n  model: @\n", parser.DiagUnexpectedToken, "unexpected character"},
+		{"stray character at a property position", "agent a:\n  @foo: 1\n", parser.DiagUnexpectedToken, "unexpected character"},
+		{"stray character at a router property position", "router r:\n  @mode: llm\n", parser.DiagUnexpectedToken, "unexpected character"},
+		{"misaligned dedent", "agent a:\n    model: \"m\"\n  output: out\n", parser.DiagBadIndentation, "does not match any outer level"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := parser.Parse("lex.bot", tc.src)
+			var found bool
+			for _, d := range pr.Diagnostics {
+				if d.Code == tc.code && strings.Contains(d.Message, tc.message) {
+					found = true
+					if d.Hint == "" || d.Hint != parser.HintFor(tc.code) {
+						t.Errorf("hint = %q, want the %s catalogue line %q", d.Hint, tc.code, parser.HintFor(tc.code))
+					}
+				}
+				if strings.Contains(d.Message, "got Error") {
+					t.Errorf("the lexer's diagnosis was thrown away: %s | fix: %s", d.Error(), d.Hint)
+				}
+				if d.Code == parser.DiagUnknownProperty && strings.Contains(d.Message, "unexpected character") {
+					t.Errorf("the lexer's diagnosis was read as a property name: %s", d.Error())
+				}
+			}
+			if !found {
+				var got []string
+				for _, d := range pr.Diagnostics {
+					got = append(got, d.Error()+" | fix: "+d.Hint)
+				}
+				t.Errorf("no %s containing %q; diagnostics:\n%s", tc.code, tc.message, strings.Join(got, "\n"))
+			}
+		})
+	}
+}

--- a/pkg/dsl/parser/lexer_error_diagnosis_test.go
+++ b/pkg/dsl/parser/lexer_error_diagnosis_test.go
@@ -21,25 +21,80 @@ func TestBadEscapeIsReportedOnce(t *testing.T) {
 	}
 }
 
-// An indented line with no open block above it (its header failed) used to
-// read "unexpected token '' at top level" — an indent token has no text.
+// An indented line where no member or property can be used to read
+// "unexpected token ” at top level", "unexpected token ” in workflow" or
+// "unknown agent property ”" depending on the block it fell into — an
+// indent token has no text. One message, from the one emitter, at all three.
 func TestIndentOutsideAnyBlockIsNamed(t *testing.T) {
-	pr := parser.Parse("ind.bot", "agent a:\n\tmodel: \"m\"\n  output: out\n")
-	var named bool
-	for _, d := range pr.Diagnostics {
-		if strings.Contains(d.Message, "unexpected token ''") {
-			t.Errorf("opaque message survived: %s", d.Error())
-		}
-		if d.Code == parser.DiagBadIndentation && strings.Contains(d.Message, "indented line outside any block") && d.Line == 3 {
-			named = true
-		}
+	cases := []struct {
+		name, src string
+		line      int
+	}{
+		{"top level after a failed header", "agent a:\n\tmodel: \"m\"\n  output: out\n", 3},
+		{"workflow body", "schema out:\n  ok: bool\nagent a:\n  model: \"m\"\n  output: out\nworkflow w:\n  entry: a\n    a -> done\n", 8},
+		{"node body", "agent a:\n  model: \"m\"\n    output: out\n", 3},
 	}
-	if !named {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := parser.Parse("ind.bot", tc.src)
+			var named bool
+			for _, d := range pr.Diagnostics {
+				if strings.Contains(d.Message, "''") {
+					t.Errorf("opaque empty-name message survived: %s", d.Error())
+				}
+				if d.Code == parser.DiagBadIndentation && strings.Contains(d.Message, "indented line where none can be") && d.Line == tc.line {
+					named = true
+				}
+			}
+			if !named {
+				var got []string
+				for _, d := range pr.Diagnostics {
+					got = append(got, d.Error())
+				}
+				t.Errorf("line %d not reported as an indented line where none can be:\n%s", tc.line, strings.Join(got, "\n"))
+			}
+		})
+	}
+}
+
+// A trailing comment stands in for that line's newline in the token stream,
+// so the recovery after an unknown property must stop at it — it used to run
+// into the next line and swallow the `expr:` header, which the compiler then
+// reported as "compute has no expr block" on a compute that has one.
+func TestRecoveryAfterUnknownPropertyStopsAtTrailingComment(t *testing.T) {
+	pr := parser.Parse("cmt.bot", "schema s:\n  kind: string\n\ncompute big:\n  output: s\n  bogus: 1 # c\n  expr:\n    kind: \"1\"\n")
+	if pr.File == nil || len(pr.File.Computes) != 1 {
+		t.Fatalf("expected one compute, got %+v", pr.File)
+	}
+	if len(pr.File.Computes[0].Expr) != 1 {
 		var got []string
 		for _, d := range pr.Diagnostics {
 			got = append(got, d.Error())
 		}
-		t.Errorf("line 3 not reported as an indented line outside any block:\n%s", strings.Join(got, "\n"))
+		t.Errorf("the expr block after the commented line was lost; diagnostics:\n%s", strings.Join(got, "\n"))
+	}
+	if n := len(pr.Diagnostics); n != 1 || pr.Diagnostics[0].Code != parser.DiagUnknownProperty {
+		var got []string
+		for _, d := range pr.Diagnostics {
+			got = append(got, d.Error())
+		}
+		t.Errorf("want exactly one E012 (bogus), got %d:\n%s", n, strings.Join(got, "\n"))
+	}
+}
+
+// The lexer's diagnosis is not a value: a bad escape where a prompt name
+// belongs must not become the prompt name the compiler then reports as
+// unknown.
+func TestLexerDiagnosisIsNotAValue(t *testing.T) {
+	pr := parser.Parse("val.bot", "# strict-escape: on\nagent a:\n  system: \"a\\db\"\n  model: \"m\"\n")
+	if pr.File == nil || len(pr.File.Agents) != 1 {
+		t.Fatalf("expected one agent, got %+v", pr.File)
+	}
+	if got := pr.File.Agents[0].System; got != "" {
+		t.Errorf("System = %q, want empty (the lexer's diagnosis is not a name)", got)
+	}
+	if got := pr.File.Agents[0].Model; got != "m" {
+		t.Errorf("Model = %q: the recovery after the bad escape lost the next property", got)
 	}
 }
 
@@ -63,6 +118,10 @@ func TestLexerDiagnosisSurvivesInsideBlocks(t *testing.T) {
 		{"stray character at a property position", "agent a:\n  @foo: 1\n", parser.DiagUnexpectedToken, "unexpected character"},
 		{"stray character at a router property position", "router r:\n  @mode: llm\n", parser.DiagUnexpectedToken, "unexpected character"},
 		{"misaligned dedent", "agent a:\n    model: \"m\"\n  output: out\n", parser.DiagBadIndentation, "does not match any outer level"},
+		// The block-scalar opener's diagnosis shares the parser's E002 code:
+		// the replacement must not depend on the codes differing.
+		{"text after a block scalar opener", "tool t:\n  command: |x\n  output: out\n", parser.DiagExpectedToken, "expected newline after '|'"},
+		{"block scalar opener before a list", "agent a:\n  capabilities: |[board.create]\n", parser.DiagExpectedToken, "expected newline after '|'"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -38,6 +38,15 @@ func (p *parser) pos(t Token) ast.Pos {
 }
 
 func (p *parser) addError(code DiagCode, t Token, msg string) {
+	p.addErrorHint(code, t, msg, "")
+}
+
+// addErrorHint records a diagnostic with a site-specific fix line; an empty
+// hint falls back to the code's catalogued one.
+func (p *parser) addErrorHint(code DiagCode, t Token, msg, hint string) {
+	if hint == "" {
+		hint = HintFor(code)
+	}
 	p.diags = append(p.diags, Diagnostic{
 		Code:     code,
 		Severity: SeverityError,
@@ -45,7 +54,7 @@ func (p *parser) addError(code DiagCode, t Token, msg string) {
 		File:     p.file,
 		Line:     t.Line,
 		Column:   t.Column,
-		Hint:     HintFor(code),
+		Hint:     hint,
 	})
 }
 
@@ -55,7 +64,7 @@ func (p *parser) expect(tt TokenType) (Token, bool) {
 	if t.Type == tt {
 		return t, true
 	}
-	p.addError(DiagExpectedToken, t, "expected "+tt.String()+", got "+t.Type.String())
+	p.addErrorHint(DiagExpectedToken, t, "expected "+tt.String()+", got "+t.Type.String(), expectedTokenHint(tt, t.Type))
 	return t, false
 }
 

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -45,6 +45,7 @@ func (p *parser) addError(code DiagCode, t Token, msg string) {
 		File:     p.file,
 		Line:     t.Line,
 		Column:   t.Column,
+		Hint:     HintFor(code),
 	})
 }
 

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -51,8 +51,18 @@ func (p *parser) addError(code DiagCode, t Token, msg string) {
 // through, so no site can report "expected X, got Error" or read the
 // diagnosis as a property name.
 func (p *parser) addErrorHint(code DiagCode, t Token, msg, hint string) {
-	if t.Type == TokenError && code != lexerCode(t) {
+	if t.Type == TokenError {
+		// Unconditional — a lexer diagnosis may share a parser code (the
+		// block-scalar opener is E002), and lexerError passes exactly
+		// this pair, so the replacement is idempotent for it.
 		code, msg, hint = lexerCode(t), t.Value, ""
+	}
+	if t.Type == TokenIndent && (code == DiagUnexpectedToken || code == DiagUnknownProperty) {
+		// "unexpected token ''" / "unknown property ''": an indent token
+		// has no text, and what the author sees is a line indented where
+		// no member or property can be — at the top level, in a workflow,
+		// in a node body alike.
+		code, msg, hint = DiagBadIndentation, indentOutsideBlockMsg, ""
 	}
 	if hint == "" {
 		hint = HintFor(code)
@@ -91,6 +101,11 @@ func (p *parser) expectFailed(t Token, want TokenType, msg string) {
 func (p *parser) lexerError(t Token) {
 	p.addError(lexerCode(t), t, t.Value)
 }
+
+// indentOutsideBlockMsg names an indented line where no member or property
+// can be. Phrased for both causes: it may be the consequence of a header
+// that failed to open (then an error precedes it) or a plain mistake.
+const indentOutsideBlockMsg = "indented line where none can be: it is indented deeper than the block it is in, or the header above it did not open (see the error before this one, if any)"
 
 // lexerCode is the diagnostic code an error token carries (E001 when the
 // lexer did not classify it).
@@ -332,11 +347,9 @@ func (p *parser) parseFile() *ast.File {
 			p.next()
 
 		case TokenIndent:
-			// An indented line with no block open above it: the header
-			// before it failed to open (the previous diagnostic says why),
-			// or the line is indented by mistake. "unexpected token ''"
-			// — an indent token has no text — said neither.
-			p.addError(DiagBadIndentation, t, "indented line outside any block: the header above it did not open (see the previous error), or the line is indented by mistake")
+			// An indented line with no block open above it (the same
+			// message addErrorHint substitutes inside a block).
+			p.addError(DiagBadIndentation, t, indentOutsideBlockMsg)
 			p.next()
 			p.skipToNextTopLevel()
 

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -43,7 +43,17 @@ func (p *parser) addError(code DiagCode, t Token, msg string) {
 
 // addErrorHint records a diagnostic with a site-specific fix line; an empty
 // hint falls back to the code's catalogued one.
+//
+// A diagnostic attributed to a lexer ERROR token is the lexer's diagnosis,
+// whatever the parser wanted at that position: the cause is the character
+// the lexer refused (a tab, an unclosed quote, a bad escape), and only the
+// lexer's message names it. This is the one place every parse site goes
+// through, so no site can report "expected X, got Error" or read the
+// diagnosis as a property name.
 func (p *parser) addErrorHint(code DiagCode, t Token, msg, hint string) {
+	if t.Type == TokenError && code != lexerCode(t) {
+		code, msg, hint = lexerCode(t), t.Value, ""
+	}
 	if hint == "" {
 		hint = HintFor(code)
 	}
@@ -64,8 +74,31 @@ func (p *parser) expect(tt TokenType) (Token, bool) {
 	if t.Type == tt {
 		return t, true
 	}
-	p.addErrorHint(DiagExpectedToken, t, "expected "+tt.String()+", got "+t.Type.String(), expectedTokenHint(tt, t.Type))
+	p.expectFailed(t, tt, "expected "+tt.String()+", got "+t.Type.String())
 	return t, false
+}
+
+// expectFailed reports a token that is not the shape the parser wanted, with
+// the remedy for that shape (a lexer error token is reported as the lexer's
+// diagnosis by addErrorHint, never as "expected INDENT, got Error" plus a
+// hint about opening a block the author did open).
+func (p *parser) expectFailed(t Token, want TokenType, msg string) {
+	p.addErrorHint(DiagExpectedToken, t, msg, expectedTokenHint(want, t.Type))
+}
+
+// lexerError surfaces a diagnosis the lexer already made: the error token
+// carries its code and message.
+func (p *parser) lexerError(t Token) {
+	p.addError(lexerCode(t), t, t.Value)
+}
+
+// lexerCode is the diagnostic code an error token carries (E001 when the
+// lexer did not classify it).
+func lexerCode(t Token) DiagCode {
+	if t.Code == "" {
+		return DiagUnexpectedToken
+	}
+	return t.Code
 }
 
 // skipNewlines consumes any consecutive newlines and inline comments.
@@ -298,13 +331,19 @@ func (p *parser) parseFile() *ast.File {
 			// Stray dedent at top level — skip
 			p.next()
 
+		case TokenIndent:
+			// An indented line with no block open above it: the header
+			// before it failed to open (the previous diagnostic says why),
+			// or the line is indented by mistake. "unexpected token ''"
+			// — an indent token has no text — said neither.
+			p.addError(DiagBadIndentation, t, "indented line outside any block: the header above it did not open (see the previous error), or the line is indented by mistake")
+			p.next()
+			p.skipToNextTopLevel()
+
 		case TokenError:
-			// The lexer packs its diagnostic message into t.Value (e.g.
-			// "source file exceeds maximum size", "maximum nesting depth
-			// exceeded"). Surface it directly instead of wrapping it as
-			// an opaque "unexpected token 'X' at top level" — that
-			// previously hid the actual cause from the operator.
-			p.addError(DiagUnexpectedToken, t, t.Value)
+			// The lexer's own diagnosis (its code and message ride the
+			// token), not an opaque "unexpected token 'X' at top level".
+			p.lexerError(t)
 			p.next()
 			p.skipToNextTopLevel()
 

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -166,7 +166,7 @@ func (p *parser) expectString() string {
 	if t.Type == TokenString {
 		return t.Value
 	}
-	p.addErrorHint(DiagExpectedToken, t, "expected string literal, got "+t.Type.String(), expectedTokenHint(TokenString, t.Type))
+	p.expectFailed(t, TokenString, "expected string literal, got "+t.Type.String())
 	return t.Value
 }
 
@@ -176,7 +176,7 @@ func (p *parser) expectIdent() string {
 	if id != "" {
 		return id
 	}
-	p.addErrorHint(DiagExpectedToken, t, "expected identifier, got "+t.Type.String(), expectedTokenHint(TokenIdent, t.Type))
+	p.expectFailed(t, TokenIdent, "expected identifier, got "+t.Type.String())
 	return t.Value
 }
 
@@ -190,7 +190,7 @@ func (p *parser) expectInt() int {
 		}
 		return v
 	}
-	p.addErrorHint(DiagExpectedToken, t, "expected integer, got "+t.Type.String(), expectedTokenHint(TokenInt, t.Type))
+	p.expectFailed(t, TokenInt, "expected integer, got "+t.Type.String())
 	return 0
 }
 
@@ -205,7 +205,7 @@ func (p *parser) expectNumber() float64 {
 		}
 		return v
 	default:
-		p.addError(DiagExpectedToken, t, "expected number, got "+t.Type.String())
+		p.expectFailed(t, TokenFloat, "expected number, got "+t.Type.String())
 		return 0
 	}
 }

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -167,6 +167,9 @@ func (p *parser) expectString() string {
 		return t.Value
 	}
 	p.expectFailed(t, TokenString, "expected string literal, got "+t.Type.String())
+	if t.Type == TokenError {
+		return "" // the lexer's diagnosis is not a value
+	}
 	return t.Value
 }
 
@@ -177,6 +180,9 @@ func (p *parser) expectIdent() string {
 		return id
 	}
 	p.expectFailed(t, TokenIdent, "expected identifier, got "+t.Type.String())
+	if t.Type == TokenError {
+		return "" // the lexer's diagnosis is not a name
+	}
 	return t.Value
 }
 
@@ -210,10 +216,14 @@ func (p *parser) expectNumber() float64 {
 	}
 }
 
+// skipToNewline drops the rest of the current line after an error. A
+// trailing comment ends the line too: the lexer emits the comment token in
+// place of that line's newline, so running past it would eat the NEXT line
+// (a `bogus: 1 # note` used to swallow the `expr:` below it).
 func (p *parser) skipToNewline() {
 	for {
 		t := p.peek()
-		if t.Type == TokenNewline || t.Type == TokenEOF || t.Type == TokenDedent {
+		if t.Type == TokenNewline || t.Type == TokenComment || t.Type == TokenEOF || t.Type == TokenDedent {
 			return
 		}
 		p.next()

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -166,7 +166,7 @@ func (p *parser) expectString() string {
 	if t.Type == TokenString {
 		return t.Value
 	}
-	p.addError(DiagExpectedToken, t, "expected string literal, got "+t.Type.String())
+	p.addErrorHint(DiagExpectedToken, t, "expected string literal, got "+t.Type.String(), expectedTokenHint(TokenString, t.Type))
 	return t.Value
 }
 
@@ -176,7 +176,7 @@ func (p *parser) expectIdent() string {
 	if id != "" {
 		return id
 	}
-	p.addError(DiagExpectedToken, t, "expected identifier, got "+t.Type.String())
+	p.addErrorHint(DiagExpectedToken, t, "expected identifier, got "+t.Type.String(), expectedTokenHint(TokenIdent, t.Type))
 	return t.Value
 }
 
@@ -190,7 +190,7 @@ func (p *parser) expectInt() int {
 		}
 		return v
 	}
-	p.addError(DiagExpectedToken, t, "expected integer, got "+t.Type.String())
+	p.addErrorHint(DiagExpectedToken, t, "expected integer, got "+t.Type.String(), expectedTokenHint(TokenInt, t.Type))
 	return 0
 }
 

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -645,7 +645,7 @@ func (p *parser) parseFallbacksBlock(propTok Token) []*ast.FallbackDecl {
 func (p *parser) parseFallbackEntry() *ast.FallbackDecl {
 	nameT := p.next()
 	if nameT.Type != TokenIdent && !isKeywordToken(nameT.Type) {
-		p.addError(DiagExpectedToken, nameT, "expected fallback name, got "+nameT.Type.String())
+		p.expectFailed(nameT, TokenIdent, "expected fallback name, got "+nameT.Type.String())
 		p.skipToNewline()
 		return nil
 	}
@@ -701,7 +701,7 @@ func (p *parser) parseFallbackEntry() *ast.FallbackDecl {
 			case TokenIdent, TokenString:
 				fd.Action = at.Value
 			default:
-				p.addError(DiagExpectedToken, at, "expected fallback action (skip), got "+at.Type.String())
+				p.expectFailed(at, TokenIdent, "expected fallback action (skip), got "+at.Type.String())
 				p.skipToNewline()
 			}
 		case "when":

--- a/pkg/dsl/parser/token.go
+++ b/pkg/dsl/parser/token.go
@@ -503,7 +503,12 @@ var keywords = map[string]TokenType{
 // Token is a single lexical token produced by the lexer.
 type Token struct {
 	Type   TokenType
-	Value  string // raw text of the token
+	Value  string // raw text of the token; for TokenError, the lexer's diagnosis
 	Line   int    // 1-based
 	Column int    // 1-based
+	// Code is set on a TokenError only: the diagnostic code of the lexer's
+	// diagnosis (a tab, an unterminated string, a bad escape), so the parser
+	// reports THAT — never "expected X, got Error" with a token-shape hint
+	// about a cause that is a character.
+	Code DiagCode
 }

--- a/pkg/dsl/workflowfile/workflowfile.go
+++ b/pkg/dsl/workflowfile/workflowfile.go
@@ -20,3 +20,29 @@ func IsWorkflowFile(path string) bool {
 	}
 	return false
 }
+
+// CommentText reports whether line is a comment line of a workflow source —
+// a `#` or `##` after optional indentation — and returns its text with the
+// hashes and one following space removed (`## note` and `# note` both yield
+// "note"; `##   - item` keeps its inner indentation as "  - item").
+//
+// It is the ONE definition of what a comment line looks like, shared by the
+// lexer's directive pre-scan, the bundle frontmatter reader and the
+// catalogue's description reader: a hash count the parser accepts must be
+// accepted by every reader of the same file, or a valid `.bot` silently loses
+// its strict-escape mode or its catalogue identity to a comment written the
+// other way.
+func CommentText(line string) (text string, ok bool) {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "#") {
+		return "", false
+	}
+	t = strings.TrimPrefix(t, "#")
+	t = strings.TrimPrefix(t, "#")
+	t = strings.TrimPrefix(t, " ")
+	return t, true
+}
+
+// FrontmatterFence is the text of the comment line that opens and closes a
+// bot's frontmatter block (`## ---` or `# ---`).
+const FrontmatterFence = "---"

--- a/pkg/dsl/workflowfile/workflowfile.go
+++ b/pkg/dsl/workflowfile/workflowfile.go
@@ -33,14 +33,17 @@ func IsWorkflowFile(path string) bool {
 // its strict-escape mode or its catalogue identity to a comment written the
 // other way.
 func CommentText(line string) (text string, ok bool) {
-	t := strings.TrimSpace(line)
+	// Only spaces may precede the hash: the lexer refuses a tab as
+	// indentation, and a reader that accepted one would give an
+	// unparseable file a catalogue identity.
+	t := strings.TrimLeft(line, " ")
 	if !strings.HasPrefix(t, "#") {
 		return "", false
 	}
 	t = strings.TrimPrefix(t, "#")
 	t = strings.TrimPrefix(t, "#")
 	t = strings.TrimPrefix(t, " ")
-	return t, true
+	return strings.TrimRight(t, " \t\r"), true
 }
 
 // FrontmatterFence is the text of the comment line that opens and closes a

--- a/pkg/runview/bundle_prompts.go
+++ b/pkg/runview/bundle_prompts.go
@@ -54,9 +54,14 @@ func MergeBundlePrompts(f *ast.File, b *bundle.Bundle) error {
 		if err != nil {
 			return fmt.Errorf("bundle: read prompt %s: %w", name, err)
 		}
+		// The declaration's origin is the markdown file: a diagnostic on a
+		// reference inside the body then points there (line 1 — the file
+		// IS the body), not at the main.bot line of the node that consumes
+		// the prompt, which contains no reference at all.
 		f.Prompts = append(f.Prompts, &ast.PromptDecl{
 			Name: stem,
 			Body: string(body),
+			Span: ast.Span{Start: ast.Pos{File: filepath.Join(b.PromptsDir, name), Line: 1, Column: 1}},
 		})
 		declared[stem] = struct{}{}
 	}

--- a/pkg/runview/bundle_prompts_test.go
+++ b/pkg/runview/bundle_prompts_test.go
@@ -3,6 +3,7 @@ package runview
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
@@ -110,6 +111,66 @@ func TestMergeBundlePrompts_DiagnosticsPointAtThePromptFile(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected a C033 on the undeclared var, got %v", res.Diagnostics)
+	}
+}
+
+// An `{{include}}` inside a bundle prompt resolves next to THAT file —
+// inside prompts/ — and never against the process working directory, which
+// on a server is nobody's: a merged prompt used to carry no span, so the
+// include base fell back to "." and slurped whatever the cwd held.
+func TestMergeBundlePrompts_IncludesResolveNextToThePromptFile(t *testing.T) {
+	dir := t.TempDir()
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "helper.md"), []byte("Helper.\n{{include \"sibling.md\"}}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptsDir, "sibling.md"), []byte("FROM-PROMPTS-DIR"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A decoy in the working directory must not be what the include reads.
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "sibling.md"), []byte("FROM-CWD"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	src := "schema out:\n  ok: bool\n\nagent a:\n  model: \"m\"\n  output: out\n  system: helper\n\nworkflow w:\n  entry: a\n  a -> done\n"
+	pr := parser.Parse(filepath.Join(dir, "main.bot"), src)
+	if err := MergeBundlePrompts(pr.File, &bundle.Bundle{PromptsDir: promptsDir}); err != nil {
+		t.Fatal(err)
+	}
+	res := ir.Compile(pr.File)
+	for _, d := range res.Diagnostics {
+		if d.Severity == ir.SeverityError {
+			t.Fatalf("unexpected compile error: %s", d.Error())
+		}
+	}
+	body := res.Workflow.Prompts["helper"].Body
+	if !strings.Contains(body, "FROM-PROMPTS-DIR") || strings.Contains(body, "FROM-CWD") {
+		t.Errorf("include resolved against the wrong directory: body = %q", body)
+	}
+
+	// With the sibling only in the cwd, the include fails loudly rather
+	// than reading the cwd.
+	if err := os.Remove(filepath.Join(promptsDir, "sibling.md")); err != nil {
+		t.Fatal(err)
+	}
+	pr = parser.Parse(filepath.Join(dir, "main.bot"), src)
+	if err := MergeBundlePrompts(pr.File, &bundle.Bundle{PromptsDir: promptsDir}); err != nil {
+		t.Fatal(err)
+	}
+	res = ir.Compile(pr.File)
+	var refused bool
+	for _, d := range res.Diagnostics {
+		if d.Code == ir.DiagBadPromptInclude {
+			refused = true
+		}
+	}
+	if !refused {
+		t.Errorf("a sibling present only in the cwd was accepted: %v", res.Diagnostics)
 	}
 }
 

--- a/pkg/runview/bundle_prompts_test.go
+++ b/pkg/runview/bundle_prompts_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 )
 
 func TestMergeBundlePrompts_InjectsNewPrompts(t *testing.T) {
@@ -70,6 +72,44 @@ func TestMergeBundlePrompts_WorkflowDeclaredWinsOnCollision(t *testing.T) {
 	}
 	if len(f.Prompts) != 1 {
 		t.Errorf("expected 1 prompt (workflow's), got %d", len(f.Prompts))
+	}
+}
+
+// A merged prompt's origin is its markdown file, so a diagnostic on a
+// reference inside the body points THERE — not at the main.bot line of the
+// node that consumes it, which contains no reference and used to be what the
+// position fell back to.
+func TestMergeBundlePrompts_DiagnosticsPointAtThePromptFile(t *testing.T) {
+	dir := t.TempDir()
+	promptsDir := filepath.Join(dir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mdPath := filepath.Join(promptsDir, "review.md")
+	if err := os.WriteFile(mdPath, []byte("Review it.\n\nUses {{vars.typo_var}}.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := "schema out:\n  ok: bool\n\nagent reviewer:\n  model: \"m\"\n  output: out\n  system: review\n\nworkflow w:\n  entry: reviewer\n  reviewer -> done\n"
+	pr := parser.Parse(filepath.Join(dir, "main.bot"), src)
+	for _, d := range pr.Diagnostics {
+		t.Fatalf("unexpected parse diagnostic: %s", d.Error())
+	}
+	if err := MergeBundlePrompts(pr.File, &bundle.Bundle{PromptsDir: promptsDir}); err != nil {
+		t.Fatal(err)
+	}
+	res := ir.Compile(pr.File)
+	var found bool
+	for _, d := range res.Diagnostics {
+		if d.Code != ir.DiagUndeclaredVar {
+			continue
+		}
+		found = true
+		if d.File != mdPath || d.Line != 1 {
+			t.Errorf("C033 at %s:%d, want %s:1 (the prompt file), got %+v", d.File, d.Line, mdPath, d)
+		}
+	}
+	if !found {
+		t.Fatalf("expected a C033 on the undeclared var, got %v", res.Diagnostics)
 	}
 }
 

--- a/pkg/server/server_dsl.go
+++ b/pkg/server/server_dsl.go
@@ -41,11 +41,6 @@ type DiagnosticDTO struct {
 	NodeID   string `json:"node_id,omitempty"`
 	EdgeID   string `json:"edge_id,omitempty"`
 	Hint     string `json:"hint,omitempty"`
-	// Source position of the named node or edge, when the compiler could
-	// attribute one (1-based; absent for a global diagnostic).
-	File   string `json:"file,omitempty"`
-	Line   int    `json:"line,omitempty"`
-	Column int    `json:"column,omitempty"`
 }
 
 func irDiagToDTO(d ir.Diagnostic) DiagnosticDTO {
@@ -60,9 +55,6 @@ func irDiagToDTO(d ir.Diagnostic) DiagnosticDTO {
 		NodeID:   d.NodeID,
 		EdgeID:   d.EdgeID,
 		Hint:     d.Hint,
-		File:     d.File,
-		Line:     d.Line,
-		Column:   d.Column,
 	}
 }
 

--- a/pkg/server/server_dsl.go
+++ b/pkg/server/server_dsl.go
@@ -41,6 +41,11 @@ type DiagnosticDTO struct {
 	NodeID   string `json:"node_id,omitempty"`
 	EdgeID   string `json:"edge_id,omitempty"`
 	Hint     string `json:"hint,omitempty"`
+	// Source position of the named node or edge, when the compiler could
+	// attribute one (1-based; absent for a global diagnostic).
+	File   string `json:"file,omitempty"`
+	Line   int    `json:"line,omitempty"`
+	Column int    `json:"column,omitempty"`
 }
 
 func irDiagToDTO(d ir.Diagnostic) DiagnosticDTO {
@@ -55,6 +60,9 @@ func irDiagToDTO(d ir.Diagnostic) DiagnosticDTO {
 		NodeID:   d.NodeID,
 		EdgeID:   d.EdgeID,
 		Hint:     d.Hint,
+		File:     d.File,
+		Line:     d.Line,
+		Column:   d.Column,
 	}
 }
 

--- a/studio/src/components/ui/PromptOverlayHighlight.tsx
+++ b/studio/src/components/ui/PromptOverlayHighlight.tsx
@@ -109,8 +109,6 @@ function Chunk({ chunk }: { chunk: HighlightChunk }) {
           {chunk.text}
         </span>
       );
-    case "comment":
-      return <span className="text-fg-subtle italic">{chunk.text}</span>;
     case "text":
     default:
       return <span>{chunk.text}</span>;

--- a/studio/src/lib/iterLanguage.test.ts
+++ b/studio/src/lib/iterLanguage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { iterLanguageConfig, iterTokensProvider } from "./iterLanguage";
+
+type Rule = [RegExp, unknown];
+
+const rulesOf = (state: string): Rule[] =>
+  (iterTokensProvider.tokenizer as Record<string, unknown[]>)[state] as Rule[];
+
+const indexOfSource = (rules: Rule[], source: string) =>
+  rules.findIndex(([re]) => re.source === source);
+
+describe("iter tokenizer", () => {
+  it("opens a raw string before it can read a hash as a comment", () => {
+    // `command: \`echo "#1"\`` — the hash is shell, not a comment. Monarch
+    // tries the rules in order, so the backtick opener must precede the
+    // comment rule or the rest of the line is painted as a comment.
+    const root = rulesOf("root");
+    const raw = indexOfSource(root, "`");
+    const comment = indexOfSource(root, "#.*$");
+    expect(raw).toBeGreaterThanOrEqual(0);
+    expect(comment).toBeGreaterThanOrEqual(0);
+    expect(raw).toBeLessThan(comment);
+  });
+
+  it("keeps a hash inside a raw string as string text until the closing backtick", () => {
+    const raw = rulesOf("rawString");
+    expect(raw).toBeDefined();
+    // Nothing in the raw-string state may yield a comment token.
+    for (const [, action] of raw) {
+      expect(JSON.stringify(action)).not.toContain("comment");
+    }
+    // Only the closing backtick pops the state.
+    const closer = raw.find(([re]) => re.source === "`");
+    expect(closer).toBeDefined();
+    expect(JSON.stringify(closer?.[1])).toContain("@pop");
+  });
+
+  it("comments open on a single hash", () => {
+    expect(iterLanguageConfig.comments?.lineComment).toBe("#");
+  });
+});

--- a/studio/src/lib/iterLanguage.test.ts
+++ b/studio/src/lib/iterLanguage.test.ts
@@ -1,38 +1,69 @@
 import { describe, expect, it } from "vitest";
-import { iterLanguageConfig, iterTokensProvider } from "./iterLanguage";
+import { ITER_LANGUAGE_ID, iterLanguageConfig, iterTokensProvider } from "./iterLanguage";
+import { tokenizeLines, typeAt } from "./monarchTokenize";
 
-type Rule = [RegExp, unknown];
-
-const rulesOf = (state: string): Rule[] =>
-  (iterTokensProvider.tokenizer as Record<string, unknown[]>)[state] as Rule[];
-
-const indexOfSource = (rules: Rule[], source: string) =>
-  rules.findIndex(([re]) => re.source === source);
+// Every assertion below runs monaco's REAL Monarch engine on the shipped
+// definition (see monarchTokenize.ts), so it certifies what the editor
+// paints — a rule-order check alone could not see a state that swallows a
+// line, or a `#` painted as a comment inside text.
+const paint = (lines: string[]) => tokenizeLines(ITER_LANGUAGE_ID, iterTokensProvider, lines);
 
 describe("iter tokenizer", () => {
-  it("opens a raw string before it can read a hash as a comment", () => {
-    // `command: \`echo "#1"\`` — the hash is shell, not a comment. Monarch
-    // tries the rules in order, so the backtick opener must precede the
-    // comment rule or the rest of the line is painted as a comment.
-    const root = rulesOf("root");
-    const raw = indexOfSource(root, "`");
-    const comment = indexOfSource(root, "#.*$");
-    expect(raw).toBeGreaterThanOrEqual(0);
-    expect(comment).toBeGreaterThanOrEqual(0);
-    expect(raw).toBeLessThan(comment);
+  it("paints a hash comment, a single hash included", () => {
+    const [top, inline] = paint(["# top comment", 'agent a: # trailing']);
+    expect(typeAt(top, 0)).toContain("comment");
+    expect(typeAt(inline, 9)).toContain("comment");
+    expect(typeAt(inline, 0)).toContain("keyword");
   });
 
-  it("keeps a hash inside a raw string as string text until the closing backtick", () => {
-    const raw = rulesOf("rawString");
-    expect(raw).toBeDefined();
-    // Nothing in the raw-string state may yield a comment token.
-    for (const [, action] of raw) {
-      expect(JSON.stringify(action)).not.toContain("comment");
-    }
-    // Only the closing backtick pops the state.
-    const closer = raw.find(([re]) => re.source === "`");
-    expect(closer).toBeDefined();
-    expect(JSON.stringify(closer?.[1])).toContain("@pop");
+  it("keeps a hash inside a backtick raw string as string text", () => {
+    const [line] = paint(['  command: `echo "#1 ok"`']);
+    expect(typeAt(line, 18)).toContain("string");
+    expect(typeAt(line, 18)).not.toContain("comment");
+  });
+
+  it("keeps a prompt body's `# Heading` as text, and ends the body at the next declaration", () => {
+    const lines = paint([
+      "prompt p:",
+      "  # Review checklist",
+      "  Read {{vars.scope}} first.",
+      "",
+      "agent a:",
+      "  # a real comment",
+      '  model: "m"',
+    ]);
+    expect(typeAt(lines[1], 2)).not.toContain("comment");
+    expect(typeAt(lines[1], 2)).toContain("string");
+    expect(typeAt(lines[2], 7)).toContain("template");
+    expect(typeAt(lines[4], 0)).toContain("keyword"); // `agent` — the body ended
+    expect(typeAt(lines[5], 2)).toContain("comment"); // back in the block grammar
+  });
+
+  it("ends a prompt body declared inside a group at the group's next member", () => {
+    const lines = paint([
+      "group g:",
+      "  prompt p:",
+      "    # Heading inside a group",
+      "    Body.",
+      "  agent a:",
+      '    model: "m"',
+    ]);
+    expect(typeAt(lines[2], 4)).not.toContain("comment");
+    expect(typeAt(lines[4], 2)).toContain("keyword"); // `agent` at the prompt's own indent
+    expect(typeAt(lines[5], 4)).toContain("keyword"); // `model`
+  });
+
+  it("keeps a shell comment inside a `|` block scalar as string text, and ends it at the next property", () => {
+    const lines = paint([
+      "tool t:",
+      "  command: |",
+      "    # not a DSL comment",
+      "    echo hi",
+      "  output: out",
+    ]);
+    expect(typeAt(lines[2], 4)).not.toContain("comment");
+    expect(typeAt(lines[2], 4)).toContain("string");
+    expect(typeAt(lines[4], 2)).toContain("keyword"); // `output` — the scalar ended
   });
 
   it("comments open on a single hash", () => {

--- a/studio/src/lib/iterLanguage.test.ts
+++ b/studio/src/lib/iterLanguage.test.ts
@@ -66,6 +66,37 @@ describe("iter tokenizer", () => {
     expect(typeAt(lines[4], 2)).toContain("keyword"); // `output` — the scalar ended
   });
 
+  it("ends a block scalar whose key sits deeper than its block's siblings", () => {
+    // `command: |` under `recovery: / repair:` — the next property is
+    // shallower than the key but deeper than column 0.
+    const lines = paint([
+      "agent a:",
+      "  recovery:",
+      "    repair:",
+      "      command: |",
+      "        echo hi",
+      "    policy: retry",
+      '  model: "m"',
+    ]);
+    expect(typeAt(lines[4], 8)).toContain("string");
+    expect(typeAt(lines[5], 4)).toContain("identifier"); // `policy` — the scalar ended
+    expect(typeAt(lines[6], 2)).toContain("keyword"); // `model`
+  });
+
+  it("ends a block scalar inside a group at the group's next member", () => {
+    const lines = paint([
+      "group g:",
+      "  tool t:",
+      "    command: |",
+      "      echo hi",
+      "  agent a:",
+      '    model: "m"',
+    ]);
+    expect(typeAt(lines[3], 6)).toContain("string");
+    expect(typeAt(lines[4], 2)).toContain("keyword"); // `agent`
+    expect(typeAt(lines[5], 4)).toContain("keyword"); // `model`
+  });
+
   it("comments open on a single hash", () => {
     expect(iterLanguageConfig.comments?.lineComment).toBe("#");
   });

--- a/studio/src/lib/iterLanguage.ts
+++ b/studio/src/lib/iterLanguage.ts
@@ -4,7 +4,7 @@ export const ITER_LANGUAGE_ID = "iter";
 
 export const iterLanguageConfig: languages.LanguageConfiguration = {
   comments: {
-    lineComment: "##",
+    lineComment: "#",
   },
   brackets: [
     ["{", "}"],
@@ -76,7 +76,7 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
   tokenizer: {
     root: [
       // Comments
-      [/##.*$/, "comment"],
+      [/#.*$/, "comment"],
 
       // Template expressions {{...}}
       [/\{\{/, { token: "delimiter.template", next: "@template" }],

--- a/studio/src/lib/iterLanguage.ts
+++ b/studio/src/lib/iterLanguage.ts
@@ -151,15 +151,16 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
       [/"/, { token: "string.quote", next: "@pop" }],
     ],
 
-    // The rest of a `prompt <name>:` header line. On the following lines a
-    // column-0 line or a line at the header's own indentation ($S2) ends the
-    // declaration; a deeper line opens the body.
+    // The rest of a `prompt <name>:` header line. On the following lines,
+    // only a line indented STRICTLY deeper than the header ($S2 followed by
+    // at least one more space) belongs to the body; any other non-blank line
+    // — at the header's indent, shallower, or at column 0 — ends the
+    // declaration and is re-read by the block grammar.
     promptHeader: [
-      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
       [/^(\s*)(?=\S)/, {
         cases: {
-          "$1==$S2": { token: "@rematch", next: "@pop" },
-          "@default": { token: "white", switchTo: "@promptBody.$S2" },
+          "$1~$S2\\s+": { token: "white", switchTo: "@promptBody.$S2" },
+          "@default": { token: "@rematch", next: "@pop" },
         },
       }],
       [/#.*$/, "comment"],
@@ -170,11 +171,10 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
     // A prompt body: text, with templates and env refs coloured, until a
     // line indented no deeper than the header.
     promptBody: [
-      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
       [/^(\s*)(?=\S)/, {
         cases: {
-          "$1==$S2": { token: "@rematch", next: "@pop" },
-          "@default": "white",
+          "$1~$S2\\s+": "white",
+          "@default": { token: "@rematch", next: "@pop" },
         },
       }],
       [/\{\{/, { token: "delimiter.template", next: "@stringTemplate" }],
@@ -184,13 +184,14 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
     ],
 
     // A block scalar body: the same shape as a prompt body, ended by a line
-    // indented no deeper than its key.
+    // indented no deeper than its key — the key may sit deeper than its
+    // block's siblings (`recovery: / repair: / command: |`), so "shallower
+    // than the key" must end it, not only "exactly the key's indent".
     blockScalar: [
-      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
       [/^(\s*)(?=\S)/, {
         cases: {
-          "$1==$S2": { token: "@rematch", next: "@pop" },
-          "@default": "white",
+          "$1~$S2\\s+": "white",
+          "@default": { token: "@rematch", next: "@pop" },
         },
       }],
       [/\{\{/, { token: "delimiter.template", next: "@stringTemplate" }],

--- a/studio/src/lib/iterLanguage.ts
+++ b/studio/src/lib/iterLanguage.ts
@@ -75,6 +75,24 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
 
   tokenizer: {
     root: [
+      // A prompt declaration: its body is TEXT on the following lines,
+      // where `# Heading` is a heading, not a comment (the lexer keeps it as
+      // prompt text). The header's indentation rides on the state name so
+      // the body ends at the first line indented no deeper than the header —
+      // a prompt inside a `group` is handled like a top-level one.
+      [/^(\s*)(prompt)(\s+)([A-Za-z_]\w*)(\s*:)/, [
+        "white", "keyword", "white", "identifier",
+        { token: "delimiter", next: "@promptHeader.$1" },
+      ]],
+
+      // A block scalar (`command: |`): its body is a script on the following
+      // lines, where `# note` is a shell comment inside the value.
+      [/^(\s*)([A-Za-z_]\w*)(\s*:\s*)(\|[-+]?)(\s*)$/, [
+        "white", "keyword", "delimiter",
+        { token: "delimiter", next: "@blockScalar.$1" },
+        "white",
+      ]],
+
       // Raw strings: a backtick opens a shell command or a literal that a
       // `#` must not close — `echo "#1"` is a command, not a comment. Read
       // before the comment rule so the hash inside stays string-coloured.
@@ -131,6 +149,54 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
       [/[^"\\{$]+/, "string"],
       [/\\./, "string.escape"],
       [/"/, { token: "string.quote", next: "@pop" }],
+    ],
+
+    // The rest of a `prompt <name>:` header line. On the following lines a
+    // column-0 line or a line at the header's own indentation ($S2) ends the
+    // declaration; a deeper line opens the body.
+    promptHeader: [
+      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
+      [/^(\s*)(?=\S)/, {
+        cases: {
+          "$1==$S2": { token: "@rematch", next: "@pop" },
+          "@default": { token: "white", switchTo: "@promptBody.$S2" },
+        },
+      }],
+      [/#.*$/, "comment"],
+      [/\s+/, "white"],
+      [/./, "white"],
+    ],
+
+    // A prompt body: text, with templates and env refs coloured, until a
+    // line indented no deeper than the header.
+    promptBody: [
+      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
+      [/^(\s*)(?=\S)/, {
+        cases: {
+          "$1==$S2": { token: "@rematch", next: "@pop" },
+          "@default": "white",
+        },
+      }],
+      [/\{\{/, { token: "delimiter.template", next: "@stringTemplate" }],
+      [/\$\{[^}]+\}/, "variable"],
+      [/[^{$]+/, "string"],
+      [/[{$]/, "string"],
+    ],
+
+    // A block scalar body: the same shape as a prompt body, ended by a line
+    // indented no deeper than its key.
+    blockScalar: [
+      [/^(?=\S)/, { token: "@rematch", next: "@pop" }],
+      [/^(\s*)(?=\S)/, {
+        cases: {
+          "$1==$S2": { token: "@rematch", next: "@pop" },
+          "@default": "white",
+        },
+      }],
+      [/\{\{/, { token: "delimiter.template", next: "@stringTemplate" }],
+      [/\$\{[^}]+\}/, "variable"],
+      [/[^{$]+/, "string"],
+      [/[{$]/, "string"],
     ],
 
     // A raw string has no escape and may span lines: only the closing

--- a/studio/src/lib/iterLanguage.ts
+++ b/studio/src/lib/iterLanguage.ts
@@ -75,6 +75,11 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
 
   tokenizer: {
     root: [
+      // Raw strings: a backtick opens a shell command or a literal that a
+      // `#` must not close — `echo "#1"` is a command, not a comment. Read
+      // before the comment rule so the hash inside stays string-coloured.
+      [/`/, { token: "string.quote", next: "@rawString" }],
+
       // Comments
       [/#.*$/, "comment"],
 
@@ -126,6 +131,16 @@ export const iterTokensProvider: languages.IMonarchLanguage = {
       [/[^"\\{$]+/, "string"],
       [/\\./, "string.escape"],
       [/"/, { token: "string.quote", next: "@pop" }],
+    ],
+
+    // A raw string has no escape and may span lines: only the closing
+    // backtick ends it. Templates and env refs keep their colour inside it.
+    rawString: [
+      [/\{\{/, { token: "delimiter.template", next: "@stringTemplate" }],
+      [/\$\{[^}]+\}/, "variable"],
+      [/[^`{$]+/, "string"],
+      [/[{$]/, "string"],
+      [/`/, { token: "string.quote", next: "@pop" }],
     ],
 
     stringTemplate: [

--- a/studio/src/lib/monarchTokenize.ts
+++ b/studio/src/lib/monarchTokenize.ts
@@ -1,0 +1,55 @@
+// Test-only driver for monaco's REAL Monarch engine: compiles a language
+// definition with the compiler the editor uses and tokenizes lines with the
+// same tokenizer class, so a highlighting assertion certifies what the editor
+// paints, not a re-implementation of its rules. Kept outside the app bundle
+// (imported by tests only); the services the tokenizer asks for are the
+// minimum it touches on the classic (non-encoded) path.
+import type { languages } from "monaco-editor";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — monaco ships these ESM internals without type declarations
+import { compile } from "monaco-editor/editor/standalone/common/monarch/monarchCompile.js";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { MonarchTokenizer } from "monaco-editor/editor/standalone/common/monarch/monarchLexer.js";
+
+export interface LineToken {
+  offset: number;
+  type: string;
+}
+
+export function tokenizeLines(languageId: string, def: languages.IMonarchLanguage, lines: string[]): LineToken[][] {
+  const lexer = compile(languageId, def);
+  const languageService = {
+    languageIdCodec: { encodeLanguageId: () => 1 },
+    getLanguageIdByLanguageName: () => null,
+    getLanguageIdByMimeType: () => null,
+    isRegisteredLanguageId: () => false,
+    requestBasicLanguageFeatures: () => undefined,
+  };
+  const themeService = { getColorTheme: () => ({ tokenTheme: { match: () => 0 } }) };
+  const configurationService = {
+    getValue: () => 20000,
+    onDidChangeConfiguration: () => ({ dispose: () => undefined }),
+  };
+  const tokenizer = new MonarchTokenizer(languageService, themeService, languageId, lexer, configurationService);
+  let state = tokenizer.getInitialState();
+  const out: LineToken[][] = [];
+  for (const line of lines) {
+    const result = tokenizer.tokenize(line, true, state);
+    out.push(result.tokens.map((t: { offset: number; type: string }) => ({ offset: t.offset, type: t.type })));
+    state = result.endState;
+  }
+  return out;
+}
+
+// typeAt returns the token type covering column `col` of a tokenized line
+// ("" for a line the input did not have).
+export function typeAt(tokens: LineToken[] | undefined, col: number): string {
+  let type = "";
+  for (const t of tokens ?? []) {
+    if (t.offset <= col) {
+      type = t.type;
+    }
+  }
+  return type;
+}

--- a/studio/src/lib/promptHighlight.test.ts
+++ b/studio/src/lib/promptHighlight.test.ts
@@ -65,17 +65,13 @@ describe("highlightPromptBody", () => {
     expect(out).toEqual([{ kind: "text", text: "value=${UNTERMINATED" }]);
   });
 
-  it("recognises ## line comments", () => {
-    const out = highlightPromptBody("## a note\nbody");
+  it("keeps a hash line as text — a prompt body has no comments, and its refs resolve", () => {
+    const out = highlightPromptBody("## Section with {{vars.x}}\n# solo");
     expect(out).toEqual([
-      { kind: "comment", text: "## a note" },
-      { kind: "text", text: "\nbody" },
+      { kind: "text", text: "## Section with " },
+      { kind: "ref", text: "{{vars.x}}" },
+      { kind: "text", text: "\n# solo" },
     ]);
-  });
-
-  it("only treats ## as comment, not # alone", () => {
-    const out = highlightPromptBody("#solo not a comment");
-    expect(out).toEqual([{ kind: "text", text: "#solo not a comment" }]);
   });
 
   it("preserves the input when concatenated across complex inputs", () => {

--- a/studio/src/lib/promptHighlight.ts
+++ b/studio/src/lib/promptHighlight.ts
@@ -10,7 +10,7 @@
  * visual styling.
  */
 
-export type HighlightKind = "text" | "ref" | "envvar" | "comment";
+export type HighlightKind = "text" | "ref" | "envvar";
 
 export interface HighlightChunk {
   kind: HighlightKind;
@@ -39,15 +39,9 @@ export function highlightPromptBody(src: string): HighlightChunk[] {
   while (i < src.length) {
     const ch = src[i];
 
-    // Line comments (## ... up to newline). Mirrors iterLanguage.ts.
-    if (ch === "#" && src[i + 1] === "#") {
-      flushText();
-      const nl = src.indexOf("\n", i);
-      const end = nl === -1 ? src.length : nl;
-      out.push({ kind: "comment", text: src.slice(i, end) });
-      i = end;
-      continue;
-    }
+    // No comment rule: a prompt body has no comments. The lexer keeps every
+    // line of it as text (`# Heading` and `## Section` are markdown), and
+    // the references on such a line are resolved like any other.
 
     // Template references {{ ... }}.
     if (ch === "{" && src[i + 1] === "{") {


### PR DESCRIPTION
Lot 0 ("safety net") of the DSL authoring program (#1010): the measured bottleneck for an agent writing a `.bot` is not the syntax but the cost of reaching correct knowledge and six rules that were written nowhere — so this lot makes the documentation provably correct, the diagnostics actionable, and the most common YAML instinct (`#`) legal. No existing valid `.bot` changes meaning.

## What changes

- **A single `#` opens a comment** (`pkg/dsl/parser/lexer.go`) — additive: 25 of the 48 unparsable doc fences failed on a `# note`. The first line of a prompt body stays text (10 shipped prompts open with `# Heading`); a comment on the prompt header line is a comment. ONE shared definition of "what a comment line looks like" — `workflowfile.CommentText` — is read by the lexer's strict-escape pre-scan, the bundle frontmatter reader (`# ---` accepted), the catalogue's description reader and the studio tokenizer (which gains a raw-string state so a `#` inside a backtick command stays a command). A tab before the hash is refused everywhere, as the lexer refuses tab indentation.
- **Every diagnostic arrives with a fix line and a source position** — `pkg/dsl/ir/diag_catalog.go` (title + fix per C-code, coverage-tested), `Hint` filled at the single `emit` helper (was 0/239 sites), `File/Line/Column` attached to the line an author has to EDIT (the edge line for an edge check, the prompt declaration for a ref inside a prompt body; ~40 sites re-attributed), parser hints per expected token (`system: "…"` → declare a prompt). `iterion validate` prints `file:line:col: severity [code]: message` + `fix:`; `--json` gains a structured `diagnostics[]` (stage, code, severity, position, message, hint, node, edge), ONE document, exit 1 via `cli.ErrReported`. The list is deterministic (position, then code/node/edge/message; position-less findings LAST, since they are usually consequences).
- **Every ```iter fence in docs/ and skills compiles in CI** — `TestDocsIterFencesCompile` over 108 fences (tags `fragment` / `fragment:edges` / `fragment:workflow` / `fragment:<kind>` / `invalid[:CODE]`; indented fences extracted, closing fence at the opening indent). A `fragment` fence is compiled too — with a synthetic workflow when it declares none, excusing only what a fragment may omit — which caught a C012 in the composition page's headline pattern and a C171 in the dsl.md block catalogue. Before: 2/91 compiled, 48 did not parse. The quickref's three broken examples, `patterns.md` (now 10 complete workflows), the `docs/index.md` landing example and 20 other pages are fixed. The six unwritten rules are in `docs/dsl.md` + `SKILL.md` ("Rules the grammar does not show", "Validate in a loop, against the right build"): loop exit on exhaustion, the tool stdout-JSON contract (with a `jq` wrapper that runs in the default sandbox image and keeps the last 20 000 chars), `outputs.*` vs `input.*`, C137, `fail <name>:`, `await_answers`.
- **The parser reports the lexer's diagnosis wherever its error token surfaces** — a tab, an unterminated string, a bad escape (new E005), a stray character or a block-scalar opener followed by text reach the author as what they are, with that code's fix line, from the one emitter every parse site goes through; never "expected INDENT, got Error" plus a hint about opening a block they had opened. An indented line where none can be is named at all three levels; one bad escape is one diagnostic.
- **Docs say what the engine does**: a tool `command:` runs through `bash -c` (not `sh -c`, as CLAUDE.md and four docs said); a spent loop with no exit edge fails `NO_OUTGOING_EDGE` (`LOOP_EXHAUSTED` has no writer); `await_answers_decl` in the EBNF and `fail` in the readable grammar, held to the parser's list by `TestTopLevelDeclarationsAreDocumented`.

## Review

Cross-family plan review (codex gpt-6-astra, xhigh): 22 findings, all dispositioned in the plan; three current bugs filed independently of this PR — #1012 (AST JSON codec drops `group`/`use`/`foreach`/named pools), #1015 (`unparse` corrupts a multi-line raw string), #1013 (inline `{{include}}` on the runner).

Adversarial loop on this diff (`::loop 6`, opus, proof by execution): 5 rounds, 47 findings (14 high, 0 critical), all confirmed, none refuted, all fixed with a test proven red against the pre-fix code first. Round 1 attacked the three surfaces (lexer / diagnostics / docs — 17); rounds 2 and 3 re-attacked each round's fix diff (6 + 6); round 4 read the six fix commits as ONE diff for interactions between fixes (6 — the two highs were a catalogue reader and a lexer diagnosis that no single diff showed); round 5 re-attacked round 4's fixes over the corpus of 142 `.bot` files old-vs-new, ~2 000 mutants and monaco's real Monarch engine (12). The merge gate's `revi/review` verdict is the external gate that closes the loop.

## Overlaps

- #936 (docs-refresh) touches 13 of the same files (SKILL.md, docs/dsl.md, dsl-grammar.md, diagnostics.md, …) with small hunks; both add `fail` to `top_level_decl` on the same line. Whichever merges second rebases.
- #480 (assistant epic): CLAUDE.md, docs/backends.md, diagnostics.md, `pkg/botregistry/registry.go`.

Refs #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)
