### PR TITLE
fix(usage): an aggregated token count no longer claims to be input

### DIFF
--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -172,8 +172,12 @@ Cost metering is "floor, not invoice":
   reports `cost_usd` per call.
 - **Every CLI delegate** (`claude_code`, Codex, `pi`, Kimi, and Grok)
   contributes its aggregate token total when the CLI reports usage. The cloud
-  runner's delegate event has no input/output split, so that total is currently
-  booked to `input_tokens`.
+  runner's delegate event carries no input/output split, so that total is
+  reported as **`aggregate_tokens`** — its own field, leaving `input_tokens`
+  and `output_tokens` for splits that were actually measured. **A true total
+  is the sum of the three**, and a per-direction ratio is only meaningful on a
+  row whose aggregate is zero. Zero in all three means *not observed*, never
+  *nothing spent*.
 - A CLI delegate's `cost_usd` **is** added to `org_usage.cost_usd` — the
   `delegate_finished` figure flows through `metricsEmitter.RunTotals` into
   `recordOrgSpend`. `claw` is the one exclusion, and deliberately: being
@@ -290,6 +294,7 @@ Both views share the same JSON shape
   "cost_usd_this_month":          18.91,
   "input_tokens_this_month":      4123890,
   "output_tokens_this_month":      921334,
+  "aggregate_tokens_this_month":  2210544,
   "monthly_cost_cap_usd":         80.0,
   "max_concurrent_runs":          5,
   "active_runs":                  2,

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -344,12 +344,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 			SessionID:    result.SessionID,
 			FinishReason: "", // claude_code SDK doesn't surface a granular reason at Result level
 			Text:         text,
-			// Token totals come from Result.Tokens (in+out) but the
-			// claude_code path doesn't split them apart — the hooks
-			// layer logs the total under InputTokens for now; a future
-			// refinement would track input/output split through the
-			// stream parser.
-			InputTokens: result.Tokens,
+			// Result.Tokens is in+out with no split available here, so it
+			// travels as the aggregate rather than being filed under a
+			// direction it was never measured in (#992).
+			AggregateTokens: result.Tokens,
 		})
 	}()
 

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -1131,9 +1131,12 @@ type TurnFinishedInfo struct {
 	// this delegate call. Used for the TextDigest fingerprint.
 	Text string
 	// InputTokens / OutputTokens come from the CLI's Result.Usage and
-	// feed the per-turn store.TurnUsage.
-	InputTokens  int
-	OutputTokens int
+	// feed the per-turn store.TurnUsage. AggregateTokens carries a total
+	// the CLI reported WITHOUT a split — filed apart so neither direction
+	// is claimed on evidence that does not exist.
+	InputTokens     int
+	OutputTokens    int
+	AggregateTokens int
 }
 
 // BuildSystemPrompt returns the task's SystemPrompt augmented with

