### PR TITLE
fix(forge): a store that could not answer is no longer read as "you have no App"

### DIFF
--- a/pkg/server/board_binding_routes.go
+++ b/pkg/server/board_binding_routes.go
@@ -213,9 +213,15 @@ func (s *Server) installationGrantsFor(ctx context.Context, conn forge.Connectio
 	if s.forgeInstallationGrants != nil {
 		return s.forgeInstallationGrants(ctx, conn)
 	}
-	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-	if !ok || conn.InstallationID == 0 {
+	cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+	switch {
+	case errors.Is(err, errNoGitHubApp), err == nil && conn.InstallationID == 0:
+		// Nothing to probe with: the recorded grant is the best answer there is.
 		return conn.GrantedPermissions, nil
+	case err != nil:
+		// A read that failed is not a grant. Returning the stored set here
+		// would present stale permissions as the live ones.
+		return nil, err
 	}
 	inst, err := forgegithub.InstallationInfo(ctx, s.forgeHTTPClient(),
 		forgegithub.APIBaseFor(conn.BaseURL()), cfg, conn.InstallationID, time.Now().UTC())

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -720,7 +720,12 @@ func (s *Server) handleListIntegrationHooks(w http.ResponseWriter, r *http.Reque
 	}
 	admin, err := s.forgeAdminFor(r.Context(), conn)
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "admin client: %v", err)
+		// forgeAdminFor is network-free in BOTH branches — the App client is
+		// constructed and cached (tokens are minted later, on use) and the
+		// token branch only unseals — so a failure here never reached the
+		// forge. 502 would send the operator to the provider's status page
+		// for our own outage.
+		httpError(w, http.StatusInternalServerError, "admin client: %v", err)
 		return
 	}
 	hooks, err := admin.ListHooks(r.Context(), ri.RepoFullName)
@@ -837,7 +842,8 @@ func (s *Server) connAdminFor(w http.ResponseWriter, ctx context.Context, teamID
 	}
 	admin, err := s.forgeAdminFor(ctx, conn)
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "admin client: %v", err)
+		// Network-free failure — see the sibling note above; 500, not 502.
+		httpError(w, http.StatusInternalServerError, "admin client: %v", err)
 		return nil, forge.Connection{}, false
 	}
 	return admin, conn, true

