### PR TITLE
fix(model): a captured turn records the backend that produced it

### DIFF
--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -1049,11 +1049,17 @@ func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, itera
 	if e.hooks.OnLLMTurnCapture != nil {
 		fn := e.hooks.OnLLMTurnCapture
 		h.OnTurnFinished = func(info delegate.TurnFinishedInfo) {
-			// One TurnCheckpoint per delegate call; the CLI's session
-			// jsonl at ~/.claude/projects/<key>/<uuid>.jsonl is the
-			// source of truth for the conversation, and SessionID is
+			// One TurnCheckpoint per delegate call. For claude_code the
+			// CLI's session jsonl at ~/.claude/projects/<key>/<uuid>.jsonl
+			// is the source of truth for the conversation, and SessionID is
 			// the anchor the Fork API uses to relaunch claude with
 			// --resume + --fork-session.
+			//
+			// Backend is the name the caller RESOLVED, never a constant:
+			// pi fires this same hook (pi_rpc.go), so stamping claude_code
+			// here recorded every pi turn under another backend's name —
+			// and fork.go decides its claw-conversation branch on this
+			// field (#1053).
 			fn(nodeID, LLMTurnCaptureInfo{
 				Step:            1,
 				Text:            info.Text,
@@ -1062,7 +1068,7 @@ func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, itera
 				OutputTokens:    info.OutputTokens,
 				AggregateTokens: info.AggregateTokens,
 				SessionID:       info.SessionID,
-				Backend:         delegate.BackendClaudeCode,
+				Backend:         backendName,
 				Iteration:       iteration,
 			})
 		}

--- a/pkg/backend/model/turn_backend_label_test.go
+++ b/pkg/backend/model/turn_backend_label_test.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+)
+
+// #1053 — delegateHooksFor receives the node's RESOLVED backend and used to
+// throw it away, stamping delegate.BackendClaudeCode on every captured turn.
+// pi fires the same OnTurnFinished hook (pi_rpc.go), so every pi turn was
+// persisted under another backend's name — a lie in a durable field, and the
+// one fork.go decides its claw-conversation branch on.
+func TestDelegateHooks_TurnCarriesTheResolvedBackend(t *testing.T) {
+	for _, backend := range []string{
+		delegate.BackendClaudeCode,
+		delegate.BackendPi,
+		delegate.BackendClaw,
+		"some-future-cli",
+	} {
+		t.Run(backend, func(t *testing.T) {
+			var got LLMTurnCaptureInfo
+			var calls int
+			e := &ClawExecutor{hooks: EventHooks{
+				OnLLMTurnCapture: func(_ string, info LLMTurnCaptureInfo) {
+					calls++
+					got = info
+				},
+			}}
+
+			h := e.delegateHooksFor("n1", backend, 0)
+			if h.OnTurnFinished == nil {
+				t.Fatal("OnTurnFinished was not wired")
+			}
+			h.OnTurnFinished(delegate.TurnFinishedInfo{SessionID: "sess-1", Text: "hi"})
+
+			if calls != 1 {
+				t.Fatalf("capture fired %d times, want 1", calls)
+			}
+			if got.Backend != backend {
+				t.Errorf("turn recorded Backend=%q, want %q — the resolved name, not a constant", got.Backend, backend)
+			}
+			if got.SessionID != "sess-1" {
+				t.Errorf("SessionID = %q, want sess-1", got.SessionID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1053.

`delegateHooksFor` already receives the node's **resolved** backend and threw it away:

```go
func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, iteration int) delegate.TaskHooks {
    ...
    Backend: delegate.BackendClaudeCode,   // ← the parameter ignored
```

`pi_rpc.go` fires the same `OnTurnFinished` hook, so **every pi turn was persisted under another backend's name** in `store.TurnCheckpoint.Backend`.

## Correcting the blast radius I claimed when filing this

The issue said a fork of a pi node would be "dispatched down a branch built for another CLI's session model". **That was wrong, and I'd rather say so than let a confident claim stand.** Tracing it:

- `resume.go` reads `cp.BackendName` only to populate `ErrNeedsInteraction.Backend`; it does **not** dispatch on it. The node's own declared `backend:` chooses the delegate, and only `SessionID` is injected into the node input.
- So a forked pi run **did** resume on pi.

What is genuinely wrong is narrower, and still worth fixing:

1. **A durable field lied.** `TurnCheckpoint.Backend` is an operator-facing record of which backend produced a turn.
2. **One decision is already taken on it.** `fork.go` branches `turn.Backend == delegate.BackendClaw` to load the conversation blob. The field is load-bearing today, and would silently mis-decide for any backend that later grows a conversation ref.

## Evidence

Table test over `claude_code`, `pi`, `claw` and an unknown name. Seen **red on three of the four** against the old constant, by restoring it under the test:

```
--- FAIL: .../pi          turn recorded Backend="claude_code", want "pi"
--- FAIL: .../claw        turn recorded Backend="claude_code", want "claw"
--- FAIL: .../some-future-cli  turn recorded Backend="claude_code", want "some-future-cli"
```

`claude_code` passes either way, which is exactly why the constant survived this long — and why the unknown-name row is in the table: it fails if anyone re-hardcodes.

`task check` — exit 0, zero FAIL lines.
