### PR TITLE
chore(dispatcher/native): Reconcile on a closed store says so, and populateIndex takes the mutex

### DIFF
--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -149,6 +149,9 @@ var rebuildPassEnding atomic.Pointer[func(*Store)]
 //
 // Concurrent callers (the ticker, an overflow) are serialised by their own
 // mutex, so two overlapping scans cannot swap in the older one last.
+//
+// Once Close has run it returns ErrStoreClosed: nothing was read, nothing
+// changed, and the index is not fresh.
 func (s *Store) Reconcile() error {
 	s.reconcileMu.Lock()
 	defer s.reconcileMu.Unlock()

--- a/pkg/dispatcher/native/reconcile.go
+++ b/pkg/dispatcher/native/reconcile.go
@@ -156,9 +156,11 @@ func (s *Store) Reconcile() error {
 	s.mu.Lock()
 	if s.closed {
 		// A rebuild asked for before Close has nothing to serve; Close
-		// waits for the one in flight and no new one starts.
+		// waits for the one in flight and no new one starts. Said so, not
+		// passed as a success: a caller must not read "the index is fresh"
+		// from a store that no longer looks at the disk.
 		s.mu.Unlock()
-		return nil
+		return ErrStoreClosed
 	}
 	epoch := s.scanEpoch
 	s.scanning++
@@ -319,7 +321,9 @@ func (s *Store) rebuildAsync(what string) {
 		defer s.rebuildWG.Done()
 		for {
 			for s.rebuildRerun.CompareAndSwap(true, false) {
-				if err := s.Reconcile(); err != nil {
+				// A store closed while the rebuild waited is not a failed
+				// rebuild: nothing will read the index it did not refresh.
+				if err := s.Reconcile(); err != nil && !errors.Is(err, ErrStoreClosed) {
 					s.getLogger().Error("native index watcher: %s and the index rebuild failed: %v — board index may serve stale reads until the next write event or restart", what, err)
 				}
 			}
@@ -358,6 +362,9 @@ func startFallbackRescan(s *Store) *indexRescanner {
 				return
 			case <-t.C:
 				err := s.Reconcile()
+				if errors.Is(err, ErrStoreClosed) {
+					return // Close is under way; its stop follows
+				}
 				msg := ""
 				if err != nil {
 					msg = err.Error()

--- a/pkg/dispatcher/native/reconcile_round4_test.go
+++ b/pkg/dispatcher/native/reconcile_round4_test.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -89,14 +90,15 @@ func TestClose_WaitsForARebuildInFlightAndRefusesALaterOne(t *testing.T) {
 	}
 	waitRebuildIdle(t, s)
 
-	// After Close, a scan is refused before it touches the disk.
+	// After Close, a scan is refused before it touches the disk — and says
+	// so: a caller must not read "the index is fresh" from a nil.
 	setSeam(t, &reconcileScanning, func(st *Store) {
 		if st == s {
 			t.Error("a scan ran on a closed store")
 		}
 	})
-	if err := s.Reconcile(); err != nil {
-		t.Fatalf("Reconcile on a closed store: %v", err)
+	if err := s.Reconcile(); !errors.Is(err, ErrStoreClosed) {
+		t.Fatalf("Reconcile on a closed store returned %v, want ErrStoreClosed", err)
 	}
 }
 

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -89,7 +89,9 @@ type Store struct {
 	// tick of a net that runs every two seconds.
 	unreadableFP string
 
-	// closed is set by Close under mu; a watch lost after that arms no net.
+	// closed is set by Close under mu — once, and never cleared: a store
+	// does not reopen. A watch lost after that arms no net, the rescan net
+	// ends on it, and every later scan is refused with ErrStoreClosed.
 	closed bool
 
 	// rebuildPending coalesces the rebuilds a kernel-queue overflow asks
@@ -306,8 +308,12 @@ var ErrStoreClosed = errors.New("native store: closed")
 // NewStore. It adds to the index rather than replacing it; the full
 // rebuild that also drops vanished files is Reconcile. A file that cannot
 // be read is skipped, and said so. The scan runs without the mutex like
-// every scan; the writes take it, so the "caller holds mu" contract of the
-// index helpers holds for its one caller today and for any later one.
+// every scan; the writes take it, which is the index helpers' contract —
+// and that is the whole of what this promises. It does NOT consult the
+// dirty set the way Reconcile's swap does: on a LIVE store a caller would
+// be race-clean and still revert a write that landed after the scan read
+// the file. NewStore's store is not shared yet; a live store rebuilds
+// through Reconcile.
 func (s *Store) populateIndex() error {
 	fresh, unreadable, err := s.scanIssues()
 	if err != nil {

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -296,18 +296,28 @@ func (s *Store) Close() error {
 	return err
 }
 
+// ErrStoreClosed is what a scan asked of a store after its Close returns:
+// nothing was read, nothing changed. A caller that reads a nil from
+// Reconcile as "the index is fresh" would otherwise be told so by a store
+// that no longer looks at the disk.
+var ErrStoreClosed = errors.New("native store: closed")
+
 // populateIndex loads every committed issue file into the index at
 // NewStore. It adds to the index rather than replacing it; the full
 // rebuild that also drops vanished files is Reconcile. A file that cannot
-// be read is skipped, and said so.
+// be read is skipped, and said so. The scan runs without the mutex like
+// every scan; the writes take it, so the "caller holds mu" contract of the
+// index helpers holds for its one caller today and for any later one.
 func (s *Store) populateIndex() error {
 	fresh, unreadable, err := s.scanIssues()
 	if err != nil {
 		return err
 	}
+	s.mu.Lock()
 	for id, iss := range fresh {
 		s.setIndexLocked(id, iss)
 	}
+	s.mu.Unlock()
 	if len(unreadable) > 0 && s.logger != nil {
 		for id, err := range unreadable {
 			s.logger.Warn("native store: %d issue file(s) could not be read at startup and were skipped (e.g. %s: %v)", len(unreadable), id, err)


### PR DESCRIPTION
Two open questions Revi left on #1051 (the native store's index reconciliation net), promised there as their own change once that PR merged.

- **`Reconcile` on a closed store says so.** It returned `nil` once `closed` was set — no caller outside the package exists today, but the next one would read "the index is fresh" from a store that no longer looks at the disk. It now returns `ErrStoreClosed`; the two in-package callers — the overflow rebuild goroutine and the rescan ticker — treat it as the shutdown it is (silent, the ticker ends), not as a failed rebuild to log.
- **`populateIndex` takes the mutex for its writes.** It wrote the index through helpers documented "caller holds mu" without holding it — benign for its one caller (`NewStore`, before the store is shared), a race for any later one. The scan stays outside the mutex like every scan; the writes take it.

`go test -race -count=3 -shuffle=on ./pkg/dispatcher/native/` green; the round-4 test that asserted the old `nil` now asserts the sentinel.

Refs #1047.
