### PR TITLE
feat(credentials): a tenant may hold a CHAIN of forfaits, not one per kind

### DIFF
--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -138,6 +138,10 @@ var (
 	// remoteLLMAccountLabel names the ACCOUNT behind a forfait, so a
 	// listing says "jothedev" instead of a bare fingerprint.
 	remoteLLMAccountLabel string
+	// remoteLLMRank selects which link of the tier's credential CHAIN a
+	// command addresses: 0 (the default) is the primary, 1 and up are the
+	// fallbacks tried in order when the one before it cannot serve.
+	remoteLLMRank int
 )
 
 var remoteAdminLLMCmd = &cobra.Command{
@@ -204,7 +208,11 @@ var remoteAdminLLMKeysCmd = &cobra.Command{
 var remoteAdminLLMOAuthCmd = &cobra.Command{
 	Use:   "oauth [set|connect|name|refresh|delete] [kind]",
 	Short: "Platform OAuth-forfait: list connections (default) or act on one kind (claude_code|codex)",
-	Args:  cobra.MaximumNArgs(2),
+	Long: "The platform tier's forfait connections. Each kind may hold a CHAIN:\n" +
+		"--rank 0 (the default) is the primary, --rank 1 and up are the fallbacks\n" +
+		"tried in order when the link before them cannot serve. Every action\n" +
+		"addresses exactly the link --rank names — including delete.",
+	Args: cobra.MaximumNArgs(2),
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		if len(args) == 0 {
 			return cli.RemoteGetPrint(cmd.Context(), c, p, "/api/admin/llm/oauth/connections")
@@ -232,9 +240,9 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			path := "/api/admin/llm/oauth/" + kind + "/credentials"
-			if lbl := strings.TrimSpace(remoteLLMAccountLabel); lbl != "" {
-				path += "?account_label=" + url.QueryEscape(lbl)
+			path, err := cli.OAuthPath("/api/admin/llm/oauth/"+kind+"/credentials", remoteLLMAccountLabel, remoteLLMRank)
+			if err != nil {
+				return err
 			}
 			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", path, blob)
 		case "connect":
@@ -243,7 +251,7 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if len(args) == 2 {
 				kind = args[1]
 			}
-			return cli.RemoteAdminLLMOAuthConnect(cmd.Context(), c, p, kind, strings.TrimSpace(remoteLLMAccountLabel))
+			return cli.RemoteAdminLLMOAuthConnect(cmd.Context(), c, p, kind, strings.TrimSpace(remoteLLMAccountLabel), remoteLLMRank)
 		case "name":
 			// Names the ACCOUNT behind a platform forfait. The listing
 			// prints only kind + fingerprint otherwise, and a fingerprint
@@ -263,19 +271,33 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "PATCH", "/api/admin/llm/oauth/"+kind, body)
+			// The label travels in the body here, so only the rank goes in
+			// the query.
+			path, err := cli.OAuthPath("/api/admin/llm/oauth/"+kind, "", remoteLLMRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "PATCH", path, body)
 		case "refresh":
 			kind, err := needKind()
 			if err != nil {
 				return err
 			}
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", "/api/admin/llm/oauth/"+kind+"/refresh", nil)
+			path, err := cli.OAuthPath("/api/admin/llm/oauth/"+kind+"/refresh", "", remoteLLMRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", path, nil)
 		case "delete":
 			kind, err := needKind()
 			if err != nil {
 				return err
 			}
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", "/api/admin/llm/oauth/"+kind, nil)
+			path, err := cli.OAuthPath("/api/admin/llm/oauth/"+kind, "", remoteLLMRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", path, nil)
 		default:
 			return fmt.Errorf("unknown oauth action %q (want set|connect|name|refresh|delete)", action)
 		}
@@ -780,6 +802,7 @@ func init() {
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMName, "name", "", "Key display name for create")
 	remoteAdminLLMKeysCmd.Flags().BoolVar(&remoteLLMDefault, "default", false, "Make the created key the provider's default")
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMKeyData, "data", "", "Patch JSON for update (literal or @file)")
+	remoteAdminLLMOAuthCmd.Flags().IntVar(&remoteLLMRank, "rank", 0, "Which link of the platform credential chain to address (0 = primary, 1+ = fallbacks tried in order)")
 	remoteAdminLLMOAuthCmd.Flags().StringVar(&remoteLLMAccountLabel, "account-label", "", "Name the account behind this forfait (with `set`/`connect`, or alone with `name`; `name --account-label \"\"` clears it)")
 	remoteAdminLLMCmd.AddCommand(remoteAdminLLMKeysCmd, remoteAdminLLMOAuthCmd)
 

--- a/cmd/iterion/remote_org_credentials.go
+++ b/cmd/iterion/remote_org_credentials.go
@@ -22,7 +22,11 @@ var remoteOrgsOAuthCmd = &cobra.Command{
 	Short: "The org's shared OAuth forfait connections (claude_code|codex)",
 	Long: "List the org's shared forfait connections, or set one from a credentials\n" +
 		"blob (--from-file/--from-env/stdin). The org tier lends these to the teams\n" +
-		"named by `orgs credential-audience`.",
+		"named by `orgs credential-audience`.\n\n" +
+		"Each kind may hold a CHAIN: --rank 0 (the default) is the primary, --rank 1\n" +
+		"and up are the fallbacks tried in order when the link before them cannot\n" +
+		"serve — a second subscription that keeps the org's teams running while the\n" +
+		"first one's usage window is shut.",
 	Args: cobra.RangeArgs(0, 2),
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		org, err := c.ResolveOrg(cmd.Context(), remoteOrgFlag)
@@ -47,11 +51,23 @@ var remoteOrgsOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			return cli.RemoteSendData(cmd.Context(), c, p, "POST", base+"/"+kind+"/credentials", string(blob), "credentials JSON")
+			path, err := cli.OAuthPath(base+"/"+kind+"/credentials", "", remoteOrgOAuthRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendData(cmd.Context(), c, p, "POST", path, string(blob), "credentials JSON")
 		case "refresh":
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", base+"/"+kind+"/refresh", nil)
+			path, err := cli.OAuthPath(base+"/"+kind+"/refresh", "", remoteOrgOAuthRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", path, nil)
 		case "delete":
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", base+"/"+kind, nil)
+			path, err := cli.OAuthPath(base+"/"+kind, "", remoteOrgOAuthRank)
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", path, nil)
 		default:
 			return fmt.Errorf("unknown action %q (want set|refresh|delete)", action)
 		}
@@ -61,6 +77,9 @@ var remoteOrgsOAuthCmd = &cobra.Command{
 var (
 	remoteAudienceTeams    string
 	remoteAudienceAllTeams string
+	// remoteOrgOAuthRank selects which link of the org's credential chain a
+	// command addresses (0 = the primary).
+	remoteOrgOAuthRank int
 )
 
 var remoteOrgsAudienceCmd = &cobra.Command{
@@ -222,6 +241,7 @@ func init() {
 	}
 	remoteOrgsSettingsCmd.Flags().StringVar(&remoteOrgApprovalRequire, "require-approval", "", "true|false — park a team admin's repo provisioning for an org admin")
 	remoteOrgsSettingsCmd.Flags().StringVar(&remoteOrgApprovalScope, "approval-scope", "", "all|shared_credentials — what the approval gate parks")
+	remoteOrgsOAuthCmd.Flags().IntVar(&remoteOrgOAuthRank, "rank", 0, "Which link of the org's credential chain to address (0 = primary, 1+ = fallbacks tried in order)")
 	remoteOrgsOAuthCmd.Flags().StringVar(&remoteSecretFromEnv, "from-env", "", "Read the credentials blob from this environment variable")
 	remoteOrgsOAuthCmd.Flags().StringVar(&remoteSecretFromFile, "from-file", "", "Read the credentials blob from this file")
 	remoteOrgsAudienceCmd.Flags().StringVar(&remoteAudienceTeams, "teams", "", "Comma-separated team ids allowed to spend the org's credentials (empty string revokes all)")

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -383,6 +383,68 @@ them was already exhausted on its weekly window. Before trusting a fallback,
 check the **account labels**, not the fingerprints — and give each tier a
 genuinely different account.
 
+## The fallback chain — several forfaits behind one tier
+
+A tier is not limited to one forfait per kind. Each connection carries a
+**rank**: `0` is the primary, `1` and up are fallbacks, and that order is the
+order they are tried in. It is the answer to the failure the section above
+describes — the tier's account shuts its window and the run has nowhere to go
+inside its own tier.
+
+**The resolution already worked this way; it just had nowhere to continue.**
+`resolveAndSealCredentials` walks the owner's records and *skips* a forfait
+whose provider window is closed (the `oauth-forfait(…) SKIPPED … falling
+through to the next credential tier` line). With one record per kind that skip
+fell straight out of the tier; with a chain it lands on rank 1 of the same
+tier first. Records come back ordered by kind then rank, so nothing had to
+learn what a rank is — `ListByUser` hands them over in try order.
+
+Provision a fallback by naming its rank. It is always explicit, never
+inferred, so no operator lands on a fallback by accident:
+
+```sh
+# Platform tier — a second Claude account behind the deployment's own.
+iterion remote admin llm oauth set claude_code --rank 1 \
+  --account-label "backup@example.org" --from-file ~/.secrets/claude-setup-token
+
+# Org tier — same idea, for the org's shared forfait.
+iterion remote orgs oauth set codex --rank 1 --from-file ~/.codex/auth.json
+
+# The team tier has no typed subcommand yet; the raw endpoint takes the same query.
+iterion remote api POST \
+  "/api/teams/<team-id>/oauth/claude_code/credentials?rank=1&account_label=backup@example.org" \
+  --data "@$HOME/.secrets/claude-setup-token"
+```
+
+Every action addresses exactly the link `--rank` names — `set`, `connect`,
+`name`, `refresh` and `delete` alike. Read the chain back with the ordinary
+listing, which reports each link's rank:
+
+```sh
+iterion remote admin llm oauth            # → connections[].rank, 0 first
+iterion remote admin llm oauth name claude_code --rank 1 --account-label backup
+iterion remote admin llm oauth delete claude_code --rank 1
+```
+
+Four things worth knowing before building one:
+
+- **Nothing moves when the feature arrives.** Rank 0 keeps the record id it
+  always had, so every credential connected before chains existed *is* the
+  primary, and the migration runs itself at startup. An invocation that names
+  no rank sends the byte-identical request it sent before.
+- **A chain of the same account is not a fallback.** The trap of the previous
+  section applies with full force here: two connections of one Anthropic
+  subscription are two fingerprints and two meters, and they shut *together*.
+  Check the account labels.
+- **`refresh --rank N` renews that link and no other.** This matters more than
+  it looks: the provider RETIRES the refresh token it is handed, so a refresh
+  aimed at the wrong record spends a live credential's token and leaves the
+  dying one exactly as dying.
+- **Only the primary can be lent to the credential pool.** A pledge is keyed
+  on (owner, source, kind) with no rank, so `pool lend` offers rank 0. Lending
+  a specific fallback is not wired — see
+  [docs/credential-pool.md](credential-pool.md).
+
 ## Activating the cross-model plan review (one credential, nothing else)
 
 The plan-phase campaign bots (feature-dev, app-dev,

--- a/pkg/cli/remote_admin_llm.go
+++ b/pkg/cli/remote_admin_llm.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -21,6 +22,32 @@ import (
 // are specific to this surface.
 
 func adminLLMOAuthBase(kind string) string { return "/api/admin/llm/oauth/" + kind }
+
+// OAuthPath composes an OAuth endpoint's query for every tier's CLI: the
+// account label to stamp (empty = none) and which link of the owner's
+// credential chain to address.
+//
+// Rank 0 is the primary and is left IMPLICIT, so a command written before
+// chains existed emits the byte-identical request it always did. A negative
+// rank is refused rather than clamped: dropping it would silently address the
+// primary, which on `delete` is the one credential the operator was not
+// aiming at.
+func OAuthPath(base, accountLabel string, rank int) (string, error) {
+	if rank < 0 {
+		return "", fmt.Errorf("--rank must be >= 0 (0 = the primary credential, 1 and up = its fallbacks), got %d", rank)
+	}
+	q := url.Values{}
+	if lbl := strings.TrimSpace(accountLabel); lbl != "" {
+		q.Set("account_label", lbl)
+	}
+	if rank > 0 {
+		q.Set("rank", strconv.Itoa(rank))
+	}
+	if len(q) == 0 {
+		return base, nil
+	}
+	return base + "?" + q.Encode(), nil
+}
 
 // ReadSecretBlob resolves a possibly multi-line secret payload (e.g. a
 // credentials.json) from --from-env, a file, or — unlike ReadSecretValue's
@@ -122,8 +149,15 @@ func credentialSourceLabel(fromEnv, fromFile string) string {
 // browser and pastes the resulting `code#state`, authorize/complete
 // exchanges it server-side into the stored credentials blob. A non-empty
 // accountLabel names the account on that completing call, so the browser
-// path can name at connect time exactly like the paste path.
-func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer, kind, accountLabel string) error {
+// path can name at connect time exactly like the paste path, and rank picks
+// which link of the chain it becomes.
+func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer, kind, accountLabel string, rank int) error {
+	// Composed before anything is minted: a rejected --rank must not surface
+	// after the operator has already been through the browser round trip.
+	complete, err := OAuthPath(adminLLMOAuthBase(kind)+"/authorize/complete", accountLabel, rank)
+	if err != nil {
+		return err
+	}
 	var start struct {
 		AuthorizeURL string `json:"authorize_url"`
 		State        string `json:"state"`
@@ -143,10 +177,6 @@ func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer
 			return fmt.Errorf("read authorization code: %w", err)
 		}
 		return fmt.Errorf("no authorization code pasted")
-	}
-	complete := adminLLMOAuthBase(kind) + "/authorize/complete"
-	if accountLabel != "" {
-		complete += "?account_label=" + url.QueryEscape(accountLabel)
 	}
 	raw, err := c.Call(ctx, "POST", complete,
 		map[string]string{"code": code, "state": start.State}, nil)

--- a/pkg/cli/remote_admin_llm_rank_test.go
+++ b/pkg/cli/remote_admin_llm_rank_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import "testing"
+
+// TestOAuthPath is the CLI half of the credential chain: which link a command
+// addresses. Two properties carry the weight.
+//
+// Rank 0 must be left IMPLICIT — every `remote admin llm oauth` and
+// `remote orgs oauth` invocation written before chains existed has to keep
+// emitting the byte-identical request, or the feature would silently rewrite
+// what those commands mean.
+//
+// A negative rank must be REFUSED. Dropping it (the shape a `rank > 0` guard
+// alone produces) would address the primary — on `delete`, the one credential
+// the operator was not aiming at.
+func TestOAuthPath(t *testing.T) {
+	const base = "/api/admin/llm/oauth/claude_code"
+
+	t.Run("the primary emits the request it always did", func(t *testing.T) {
+		got, err := OAuthPath(base, "", 0)
+		if err != nil {
+			t.Fatalf("rank 0: %v", err)
+		}
+		if got != base {
+			t.Fatalf("rank 0 = %q, want the bare path %q — an implicit primary must add nothing", got, base)
+		}
+	})
+
+	t.Run("a fallback is named explicitly", func(t *testing.T) {
+		got, err := OAuthPath(base, "", 2)
+		if err != nil {
+			t.Fatalf("rank 2: %v", err)
+		}
+		if got != base+"?rank=2" {
+			t.Fatalf("rank 2 = %q, want %q", got, base+"?rank=2")
+		}
+	})
+
+	t.Run("label and rank travel together, escaped", func(t *testing.T) {
+		got, err := OAuthPath(base, "  jo the dev  ", 1)
+		if err != nil {
+			t.Fatalf("label+rank: %v", err)
+		}
+		// url.Values.Encode sorts keys, so account_label precedes rank.
+		const want = base + "?account_label=jo+the+dev&rank=1"
+		if got != want {
+			t.Fatalf("label+rank = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("a negative rank is refused, never clamped to the primary", func(t *testing.T) {
+		got, err := OAuthPath(base, "", -1)
+		if err == nil {
+			t.Fatalf("rank -1 was accepted and produced %q — it must be refused, not silently addressed at the primary", got)
+		}
+	})
+}

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -645,7 +645,7 @@ func TestMarkUnhealthy_doesNotResurrectAWithdrawnPledge(t *testing.T) {
 	if err := h.pledges.Delete(ctx, p.ID); err != nil {
 		t.Fatalf("withdraw: %v", err)
 	}
-	if err := h.oauth.Delete(ctx, "alice", secrets.OAuthKindClaudeCode); err != nil {
+	if err := h.oauth.Delete(ctx, secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0)); err != nil {
 		t.Fatalf("disconnect: %v", err)
 	}
 

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -511,7 +511,7 @@ func TestBroker_disconnectedCredentialParksThePledge(t *testing.T) {
 	ctx := context.Background()
 	h.donor(t, "alice", Limits{})
 	// The donor disconnected the subscription but left the pledge behind.
-	if err := h.oauth.Delete(ctx, "alice", secrets.OAuthKindClaudeCode); err != nil {
+	if err := h.oauth.Delete(ctx, secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0)); err != nil {
 		t.Fatalf("delete oauth: %v", err)
 	}
 
@@ -918,7 +918,7 @@ func TestBroker_AbstentionSkipsNameEachPledgeStatus(t *testing.T) {
 	t.Run("credential gone (parked as unhealthy)", func(t *testing.T) {
 		h := newHarness(t)
 		h.donor(t, "alice", Limits{})
-		if err := h.oauth.Delete(ctx, "alice", secrets.OAuthKindClaudeCode); err != nil {
+		if err := h.oauth.Delete(ctx, secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0)); err != nil {
 			t.Fatalf("delete donor credential: %v", err)
 		}
 		if got := skipOf(t, h, "r"); got.Status != StatusUnhealthy {

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -142,26 +144,58 @@ type OAuthRecord struct {
 	// documented on AccountLabel. Clearing has to travel on the wire.
 	RefreshClaimOwner string     `bson:"refresh_claim_owner" json:"-"`
 	RefreshNotBefore  *time.Time `bson:"refresh_not_before" json:"-"`
-	CreatedAt         time.Time  `bson:"created_at" json:"created_at"`
-	UpdatedAt         time.Time  `bson:"updated_at" json:"updated_at"`
+	// Rank orders the credentials an owner holds for ONE kind, lowest first.
+	// Rank 0 is the primary — what a reader means by "the tenant's Claude
+	// forfait" — and the higher ranks are its fallbacks, tried in order when
+	// a provider window is closed.
+	//
+	// It exists because the store used to hold exactly one record per
+	// (owner, kind), which made the credential chain no deeper than the
+	// tiers themselves: an operator with four Claude subscriptions could
+	// wire two (their org's and the deployment's) and had no way to say
+	// "try these in this order". Measured 2026-09-08, that ceiling stopped
+	// every claude_code run on a deployment for three hours.
+	//
+	// No bson omitempty: the Mongo store writes through $set, and an
+	// omitted key leaves the OLD value in place — the trap already
+	// documented on AccountLabel. A record demoted to rank 0 has to say so
+	// on the wire. Records written before ranks existed carry no field at
+	// all, which Mongo does not match against 0; EnsureSchema backfills
+	// them once.
+	Rank      int       `bson:"rank" json:"rank"`
+	CreatedAt time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
 }
 
 // OAuthStore is the persistence interface for sealed OAuth records.
 type OAuthStore interface {
 	Upsert(ctx context.Context, rec OAuthRecord) error
+	// Get returns the PRIMARY record (rank 0) for the pair — what every
+	// reader means by "this owner's Claude forfait". The fallbacks behind it
+	// are reached through ListByUser, which is what the publisher walks.
 	Get(ctx context.Context, userID string, kind OAuthKind) (OAuthRecord, error)
+	// ListByUser returns every record the owner holds, ordered by kind then
+	// RANK — so a caller that iterates gets the chain in the order it is
+	// meant to be tried, without knowing ranks exist.
 	ListByUser(ctx context.Context, userID string) ([]OAuthRecord, error)
-	Delete(ctx context.Context, userID string, kind OAuthKind) error
+	// Delete removes ONE record, addressed by its id. Missing → ErrOAuthNotFound.
+	Delete(ctx context.Context, id string) error
 	// ExpiringBefore returns records whose access token is set and
 	// expires before t — used by the background refresh worker.
 	ExpiringBefore(ctx context.Context, t time.Time) ([]OAuthRecord, error)
+	// The four writers below address ONE record by its id, not by
+	// (owner, kind): that pair stopped being unique when a chain became
+	// possible, and a writer that still keyed on it would silently land
+	// on the primary — a refresh renewing rank 0 forever while the
+	// fallback it was called for expired. Every record a caller holds
+	// carries its id, so nothing has to be looked up to write it.
 	// SetAccountLabel writes ONLY the label (and updated_at) of an existing
 	// record; "" clears it. A rename must not travel through Upsert: that
 	// rewrites the whole record, sealed payload included, so a refresh
 	// committed between the caller's Get and its Upsert would be reverted
 	// to a token the provider may already have rotated out. Missing record
 	// → ErrOAuthNotFound.
-	SetAccountLabel(ctx context.Context, userID string, kind OAuthKind, label string) error
+	SetAccountLabel(ctx context.Context, id string, label string) error
 	// UpdateTokens writes ONLY the keys a token refresh owns — the mirror
 	// of SetAccountLabel on the other side of the same race. A refresh
 	// reads a record, spends a round trip at the provider, then persists;
@@ -176,7 +210,7 @@ type OAuthStore interface {
 	// since a claim is all a fenced write can ask about (the Mongo twin
 	// reads one MatchedCount for both). ErrOAuthNotFound stays the answer
 	// for an unclaimed write, which is the shape the self-heal uses.
-	UpdateTokens(ctx context.Context, userID string, kind OAuthKind, upd OAuthTokenUpdate) error
+	UpdateTokens(ctx context.Context, id string, upd OAuthTokenUpdate) error
 	// ClaimRefresh elects the ONE holder allowed to exchange this record's
 	// refresh token, by compare-and-swap: it succeeds only while nobody
 	// holds a live claim (RefreshNotBefore absent or already past), and
@@ -184,14 +218,14 @@ type OAuthStore interface {
 	// when someone else holds it; that caller must not touch the provider.
 	// A crashed holder's claim is re-claimable as soon as `until` passes,
 	// so nothing has to release it. Missing record → false, no error.
-	ClaimRefresh(ctx context.Context, userID string, kind OAuthKind, owner string, now, until time.Time) (bool, error)
+	ClaimRefresh(ctx context.Context, id string, owner string, now, until time.Time) (bool, error)
 	// ReleaseRefreshClaim hands the claim back without writing tokens — the
 	// path a FAILED exchange takes, so the next sweep may retry at once
 	// instead of waiting the lease out. Conditional on still owning the
 	// claim (ErrRefreshClaimLost otherwise), so a slow holder can never
 	// free its successor's. notBefore sets the cool-down the sweep must
 	// respect afterwards; nil clears it.
-	ReleaseRefreshClaim(ctx context.Context, userID string, kind OAuthKind, owner string, notBefore *time.Time) error
+	ReleaseRefreshClaim(ctx context.Context, id string, owner string, notBefore *time.Time) error
 }
 
 // ErrRefreshClaimLost is the outcome of a refresh whose claim no longer
@@ -716,28 +750,59 @@ func NewMemoryOAuthStore() *MemoryOAuthStore {
 	return &MemoryOAuthStore{m: make(map[string]OAuthRecord)}
 }
 
-func mkOAuthKey(userID string, kind OAuthKind) string {
-	return userID + "|" + string(kind)
+// mkOAuthKey builds a record's stable identity.
+//
+// Rank 0 keeps the historical two-part form, so every record written before
+// ranks existed keeps the `_id` it already has — no migration of primary
+// keys, and an operator's existing forfait stays the primary by construction.
+// Only the fallbacks an operator adds deliberately carry the third part.
+// sortOAuthChain orders records the way they are meant to be TRIED: by kind,
+// then by rank. Callers walk the slice and take the first that serves, which
+// is what makes a chain a chain without any of them knowing ranks exist.
+func sortOAuthChain(recs []OAuthRecord) {
+	sort.SliceStable(recs, func(i, j int) bool {
+		if recs[i].Kind != recs[j].Kind {
+			return recs[i].Kind < recs[j].Kind
+		}
+		return recs[i].Rank < recs[j].Rank
+	})
+}
+
+// OAuthRecordID is the identity a caller addresses a record by. Exported
+// because the write paths take an id now, and every caller that knows an
+// (owner, kind, rank) must be able to name the record without re-deriving
+// the format — a format duplicated in three places is a format that drifts.
+func OAuthRecordID(userID string, kind OAuthKind, rank int) string {
+	return mkOAuthKey(userID, kind, rank)
+}
+
+func mkOAuthKey(userID string, kind OAuthKind, rank int) string {
+	key := userID + "|" + string(kind)
+	if rank > 0 {
+		key += "|" + strconv.Itoa(rank)
+	}
+	return key
 }
 
 func (s *MemoryOAuthStore) Upsert(_ context.Context, rec OAuthRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if rec.ID == "" {
-		rec.ID = mkOAuthKey(rec.UserID, rec.Kind)
+		rec.ID = mkOAuthKey(rec.UserID, rec.Kind, rec.Rank)
 	}
-	s.m[mkOAuthKey(rec.UserID, rec.Kind)] = rec
+	s.m[rec.ID] = rec
 	return nil
 }
 
 func (s *MemoryOAuthStore) Get(_ context.Context, userID string, kind OAuthKind) (OAuthRecord, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	r, ok := s.m[mkOAuthKey(userID, kind)]
-	if !ok {
-		return OAuthRecord{}, ErrOAuthNotFound
+	for _, r := range s.m {
+		if r.UserID == userID && r.Kind == kind && r.Rank == 0 {
+			return r, nil
+		}
 	}
-	return r, nil
+	return OAuthRecord{}, ErrOAuthNotFound
 }
 
 func (s *MemoryOAuthStore) ListByUser(_ context.Context, userID string) ([]OAuthRecord, error) {
@@ -749,10 +814,11 @@ func (s *MemoryOAuthStore) ListByUser(_ context.Context, userID string) ([]OAuth
 			out = append(out, r)
 		}
 	}
+	sortOAuthChain(out)
 	return out, nil
 }
 
-func (s *MemoryOAuthStore) Delete(_ context.Context, userID string, kind OAuthKind) error {
+func (s *MemoryOAuthStore) Delete(_ context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// Report ErrOAuthNotFound for a missing key, matching MongoOAuthStore
@@ -760,11 +826,10 @@ func (s *MemoryOAuthStore) Delete(_ context.Context, userID string, kind OAuthKi
 	// the outcome — e.g. auditing a delete only when something was actually
 	// removed — is correct against Mongo but silently wrong under the memory
 	// store used by tests and local mode.
-	key := mkOAuthKey(userID, kind)
-	if _, ok := s.m[key]; !ok {
+	if _, ok := s.m[id]; !ok {
 		return ErrOAuthNotFound
 	}
-	delete(s.m, key)
+	delete(s.m, id)
 	return nil
 }
 
@@ -780,25 +845,23 @@ func (s *MemoryOAuthStore) ExpiringBefore(_ context.Context, t time.Time) ([]OAu
 	return out, nil
 }
 
-func (s *MemoryOAuthStore) SetAccountLabel(_ context.Context, userID string, kind OAuthKind, label string) error {
+func (s *MemoryOAuthStore) SetAccountLabel(_ context.Context, id string, label string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := mkOAuthKey(userID, kind)
-	r, ok := s.m[key]
+	r, ok := s.m[id]
 	if !ok {
 		return ErrOAuthNotFound
 	}
 	r.AccountLabel = label
 	r.UpdatedAt = time.Now().UTC()
-	s.m[key] = r
+	s.m[id] = r
 	return nil
 }
 
-func (s *MemoryOAuthStore) ClaimRefresh(_ context.Context, userID string, kind OAuthKind, owner string, now, until time.Time) (bool, error) {
+func (s *MemoryOAuthStore) ClaimRefresh(_ context.Context, id string, owner string, now, until time.Time) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := mkOAuthKey(userID, kind)
-	r, ok := s.m[key]
+	r, ok := s.m[id]
 	if !ok {
 		return false, nil
 	}
@@ -808,15 +871,14 @@ func (s *MemoryOAuthStore) ClaimRefresh(_ context.Context, userID string, kind O
 	u := until.UTC()
 	r.RefreshClaimOwner = owner
 	r.RefreshNotBefore = &u
-	s.m[key] = r
+	s.m[id] = r
 	return true, nil
 }
 
-func (s *MemoryOAuthStore) ReleaseRefreshClaim(_ context.Context, userID string, kind OAuthKind, owner string, notBefore *time.Time) error {
+func (s *MemoryOAuthStore) ReleaseRefreshClaim(_ context.Context, id string, owner string, notBefore *time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := mkOAuthKey(userID, kind)
-	r, ok := s.m[key]
+	r, ok := s.m[id]
 	// A record that vanished under the holder is the claim-lost outcome,
 	// not a lookup failure — same verdict the Mongo twin's MatchedCount
 	// gives, and the caller acts on it identically.
@@ -825,7 +887,7 @@ func (s *MemoryOAuthStore) ReleaseRefreshClaim(_ context.Context, userID string,
 	}
 	r.RefreshClaimOwner = ""
 	r.RefreshNotBefore = copyTimePtr(notBefore)
-	s.m[key] = r
+	s.m[id] = r
 	return nil
 }
 
@@ -837,11 +899,10 @@ func copyTimePtr(t *time.Time) *time.Time {
 	return &c
 }
 
-func (s *MemoryOAuthStore) UpdateTokens(_ context.Context, userID string, kind OAuthKind, upd OAuthTokenUpdate) error {
+func (s *MemoryOAuthStore) UpdateTokens(_ context.Context, id string, upd OAuthTokenUpdate) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := mkOAuthKey(userID, kind)
-	r, ok := s.m[key]
+	r, ok := s.m[id]
 	if upd.ClaimOwner != "" {
 		// A fenced commit reads its verdict off the fence, exactly like
 		// ReleaseRefreshClaim: a record that vanished under the holder is
@@ -872,7 +933,7 @@ func (s *MemoryOAuthStore) UpdateTokens(_ context.Context, userID string, kind O
 	}
 	r.NotRefreshable = upd.NotRefreshable
 	r.UpdatedAt = time.Now().UTC()
-	s.m[key] = r
+	s.m[id] = r
 	return nil
 }
 
@@ -887,9 +948,39 @@ func NewMongoOAuthStore(db *mongo.Database) *MongoOAuthStore {
 	return &MongoOAuthStore{coll: db.Collection(OAuthCollectionName)}
 }
 
+// isIndexMissing reports the one DropOne outcome that is not a failure: the
+// index is already gone. Mongo answers IndexNotFound (27); the driver may
+// also surface it as a plain message on older servers, so both are read.
+func isIndexMissing(err error) bool {
+	var ce mongo.CommandError
+	if errors.As(err, &ce) && ce.Code == 27 {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "index not found")
+}
+
 func (s *MongoOAuthStore) EnsureSchema(ctx context.Context) error {
+	// Records written before ranks existed carry no `rank` field, and Mongo
+	// does not match a missing field against 0 — so Get(primary) would stop
+	// finding them, and the unique index below would admit a SECOND rank-0
+	// record beside each. Backfill first, idempotently: after the first pass
+	// this matches nothing.
+	if _, err := s.coll.UpdateMany(ctx,
+		bson.M{"rank": bson.M{"$exists": false}},
+		bson.M{"$set": bson.M{"rank": 0}},
+	); err != nil {
+		return fmt.Errorf("secrets: backfill oauth rank: %w", err)
+	}
+	// The old (user_id, kind) unique index IS the ceiling this change
+	// removes: it has to go, not gain a sibling, or a second credential for
+	// one kind is still refused. An absent index is the steady state after
+	// the first pass, so only an unexpected failure propagates.
+	if err := s.coll.Indexes().DropOne(ctx, "user_kind_unique"); err != nil &&
+		!isIndexMissing(err) {
+		return fmt.Errorf("secrets: drop legacy oauth index: %w", err)
+	}
 	_, err := s.coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
-		{Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "kind", Value: 1}}, Options: options.Index().SetUnique(true).SetName("user_kind_unique")},
+		{Keys: bson.D{{Key: "user_id", Value: 1}, {Key: "kind", Value: 1}, {Key: "rank", Value: 1}}, Options: options.Index().SetUnique(true).SetName("user_kind_rank_unique")},
 		{Keys: bson.D{{Key: "access_token_expires_at", Value: 1}}, Options: options.Index().SetName("access_expiry_partial").SetPartialFilterExpression(bson.M{"access_token_expires_at": bson.M{"$exists": true}})},
 	})
 	if err != nil && !mongoutil.IsIndexConflict(err) {
@@ -900,7 +991,7 @@ func (s *MongoOAuthStore) EnsureSchema(ctx context.Context) error {
 
 func (s *MongoOAuthStore) Upsert(ctx context.Context, rec OAuthRecord) error {
 	if rec.ID == "" {
-		rec.ID = mkOAuthKey(rec.UserID, rec.Kind)
+		rec.ID = mkOAuthKey(rec.UserID, rec.Kind, rec.Rank)
 	}
 	rec.UpdatedAt = time.Now().UTC()
 	if rec.CreatedAt.IsZero() {
@@ -915,7 +1006,7 @@ func (s *MongoOAuthStore) Upsert(ctx context.Context, rec OAuthRecord) error {
 
 	_, err = s.coll.UpdateOne(
 		ctx,
-		bson.M{"user_id": rec.UserID, "kind": rec.Kind},
+		bson.M{"_id": rec.ID},
 		bson.M{
 			"$set":         setBody,
 			"$setOnInsert": bson.M{"_id": rec.ID},
@@ -929,23 +1020,31 @@ func (s *MongoOAuthStore) Upsert(ctx context.Context, rec OAuthRecord) error {
 }
 
 func (s *MongoOAuthStore) Get(ctx context.Context, userID string, kind OAuthKind) (OAuthRecord, error) {
-	return mongoutil.FindOne[OAuthRecord](ctx, s.coll, bson.M{"user_id": userID, "kind": kind}, ErrOAuthNotFound, "secrets: get oauth")
+	return mongoutil.FindOne[OAuthRecord](ctx, s.coll, bson.M{"user_id": userID, "kind": kind, "rank": 0}, ErrOAuthNotFound, "secrets: get oauth")
 }
 
 func (s *MongoOAuthStore) ListByUser(ctx context.Context, userID string) ([]OAuthRecord, error) {
-	return mongoutil.FindAllSorted[OAuthRecord](ctx, s.coll, bson.M{"user_id": userID}, "kind",
+	recs, err := mongoutil.FindAllSorted[OAuthRecord](ctx, s.coll, bson.M{"user_id": userID}, "kind",
 		"secrets: list oauth", "secrets: decode oauth")
+	if err != nil {
+		return nil, err
+	}
+	// The chain order is (kind, rank); Mongo sorted the first half, and the
+	// second is settled here rather than in a compound sort so both stores
+	// answer with one shared comparator.
+	sortOAuthChain(recs)
+	return recs, nil
 }
 
-func (s *MongoOAuthStore) Delete(ctx context.Context, userID string, kind OAuthKind) error {
-	return mongoutil.DeleteOneChecked(ctx, s.coll, bson.M{"user_id": userID, "kind": kind}, ErrOAuthNotFound, "secrets: delete oauth")
+func (s *MongoOAuthStore) Delete(ctx context.Context, id string) error {
+	return mongoutil.DeleteOneChecked(ctx, s.coll, bson.M{"_id": id}, ErrOAuthNotFound, "secrets: delete oauth")
 }
 
-func (s *MongoOAuthStore) SetAccountLabel(ctx context.Context, userID string, kind OAuthKind, label string) error {
+func (s *MongoOAuthStore) SetAccountLabel(ctx context.Context, id string, label string) error {
 	// A literal $set of the two keys, never the struct: the sealed payload
 	// and the fingerprint stay whatever the last connect/refresh wrote.
 	res, err := s.coll.UpdateOne(ctx,
-		bson.M{"user_id": userID, "kind": kind},
+		bson.M{"_id": id},
 		bson.M{"$set": bson.M{"account_label": label, "updated_at": time.Now().UTC()}},
 	)
 	if err != nil {
@@ -961,9 +1060,9 @@ func (s *MongoOAuthStore) SetAccountLabel(ctx context.Context, userID string, ki
 // stands (refresh_not_before absent, null, or already past — `nil` matches
 // the first two in Mongo), so the first replica to stamp its owner wins and
 // the rest get (false, nil). One refresher per record, no leader.
-func (s *MongoOAuthStore) ClaimRefresh(ctx context.Context, userID string, kind OAuthKind, owner string, now, until time.Time) (bool, error) {
+func (s *MongoOAuthStore) ClaimRefresh(ctx context.Context, id string, owner string, now, until time.Time) (bool, error) {
 	res, err := s.coll.UpdateOne(ctx,
-		bson.M{"user_id": userID, "kind": kind, "$or": []bson.M{
+		bson.M{"_id": id, "$or": []bson.M{
 			{"refresh_not_before": nil},
 			{"refresh_not_before": bson.M{"$lte": now.UTC()}},
 		}},
@@ -978,7 +1077,7 @@ func (s *MongoOAuthStore) ClaimRefresh(ctx context.Context, userID string, kind 
 	return res.MatchedCount > 0, nil
 }
 
-func (s *MongoOAuthStore) ReleaseRefreshClaim(ctx context.Context, userID string, kind OAuthKind, owner string, notBefore *time.Time) error {
+func (s *MongoOAuthStore) ReleaseRefreshClaim(ctx context.Context, id string, owner string, notBefore *time.Time) error {
 	// updated_at is deliberately NOT touched here, nor in ClaimRefresh:
 	// taking or dropping the lock changes no credential, and the field is
 	// rendered to operators as when this connection last changed. A refresh
@@ -988,7 +1087,7 @@ func (s *MongoOAuthStore) ReleaseRefreshClaim(ctx context.Context, userID string
 		"refresh_not_before":  notBeforeValue(notBefore),
 	}
 	res, err := s.coll.UpdateOne(ctx,
-		bson.M{"user_id": userID, "kind": kind, "refresh_claim_owner": owner},
+		bson.M{"_id": id, "refresh_claim_owner": owner},
 		bson.M{"$set": set},
 	)
 	if err != nil {
@@ -1024,7 +1123,7 @@ func notBeforeValue(t *time.Time) any {
 //   - the filter arrives as a RETURNED value, so a call site that passes a
 //     literal instead leaves it unused and does not compile. Built in place,
 //     it was "used" by its own map-index assignments and compiled fine.
-func oauthTokenUpdateWrite(userID string, kind OAuthKind, upd OAuthTokenUpdate, now time.Time) (bson.M, bson.M) {
+func oauthTokenUpdateWrite(id string, upd OAuthTokenUpdate, now time.Time) (bson.M, bson.M) {
 	// A literal $set of the refresh-owned keys, never the struct: the
 	// account label — and anything else a future writer owns — stays
 	// whatever its own endpoint last wrote.
@@ -1032,7 +1131,7 @@ func oauthTokenUpdateWrite(userID string, kind OAuthKind, upd OAuthTokenUpdate, 
 		"not_refreshable": upd.NotRefreshable,
 		"updated_at":      now.UTC(),
 	}
-	filter := bson.M{"user_id": userID, "kind": kind}
+	filter := bson.M{"_id": id}
 	if upd.ClaimOwner != "" {
 		// Fenced commit: the tokens land only while this holder still owns
 		// the claim, and the claim is released by the same write. A lost
@@ -1061,8 +1160,8 @@ func oauthTokenUpdateWrite(userID string, kind OAuthKind, upd OAuthTokenUpdate, 
 	return filter, bson.M{"$set": set}
 }
 
-func (s *MongoOAuthStore) UpdateTokens(ctx context.Context, userID string, kind OAuthKind, upd OAuthTokenUpdate) error {
-	filter, update := oauthTokenUpdateWrite(userID, kind, upd, time.Now())
+func (s *MongoOAuthStore) UpdateTokens(ctx context.Context, id string, upd OAuthTokenUpdate) error {
+	filter, update := oauthTokenUpdateWrite(id, upd, time.Now())
 	res, err := s.coll.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return fmt.Errorf("secrets: update oauth tokens: %w", err)

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -948,15 +948,27 @@ func NewMongoOAuthStore(db *mongo.Database) *MongoOAuthStore {
 	return &MongoOAuthStore{coll: db.Collection(OAuthCollectionName)}
 }
 
-// isIndexMissing reports the one DropOne outcome that is not a failure: the
-// index is already gone. Mongo answers IndexNotFound (27); the driver may
-// also surface it as a plain message on older servers, so both are read.
+// isIndexMissing reports the DropOne outcomes that are not failures. Both
+// mean the same thing: there is no legacy index here to remove.
+//
+//   - IndexNotFound (27) — the collection exists and the index is already
+//     gone, which is the steady state after the first pass;
+//   - NamespaceNotFound (26) — the COLLECTION does not exist yet, i.e. every
+//     brand-new deployment. Without this arm EnsureSchema fails on a fresh
+//     database: an install with nothing to migrate refused by the migration.
+//
+// The second arm is invisible to `task check`, which skips every Mongo-gated
+// suite; the mongo-conformance harness is what surfaces it.
+//
+// The driver may also surface either as a plain message on older servers, so
+// the text is read as a fallback.
 func isIndexMissing(err error) bool {
 	var ce mongo.CommandError
-	if errors.As(err, &ce) && ce.Code == 27 {
+	if errors.As(err, &ce) && (ce.Code == 27 || ce.Code == 26) {
 		return true
 	}
-	return strings.Contains(strings.ToLower(err.Error()), "index not found")
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "index not found") || strings.Contains(msg, "ns not found")
 }
 
 func (s *MongoOAuthStore) EnsureSchema(ctx context.Context) error {

--- a/pkg/secrets/oauth_chain_test.go
+++ b/pkg/secrets/oauth_chain_test.go
@@ -1,0 +1,125 @@
+package secrets
+
+import (
+	"testing"
+	"time"
+)
+
+// The ceiling this whole change removes: the store held exactly ONE record
+// per (owner, kind), so an operator holding four Claude subscriptions could
+// wire two — their org's and the deployment's — and had no way to say "try
+// these in this order". On 2026-09-08 that stopped every claude_code run on
+// a production deployment for three hours: the org forfait's five-hour
+// window closed, the single tier behind it was already spent on its weekly
+// one, and there was nowhere to put a third.
+//
+// Two records for one kind must therefore COEXIST, and come back in the
+// order they are meant to be tried.
+func TestOAuthChain_TwoCredentialsOfOneKindCoexist(t *testing.T) {
+	s := NewMemoryOAuthStore()
+	ctx := t.Context()
+
+	primary := OAuthRecord{UserID: "org:acme", Kind: OAuthKindClaudeCode, Rank: 0,
+		SealedPayload: []byte("primary"), AccountLabel: "devthejo@gmail.com"}
+	fallback := OAuthRecord{UserID: "org:acme", Kind: OAuthKindClaudeCode, Rank: 1,
+		SealedPayload: []byte("fallback"), AccountLabel: "jothedev@proton.me"}
+	for _, rec := range []OAuthRecord{fallback, primary} { // inserted out of order on purpose
+		if err := s.Upsert(ctx, rec); err != nil {
+			t.Fatalf("upsert rank %d: %v", rec.Rank, err)
+		}
+	}
+
+	recs, err := s.ListByUser(ctx, "org:acme")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("the chain holds %d record(s), want 2 — a second credential for one kind was swallowed, "+
+			"which is exactly the ceiling that stopped a production fleet", len(recs))
+	}
+	// Order is the contract: a caller walks the slice and takes the first
+	// that serves, without knowing ranks exist.
+	if recs[0].Rank != 0 || recs[1].Rank != 1 {
+		t.Fatalf("chain order = [%d %d], want [0 1] — the publisher would try the fallback first",
+			recs[0].Rank, recs[1].Rank)
+	}
+	if string(recs[0].SealedPayload) != "primary" || string(recs[1].SealedPayload) != "fallback" {
+		t.Fatalf("payloads swapped: %q then %q", recs[0].SealedPayload, recs[1].SealedPayload)
+	}
+
+	// Get keeps meaning "the primary" for every reader written before chains.
+	got, err := s.Get(ctx, "org:acme", OAuthKindClaudeCode)
+	if err != nil {
+		t.Fatalf("get primary: %v", err)
+	}
+	if got.Rank != 0 || string(got.SealedPayload) != "primary" {
+		t.Fatalf("Get returned rank %d (%q), want the primary", got.Rank, got.SealedPayload)
+	}
+}
+
+// Each link is addressed on its own. A writer that still keyed on
+// (owner, kind) would land on the primary whatever rank it was called for —
+// deleting, renaming or refreshing the wrong credential while reporting
+// success, which is worse than refusing.
+func TestOAuthChain_WritesAddressOneLinkNotThePair(t *testing.T) {
+	s := NewMemoryOAuthStore()
+	ctx := t.Context()
+	for rank, label := range map[int]string{0: "primary", 1: "fallback"} {
+		if err := s.Upsert(ctx, OAuthRecord{UserID: "u", Kind: OAuthKindCodex, Rank: rank,
+			SealedPayload: []byte(label), AccountLabel: label}); err != nil {
+			t.Fatalf("seed rank %d: %v", rank, err)
+		}
+	}
+
+	// Rename the FALLBACK only.
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("u", OAuthKindCodex, 1), "renamed"); err != nil {
+		t.Fatalf("rename rank 1: %v", err)
+	}
+	primary, err := s.Get(ctx, "u", OAuthKindCodex)
+	if err != nil {
+		t.Fatalf("get primary: %v", err)
+	}
+	if primary.AccountLabel != "primary" {
+		t.Fatalf("the primary was renamed to %q — the write landed on the wrong link", primary.AccountLabel)
+	}
+
+	// Delete the FALLBACK only.
+	if err := s.Delete(ctx, OAuthRecordID("u", OAuthKindCodex, 1)); err != nil {
+		t.Fatalf("delete rank 1: %v", err)
+	}
+	recs, err := s.ListByUser(ctx, "u")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(recs) != 1 || recs[0].Rank != 0 {
+		t.Fatalf("after deleting rank 1 the chain is %+v, want the primary alone", recs)
+	}
+}
+
+// A refresh claims ONE record. Two links of the same chain must be claimable
+// independently — otherwise the sweep renewing the primary would fence the
+// fallback out of its own refresh, and the fallback would expire quietly
+// while every claim test stayed green.
+func TestOAuthChain_ClaimsArePerLink(t *testing.T) {
+	s := NewMemoryOAuthStore()
+	ctx := t.Context()
+	now := time.Now().UTC()
+	for _, rank := range []int{0, 1} {
+		if err := s.Upsert(ctx, OAuthRecord{UserID: "u", Kind: OAuthKindClaudeCode, Rank: rank,
+			SealedPayload: []byte("x")}); err != nil {
+			t.Fatalf("seed rank %d: %v", rank, err)
+		}
+	}
+	okPrimary, err := s.ClaimRefresh(ctx, OAuthRecordID("u", OAuthKindClaudeCode, 0), "sweep-a", now, now.Add(time.Minute))
+	if err != nil || !okPrimary {
+		t.Fatalf("claim primary = %v, %v; want true", okPrimary, err)
+	}
+	okFallback, err := s.ClaimRefresh(ctx, OAuthRecordID("u", OAuthKindClaudeCode, 1), "sweep-b", now, now.Add(time.Minute))
+	if err != nil {
+		t.Fatalf("claim fallback: %v", err)
+	}
+	if !okFallback {
+		t.Fatal("claiming the fallback was refused while the primary was claimed — the fence is on the pair, " +
+			"not on the record, so the fallback would never be refreshed")
+	}
+}

--- a/pkg/secrets/oauth_mongo_test.go
+++ b/pkg/secrets/oauth_mongo_test.go
@@ -75,7 +75,7 @@ func TestMongoOAuth_EmptyLabelClearsThroughUpsert(t *testing.T) {
 // caller's copy of the record is stale.
 func TestMongoOAuth_SetAccountLabelIsMetadataOnly(t *testing.T) {
 	s, ctx := mongoOAuthStore(t)
-	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, "x"); !errors.Is(err, ErrOAuthNotFound) {
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "x"); !errors.Is(err, ErrOAuthNotFound) {
 		t.Fatalf("SetAccountLabel on a missing record = %v, want ErrOAuthNotFound", err)
 	}
 	if err := s.Upsert(ctx, OAuthRecord{UserID: "alice", Kind: OAuthKindCodex, SealedPayload: []byte("sealed-v1"), Fingerprint: "fp-1"}); err != nil {
@@ -85,7 +85,7 @@ func TestMongoOAuth_SetAccountLabelIsMetadataOnly(t *testing.T) {
 	if err := s.Upsert(ctx, OAuthRecord{UserID: "alice", Kind: OAuthKindCodex, SealedPayload: []byte("sealed-v2"), Fingerprint: "fp-1"}); err != nil {
 		t.Fatalf("refresh upsert: %v", err)
 	}
-	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, "alice@openai"); err != nil {
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "alice@openai"); err != nil {
 		t.Fatalf("SetAccountLabel: %v", err)
 	}
 	got, err := s.Get(ctx, "alice", OAuthKindCodex)
@@ -98,7 +98,7 @@ func TestMongoOAuth_SetAccountLabelIsMetadataOnly(t *testing.T) {
 	if string(got.SealedPayload) != "sealed-v2" || got.Fingerprint != "fp-1" {
 		t.Fatalf("rename disturbed the credential: payload=%q fp=%q", got.SealedPayload, got.Fingerprint)
 	}
-	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, ""); err != nil {
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), ""); err != nil {
 		t.Fatalf("clear: %v", err)
 	}
 	if got, _ = s.Get(ctx, "alice", OAuthKindCodex); got.AccountLabel != "" {
@@ -113,7 +113,7 @@ func TestMongoOAuth_SetAccountLabelIsMetadataOnly(t *testing.T) {
 // only Mongo can prove the $set body.)
 func TestMongoOAuth_UpdateTokensIsRefreshOnly(t *testing.T) {
 	s, ctx := mongoOAuthStore(t)
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindClaudeCode, OAuthTokenUpdate{}); !errors.Is(err, ErrOAuthNotFound) {
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), OAuthTokenUpdate{}); !errors.Is(err, ErrOAuthNotFound) {
 		t.Fatalf("UpdateTokens on a missing record = %v, want ErrOAuthNotFound", err)
 	}
 	if err := s.Upsert(ctx, OAuthRecord{
@@ -124,12 +124,12 @@ func TestMongoOAuth_UpdateTokensIsRefreshOnly(t *testing.T) {
 		t.Fatalf("upsert: %v", err)
 	}
 	// The operator renames while the refresh is out at the provider.
-	if err := s.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "jothedev"); err != nil {
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), "jothedev"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
 	exp := time.Now().Add(8 * time.Hour).UTC().Truncate(time.Millisecond)
 	last := time.Now().UTC().Truncate(time.Millisecond)
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindClaudeCode, OAuthTokenUpdate{
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), OAuthTokenUpdate{
 		SealedPayload:        []byte("sealed-v2"),
 		AccessTokenExpiresAt: &exp,
 		LastRefreshedAt:      &last,
@@ -165,7 +165,7 @@ func TestMongoOAuth_UpdateTokensIsRefreshOnly(t *testing.T) {
 	}
 
 	// The self-heal shape: one flag, nothing else disturbed.
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindClaudeCode, OAuthTokenUpdate{NotRefreshable: true}); err != nil {
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), OAuthTokenUpdate{NotRefreshable: true}); err != nil {
 		t.Fatalf("self-heal: %v", err)
 	}
 	got, err = s.Get(ctx, "alice", OAuthKindClaudeCode)
@@ -197,20 +197,20 @@ func TestMongoOAuth_RefreshClaimIsFencedOnTheWire(t *testing.T) {
 	now := time.Now().UTC()
 
 	// A record nobody has claimed carries no cool-down, so the CAS matches.
-	ok, err := s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-a", now, now.Add(2*time.Minute))
+	ok, err := s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-a", now, now.Add(2*time.Minute))
 	if err != nil || !ok {
 		t.Fatalf("first claim: ok=%v err=%v, want acquired", ok, err)
 	}
 	// While it stands, nobody else may exchange.
-	ok, err = s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-b", now, now.Add(2*time.Minute))
+	ok, err = s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-b", now, now.Add(2*time.Minute))
 	if err != nil || ok {
 		t.Fatalf("competing claim: ok=%v err=%v, want refused", ok, err)
 	}
 	// Neither may they release it or commit through it.
-	if err := s.ReleaseRefreshClaim(ctx, "alice", OAuthKindCodex, "owner-b", nil); !errors.Is(err, ErrRefreshClaimLost) {
+	if err := s.ReleaseRefreshClaim(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-b", nil); !errors.Is(err, ErrRefreshClaimLost) {
 		t.Fatalf("release by a non-owner = %v, want ErrRefreshClaimLost", err)
 	}
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex,
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0),
 		OAuthTokenUpdate{SealedPayload: []byte("sealed-from-b")}.WithClaim("owner-b")); !errors.Is(err, ErrRefreshClaimLost) {
 		t.Fatalf("commit by a non-owner = %v, want ErrRefreshClaimLost", err)
 	}
@@ -237,7 +237,7 @@ func TestMongoOAuth_RefreshClaimIsFencedOnTheWire(t *testing.T) {
 		t.Fatalf("re-connect left claim owner=%q not_before=%v, want both cleared on the wire",
 			got.RefreshClaimOwner, got.RefreshNotBefore)
 	}
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex,
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0),
 		OAuthTokenUpdate{SealedPayload: []byte("sealed-from-a")}.WithClaim("owner-a")); !errors.Is(err, ErrRefreshClaimLost) {
 		t.Fatalf("commit after a re-connect = %v, want ErrRefreshClaimLost", err)
 	}
@@ -247,17 +247,17 @@ func TestMongoOAuth_RefreshClaimIsFencedOnTheWire(t *testing.T) {
 
 	// A holder that dies costs one sweep: the lease expiring is what makes
 	// the record claimable again, so nothing has to reap it.
-	ok, err = s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-c", now, now.Add(time.Minute))
+	ok, err = s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-c", now, now.Add(time.Minute))
 	if err != nil || !ok {
 		t.Fatalf("claim after the re-connect cleared it: ok=%v err=%v", ok, err)
 	}
 	later := now.Add(2 * time.Minute)
-	ok, err = s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-d", later, later.Add(time.Minute))
+	ok, err = s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-d", later, later.Add(time.Minute))
 	if err != nil || !ok {
 		t.Fatalf("claim once the lease expired: ok=%v err=%v, want acquired", ok, err)
 	}
 	// The holder's own commit lands AND releases the claim in one write.
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex,
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0),
 		OAuthTokenUpdate{SealedPayload: []byte("sealed-from-d"), Fingerprint: "fp-2"}.WithClaim("owner-d")); err != nil {
 		t.Fatalf("commit by the holder: %v", err)
 	}
@@ -284,11 +284,11 @@ func TestMongoOAuth_CoolDownSurvivesAndUnfencedWritesLeaveItAlone(t *testing.T) 
 		t.Fatalf("upsert: %v", err)
 	}
 	now := time.Now().UTC()
-	if ok, err := s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-a", now, now.Add(2*time.Minute)); err != nil || !ok {
+	if ok, err := s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-a", now, now.Add(2*time.Minute)); err != nil || !ok {
 		t.Fatalf("claim: ok=%v err=%v", ok, err)
 	}
 	cool := now.Add(time.Hour).Truncate(time.Millisecond)
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex, OAuthTokenUpdate{
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), OAuthTokenUpdate{
 		SealedPayload: []byte("sealed-v2"), RefreshNotBefore: &cool,
 	}.WithClaim("owner-a")); err != nil {
 		t.Fatalf("commit with a cool-down: %v", err)
@@ -304,11 +304,11 @@ func TestMongoOAuth_CoolDownSurvivesAndUnfencedWritesLeaveItAlone(t *testing.T) 
 		t.Fatalf("claim owner = %q, want released beside the cool-down", got.RefreshClaimOwner)
 	}
 	// The cool-down holds the CAS off until it passes.
-	if ok, err := s.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-b", now, now.Add(time.Minute)); err != nil || ok {
+	if ok, err := s.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-b", now, now.Add(time.Minute)); err != nil || ok {
 		t.Fatalf("claim during the cool-down: ok=%v err=%v, want refused", ok, err)
 	}
 	// The self-heal writes no claim, so it must leave the cool-down as it is.
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex, OAuthTokenUpdate{NotRefreshable: true}); err != nil {
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), OAuthTokenUpdate{NotRefreshable: true}); err != nil {
 		t.Fatalf("unfenced self-heal: %v", err)
 	}
 	got, err = s.Get(ctx, "alice", OAuthKindCodex)

--- a/pkg/secrets/oauth_refresh_claim_test.go
+++ b/pkg/secrets/oauth_refresh_claim_test.go
@@ -243,18 +243,18 @@ func TestMemoryOAuthStore_RefreshClaimIsFencedAndSelfHealing(t *testing.T) {
 	}
 	now := time.Now().UTC()
 
-	ok, err := st.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-a", now, now.Add(2*time.Minute))
+	ok, err := st.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-a", now, now.Add(2*time.Minute))
 	if err != nil || !ok {
 		t.Fatalf("first claim: ok=%v err=%v, want acquired", ok, err)
 	}
-	ok, err = st.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-b", now, now.Add(2*time.Minute))
+	ok, err = st.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-b", now, now.Add(2*time.Minute))
 	if err != nil || ok {
 		t.Fatalf("second claim: ok=%v err=%v, want refused while owner-a holds it", ok, err)
 	}
-	if err := st.ReleaseRefreshClaim(ctx, "alice", OAuthKindCodex, "owner-b", nil); !errors.Is(err, ErrRefreshClaimLost) {
+	if err := st.ReleaseRefreshClaim(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-b", nil); !errors.Is(err, ErrRefreshClaimLost) {
 		t.Fatalf("release by a non-owner = %v, want ErrRefreshClaimLost: it must not free owner-a's claim", err)
 	}
-	if err := st.UpdateTokens(ctx, "alice", OAuthKindCodex,
+	if err := st.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0),
 		OAuthTokenUpdate{SealedPayload: []byte("from-owner-b")}.WithClaim("owner-b")); !errors.Is(err, ErrRefreshClaimLost) {
 		t.Fatalf("commit by a non-owner = %v, want ErrRefreshClaimLost", err)
 	}
@@ -266,11 +266,11 @@ func TestMemoryOAuthStore_RefreshClaimIsFencedAndSelfHealing(t *testing.T) {
 	// owner-a dies without releasing: the lease expiring is what unblocks
 	// the record, so nothing needs a janitor.
 	later := now.Add(3 * time.Minute)
-	ok, err = st.ClaimRefresh(ctx, "alice", OAuthKindCodex, "owner-c", later, later.Add(2*time.Minute))
+	ok, err = st.ClaimRefresh(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), "owner-c", later, later.Add(2*time.Minute))
 	if err != nil || !ok {
 		t.Fatalf("claim after the lease expired: ok=%v err=%v, want acquired", ok, err)
 	}
-	if err := st.UpdateTokens(ctx, "alice", OAuthKindCodex,
+	if err := st.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0),
 		OAuthTokenUpdate{SealedPayload: []byte("from-owner-c")}.WithClaim("owner-c")); err != nil {
 		t.Fatalf("commit by the holder: %v", err)
 	}
@@ -297,13 +297,18 @@ func TestOAuthTokenUpdateWrite_FencesOnTheClaim(t *testing.T) {
 	now := time.Now().UTC()
 	cool := now.Add(time.Hour)
 
-	filter, update := oauthTokenUpdateWrite("alice", OAuthKindCodex,
+	id := OAuthRecordID("alice", OAuthKindCodex, 1)
+	filter, update := oauthTokenUpdateWrite(id,
 		OAuthTokenUpdate{SealedPayload: []byte("sealed-v2"), RefreshNotBefore: &cool}.WithClaim("owner-a"), now)
-	if got := filter["user_id"]; got != "alice" {
-		t.Fatalf("filter user_id = %v, want alice", got)
+	// The write addresses ONE record by its id. A filter that still keyed on
+	// (user_id, kind) would match the chain's PRIMARY whatever link the
+	// refresh was called for — renewing rank 0 forever while the fallback it
+	// held a claim on expired, with every claim test still green.
+	if got := filter["_id"]; got != id {
+		t.Fatalf("filter _id = %v, want %v (the record the refresh claimed)", got, id)
 	}
-	if got := filter["kind"]; got != OAuthKindCodex {
-		t.Fatalf("filter kind = %v, want %v", got, OAuthKindCodex)
+	if _, keyedOnPair := filter["user_id"]; keyedOnPair {
+		t.Fatal("filter still carries user_id — that pair stopped identifying one record when a chain became possible")
 	}
 	if got := filter["refresh_claim_owner"]; got != "owner-a" {
 		t.Fatalf("fenced commit filter refresh_claim_owner = %v, want owner-a — without it a superseded "+
@@ -325,7 +330,7 @@ func TestOAuthTokenUpdateWrite_FencesOnTheClaim(t *testing.T) {
 
 	// The unfenced shape (the self-heal, which takes no claim) must neither
 	// fence on a claim it does not hold nor clear the holder's.
-	filter, update = oauthTokenUpdateWrite("alice", OAuthKindCodex, OAuthTokenUpdate{NotRefreshable: true}, now)
+	filter, update = oauthTokenUpdateWrite(OAuthRecordID("alice", OAuthKindCodex, 0), OAuthTokenUpdate{NotRefreshable: true}, now)
 	if _, fenced := filter["refresh_claim_owner"]; fenced {
 		t.Fatalf("unfenced write filtered on a claim: %v", filter)
 	}

--- a/pkg/secrets/oauth_refresh_worker.go
+++ b/pkg/secrets/oauth_refresh_worker.go
@@ -114,7 +114,7 @@ func (w *OAuthRefreshWorker) RunOnce(ctx context.Context) (int, error) {
 			return refreshed, fmt.Errorf("secrets: oauth refresh sweep: %w", oerr)
 		}
 		now := time.Now().UTC()
-		claimed, cerr := w.Store.ClaimRefresh(ctx, rec.UserID, rec.Kind, owner, now, now.Add(RefreshClaimTTL))
+		claimed, cerr := w.Store.ClaimRefresh(ctx, rec.ID, owner, now, now.Add(RefreshClaimTTL))
 		if cerr != nil {
 			failures++
 			if firstErr == nil {
@@ -130,13 +130,13 @@ func (w *OAuthRefreshWorker) RunOnce(ctx context.Context) (int, error) {
 			// rather than wait the lease out. Best-effort: a claim we no
 			// longer own has already been superseded, and there is nothing
 			// to give back.
-			_ = w.Store.ReleaseRefreshClaim(ctx, rec.UserID, rec.Kind, owner, nil)
+			_ = w.Store.ReleaseRefreshClaim(ctx, rec.ID, owner, nil)
 			if errors.Is(err, ErrNotRefreshable) {
 				// Self-heal legacy records sealed before NotRefreshable
 				// existed so future sweeps skip them without decrypting.
 				// A partial write: the flag is the only thing learned here,
 				// and the record read a round trip ago may already be stale.
-				if uerr := w.Store.UpdateTokens(ctx, rec.UserID, rec.Kind, OAuthTokenUpdate{NotRefreshable: true}); uerr != nil {
+				if uerr := w.Store.UpdateTokens(ctx, rec.ID, OAuthTokenUpdate{NotRefreshable: true}); uerr != nil {
 					failures++
 					if firstErr == nil {
 						firstErr = fmt.Errorf("mark not-refreshable %s/%s: %w", rec.UserID, rec.Kind, uerr)
@@ -155,7 +155,7 @@ func (w *OAuthRefreshWorker) RunOnce(ctx context.Context) (int, error) {
 		// clears it, and its credential must win — overwriting it here
 		// would replace an operator's freshly uploaded session with one
 		// refreshed from the session it replaced.
-		if err := w.Store.UpdateTokens(ctx, rec.UserID, rec.Kind, OAuthTokenUpdateFrom(rec).WithClaim(owner)); err != nil {
+		if err := w.Store.UpdateTokens(ctx, rec.ID, OAuthTokenUpdateFrom(rec).WithClaim(owner)); err != nil {
 			if errors.Is(err, ErrRefreshClaimLost) {
 				if w.Logger != nil {
 					w.Logger.Warn("oauth-forfait refresh: %s/%s exchanged then DISCARDED — the record was "+

--- a/pkg/secrets/oauth_test.go
+++ b/pkg/secrets/oauth_test.go
@@ -52,7 +52,7 @@ func TestMemoryOAuthStoreUpsertGetDelete(t *testing.T) {
 	if _, err := store.Get(ctx, "alice", OAuthKindCodex); !errors.Is(err, ErrOAuthNotFound) {
 		t.Fatalf("expected ErrOAuthNotFound, got %v", err)
 	}
-	if err := store.Delete(ctx, "alice", OAuthKindClaudeCode); err != nil {
+	if err := store.Delete(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0)); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if _, err := store.Get(ctx, "alice", OAuthKindClaudeCode); !errors.Is(err, ErrOAuthNotFound) {
@@ -67,7 +67,7 @@ func TestMemoryOAuthStoreUpsertGetDelete(t *testing.T) {
 func TestMemoryOAuthStoreSetAccountLabel(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryOAuthStore()
-	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "alice perso"); !errors.Is(err, ErrOAuthNotFound) {
+	if err := store.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), "alice perso"); !errors.Is(err, ErrOAuthNotFound) {
 		t.Fatalf("SetAccountLabel on a missing record = %v, want ErrOAuthNotFound", err)
 	}
 	if err := store.Upsert(ctx, OAuthRecord{
@@ -76,7 +76,7 @@ func TestMemoryOAuthStoreSetAccountLabel(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "alice perso"); err != nil {
+	if err := store.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), "alice perso"); err != nil {
 		t.Fatalf("SetAccountLabel: %v", err)
 	}
 	got, err := store.Get(ctx, "alice", OAuthKindClaudeCode)
@@ -86,7 +86,7 @@ func TestMemoryOAuthStoreSetAccountLabel(t *testing.T) {
 	if got.AccountLabel != "alice perso" || string(got.SealedPayload) != "sealed" || got.Fingerprint != "fp-1" {
 		t.Fatalf("after rename: %+v", got)
 	}
-	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, ""); err != nil {
+	if err := store.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), ""); err != nil {
 		t.Fatalf("clear: %v", err)
 	}
 	if got, _ = store.Get(ctx, "alice", OAuthKindClaudeCode); got.AccountLabel != "" {

--- a/pkg/secrets/oauth_updatetokens_test.go
+++ b/pkg/secrets/oauth_updatetokens_test.go
@@ -27,7 +27,7 @@ func TestMemoryOAuthStore_UpdateTokensKeepsAConcurrentRename(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "jothedev"); err != nil {
+	if err := s.SetAccountLabel(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), "jothedev"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
 	// …then the refresh lands.
@@ -36,7 +36,7 @@ func TestMemoryOAuthStore_UpdateTokensKeepsAConcurrentRename(t *testing.T) {
 	stale.SealedPayload = []byte("sealed-v2")
 	stale.AccessTokenExpiresAt = &exp
 	stale.LastRefreshedAt = &last
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindClaudeCode, OAuthTokenUpdateFrom(stale)); err != nil {
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindClaudeCode, 0), OAuthTokenUpdateFrom(stale)); err != nil {
 		t.Fatalf("UpdateTokens: %v", err)
 	}
 	got, err := s.Get(ctx, "alice", OAuthKindClaudeCode)
@@ -64,7 +64,7 @@ func TestMemoryOAuthStore_UpdateTokensNilPayloadKeepsTheBlob(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
-	if err := s.UpdateTokens(ctx, "alice", OAuthKindCodex, OAuthTokenUpdate{NotRefreshable: true}); err != nil {
+	if err := s.UpdateTokens(ctx, OAuthRecordID("alice", OAuthKindCodex, 0), OAuthTokenUpdate{NotRefreshable: true}); err != nil {
 		t.Fatalf("UpdateTokens: %v", err)
 	}
 	got, err := s.Get(ctx, "alice", OAuthKindCodex)
@@ -81,7 +81,7 @@ func TestMemoryOAuthStore_UpdateTokensNilPayloadKeepsTheBlob(t *testing.T) {
 
 func TestMemoryOAuthStore_UpdateTokensMissingRecord(t *testing.T) {
 	s := NewMemoryOAuthStore()
-	if err := s.UpdateTokens(context.Background(), "nobody", OAuthKindClaudeCode, OAuthTokenUpdate{}); !errors.Is(err, ErrOAuthNotFound) {
+	if err := s.UpdateTokens(context.Background(), OAuthRecordID("nobody", OAuthKindClaudeCode, 0), OAuthTokenUpdate{}); !errors.Is(err, ErrOAuthNotFound) {
 		t.Fatalf("UpdateTokens on a missing record = %v, want ErrOAuthNotFound", err)
 	}
 }
@@ -98,13 +98,13 @@ func TestOAuthRefreshWorker_RenameDuringTheRoundTripSurvives(t *testing.T) {
 	}
 	st := NewMemoryOAuthStore()
 	seedRecord(t, st, sealer, "alice", OAuthKindClaudeCode, time.Now().Add(5*time.Minute))
-	if err := st.SetAccountLabel(context.Background(), "alice", OAuthKindClaudeCode, "old name"); err != nil {
+	if err := st.SetAccountLabel(context.Background(), OAuthRecordID("alice", OAuthKindClaudeCode, 0), "old name"); err != nil {
 		t.Fatalf("seed label: %v", err)
 	}
 
 	// The provider hop is where the operator renames the connection.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if err := st.SetAccountLabel(context.Background(), "alice", OAuthKindClaudeCode, "jothedev"); err != nil {
+		if err := st.SetAccountLabel(context.Background(), OAuthRecordID("alice", OAuthKindClaudeCode, 0), "jothedev"); err != nil {
 			t.Errorf("concurrent rename: %v", err)
 		}
 		w.WriteHeader(http.StatusOK)

--- a/pkg/server/oauth_chain_routes_test.go
+++ b/pkg/server/oauth_chain_routes_test.go
@@ -1,0 +1,228 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// chainBlob builds a claude_code credentials.json for a chain test. Without a
+// refreshToken the record is NOT refreshable, which RefreshRecord answers
+// before it reaches the provider — so these cases make no network call.
+func chainBlob(token, refreshToken string) string {
+	rt := ""
+	if refreshToken != "" {
+		rt = `"refreshToken":"` + refreshToken + `",`
+	}
+	return `{"claudeAiOauth":{"accessToken":"` + token + `",` + rt +
+		`"expiresAt":4102444800000,"scopes":["user:inference"]}}`
+}
+
+// chainRecord returns the caller's claude_code record at `rank`, read from the
+// store rather than from a response: the store is the oracle for everything
+// these cases assert.
+func chainRecord(t *testing.T, st *secrets.MemoryOAuthStore, user string, rank int) secrets.OAuthRecord {
+	t.Helper()
+	recs, err := st.ListByUser(t.Context(), user)
+	if err != nil {
+		t.Fatalf("list %s: %v", user, err)
+	}
+	for _, r := range recs {
+		if r.Kind == secrets.OAuthKindClaudeCode && r.Rank == rank {
+			return r
+		}
+	}
+	t.Fatalf("no claude_code record at rank %d for %s (have %d records)", rank, user, len(recs))
+	return secrets.OAuthRecord{}
+}
+
+// TestOAuthChainRoutes_AWriteAnswersAboutTheLinkItAddressed is the class sweep
+// for `?rank=`: once an owner may hold a CHAIN of forfaits of one kind, every
+// handler that selects a record must select the one the request names. A
+// handler that still reads (owner, kind) lands on the PRIMARY, and each case
+// below is one such site — none of which fails loudly, which is exactly why
+// they are pinned here:
+//
+//   - rename writes the right link and then reports the primary's identity,
+//     so the audit line names the wrong credential;
+//   - refresh renews the primary whatever rank is asked for — and the provider
+//     RETIRES the refresh token it is handed, so trying to renew a dying
+//     fallback spends the primary's instead and leaves the fallback dying;
+//   - the 409 explaining a refused refresh describes the primary's state;
+//   - a re-upload that names no account inherits a label by fingerprint, and
+//     comparing against the primary's means a rotated fallback silently loses
+//     the name it had.
+func TestOAuthChainRoutes_AWriteAnswersAboutTheLinkItAddressed(t *testing.T) {
+	t.Run("rename reports the link it renamed, not the primary", func(t *testing.T) {
+		_, hs, signer, st := oauthTestServer(t)
+		tok := oauthJWT(t, signer, "alice")
+
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?account_label=primary",
+			tok, chainBlob("sk-ant-oat01-PRIMARY", "")); code != http.StatusOK {
+			t.Fatalf("upload primary = %d %s", code, body)
+		}
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?rank=1&account_label=fallback",
+			tok, chainBlob("sk-ant-oat01-FALLBACK", "")); code != http.StatusOK {
+			t.Fatalf("upload fallback = %d %s", code, body)
+		}
+		wantFP := chainRecord(t, st, "alice", 1).Fingerprint
+		primaryFP := chainRecord(t, st, "alice", 0).Fingerprint
+		if wantFP == "" || wantFP == primaryFP {
+			t.Fatalf("the two links are not distinguishable (rank0=%q rank1=%q) — the case would pass for the wrong reason", primaryFP, wantFP)
+		}
+
+		code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code?rank=1",
+			tok, `{"account_label":"renamed-fallback"}`)
+		if code != http.StatusOK {
+			t.Fatalf("rename = %d %s", code, body)
+		}
+		var view oauthConnectionView
+		if err := json.Unmarshal([]byte(body), &view); err != nil {
+			t.Fatalf("decode view: %v (%s)", err, body)
+		}
+		// The response is what the audit line is built from, so a view of the
+		// wrong record is an audit entry naming the wrong credential.
+		if view.Fingerprint != wantFP {
+			t.Fatalf("rename ?rank=1 answered about fp=%q, want the rank-1 link fp=%q (primary is %q)",
+				view.Fingerprint, wantFP, primaryFP)
+		}
+		if view.AccountLabel != "renamed-fallback" {
+			t.Fatalf("rename ?rank=1 answered account_label=%q, want %q", view.AccountLabel, "renamed-fallback")
+		}
+		if got := chainRecord(t, st, "alice", 0).AccountLabel; got != "primary" {
+			t.Fatalf("renaming rank 1 changed the PRIMARY's label to %q", got)
+		}
+		if got := chainRecord(t, st, "alice", 1).AccountLabel; got != "renamed-fallback" {
+			t.Fatalf("rank 1 label = %q after rename", got)
+		}
+	})
+
+	t.Run("the listing names each link's rank", func(t *testing.T) {
+		// Without it the two links of a chain are indistinguishable in the
+		// only listing there is, and `?rank=` — which every write takes — has
+		// no value an operator could have read anywhere.
+		_, hs, signer, _ := oauthTestServer(t)
+		tok := oauthJWT(t, signer, "erin")
+		for _, up := range []struct{ path, token string }{
+			{"/api/me/oauth/claude_code/credentials", "sk-ant-oat01-PRIMARY"},
+			{"/api/me/oauth/claude_code/credentials?rank=1", "sk-ant-oat01-FALLBACK"},
+		} {
+			if code, body := oauthCall(t, hs, http.MethodPost, up.path, tok, chainBlob(up.token, "")); code != http.StatusOK {
+				t.Fatalf("upload %s = %d %s", up.path, code, body)
+			}
+		}
+		code, body := oauthCall(t, hs, http.MethodGet, "/api/me/oauth/connections", tok, "")
+		if code != http.StatusOK {
+			t.Fatalf("list = %d %s", code, body)
+		}
+		var envelope struct {
+			Connections []oauthConnectionView `json:"connections"`
+		}
+		if err := json.Unmarshal([]byte(body), &envelope); err != nil {
+			t.Fatalf("decode listing: %v (%s)", err, body)
+		}
+		got := envelope.Connections
+		if len(got) != 2 {
+			t.Fatalf("listing has %d entries, want the 2 links of the chain: %s", len(got), body)
+		}
+		if got[0].Rank != 0 || got[1].Rank != 1 {
+			t.Fatalf("listing ranks = %d,%d — want 0,1 in try order: %s", got[0].Rank, got[1].Rank, body)
+		}
+	})
+
+	t.Run("refresh acts on the link it was asked for", func(t *testing.T) {
+		_, hs, signer, _ := oauthTestServer(t)
+		tok := oauthJWT(t, signer, "bob")
+
+		// The two links differ in exactly the property the handler branches on.
+		// The primary CAN refresh (and, with no client id configured, fails
+		// 502 before any network call); the fallback cannot (409). So the
+		// status code alone names which record the handler read.
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials", tok,
+			chainBlob("sk-ant-oat01-PRIMARY", "rt-primary")); code != http.StatusOK {
+			t.Fatalf("upload primary = %d %s", code, body)
+		}
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?rank=1", tok,
+			chainBlob("sk-ant-oat01-FALLBACK", "")); code != http.StatusOK {
+			t.Fatalf("upload fallback = %d %s", code, body)
+		}
+
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/refresh?rank=1", tok, "")
+		if code == http.StatusBadGateway {
+			t.Fatalf("refresh ?rank=1 refreshed the PRIMARY (502 = it reached the refreshable record); "+
+				"the rank-1 link has no refresh token and must answer 409. body=%s", body)
+		}
+		if code != http.StatusConflict {
+			t.Fatalf("refresh ?rank=1 = %d %s, want 409 (the addressed link cannot auto-refresh)", code, body)
+		}
+	})
+
+	t.Run("a refused refresh describes the addressed link's state", func(t *testing.T) {
+		_, hs, signer, st := oauthTestServer(t)
+		tok := oauthJWT(t, signer, "carol")
+
+		// Both links refreshable; only the FALLBACK is in a refresh cool-down.
+		// Reading the primary here answers "a refresh is already in flight",
+		// which sends the operator back to a button that will refuse again.
+		for _, up := range []struct{ path, token string }{
+			{"/api/me/oauth/claude_code/credentials", "sk-ant-oat01-PRIMARY"},
+			{"/api/me/oauth/claude_code/credentials?rank=1", "sk-ant-oat01-FALLBACK"},
+		} {
+			if code, body := oauthCall(t, hs, http.MethodPost, up.path, tok,
+				chainBlob(up.token, "rt-"+up.token)); code != http.StatusOK {
+				t.Fatalf("upload %s = %d %s", up.path, code, body)
+			}
+		}
+		rec := chainRecord(t, st, "carol", 1)
+		until := time.Now().UTC().Add(42 * time.Minute)
+		rec.RefreshNotBefore = &until
+		if err := st.Upsert(t.Context(), rec); err != nil {
+			t.Fatalf("seed cool-down: %v", err)
+		}
+
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/refresh?rank=1", tok, "")
+		if code != http.StatusConflict {
+			t.Fatalf("refresh of a cool-down link = %d %s, want 409", code, body)
+		}
+		if !strings.Contains(body, "cool-down") {
+			t.Fatalf("the 409 describes some OTHER record's state (no cool-down mentioned): %s", body)
+		}
+	})
+
+	t.Run("re-uploading a link without a label keeps ITS name", func(t *testing.T) {
+		_, hs, signer, st := oauthTestServer(t)
+		tok := oauthJWT(t, signer, "dave")
+		const fallback = "sk-ant-oat01-FALLBACK"
+
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?account_label=primary",
+			tok, chainBlob("sk-ant-oat01-PRIMARY", "")); code != http.StatusOK {
+			t.Fatalf("upload primary = %d %s", code, body)
+		}
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?rank=1&account_label=jothedev",
+			tok, chainBlob(fallback, "")); code != http.StatusOK {
+			t.Fatalf("upload fallback = %d %s", code, body)
+		}
+		// The same subscription re-uploaded at the same rank, naming no
+		// account — a rotation. The label is kept because the fingerprint
+		// proves it is the same subscription; compared against the PRIMARY's
+		// fingerprint it never matches, and the name is dropped.
+		if code, body := oauthCall(t, hs, http.MethodPost,
+			"/api/me/oauth/claude_code/credentials?rank=1",
+			tok, chainBlob(fallback, "")); code != http.StatusOK {
+			t.Fatalf("re-upload fallback = %d %s", code, body)
+		}
+		if got := chainRecord(t, st, "dave", 1).AccountLabel; got != "jothedev" {
+			t.Fatalf("the rank-1 link lost its name on re-upload: account_label = %q, want %q", got, "jothedev")
+		}
+	})
+}

--- a/pkg/server/oauth_codex_expiry_test.go
+++ b/pkg/server/oauth_codex_expiry_test.go
@@ -202,7 +202,7 @@ func TestOAuthRefresh_ManualRefreshIsFencedByTheSameClaim(t *testing.T) {
 
 	// Somebody else (a sweep, another operator) holds the claim.
 	now := time.Now().UTC()
-	ok, err := store.ClaimRefresh(t.Context(), "jo", secrets.OAuthKindClaudeCode, "someone-else", now, now.Add(secrets.RefreshClaimTTL))
+	ok, err := store.ClaimRefresh(t.Context(), secrets.OAuthRecordID("jo", secrets.OAuthKindClaudeCode, 0), "someone-else", now, now.Add(secrets.RefreshClaimTTL))
 	if err != nil || !ok {
 		t.Fatalf("seed claim: ok=%v err=%v", ok, err)
 	}
@@ -219,7 +219,7 @@ func TestOAuthRefresh_ManualRefreshIsFencedByTheSameClaim(t *testing.T) {
 	// in flight: the record it is about to write no longer exists. The
 	// re-connect (Upsert) clears the claim, which is what makes the commit
 	// fail closed.
-	if err := store.ReleaseRefreshClaim(t.Context(), "jo", secrets.OAuthKindClaudeCode, "someone-else", nil); err != nil {
+	if err := store.ReleaseRefreshClaim(t.Context(), secrets.OAuthRecordID("jo", secrets.OAuthKindClaudeCode, 0), "someone-else", nil); err != nil {
 		t.Fatalf("release: %v", err)
 	}
 	reconnected, err := secrets.SealOAuthPayload(srv.sealer, "jo", secrets.OAuthKindClaudeCode,
@@ -290,11 +290,11 @@ func TestOAuthRefresh_ACoolDownIsNotReportedAsARefreshInFlight(t *testing.T) {
 
 	// The state an undatable refresh leaves: no owner, a cool-down an hour out.
 	now := time.Now().UTC()
-	if ok, err := store.ClaimRefresh(t.Context(), "jo", secrets.OAuthKindCodex, "previous-sweep", now, now.Add(secrets.RefreshClaimTTL)); err != nil || !ok {
+	if ok, err := store.ClaimRefresh(t.Context(), secrets.OAuthRecordID("jo", secrets.OAuthKindCodex, 0), "previous-sweep", now, now.Add(secrets.RefreshClaimTTL)); err != nil || !ok {
 		t.Fatalf("seed claim: ok=%v err=%v", ok, err)
 	}
 	cool := now.Add(time.Hour).Truncate(time.Second)
-	if err := store.ReleaseRefreshClaim(t.Context(), "jo", secrets.OAuthKindCodex, "previous-sweep", &cool); err != nil {
+	if err := store.ReleaseRefreshClaim(t.Context(), secrets.OAuthRecordID("jo", secrets.OAuthKindCodex, 0), "previous-sweep", &cool); err != nil {
 		t.Fatalf("seed cool-down: %v", err)
 	}
 
@@ -321,7 +321,7 @@ func TestOAuthRefresh_ACoolDownIsNotReportedAsARefreshInFlight(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("re-upsert: %v", err)
 	}
-	if ok, err := store.ClaimRefresh(t.Context(), "jo", secrets.OAuthKindCodex, "someone-else", now, now.Add(secrets.RefreshClaimTTL)); err != nil || !ok {
+	if ok, err := store.ClaimRefresh(t.Context(), secrets.OAuthRecordID("jo", secrets.OAuthKindCodex, 0), "someone-else", now, now.Add(secrets.RefreshClaimTTL)); err != nil || !ok {
 		t.Fatalf("seed live claim: ok=%v err=%v", ok, err)
 	}
 	code, body = oauthCall(t, hs, http.MethodPost, "/api/me/oauth/codex/refresh", jo, "")

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -38,6 +38,13 @@ func (s *Server) registerOAuthForfaitRoutes() {
 // OAuthRecord. Plaintext / sealed payload never leave the server.
 type oauthConnectionView struct {
 	Kind string `json:"kind"`
+	// Rank is which link of the owner's chain for this kind this is: 0 the
+	// primary, 1 and up the fallbacks tried in order. Not omitempty — a
+	// listing where the primary alone has no rank would be read as a
+	// different KIND of entry, and this value is exactly what every write
+	// takes as `?rank=`, so withholding it makes a chain unmanageable
+	// through the API that reports it.
+	Rank int `json:"rank"`
 	// AccountLabel is the operator's name for the account behind this
 	// credential ("jothedev"). Empty on records connected before labels
 	// existed — rename them with PATCH.
@@ -62,6 +69,7 @@ type oauthConnectionView struct {
 func toOAuthView(r secrets.OAuthRecord) oauthConnectionView {
 	return oauthConnectionView{
 		Kind:                 string(r.Kind),
+		Rank:                 r.Rank,
 		AccountLabel:         r.AccountLabel,
 		Fingerprint:          r.Fingerprint,
 		Scopes:               r.Scopes,
@@ -472,8 +480,9 @@ func (s *Server) refuseOAuthCredential(w http.ResponseWriter, r *http.Request, o
 func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string, origin credentialOrigin, rank int) (secrets.OAuthRecord, error) {
 	now := time.Now().UTC()
 	rec := secrets.OAuthRecord{
-		// ID is derived in the OAuth store's Upsert (memory + Mongo
-		// agree on `<ownerKey>|<kind>`), so we leave it empty here.
+		// ID is derived in the OAuth store's Upsert (memory + Mongo agree
+		// on `<ownerKey>|<kind>`, plus `|<rank>` past the primary), so we
+		// leave it empty here.
 		UserID:    ownerKey,
 		Kind:      kind,
 		Rank:      rank,
@@ -628,7 +637,10 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// listing shows no name.
 	rec.AccountLabel = accountLabel
 	if rec.AccountLabel == "" {
-		if prev, err := s.oauthStore.Get(ctx, ownerKey, kind); err == nil && prev.Fingerprint == rec.Fingerprint {
+		// The link being replaced, not the primary: comparing a fallback's
+		// fingerprint against rank 0's never matches, so rotating a named
+		// fallback would drop its name on every rotation.
+		if prev, err := s.resolveOAuthRecord(ctx, ownerKey, kind, rank); err == nil && prev.Fingerprint == rec.Fingerprint {
 			rec.AccountLabel = prev.AccountLabel
 		}
 	}
@@ -650,10 +662,19 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 		httpError(w, http.StatusBadRequest, "unknown oauth kind")
 		return
 	}
-	rec, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
+	// Which link of the chain to renew. A refresh is the write where reading
+	// the primary regardless costs the most: the provider RETIRES the refresh
+	// token it is handed, so renewing "the fallback" would spend the primary's
+	// and leave the fallback to expire anyway.
+	rank, rerr := oauthRankParam(r)
+	if rerr != nil {
+		httpError(w, http.StatusBadRequest, "%s", rerr.Error())
+		return
+	}
+	rec, err := s.resolveOAuthRecord(r.Context(), ownerKey, kind, rank)
 	if err != nil {
 		if errors.Is(err, secrets.ErrOAuthNotFound) {
-			httpError(w, http.StatusNotFound, "no oauth connection of kind %s", kind)
+			httpError(w, http.StatusNotFound, "no %s connection at rank %d", kind, rank)
 			return
 		}
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
@@ -677,7 +698,7 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 		return
 	}
 	if !claimed {
-		httpError(w, http.StatusConflict, "%s", s.refreshClaimRefusal(r.Context(), ownerKey, kind))
+		httpError(w, http.StatusConflict, "%s", s.refreshClaimRefusal(r.Context(), ownerKey, kind, rank))
 		return
 	}
 	if err := secrets.RefreshRecord(r.Context(), s.sealer, s.httpClient, s.cfg.AnthropicOAuthClientID, s.cfg.CodexOAuthClientID, &rec); err != nil {
@@ -718,8 +739,9 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 	}
 	// Re-read rather than render the in-hand copy, for the same reason:
 	// the stored record is the truth about the fields this write did not
-	// touch.
-	fresh, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
+	// touch. At the same rank, which is the record just written — nothing
+	// renumbers a chain, so a link's rank is stable for its lifetime.
+	fresh, err := s.resolveOAuthRecord(r.Context(), ownerKey, kind, rank)
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -740,9 +762,9 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 // instant, with no owner), so only the stored record can tell them apart.
 // Best-effort: a read that fails falls back to the generic answer rather
 // than turning a 409 into a 500.
-func (s *Server) refreshClaimRefusal(ctx context.Context, ownerKey string, kind secrets.OAuthKind) string {
+func (s *Server) refreshClaimRefusal(ctx context.Context, ownerKey string, kind secrets.OAuthKind, rank int) string {
 	const inFlight = "a refresh of this connection is already in flight — retry in a moment"
-	cur, err := s.oauthStore.Get(ctx, ownerKey, kind)
+	cur, err := s.resolveOAuthRecord(ctx, ownerKey, kind, rank)
 	if err != nil || cur.RefreshClaimOwner != "" || cur.RefreshNotBefore == nil {
 		return inFlight
 	}
@@ -810,7 +832,10 @@ func (s *Server) renameOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
-	rec, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
+	// Re-read the link that was written, not the primary: this record is what
+	// the audit line names and what the response describes, so reading the
+	// wrong one credits the rename to a credential nobody touched.
+	rec, err := s.resolveOAuthRecord(r.Context(), ownerKey, kind, rank)
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -108,6 +109,43 @@ func (s *Server) handleRenameOAuth(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteOAuth(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	s.deleteOAuthForOwner(w, r, id.UserID, secrets.OAuthKind(r.PathValue("kind")))
+}
+
+// oauthRankParam reads the `rank` query parameter: which link of the owner's
+// credential chain for this kind the request addresses. Absent means 0, the
+// primary — so every caller written before chains existed keeps its meaning.
+func oauthRankParam(r *http.Request) (int, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("rank"))
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("rank must be a non-negative integer, got %q", raw)
+	}
+	return n, nil
+}
+
+// resolveOAuthRecord returns the record at `rank` in this owner's chain for
+// `kind`. It exists because the four write paths address a record by id now:
+// (owner, kind) stopped being unique the day a chain became possible, and a
+// handler that still keyed on it would land on the primary whatever rank the
+// operator asked for — renaming, refreshing or deleting the wrong credential
+// while reporting success.
+func (s *Server) resolveOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, rank int) (secrets.OAuthRecord, error) {
+	if rank == 0 {
+		return s.oauthStore.Get(ctx, ownerKey, kind)
+	}
+	recs, err := s.oauthStore.ListByUser(ctx, ownerKey)
+	if err != nil {
+		return secrets.OAuthRecord{}, err
+	}
+	for _, rec := range recs {
+		if rec.Kind == kind && rec.Rank == rank {
+			return rec, nil
+		}
+	}
+	return secrets.OAuthRecord{}, secrets.ErrOAuthNotFound
 }
 
 // ---- owner-keyed helpers (shared by /me and /teams) ----
@@ -274,6 +312,15 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
+	// Which link of the chain this upload occupies. Absent = 0 = the
+	// primary, so connecting a first credential is unchanged; a fallback is
+	// an explicit `?rank=1`, never something an operator lands on by
+	// accident.
+	rank, err := oauthRankParam(r)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	pending, err := s.oauthPending.Take(r.Context(), ownerKey, kind)
 	if err != nil {
 		httpError(w, http.StatusBadRequest, "no pending authorization (expired? restart the connect)")
@@ -301,7 +348,7 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusInternalServerError, "build credentials: %v", err)
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, accountLabel, credentialServerBuilt)
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, accountLabel, credentialServerBuilt, rank)
 	if err != nil {
 		if s.refuseOAuthCredential(w, r, ownerKey, kind, "browser", err) {
 			return
@@ -335,7 +382,12 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, accountLabel, credentialPasted)
+	rank, err := oauthRankParam(r)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, accountLabel, credentialPasted, rank)
 	if err != nil {
 		if s.refuseOAuthCredential(w, r, ownerKey, kind, "paste", err) {
 			return
@@ -417,13 +469,14 @@ func (s *Server) refuseOAuthCredential(w http.ResponseWriter, r *http.Request, o
 // Shared by the browser flow and the paste path; accountLabel arrives
 // already normalized by the handler. Every refusal of the blob's SHAPE is
 // a *secrets.ShapeError; anything else is a parse, seal or store failure.
-func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string, origin credentialOrigin) (secrets.OAuthRecord, error) {
+func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string, origin credentialOrigin, rank int) (secrets.OAuthRecord, error) {
 	now := time.Now().UTC()
 	rec := secrets.OAuthRecord{
 		// ID is derived in the OAuth store's Upsert (memory + Mongo
 		// agree on `<ownerKey>|<kind>`), so we leave it empty here.
 		UserID:    ownerKey,
 		Kind:      kind,
+		Rank:      rank,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -618,7 +671,7 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 		return
 	}
 	now := time.Now().UTC()
-	claimed, err := s.oauthStore.ClaimRefresh(r.Context(), ownerKey, kind, owner, now, now.Add(secrets.RefreshClaimTTL))
+	claimed, err := s.oauthStore.ClaimRefresh(r.Context(), rec.ID, owner, now, now.Add(secrets.RefreshClaimTTL))
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -630,7 +683,7 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 	if err := secrets.RefreshRecord(r.Context(), s.sealer, s.httpClient, s.cfg.AnthropicOAuthClientID, s.cfg.CodexOAuthClientID, &rec); err != nil {
 		// Give the claim back so the sweep is not held off by a failed
 		// attempt; a claim already superseded has nothing to release.
-		if rerr := s.oauthStore.ReleaseRefreshClaim(r.Context(), ownerKey, kind, owner, nil); rerr != nil && !errors.Is(rerr, secrets.ErrRefreshClaimLost) {
+		if rerr := s.oauthStore.ReleaseRefreshClaim(r.Context(), rec.ID, owner, nil); rerr != nil && !errors.Is(rerr, secrets.ErrRefreshClaimLost) {
 			s.logger.Warn("oauth: release refresh claim %s/%s: %v", ownerKey, kind, rerr)
 		}
 		if errors.Is(err, secrets.ErrNotRefreshable) {
@@ -640,7 +693,7 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 			if !rec.NotRefreshable {
 				// Partial write: the flag is all this path learned, and a
 				// rename may have landed since the Get above.
-				if uerr := s.oauthStore.UpdateTokens(r.Context(), ownerKey, kind, secrets.OAuthTokenUpdate{NotRefreshable: true}); uerr != nil {
+				if uerr := s.oauthStore.UpdateTokens(r.Context(), rec.ID, secrets.OAuthTokenUpdate{NotRefreshable: true}); uerr != nil {
 					s.logger.Warn("oauth: mark not-refreshable %s/%s: %v", ownerKey, kind, uerr)
 				}
 			}
@@ -655,7 +708,7 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 	// by the claim, so a re-connect that landed during the exchange (which
 	// clears the claim) keeps the credential the operator just uploaded
 	// instead of being overwritten by a refresh of the session it replaced.
-	if err := s.oauthStore.UpdateTokens(r.Context(), ownerKey, kind, secrets.OAuthTokenUpdateFrom(rec).WithClaim(owner)); err != nil {
+	if err := s.oauthStore.UpdateTokens(r.Context(), rec.ID, secrets.OAuthTokenUpdateFrom(rec).WithClaim(owner)); err != nil {
 		if errors.Is(err, secrets.ErrRefreshClaimLost) {
 			httpError(w, http.StatusConflict, "this connection was replaced while the refresh was in flight — the refreshed tokens were discarded")
 			return
@@ -735,7 +788,21 @@ func (s *Server) renameOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 	// Store-level metadata write, not Get → Upsert: the latter would carry
 	// the sealed payload this handler read back over whatever a concurrent
 	// refresh committed in between.
-	if err := s.oauthStore.SetAccountLabel(r.Context(), ownerKey, kind, label); err != nil {
+	rank, rerr := oauthRankParam(r)
+	if rerr != nil {
+		httpError(w, http.StatusBadRequest, "%s", rerr.Error())
+		return
+	}
+	target, err := s.resolveOAuthRecord(r.Context(), ownerKey, kind, rank)
+	if err != nil {
+		if errors.Is(err, secrets.ErrOAuthNotFound) {
+			httpError(w, http.StatusNotFound, "no %s connection at rank %d", kind, rank)
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	if err := s.oauthStore.SetAccountLabel(r.Context(), target.ID, label); err != nil {
 		if errors.Is(err, secrets.ErrOAuthNotFound) {
 			httpError(w, http.StatusNotFound, "no %s connection", kind)
 			return
@@ -774,7 +841,21 @@ func (s *Server) deleteOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 			s.logger.Warn("credential pool: could not withdraw %s's %s contribution on disconnect: %v (it is parked at the next acquisition)", ownerKey, kind, err)
 		}
 	}
-	if err := s.oauthStore.Delete(r.Context(), ownerKey, kind); err != nil {
+	rank, rerr := oauthRankParam(r)
+	if rerr != nil {
+		httpError(w, http.StatusBadRequest, "%s", rerr.Error())
+		return
+	}
+	victim, verr := s.resolveOAuthRecord(r.Context(), ownerKey, kind, rank)
+	if verr != nil {
+		if errors.Is(verr, secrets.ErrOAuthNotFound) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", verr.Error())
+		return
+	}
+	if err := s.oauthStore.Delete(r.Context(), victim.ID); err != nil {
 		if errors.Is(err, secrets.ErrOAuthNotFound) {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -498,7 +498,7 @@ func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Wipe first so a residue from an earlier subtest cannot mask a
 			// silent write here.
-			_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+			_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 
 			code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, tc.blob)
 			if code != http.StatusBadRequest {
@@ -515,7 +515,7 @@ func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
 	}
 
 	t.Run("healthy full-shape blob still passes", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
 		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
 		if code != http.StatusOK {
@@ -543,7 +543,7 @@ func TestOAuthCredentialIngestion_ExpiredIsRefusedOnlyWithoutARefreshToken(t *te
 	expired := time.Now().Add(-time.Hour).UnixMilli()
 
 	t.Run("expired + refreshToken → accepted, refreshable", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		blob := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-stale","refreshToken":"rt","expiresAt":%d,"scopes":["user:inference"]}}`, expired)
 		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
 		if code != http.StatusOK {
@@ -566,7 +566,7 @@ func TestOAuthCredentialIngestion_ExpiredIsRefusedOnlyWithoutARefreshToken(t *te
 	})
 
 	t.Run("expired + no refreshToken → refused, remedy names the refreshToken", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		blob := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-stale","expiresAt":%d,"scopes":["user:inference"]}}`, expired)
 		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
 		if code != http.StatusBadRequest {
@@ -581,7 +581,7 @@ func TestOAuthCredentialIngestion_ExpiredIsRefusedOnlyWithoutARefreshToken(t *te
 	})
 
 	t.Run("missing expiresAt → refused", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good","refreshToken":"rt","scopes":["user:inference"]}}`
 		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
 		if code != http.StatusBadRequest || !strings.Contains(body, "expiresAt") {
@@ -655,7 +655,7 @@ func TestOAuthBrowserCompletion_ServerBuiltBlobIsNotHeldToPasteRules(t *testing.
 	srv.cfg.AnthropicOAuthClientID = "client-x"
 
 	t.Run("scope-less, expiry-less exchange → stored", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		state := seedPending(t, srv, "alice")
 		rt := &cannedTokenTransport{status: 200, body: `{"access_token":"sk-ant-oat01-browser-token","refresh_token":"rt-browser","token_type":"Bearer"}`}
 		srv.httpClient = &http.Client{Transport: rt}
@@ -676,7 +676,7 @@ func TestOAuthBrowserCompletion_ServerBuiltBlobIsNotHeldToPasteRules(t *testing.
 	})
 
 	t.Run("exchange answers a malformed token → 400, nothing stored", func(t *testing.T) {
-		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 		state := seedPending(t, srv, "alice")
 		srv.httpClient = &http.Client{Transport: &cannedTokenTransport{status: 200, body: `{"access_token":"sk-ant-oat01-browser\ntoken","refresh_token":"rt"}`}}
 		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/authorize/complete", alice, `{"code":"code-x","state":"`+state+`"}`)

--- a/pkg/server/oauth_setuptoken_ingest_test.go
+++ b/pkg/server/oauth_setuptoken_ingest_test.go
@@ -122,7 +122,7 @@ func TestOAuthCredentialIngestion_SetupTokenPathKeepsTheTypedRefusals(t *testing
 		{"an API key, not an OAuth token", "sk-ant-api03-whatever", "is not a JSON object"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+			_ = oauthStore.Delete(t.Context(), secrets.OAuthRecordID("alice", secrets.OAuthKindClaudeCode, 0))
 			code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, tc.blob)
 			if code != http.StatusBadRequest {
 				t.Fatalf("upload = %d body=%s, want 400", code, body)


### PR DESCRIPTION
Refs #945.

A tenant could hold exactly **one** forfait per kind. When that account's
provider window shut, the tier had nowhere to go — it fell straight through to
the next tier, or to nothing. Measured on 2026-09-08: three teams holding what
read as three credentials were one Anthropic account, and they stopped
together.

Each connection now carries a **rank**: `0` the primary, `1`+ the fallbacks,
tried in that order.

## The resolution needed no new logic

`resolveAndSealCredentials` already *skipped* a forfait whose window is closed
(the `oauth-forfait(…) SKIPPED … falling through to the next credential tier`
line) — it simply had nowhere to continue inside its own tier. `ListByUser`
returns records ordered by kind then rank, so the existing `continue` now lands
on rank 1 before leaving the tier. No publisher change.

## Store

- `Rank` on `OAuthRecord`; id is `<owner>|<kind>` at rank 0 (**unchanged**, so
  every existing credential *is* the primary) and `<owner>|<kind>|<rank>` past it.
- The writers address **one record by `id`**, not by `(owner, kind)`: that pair
  stopped being unique here, and a writer still keyed on it lands on the primary
  — a refresh renewing rank 0 forever while the fallback it was called for
  expires, with every existing claim test still green.
- `EnsureSchema` backfills `rank: 0` then **drops** `user_kind_unique` (it *is*
  the ceiling) and creates `user_kind_rank_unique`. Order matters: Mongo does
  not match an absent field to 0, so backfilling second would make `Get` stop
  finding existing records.

## The class sweep found four more (second commit)

Every site selecting a record by `(owner, kind)`. None failed loudly:

| site | what it did |
|---|---|
| `refresh` | never parsed `rank`. The provider **retires** the refresh token it is handed, so renewing a dying fallback spent the primary's and left the fallback dying |
| the refused-refresh `409` | described the primary's state — an operator in an hour-long cool-down was told "retry in a moment" |
| `rename` | wrote the right link, then re-read the primary for the response **and the audit line** |
| re-upload with no label | inherits its label by fingerprint; compared against the primary's it never matches, so a rotated fallback lost its name every time |

All four go through the one chokepoint, `resolveOAuthRecord`.

`rank` also joins the connection view — without it the two links are
indistinguishable in the only listing there is, and `?rank=` had no value an
operator could have read anywhere. The generated spec does not type these
bodies, so `openapi.json`/`schema.ts` are unchanged (verified by regenerating).

## Surface

`--rank` on `remote admin llm oauth` and `remote orgs oauth`, over a shared
`cli.OAuthPath` that leaves rank 0 **implicit** — every invocation written
before chains emits the identical request — and **refuses** a negative rank
rather than clamping it to the primary, which on `delete` is the one credential
the operator was not aiming at. The team tier has no typed subcommand yet;
`remote api` takes the same query. Doc: `docs/cloud-llm-credentials.md`.

## Verification

- `task check`: **EXIT=0**, 144 packages, 0 FAIL, golangci 0 issues — re-run
  after rebasing onto v3.131.2, since the earlier pass did not certify this HEAD.
- Both new test files were written **red first** and each case observed failing
  for its own predicted reason before the fix. The refresh case discriminates by
  status code (an unconfigured client id short-circuits **before** any network
  call), not by prose.
- `--rank` proven present by running `--help` on both commands, not asserted.

## Not in scope

Only the **primary** can be lent to the credential pool — a pledge is keyed
`(owner, source, kind)` with no rank. Stated in the doc rather than left to be
discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)