--- a/pkg/server/forge_app_degraded_read_test.go
+++ b/pkg/server/forge_app_degraded_read_test.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// errStoreDown is what a Mongo blip looks like from the store's caller.
+var errStoreDown = errors.New("mongo: connection refused")
+
+// degradedOAuthAppStore is a real store whose READS can be switched off — the
+// only way to exercise the difference between "this tenant has no App" and
+// "I could not find out".
+type degradedOAuthAppStore struct {
+	forge.OAuthAppStore
+	down *atomic.Bool
+}
+
+func (d degradedOAuthAppStore) Get(ctx context.Context, id string) (forge.ForgeOAuthApp, error) {
+	if d.down.Load() {
+		return forge.ForgeOAuthApp{}, errStoreDown
+	}
+	return d.OAuthAppStore.Get(ctx, id)
+}
+
+func (d degradedOAuthAppStore) GetByInstance(ctx context.Context, tenantID string, p forge.Provider, baseURL string) (forge.ForgeOAuthApp, error) {
+	if d.down.Load() {
+		return forge.ForgeOAuthApp{}, errStoreDown
+	}
+	return d.OAuthAppStore.GetByInstance(ctx, tenantID, p, baseURL)
+}
+
+func (d degradedOAuthAppStore) ListByInstance(ctx context.Context, tenantID string, p forge.Provider, baseURL string) ([]forge.ForgeOAuthApp, error) {
+	if d.down.Load() {
+		return nil, errStoreDown
+	}
+	return d.OAuthAppStore.ListByInstance(ctx, tenantID, p, baseURL)
+}
+
+// newDegradableAppServer returns a server whose OAuth-app store can be pushed
+// over, plus the switch.
+func newDegradableAppServer(t *testing.T) (*Server, *atomic.Bool) {
+	t.Helper()
+	s := newForgeTestServer(t)
+	down := &atomic.Bool{}
+	s.forgeOAuthApps = degradedOAuthAppStore{OAuthAppStore: forge.NewMemoryOAuthAppStore(), down: down}
+	return s, down
+}
+
+// #969 — "no App configured" and "the store could not answer" are different
+// facts. Collapsing them into one `ok bool` makes a Mongo blip indistinguishable
+// from a deliberate absence, and every caller then acts on the wrong one.
+func TestGitHubAppConfig_DegradedReadIsNotAbsence(t *testing.T) {
+	s, down := newDegradableAppServer(t)
+	t0 := time.Unix(1700000000, 0).UTC()
+	app := storeApp(t, s, "app-1", "t1", "SocialGouv", "111", "PEM-1", t0)
+	ctx := context.Background()
+	conn := forge.Connection{ID: "c1", TenantID: "t1", Kind: forge.KindGitHubApp, OAuthAppID: app.ID}
+
+	// Sanity: healthy store resolves.
+	if _, _, err := s.githubAppConfigForConnection(ctx, conn); err != nil {
+		t.Fatalf("healthy read: %v", err)
+	}
+
+	down.Store(true)
+	_, _, err := s.githubAppConfigForConnection(ctx, conn)
+	if err == nil {
+		t.Fatal("a store that cannot answer must not report a resolved App")
+	}
+	if errors.Is(err, errNoGitHubApp) {
+		t.Error("a degraded read reported as errNoGitHubApp — a blip is being sold as a definite absence")
+	}
+	if !errors.Is(err, errStoreDown) {
+		t.Errorf("the store's own error must survive for the log: %v", err)
+	}
+}
+
+// A connection that genuinely names no App, on a healthy store, is a DEFINITE
+// negative — the sentinel says so, and callers may act on it.
+func TestGitHubAppConfig_GenuineAbsenceIsDefinite(t *testing.T) {
+	s, _ := newDegradableAppServer(t)
+	ctx := context.Background()
+	conn := forge.Connection{ID: "c1", TenantID: "t-empty", Kind: forge.KindGitHubApp}
+
+	_, _, err := s.githubAppConfigForConnection(ctx, conn)
+	if !errors.Is(err, errNoGitHubApp) {
+		t.Fatalf("a tenant with no App on a healthy store must answer errNoGitHubApp, got %v", err)
+	}
+}
+
+// The dangerous half: when the tenant's OWN app cannot be read, falling
+// through to the SHARED platform App swaps the signing identity behind the
+// operator's back. The platform key can mint for ANY installation, so this is
+// not a graceful degradation.
+func TestGitHubAppConfigForTenant_DegradedReadDoesNotServeThePlatformApp(t *testing.T) {
+	s, down := newDegradableAppServer(t)
+	t0 := time.Unix(1700000000, 0).UTC()
+	storeApp(t, s, "app-1", "t1", "SocialGouv", "111", "PEM-1", t0)
+	// A configured platform App is exactly the tempting fallback.
+	s.forgeGitHubApp = ForgeGitHubAppConfig{AppID: 42, PrivateKey: testAppKeyPEM(t), AppSlug: "iterion-forge-x"}
+	ctx := context.Background()
+
+	down.Store(true)
+	cfg, shared, err := s.githubAppConfigForTenant(ctx, "t1")
+	if err == nil {
+		t.Fatalf("a degraded tenant read resolved to %+v (shared=%v) — the tenant's own App was simply not consulted", cfg, shared)
+	}
+	if shared {
+		t.Error("the SHARED platform App was served for a tenant whose own App merely could not be read")
+	}
+	if errors.Is(err, errNoGitHubApp) {
+		t.Error("a degraded read must not be reported as a definite absence")
+	}
+}
+
+// The user-visible half of the same defect: a blip answered 502 Bad Gateway —
+// blaming the forge for a failure that never opened a socket. forgeAdminFor is
+// network-free in BOTH branches (the App client is constructed and cached, the
+// token branch unseals), so 502 there is structurally wrong.
+func TestForgeAdminFor_LocalFailureAnswers500Not502(t *testing.T) {
+	s, down := newDegradableAppServer(t)
+	t0 := time.Unix(1700000000, 0).UTC()
+	app := storeApp(t, s, "app-1", "t1", "SocialGouv", "111", "PEM-1", t0)
+	s.forgeConnections = forge.NewMemoryConnectionStore()
+	conn := forge.Connection{
+		ID: "conn1", TenantID: "t1", Provider: forge.ProviderGitHub,
+		Kind: forge.KindGitHubApp, OAuthAppID: app.ID, InstallationID: 42,
+	}
+	if err := s.forgeConnections.Create(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+
+	down.Store(true)
+	w := httptest.NewRecorder()
+	_, _, ok := s.connAdminFor(w, context.Background(), "t1", "conn1")
+	if ok {
+		t.Fatal("a degraded read must not yield an admin client")
+	}
+	if w.Code == http.StatusBadGateway {
+		t.Error("answered 502 Bad Gateway — nothing reached the forge; forgeAdminFor is network-free")
+	}
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 (iterion could not build its own client)", w.Code)
+	}
+}

