### PR TITLE
fix(dispatcher/native): a refused inotify watch no longer freezes the board index until restart

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,18 @@ the hours this one spent.
   by TRANSFER and routes the card by `DecideStuckCard`, the
   terminal-state sink + operator `Reopen`, and the two-release
   expand/contract rollout. Read it when a native-board card is stuck
-  `in_progress` with a dead owner, or before enabling the reaper.
+  `in_progress` with a dead owner, or before enabling the reaper. Read it
+  also on the OTHER native-board silence — **a card written on disk that
+  `/board` and the dispatcher never show**: the store's index rides an
+  inotify watch, and inotify is lossy by construction (`ENOSPC` at
+  `fs.inotify.max_user_watches`, `EMFILE` at `max_user_instances`,
+  `ErrEventOverflow` on a full kernel queue, a watch silently dropped when
+  the directory is removed or renamed). Each of those used to freeze the
+  index until the daemon restarted; each now falls back to a full
+  `issues/` rescan every `ITERION_NATIVE_INDEX_RESCAN` (default `2s`,
+  `off` to disable), taken outside the store mutex. The log names which
+  mode a store is in — that line, not the board, is what tells you the
+  fast path is gone.
 - [docs/github-board-sync.md](docs/github-board-sync.md) — making a GitHub
   **Projects v2** board and the native board the same tickets (ADR-097): the
   permissions (App `organization_projects`, PAT `project`), `iterion issue

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -971,6 +971,31 @@ accept. Anything else leaves the watchdog OFF and is logged once at
 startup on both surfaces, so a mistyped cutover shows up in the log
 rather than as cards that quietly stay stuck.
 
+**The index net (native board, `ITERION_NATIVE_INDEX_RESCAN`).** The
+native store keeps an in-memory index of `issues/*.json`, kept current
+by an inotify watch so a write another process makes (the
+`iterion __mcp-board` subprocess of a run) shows on `/board` and to the
+dispatcher at once. inotify is a lossy carrier: a host at
+`fs.inotify.max_user_watches` refuses the watch (`ENOSPC`), one at
+`max_user_instances` refuses the descriptor (`EMFILE`), a full kernel
+queue drops events (`ErrEventOverflow`), and a watched directory that is
+removed, renamed or unmounted loses its watch without a word (the loop
+asks fsnotify every 5 s whether the watch still exists). Each of those
+used to leave the index frozen until the daemon restarted; each now
+falls back to a full rescan of `issues/` — outside the store mutex, so
+board reads never wait behind disk I/O — every `ITERION_NATIVE_INDEX_RESCAN`
+(a Go duration or a bare number of seconds, default `2s`; measured at
+~4 ms for 200 cards and ~19 ms for 2 000). `off`, `0`, `0s` or any
+non-positive value disables the net and restores the blind-until-restart
+behaviour; an unparsable value falls back to `2s`. The symptom the net
+answers is a card written on disk that `/board` never shows; the log
+says which mode the store is in (`native index watcher unavailable: …
+falling back to a 2s disk rescan`, `kernel event queue overflowed; index
+rebuilt from disk`, `inotify watch on issues/ lost mid-life`). A card
+whose file is present but momentarily unreadable is kept as last seen,
+never dropped; a vanished `issues/` directory is an error that leaves the
+index as it was, never an empty board.
+
 **The un-leased horizon (cloud board).** A claim a mixed-fleet write
 stripped of its lease is only reclaimable once nothing has touched the
 card for `ITERION_BOARD_UNLEASED_CLAIM_HORIZON` (default `24h`): an

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -980,14 +980,17 @@ dispatcher at once. inotify is a lossy carrier: a host at
 `max_user_instances` refuses the descriptor (`EMFILE`), a full kernel
 queue drops events (`ErrEventOverflow`), and a watched directory that is
 removed, renamed or unmounted loses its watch without a word (the loop
-asks fsnotify every 5 s whether the watch still exists, and hands over after two consecutive empty answers). Each of those
-used to leave the index frozen until the daemon restarted; each now
-falls back to a full rescan of `issues/` — outside the store mutex, so
-board reads never wait behind disk I/O — every `ITERION_NATIVE_INDEX_RESCAN`
-(a Go duration or a bare number of seconds, default `2s`; measured at
-~4 ms for 200 cards and ~19 ms for 2 000). `off`, `0`, `0s` or any
-non-positive value disables the net and restores the blind-until-restart
-behaviour; an unparsable value falls back to `2s`. The symptom the net
+asks fsnotify every 5 s whether the watch still exists, and hands over
+after two consecutive empty answers). Each of those used to leave the
+index frozen until the daemon restarted; each now falls back to a full
+rescan of `issues/` — outside the store mutex, so board reads never wait
+behind disk I/O — every `ITERION_NATIVE_INDEX_RESCAN` (a Go duration or a
+bare number of seconds, default `2s`; measured at ~4 ms for 200 cards and
+~19 ms for 2 000). `off`, `0`, `0s` or any non-positive value disables the
+net and restores the blind-until-restart behaviour. Anything else — `OFF`,
+`none`, `2 s` — is not a disable this recognises: it falls back to `2s`
+rather than guess an operator out of their net, and the line the store
+writes when it arms one names the value it ignored. The symptom the net
 answers is a card written on disk that `/board` never shows; the log
 says which mode the store is in (`native index watcher unavailable: …
 falling back to a 2s disk rescan`, `kernel event queue overflowed; index

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -980,7 +980,7 @@ dispatcher at once. inotify is a lossy carrier: a host at
 `max_user_instances` refuses the descriptor (`EMFILE`), a full kernel
 queue drops events (`ErrEventOverflow`), and a watched directory that is
 removed, renamed or unmounted loses its watch without a word (the loop
-asks fsnotify every 5 s whether the watch still exists). Each of those
+asks fsnotify every 5 s whether the watch still exists, and hands over after two consecutive empty answers). Each of those
 used to leave the index frozen until the daemon restarted; each now
 falls back to a full rescan of `issues/` — outside the store mutex, so
 board reads never wait behind disk I/O — every `ITERION_NATIVE_INDEX_RESCAN`

--- a/pkg/dispatcher/native/index_write_sweep_test.go
+++ b/pkg/dispatcher/native/index_write_sweep_test.go
@@ -1,0 +1,54 @@
+package native
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The dirty-set merge of Reconcile rests on one invariant: every write to
+// s.index goes through setIndexLocked or dropIndexLocked, which mark the
+// id while a scan is in flight. A mutator that wrote the map directly
+// would be reverted by the next overflow rebuild without a test noticing,
+// so the invariant is held by this sweep over the package's source, the
+// way bot_resolver_sweep_test.go holds the role-bot constants.
+func TestEveryIndexWriteGoesThroughTheChokePoint(t *testing.T) {
+	direct := regexp.MustCompile(`s\.index\[[^\]]+\]\s*=|delete\(s\.index,`)
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var offenders []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == "store_index.go" {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if direct.MatchString(line) {
+				offenders = append(offenders, name+":"+itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("index written outside setIndexLocked/dropIndexLocked (the write would escape the rebuild's dirty set):\n  %s", strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/pkg/dispatcher/native/index_write_sweep_test.go
+++ b/pkg/dispatcher/native/index_write_sweep_test.go
@@ -1,12 +1,17 @@
 package native
 
 import (
-	"os"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 )
+
+// chokePointFile holds setIndexLocked and dropIndexLocked themselves, so
+// it is the one file allowed to touch the map's entries directly.
+const chokePointFile = "store_index.go"
 
 // The dirty-set merge of Reconcile rests on one invariant: every write to
 // s.index goes through setIndexLocked or dropIndexLocked, which mark the
@@ -14,41 +19,78 @@ import (
 // would be reverted by the next overflow rebuild without a test noticing,
 // so the invariant is held by this sweep over the package's source, the
 // way bot_resolver_sweep_test.go holds the role-bot constants.
+//
+// The sweep reads the package's SYNTAX, not its spelling. A regexp over
+// the text got this wrong in both directions, and both were reachable:
+//
+//	`s\.index\[[^\]]+\]\s*=` swallows the first `=` of `==`, so
+//	`if s.index[id] == nil {` — a pure READ — failed the build with
+//	"index written outside setIndexLocked", which is exactly wrong; and
+//
+//	it anchors on a receiver spelled `s`, so `x.index[id] = iss` or
+//	`delete(g.s.index, id)` walked straight past it — and the package
+//	already reads through a second chain (store_issues.go's g.s.index),
+//	so that rename is one method away.
+//
+// Walking for an IndexExpr over a `.index` selector has neither problem,
+// and it closes the third hole for free: an ALIAS of the whole map
+// (`idx := s.index; idx[k] = v`) writes it with no dirty mark at all.
+// The one deliberate whole-map write — swapIndexLocked's `s.index =
+// fresh` — is not an entry write and not an alias; the swap IS the choke
+// point for that operation, and it holds mu.
 func TestEveryIndexWriteGoesThroughTheChokePoint(t *testing.T) {
-	direct := regexp.MustCompile(`s\.index\[[^\]]+\]\s*=|delete\(s\.index,`)
-	entries, err := os.ReadDir(".")
+	names, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatal(err)
 	}
+	fset := token.NewFileSet()
 	var offenders []string
-	for _, e := range entries {
-		name := e.Name()
-		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") || name == "store_index.go" {
+	report := func(n ast.Node, what string) {
+		offenders = append(offenders, fset.Position(n.Pos()).String()+": "+what)
+	}
+	for _, name := range names {
+		if strings.HasSuffix(name, "_test.go") || name == chokePointFile {
 			continue
 		}
-		src, err := os.ReadFile(filepath.Join(".", name))
+		f, err := parser.ParseFile(fset, name, nil, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
-		for i, line := range strings.Split(string(src), "\n") {
-			if direct.MatchString(line) {
-				offenders = append(offenders, name+":"+itoa(i+1)+": "+strings.TrimSpace(line))
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.AssignStmt:
+				for _, lhs := range x.Lhs {
+					if isIndexEntry(lhs) {
+						report(lhs, "writes an index entry directly — call setIndexLocked")
+					}
+				}
+				for _, rhs := range x.Rhs {
+					if isIndexMap(rhs) {
+						report(rhs, "aliases the index map — the alias can be written without a dirty mark")
+					}
+				}
+			case *ast.CallExpr:
+				if id, ok := x.Fun.(*ast.Ident); ok && id.Name == "delete" &&
+					len(x.Args) == 2 && isIndexMap(x.Args[0]) {
+					report(x, "deletes an index entry directly — call dropIndexLocked")
+				}
 			}
-		}
+			return true
+		})
 	}
 	if len(offenders) > 0 {
-		t.Fatalf("index written outside setIndexLocked/dropIndexLocked (the write would escape the rebuild's dirty set):\n  %s", strings.Join(offenders, "\n  "))
+		t.Fatalf("the index was written outside setIndexLocked/dropIndexLocked (the write would escape the rebuild's dirty set and be reverted by the next scan):\n  %s", strings.Join(offenders, "\n  "))
 	}
 }
 
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b []byte
-	for n > 0 {
-		b = append([]byte{byte('0' + n%10)}, b...)
-		n /= 10
-	}
-	return string(b)
+// isIndexMap reports whether e is a `….index` selector — the map itself.
+func isIndexMap(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "index"
+}
+
+// isIndexEntry reports whether e is `….index[…]` — one entry of it.
+func isIndexEntry(e ast.Expr) bool {
+	ix, ok := e.(*ast.IndexExpr)
+	return ok && isIndexMap(ix.X)
 }

--- a/pkg/dispatcher/native/labels_adjust.go
+++ b/pkg/dispatcher/native/labels_adjust.go
@@ -77,7 +77,7 @@ func (s *Store) AdjustLabels(id string, add, remove []string) (updated *Issue, c
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, false, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueUpdated,
 		IssueID: iss.ID,

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -71,14 +71,20 @@ var (
 	reconcileScanned  func(*Store)
 )
 
-// markDirtyLocked records an in-process write while a scan is in flight,
+// markDirtyLocked records a write to the index while a scan is in flight,
 // so the swap keeps the index's value for that id. Caller holds mu; every
-// mutator funnels through writeIssueLocked or Delete, which call it.
+// index write funnels through setIndexLocked or dropIndexLocked, which
+// call it.
 func (s *Store) markDirtyLocked(id string) {
 	if s.scanning > 0 {
 		s.dirty[id] = true
 	}
 }
+
+// rebuildPassEnding is a test seam, nil in production: called by the
+// overflow rebuild goroutine after its last scan and before it releases
+// the pending flag — the window in which a request used to be lost.
+var rebuildPassEnding func(*Store)
 
 // Reconcile rebuilds the index from the authoritative on-disk state.
 //
@@ -111,6 +117,13 @@ func (s *Store) Reconcile() error {
 	defer s.reconcileMu.Unlock()
 
 	s.mu.Lock()
+	if s.closed {
+		// A rebuild asked for before Close has nothing to serve; Close
+		// waits for the one in flight and no new one starts.
+		s.mu.Unlock()
+		return nil
+	}
+	epoch := s.scanEpoch
 	s.scanning++
 	if s.dirty == nil {
 		s.dirty = map[string]bool{}
@@ -131,6 +144,14 @@ func (s *Store) Reconcile() error {
 
 	s.mu.Lock()
 	s.scanning--
+	if s.scanEpoch != epoch {
+		// The panic-recovery rebuild swapped a NEWER snapshot in while this
+		// scan ran (it holds mu, so it cannot take reconcileMu); this
+		// older one must not land on top of it. The next tick scans again.
+		s.dirty = nil
+		s.mu.Unlock()
+		return nil
+	}
 	for id := range s.dirty {
 		if cur, ok := s.index[id]; ok {
 			fresh[id] = cur
@@ -157,6 +178,7 @@ func (s *Store) reconcileLocked() error {
 	if err != nil {
 		return err
 	}
+	s.scanEpoch++ // an unlocked scan in flight is now older than the index
 	if warn := s.swapIndexLocked(fresh, unreadable); warn != "" && s.logger != nil {
 		s.logger.Warn("%s", warn)
 	}
@@ -249,10 +271,21 @@ func (s *Store) rebuildAsync(what string) {
 		return // the running pass will see the rerun flag and go again
 	}
 	go func() {
-		defer s.rebuildPending.Store(false)
-		for s.rebuildRerun.CompareAndSwap(true, false) {
-			if err := s.Reconcile(); err != nil {
-				s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
+		for {
+			for s.rebuildRerun.CompareAndSwap(true, false) {
+				if err := s.Reconcile(); err != nil {
+					s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
+				}
+			}
+			if rebuildPassEnding != nil {
+				rebuildPassEnding(s)
+			}
+			s.rebuildPending.Store(false)
+			// A request that arrived between the last check above and this
+			// release failed its own claim on the pending flag and is
+			// relying on this goroutine: look once more, and re-claim.
+			if !s.rebuildRerun.Load() || !s.rebuildPending.CompareAndSwap(false, true) {
+				return
 			}
 		}
 	}()

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -28,9 +28,12 @@ var rescanIntervalOverride *time.Duration
 
 // rescanInterval resolves ITERION_NATIVE_INDEX_RESCAN when the net starts —
 // not at package init, which would read the environment before a test's
-// t.Setenv or an embedding process had set it. A Go duration; "off" or "0"
-// disables the net and restores the historical blind-until-restart
-// behaviour; an unparsable value falls back to the default.
+// t.Setenv or an embedding process had set it. A Go duration or a bare
+// number of seconds; "off", or any duration or number that is zero or
+// negative ("0", "0s", "-1"), disables the net and restores the
+// historical blind-until-restart behaviour — an explicit disable in any
+// spelling is honoured, never quietly replaced by the default; an
+// unparsable value falls back to the default.
 func rescanInterval() time.Duration {
 	if rescanIntervalOverride != nil {
 		return *rescanIntervalOverride
@@ -39,13 +42,19 @@ func rescanInterval() time.Duration {
 	if raw == "" {
 		return defaultRescanInterval
 	}
-	if raw == "off" || raw == "0" {
+	if raw == "off" {
 		return 0
 	}
-	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d <= 0 {
+			return 0
+		}
 		return d
 	}
-	if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+	if n, err := strconv.Atoi(raw); err == nil {
+		if n <= 0 {
+			return 0
+		}
 		return time.Duration(n) * time.Second
 	}
 	return defaultRescanInterval
@@ -226,19 +235,25 @@ func (s *Store) scanIssues() (fresh map[string]*Issue, unreadable map[string]err
 	return fresh, unreadable, nil
 }
 
-// rebuildAsync runs one Reconcile on its own goroutine, coalescing the
-// requests that arrive while it runs. The watcher loop asks for it on a
-// kernel-queue overflow: fsnotify's event channel is unbuffered, so a
-// rebuild run ON the loop's goroutine would stop draining the very queue
-// that just overflowed for the whole of the scan.
+// rebuildAsync runs Reconcile on its own goroutine, coalescing the
+// requests that arrive while one runs into ONE more pass — never dropping
+// them: a request that arrives mid-scan concerns files the running scan
+// listed before they changed. The watcher loop asks for it on a
+// kernel-queue overflow: the store opens fsnotify with NewWatcher, whose
+// event channel is unbuffered, so a rebuild run ON the loop's goroutine
+// would stop draining the very queue that just overflowed for the whole
+// of the scan.
 func (s *Store) rebuildAsync(what string) {
+	s.rebuildRerun.Store(true)
 	if !s.rebuildPending.CompareAndSwap(false, true) {
-		return
+		return // the running pass will see the rerun flag and go again
 	}
 	go func() {
 		defer s.rebuildPending.Store(false)
-		if err := s.Reconcile(); err != nil {
-			s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
+		for s.rebuildRerun.CompareAndSwap(true, false) {
+			if err := s.Reconcile(); err != nil {
+				s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
+			}
 		}
 	}()
 }

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -17,9 +17,19 @@ import (
 )
 
 // defaultRescanInterval is how often a Store whose watch the host refused
-// re-reads issues/ from disk. Measured: a full scan costs ~4 ms for 200
-// cards and ~19 ms for 2000 (≈10 µs a card), and it runs OUTSIDE the store
-// mutex, so at this cadence it is ~1% of one core and stalls no reader.
+// re-reads issues/ from disk.
+//
+// The cost is one ReadDir plus an open+read+parse per card, so it is
+// linear in the board and dominated by the filesystem — measured at ~10 µs
+// a card on a dev box (4 ms for 200, 19 ms for 2 000) and ~45 µs a card in
+// a container on overlayfs (8 ms for 200, 99 ms for 2 000), which is the
+// shape a cloud dispatcher actually runs in. Read it as `cards ×
+// per-card ÷ interval` rather than as one number: at this cadence that is
+// well under 1% of a core for a few hundred cards and a few percent for a
+// few thousand on the slower end.
+//
+// What does NOT vary is the property the cadence rests on: the scan runs
+// OUTSIDE the store mutex, so however long it takes it stalls no reader.
 const defaultRescanInterval = 2 * time.Second
 
 // rescanIntervalOverride lets a test pin the interval; production resolves

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -286,7 +286,20 @@ func (s *Store) rebuildAsync(what string) {
 	if !s.rebuildPending.CompareAndSwap(false, true) {
 		return // the running pass will see the rerun flag and go again
 	}
+	// The ticket Close waits on. Taken under mu and refused once closed is
+	// set, so a request that arrives during or after Close cannot add a
+	// goroutine to a WaitGroup that is already being waited on — and the
+	// pending flag is released, since no goroutine is coming to release it.
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		s.rebuildPending.Store(false)
+		return
+	}
+	s.rebuildWG.Add(1)
+	s.mu.Unlock()
 	go func() {
+		defer s.rebuildWG.Done()
 		for {
 			for s.rebuildRerun.CompareAndSwap(true, false) {
 				if err := s.Reconcile(); err != nil {

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
@@ -23,8 +24,9 @@ import (
 const defaultRescanInterval = 2 * time.Second
 
 // rescanIntervalOverride lets a test pin the interval; production resolves
-// it from the environment when the net starts.
-var rescanIntervalOverride *time.Duration
+// it from the environment when the net starts. Atomic like every seam in
+// this package — see fireSeam.
+var rescanIntervalOverride atomic.Pointer[time.Duration]
 
 // rescanInterval resolves ITERION_NATIVE_INDEX_RESCAN when the net starts —
 // not at package init, which would read the environment before a test's
@@ -35,8 +37,8 @@ var rescanIntervalOverride *time.Duration
 // spelling is honoured, never quietly replaced by the default; an
 // unparsable value falls back to the default.
 func rescanInterval() time.Duration {
-	if rescanIntervalOverride != nil {
-		return *rescanIntervalOverride
+	if d := rescanIntervalOverride.Load(); d != nil {
+		return *d
 	}
 	raw := os.Getenv("ITERION_NATIVE_INDEX_RESCAN")
 	if raw == "" {
@@ -60,16 +62,34 @@ func rescanInterval() time.Duration {
 	return defaultRescanInterval
 }
 
-// reconcileScanning and reconcileScanned are test seams, nil in
+// reconcileScanning and reconcileScanned are test seams, unset in
 // production: the first is called at the start of every disk scan — an
 // in-process write must be able to land while it runs, which it could not
 // if the scan held the store mutex; the second is called by Reconcile
 // after its scan and before the swap — a write that lands there is one
 // the scan did not see, and a swap must not revert it.
 var (
-	reconcileScanning func(*Store)
-	reconcileScanned  func(*Store)
+	reconcileScanning atomic.Pointer[func(*Store)]
+	reconcileScanned  atomic.Pointer[func(*Store)]
 )
+
+// fireSeam calls a seam if one is installed.
+//
+// Every seam in this package is an atomic, never a bare package var,
+// because the goroutines that read them belong to a Store and outlive the
+// test that made it: the watcher loop reads watchCheckIntervalOverride on
+// its own goroutine, the rescan ticker and the rebuild goroutine read
+// these two and rebuildPassEnding on theirs. A store a test leaves
+// running therefore reads the seam the NEXT test assigns — a real data
+// race, reported by `go test -race -shuffle=on ./pkg/dispatcher/native/`
+// against a bare var (write in setWatchCheckInterval, read in
+// (*indexWatcher).loop of an earlier test's store), and the `race` job is
+// a required check.
+func fireSeam(p *atomic.Pointer[func(*Store)], s *Store) {
+	if f := p.Load(); f != nil {
+		(*f)(s)
+	}
+}
 
 // markDirtyLocked records a write to the index while a scan is in flight,
 // so the swap keeps the index's value for that id. Caller holds mu; every
@@ -81,10 +101,10 @@ func (s *Store) markDirtyLocked(id string) {
 	}
 }
 
-// rebuildPassEnding is a test seam, nil in production: called by the
+// rebuildPassEnding is a test seam, unset in production: called by the
 // overflow rebuild goroutine after its last scan and before it releases
 // the pending flag — the window in which a request used to be lost.
-var rebuildPassEnding func(*Store)
+var rebuildPassEnding atomic.Pointer[func(*Store)]
 
 // Reconcile rebuilds the index from the authoritative on-disk state.
 //
@@ -138,9 +158,7 @@ func (s *Store) Reconcile() error {
 		s.mu.Unlock()
 		return err
 	}
-	if reconcileScanned != nil {
-		reconcileScanned(s)
-	}
+	fireSeam(&reconcileScanned, s)
 
 	s.mu.Lock()
 	s.scanning--
@@ -225,9 +243,7 @@ func (s *Store) swapIndexLocked(fresh map[string]*Issue, unreadable map[string]e
 // error, for the caller to decide — the rebuild keeps the last value,
 // NewStore skips it.
 func (s *Store) scanIssues() (fresh map[string]*Issue, unreadable map[string]error, err error) {
-	if reconcileScanning != nil {
-		reconcileScanning(s)
-	}
+	fireSeam(&reconcileScanning, s)
 	fresh = map[string]*Issue{}
 	entries, err := os.ReadDir(filepath.Join(s.root, issuesDir))
 	if err != nil {
@@ -277,9 +293,7 @@ func (s *Store) rebuildAsync(what string) {
 					s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
 				}
 			}
-			if rebuildPassEnding != nil {
-				rebuildPassEnding(s)
-			}
+			fireSeam(&rebuildPassEnding, s)
 			s.rebuildPending.Store(false)
 			// A request that arrived between the last check above and this
 			// release failed its own claim on the pending flag and is

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
-	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
 // defaultRescanInterval is how often a Store whose watch the host refused
@@ -377,7 +376,3 @@ func (r *indexRescanner) Close() error {
 	})
 	return nil
 }
-
-// unused keeps iterlog imported for the logger type used by tests that
-// capture warnings; the package logger is *iterlog.Logger.
-var _ *iterlog.Logger

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -57,13 +58,18 @@ func rescanInterval() time.Duration {
 // after its scan and before the swap — a write that lands there is one
 // the scan did not see, and a swap must not revert it.
 var (
-	reconcileScanning func()
-	reconcileScanned  func()
+	reconcileScanning func(*Store)
+	reconcileScanned  func(*Store)
 )
 
-// reconcileRetries is how many times Reconcile re-scans when an in-process
-// write landed during the scan before it falls back to a locked rebuild.
-const reconcileRetries = 3
+// markDirtyLocked records an in-process write while a scan is in flight,
+// so the swap keeps the index's value for that id. Caller holds mu; every
+// mutator funnels through writeIssueLocked or Delete, which call it.
+func (s *Store) markDirtyLocked(id string) {
+	if s.scanning > 0 {
+		s.dirty[id] = true
+	}
+}
 
 // Reconcile rebuilds the index from the authoritative on-disk state.
 //
@@ -71,109 +77,132 @@ const reconcileRetries = 3
 // a lossy carrier by construction — a host at fs.inotify.max_user_watches
 // refuses the watch outright (ENOSPC), a host at max_user_instances
 // refuses the inotify fd (EMFILE), a full kernel queue drops events
-// (ErrEventOverflow), a watch can go away mid-life — and none of those is
-// recoverable by waiting for an event that will never be sent. Without a
-// net the index is then frozen for the life of the process: every
-// `iterion __mcp-board` write is invisible to /board and to the
-// dispatcher until the daemon restarts.
+// (ErrEventOverflow), the kernel drops a watch whose directory is removed
+// or renamed — and none of those is recoverable by waiting for an event
+// that will never be sent. Without a net the index is then frozen for the
+// life of the process: every `iterion __mcp-board` write is invisible to
+// /board and to the dispatcher until the daemon restarts.
 //
 // The scan — one ReadDir plus a read and a parse per card — runs WITHOUT
 // the store mutex, so a board read never waits behind disk I/O; only the
-// swap takes the lock. An in-process write that lands during the scan
-// (Create, a state move, a Delete) is detected by the write counter and
-// the stale scan is discarded rather than allowed to revert it. A card
-// whose file is present but could not be read keeps the entry the index
-// already holds — a stale-but-readable card beats a forced 404, the policy
-// applyEvent has — and only a file that is gone leaves the index.
+// swap takes the lock, and there is exactly one scan per call whatever
+// the write load. An in-process write that lands during the scan (Create,
+// a state move, a Delete) marks its id dirty, and the swap takes the
+// index's own value for that id — never the scan's, which may predate it.
+// A card whose file is present but could not be read keeps the entry the
+// index already holds (a stale-but-readable card beats a forced 404, the
+// policy applyEvent has); only a file that is gone leaves the index; and
+// an issues/ directory that is gone is an error that leaves the index as
+// it was — never an empty board.
 //
 // Concurrent callers (the ticker, an overflow) are serialised by their own
 // mutex, so two overlapping scans cannot swap in the older one last.
 func (s *Store) Reconcile() error {
 	s.reconcileMu.Lock()
 	defer s.reconcileMu.Unlock()
-	for attempt := 0; attempt < reconcileRetries; attempt++ {
-		s.mu.Lock()
-		before := s.writes
-		s.mu.Unlock()
 
-		fresh, unreadable, err := s.scanIssues()
-		if err != nil {
-			return err
-		}
-		if reconcileScanned != nil {
-			reconcileScanned()
-		}
-
-		s.mu.Lock()
-		if s.writes == before {
-			s.swapIndexLocked(fresh, unreadable)
-			logger := s.logger
-			s.mu.Unlock()
-			warnUnreadable(logger, unreadable)
-			return nil
-		}
-		s.mu.Unlock()
-	}
-	// A write raced every scan: rebuild under the lock, the one window no
-	// write can enter.
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.reconcileLocked()
+	s.scanning++
+	if s.dirty == nil {
+		s.dirty = map[string]bool{}
+	}
+	s.mu.Unlock()
+
+	fresh, unreadable, err := s.scanIssues()
+	if err != nil {
+		s.mu.Lock()
+		s.scanning--
+		s.dirty = nil
+		s.mu.Unlock()
+		return err
+	}
+	if reconcileScanned != nil {
+		reconcileScanned(s)
+	}
+
+	s.mu.Lock()
+	s.scanning--
+	for id := range s.dirty {
+		if cur, ok := s.index[id]; ok {
+			fresh[id] = cur
+		} else {
+			delete(fresh, id)
+		}
+	}
+	s.dirty = nil
+	warn := s.swapIndexLocked(fresh, unreadable)
+	logger := s.logger
+	s.mu.Unlock()
+	if warn != "" && logger != nil {
+		logger.Warn("%s", warn)
+	}
+	return nil
 }
 
 // reconcileLocked is Reconcile with the store mutex already held (the
-// panic-recovery path, and Reconcile's own fallback). On error the previous
-// index is preserved: a stale-but-readable board beats an empty one.
+// panic-recovery path). No in-process write can race it. On error the
+// previous index is preserved: a stale-but-readable board beats an empty
+// one.
 func (s *Store) reconcileLocked() error {
 	fresh, unreadable, err := s.scanIssues()
 	if err != nil {
 		return err
 	}
-	s.swapIndexLocked(fresh, unreadable)
-	warnUnreadable(s.logger, unreadable)
+	if warn := s.swapIndexLocked(fresh, unreadable); warn != "" && s.logger != nil {
+		s.logger.Warn("%s", warn)
+	}
 	return nil
 }
 
 // swapIndexLocked replaces the index with a scan, keeping the entry it
-// already holds for every card the scan could not read. Caller holds mu.
-func (s *Store) swapIndexLocked(fresh map[string]*Issue, unreadable map[string]error) {
+// already holds for every card the scan could not read. It returns the
+// warning to write when the set of unreadable cards CHANGED since the
+// last swap — "" otherwise, so a net ticking every two seconds over one
+// corrupt file says so once, not 1 800 times an hour. Caller holds mu.
+func (s *Store) swapIndexLocked(fresh map[string]*Issue, unreadable map[string]error) string {
 	for id := range unreadable {
 		if prev, ok := s.index[id]; ok {
 			fresh[id] = prev
 		}
 	}
 	s.index = fresh
-}
 
-// warnUnreadable says, once per scan, how many cards were kept from the
-// previous index because their file could not be read, and why for one.
-func warnUnreadable(logger *iterlog.Logger, unreadable map[string]error) {
-	if len(unreadable) == 0 || logger == nil {
-		return
+	ids := make([]string, 0, len(unreadable))
+	for id := range unreadable {
+		ids = append(ids, id)
 	}
-	for id, err := range unreadable {
-		logger.Warn("native index rescan: %d card(s) could not be read and were kept as last seen (e.g. %s: %v)", len(unreadable), id, err)
-		return
+	sort.Strings(ids)
+	fp := strings.Join(ids, ",")
+	if fp == s.unreadableFP {
+		return ""
 	}
+	s.unreadableFP = fp
+	if len(ids) == 0 {
+		return "native index rescan: every issue file reads again"
+	}
+	return fmt.Sprintf("native index rescan: %d card(s) could not be read and are kept as last seen (e.g. %s: %v)", len(ids), ids[0], unreadable[ids[0]])
 }
 
 // scanIssues reads every committed issue file under issues/ into a new
 // map. It touches no store state, so it is safe to call with or without
-// the mutex. A missing issues/ directory is an empty board, not an error.
-// A file that vanished between the listing and the read is gone; a file
-// that is present but could not be read or parsed is returned apart, with
-// its error, for the caller to decide — the rebuild keeps the last value,
+// the mutex. A missing issues/ directory is an ERROR: NewStore creates
+// the directory before it ever scans, so the only way to meet its absence
+// is a directory removed under a running store, and a scan that read it
+// as an empty board would erase every card the index holds. A file that
+// vanished between the listing and the read is gone; a file that is
+// present but could not be read or parsed is returned apart, with its
+// error, for the caller to decide — the rebuild keeps the last value,
 // NewStore skips it.
 func (s *Store) scanIssues() (fresh map[string]*Issue, unreadable map[string]error, err error) {
 	if reconcileScanning != nil {
-		reconcileScanning()
+		reconcileScanning(s)
 	}
 	fresh = map[string]*Issue{}
 	entries, err := os.ReadDir(filepath.Join(s.root, issuesDir))
-	if errors.Is(err, fs.ErrNotExist) {
-		return fresh, nil, nil
-	}
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, fmt.Errorf("native store: scan issues: the issues/ directory is gone (%w) — index kept as last seen", err)
+		}
 		return nil, nil, fmt.Errorf("native store: scan issues: %w", err)
 	}
 	for _, e := range entries {
@@ -197,11 +226,29 @@ func (s *Store) scanIssues() (fresh map[string]*Issue, unreadable map[string]err
 	return fresh, unreadable, nil
 }
 
+// rebuildAsync runs one Reconcile on its own goroutine, coalescing the
+// requests that arrive while it runs. The watcher loop asks for it on a
+// kernel-queue overflow: fsnotify's event channel is unbuffered, so a
+// rebuild run ON the loop's goroutine would stop draining the very queue
+// that just overflowed for the whole of the scan.
+func (s *Store) rebuildAsync(what string) {
+	if !s.rebuildPending.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer s.rebuildPending.Store(false)
+		if err := s.Reconcile(); err != nil {
+			s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
+		}
+	}()
+}
+
 // startFallbackRescan runs Reconcile on a ticker for a Store that has no
 // watcher. It exists so the store's promise — "a write another process
 // makes under issues/ becomes visible through List/Get" — holds on a host
 // that cannot give us a watch, instead of degrading silently until
-// restart. Returns nil when the net is disabled.
+// restart. Returns nil when the net is disabled. A rescan error is logged
+// when it changes, not on every tick.
 func startFallbackRescan(s *Store) *indexRescanner {
 	interval := rescanInterval()
 	if interval <= 0 {
@@ -212,13 +259,24 @@ func startFallbackRescan(s *Store) *indexRescanner {
 		defer close(r.done)
 		t := time.NewTicker(interval)
 		defer t.Stop()
+		lastErr := ""
 		for {
 			select {
 			case <-r.stop:
 				return
 			case <-t.C:
-				if err := s.Reconcile(); err != nil {
-					s.getLogger().Warn("native index rescan: %v", err)
+				err := s.Reconcile()
+				msg := ""
+				if err != nil {
+					msg = err.Error()
+				}
+				if msg != lastErr {
+					lastErr = msg
+					if err != nil {
+						s.getLogger().Warn("native index rescan: %v", err)
+					} else {
+						s.getLogger().Warn("native index rescan: scanning again")
+					}
 				}
 			}
 		}
@@ -244,3 +302,7 @@ func (r *indexRescanner) Close() error {
 	})
 	return nil
 }
+
+// unused keeps iterlog imported for the logger type used by tests that
+// capture warnings; the package logger is *iterlog.Logger.
+var _ *iterlog.Logger

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -30,35 +30,43 @@ var rescanIntervalOverride atomic.Pointer[time.Duration]
 // rescanInterval resolves ITERION_NATIVE_INDEX_RESCAN when the net starts —
 // not at package init, which would read the environment before a test's
 // t.Setenv or an embedding process had set it. A Go duration or a bare
-// number of seconds; "off", or any duration or number that is zero or
-// negative ("0", "0s", "-1"), disables the net and restores the
-// historical blind-until-restart behaviour — an explicit disable in any
-// spelling is honoured, never quietly replaced by the default; an
-// unparsable value falls back to the default.
-func rescanInterval() time.Duration {
+// number of seconds; "off", or a duration or number that is zero or
+// negative ("0", "0s", "-1"), disables the net and restores the historical
+// blind-until-restart behaviour — every DISABLING spelling is honoured,
+// never quietly replaced by the default.
+//
+// Anything else — "OFF", "none", "2 s", a typo — is not a disable this can
+// recognise, and it is deliberately NOT read as one: the fallback is the
+// 2s default, because guessing "the operator meant off" would silently
+// remove the correctness net on a host that has no watch. It is also not
+// swallowed. The second return is that raw value, which the caller (which
+// owns the logger this does not) names in the line it writes when the net
+// starts — an operator who mistyped learns it from the log instead of from
+// a board that stops updating.
+func rescanInterval() (interval time.Duration, unread string) {
 	if d := rescanIntervalOverride.Load(); d != nil {
-		return *d
+		return *d, ""
 	}
 	raw := os.Getenv("ITERION_NATIVE_INDEX_RESCAN")
 	if raw == "" {
-		return defaultRescanInterval
+		return defaultRescanInterval, ""
 	}
 	if raw == "off" {
-		return 0
+		return 0, ""
 	}
 	if d, err := time.ParseDuration(raw); err == nil {
 		if d <= 0 {
-			return 0
+			return 0, ""
 		}
-		return d
+		return d, ""
 	}
 	if n, err := strconv.Atoi(raw); err == nil {
 		if n <= 0 {
-			return 0
+			return 0, ""
 		}
-		return time.Duration(n) * time.Second
+		return time.Duration(n) * time.Second, ""
 	}
-	return defaultRescanInterval
+	return defaultRescanInterval, raw
 }
 
 // reconcileScanning and reconcileScanned are test seams, unset in
@@ -324,11 +332,11 @@ func (s *Store) rebuildAsync(what string) {
 // restart. Returns nil when the net is disabled. A rescan error is logged
 // when it changes, not on every tick.
 func startFallbackRescan(s *Store) *indexRescanner {
-	interval := rescanInterval()
+	interval, unread := rescanInterval()
 	if interval <= 0 {
 		return nil
 	}
-	r := &indexRescanner{interval: interval, stop: make(chan struct{}), done: make(chan struct{})}
+	r := &indexRescanner{interval: interval, envUnread: unread, stop: make(chan struct{}), done: make(chan struct{})}
 	go func() {
 		defer close(r.done)
 		t := time.NewTicker(interval)
@@ -360,10 +368,25 @@ func startFallbackRescan(s *Store) *indexRescanner {
 
 // indexRescanner is the fallback net's goroutine handle.
 type indexRescanner struct {
-	interval  time.Duration
+	interval time.Duration
+	// envUnread is the ITERION_NATIVE_INDEX_RESCAN value the resolver
+	// could not read, "" when there was none — see describe.
+	envUnread string
 	stop      chan struct{}
 	done      chan struct{}
 	closeOnce sync.Once
+}
+
+// describe names the cadence the net runs at, for the one line each
+// caller writes when it arms one. It also names a value the operator set
+// and this could not read: falling back to the default is the safe
+// choice, doing it in silence is not — the board would just keep
+// updating at a cadence nobody asked for.
+func (r *indexRescanner) describe() string {
+	if r.envUnread == "" {
+		return r.interval.String()
+	}
+	return fmt.Sprintf("%s (ITERION_NATIVE_INDEX_RESCAN=%q is neither a Go duration nor a number of seconds and was ignored; %q disables the net)", r.interval, r.envUnread, "off")
 }
 
 func (r *indexRescanner) Close() error {

--- a/pkg/dispatcher/native/reconcile_errors_test.go
+++ b/pkg/dispatcher/native/reconcile_errors_test.go
@@ -3,6 +3,7 @@ package native
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 // A card whose file is present but momentarily unreadable (EACCES here;
@@ -48,5 +49,39 @@ func TestReconcile_KeepsACardWhoseFileIsMomentarilyUnreadable(t *testing.T) {
 	}
 	if _, err := s.Get(gone.ID); err == nil {
 		t.Fatal("a card whose file is gone is still served from the index")
+	}
+}
+
+// A watch-loss callback may already have passed its stop-channel check when
+// Close begins. Once Close has marked the store closed, that late callback
+// must not arm a rescanner that outlives the store. (Landed first in #1020
+// under a `closing` flag of its own; the store's `closed` is that flag.)
+func TestWatchLostAfterCloseBeganArmsNoNet(t *testing.T) {
+	setRescanInterval(t, 20*time.Millisecond)
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	watcher, _, werr := s.watchState()
+	if watcher == nil {
+		_ = s.Close()
+		t.Skipf("this host refused a watch (%v); a watch cannot be lost", werr)
+	}
+
+	// Stage the exact Close boundary under the same mutex: a loss callback
+	// that reaches watchLost after this point is late and must be ignored.
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+	s.watchLost(watcher)
+
+	_, rescanner, _ := s.watchState()
+	if rescanner != nil {
+		_ = rescanner.Close()
+		_ = watcher.Close()
+		t.Fatal("a watch lost after Close began armed a fallback rescanner")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }

--- a/pkg/dispatcher/native/reconcile_errors_test.go
+++ b/pkg/dispatcher/native/reconcile_errors_test.go
@@ -1,11 +1,8 @@
 package native
 
 import (
-	"encoding/json"
 	"os"
-	"path/filepath"
 	"testing"
-	"time"
 )
 
 // A card whose file is present but momentarily unreadable (EACCES here;
@@ -51,98 +48,5 @@ func TestReconcile_KeepsACardWhoseFileIsMomentarilyUnreadable(t *testing.T) {
 	}
 	if _, err := s.Get(gone.ID); err == nil {
 		t.Fatal("a card whose file is gone is still served from the index")
-	}
-}
-
-// A watch lost mid-life — fsnotify's channels closing under the loop —
-// arms the same net as a watch refused at startup, instead of leaving the
-// store blind until restart.
-func TestWatcher_ArmsTheNetWhenTheWatchIsLost(t *testing.T) {
-	setRescanInterval(t, 20*time.Millisecond)
-
-	dir := t.TempDir()
-	s, err := NewStore(dir)
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
-	t.Cleanup(func() { _ = s.Close() })
-	if s.watcher == nil {
-		t.Skipf("this host refused a watch (%v); a watch cannot be lost", s.watcherErr)
-	}
-
-	// The kernel side goes away under the loop's feet.
-	if err := s.watcher.w.Close(); err != nil {
-		t.Fatalf("close the fsnotify watcher: %v", err)
-	}
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		s.mu.Lock()
-		armed := s.watcher == nil && s.rescanner != nil && s.watcherErr != nil
-		s.mu.Unlock()
-		if armed {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	s.mu.Lock()
-	armed := s.watcher == nil && s.rescanner != nil
-	s.mu.Unlock()
-	if !armed {
-		t.Fatal("the lost watch did not arm the fallback net: the store is blind until restart")
-	}
-
-	now := time.Now().UTC().Truncate(time.Second)
-	iss := Issue{ID: "native:after-the-loss", Title: "Seen by the net", State: "backlog", CreatedAt: now, UpdatedAt: now}
-	data, err := json.MarshalIndent(&iss, "", "  ")
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, issuesDir, encodeID(iss.ID)+".json"), data, filePerm); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	deadline = time.Now().Add(fastPathBudget)
-	for time.Now().Before(deadline) {
-		if _, err := s.Get(iss.ID); err == nil {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatal("after the watch was lost, an out-of-process create never became visible")
-}
-
-// A watcher-loss callback may already have passed its stop-channel check when
-// Close begins. Once Close has marked the store as closing, that late callback
-// must not install a fresh rescanner that outlives the store.
-func TestWatcherLossDoesNotArmNetAfterCloseBegins(t *testing.T) {
-	setRescanInterval(t, 20*time.Millisecond)
-
-	s, err := NewStore(t.TempDir())
-	if err != nil {
-		t.Fatalf("NewStore: %v", err)
-	}
-	if s.watcher == nil {
-		_ = s.Close()
-		t.Skipf("this host refused a watch (%v); a watch cannot be lost", s.watcherErr)
-	}
-	watcher := s.watcher
-
-	// Stage the exact Close boundary under the same mutex: a loss callback
-	// that reaches watchLost after this point is late and must be ignored.
-	s.mu.Lock()
-	s.closing = true
-	s.mu.Unlock()
-	s.watchLost(watcher)
-
-	s.mu.Lock()
-	rescanner := s.rescanner
-	s.mu.Unlock()
-	if rescanner != nil {
-		_ = rescanner.Close()
-		_ = watcher.Close()
-		t.Fatal("watcher loss armed a fallback rescanner after close began")
-	}
-	if err := s.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
 	}
 }

--- a/pkg/dispatcher/native/reconcile_reattack_test.go
+++ b/pkg/dispatcher/native/reconcile_reattack_test.go
@@ -88,8 +88,8 @@ func TestWatcher_ArmsTheNetWhenTheKernelDropsTheWatch(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	if s.watcher == nil {
-		t.Skipf("this host refused a watch (%v); a watch cannot be lost", s.watcherErr)
+	if w, _, werr := s.watchState(); w == nil {
+		t.Skipf("this host refused a watch (%v); a watch cannot be lost", werr)
 	}
 
 	issues := filepath.Join(dir, issuesDir)
@@ -140,8 +140,8 @@ func TestClose_LeavesNoNetRunningAfterALostWatch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewStore: %v", err)
 		}
-		if s.watcher == nil {
-			t.Skipf("this host refused a watch (%v)", s.watcherErr)
+		if w, _, werr := s.watchState(); w == nil {
+			t.Skipf("this host refused a watch (%v)", werr)
 		}
 		go func() { _ = os.RemoveAll(filepath.Join(dir, issuesDir)) }()
 		time.Sleep(time.Duration(i%7) * time.Millisecond)
@@ -165,10 +165,10 @@ func TestClose_LeavesNoNetRunningAfterALostWatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
-	if s.watcher == nil {
-		t.Skipf("this host refused a watch (%v)", s.watcherErr)
+	iw, _, werr := s.watchState()
+	if iw == nil {
+		t.Skipf("this host refused a watch (%v)", werr)
 	}
-	iw := s.watcher
 	if err := s.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
@@ -324,8 +324,9 @@ func TestWatcher_OverflowRebuildDoesNotStallTheEventLoop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
-	if s.watcher == nil {
-		t.Skipf("this host refused a watch (%v); the overflow path needs one", s.watcherErr)
+	w, _, werr := s.watchState()
+	if w == nil {
+		t.Skipf("this host refused a watch (%v); the overflow path needs one", werr)
 	}
 
 	stall := make(chan struct{})
@@ -351,7 +352,7 @@ func TestWatcher_OverflowRebuildDoesNotStallTheEventLoop(t *testing.T) {
 		_ = s.Close()
 	})
 
-	s.watcher.w.Errors <- fsnotify.ErrEventOverflow
+	w.w.Errors <- fsnotify.ErrEventOverflow
 	// The rebuild is now parked in its scan. The fast path must still work.
 	writeExternal(t, dir, "native:during-the-rebuild", "Delivered while the rebuild is stalled")
 	deadline := time.Now().Add(2 * time.Second)

--- a/pkg/dispatcher/native/reconcile_reattack_test.go
+++ b/pkg/dispatcher/native/reconcile_reattack_test.go
@@ -20,9 +20,7 @@ import (
 // whether its watch still exists.
 func setWatchCheckInterval(t *testing.T, d time.Duration) {
 	t.Helper()
-	prev := watchCheckIntervalOverride
-	watchCheckIntervalOverride = &d
-	t.Cleanup(func() { watchCheckIntervalOverride = prev })
+	setSeam(t, &watchCheckIntervalOverride, d)
 }
 
 // writeExternal drops an issue file under issues/ behind the store's
@@ -204,13 +202,11 @@ func TestReconcile_ScansOnceWhateverTheWriteLoad(t *testing.T) {
 	}
 
 	var scans atomic.Int32
-	prev := reconcileScanning
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s { // another test's store may still be ticking down its Cleanup
 			scans.Add(1)
 		}
-	}
-	t.Cleanup(func() { reconcileScanning = prev })
+	})
 
 	stop := make(chan struct{})
 	done := make(chan struct{})
@@ -330,13 +326,11 @@ func TestWatcher_OverflowRebuildDoesNotStallTheEventLoop(t *testing.T) {
 	}
 
 	stall := make(chan struct{})
-	prev := reconcileScanning
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s { // stall only this store's rebuild
 			<-stall
 		}
-	}
-	t.Cleanup(func() { reconcileScanning = prev })
+	})
 	release := func() {
 		select {
 		case <-stall:

--- a/pkg/dispatcher/native/reconcile_reattack_test.go
+++ b/pkg/dispatcher/native/reconcile_reattack_test.go
@@ -1,0 +1,368 @@
+package native
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// setWatchCheckInterval pins how often the watcher loop asks fsnotify
+// whether its watch still exists.
+func setWatchCheckInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := watchCheckIntervalOverride
+	watchCheckIntervalOverride = &d
+	t.Cleanup(func() { watchCheckIntervalOverride = prev })
+}
+
+// writeExternal drops an issue file under issues/ behind the store's
+// back, the way `iterion __mcp-board` does.
+func writeExternal(t *testing.T, dir, id, title string) {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	iss := Issue{ID: id, Title: title, State: "backlog", CreatedAt: now, UpdatedAt: now}
+	data, err := json.MarshalIndent(&iss, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, issuesDir, encodeID(id)+".json"), data, filePerm); err != nil {
+		t.Fatalf("write external issue: %v", err)
+	}
+}
+
+// The issues/ directory going away under a running store is an error
+// that leaves the index as it was — never an empty board swapped in
+// without a word, which is what a "missing directory = empty board"
+// reading did on exactly the host the net runs on.
+func TestReconcile_KeepsTheIndexWhenTheIssuesDirectoryVanishes(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	for i := 0; i < 3; i++ {
+		if _, err := s.Create(Issue{Title: fmt.Sprintf("card %d", i), State: "backlog"}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+	if err := os.RemoveAll(filepath.Join(dir, issuesDir)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Reconcile(); err == nil {
+		t.Fatal("a vanished issues/ directory was read as an empty board, not reported")
+	}
+	got, err := s.List(ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("the board was wiped by a vanished directory: %d cards left", len(got))
+	}
+}
+
+// The loss that really happens: the watched directory is removed or
+// replaced, the kernel drops the inotify watch (IN_IGNORED) and fsnotify
+// forgets it without closing a channel or sending an error. The loop
+// notices from fsnotify's own watch list and hands the store to the net.
+func TestWatcher_ArmsTheNetWhenTheKernelDropsTheWatch(t *testing.T) {
+	setRescanInterval(t, 20*time.Millisecond)
+	setWatchCheckInterval(t, 20*time.Millisecond)
+
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if s.watcher == nil {
+		t.Skipf("this host refused a watch (%v); a watch cannot be lost", s.watcherErr)
+	}
+
+	issues := filepath.Join(dir, issuesDir)
+	if err := os.RemoveAll(issues); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(issues, dirPerm); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		armed := s.watcher == nil && s.rescanner != nil && s.watcherErr == errWatchLost
+		s.mu.Unlock()
+		if armed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	s.mu.Lock()
+	armed := s.watcher == nil && s.rescanner != nil
+	s.mu.Unlock()
+	if !armed {
+		t.Fatal("the kernel dropped the watch and the store still believes its fast path is armed: blind until restart")
+	}
+
+	writeExternal(t, dir, "native:after-the-loss", "Seen by the net")
+	deadline = time.Now().Add(fastPathBudget)
+	for time.Now().Before(deadline) {
+		if _, err := s.Get("native:after-the-loss"); err == nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("after the kernel dropped the watch, an out-of-process create never became visible")
+}
+
+// A watch lost while the store is closing arms nothing, and a net armed
+// just before Close does not outlive it.
+func TestClose_LeavesNoNetRunningAfterALostWatch(t *testing.T) {
+	setRescanInterval(t, 20*time.Millisecond)
+	setWatchCheckInterval(t, 2*time.Millisecond)
+
+	for i := 0; i < 30; i++ {
+		dir := t.TempDir()
+		s, err := NewStore(dir)
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		if s.watcher == nil {
+			t.Skipf("this host refused a watch (%v)", s.watcherErr)
+		}
+		go func() { _ = os.RemoveAll(filepath.Join(dir, issuesDir)) }()
+		time.Sleep(time.Duration(i%7) * time.Millisecond)
+		if err := s.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		s.mu.Lock()
+		r := s.rescanner
+		s.mu.Unlock()
+		if r != nil {
+			select {
+			case <-r.done:
+			default:
+				t.Fatalf("iteration %d: a rescanner armed by the lost watch is still running after Close", i)
+			}
+		}
+	}
+
+	// And a loss reported after Close arms nothing at all.
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if s.watcher == nil {
+		t.Skipf("this host refused a watch (%v)", s.watcherErr)
+	}
+	iw := s.watcher
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s.watchLost(iw)
+	s.mu.Lock()
+	r := s.rescanner
+	s.mu.Unlock()
+	if r != nil {
+		t.Fatal("a loss reported after Close armed a net")
+	}
+}
+
+// Under sustained in-process writes the rebuild still scans exactly once
+// per call — no retry, no fall-back to a scan under the store mutex — and
+// loses no card.
+func TestReconcile_ScansOnceWhateverTheWriteLoad(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	ids := make([]string, 0, 50)
+	for i := 0; i < 50; i++ {
+		iss, err := s.Create(Issue{Title: fmt.Sprintf("card %d", i), State: "backlog"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		ids = append(ids, iss.ID)
+	}
+
+	var scans atomic.Int32
+	prev := reconcileScanning
+	reconcileScanning = func(st *Store) {
+		if st == s { // another test's store may still be ticking down its Cleanup
+			scans.Add(1)
+		}
+	}
+	t.Cleanup(func() { reconcileScanning = prev })
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for n := 0; ; n++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			title := fmt.Sprintf("edit %d", n)
+			if _, err := s.Update(ids[n%len(ids)], Patch{Title: &title}); err != nil {
+				t.Errorf("Update: %v", err)
+				return
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+	const calls = 5
+	for i := 0; i < calls; i++ {
+		if err := s.Reconcile(); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+	}
+	close(stop)
+	<-done
+
+	if got := scans.Load(); got != calls {
+		t.Fatalf("%d Reconcile calls under write load performed %d scans; want exactly one scan per call", calls, got)
+	}
+	got, err := s.List(ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(ids) {
+		t.Fatalf("cards lost under write load: %d of %d left", len(got), len(ids))
+	}
+}
+
+// The "cards could not be read" warning is written when the set changes,
+// not on every tick of a two-second net over one corrupt file.
+func TestReconcile_WarnsAboutUnreadableCardsWhenTheSetChanges(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a 000 file; the unreadable case cannot be staged")
+	}
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	var buf bytes.Buffer
+	s.SetLogger(iterlog.NewFallback(iterlog.LevelWarn, &buf))
+
+	a, err := s.Create(Issue{Title: "a", State: "backlog"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.Create(Issue{Title: "b", State: "backlog"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(s.issuePath(a.ID), filePerm)
+		_ = os.Chmod(s.issuePath(b.ID), filePerm)
+	})
+
+	count := func() int { return strings.Count(buf.String(), "could not be read") }
+	if err := os.Chmod(s.issuePath(a.ID), 0); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := s.Reconcile(); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+	}
+	if got := count(); got != 1 {
+		t.Fatalf("one unreadable card over five rescans produced %d warnings, want 1\n%s", got, buf.String())
+	}
+	if err := os.Chmod(s.issuePath(b.ID), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := count(); got != 2 {
+		t.Fatalf("a second unreadable card did not produce a new warning (%d)", got)
+	}
+	_ = os.Chmod(s.issuePath(a.ID), filePerm)
+	_ = os.Chmod(s.issuePath(b.ID), filePerm)
+	if err := s.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !strings.Contains(buf.String(), "reads again") {
+		t.Fatalf("recovery was not reported\n%s", buf.String())
+	}
+}
+
+// The rebuild a kernel-queue overflow asks for runs off the watcher
+// goroutine: fsnotify's event channel is unbuffered, so a rebuild ON the
+// loop would stop draining the very queue that just overflowed for the
+// whole of the scan. While the rebuild is stalled, the fast path still
+// delivers.
+func TestWatcher_OverflowRebuildDoesNotStallTheEventLoop(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if s.watcher == nil {
+		t.Skipf("this host refused a watch (%v); the overflow path needs one", s.watcherErr)
+	}
+
+	stall := make(chan struct{})
+	prev := reconcileScanning
+	reconcileScanning = func(st *Store) {
+		if st == s { // stall only this store's rebuild
+			<-stall
+		}
+	}
+	t.Cleanup(func() { reconcileScanning = prev })
+	release := func() {
+		select {
+		case <-stall:
+		default:
+			close(stall)
+		}
+	}
+	t.Cleanup(func() {
+		release()
+		for s.rebuildPending.Load() {
+			time.Sleep(time.Millisecond)
+		}
+		_ = s.Close()
+	})
+
+	s.watcher.w.Errors <- fsnotify.ErrEventOverflow
+	// The rebuild is now parked in its scan. The fast path must still work.
+	writeExternal(t, dir, "native:during-the-rebuild", "Delivered while the rebuild is stalled")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		s.mu.Lock()
+		_, ok := s.index["native:during-the-rebuild"]
+		s.mu.Unlock()
+		if ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("the event loop stopped delivering while the overflow rebuild ran")
+}

--- a/pkg/dispatcher/native/reconcile_round3_test.go
+++ b/pkg/dispatcher/native/reconcile_round3_test.go
@@ -35,14 +35,12 @@ func TestApplyEvent_DuringARebuildIsNotReverted(t *testing.T) {
 	scanned := make(chan struct{})
 	release := make(chan struct{})
 	var once atomic.Bool
-	prev := reconcileScanned
-	reconcileScanned = func(st *Store) {
+	setSeam(t, &reconcileScanned, func(st *Store) {
 		if st == s && once.CompareAndSwap(false, true) {
 			close(scanned)
 			<-release
 		}
-	}
-	t.Cleanup(func() { reconcileScanned = prev })
+	})
 	t.Cleanup(func() {
 		select {
 		case <-release:
@@ -94,8 +92,7 @@ func TestRebuildAsync_RerunsForARequestThatArrivedMidPass(t *testing.T) {
 	var scans atomic.Int32
 	entered := make(chan struct{}, 1)
 	release := make(chan struct{})
-	prev := reconcileScanning
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st != s {
 			return
 		}
@@ -103,8 +100,7 @@ func TestRebuildAsync_RerunsForARequestThatArrivedMidPass(t *testing.T) {
 			entered <- struct{}{}
 			<-release
 		}
-	}
-	t.Cleanup(func() { reconcileScanning = prev })
+	})
 
 	s.rebuildAsync("first")
 	<-entered

--- a/pkg/dispatcher/native/reconcile_round3_test.go
+++ b/pkg/dispatcher/native/reconcile_round3_test.go
@@ -1,6 +1,8 @@
 package native
 
 import (
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -136,5 +138,36 @@ func TestRescanInterval_HonoursEveryZeroSpelling(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 	if _, r, _ := s.watchState(); r == nil || r.interval != 1500*time.Millisecond {
 		t.Fatalf("1500ms not honoured: %+v", r)
+	}
+}
+
+// A value the resolver cannot read is not a disable and is not swallowed:
+// the net falls back to the default (guessing "they meant off" would
+// remove the correctness net on a host that has no watch), and the line
+// the store writes when it arms the net names the value it ignored — the
+// only way an operator who mistyped finds out before the board stops
+// updating.
+func TestRescanInterval_NamesTheValueItCouldNotRead(t *testing.T) {
+	refuseWatch(t)
+	for _, raw := range []string{"2 s", "OFF", "none", "later"} {
+		t.Setenv("ITERION_NATIVE_INDEX_RESCAN", raw)
+		s, err := NewStore(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		_, r, _ := s.watchState()
+		if r == nil {
+			_ = s.Close()
+			t.Fatalf("ITERION_NATIVE_INDEX_RESCAN=%q disabled the net; only a disabling spelling may do that", raw)
+		}
+		if r.interval != defaultRescanInterval {
+			_ = s.Close()
+			t.Fatalf("ITERION_NATIVE_INDEX_RESCAN=%q armed a %s net, want the %s default", raw, r.interval, defaultRescanInterval)
+		}
+		if got := r.describe(); !strings.Contains(got, strconv.Quote(raw)) {
+			_ = s.Close()
+			t.Fatalf("the store armed the net without naming the value it ignored: %q does not mention %q", got, raw)
+		}
+		_ = s.Close()
 	}
 }

--- a/pkg/dispatcher/native/reconcile_round3_test.go
+++ b/pkg/dispatcher/native/reconcile_round3_test.go
@@ -1,0 +1,144 @@
+package native
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitRebuildIdle blocks until no overflow rebuild is pending.
+func waitRebuildIdle(t *testing.T, s *Store) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for s.rebuildPending.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("the overflow rebuild never finished")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// An update the watcher applies while an overflow rebuild has scanned and
+// not yet swapped is marked dirty like an in-process write, so the swap
+// keeps it: the scan read the directory before the event's file existed,
+// and without the mark the swap would put the index back to before it.
+func TestApplyEvent_DuringARebuildIsNotReverted(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if w, _, werr := s.watchState(); w == nil {
+		t.Skipf("this host refused a watch (%v); the overflow path needs one", werr)
+	}
+
+	scanned := make(chan struct{})
+	release := make(chan struct{})
+	var once atomic.Bool
+	prev := reconcileScanned
+	reconcileScanned = func(st *Store) {
+		if st == s && once.CompareAndSwap(false, true) {
+			close(scanned)
+			<-release
+		}
+	}
+	t.Cleanup(func() { reconcileScanned = prev })
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+		waitRebuildIdle(t, s)
+		_ = s.Close()
+	})
+
+	s.rebuildAsync("test")
+	<-scanned // the scan is done and saw no such file; the swap waits
+
+	// The event the watcher applies in between.
+	writeExternal(t, dir, "native:applied-mid-rebuild", "Applied between the scan and the swap")
+	deadline := time.Now().Add(fastPathBudget)
+	for {
+		s.mu.Lock()
+		_, ok := s.index["native:applied-mid-rebuild"]
+		s.mu.Unlock()
+		if ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the fast path did not deliver the create while the rebuild waited")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	close(release)
+	waitRebuildIdle(t, s)
+	if _, err := s.Get("native:applied-mid-rebuild"); err != nil {
+		t.Fatalf("the rebuild's swap reverted a card the watcher applied after the scan: %v", err)
+	}
+}
+
+// A request that arrives while a rebuild runs is deferred to one more
+// pass, never dropped: the running scan listed the directory before the
+// change that prompted the request.
+func TestRebuildAsync_RerunsForARequestThatArrivedMidPass(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var scans atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	prev := reconcileScanning
+	reconcileScanning = func(st *Store) {
+		if st != s {
+			return
+		}
+		if scans.Add(1) == 1 {
+			entered <- struct{}{}
+			<-release
+		}
+	}
+	t.Cleanup(func() { reconcileScanning = prev })
+
+	s.rebuildAsync("first")
+	<-entered
+	s.rebuildAsync("second, mid-pass") // must not be dropped
+	close(release)
+	waitRebuildIdle(t, s)
+	if got := scans.Load(); got != 2 {
+		t.Fatalf("a request that arrived mid-pass produced %d scans in total, want 2 (the running pass plus one more)", got)
+	}
+}
+
+// An explicit disable in any spelling is honoured: "0s" and "-1" are not
+// "unparsable, use the default".
+func TestRescanInterval_HonoursEveryZeroSpelling(t *testing.T) {
+	refuseWatch(t)
+	for _, raw := range []string{"off", "0", "0s", "0ms", "-1", "-5s"} {
+		t.Setenv("ITERION_NATIVE_INDEX_RESCAN", raw)
+		s, err := NewStore(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		_, r, _ := s.watchState()
+		_ = s.Close()
+		if r != nil {
+			t.Fatalf("ITERION_NATIVE_INDEX_RESCAN=%q armed a %s net; an explicit disable was replaced by the default", raw, r.interval)
+		}
+	}
+	t.Setenv("ITERION_NATIVE_INDEX_RESCAN", "1500ms")
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if _, r, _ := s.watchState(); r == nil || r.interval != 1500*time.Millisecond {
+		t.Fatalf("1500ms not honoured: %+v", r)
+	}
+}

--- a/pkg/dispatcher/native/reconcile_round4_test.go
+++ b/pkg/dispatcher/native/reconcile_round4_test.go
@@ -20,22 +20,18 @@ func TestRebuildAsync_DoesNotLoseARequestAtTheEndOfAPass(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	var scans atomic.Int32
-	prevScanning := reconcileScanning
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s {
 			scans.Add(1)
 		}
-	}
-	t.Cleanup(func() { reconcileScanning = prevScanning })
+	})
 
 	var late atomic.Bool
-	prevEnding := rebuildPassEnding
-	rebuildPassEnding = func(st *Store) {
+	setSeam(t, &rebuildPassEnding, func(st *Store) {
 		if st == s && late.CompareAndSwap(false, true) {
 			s.rebuildAsync("arrived as the pass was ending") // the lost-wakeup window
 		}
-	}
-	t.Cleanup(func() { rebuildPassEnding = prevEnding })
+	})
 
 	s.rebuildAsync("first")
 	waitRebuildIdle(t, s)
@@ -63,8 +59,7 @@ func TestClose_WaitsForARebuildInFlightAndRefusesALaterOne(t *testing.T) {
 
 	entered := make(chan struct{}, 1)
 	release := make(chan struct{})
-	prev := reconcileScanning
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s {
 			select {
 			case entered <- struct{}{}:
@@ -72,8 +67,7 @@ func TestClose_WaitsForARebuildInFlightAndRefusesALaterOne(t *testing.T) {
 			}
 			<-release
 		}
-	}
-	t.Cleanup(func() { reconcileScanning = prev })
+	})
 
 	s.rebuildAsync("in flight at Close")
 	<-entered
@@ -96,11 +90,11 @@ func TestClose_WaitsForARebuildInFlightAndRefusesALaterOne(t *testing.T) {
 	waitRebuildIdle(t, s)
 
 	// After Close, a scan is refused before it touches the disk.
-	reconcileScanning = func(st *Store) {
+	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s {
 			t.Error("a scan ran on a closed store")
 		}
-	}
+	})
 	if err := s.Reconcile(); err != nil {
 		t.Fatalf("Reconcile on a closed store: %v", err)
 	}
@@ -120,8 +114,7 @@ func TestReconcile_DoesNotLandAnOlderScanOverTheLockedRebuild(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	var once atomic.Bool
-	prev := reconcileScanned
-	reconcileScanned = func(st *Store) {
+	setSeam(t, &reconcileScanned, func(st *Store) {
 		if st != s || !once.CompareAndSwap(false, true) {
 			return
 		}
@@ -134,8 +127,7 @@ func TestReconcile_DoesNotLandAnOlderScanOverTheLockedRebuild(t *testing.T) {
 		if err != nil {
 			t.Errorf("reconcileLocked: %v", err)
 		}
-	}
-	t.Cleanup(func() { reconcileScanned = prev })
+	})
 
 	if err := s.Reconcile(); err != nil {
 		t.Fatalf("Reconcile: %v", err)

--- a/pkg/dispatcher/native/reconcile_round4_test.go
+++ b/pkg/dispatcher/native/reconcile_round4_test.go
@@ -1,0 +1,146 @@
+package native
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A request that arrives after the rebuild goroutine's last check and
+// before it releases the pending flag used to be lost: it failed its own
+// claim and relied on a pass that was already leaving. The goroutine now
+// looks once more after releasing, and re-claims.
+func TestRebuildAsync_DoesNotLoseARequestAtTheEndOfAPass(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var scans atomic.Int32
+	prevScanning := reconcileScanning
+	reconcileScanning = func(st *Store) {
+		if st == s {
+			scans.Add(1)
+		}
+	}
+	t.Cleanup(func() { reconcileScanning = prevScanning })
+
+	var late atomic.Bool
+	prevEnding := rebuildPassEnding
+	rebuildPassEnding = func(st *Store) {
+		if st == s && late.CompareAndSwap(false, true) {
+			s.rebuildAsync("arrived as the pass was ending") // the lost-wakeup window
+		}
+	}
+	t.Cleanup(func() { rebuildPassEnding = prevEnding })
+
+	s.rebuildAsync("first")
+	waitRebuildIdle(t, s)
+	if got := scans.Load(); got != 2 {
+		t.Fatalf("a request that arrived as the pass was ending produced %d scans in total, want 2", got)
+	}
+	if s.rebuildRerun.Load() {
+		t.Fatal("the rerun flag is left set with no goroutine to honour it")
+	}
+}
+
+// Nothing of a store runs after Close returns: a rebuild in flight is
+// waited for, one asked for afterwards returns at once.
+func TestClose_WaitsForARebuildInFlightAndRefusesALaterOne(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := s.Create(Issue{Title: "kept", State: "backlog"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	prev := reconcileScanning
+	reconcileScanning = func(st *Store) {
+		if st == s {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+		}
+	}
+	t.Cleanup(func() { reconcileScanning = prev })
+
+	s.rebuildAsync("in flight at Close")
+	<-entered
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		_ = s.Close()
+	}()
+	select {
+	case <-closed:
+		t.Fatal("Close returned while a rebuild was still scanning")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close never returned after the rebuild finished")
+	}
+	waitRebuildIdle(t, s)
+
+	// After Close, a scan is refused before it touches the disk.
+	reconcileScanning = func(st *Store) {
+		if st == s {
+			t.Error("a scan ran on a closed store")
+		}
+	}
+	if err := s.Reconcile(); err != nil {
+		t.Fatalf("Reconcile on a closed store: %v", err)
+	}
+}
+
+// A locked rebuild (the panic-recovery path) that lands while an unlocked
+// scan is in flight is NEWER than that scan: the scan's swap must not put
+// the index back to before it.
+func TestReconcile_DoesNotLandAnOlderScanOverTheLockedRebuild(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var once atomic.Bool
+	prev := reconcileScanned
+	reconcileScanned = func(st *Store) {
+		if st != s || !once.CompareAndSwap(false, true) {
+			return
+		}
+		// Between the scan and the swap: a card appears on disk and the
+		// locked rebuild (as recoverMutator would run it) picks it up.
+		writeExternal(t, dir, "native:seen-by-the-locked-rebuild", "Newer than the scan")
+		s.mu.Lock()
+		err := s.reconcileLocked()
+		s.mu.Unlock()
+		if err != nil {
+			t.Errorf("reconcileLocked: %v", err)
+		}
+	}
+	t.Cleanup(func() { reconcileScanned = prev })
+
+	if err := s.Reconcile(); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if _, err := s.Get("native:seen-by-the-locked-rebuild"); err != nil {
+		t.Fatalf("the older unlocked scan landed over the locked rebuild and dropped the card: %v", err)
+	}
+}

--- a/pkg/dispatcher/native/reconcile_round4_test.go
+++ b/pkg/dispatcher/native/reconcile_round4_test.go
@@ -136,3 +136,64 @@ func TestReconcile_DoesNotLandAnOlderScanOverTheLockedRebuild(t *testing.T) {
 		t.Fatalf("the older unlocked scan landed over the locked rebuild and dropped the card: %v", err)
 	}
 }
+
+// Close waits for the rebuild GOROUTINE, not only for the scan inside it.
+// Its work does not end when Reconcile returns: there is a tail — fire the
+// pass-ending seam, release the pending flag, look once more for a request
+// that raced it — and reconcileMu, which Reconcile releases on its way out,
+// says nothing about that. Waiting on reconcileMu alone let Close return
+// with the goroutine still running, which is how a test's own hook gets
+// called after the test completed (a t.Errorf from a dead test panics the
+// binary) and how a leak checker sees a goroutine a closed store still owns.
+func TestClose_WaitsForTheRebuildGoroutineNotOnlyItsScan(t *testing.T) {
+	refuseWatch(t)
+	setRescanInterval(t, 0)
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	inTail := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var once atomic.Bool
+	setSeam(t, &rebuildPassEnding, func(st *Store) {
+		if st != s || !once.CompareAndSwap(false, true) {
+			return
+		}
+		inTail <- struct{}{}
+		<-release
+	})
+
+	s.rebuildAsync("in flight at Close")
+	<-inTail // the scan is over and reconcileMu is released; the goroutine lives on
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		_ = s.Close()
+	}()
+	select {
+	case <-closed:
+		t.Fatal("Close returned while the rebuild goroutine was still running its tail")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close never returned after the rebuild goroutine finished")
+	}
+
+	// And a request that arrives after Close starts no goroutine at all —
+	// it must also hand back the pending flag it claimed, or the store
+	// would look forever busy to anything watching it.
+	setSeam(t, &reconcileScanning, func(st *Store) {
+		if st == s {
+			t.Error("a scan ran on a closed store")
+		}
+	})
+	s.rebuildAsync("after Close")
+	if s.rebuildPending.Load() {
+		t.Fatal("a rebuild refused after Close left the pending flag set")
+	}
+}

--- a/pkg/dispatcher/native/reconcile_test.go
+++ b/pkg/dispatcher/native/reconcile_test.go
@@ -98,8 +98,9 @@ func TestWatcher_ReconcilesOnKernelQueueOverflow(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	if s.watcher == nil {
-		t.Skipf("this host refused a watch (%v); the overflow path needs one", s.watcherErr)
+	w, _, werr := s.watchState()
+	if w == nil {
+		t.Skipf("this host refused a watch (%v); the overflow path needs one", werr)
 	}
 
 	now := time.Now().UTC().Truncate(time.Second)
@@ -122,7 +123,7 @@ func TestWatcher_ReconcilesOnKernelQueueOverflow(t *testing.T) {
 	delete(s.index, iss.ID)
 	s.mu.Unlock()
 
-	s.watcher.w.Errors <- fsnotify.ErrEventOverflow
+	w.w.Errors <- fsnotify.ErrEventOverflow
 
 	waitForIndex(t, s, func() bool {
 		_, ok := s.index[iss.ID]

--- a/pkg/dispatcher/native/reconcile_test.go
+++ b/pkg/dispatcher/native/reconcile_test.go
@@ -51,7 +51,16 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 
 	var duringScan, afterScan *Issue
 	var scanningOnce, scannedOnce sync.Once
-	setSeam(t, &reconcileScanning, func(*Store) {
+	// Both seams check the store: a seam is a PACKAGE hook, and any other
+	// store alive in the binary — one an earlier test left ticking its own
+	// 2s net — fires it too. Unguarded, that store's scan would spend the
+	// sync.Once, this store's scan would find both hooks already used, and
+	// the test would fail on duringScan == nil naming a mutex bug that is
+	// not there. Every other seam in the package is guarded the same way.
+	setSeam(t, &reconcileScanning, func(st *Store) {
+		if st != s {
+			return
+		}
 		scanningOnce.Do(func() {
 			// From another goroutine, bounded: a Create that cannot take
 			// the lock while the scan runs is the failure named.
@@ -72,7 +81,10 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 			}
 		})
 	})
-	setSeam(t, &reconcileScanned, func(*Store) {
+	setSeam(t, &reconcileScanned, func(st *Store) {
+		if st != s {
+			return
+		}
 		scannedOnce.Do(func() {
 			iss, err := s.Create(Issue{Title: "Landed after the scan, before the swap", State: "backlog"})
 			if err != nil {

--- a/pkg/dispatcher/native/reconcile_test.go
+++ b/pkg/dispatcher/native/reconcile_test.go
@@ -5,19 +5,29 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
 
+// setSeam installs a package seam for one test and puts the previous
+// value back afterwards. Every seam is an atomic (see fireSeam) because
+// the goroutines that read them belong to a Store and outlive the test
+// that made it — a bare assignment here races the watcher loop of a store
+// an earlier test left running.
+func setSeam[T any](t *testing.T, p *atomic.Pointer[T], v T) {
+	t.Helper()
+	prev := p.Swap(&v)
+	t.Cleanup(func() { p.Store(prev) })
+}
+
 // setRescanInterval pins the fallback net's interval for one test; 0
 // disables the net.
 func setRescanInterval(t *testing.T, d time.Duration) {
 	t.Helper()
-	prev := rescanIntervalOverride
-	rescanIntervalOverride = &d
-	t.Cleanup(func() { rescanIntervalOverride = prev })
+	setSeam(t, &rescanIntervalOverride, d)
 }
 
 // TestReconcile_DoesNotRevertAWriteThatRacedTheScan pins the two
@@ -41,8 +51,7 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 
 	var duringScan, afterScan *Issue
 	var scanningOnce, scannedOnce sync.Once
-	prevScanning, prevScanned := reconcileScanning, reconcileScanned
-	reconcileScanning = func(*Store) {
+	setSeam(t, &reconcileScanning, func(*Store) {
 		scanningOnce.Do(func() {
 			// From another goroutine, bounded: a Create that cannot take
 			// the lock while the scan runs is the failure named.
@@ -62,8 +71,8 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 				t.Fatal("a Create blocked while Reconcile was scanning: the scan holds the store mutex across its disk I/O")
 			}
 		})
-	}
-	reconcileScanned = func(*Store) {
+	})
+	setSeam(t, &reconcileScanned, func(*Store) {
 		scannedOnce.Do(func() {
 			iss, err := s.Create(Issue{Title: "Landed after the scan, before the swap", State: "backlog"})
 			if err != nil {
@@ -71,8 +80,7 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 			}
 			afterScan = iss
 		})
-	}
-	t.Cleanup(func() { reconcileScanning, reconcileScanned = prevScanning, prevScanned })
+	})
 
 	if err := s.Reconcile(); err != nil {
 		t.Fatalf("Reconcile: %v", err)

--- a/pkg/dispatcher/native/reconcile_test.go
+++ b/pkg/dispatcher/native/reconcile_test.go
@@ -42,7 +42,7 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 	var duringScan, afterScan *Issue
 	var scanningOnce, scannedOnce sync.Once
 	prevScanning, prevScanned := reconcileScanning, reconcileScanned
-	reconcileScanning = func() {
+	reconcileScanning = func(*Store) {
 		scanningOnce.Do(func() {
 			// From another goroutine, bounded: a Create that cannot take
 			// the lock while the scan runs is the failure named.
@@ -63,7 +63,7 @@ func TestReconcile_DoesNotRevertAWriteThatRacedTheScan(t *testing.T) {
 			}
 		})
 	}
-	reconcileScanned = func() {
+	reconcileScanned = func(*Store) {
 		scannedOnce.Do(func() {
 			iss, err := s.Create(Issue{Title: "Landed after the scan, before the swap", State: "backlog"})
 			if err != nil {

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -209,7 +209,7 @@ func NewStore(root string) (*Store, error) {
 		r := s.rescanner
 		s.mu.Unlock()
 		if r != nil {
-			s.logger.Warn("native index watcher unavailable: %v — falling back to a %s disk rescan for out-of-process issue changes", err, r.interval)
+			s.logger.Warn("native index watcher unavailable: %v — falling back to a %s disk rescan for out-of-process issue changes", err, r.describe())
 		} else {
 			s.logger.Warn("native index watcher unavailable: %v, and the rescan net is disabled (ITERION_NATIVE_INDEX_RESCAN=off) — out-of-process issue changes will not be seen until restart", err)
 		}
@@ -338,7 +338,7 @@ func (s *Store) watchLost(iw *indexWatcher) {
 	switch {
 	case logger == nil:
 	case r != nil:
-		logger.Warn("native index watcher: %v — falling back to a %s disk rescan for out-of-process issue changes", errWatchLost, r.interval)
+		logger.Warn("native index watcher: %v — falling back to a %s disk rescan for out-of-process issue changes", errWatchLost, r.describe())
 	default:
 		logger.Warn("native index watcher: %v, and the rescan net is disabled (ITERION_NATIVE_INDEX_RESCAN=off) — out-of-process issue changes will not be seen until restart", errWatchLost)
 	}

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -238,9 +238,18 @@ func (s *Store) getLogger() *iterlog.Logger {
 	return s.logger
 }
 
-// Close releases store-owned resources (currently the fsnotify
-// watcher goroutine). Safe to call multiple times; safe on a Store
+// Close releases what the store owns: the fsnotify watcher goroutine, the
+// rescan net that replaces it on a host that refused a watch, and the
+// overflow-rebuild goroutine. Safe to call multiple times; safe on a Store
 // whose watcher never started.
+//
+// The guarantee, stated as narrowly as it is true: when Close returns, no
+// scan, no index write and no disk I/O of this store is in flight, and
+// none will start. What it does not promise is that every goroutine that
+// ever mentioned this store has returned — a watcher loop that handed the
+// store over itself (watchLost) is not waited for, because the store no
+// longer holds it by then. It is on its last two instructions and touches
+// no store state.
 func (s *Store) Close() error {
 	if s == nil {
 		return nil

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -87,8 +87,11 @@ type Store struct {
 	closed bool
 
 	// rebuildPending coalesces the rebuilds a kernel-queue overflow asks
-	// for: one runs at a time, the next overflow waits for it.
+	// for: one runs at a time; rebuildRerun records that a request came
+	// in while it ran, so the goroutine goes once more instead of
+	// dropping a request the running scan could not have covered.
 	rebuildPending atomic.Bool
+	rebuildRerun   atomic.Bool
 
 	// reconcileMu serialises Reconcile callers (the rescan ticker, a
 	// kernel-queue overflow, an explicit call) so two scans cannot
@@ -274,6 +277,15 @@ func (s *Store) populateIndex() error {
 		}
 	}
 	return nil
+}
+
+// watchState reports the watcher, the net and the reason for its absence
+// under the lock — the watcher goroutine swaps them when a watch is lost,
+// so a reader outside the lock races it.
+func (s *Store) watchState() (*indexWatcher, *indexRescanner, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.watcher, s.rescanner, s.watcherErr
 }
 
 // errWatchLost is recorded on a store whose armed watch went away

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -54,6 +55,7 @@ type Store struct {
 	// host refused a watch — the rescanner below then carries the same
 	// promise on a slower path.
 	watcher *indexWatcher
+
 	// watcherErr records why the watch could not be armed. From the
 	// outside an absent watcher is a nil field either way, so without
 	// this a host that refused the watch (ENOSPC at max_user_watches,
@@ -67,17 +69,26 @@ type Store struct {
 	// was armed (the fast path needs no net) or when the net is off.
 	rescanner *indexRescanner
 
-	// closing is set under mu before Close snapshots the background workers.
-	// It prevents a watcher-loss callback that was already in flight from
-	// installing a new rescanner after that snapshot.
-	closing bool
+	// scanning is >0 while Reconcile's disk scan is in flight, and dirty
+	// collects the ids the process wrote meanwhile (every file write
+	// through writeIssueLocked, every Delete) — both under mu. The scan
+	// runs WITHOUT the mutex, so a write that lands during it is one the
+	// scan may or may not have seen; the swap takes the index's own value
+	// for those ids instead of the scan's, and never reverts one.
+	scanning int
+	dirty    map[string]bool
 
-	// writes counts the in-process mutations of issues/ (every file write
-	// through writeIssueLocked, every Delete), under mu. Reconcile scans
-	// the disk WITHOUT the mutex and compares this counter before it
-	// swaps the scan in: a write that landed during the scan makes the
-	// scan stale, and a stale swap would revert it.
-	writes uint64
+	// unreadableFP fingerprints the set of cards the last scan could not
+	// read, so the warning is written when the set CHANGES, not on every
+	// tick of a net that runs every two seconds.
+	unreadableFP string
+
+	// closed is set by Close under mu; a watch lost after that arms no net.
+	closed bool
+
+	// rebuildPending coalesces the rebuilds a kernel-queue overflow asks
+	// for: one runs at a time, the next overflow waits for it.
+	rebuildPending atomic.Bool
 
 	// reconcileMu serialises Reconcile callers (the rescan ticker, a
 	// kernel-queue overflow, an explicit call) so two scans cannot
@@ -174,12 +185,16 @@ func NewStore(root string) (*Store, error) {
 	// store is blind until the daemon restarts". Record why, say so,
 	// and fall back to the reconciliation net so the store's promise
 	// survives a host that has no watch descriptor to give.
-	if w, err := startIndexWatcher(s); err == nil {
-		s.watcher = w
-	} else {
+	// startIndexWatcher publishes the watcher on the store itself, under
+	// the lock and before its loop runs.
+	if _, err := startIndexWatcher(s); err != nil {
+		s.mu.Lock()
 		s.watcherErr = err
-		if s.rescanner = startFallbackRescan(s); s.rescanner != nil {
-			s.logger.Warn("native index watcher unavailable: %v — falling back to a %s disk rescan for out-of-process issue changes", err, s.rescanner.interval)
+		s.rescanner = startFallbackRescan(s)
+		r := s.rescanner
+		s.mu.Unlock()
+		if r != nil {
+			s.logger.Warn("native index watcher unavailable: %v — falling back to a %s disk rescan for out-of-process issue changes", err, r.interval)
 		} else {
 			s.logger.Warn("native index watcher unavailable: %v, and the rescan net is disabled (ITERION_NATIVE_INDEX_RESCAN=off) — out-of-process issue changes will not be seen until restart", err)
 		}
@@ -216,18 +231,28 @@ func (s *Store) Close() error {
 	}
 	// Snapshot under the lock — a watch lost mid-life swaps these from the
 	// watcher goroutine — and close outside it: closing the watcher waits
-	// for its loop, which may itself be waiting for the store mutex.
+	// for its loop, which may itself be waiting for the store mutex. The
+	// closed flag stops a loss detected after this point from arming a
+	// net; one that was armed between the snapshot and the watcher's exit
+	// is picked up by the second look.
 	s.mu.Lock()
-	s.closing = true
+	s.closed = true
 	rescanner, watcher := s.rescanner, s.watcher
 	s.mu.Unlock()
 	if rescanner != nil {
 		_ = rescanner.Close()
 	}
+	var err error
 	if watcher != nil {
-		return watcher.Close()
+		err = watcher.Close()
 	}
-	return nil
+	s.mu.Lock()
+	late := s.rescanner
+	s.mu.Unlock()
+	if late != nil && late != rescanner {
+		_ = late.Close()
+	}
+	return err
 }
 
 // populateIndex loads every committed issue file into the index at
@@ -252,16 +277,20 @@ func (s *Store) populateIndex() error {
 }
 
 // errWatchLost is recorded on a store whose armed watch went away
-// mid-life: fsnotify closed its channels under the loop.
-var errWatchLost = errors.New("fsnotify watch lost mid-life (event channel closed)")
+// mid-life: the kernel dropped it (issues/ removed, renamed or unmounted
+// — fsnotify forgets the watch and says nothing), or fsnotify closed its
+// channels under the loop.
+var errWatchLost = errors.New("inotify watch on issues/ lost mid-life")
 
-// watchLost is called by the watcher loop when its channels close without
-// a Close: the fast path is gone, so the store arms the same net a watch
-// refused at startup gets, with the reason recorded, instead of serving
-// its last snapshot until restart.
+// watchLost is called by the watcher loop once it has established that
+// its watch is gone: the fast path is over, so the store arms the same
+// net a watch refused at startup gets, with the reason recorded, instead
+// of serving its last snapshot until restart. The fsnotify watcher is
+// closed here — its inotify descriptor is the scarce thing on the host
+// this happens on — and a store that is closing arms nothing.
 func (s *Store) watchLost(iw *indexWatcher) {
 	s.mu.Lock()
-	if s.closing || s.watcher != iw {
+	if s.watcher != iw || s.closed {
 		s.mu.Unlock()
 		return
 	}
@@ -270,6 +299,7 @@ func (s *Store) watchLost(iw *indexWatcher) {
 	s.rescanner = startFallbackRescan(s)
 	r, logger := s.rescanner, s.logger
 	s.mu.Unlock()
+	_ = iw.w.Close()
 	switch {
 	case logger == nil:
 	case r != nil:

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -99,6 +99,12 @@ type Store struct {
 	rebuildPending atomic.Bool
 	rebuildRerun   atomic.Bool
 
+	// rebuildWG counts the rebuild goroutines that are alive, so Close
+	// waits for the whole goroutine and not merely for the scan inside it.
+	// The Add happens under mu and only while !closed, which is what keeps
+	// it from racing Close's Wait.
+	rebuildWG sync.WaitGroup
+
 	// reconcileMu serialises Reconcile callers (the rescan ticker, a
 	// kernel-queue overflow, an explicit call) so two scans cannot
 	// overlap and swap in the older one last. Never held with mu by the
@@ -261,9 +267,15 @@ func (s *Store) Close() error {
 	if late != nil && late != rescanner {
 		_ = late.Close()
 	}
-	// An overflow rebuild already scanning finishes under reconcileMu;
-	// wait for it so nothing of this store runs after Close returns. One
-	// asked for later returns at once: Reconcile refuses a closed store.
+	// Wait for the overflow rebuild GOROUTINE, not just for the scan it is
+	// running. Its work does not end when Reconcile returns: it still has
+	// to release the pending flag and look once more for a request that
+	// raced it, and reconcileMu — released inside Reconcile — says nothing
+	// about that tail. rebuildAsync takes a ticket under mu and refuses one
+	// once closed is set, which is set above, so no goroutine can be added
+	// after this Wait starts.
+	s.rebuildWG.Wait()
+	// And for an explicit Reconcile from outside, which owns no ticket.
 	s.reconcileMu.Lock()
 	s.reconcileMu.Unlock() //nolint:staticcheck // an empty critical section is the wait
 	return err

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -187,8 +187,9 @@ func NewStore(root string) (*Store, error) {
 	}
 	s.seq = maxSeq + 1
 
-	// Populate the index from disk. Corrupt files are skipped (a
-	// warning would be nice but the store doesn't carry a logger).
+	// Populate the index from disk. A file that cannot be read is skipped
+	// and said so — the store carries a logger from its construction above,
+	// which is what the note that used to sit here said it did not.
 	if err := s.populateIndex(); err != nil {
 		return nil, err
 	}
@@ -246,10 +247,15 @@ func (s *Store) Close() error {
 	}
 	// Snapshot under the lock — a watch lost mid-life swaps these from the
 	// watcher goroutine — and close outside it: closing the watcher waits
-	// for its loop, which may itself be waiting for the store mutex. The
-	// closed flag stops a loss detected after this point from arming a
-	// net; one that was armed between the snapshot and the watcher's exit
-	// is picked up by the second look.
+	// for its loop, which may itself be waiting for the store mutex.
+	//
+	// Setting closed and taking the snapshot in ONE critical section is
+	// what makes the hand-over safe, and watchLost reads both in one of
+	// its own: it either finished arming its net before this snapshot (so
+	// the snapshot has it) or is refused after (so there is nothing to
+	// find). The second look further down is therefore belt and braces
+	// today, kept because it costs one mutex and because it is what a
+	// future change that splits this critical section would need.
 	s.mu.Lock()
 	s.closed = true
 	rescanner, watcher := s.rescanner, s.watcher

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -78,6 +78,12 @@ type Store struct {
 	scanning int
 	dirty    map[string]bool
 
+	// scanEpoch is bumped by the locked rebuild (the panic-recovery path,
+	// which holds mu and so cannot wait on reconcileMu): an unlocked scan
+	// that started before the bump is older than the index and does not
+	// swap in.
+	scanEpoch uint64
+
 	// unreadableFP fingerprints the set of cards the last scan could not
 	// read, so the warning is written when the set CHANGES, not on every
 	// tick of a net that runs every two seconds.
@@ -255,6 +261,11 @@ func (s *Store) Close() error {
 	if late != nil && late != rescanner {
 		_ = late.Close()
 	}
+	// An overflow rebuild already scanning finishes under reconcileMu;
+	// wait for it so nothing of this store runs after Close returns. One
+	// asked for later returns at once: Reconcile refuses a closed store.
+	s.reconcileMu.Lock()
+	s.reconcileMu.Unlock() //nolint:staticcheck // an empty critical section is the wait
 	return err
 }
 
@@ -268,7 +279,7 @@ func (s *Store) populateIndex() error {
 		return err
 	}
 	for id, iss := range fresh {
-		s.index[id] = iss
+		s.setIndexLocked(id, iss)
 	}
 	if len(unreadable) > 0 && s.logger != nil {
 		for id, err := range unreadable {

--- a/pkg/dispatcher/native/store_board.go
+++ b/pkg/dispatcher/native/store_board.go
@@ -110,7 +110,7 @@ func (s *Store) migrateStateLocked(from, to, reason string) (int, error) {
 		if err := s.writeIssueLocked(next); err != nil {
 			return touched, fmt.Errorf("native store: write %s during state migration: %w", id, err)
 		}
-		s.index[id] = next
+		s.setIndexLocked(id, next)
 		if err := s.emitPostCommitEvent(Event{
 			Type:    EvtIssueState,
 			IssueID: id,

--- a/pkg/dispatcher/native/store_fields.go
+++ b/pkg/dispatcher/native/store_fields.go
@@ -30,7 +30,7 @@ func (s *Store) applyFieldRewriteLocked(
 		if err := s.writeIssueLocked(next); err != nil {
 			return touched, fmt.Errorf("native store: write %s during %s: %w", id, reason, err)
 		}
-		s.index[id] = next
+		s.setIndexLocked(id, next)
 		if err := s.emitPostCommitEvent(Event{
 			Type:    EvtIssueUpdated,
 			IssueID: id,

--- a/pkg/dispatcher/native/store_index.go
+++ b/pkg/dispatcher/native/store_index.go
@@ -1,0 +1,18 @@
+package native
+
+// setIndexLocked and dropIndexLocked are the ONLY two writes to the index
+// (index_write_sweep_test.go refuses any other). Every mutation — an
+// in-process mutator, the watcher applying an out-of-process event — is
+// marked dirty while a rebuild's scan is in flight, so the swap that
+// follows takes the index's own value for that id and never reverts what
+// landed after the scan read the directory. Caller holds mu.
+func (s *Store) setIndexLocked(id string, iss *Issue) {
+	s.index[id] = iss
+	s.markDirtyLocked(id)
+}
+
+// dropIndexLocked removes id from the index; see setIndexLocked.
+func (s *Store) dropIndexLocked(id string) {
+	delete(s.index, id)
+	s.markDirtyLocked(id)
+}

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -113,7 +113,7 @@ func (s *Store) createLocked(in Issue) (created *Issue, err error) {
 	if err := s.writeIssueLocked(&in); err != nil {
 		return nil, err
 	}
-	s.index[in.ID] = cloneIssue(&in)
+	s.setIndexLocked(in.ID, cloneIssue(&in))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueCreated,
 		IssueID: in.ID,
@@ -363,7 +363,7 @@ func (s *Store) Update(id string, p Patch) (updated *Issue, err error) {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueUpdated,
 		IssueID: iss.ID,
@@ -508,7 +508,7 @@ func (s *Store) Reopen(id, toState string) (updated *Issue, err error) {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueState,
 		IssueID: iss.ID,
@@ -600,7 +600,7 @@ func (s *Store) setStateReasonLocked(iss *Issue, newState, byMarker, reason stri
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueState,
 		IssueID: iss.ID,
@@ -647,7 +647,7 @@ func (s *Store) ClaimForLaunch(id string) (claimed *Issue, won bool, err error) 
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, false, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueState,
 		IssueID: iss.ID,
@@ -711,7 +711,7 @@ func (s *Store) promoteUnblockedDependentsLocked(closedID string) error {
 		if err := s.writeIssueLocked(next); err != nil {
 			return err
 		}
-		s.index[id] = cloneIssue(next)
+		s.setIndexLocked(id, cloneIssue(next))
 		if err := s.emitPostCommitEvent(Event{
 			Type:    EvtIssueUnblocked,
 			IssueID: id,
@@ -758,8 +758,7 @@ func (s *Store) Delete(id string) (err error) {
 	if err := os.Remove(s.issuePath(id)); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("native store: remove issue: %w", err)
 	}
-	delete(s.index, id)
-	s.markDirtyLocked(id)
+	s.dropIndexLocked(id)
 	return s.emitPostCommitEvent(Event{Type: EvtIssueDeleted, IssueID: id})
 }
 
@@ -808,7 +807,6 @@ func (s *Store) writeIssueLocked(iss *Issue) error {
 	if err := store.WriteFileAtomic(p, data, filePerm); err != nil {
 		return fmt.Errorf("native store: write issue: %w", err)
 	}
-	s.markDirtyLocked(iss.ID)
 	return nil
 }
 

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -759,7 +759,7 @@ func (s *Store) Delete(id string) (err error) {
 		return fmt.Errorf("native store: remove issue: %w", err)
 	}
 	delete(s.index, id)
-	s.writes++
+	s.markDirtyLocked(id)
 	return s.emitPostCommitEvent(Event{Type: EvtIssueDeleted, IssueID: id})
 }
 
@@ -808,7 +808,7 @@ func (s *Store) writeIssueLocked(iss *Issue) error {
 	if err := store.WriteFileAtomic(p, data, filePerm); err != nil {
 		return fmt.Errorf("native store: write issue: %w", err)
 	}
-	s.writes++
+	s.markDirtyLocked(iss.ID)
 	return nil
 }
 

--- a/pkg/dispatcher/native/store_labels.go
+++ b/pkg/dispatcher/native/store_labels.go
@@ -186,7 +186,7 @@ func (s *Store) applyLabelRewriteLocked(
 		if err := s.writeIssueLocked(next); err != nil {
 			return touched, fmt.Errorf("native store: write %s during %s: %w", id, eventType, err)
 		}
-		s.index[id] = next
+		s.setIndexLocked(id, next)
 		evtPayload := map[string]any{"issue_id": id}
 		for k, v := range payload {
 			evtPayload[k] = v

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -40,7 +40,7 @@ func (s *Store) Claim(id, marker string) (tok tracker.ClaimToken, err error) {
 		if err := s.writeIssueLocked(iss); err != nil {
 			return tracker.ClaimToken{}, err
 		}
-		s.index[iss.ID] = cloneIssue(iss)
+		s.setIndexLocked(iss.ID, cloneIssue(iss))
 		return tracker.ClaimToken{Marker: marker, Epoch: iss.ClaimEpoch}, nil
 	}
 	iss.Claim = marker
@@ -51,7 +51,7 @@ func (s *Store) Claim(id, marker string) (tok tracker.ClaimToken, err error) {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return tracker.ClaimToken{}, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type: EvtIssueClaimed, IssueID: id,
 		Payload: map[string]any{"marker": marker, "claim_epoch": iss.ClaimEpoch},
@@ -94,7 +94,7 @@ func (s *Store) RenewClaim(id string, tok tracker.ClaimToken) (err error) {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (s *Store) setLaunchRefusalLocked(iss *Issue, r *LaunchRefusal) error {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	return s.emitPostCommitEvent(Event{
 		Type:    EvtIssueLaunchRefused,
 		IssueID: iss.ID,
@@ -238,7 +238,7 @@ func (s *Store) setLastRunLocked(iss *Issue, runID, workdir string) error {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	return s.emitPostCommitEvent(Event{
 		Type:    EvtIssueLastRun,
 		IssueID: iss.ID,
@@ -272,7 +272,7 @@ func (s *Store) setAwaitingInputLocked(iss *Issue, v bool) error {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	return s.emitPostCommitEvent(Event{
 		Type:    EvtIssueUpdated,
 		IssueID: iss.ID,
@@ -329,7 +329,7 @@ func (s *Store) setGaveUpLocked(iss *Issue, g *GiveUp) error {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	payload := map[string]any{"gave_up": stamped != nil}
 	if stamped != nil {
 		payload["run_id"] = stamped.RunID
@@ -412,7 +412,7 @@ func (s *Store) AddComment(id, author, body string) (updated *Issue, comment *Co
 	if err := s.writeIssueLocked(iss); err != nil {
 		return nil, nil, err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type:    EvtIssueComment,
 		IssueID: id,
@@ -452,7 +452,7 @@ func (s *Store) releaseLocked(iss *Issue, marker string) error {
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	return s.emitPostCommitEvent(Event{
 		Type: EvtIssueReleased, IssueID: iss.ID,
 		Payload: map[string]any{"marker": marker},

--- a/pkg/dispatcher/native/store_reaper.go
+++ b/pkg/dispatcher/native/store_reaper.go
@@ -62,7 +62,7 @@ func (s *Store) ReclaimExpired(id string, prev tracker.ClaimToken, marker string
 	if err := s.writeIssueLocked(iss); err != nil {
 		return tracker.ClaimToken{}, "", err
 	}
-	s.index[iss.ID] = cloneIssue(iss)
+	s.setIndexLocked(iss.ID, cloneIssue(iss))
 	if err := s.emitPostCommitEvent(Event{
 		Type: EvtIssueClaimed, IssueID: id,
 		Payload: map[string]any{"marker": marker, "claim_epoch": iss.ClaimEpoch, "reclaimed_from": prev.Marker},

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -19,6 +19,15 @@ func newTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
+	// A store that is never closed keeps its inotify instance and, since
+	// the reconciliation net landed, a rescan ticker that ReadDirs the
+	// t.TempDir long after it was removed. Measured on `go test -count=4
+	// -v` before this line: 475 EMFILE ("too many open files") at
+	// fs.inotify.max_user_instances, 221 rescans of a deleted issues/,
+	// and — the part that cost real coverage — five of the watch-dependent
+	// tests SKIPPING, because by the time they ran there was no inotify
+	// instance left for them to arm a watch with.
+	t.Cleanup(func() { _ = s.Close() })
 	return s
 }
 

--- a/pkg/dispatcher/native/watcher.go
+++ b/pkg/dispatcher/native/watcher.go
@@ -239,8 +239,13 @@ func idFromIssuePath(eventPath, issuesPath string) string {
 func applyEvent(s *Store, id string, op fsnotify.Op) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Every mutation here is marked dirty like an in-process write: an
+	// overflow-triggered rebuild scans the disk with the mutex released
+	// while this loop keeps draining the backlog, and its swap must not
+	// revert what the events applied after the scan read those files.
 	if op&fsnotify.Remove == fsnotify.Remove {
 		delete(s.index, id)
+		s.markDirtyLocked(id)
 		return
 	}
 	iss, err := s.readIssueFromDisk(id)
@@ -255,8 +260,10 @@ func applyEvent(s *Store, id string, op fsnotify.Op) {
 		// never fires and leaves the tombstone in the index.
 		if errors.Is(err, tracker.ErrNotFound) {
 			delete(s.index, id)
+			s.markDirtyLocked(id)
 		}
 		return
 	}
 	s.index[id] = iss
+	s.markDirtyLocked(id)
 }

--- a/pkg/dispatcher/native/watcher.go
+++ b/pkg/dispatcher/native/watcher.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -72,6 +73,12 @@ func startIndexWatcher(s *Store) (*indexWatcher, error) {
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
 	}
+	// Published on the store BEFORE the loop starts: the loop may report
+	// the watch lost within its first tick, and watchLost only acts on the
+	// watcher the store holds.
+	s.mu.Lock()
+	s.watcher = iw
+	s.mu.Unlock()
 	go iw.loop(s, issuesPath)
 	return iw, nil
 }
@@ -93,10 +100,29 @@ func (iw *indexWatcher) Close() error {
 	return iw.closeErr
 }
 
-// lost is called when a channel closed under the loop. Close closes the
-// stop channel BEFORE it closes the fsnotify watcher, so a closed channel
-// with no stop pending is a watch that went away on its own: hand the
-// store over to the fallback net.
+// defaultWatchCheckInterval is how often the loop asks fsnotify whether
+// its watch still exists. The kernel drops an inotify watch when the
+// watched directory is removed, renamed or unmounted (IN_IGNORED), and
+// fsnotify then forgets it WITHOUT closing a channel or sending an error —
+// the loop would sit forever on a watch that no longer exists. The
+// question costs one mutex and a map lookup.
+const defaultWatchCheckInterval = 5 * time.Second
+
+// watchCheckIntervalOverride lets a test tighten the check.
+var watchCheckIntervalOverride *time.Duration
+
+func watchCheckInterval() time.Duration {
+	if watchCheckIntervalOverride != nil {
+		return *watchCheckIntervalOverride
+	}
+	return defaultWatchCheckInterval
+}
+
+// lost is called when the loop has established that its watch is gone:
+// fsnotify forgot it (the directory went away), or a channel closed
+// without a Close pending — Close closes the stop channel BEFORE it closes
+// the fsnotify watcher, so a closed channel with no stop pending is not a
+// Close. Hand the store over to the fallback net.
 func (iw *indexWatcher) lost(s *Store) {
 	select {
 	case <-iw.stop:
@@ -110,10 +136,17 @@ func (iw *indexWatcher) loop(s *Store, issuesPath string) {
 	defer close(iw.done)
 	var mu sync.Mutex // guards seenErr only — store mutex covers index access.
 	var seenErr bool
+	check := time.NewTicker(watchCheckInterval())
+	defer check.Stop()
 	for {
 		select {
 		case <-iw.stop:
 			return
+		case <-check.C:
+			if len(iw.w.WatchList()) == 0 {
+				iw.lost(s)
+				return
+			}
 		case ev, ok := <-iw.w.Events:
 			if !ok {
 				iw.lost(s)
@@ -136,18 +169,20 @@ func (iw *indexWatcher) loop(s *Store, issuesPath string) {
 			// signal: events were DROPPED, and nothing will resend
 			// them. The watcher stays alive and the index is rebuilt
 			// from disk — the second lossy carrier gets the same net
-			// as a refused watch. Log once per session so a host that
-			// overflows every second does not flood the log. Wrap the
-			// flag in a tiny mutex because the events + errors selects
-			// run on the same goroutine but the linter cannot prove that.
+			// as a refused watch — on another goroutine: this one must
+			// keep draining the unbuffered event channel, or the queue
+			// that just overflowed fills again during the repair. Log
+			// once per session so a host that overflows every second
+			// does not flood the log. Wrap the flag in a tiny mutex
+			// because the events + errors selects run on the same
+			// goroutine but the linter cannot prove that.
 			mu.Lock()
 			first := !seenErr
 			seenErr = true
 			mu.Unlock()
 			if errors.Is(err, fsnotify.ErrEventOverflow) {
-				if rerr := s.Reconcile(); rerr != nil {
-					s.getLogger().Error("native index watcher: kernel event queue overflowed and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", rerr)
-				} else if first {
+				s.rebuildAsync("kernel event queue overflowed")
+				if first {
 					s.getLogger().Warn("native index watcher: kernel event queue overflowed; index rebuilt from disk (further overflows rebuild silently this session)")
 				}
 				continue

--- a/pkg/dispatcher/native/watcher.go
+++ b/pkg/dispatcher/native/watcher.go
@@ -138,15 +138,25 @@ func (iw *indexWatcher) loop(s *Store, issuesPath string) {
 	var seenErr bool
 	check := time.NewTicker(watchCheckInterval())
 	defer check.Stop()
+	misses := 0 // consecutive empty watch lists: two before the watch is declared lost
 	for {
 		select {
 		case <-iw.stop:
 			return
 		case <-check.C:
+			// Two consecutive empty answers before the hand-over: on Linux
+			// the list empties only when the kernel dropped the watch, and
+			// a second look costs one tick; on a backend where the list
+			// could read empty for an instant, one look would demote a live
+			// watch to the rescan net for good.
 			if len(iw.w.WatchList()) == 0 {
-				iw.lost(s)
-				return
+				if misses++; misses >= 2 {
+					iw.lost(s)
+					return
+				}
+				continue
 			}
+			misses = 0
 		case ev, ok := <-iw.w.Events:
 			if !ok {
 				iw.lost(s)
@@ -244,8 +254,7 @@ func applyEvent(s *Store, id string, op fsnotify.Op) {
 	// while this loop keeps draining the backlog, and its swap must not
 	// revert what the events applied after the scan read those files.
 	if op&fsnotify.Remove == fsnotify.Remove {
-		delete(s.index, id)
-		s.markDirtyLocked(id)
+		s.dropIndexLocked(id)
 		return
 	}
 	iss, err := s.readIssueFromDisk(id)
@@ -259,11 +268,9 @@ func applyEvent(s *Store, id string, op fsnotify.Op) {
 		// which does not wrap fs.ErrNotExist — matching on the latter
 		// never fires and leaves the tombstone in the index.
 		if errors.Is(err, tracker.ErrNotFound) {
-			delete(s.index, id)
-			s.markDirtyLocked(id)
+			s.dropIndexLocked(id)
 		}
 		return
 	}
-	s.index[id] = iss
-	s.markDirtyLocked(id)
+	s.setIndexLocked(id, iss)
 }

--- a/pkg/dispatcher/native/watcher.go
+++ b/pkg/dispatcher/native/watcher.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -13,9 +14,17 @@ import (
 )
 
 // newFSWatcher is the seam through which a test can make the host refuse
-// a watch (the ENOSPC/EMFILE a loaded CI runner really returns). Production
-// always gets fsnotify's own constructor.
-var newFSWatcher = fsnotify.NewWatcher
+// a watch (the ENOSPC/EMFILE a loaded CI runner really returns). Atomic
+// like every seam in this package — see fireSeam.
+var newFSWatcher atomic.Pointer[func() (*fsnotify.Watcher, error)]
+
+// fsWatcherCtor is fsnotify's own constructor unless a test installed one.
+func fsWatcherCtor() func() (*fsnotify.Watcher, error) {
+	if f := newFSWatcher.Load(); f != nil {
+		return *f
+	}
+	return fsnotify.NewWatcher
+}
 
 // indexWatcher watches <root>/issues/ for filesystem changes made by
 // out-of-process writers (typically the `iterion __mcp-board` stdio
@@ -55,7 +64,7 @@ type indexWatcher struct {
 // environment); the Store still works, it just can't see out-of-
 // process writes — same as before this watcher existed.
 func startIndexWatcher(s *Store) (*indexWatcher, error) {
-	w, err := newFSWatcher()
+	w, err := fsWatcherCtor()()
 	if err != nil {
 		return nil, err
 	}
@@ -108,12 +117,14 @@ func (iw *indexWatcher) Close() error {
 // question costs one mutex and a map lookup.
 const defaultWatchCheckInterval = 5 * time.Second
 
-// watchCheckIntervalOverride lets a test tighten the check.
-var watchCheckIntervalOverride *time.Duration
+// watchCheckIntervalOverride lets a test tighten the check. Atomic like
+// every seam in this package — and this is the one the race detector
+// catches first, since loop() reads it on the watcher's own goroutine.
+var watchCheckIntervalOverride atomic.Pointer[time.Duration]
 
 func watchCheckInterval() time.Duration {
-	if watchCheckIntervalOverride != nil {
-		return *watchCheckIntervalOverride
+	if d := watchCheckIntervalOverride.Load(); d != nil {
+		return *d
 	}
 	return defaultWatchCheckInterval
 }

--- a/pkg/dispatcher/native/watcher_test.go
+++ b/pkg/dispatcher/native/watcher_test.go
@@ -16,11 +16,9 @@ import (
 // degraded path is exercised on any host instead of only on an exhausted one.
 func refuseWatch(t *testing.T) {
 	t.Helper()
-	prev := newFSWatcher
-	newFSWatcher = func() (*fsnotify.Watcher, error) {
+	setSeam(t, &newFSWatcher, func() (*fsnotify.Watcher, error) {
 		return nil, &os.SyscallError{Syscall: "inotify_init1", Err: syscall.EMFILE}
-	}
-	t.Cleanup(func() { newFSWatcher = prev })
+	})
 }
 
 // fastPathBudget is how long waitForIndex gives the fsnotify fast path

--- a/pkg/dispatcher/native/watcher_test.go
+++ b/pkg/dispatcher/native/watcher_test.go
@@ -56,18 +56,18 @@ func waitForIndex(t *testing.T, s *Store, cond func() bool, label string) {
 		return cond()
 	}
 
-	if s.watcher == nil {
-		if s.watcherErr == nil {
+	if w, _, werr := s.watchState(); w == nil {
+		if werr == nil {
 			t.Fatalf("watcher: %s: no watcher and no recorded reason — startIndexWatcher returned (nil, nil)", label)
 		}
 		// The host would not give us a watch. That says nothing about
 		// iterion's code, but the store still owes visibility, so assert
 		// the net instead of skipping the guard.
 		if err := s.Reconcile(); err != nil {
-			t.Fatalf("watcher: %s: host refused a watch (%v) and the reconcile net failed: %v", label, s.watcherErr, err)
+			t.Fatalf("watcher: %s: host refused a watch (%v) and the reconcile net failed: %v", label, werr, err)
 		}
 		if !check() {
-			t.Fatalf("watcher: %s: host refused a watch (%v) AND the reconcile net did not make the change visible", label, s.watcherErr)
+			t.Fatalf("watcher: %s: host refused a watch (%v) AND the reconcile net did not make the change visible", label, werr)
 		}
 		return
 	}
@@ -211,7 +211,7 @@ func TestWatcher_ExternalCreateVisibleWhenWatchRefused(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	if s.watcher != nil {
+	if w, _, _ := s.watchState(); w != nil {
 		t.Fatal("test setup: expected the watch to be refused")
 	}
 
@@ -246,11 +246,13 @@ func TestStore_ReconcileSeesExternalWrites(t *testing.T) {
 
 	// Take the fast path out of the picture entirely: the net alone
 	// must carry all three shapes of out-of-process change.
-	if s.watcher != nil {
-		if err := s.watcher.Close(); err != nil {
+	if w, _, _ := s.watchState(); w != nil {
+		if err := w.Close(); err != nil {
 			t.Fatalf("close watcher: %v", err)
 		}
+		s.mu.Lock()
 		s.watcher = nil
+		s.mu.Unlock()
 	}
 
 	doomed, err := s.Create(Issue{Title: "Removed externally", State: "backlog"})
@@ -359,10 +361,11 @@ func TestStore_FallbackRescanWhenWatchRefused(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = s.Close() })
-	if s.watcher != nil {
+	w, r, _ := s.watchState()
+	if w != nil {
 		t.Fatal("test setup: expected the watch to be refused")
 	}
-	if s.rescanner == nil {
+	if r == nil {
 		t.Fatal("watch refused but no fallback rescan started: the store is blind until restart")
 	}
 


### PR DESCRIPTION
## What

Closes #1047. `native.Store` fills its in-memory index once at `NewStore` and keeps it current only through an fsnotify watcher, and `NewStore` dropped the watcher's error on the floor. On a host at `fs.inotify.max_user_watches` (ENOSPC) or `max_user_instances` (EMFILE) — per-UID, node-wide limits the CI jobs sharing an `arc-runners` node contend for — the store was silently and permanently blind to out-of-process writes: an `iterion __mcp-board` write landed on disk and `/board` never showed it, the dispatcher never dispatched it, until the daemon restarted.

The same state is the flake that ejected the fully green #1039 from the merge queue twice on 2026-09-09: `TestWatcher_PicksUpExternalCreate` burned its full 10 s deadline (propagation is p99 1.3 ms when a watch exists, 200 samples) because no event was ever going to be sent.

## The fix

- **A reconciliation net behind the fast path** (the CLAUDE.md doctrine: a lossy bus needs a net). The store records why the watch could not be armed (`watcherErr`), logs it, and runs `Reconcile` — a full rebuild of the index from disk, so an issue removed out-of-process leaves the index too — on a ticker while no watcher exists. `ITERION_NATIVE_INDEX_RESCAN` sets the interval (default 2s; `off` restores the old blind-until-restart behaviour). The panic-recovery reload goes through the same rebuild.
- **A dead branch revived.** `applyEvent`'s "file vanished between the event and our read" branch matched `fs.ErrNotExist`; `readIssueFromDisk` maps a missing file to `tracker.ErrNotFound`, which does not wrap it, so the branch never fired and a vanished issue kept serving from the index.
- **Guards that name a mechanism, not a duration.** `waitForIndex` follows the carrier the store actually selected: with no watch armed it asserts the net (one `Reconcile`, one assertion, zero clock); with a watch armed it waits for the event and then uses `Reconcile` as the oracle that tells "the write landed and the fsnotify path dropped it" from "the write or the id mapping is wrong". `newFSWatcher` is the seam a test uses to make the host refuse a watch, so the degraded path runs on every host instead of only on an exhausted one.

## Proof

- Red with a watcher that drops every event: the three `TestWatcher_*` guards fail with "the watch was armed but no event reached the index in 10s — a reconcile made the change visible, so the write landed and the fsnotify path dropped it".
- Red with the `fs.ErrNotExist` dead branch restored: `TestApplyEvent_DropsEntryWhenFileVanished` fails.
- Green: `go test ./pkg/dispatcher/native/ -count=3`, `go test -race ./pkg/dispatcher/native/ ./pkg/dispatcher/`, `task lint` 0 issues.

## Overlap

#1020 (`feat/1006-artifact-contract`) skips the flaking test; with this fix the skip becomes moot and that PR will need a small rebase on `store.go` / `watcher_test.go`. Commented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