--- a/pkg/backend/model/events.go
+++ b/pkg/backend/model/events.go
@@ -184,12 +184,15 @@ type LLMCompactInfo struct {
 // natural end-of-iteration boundary — the very state the next LLM
 // call would observe if the loop continued. Treat as immutable.
 type LLMTurnCaptureInfo struct {
-	Step             int
-	Text             string
-	ToolCalls        []ToolCallEntry
-	FinishReason     string
-	InputTokens      int
-	OutputTokens     int
+	Step         int
+	Text         string
+	ToolCalls    []ToolCallEntry
+	FinishReason string
+	InputTokens  int
+	OutputTokens int
+	// AggregateTokens is a turn total the backend could not split. Filled
+	// instead of InputTokens/OutputTokens, never alongside them.
+	AggregateTokens  int
 	CacheReadTokens  int
 	CacheWriteTokens int
 	// Iteration is the 0-based loop iteration (see LLMRequestInfo.Iteration).

--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -1055,14 +1055,15 @@ func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, itera
 			// the anchor the Fork API uses to relaunch claude with
 			// --resume + --fork-session.
 			fn(nodeID, LLMTurnCaptureInfo{
-				Step:         1,
-				Text:         info.Text,
-				FinishReason: info.FinishReason,
-				InputTokens:  info.InputTokens,
-				OutputTokens: info.OutputTokens,
-				SessionID:    info.SessionID,
-				Backend:      delegate.BackendClaudeCode,
-				Iteration:    iteration,
+				Step:            1,
+				Text:            info.Text,
+				FinishReason:    info.FinishReason,
+				InputTokens:     info.InputTokens,
+				OutputTokens:    info.OutputTokens,
+				AggregateTokens: info.AggregateTokens,
+				SessionID:       info.SessionID,
+				Backend:         delegate.BackendClaudeCode,
+				Iteration:       iteration,
 			})
 		}
 	}

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -753,8 +753,9 @@ func (h *storeHooks) onLLMTurnCapture(nodeID string, info LLMTurnCaptureInfo) {
 		ToolCalls:    toolCalls,
 		TextDigest:   sha256Hex(info.Text),
 		Usage: store.TurnUsage{
-			InputTokens:  info.InputTokens,
-			OutputTokens: info.OutputTokens,
+			InputTokens:     info.InputTokens,
+			OutputTokens:    info.OutputTokens,
+			AggregateTokens: info.AggregateTokens,
 		},
 		SessionID: info.SessionID,
 	}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -807,10 +807,15 @@ func (b *Broker) releaseLease(ctx context.Context, lease Lease) {
 // boundary leaves this package a pure domain — stores, limits, fairness —
 // with no dependency on the execution stack.
 type Outcome struct {
-	CostUSD      float64
-	InputTokens  int64
-	OutputTokens int64
-	Condition    Condition
+	CostUSD float64
+	// InputTokens / OutputTokens carry an observed split; AggregateTokens
+	// carries a CLI delegate's unsplittable total. A donor's ledger reads
+	// zero as "not observed", so the aggregate must not be filed under a
+	// direction it was never measured in.
+	InputTokens     int64
+	OutputTokens    int64
+	AggregateTokens int64
+	Condition       Condition
 	// CooldownUntil is the provider's own reset instant, when the caller
 	// could parse one from ConditionUsageWindow. Zero falls back to a
 	// bounded blind wait.
@@ -905,12 +910,12 @@ func (b *Broker) Report(ctx context.Context, runID string, out Outcome) error {
 // what that attempt says about their credential. Shared by the closing and
 // interim report paths.
 func (b *Broker) chargeAndReact(ctx context.Context, lease Lease, out Outcome, now time.Time, runID string) error {
-	if out.CostUSD > 0 || out.InputTokens > 0 || out.OutputTokens > 0 {
+	if out.CostUSD > 0 || out.InputTokens > 0 || out.OutputTokens > 0 || out.AggregateTokens > 0 {
 		// Charged against the lease's ACQUISITION instant, not now: a run
 		// that starts at 23:50 and ends at 00:10 must debit the day whose
 		// allowance admitted it, or the donor's daily cap silently leaks
 		// across the boundary.
-		if err := b.ledger.AddSpend(ctx, lease.PledgeID, lease.AcquiredAt, out.CostUSD, out.InputTokens, out.OutputTokens); err != nil {
+		if err := b.ledger.AddSpend(ctx, lease.PledgeID, lease.AcquiredAt, out.CostUSD, out.InputTokens, out.OutputTokens, out.AggregateTokens); err != nil {
 			// The lease is already closed, so this spend will never be
 			// retried — say so loudly rather than under-reporting a
 			// donation in silence.

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -107,7 +107,7 @@ func TestAcquire_exhaustedDonorIsRefusedNotGrantedZero(t *testing.T) {
 	h := newHarness(t)
 	ctx := context.Background()
 	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
-	if err := h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0); err != nil {
+	if err := h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0, 0); err != nil {
 		t.Fatalf("seed spend: %v", err)
 	}
 	grant, err := h.broker.Acquire(ctx, h.request("run-1"))

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -191,7 +191,7 @@ func TestBroker_fairnessPrefersTheLeastConsumedDonor(t *testing.T) {
 	h.donor(t, "bob", Limits{MaxUSDPerDay: 10})
 
 	// Alice has already given $8 of her 10 today; Bob nothing.
-	if err := h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 8, 0, 0); err != nil {
+	if err := h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 8, 0, 0, 0); err != nil {
 		t.Fatalf("seed spend: %v", err)
 	}
 	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
@@ -213,8 +213,8 @@ func TestBroker_fairnessIsProportional(t *testing.T) {
 	h.donor(t, "modest", Limits{MaxUSDPerDay: 2})
 
 	// Generous gave $20 (20% of their offer); modest gave $1 (50%).
-	_ = h.ledger.AddSpend(ctx, PledgeID("generous", SourceOAuth, "claude_code"), h.now, 20, 0, 0)
-	_ = h.ledger.AddSpend(ctx, PledgeID("modest", SourceOAuth, "claude_code"), h.now, 1, 0, 0)
+	_ = h.ledger.AddSpend(ctx, PledgeID("generous", SourceOAuth, "claude_code"), h.now, 20, 0, 0, 0)
+	_ = h.ledger.AddSpend(ctx, PledgeID("modest", SourceOAuth, "claude_code"), h.now, 1, 0, 0, 0)
 
 	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
 	if err != nil {
@@ -231,7 +231,7 @@ func TestBroker_exhaustedDonorYieldsToTheNext(t *testing.T) {
 	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
 	h.donor(t, "bob", Limits{MaxUSDPerDay: 5})
 	// Alice is spent; she must be skipped, not fail the acquisition.
-	_ = h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0)
+	_ = h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0, 0)
 
 	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
 	if err != nil {
@@ -246,7 +246,7 @@ func TestBroker_everyDonorExhausted(t *testing.T) {
 	h := newHarness(t)
 	ctx := context.Background()
 	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
-	_ = h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0)
+	_ = h.ledger.AddSpend(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now, 5, 0, 0, 0)
 
 	if _, err := h.broker.Acquire(ctx, h.request("run-1")); !errors.Is(err, ErrNoDonor) {
 		t.Errorf("Acquire = %v, want ErrNoDonor", err)

--- a/pkg/credpool/memory.go
+++ b/pkg/credpool/memory.go
@@ -305,6 +305,7 @@ type memBucket struct {
 	runs                     int
 	costMillis               int64
 	inputTokens, outputToken int64
+	aggregateTokens          int64
 }
 
 type MemoryLedger struct {
@@ -376,11 +377,11 @@ func (l *MemoryLedger) ReleaseRun(_ context.Context, pledgeID string, when time.
 	return nil
 }
 
-func (l *MemoryLedger) AddSpend(_ context.Context, pledgeID string, when time.Time, costUSD float64, in, out int64) error {
+func (l *MemoryLedger) AddSpend(_ context.Context, pledgeID string, when time.Time, costUSD float64, in, out, aggregate int64) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	millis := CostToMillis(costUSD)
-	if millis == 0 && in <= 0 && out <= 0 {
+	if millis == 0 && in <= 0 && out <= 0 && aggregate <= 0 {
 		return nil
 	}
 	for _, key := range []string{
@@ -394,6 +395,9 @@ func (l *MemoryLedger) AddSpend(_ context.Context, pledgeID string, when time.Ti
 		}
 		if out > 0 {
 			b.outputToken += out
+		}
+		if aggregate > 0 {
+			b.aggregateTokens += aggregate
 		}
 	}
 	return nil

--- a/pkg/credpool/mongo.go
+++ b/pkg/credpool/mongo.go
@@ -382,11 +382,14 @@ func NewMongoLedger(db *mongo.Database) *MongoLedger {
 func (l *MongoLedger) WithLogger(lg *iterlog.Logger) *MongoLedger { l.logger = lg; return l }
 
 type ledgerDoc struct {
-	Runs         int       `bson:"runs"`
-	CostMillis   int64     `bson:"cost_usd_millis"`
-	InputTokens  int64     `bson:"input_tokens"`
-	OutputTokens int64     `bson:"output_tokens"`
-	PeriodStart  time.Time `bson:"period_start"`
+	Runs         int   `bson:"runs"`
+	CostMillis   int64 `bson:"cost_usd_millis"`
+	InputTokens  int64 `bson:"input_tokens"`
+	OutputTokens int64 `bson:"output_tokens"`
+	// Absent before the aggregate got its own counter; those periods'
+	// aggregates sit inside InputTokens.
+	AggregateTokens int64     `bson:"aggregate_tokens"`
+	PeriodStart     time.Time `bson:"period_start"`
 }
 
 func (l *MongoLedger) Reserve(ctx context.Context, pledgeID string, when time.Time, lim Limits, live LiveCommitment) (float64, DenyReason, error) {
@@ -475,7 +478,7 @@ func (l *MongoLedger) ReleaseRun(ctx context.Context, pledgeID string, when time
 	return nil
 }
 
-func (l *MongoLedger) AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, in, out int64) error {
+func (l *MongoLedger) AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, in, out, aggregate int64) error {
 	inc := bson.M{}
 	if m := CostToMillis(costUSD); m > 0 {
 		inc["cost_usd_millis"] = m
@@ -485,6 +488,9 @@ func (l *MongoLedger) AddSpend(ctx context.Context, pledgeID string, when time.T
 	}
 	if out > 0 {
 		inc["output_tokens"] = out
+	}
+	if aggregate > 0 {
+		inc["aggregate_tokens"] = aggregate
 	}
 	if len(inc) == 0 {
 		return nil
@@ -532,6 +538,7 @@ func (l *MongoLedger) readBucket(ctx context.Context, pledgeID, period, key stri
 	u.CostUSD = millisToCost(doc.CostMillis)
 	u.InputTokens = doc.InputTokens
 	u.OutputTokens = doc.OutputTokens
+	u.AggregateTokens = doc.AggregateTokens
 	return u, nil
 }
 

--- a/pkg/credpool/store.go
+++ b/pkg/credpool/store.go
@@ -101,6 +101,10 @@ type Usage struct {
 	CostUSD      float64 `json:"cost_usd"`
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
+	// AggregateTokens holds a CLI delegate's unsplittable total. Zero in
+	// all three token fields means "not observed", never "nothing spent";
+	// a true total is their sum.
+	AggregateTokens int64 `json:"aggregate_tokens"`
 }
 
 // Ledger meters per-pledge consumption and enforces the donor's limits.
@@ -132,7 +136,7 @@ type Ledger interface {
 	ReleaseRun(ctx context.Context, pledgeID string, when time.Time) error
 	// AddSpend records what a served run actually consumed, into both the
 	// day and week buckets.
-	AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, inputTokens, outputTokens int64) error
+	AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, inputTokens, outputTokens, aggregateTokens int64) error
 	// Usage reads one pledge's day and week buckets.
 	Usage(ctx context.Context, pledgeID string, when time.Time) (day Usage, week Usage, err error)
 	// UsageMany reads the day bucket of several pledges at once — the

--- a/pkg/credusage/counter_conformance_test.go
+++ b/pkg/credusage/counter_conformance_test.go
@@ -45,11 +45,22 @@ func runCounterConformance(t *testing.T, c Counter) {
 			t.Fatalf("AddSpend(%s): %v", k.Fingerprint, err)
 		}
 	}
+	addAggregate := func(k Key, nature Nature, backend string, cost float64, aggregate int64, when time.Time) {
+		t.Helper()
+		if err := c.AddSpend(ctx, when, Spend{
+			Key: k, Nature: nature, Backend: backend,
+			CostUSD: cost, AggregateTokens: aggregate,
+		}); err != nil {
+			t.Fatalf("AddSpend(%s): %v", k.Fingerprint, err)
+		}
+	}
 	add(teamKey, NatureMetered, "claw", 1.25, 1000, 200, sept)
 	add(teamKey, NatureMetered, "claw", 0.75, 500, 100, sept)
 	// The SAME run's other half, on another credential and another
 	// backend — the case a single RunTotals() figure cannot express.
-	add(forfait, NatureEstimate, "claude_code", 4.5, 9000, 1200, sept)
+	// A CLI delegate reports ONE count and no split (#992): it must land in
+	// the aggregate on BOTH twins, leaving the directional pair at zero.
+	addAggregate(forfait, NatureEstimate, "claude_code", 4.5, 9000, sept)
 	add(platform, NatureEstimate, "codex", 2.0, 300, 60, sept)
 
 	got, err = c.Usage(ctx, sept, teamKey)
@@ -66,12 +77,25 @@ func runCounterConformance(t *testing.T, c Counter) {
 		t.Fatalf("backends = %v, want [claw]", got.Backends)
 	}
 
+	// A spend carrying ONLY an aggregate is recordable: a delegation whose
+	// price sources knew nothing still proves the credential was used.
+	addAggregate(forfait, NatureEstimate, "claude_code", 0, 1000, sept)
+
 	fRow, err := c.Usage(ctx, sept, forfait)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if fRow.Nature != NatureEstimate {
 		t.Fatalf("forfait nature = %q, want estimate — a subscription bills nothing per call", fRow.Nature)
+	}
+	if fRow.AggregateTokens != 10000 {
+		t.Fatalf("forfait aggregate tokens = %d, want 10000 (9000 + the unpriced 1000)", fRow.AggregateTokens)
+	}
+	if fRow.InputTokens != 0 || fRow.OutputTokens != 0 {
+		t.Fatalf("forfait row = in %d / out %d, want 0/0 — the delegate never reported a split (#992)", fRow.InputTokens, fRow.OutputTokens)
+	}
+	if fRow.Runs != 2 {
+		t.Fatalf("forfait runs = %d, want 2 — an aggregate-only spend is not an empty one", fRow.Runs)
 	}
 
 	// A tenant listing carries every credential that served it, biggest

--- a/pkg/credusage/credusage.go
+++ b/pkg/credusage/credusage.go
@@ -112,9 +112,19 @@ type MonthlyUsage struct {
 	Nature Nature `json:"nature"`
 	// CostUSD is the accumulated figure — real money when Nature is
 	// metered, the metered-equivalent price when it is estimate.
-	CostUSD      float64 `json:"cost_usd"`
-	InputTokens  int64   `json:"input_tokens"`
-	OutputTokens int64   `json:"output_tokens"`
+	CostUSD float64 `json:"cost_usd"`
+	// InputTokens / OutputTokens are DIRECTIONAL: they carry a split that
+	// was actually observed, and stay zero when none was. AggregateTokens
+	// carries the other case — a CLI delegate that reports one total and no
+	// split at all. Zero everywhere is "not observed", never "none spent".
+	//
+	// A total is therefore the sum of the three, and a per-direction ratio
+	// is only meaningful against the directional pair: a row with a non-zero
+	// aggregate is telling the reader that iterion cannot split it, instead
+	// of picking a side and being wrong in silence.
+	InputTokens     int64 `json:"input_tokens"`
+	OutputTokens    int64 `json:"output_tokens"`
+	AggregateTokens int64 `json:"aggregate_tokens"`
 	// Runs counts the attempts that spent anything on this credential.
 	Runs int `json:"runs"`
 	// Backends lists the backends that drew on it this month, so a mixed
@@ -128,10 +138,14 @@ type Spend struct {
 	// Nature qualifies CostUSD (see the package doc). Required.
 	Nature Nature
 	// Backend is the delegate that spent it ("claude_code", "claw", …).
-	Backend      string
-	CostUSD      float64
-	InputTokens  int64
-	OutputTokens int64
+	Backend string
+	CostUSD float64
+	// InputTokens / OutputTokens carry an observed split; AggregateTokens
+	// carries an unsplittable total. A spend fills one or the other, never
+	// both — see MonthlyUsage.
+	InputTokens     int64
+	OutputTokens    int64
+	AggregateTokens int64
 }
 
 // Counter is the per-credential monthly metering surface, mirroring
@@ -200,8 +214,12 @@ func CostToMillis(usd float64) int64 {
 func millisToCost(m int64) float64 { return float64(m) / 1000 }
 
 // empty reports whether a spend carries nothing worth recording.
+//
+// AggregateTokens counts here: a CLI delegate whose price sources did not
+// know the model reports tokens and no cost, and that is the ONLY evidence
+// the credential was used at all.
 func (s Spend) empty() bool {
-	return s.CostUSD <= 0 && s.InputTokens <= 0 && s.OutputTokens <= 0
+	return s.CostUSD <= 0 && s.InputTokens <= 0 && s.OutputTokens <= 0 && s.AggregateTokens <= 0
 }
 
 // recordable reports whether a spend can be counted at all.

--- a/pkg/credusage/memory.go
+++ b/pkg/credusage/memory.go
@@ -15,14 +15,15 @@ type MemoryCounter struct {
 }
 
 type memRow struct {
-	key           Key
-	month         string
-	nature        Nature
-	costUSDMillis int64
-	inputTokens   int64
-	outputTokens  int64
-	runs          int
-	backends      map[string]bool
+	key             Key
+	month           string
+	nature          Nature
+	costUSDMillis   int64
+	inputTokens     int64
+	outputTokens    int64
+	aggregateTokens int64
+	runs            int
+	backends        map[string]bool
 }
 
 func NewMemoryCounter() *MemoryCounter {
@@ -47,6 +48,9 @@ func (c *MemoryCounter) AddSpend(_ context.Context, when time.Time, s Spend) err
 	}
 	if s.OutputTokens > 0 {
 		r.outputTokens += s.OutputTokens
+	}
+	if s.AggregateTokens > 0 {
+		r.aggregateTokens += s.AggregateTokens
 	}
 	r.runs++
 	if s.Backend != "" {
@@ -111,17 +115,18 @@ func (r *memRow) view() MonthlyUsage {
 	}
 	sort.Strings(backends)
 	return MonthlyUsage{
-		Month:        r.month,
-		Fingerprint:  r.key.Fingerprint,
-		Provider:     r.key.Provider,
-		Tier:         r.key.Tier,
-		TenantID:     r.key.TenantID,
-		Nature:       r.nature,
-		CostUSD:      millisToCost(r.costUSDMillis),
-		InputTokens:  r.inputTokens,
-		OutputTokens: r.outputTokens,
-		Runs:         r.runs,
-		Backends:     backends,
+		Month:           r.month,
+		Fingerprint:     r.key.Fingerprint,
+		Provider:        r.key.Provider,
+		Tier:            r.key.Tier,
+		TenantID:        r.key.TenantID,
+		Nature:          r.nature,
+		CostUSD:         millisToCost(r.costUSDMillis),
+		InputTokens:     r.inputTokens,
+		OutputTokens:    r.outputTokens,
+		AggregateTokens: r.aggregateTokens,
+		Runs:            r.runs,
+		Backends:        backends,
 	}
 }
 

--- a/pkg/credusage/mongo.go
+++ b/pkg/credusage/mongo.go
@@ -49,33 +49,38 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 }
 
 type usageDoc struct {
-	Month         string    `bson:"month"`
-	Fingerprint   string    `bson:"fingerprint"`
-	Provider      string    `bson:"provider"`
-	Tier          string    `bson:"tier"`
-	TenantID      string    `bson:"tenant_id"`
-	Nature        string    `bson:"nature"`
-	CostUSDMillis int64     `bson:"cost_usd_millis"`
-	InputTokens   int64     `bson:"input_tokens"`
-	OutputTokens  int64     `bson:"output_tokens"`
-	Runs          int       `bson:"runs"`
-	Backends      []string  `bson:"backends,omitempty"`
-	MonthStart    time.Time `bson:"month_start"`
+	Month         string `bson:"month"`
+	Fingerprint   string `bson:"fingerprint"`
+	Provider      string `bson:"provider"`
+	Tier          string `bson:"tier"`
+	TenantID      string `bson:"tenant_id"`
+	Nature        string `bson:"nature"`
+	CostUSDMillis int64  `bson:"cost_usd_millis"`
+	InputTokens   int64  `bson:"input_tokens"`
+	OutputTokens  int64  `bson:"output_tokens"`
+	// Absent on documents written before the aggregate got its own
+	// counter: those months' aggregates are inside InputTokens and
+	// cannot be separated after the fact.
+	AggregateTokens int64     `bson:"aggregate_tokens"`
+	Runs            int       `bson:"runs"`
+	Backends        []string  `bson:"backends,omitempty"`
+	MonthStart      time.Time `bson:"month_start"`
 }
 
 func (d usageDoc) view() MonthlyUsage {
 	return MonthlyUsage{
-		Month:        d.Month,
-		Fingerprint:  d.Fingerprint,
-		Provider:     d.Provider,
-		Tier:         Tier(d.Tier),
-		TenantID:     d.TenantID,
-		Nature:       Nature(d.Nature),
-		CostUSD:      millisToCost(d.CostUSDMillis),
-		InputTokens:  d.InputTokens,
-		OutputTokens: d.OutputTokens,
-		Runs:         d.Runs,
-		Backends:     d.Backends,
+		Month:           d.Month,
+		Fingerprint:     d.Fingerprint,
+		Provider:        d.Provider,
+		Tier:            Tier(d.Tier),
+		TenantID:        d.TenantID,
+		Nature:          Nature(d.Nature),
+		CostUSD:         millisToCost(d.CostUSDMillis),
+		InputTokens:     d.InputTokens,
+		OutputTokens:    d.OutputTokens,
+		AggregateTokens: d.AggregateTokens,
+		Runs:            d.Runs,
+		Backends:        d.Backends,
 	}
 }
 
@@ -92,6 +97,9 @@ func (c *MongoCounter) AddSpend(ctx context.Context, when time.Time, s Spend) er
 	}
 	if s.OutputTokens > 0 {
 		inc["output_tokens"] = s.OutputTokens
+	}
+	if s.AggregateTokens > 0 {
+		inc["aggregate_tokens"] = s.AggregateTokens
 	}
 	update := bson.M{
 		"$inc": inc,

--- a/pkg/orgusage/memory.go
+++ b/pkg/orgusage/memory.go
@@ -14,10 +14,11 @@ type MemoryCounter struct {
 }
 
 type memUsage struct {
-	runs          int
-	costUSDMillis int64
-	inputTokens   int64
-	outputTokens  int64
+	runs            int
+	costUSDMillis   int64
+	inputTokens     int64
+	outputTokens    int64
+	aggregateTokens int64
 }
 
 func NewMemoryCounter() *MemoryCounter {
@@ -57,7 +58,7 @@ func (c *MemoryCounter) ReleaseRun(_ context.Context, tenantID string, when time
 	return nil
 }
 
-func (c *MemoryCounter) AddSpend(_ context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens int64) error {
+func (c *MemoryCounter) AddSpend(_ context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens, aggregateTokens int64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	u := c.get(tenantID, when)
@@ -67,6 +68,9 @@ func (c *MemoryCounter) AddSpend(_ context.Context, tenantID string, when time.T
 	}
 	if outputTokens > 0 {
 		u.outputTokens += outputTokens
+	}
+	if aggregateTokens > 0 {
+		u.aggregateTokens += aggregateTokens
 	}
 	return nil
 }
@@ -80,6 +84,7 @@ func (c *MemoryCounter) Usage(_ context.Context, tenantID string, when time.Time
 		out.CostUSD = millisToCost(u.costUSDMillis)
 		out.InputTokens = u.inputTokens
 		out.OutputTokens = u.outputTokens
+		out.AggregateTokens = u.aggregateTokens
 	}
 	return out, nil
 }

--- a/pkg/orgusage/mongo.go
+++ b/pkg/orgusage/mongo.go
@@ -40,11 +40,15 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 }
 
 type usageDoc struct {
-	Runs          int       `bson:"runs"`
-	CostUSDMillis int64     `bson:"cost_usd_millis"`
-	InputTokens   int64     `bson:"input_tokens"`
-	OutputTokens  int64     `bson:"output_tokens"`
-	MonthStart    time.Time `bson:"month_start"`
+	Runs          int   `bson:"runs"`
+	CostUSDMillis int64 `bson:"cost_usd_millis"`
+	InputTokens   int64 `bson:"input_tokens"`
+	OutputTokens  int64 `bson:"output_tokens"`
+	// Absent on documents written before the aggregate got its own
+	// counter: those months' aggregates sit inside InputTokens and
+	// cannot be separated after the fact.
+	AggregateTokens int64     `bson:"aggregate_tokens"`
+	MonthStart      time.Time `bson:"month_start"`
 }
 
 func (c *MongoCounter) AllowRun(ctx context.Context, tenantID string, when time.Time, maxRuns int, maxCostMillis int64) (DenyReason, error) {
@@ -96,7 +100,7 @@ func (c *MongoCounter) ReleaseRun(ctx context.Context, tenantID string, when tim
 	return nil
 }
 
-func (c *MongoCounter) AddSpend(ctx context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens int64) error {
+func (c *MongoCounter) AddSpend(ctx context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens, aggregateTokens int64) error {
 	inc := bson.M{}
 	if m := CostToMillis(costUSD); m > 0 {
 		inc["cost_usd_millis"] = m
@@ -106,6 +110,9 @@ func (c *MongoCounter) AddSpend(ctx context.Context, tenantID string, when time.
 	}
 	if outputTokens > 0 {
 		inc["output_tokens"] = outputTokens
+	}
+	if aggregateTokens > 0 {
+		inc["aggregate_tokens"] = aggregateTokens
 	}
 	if len(inc) == 0 {
 		return nil
@@ -137,6 +144,7 @@ func (c *MongoCounter) Usage(ctx context.Context, tenantID string, when time.Tim
 	out.Runs = doc.Runs
 	out.CostUSD = millisToCost(doc.CostUSDMillis)
 	out.InputTokens = doc.InputTokens
+	out.AggregateTokens = doc.AggregateTokens
 	out.OutputTokens = doc.OutputTokens
 	return out, nil
 }

--- a/pkg/orgusage/orgusage.go
+++ b/pkg/orgusage/orgusage.go
@@ -29,9 +29,14 @@ type MonthlyUsage struct {
 	// when it reports none (a subscription session bills nothing per
 	// call). A node whose model the price table cannot price adds
 	// nothing — treat this as a floor, not an exact invoice.
-	CostUSD      float64 `json:"cost_usd"`
-	InputTokens  int64   `json:"input_tokens"`
-	OutputTokens int64   `json:"output_tokens"`
+	CostUSD float64 `json:"cost_usd"`
+	// InputTokens / OutputTokens are DIRECTIONAL — a split that was
+	// actually observed. AggregateTokens holds what a CLI delegate
+	// reported as one unsplittable total. Zero means "not observed",
+	// never "none spent", and a true total is the sum of the three.
+	InputTokens     int64 `json:"input_tokens"`
+	OutputTokens    int64 `json:"output_tokens"`
+	AggregateTokens int64 `json:"aggregate_tokens"`
 }
 
 // DenyReason qualifies an AllowRun refusal so the launch gate can map
@@ -62,7 +67,7 @@ type Counter interface {
 	AllowRun(ctx context.Context, tenantID string, when time.Time, maxRuns int, maxCostMillis int64) (DenyReason, error)
 	// AddSpend accumulates post-hoc LLM cost/token usage for the
 	// month. Never gates — AllowRun enforces the cap pre-launch.
-	AddSpend(ctx context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens int64) error
+	AddSpend(ctx context.Context, tenantID string, when time.Time, costUSD float64, inputTokens, outputTokens, aggregateTokens int64) error
 	// ReleaseRun undoes one AllowRun admission whose launch was
 	// ultimately abandoned without any run being created (e.g. the
 	// loser of two concurrent duplicate webhook deliveries). Decrements

--- a/pkg/orgusage/orgusage_test.go
+++ b/pkg/orgusage/orgusage_test.go
@@ -75,14 +75,14 @@ func runCounterSuite(t *testing.T, c Counter) {
 	})
 
 	t.Run("spend accumulates", func(t *testing.T) {
-		if err := c.AddSpend(ctx, "t-spend", now, 1.234, 1000, 200); err != nil {
+		if err := c.AddSpend(ctx, "t-spend", now, 1.234, 1000, 200, 0); err != nil {
 			t.Fatalf("AddSpend: %v", err)
 		}
-		if err := c.AddSpend(ctx, "t-spend", now, 0.766, 500, 100); err != nil {
+		if err := c.AddSpend(ctx, "t-spend", now, 0.766, 500, 100, 0); err != nil {
 			t.Fatalf("AddSpend: %v", err)
 		}
 		// Zero-valued spend must be a no-op, not an error.
-		if err := c.AddSpend(ctx, "t-spend", now, 0, 0, 0); err != nil {
+		if err := c.AddSpend(ctx, "t-spend", now, 0, 0, 0, 0); err != nil {
 			t.Fatalf("AddSpend zero: %v", err)
 		}
 		u, err := c.Usage(ctx, "t-spend", now)
@@ -111,7 +111,7 @@ func runCounterSuite(t *testing.T, c Counter) {
 	})
 
 	t.Run("cost cap denies new launches", func(t *testing.T) {
-		if err := c.AddSpend(ctx, "t-costcap", now, 5.0, 0, 0); err != nil {
+		if err := c.AddSpend(ctx, "t-costcap", now, 5.0, 0, 0, 0); err != nil {
 			t.Fatal(err)
 		}
 		deny, err := c.AllowRun(ctx, "t-costcap", now, 0, CostToMillis(5.0))

--- a/pkg/runner/aggregate_tokens_test.go
+++ b/pkg/runner/aggregate_tokens_test.go
@@ -1,0 +1,97 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/credusage"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #992 — a CLI delegate reports ONE aggregated token count. Booking it under
+// `input_tokens` keeps a sum correct and makes the named field a lie: every
+// per-token ratio, cache-hit reading and input/output share computed from the
+// public endpoint is wrong, with nothing on the row saying so.
+//
+// The aggregate travels in its own counter, and the two directional fields
+// stay at zero — "not observed", which is the truth.
+func TestDelegateAggregate_IsNotClaimedAsInput(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	r := &Runner{cfg: Config{Logger: iterlog.Nop(), CredUsage: counter}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: "/tmp/oauth"},
+		Fingerprints:         map[string]string{delegate.BackendClaudeCode: "fp-forfait"},
+	})
+
+	usage := newMetricsEmitter(nil, nil)
+	usage.observe(store.Event{Type: store.EventLLMRequest, NodeID: "implement",
+		Data: map[string]any{"model": "anthropic/claude-opus-5"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "implement",
+		Data: map[string]any{"backend": delegate.BackendClaudeCode, "tokens": float64(9000), "cost_usd": 4.5}})
+
+	now := time.Now().UTC()
+	r.recordCredentialSpend(ctx, &queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, usage, now)
+
+	rows, err := counter.List(ctx, now, "team-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("recorded %d credential rows, want 1: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.AggregateTokens != 9000 {
+		t.Errorf("AggregateTokens = %d, want 9000 — the delegate's only observation", row.AggregateTokens)
+	}
+	if row.InputTokens != 0 {
+		t.Errorf("InputTokens = %d, want 0 — the delegate never reported a split, so claiming one is a lie", row.InputTokens)
+	}
+	if row.OutputTokens != 0 {
+		t.Errorf("OutputTokens = %d, want 0", row.OutputTokens)
+	}
+	// The property the old convention protected must survive: a consumer
+	// summing every token field still gets the true total.
+	if total := row.InputTokens + row.OutputTokens + row.AggregateTokens; total != 9000 {
+		t.Errorf("summed tokens = %d, want 9000 — the aggregate must stay countable", total)
+	}
+}
+
+// The in-process claw path observes a real split, so it keeps reporting one:
+// the fix must not flatten a genuine measurement into "unknown".
+func TestClawStepSplit_StaysADirectionalSplit(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	r := &Runner{cfg: Config{Logger: iterlog.Nop(), CredUsage: counter}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:      map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-team"},
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): "fp-anthropic"},
+	})
+
+	usage := newMetricsEmitter(nil, nil)
+	usage.observe(store.Event{Type: store.EventLLMRequest, NodeID: "n",
+		Data: map[string]any{"model": "anthropic/claude-opus-5"}})
+	usage.observe(store.Event{Type: store.EventLLMStepFinished, NodeID: "n",
+		Data: map[string]any{"input_tokens": float64(700), "output_tokens": float64(300)}})
+
+	now := time.Now().UTC()
+	r.recordCredentialSpend(ctx, &queue.RunMessage{RunID: "run-2", TenantID: "team-b"}, usage, now)
+
+	rows, err := counter.List(ctx, now, "team-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("recorded %d credential rows, want 1: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.InputTokens != 700 || row.OutputTokens != 300 {
+		t.Errorf("row = in %d / out %d, want 700/300 — a measured split", row.InputTokens, row.OutputTokens)
+	}
+	if row.AggregateTokens != 0 {
+		t.Errorf("AggregateTokens = %d, want 0 — this path observed both directions", row.AggregateTokens)
+	}
+}

--- a/pkg/runner/cred_spend_test.go
+++ b/pkg/runner/cred_spend_test.go
@@ -64,7 +64,7 @@ func TestRecordCredentialSpend_SplitsOneRunAcrossItsCredentials(t *testing.T) {
 	if !ok {
 		t.Fatalf("no row for the forfait: %+v", rows)
 	}
-	if forfait.CostUSD != 4.5 || forfait.InputTokens != 9000 {
+	if forfait.CostUSD != 4.5 || forfait.AggregateTokens != 9000 {
 		t.Fatalf("forfait row = %+v, want $4.50 / 9000 tokens — not the run total", forfait)
 	}
 	// A subscription bills nothing per call: its figure is what the calls
@@ -221,8 +221,8 @@ func TestRecordCredentialSpend_SandboxedClawChargesTheCodexSlot(t *testing.T) {
 	if row.Fingerprint != "fp-codex-platform" {
 		t.Fatalf("charged fingerprint %q, want fp-codex-platform — the OpenAI tokens landed on the Anthropic credential", row.Fingerprint)
 	}
-	if row.InputTokens != 25000 {
-		t.Errorf("input tokens = %d, want 25000", row.InputTokens)
+	if row.AggregateTokens != 25000 {
+		t.Errorf("aggregate tokens = %d, want 25000", row.AggregateTokens)
 	}
 	if row.CostUSD <= 0 {
 		t.Errorf("cost = %v, want > 0 — a priced model's delegation is not a free call", row.CostUSD)

--- a/pkg/runner/loop_cred_spend.go
+++ b/pkg/runner/loop_cred_spend.go
@@ -73,11 +73,12 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 				Tier:        credentialTier(creds, slot),
 				TenantID:    msg.TenantID,
 			},
-			Nature:       credentialNature(slot),
-			Backend:      route.backend,
-			CostUSD:      totals.costUSD,
-			InputTokens:  totals.inputTokens,
-			OutputTokens: totals.outputTokens,
+			Nature:          credentialNature(slot),
+			Backend:         route.backend,
+			CostUSD:         totals.costUSD,
+			InputTokens:     totals.inputTokens,
+			OutputTokens:    totals.outputTokens,
+			AggregateTokens: totals.aggregateTokens,
 		}
 		if err := r.cfg.CredUsage.AddSpend(bg, at, spend); err != nil && r.cfg.Logger != nil {
 			r.cfg.Logger.Warn("runner: credential spend record for %s (run %s): %v", fp, msg.RunID, err)

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -61,9 +61,10 @@ type metricsEmitter struct {
 	// Per-run accumulation for org metering. Covers both claw steps and
 	// delegate calls; a node whose model the price table cannot price
 	// contributes nothing, so this is a floor, not an exact invoice.
-	runCostUSD      float64
-	runInputTokens  int64
-	runOutputTokens int64
+	runCostUSD         float64
+	runInputTokens     int64
+	runOutputTokens    int64
+	runAggregateTokens int64
 
 	// byRoute splits the same accumulation per (backend, model) — the unit
 	// per-CREDENTIAL metering needs. One run can spend two credentials (a
@@ -100,9 +101,13 @@ type routeKey struct{ backend, model string }
 
 // routeTotals is one route's slice of the run's consumption.
 type routeTotals struct {
-	costUSD      float64
-	inputTokens  int64
-	outputTokens int64
+	costUSD float64
+	// inputTokens / outputTokens hold an OBSERVED split; aggregateTokens
+	// holds a total the delegate could not split. A route fills one or the
+	// other — see credusage.MonthlyUsage for why the distinction is public.
+	inputTokens     int64
+	outputTokens    int64
+	aggregateTokens int64
 }
 
 func newMetricsEmitter(inner model.EventEmitter, reg *metrics.Registry) *metricsEmitter {
@@ -158,7 +163,7 @@ func (m *metricsEmitter) noteDeclinedRoute(k routeKey) (first bool) {
 // Called with m.mu held, alongside the run-total accumulation it mirrors —
 // the two must never diverge, so they are updated in the same critical
 // section.
-func (m *metricsEmitter) addRouteLocked(backend, modelName string, cost float64, in, out int64) {
+func (m *metricsEmitter) addRouteLocked(backend, modelName string, cost float64, in, out, aggregate int64) {
 	if m.byRoute == nil {
 		m.byRoute = make(map[routeKey]routeTotals)
 	}
@@ -167,6 +172,7 @@ func (m *metricsEmitter) addRouteLocked(backend, modelName string, cost float64,
 	t.costUSD += cost
 	t.inputTokens += in
 	t.outputTokens += out
+	t.aggregateTokens += aggregate
 	m.byRoute[k] = t
 }
 
@@ -327,7 +333,7 @@ func (m *metricsEmitter) observe(evt store.Event) {
 				}
 			}
 		}
-		m.addRouteLocked(backend, modelName, costDelta, int64(inputT), int64(outputT))
+		m.addRouteLocked(backend, modelName, costDelta, int64(inputT), int64(outputT), 0)
 		m.mu.Unlock()
 
 		m.addTokens(backend, modelName, "input", evt.Data["input_tokens"])
@@ -416,21 +422,25 @@ func (m *metricsEmitter) observe(evt store.Event) {
 					costDelta = tokensF * rate.inputUSDPerToken
 				}
 			}
-			m.runInputTokens += int64(tokensF)
+			m.runAggregateTokens += int64(tokensF)
 			m.runCostUSD += costDelta
-			// The delegate reports one aggregated token count; booked as
-			// input here for the same reason addTokens labels it that way,
-			// so a sum across directions stays meaningful.
-			m.addRouteLocked(backend, modelName, costDelta, int64(tokensF), 0)
+			// The delegate reports ONE token count and no split. It goes to
+			// the aggregate counter rather than to input: a sum stays exact
+			// either way, and only this way does a reader of the public
+			// per-credential endpoint see "not split" instead of a
+			// confident, wrong input figure (#992).
+			m.addRouteLocked(backend, modelName, costDelta, 0, 0, int64(tokensF))
 		}
 		m.mu.Unlock()
 		if summarised {
 			return
 		}
 
-		// Delegate events report a single aggregated token count;
-		// label as input so a sum across directions stays meaningful.
-		m.addTokens(backend, modelName, "input", evt.Data["tokens"])
+		// Delegate events report a single aggregated token count. It gets
+		// its own direction label: summing every direction stays exact,
+		// and a dashboard reading `direction="input"` is no longer served
+		// output tokens under that name.
+		m.addTokens(backend, modelName, "aggregate", evt.Data["tokens"])
 		if costDelta > 0 && m.reg != nil {
 			m.reg.LLMCostUSDTotal.WithLabelValues(backend, normalizeModelLabel(modelName)).Add(costDelta)
 		}
@@ -439,10 +449,14 @@ func (m *metricsEmitter) observe(evt store.Event) {
 
 // RunTotals snapshots the run's accumulated LLM consumption — what
 // the runner charges to the org's monthly usage bucket.
-func (m *metricsEmitter) RunTotals() (costUSD float64, inputTokens, outputTokens int64) {
+//
+// The three token counts are disjoint: a run mixing an in-process claw loop
+// with a CLI delegate fills the directional pair AND the aggregate, and its
+// true total is the sum of all three.
+func (m *metricsEmitter) RunTotals() (costUSD float64, inputTokens, outputTokens, aggregateTokens int64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.runCostUSD, m.runInputTokens, m.runOutputTokens
+	return m.runCostUSD, m.runInputTokens, m.runOutputTokens, m.runAggregateTokens
 }
 
 // SawAuthFailure reports whether the provider rejected this run's

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -41,8 +41,8 @@ func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usag
 	// instead of by org (#641). Independent of the org gate below: a route
 	// the org bucket cannot break apart is exactly what this answers.
 	r.recordCredentialSpend(ctx, msg, usage, now)
-	costUSD, in, out := usage.RunTotals()
-	spent := costUSD > 0 || in > 0 || out > 0
+	costUSD, in, out, aggregate := usage.RunTotals()
+	spent := costUSD > 0 || in > 0 || out > 0 || aggregate > 0
 	if !spent {
 		return
 	}
@@ -60,7 +60,7 @@ func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usag
 			key = msg.TenantID
 		}
 		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		if err := r.cfg.OrgUsage.AddSpend(bg, key, now, costUSD, in, out); err != nil {
+		if err := r.cfg.OrgUsage.AddSpend(bg, key, now, costUSD, in, out, aggregate); err != nil {
 			r.cfg.Logger.Warn("runner: org spend record for %s (run %s): %v", key, msg.RunID, err)
 		}
 		cancel()
@@ -140,7 +140,7 @@ func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, e
 	if r.cfg.CredPool == nil || usage == nil {
 		return
 	}
-	costUSD, in, out := usage.RunTotals()
+	costUSD, in, out, aggregate := usage.RunTotals()
 	condition, cooldownUntil := classifyPoolCondition(execErr, time.Now().UTC())
 	// An auth rejection the recovery machinery absorbed into a human pause
 	// leaves execErr saying only "paused". Without this the donor's dead
@@ -152,12 +152,13 @@ func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, e
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := r.cfg.CredPool.Report(bg, msg.RunID, credpool.Outcome{
-		CostUSD:       costUSD,
-		InputTokens:   in,
-		OutputTokens:  out,
-		Condition:     condition,
-		CooldownUntil: cooldownUntil,
-		Interim:       interim,
+		CostUSD:         costUSD,
+		InputTokens:     in,
+		OutputTokens:    out,
+		AggregateTokens: aggregate,
+		Condition:       condition,
+		CooldownUntil:   cooldownUntil,
+		Interim:         interim,
 	}); err != nil {
 		r.cfg.Logger.Warn("runner: credential-pool report for run %s: %v (the donor's slot frees on lease expiry)", msg.RunID, err)
 	}

--- a/pkg/runner/metrics_test.go
+++ b/pkg/runner/metrics_test.go
@@ -265,12 +265,21 @@ func TestMetricsEmitter_delegateFinished_aggregatedTokens(t *testing.T) {
 		},
 	})
 
-	c, err := reg.LLMTokensTotal.GetMetricWithLabelValues("claude_code", "unknown", "input")
+	// The delegate's one number gets its own direction label. A dashboard
+	// panel filtering direction="input" must not be served it (#992).
+	c, err := reg.LLMTokensTotal.GetMetricWithLabelValues("claude_code", "unknown", "aggregate")
 	if err != nil {
 		t.Fatalf("GetMetricWithLabelValues: %v", err)
 	}
 	if got := counterValue(t, c); got != 420 {
-		t.Errorf("delegate tokens = %v, want 420", got)
+		t.Errorf("delegate tokens under direction=aggregate = %v, want 420", got)
+	}
+	in, err := reg.LLMTokensTotal.GetMetricWithLabelValues("claude_code", "unknown", "input")
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	if got := counterValue(t, in); got != 0 {
+		t.Errorf("direction=input = %v, want 0 — the delegate never reported a split", got)
 	}
 }
 
@@ -324,12 +333,15 @@ func TestMetricsEmitter_delegateFinished_costReachesRunTotals(t *testing.T) {
 		t.Errorf("emitted cost_usd = %v, want 0.4242 — the hook is dropping the delegation's cost", got)
 	}
 
-	costUSD, in, _ := usage.RunTotals()
+	costUSD, in, _, aggregate := usage.RunTotals()
 	if costUSD != 0.4242 {
 		t.Errorf("RunTotals cost = %v, want 0.4242 — delegate spend is not charged to the run", costUSD)
 	}
-	if in != 1200 {
-		t.Errorf("RunTotals input tokens = %d, want 1200", in)
+	if aggregate != 1200 {
+		t.Errorf("RunTotals aggregate tokens = %d, want 1200", aggregate)
+	}
+	if in != 0 {
+		t.Errorf("RunTotals input tokens = %d, want 0 — the delegate reported no split (#992)", in)
 	}
 }
 
@@ -348,7 +360,7 @@ func TestMetricsEmitter_delegateFinished_unpricedStaysZero(t *testing.T) {
 	if _, present := inner.events[0].Data["cost_usd"]; present {
 		t.Error("cost_usd present for an unpriced delegation — 'no data' must stay distinguishable from $0")
 	}
-	if costUSD, _, _ := usage.RunTotals(); costUSD != 0 {
+	if costUSD, _, _, _ := usage.RunTotals(); costUSD != 0 {
 		t.Errorf("RunTotals cost = %v, want 0", costUSD)
 	}
 }
@@ -372,7 +384,7 @@ func TestMetricsEmitter_clawCostIsNotCountedTwice(t *testing.T) {
 		Type: store.EventLLMStepFinished, RunID: "run-1", NodeID: "n1",
 		Data: map[string]any{"input_tokens": float64(1000), "output_tokens": float64(500)},
 	})
-	perStep, _, _ := usage.RunTotals()
+	perStep, _, _, _ := usage.RunTotals()
 	if perStep <= 0 {
 		t.Fatalf("the step itself priced to %v — the test cannot show a double count", perStep)
 	}
@@ -382,7 +394,10 @@ func TestMetricsEmitter_clawCostIsNotCountedTwice(t *testing.T) {
 		Data: map[string]any{"backend": "claw", "tokens": float64(1500), "cost_usd": perStep},
 	})
 
-	total, in, out := usage.RunTotals()
+	total, in, out, aggregate := usage.RunTotals()
+	if aggregate != 0 {
+		t.Errorf("aggregate tokens = %d, want 0 — the summarised delegation must not be booked at all", aggregate)
+	}
 	if total != perStep {
 		t.Errorf("cost = %v after the delegation total, want %v — claw was charged twice", total, perStep)
 	}
@@ -401,7 +416,7 @@ func TestMetricsEmitter_cliDelegateCostIsStillCounted(t *testing.T) {
 		Type: store.EventDelegateFinished, RunID: "run-2", NodeID: "n1",
 		Data: map[string]any{"backend": "claude_code", "tokens": float64(900), "cost_usd": 0.42},
 	})
-	if cost, _, _ := usage.RunTotals(); cost != 0.42 {
+	if cost, _, _, _ := usage.RunTotals(); cost != 0.42 {
 		t.Errorf("cost = %v, want 0.42", cost)
 	}
 }
@@ -434,15 +449,18 @@ func TestMetricsEmitter_sandboxedClaw_delegateOnlyIsPricedAndRouted(t *testing.T
 	if !ok {
 		t.Fatalf("routes = %v, want one keyed (claw, openai/gpt-5.6-sol) — the declared model must name the route", routes)
 	}
-	if got.inputTokens != 25000 {
-		t.Errorf("route input tokens = %d, want 25000", got.inputTokens)
+	if got.aggregateTokens != 25000 {
+		t.Errorf("route aggregate tokens = %d, want 25000", got.aggregateTokens)
+	}
+	if got.inputTokens != 0 {
+		t.Errorf("route input tokens = %d, want 0 — one aggregate count is not an input count (#992)", got.inputTokens)
 	}
 	if got.costUSD <= 0 {
 		t.Errorf("route cost = %v, want > 0: the table prices gpt-5.6-sol, and a delegation the guard excluded is not a free call", got.costUSD)
 	}
-	cost, in, _ := usage.RunTotals()
-	if cost != got.costUSD || in != 25000 {
-		t.Errorf("RunTotals = ($%v, %d) — must mirror the route (%+v)", cost, in, got)
+	cost, _, _, aggregate := usage.RunTotals()
+	if cost != got.costUSD || aggregate != 25000 {
+		t.Errorf("RunTotals = ($%v, %d) — must mirror the route (%+v)", cost, aggregate, got)
 	}
 }
 
@@ -455,8 +473,8 @@ func TestMetricsEmitter_sandboxedClaw_delegateCostWinsOverTheTable(t *testing.T)
 		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-5.6-sol"}})
 	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
 		Data: map[string]any{"backend": "claw", "tokens": float64(25000), "cost_usd": 0.1234}})
-	if cost, in, _ := usage.RunTotals(); cost != 0.1234 || in != 25000 {
-		t.Fatalf("RunTotals = ($%v, %d), want ($0.1234, 25000)", cost, in)
+	if cost, _, _, aggregate := usage.RunTotals(); cost != 0.1234 || aggregate != 25000 {
+		t.Fatalf("RunTotals = ($%v, %d), want ($0.1234, 25000)", cost, aggregate)
 	}
 }
 
@@ -468,12 +486,12 @@ func TestMetricsEmitter_sandboxedClaw_unknownModelStaysUnpriced(t *testing.T) {
 		Data: map[string]any{"backend": "claw", "declared_model": "openai/gpt-99-nowhere"}})
 	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
 		Data: map[string]any{"backend": "claw", "tokens": float64(400)}})
-	cost, in, _ := usage.RunTotals()
+	cost, _, _, aggregate := usage.RunTotals()
 	if cost != 0 {
 		t.Errorf("cost = %v for a model no source prices, want 0 (unknown)", cost)
 	}
-	if in != 400 {
-		t.Errorf("input tokens = %d, want 400 — the tokens are known even when the price is not", in)
+	if aggregate != 400 {
+		t.Errorf("aggregate tokens = %d, want 400 — the tokens are known even when the price is not", aggregate)
 	}
 	if _, ok := usage.RouteTotals()[routeKey{backend: "claw", model: "openai/gpt-99-nowhere"}]; !ok {
 		t.Errorf("routes = %v, want the unpriced route present so the credential still sees its tokens", usage.RouteTotals())
@@ -549,7 +567,7 @@ func TestMetricsEmitter_relayedSandboxedClawStepsMeterLikeInProcess(t *testing.T
 	relay.OnLLMRequest("plan_review", model.LLMRequestInfo{Model: "gpt-5.6-sol"})
 	relay.OnLLMStepFinish("plan_review", model.LLMStepInfo{Number: 1, InputTokens: 20000, OutputTokens: 3000})
 	relay.OnLLMStepFinish("plan_review", model.LLMStepInfo{Number: 2, InputTokens: 20000, OutputTokens: 3000})
-	stepsCost, _, _ := usage.RunTotals()
+	stepsCost, _, _, _ := usage.RunTotals()
 	if stepsCost <= 0 {
 		t.Fatalf("the relayed steps priced to %v — gpt-5.6-sol is in the table", stepsCost)
 	}
@@ -569,7 +587,7 @@ func TestMetricsEmitter_relayedSandboxedClawStepsMeterLikeInProcess(t *testing.T
 	if len(routes) != 1 {
 		t.Errorf("routes = %v, want the one route", routes)
 	}
-	if cost, in, out := usage.RunTotals(); cost != stepsCost || in != 40000 || out != 6000 {
+	if cost, in, out, _ := usage.RunTotals(); cost != stepsCost || in != 40000 || out != 6000 {
 		t.Errorf("RunTotals = ($%v, %d, %d), want ($%v, 40000, 6000)", cost, in, out, stepsCost)
 	}
 }
@@ -586,13 +604,13 @@ func TestMetricsEmitter_newAttemptResetsTheStepGuard(t *testing.T) {
 		Data: map[string]any{"input_tokens": float64(1000), "output_tokens": float64(0)}})
 	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
 		Data: map[string]any{"backend": "claw", "tokens": float64(1000)}})
-	if _, in, _ := usage.RunTotals(); in != 1000 {
-		t.Fatalf("after a summarised first attempt: input tokens = %d, want 1000", in)
+	if _, in, _, aggregate := usage.RunTotals(); in != 1000 || aggregate != 0 {
+		t.Fatalf("after a summarised first attempt: in %d / aggregate %d, want 1000/0", in, aggregate)
 	}
 	usage.observe(start)
 	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
 		Data: map[string]any{"backend": "claw", "tokens": float64(500)}})
-	if _, in, _ := usage.RunTotals(); in != 1500 {
-		t.Fatalf("after an unrelayed second attempt: input tokens = %d, want 1500 — the guard must reset per attempt", in)
+	if _, in, _, aggregate := usage.RunTotals(); in != 1000 || aggregate != 500 {
+		t.Fatalf("after an unrelayed second attempt: in %d / aggregate %d, want 1000/500 — the guard must reset per attempt", in, aggregate)
 	}
 }

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -146,12 +146,22 @@ func TestMetricsEmitter_RunTotalsAccumulate(t *testing.T) {
 		Data: map[string]any{"backend": "claude_code", "tokens": float64(420)},
 	})
 
-	cost, in, out := m.RunTotals()
-	if in != 1420 {
-		t.Errorf("input tokens = %d, want 1420 (claw 1000 + delegate 420)", in)
+	// The mixed shape #992 is about: claw measured a real 1000/500 split,
+	// the claude_code delegate reported 420 it could not split. Merging the
+	// two under `input` made the measured figure unreadable — 1420 input is
+	// neither a measurement nor a total.
+	cost, in, out, aggregate := m.RunTotals()
+	if in != 1000 {
+		t.Errorf("input tokens = %d, want 1000 — claw's measured input alone", in)
 	}
 	if out != 500 {
 		t.Errorf("output tokens = %d, want 500", out)
+	}
+	if aggregate != 420 {
+		t.Errorf("aggregate tokens = %d, want 420 — the delegate's unsplittable total", aggregate)
+	}
+	if total := in + out + aggregate; total != 1920 {
+		t.Errorf("summed tokens = %d, want 1920 — the total must stay exact", total)
 	}
 	if cost <= 0 {
 		t.Errorf("cost = %v, want > 0 for a priced claw model", cost)

--- a/pkg/server/admin_orgs_routes.go
+++ b/pkg/server/admin_orgs_routes.go
@@ -115,6 +115,9 @@ type orgUsageView struct {
 	CostUSDThisMonth float64 `json:"cost_usd_this_month"`
 	InputTokens      int64   `json:"input_tokens_this_month"`
 	OutputTokens     int64   `json:"output_tokens_this_month"`
+	// A CLI delegate's unsplittable total, kept out of the directional
+	// pair so neither is claimed on evidence that does not exist (#992).
+	AggregateTokens int64 `json:"aggregate_tokens_this_month"`
 	// Caps as enforced by the launch gate (org override or platform
 	// default; 0 = unlimited).
 	MonthlyCostCapUSD float64 `json:"monthly_cost_cap_usd,omitempty"`
@@ -462,6 +465,7 @@ func (s *Server) buildOrgUsageView(ctx context.Context, st identity.Store, o ide
 			v.RunsThisMonth = u.Runs
 			v.CostUSDThisMonth = u.CostUSD
 			v.InputTokens = u.InputTokens
+			v.AggregateTokens = u.AggregateTokens
 			v.OutputTokens = u.OutputTokens
 		}
 	}

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -133,7 +133,7 @@ func TestPoolTier_credentiallessRunGetsADonorsSubscription(t *testing.T) {
 func TestPoolTier_runBudgetIsCappedAtTheDonorsAllowance(t *testing.T) {
 	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
 	// The donor has already given $3 today.
-	if err := f.ledger.AddSpend(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), time.Now().UTC(), 3, 0, 0); err != nil {
+	if err := f.ledger.AddSpend(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), time.Now().UTC(), 3, 0, 0, 0); err != nil {
 		t.Fatalf("seed spend: %v", err)
 	}
 

--- a/pkg/server/cred_usage_routes.go
+++ b/pkg/server/cred_usage_routes.go
@@ -25,17 +25,22 @@ func (s *Server) registerCredUsageRoutes() {
 // never be summed, and a client that only reads cost_usd would do exactly
 // that — so the API states it rather than leaving it to a doc nobody opens.
 type credentialUsageView struct {
-	Month        string   `json:"month"`
-	Fingerprint  string   `json:"fingerprint"`
-	Provider     string   `json:"provider"`
-	Tier         string   `json:"tier"`
-	TenantID     string   `json:"tenant_id,omitempty"`
-	Nature       string   `json:"nature"`
-	CostUSD      float64  `json:"cost_usd"`
-	InputTokens  int64    `json:"input_tokens"`
-	OutputTokens int64    `json:"output_tokens"`
-	Runs         int      `json:"runs"`
-	Backends     []string `json:"backends,omitempty"`
+	Month       string  `json:"month"`
+	Fingerprint string  `json:"fingerprint"`
+	Provider    string  `json:"provider"`
+	Tier        string  `json:"tier"`
+	TenantID    string  `json:"tenant_id,omitempty"`
+	Nature      string  `json:"nature"`
+	CostUSD     float64 `json:"cost_usd"`
+	// InputTokens / OutputTokens are a MEASURED split and stay zero when
+	// none was observed; AggregateTokens holds a CLI delegate's
+	// unsplittable total. A per-direction ratio is only meaningful when
+	// the aggregate is zero (#992).
+	InputTokens     int64    `json:"input_tokens"`
+	OutputTokens    int64    `json:"output_tokens"`
+	AggregateTokens int64    `json:"aggregate_tokens"`
+	Runs            int      `json:"runs"`
+	Backends        []string `json:"backends,omitempty"`
 }
 
 // credentialUsageListView is the response envelope.
@@ -55,7 +60,8 @@ func toCredentialUsageList(month string, rows []credusage.MonthlyUsage) credenti
 			Month: r.Month, Fingerprint: r.Fingerprint, Provider: r.Provider,
 			Tier: string(r.Tier), TenantID: r.TenantID, Nature: string(r.Nature),
 			CostUSD: r.CostUSD, InputTokens: r.InputTokens, OutputTokens: r.OutputTokens,
-			Runs: r.Runs, Backends: r.Backends,
+			AggregateTokens: r.AggregateTokens,
+			Runs:            r.Runs, Backends: r.Backends,
 		})
 		if r.Nature == credusage.NatureMetered {
 			out.MeteredUSD += r.CostUSD

--- a/pkg/server/credpool_routes.go
+++ b/pkg/server/credpool_routes.go
@@ -77,6 +77,9 @@ type usageView struct {
 	CostUSD      float64 `json:"cost_usd"`
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
+	// A CLI delegate's unsplittable total. A donor reading zero across all
+	// three sees "not observed", never "nothing spent" (#992).
+	AggregateTokens int64 `json:"aggregate_tokens"`
 }
 
 // leaseView is one entry of a donor's history: which bot ran, for which
@@ -507,7 +510,7 @@ func (s *Server) toPledgeView(r *http.Request, p credpool.Pledge, now time.Time,
 }
 
 func toUsageView(u credpool.Usage) usageView {
-	return usageView{Runs: u.Runs, CostUSD: u.CostUSD, InputTokens: u.InputTokens, OutputTokens: u.OutputTokens}
+	return usageView{Runs: u.Runs, CostUSD: u.CostUSD, InputTokens: u.InputTokens, OutputTokens: u.OutputTokens, AggregateTokens: u.AggregateTokens}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/server/launch_gate_test.go
+++ b/pkg/server/launch_gate_test.go
@@ -31,7 +31,7 @@ type erroringCounter struct{}
 func (erroringCounter) AllowRun(context.Context, string, time.Time, int, int64) (orgusage.DenyReason, error) {
 	return orgusage.DenyNone, context.DeadlineExceeded
 }
-func (erroringCounter) AddSpend(context.Context, string, time.Time, float64, int64, int64) error {
+func (erroringCounter) AddSpend(context.Context, string, time.Time, float64, int64, int64, int64) error {
 	return context.DeadlineExceeded
 }
 func (erroringCounter) ReleaseRun(context.Context, string, time.Time) error {
@@ -156,7 +156,7 @@ func TestGateLaunch_CostCap(t *testing.T) {
 	if _, d := s.gateLaunch(ctx); d != nil {
 		t.Fatalf("under-cap launch denied: %+v", d)
 	}
-	if err := counter.AddSpend(context.Background(), "t1", time.Now().UTC(), 6.0, 0, 0); err != nil {
+	if err := counter.AddSpend(context.Background(), "t1", time.Now().UTC(), 6.0, 0, 0, 0); err != nil {
 		t.Fatal(err)
 	}
 	_, d := s.gateLaunch(ctx)
@@ -360,7 +360,7 @@ func TestGateLaunch_CostCapAcrossTeams(t *testing.T) {
 		t.Fatalf("under-cap launch denied: %+v", d)
 	}
 	// Runner-side spend lands on the ORG key (RunMessage.OrgID).
-	if err := counter.AddSpend(ctx, "o1", time.Now().UTC(), 6.0, 0, 0); err != nil {
+	if err := counter.AddSpend(ctx, "o1", time.Now().UTC(), 6.0, 0, 0, 0); err != nil {
 		t.Fatal(err)
 	}
 	_, d := s.gateLaunch(ctxA)

--- a/pkg/store/turn.go
+++ b/pkg/store/turn.go
@@ -159,6 +159,10 @@ type TurnUsage struct {
 	InputTokens  int     `json:"input_tokens,omitempty"`
 	OutputTokens int     `json:"output_tokens,omitempty"`
 	CostUSD      float64 `json:"cost_usd,omitempty"`
+	// AggregateTokens holds a turn total the backend could not split.
+	// Absent when the backend reported a real split, and never counted
+	// twice with the pair above — a total is the sum of the three.
+	AggregateTokens int `json:"aggregate_tokens,omitempty"`
 }
 
 // TurnIndexEntry is the per-node directory's `index.json` row,


### PR DESCRIPTION
Closes #992.

## What was wrong

A CLI delegate reports **one** token count and no split. Every usage surface booked it under `input_tokens` — which keeps a *sum* correct and makes the *named field* a lie. Measured on ovh-prod, in the ticket:

| fingerprint | provider | runs | input_tokens | output_tokens |
|---|---|---|---|---|
| `e4ecd228` | claude_code | 94 | 3 007 491 | **0** |
| `4163b9b5` | codex | 30 | **0** | 641 516 |

Every credential filled exactly one field and zeroed the other, so every per-token ratio, cache-hit reading and input/output share taken from the public endpoint was wrong — with nothing on the row saying so.

## Why a third field rather than a `tokens_split_known` flag

The ticket offered both. The data model picks one: **a row is a monthly aggregate**, and `Backends []string` on that same record proves one fingerprint routinely mixes backends within a month.

A boolean is **not closed under aggregation** — a month mixing `claw` (split measured) with `claude_code` (no split) has no honest value for it. A counter is:

```
input=X (measured) · output=Y (measured) · aggregate=Z (unsplittable) · total = X+Y+Z
```

The property the old convention protected — an exact total — survives, and a reader can finally tell *"0 output tokens"* from *"I cannot split this"*.

## Treated at the class, not at the site the ticket named

Four consumers read the same `tokensF` from the same `delegate_finished` event:

- **three monthly buckets** — `credusage` (the reported one), `orgusage`, and the `credpool` donor ledger — each with a memory **and** a Mongo twin, and each sitting behind a **hand-copied REST DTO** that would otherwise have dropped the new field silently;
- the **Prometheus** counter, which now gets `direction="aggregate"` instead of serving output tokens to a dashboard panel filtering on `input`;
- **`store.TurnUsage`**, fed by the claude_code delegate's own turn hook.

## Why this is safe

**Token counts are reporting-only** — verified: no cap, gate or budget meters on them, so moving the aggregate out of `input_tokens` cannot under-count an enforcement axis. Cost accounting is untouched.

Rows written before this change keep their aggregates inside `input_tokens`; they cannot be separated after the fact, and the Mongo field is simply absent on them.

## Evidence

- Both new tests in `pkg/runner/aggregate_tokens_test.go` seen **red first** (`row.AggregateTokens undefined`), then green.
- Nine existing tests pinned the old convention and were read individually rather than blind-patched. The clearest is `org_spend_test.go` — claw measured `1000/500`, a delegate reported `420` it could not split, and the old assertion merged them into `in = 1420`, which is neither a measurement nor a total. It now asserts `1000 / 500 / 420` and that the sum is still `1920`.
- `task check` — exit 0, zero FAIL lines.
- `go test -race` clean on the six touched packages.
- **Mongo conformance** against a real `mongo:8.0` replica set: exit 0 across all 21 gated trees, with `TestMongoCounter_Conformance` confirmed to have *run* rather than skipped.
- `iterion openapi` regenerated: no spec drift (these bodies are not enumerated in the schema), so `studio/src/api/schema.ts` is unaffected.

## Found but deliberately left out of scope

`pkg/backend/model/executor.go` hardcodes `Backend: delegate.BackendClaudeCode` while `delegateHooksFor` already receives the real `backendName` — and `pi_rpc.go` fires the same `OnTurnFinished` hook, so **every pi turn is recorded as a claude_code turn**. It is a real defect, but `pkg/runview/fork.go` reads `turn.Backend` to choose the rehydration path, so correcting it has its own blast radius and deserves its own ticket.

## Conflict surface

Touches `docs/quotas-and-limits.md` (also in #936) and `pkg/backend/delegate/delegate.go` + `pkg/backend/model/executor.go` (also in #480). Neither duplicates this work; whichever merges second rebases.