--- a/pkg/server/forge_app_resolution_test.go
+++ b/pkg/server/forge_app_resolution_test.go
@@ -44,8 +44,8 @@ func TestGitHubAppConfigForConnection(t *testing.T) {
 
 	t.Run("resolves the app the connection names", func(t *testing.T) {
 		conn := forge.Connection{ID: "c1", TenantID: "t1", Kind: forge.KindGitHubApp, OAuthAppID: sandbox.ID}
-		cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-		if !ok {
+		cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+		if err != nil {
 			t.Fatal("want the sandbox app to resolve")
 		}
 		if cfg.AppID != 222 || cfg.PrivateKeyPEM != "PEM-SANDBOX" {
@@ -58,8 +58,8 @@ func TestGitHubAppConfigForConnection(t *testing.T) {
 	// collapsed onto one.
 	t.Run("a sibling connection on the same host resolves its own app", func(t *testing.T) {
 		conn := forge.Connection{ID: "c2", TenantID: "t1", Kind: forge.KindGitHubApp, OAuthAppID: prod.ID}
-		cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-		if !ok {
+		cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+		if err != nil {
 			t.Fatal("want the prod app to resolve")
 		}
 		if cfg.AppID != 111 {
@@ -72,8 +72,8 @@ func TestGitHubAppConfigForConnection(t *testing.T) {
 	// they keep resolving to the oldest.
 	t.Run("legacy connection falls back to the oldest app on the host", func(t *testing.T) {
 		conn := forge.Connection{ID: "c3", TenantID: "t1", Kind: forge.KindGitHubApp}
-		cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-		if !ok {
+		cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+		if err != nil {
 			t.Fatal("want the legacy fallback to resolve")
 		}
 		if cfg.AppID != 111 {
@@ -85,14 +85,14 @@ func TestGitHubAppConfigForConnection(t *testing.T) {
 	// identity the operator did not choose.
 	t.Run("cross-tenant app id resolves to nothing", func(t *testing.T) {
 		conn := forge.Connection{ID: "c4", TenantID: "t1", Kind: forge.KindGitHubApp, OAuthAppID: other.ID}
-		if _, _, ok := s.githubAppConfigForConnection(ctx, conn); ok {
+		if _, _, err := s.githubAppConfigForConnection(ctx, conn); err == nil {
 			t.Fatal("a connection must never resolve another tenant's app")
 		}
 	})
 
 	t.Run("dangling app id resolves to nothing", func(t *testing.T) {
 		conn := forge.Connection{ID: "c5", TenantID: "t1", Kind: forge.KindGitHubApp, OAuthAppID: "deleted-app"}
-		if _, _, ok := s.githubAppConfigForConnection(ctx, conn); ok {
+		if _, _, err := s.githubAppConfigForConnection(ctx, conn); err == nil {
 			t.Fatal("a dangling app reference must not silently fall back")
 		}
 	})
@@ -108,19 +108,19 @@ func TestGitHubAppForInstall(t *testing.T) {
 	sandbox := storeApp(t, s, "app-sandbox", "t1", "iterion-sandbox", "222", "PEM-SANDBOX", t0.Add(time.Hour))
 	ctx := context.Background()
 
-	cfg, id, shared, ok := s.githubAppForInstall(ctx, "t1", sandbox.ID)
-	if !ok || id != sandbox.ID || cfg.AppID != 222 || shared {
-		t.Fatalf("explicit selection failed: ok=%v id=%q appID=%d shared=%v", ok, id, cfg.AppID, shared)
+	cfg, id, shared, err := s.githubAppForInstall(ctx, "t1", sandbox.ID)
+	if err != nil || id != sandbox.ID || cfg.AppID != 222 || shared {
+		t.Fatalf("explicit selection failed: err=%v id=%q appID=%d shared=%v", err, id, cfg.AppID, shared)
 	}
 
 	// No explicit choice keeps the legacy answer AND pins its record, so the
 	// resulting connection stops depending on the host lookup from then on.
-	cfg, id, _, ok = s.githubAppForInstall(ctx, "t1", "")
-	if !ok || id != prod.ID || cfg.AppID != 111 {
-		t.Fatalf("default selection failed: ok=%v id=%q appID=%d", ok, id, cfg.AppID)
+	cfg, id, _, err = s.githubAppForInstall(ctx, "t1", "")
+	if err != nil || id != prod.ID || cfg.AppID != 111 {
+		t.Fatalf("default selection failed: err=%v id=%q appID=%d", err, id, cfg.AppID)
 	}
 
-	if _, _, _, ok := s.githubAppForInstall(ctx, "t2", sandbox.ID); ok {
+	if _, _, _, err := s.githubAppForInstall(ctx, "t2", sandbox.ID); err == nil {
 		t.Fatal("a team must not be able to install another team's app")
 	}
 }

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -159,9 +160,9 @@ type cachedForgeAppClient struct {
 // network-free at construction; a slug it learns lazily is recorded on the
 // connection through OnSlugResolved.
 func (s *Server) githubAppClientFor(ctx context.Context, conn forge.Connection) (forge.Admin, error) {
-	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-	if !ok {
-		return nil, fmt.Errorf("forge: no github app available for this connection")
+	cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+	if err != nil {
+		return nil, err
 	}
 	if cfg.AppSlug == "" {
 		cfg.AppSlug = conn.AppSlug
@@ -296,30 +297,56 @@ func preflightForgeClient(ctx context.Context, c any, need ...string) error {
 	return nil
 }
 
+// errNoGitHubApp is the DEFINITE answer: there is no GitHub-App identity to
+// sign with here. A caller may act on it — fall back to another auth path,
+// tell the operator to install the App, skip a lane.
+//
+// It exists to be distinguishable from a store that could not ANSWER. The two
+// used to share one `ok bool`, so a Mongo blip was indistinguishable from a
+// deliberate absence and every caller acted on the wrong one — the operator
+// being told "no github app available for this connection" about a connection
+// whose App is sitting in the database.
+var errNoGitHubApp = errors.New("forge: no github app available for this connection")
+
 // githubAppConfigForTenant returns the GitHub-App identity (app id + private key
 // + slug) used to mint installation tokens for the least-privilege github_app
 // path. It prefers the tenant's own manifest-created App (its sealed private
-// key), falling back to the platform App (ITERION_FORGE_GITHUB_APP_*). ok is
-// false when neither is available.
+// key), falling back to the platform App (ITERION_FORGE_GITHUB_APP_*).
+//
+// The error is errNoGitHubApp when neither is available, and the store's own
+// error — never errNoGitHubApp — when the tenant's App could not be READ. That
+// distinction is load-bearing rather than cosmetic: falling through to the
+// SHARED platform App on a failed read swaps the signing identity behind the
+// operator's back, and the platform key can mint for ANY installation.
 //
 // shared reports whether the returned config is the SHARED platform App (the
 // fallback). It matters for the install callback: a per-tenant App's private
 // key is tenant-scoped, so it can only mint tokens for that tenant's own
 // installations, whereas the shared App's key can mint for ANY installation —
 // so the shared path (and only it) must verify installation ownership.
-func (s *Server) githubAppConfigForTenant(ctx context.Context, tenantID string) (cfg forgegithub.AppConfig, shared bool, ok bool) {
+func (s *Server) githubAppConfigForTenant(ctx context.Context, tenantID string) (cfg forgegithub.AppConfig, shared bool, err error) {
 	if s.forgeOAuthApps != nil {
 		base := forge.CanonicalBaseURL(forge.ProviderGitHub, "")
-		if app, err := s.forgeOAuthApps.GetByInstance(ctx, tenantID, forge.ProviderGitHub, base); err == nil {
+		app, readErr := s.forgeOAuthApps.GetByInstance(ctx, tenantID, forge.ProviderGitHub, base)
+		switch {
+		case readErr == nil:
+			// A row that cannot mint (no key, unsealable, non-numeric id) is
+			// deliberately treated as "no app rather than half-valid" — see
+			// githubAppConfigFromRecord — so it falls through to the platform.
 			if cfg, ok := s.githubAppConfigFromRecord(app); ok {
-				return cfg, false, true
+				return cfg, false, nil
 			}
+		case errors.Is(readErr, forge.ErrOAuthAppNotFound):
+			// A definite "this tenant registered none": the platform App below
+			// is exactly the intended fallback.
+		default:
+			return forgegithub.AppConfig{}, false, fmt.Errorf("forge: github app for tenant %s is unreadable: %w", tenantID, readErr)
 		}
 	}
 	if s.forgeGitHubApp.Configured() {
-		return s.githubAppConfig(), true, true
+		return s.githubAppConfig(), true, nil
 	}
-	return forgegithub.AppConfig{}, false, false
+	return forgegithub.AppConfig{}, false, errNoGitHubApp
 }
 
 // githubAppConfigForConnection resolves the App identity that owns a
@@ -335,13 +362,26 @@ func (s *Server) githubAppConfigForTenant(ctx context.Context, tenantID string) 
 // Resolution order: the connection's own OAuthAppID, then the legacy
 // per-instance lookup (unambiguous for connections created while only one app
 // per host could exist), then the shared platform App.
-func (s *Server) githubAppConfigForConnection(ctx context.Context, conn forge.Connection) (cfg forgegithub.AppConfig, shared bool, ok bool) {
+//
+// The error is errNoGitHubApp for a definite absence and the store's own error
+// for a read that could not answer — see githubAppConfigForTenant.
+func (s *Server) githubAppConfigForConnection(ctx context.Context, conn forge.Connection) (cfg forgegithub.AppConfig, shared bool, err error) {
 	if conn.OAuthAppID != "" && s.forgeOAuthApps != nil {
-		app, err := s.forgeOAuthApps.Get(ctx, conn.OAuthAppID)
-		if err == nil && app.TenantID == conn.TenantID {
-			if cfg, ok := s.githubAppConfigFromRecord(app); ok {
-				return cfg, false, true
+		app, readErr := s.forgeOAuthApps.Get(ctx, conn.OAuthAppID)
+		switch {
+		case readErr == nil:
+			if app.TenantID == conn.TenantID {
+				if cfg, ok := s.githubAppConfigFromRecord(app); ok {
+					return cfg, false, nil
+				}
 			}
+		case errors.Is(readErr, forge.ErrOAuthAppNotFound):
+			// A dangling reference: the app it names is gone. Definite.
+		default:
+			// The read failed. Reporting this as "no app" would send the
+			// caller down a fallback path on a blip — and, worse, tell the
+			// operator their App is missing when it is merely unreachable.
+			return forgegithub.AppConfig{}, false, fmt.Errorf("forge: oauth app %s for connection %s is unreadable: %w", conn.OAuthAppID, conn.ID, readErr)
 		}
 		// Deliberate: a connection that NAMES an app whose key is unusable must
 		// not silently fall back to another tenant-level app and sign with the
@@ -349,7 +389,7 @@ func (s *Server) githubAppConfigForConnection(ctx context.Context, conn forge.Co
 		if s.logger != nil {
 			s.logger.Warn("forge: connection %s references oauth app %s which did not resolve to a usable key", conn.ID, conn.OAuthAppID)
 		}
-		return forgegithub.AppConfig{}, false, false
+		return forgegithub.AppConfig{}, false, errNoGitHubApp
 	}
 	return s.githubAppConfigForTenant(ctx, conn.TenantID)
 }
@@ -364,32 +404,42 @@ func (s *Server) githubAppConfigForConnection(ctx context.Context, conn forge.Co
 // does — the install callback's IDOR guard keys on it, so it is returned
 // explicitly rather than inferred from an empty record id (a tenant app whose
 // record lookup merely failed must not be mistaken for the platform app).
-func (s *Server) githubAppForInstall(ctx context.Context, tenantID, appID string) (cfg forgegithub.AppConfig, resolvedID string, shared bool, ok bool) {
+func (s *Server) githubAppForInstall(ctx context.Context, tenantID, appID string) (cfg forgegithub.AppConfig, resolvedID string, shared bool, err error) {
 	if appID != "" && s.forgeOAuthApps != nil {
-		app, err := s.forgeOAuthApps.Get(ctx, appID)
-		if err != nil || app.TenantID != tenantID {
-			return forgegithub.AppConfig{}, "", false, false
+		app, readErr := s.forgeOAuthApps.Get(ctx, appID)
+		switch {
+		case readErr == nil:
+			if app.TenantID != tenantID {
+				// Another team's App: a definite refusal, not a blip.
+				return forgegithub.AppConfig{}, "", false, errNoGitHubApp
+			}
+		case errors.Is(readErr, forge.ErrOAuthAppNotFound):
+			return forgegithub.AppConfig{}, "", false, errNoGitHubApp
+		default:
+			// Without this the operator is told to CREATE an App they
+			// already own, and blamed for it with a 400.
+			return forgegithub.AppConfig{}, "", false, fmt.Errorf("forge: oauth app %s is unreadable: %w", appID, readErr)
 		}
 		cfg, ok := s.githubAppConfigFromRecord(app)
 		if !ok {
-			return forgegithub.AppConfig{}, "", false, false
+			return forgegithub.AppConfig{}, "", false, errNoGitHubApp
 		}
-		return cfg, app.ID, false, true
+		return cfg, app.ID, false, nil
 	}
-	cfg, shared, ok = s.githubAppConfigForTenant(ctx, tenantID)
-	if !ok {
-		return forgegithub.AppConfig{}, "", false, false
+	cfg, shared, err = s.githubAppConfigForTenant(ctx, tenantID)
+	if err != nil {
+		return forgegithub.AppConfig{}, "", false, err
 	}
 	// Only a tenant-owned app has a record to pin; the shared platform app has
 	// none, and pinning "" keeps those connections on the legacy resolution.
 	if shared || s.forgeOAuthApps == nil {
-		return cfg, "", shared, true
+		return cfg, "", shared, nil
 	}
 	app, err := s.forgeOAuthApps.GetByInstance(ctx, tenantID, forge.ProviderGitHub, forge.CanonicalBaseURL(forge.ProviderGitHub, ""))
 	if err != nil {
-		return cfg, "", shared, true
+		return cfg, "", shared, nil
 	}
-	return cfg, app.ID, shared, true
+	return cfg, app.ID, shared, nil
 }
 
 // githubAppConfigFromRecord unseals an app row into a usable App identity.
@@ -519,9 +569,9 @@ func (s *Server) forgeAppMinter(ctx context.Context, conn forge.Connection) (str
 	if conn.Kind != forge.KindGitHubApp {
 		return "", fmt.Errorf("forge: not a github_app connection")
 	}
-	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-	if !ok {
-		return "", fmt.Errorf("forge: no github app available for this connection")
+	cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+	if err != nil {
+		return "", err
 	}
 	// Fail closed: if the provisioned repo set can't be determined (transient
 	// store error), do NOT fall back to a whole-installation token. The
@@ -560,9 +610,9 @@ func (s *Server) forgeSecurityTokenMinter(ctx context.Context, conn forge.Connec
 	if conn.Kind != forge.KindGitHubApp {
 		return "", time.Time{}, fmt.Errorf("forge: security-read tokens require a github_app connection")
 	}
-	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
-	if !ok {
-		return "", time.Time{}, fmt.Errorf("forge: no github app available for this connection")
+	cfg, _, err := s.githubAppConfigForConnection(ctx, conn)
+	if err != nil {
+		return "", time.Time{}, err
 	}
 	// A known-narrow grant fails BEFORE the mint with the remediation named,
 	// instead of surfacing GitHub's generic 422. An unknown grant set
@@ -735,8 +785,16 @@ func repoOutsideInstallationErr(repos []forge.RepoSummary, repoFullName string) 
 // OAuthExchanger and TokenRefresher.
 func (s *Server) forgeRefresherFor(conn forge.Connection) forge.TokenRefresher {
 	if conn.Kind == forge.KindGitHubApp {
-		cfg, _, ok := s.githubAppConfigForConnection(context.Background(), conn)
-		if !ok {
+		cfg, _, err := s.githubAppConfigForConnection(context.Background(), conn)
+		if err != nil {
+			// Returning nil here means "this connection has nothing to
+			// refresh", and the worker moves on for good. A definite
+			// absence deserves that silence; an unreadable store does
+			// not — without a line, a blip retires a live connection's
+			// refresher and the token expires hours later, far from here.
+			if !errors.Is(err, errNoGitHubApp) && s.logger != nil {
+				s.logger.Warn("forge: no refresher for connection %s — its app could not be read (%v); the connection is treated as having none until the next resolution", conn.ID, err)
+			}
 			return nil
 		}
 		return forgegithub.AppRefresher{HTTP: s.forgeHTTPClient(), Cfg: cfg, Repos: s.forgeMintRepoNames}

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -77,9 +77,15 @@ func (s *Server) connectForgeGitHubApp(w http.ResponseWriter, r *http.Request, t
 		httpError(w, http.StatusBadRequest, "the app mode is GitHub-only")
 		return
 	}
-	cfg, appID, _, ok := s.githubAppForInstall(r.Context(), teamID, req.OAuthAppID)
-	if !ok {
+	cfg, appID, _, err := s.githubAppForInstall(r.Context(), teamID, req.OAuthAppID)
+	switch {
+	case errors.Is(err, errNoGitHubApp):
 		httpError(w, http.StatusBadRequest, "no GitHub App available — first create one (Register an OAuth app → Create a GitHub App), or use OAuth/PAT")
+		return
+	case err != nil:
+		// Not the operator's fault, and not something they can fix by
+		// creating an App they may already own.
+		httpError(w, http.StatusInternalServerError, "cannot resolve the GitHub App to install with: %v", err)
 		return
 	}
 	state, _, _, err := oidc.GenerateStateAndPKCE()
@@ -340,9 +346,13 @@ func (s *Server) handleForgeGitHubAppCallback(w http.ResponseWriter, r *http.Req
 	// not "the team's app for this host" — with several apps per host the
 	// latter can pick the wrong private key, which cannot mint for this
 	// installation at all.
-	cfg, appRecordID, shared, ok := s.githubAppForInstall(r.Context(), pending.TenantID, pending.OAuthAppID)
-	if !ok {
+	cfg, appRecordID, shared, err := s.githubAppForInstall(r.Context(), pending.TenantID, pending.OAuthAppID)
+	switch {
+	case errors.Is(err, errNoGitHubApp):
 		httpError(w, http.StatusBadRequest, "no github app available for this org")
+		return
+	case err != nil:
+		httpError(w, http.StatusInternalServerError, "cannot resolve the GitHub App for this install: %v", err)
 		return
 	}
 	base := forge.DefaultBaseURL(forge.ProviderGitHub)

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -254,7 +254,14 @@ func (s *Server) handleForgeConnectionHealth(w http.ResponseWriter, r *http.Requ
 		h.ProvisionedRepoCount = len(names)
 	}
 	if conn.Kind == forge.KindGitHubApp && conn.InstallationID != 0 {
-		if cfg, _, ok := s.githubAppConfigForConnection(r.Context(), conn); ok {
+		cfg, _, appErr := s.githubAppConfigForConnection(r.Context(), conn)
+		// A read that could not answer is reported, not skipped: this view is
+		// exactly where an operator looks to find out why a connection is
+		// misbehaving, and a silently missing live section reads as "fine".
+		if appErr != nil && !errors.Is(appErr, errNoGitHubApp) {
+			h.LiveError = appErr.Error()
+		}
+		if appErr == nil {
 			inst, err := forgegithub.InstallationInfo(r.Context(), s.forgeHTTPClient(),
 				forgegithub.APIBaseFor(conn.BaseURL()), cfg, conn.InstallationID, time.Now().UTC())
 			if err != nil {

--- a/pkg/server/forge_pullstate.go
+++ b/pkg/server/forge_pullstate.go
@@ -87,7 +87,10 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 	}
 	gc, err := s.gateClientFor(r.Context(), conn)
 	if err != nil {
-		httpError(w, http.StatusBadGateway, "forge client: %v", err)
+		// Resolving the client touches no network: forgeAdminFor constructs
+		// and caches the App client (its tokens are minted later, on use) or
+		// unseals a stored token. 502 would blame the forge for our outage.
+		httpError(w, http.StatusInternalServerError, "forge client: %v", err)
 		return
 	}
 	if gc == nil {
@@ -112,15 +115,11 @@ func (s *Server) handleForgePullRequest(w http.ResponseWriter, r *http.Request) 
 			// answers 500. What reaches here is an unclassified failure
 			// of a round trip that did happen.
 			//
-			// This ARM, not the route: `forge client:` above still
-			// answers 502 for a gateClientFor failure, which touches no
-			// network at all — an App config that did not resolve, a
-			// token that will not unseal. The sibling list-repos route
-			// answers 500 for the identical failure, and board_forge /
-			// forge_publish answer 502 like this one. Nothing marks
-			// those and no marker would reach them (the arms never ask
-			// the junction), so aligning them is its own change across
-			// four routes. Residual on #969.
+			// The `forge client:` arm above is settled now: it
+			// answers 500, like the sibling list-repos route and
+			// board_forge's two, because forgeAdminFor never opens a
+			// socket. THIS arm stays 502 on purpose — a round trip did
+			// happen here and failed unclassified.
 			httpError(w, http.StatusBadGateway, "read pull request %s#%d: %v", repo, number, err)
 		}
 		return

--- a/pkg/server/forge_refresh_route.go
+++ b/pkg/server/forge_refresh_route.go
@@ -37,9 +37,12 @@ func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Req
 		httpError(w, http.StatusBadRequest, "refresh applies to GitHub-App connections only")
 		return
 	}
-	cfg, _, hasApp := s.githubAppConfigForConnection(r.Context(), conn)
-	if !hasApp {
-		httpError(w, http.StatusBadGateway, "no github app available for this connection")
+	cfg, _, appErr := s.githubAppConfigForConnection(r.Context(), conn)
+	if appErr != nil {
+		// Never 502 here: resolving the App reads iterion's own store and
+		// unseals its own key — no socket is opened, so blaming the forge
+		// would send the operator to GitHub's status page for our outage.
+		httpError(w, http.StatusInternalServerError, "%v", appErr)
 		return
 	}
 	inst, err := forgegithub.InstallationInfo(r.Context(), s.forgeHTTPClient(),


### PR DESCRIPTION
Closes #969 — the two residuals it left behind turn out to be **one** user-visible defect.

## What was wrong

Resolving a connection's GitHub App returned a single `ok bool`, so *"this tenant registered none"* and *"the store could not be read"* were the same answer. Every caller then acted on the wrong one:

| caller | on a Mongo blip, before |
|---|---|
| install flow | **400** telling the operator to *create a GitHub App they already own* |
| connection-health view | live section silently dropped — which reads as "fine" |
| refresh worker | retired a live connection's refresher **for good**; its token expired hours later, far from the cause |
| `githubAppConfigForTenant` | fell through to the **SHARED platform App** — swapping the signing identity behind the operator's back, with a key that can mint for **any** installation |

## The fix

Resolution returns an `error`: `errNoGitHubApp` for a definite absence, the store's own error otherwise. Callers that may legitimately act on absence test the sentinel; the rest propagate.

Both store twins already map not-found to `forge.ErrOAuthAppNotFound` (`mongoutil.FindOne(..., ErrOAuthAppNotFound, ...)`), so the guard is right in production and not only against the memory store.

A row that exists but **cannot mint** (no key, unsealable, non-numeric id) stays a definite negative — that arbitration is already documented on `githubAppConfigFromRecord` and this change does not re-open it.

## The second half: 502 was structurally wrong

`forgeAdminFor` is network-free in **both** branches — verified rather than assumed:

- the App branch resolves config, fingerprints, constructs an `AppClient` and caches it; **tokens are minted later, on use**;
- the token branch unseals a stored token (pure crypto) and constructs a client.

So a failure there never reached the forge. Three routes answered **502 Bad Gateway** for it — blaming the provider for our own outage and sending the operator to GitHub's status page — while two sibling routes already answered 500. All five agree now.

The two 502s that remain are the arms where a round trip **did** happen (`ListRepos`, `GetPullRequest`) and are correct. The forward-pointing "Residual on #969" note I left in `forge_pullstate.go` during #1030 is replaced by what is now true.

## Evidence

- Four new tests in `forge_app_degraded_read_test.go`, each **seen red first**, driven by a real store whose reads can be switched off (`degradedOAuthAppStore`) — the only way to exercise the difference between "none" and "could not find out".
- The five pre-existing resolution subtests still pass unchanged in meaning.
- `task check` — exit 0, zero FAIL lines.
- `go test -race ./pkg/server/` clean.

## Class rendered

```
$ grep 'githubAppConfig(ForConnection|ForTenant)|githubAppForInstall' pkg/server/*.go | grep ', ok |ok :=|ok ='
(empty)

$ forgeAdminFor/gateClientFor → HTTP status
      2 StatusBadGateway          ← both are real round trips
      5 StatusInternalServerError
```
