### PR TITLE
feat(credusage): the repository becomes an accounting dimension

### DIFF
--- a/cmd/iterion/remote_gov.go
+++ b/cmd/iterion/remote_gov.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/spf13/cobra"
@@ -54,6 +56,12 @@ var remoteAuditCmd = &cobra.Command{
 // counter cannot answer because it charges every tier to one org key.
 var remoteUsageByCredential bool
 
+// remoteUsageRepo narrows that ledger to ONE repository — the forge slug the
+// run targeted ("owner/repo"). Spend a run attributed to no repository is
+// unreachable through it by construction, which is the point: a repository's
+// bill must never quietly include the deployment's unattributed runs.
+var remoteUsageRepo string
+
 var remoteUsageCmd = &cobra.Command{
 	Use:   "usage",
 	Short: "Org monthly usage (alias of `orgs usage`); --by-credential for the per-credential ledger",
@@ -65,7 +73,11 @@ var remoteUsageCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				return cli.RemoteGetPrint(cmd.Context(), c, p, "/api/teams/"+team+"/credentials/usage")
+				path := "/api/teams/" + team + "/credentials/usage"
+				if repo := strings.TrimSpace(remoteUsageRepo); repo != "" {
+					path += "?repo=" + url.QueryEscape(repo)
+				}
+				return cli.RemoteGetPrint(cmd.Context(), c, p, path)
 			})(cmd, args)
 		}
 		// True alias: same body as `orgs usage`.
@@ -215,6 +227,8 @@ func init() {
 	remoteUsageCmd.Flags().StringVar(&remoteTeamFlag, "team", "", "Team id (with --by-credential; default: switched/active team)")
 	remoteUsageCmd.Flags().BoolVar(&remoteUsageByCredential, "by-credential", false,
 		"Per-credential ledger for the team instead of the org bucket (each amount typed metered|estimate)")
+	remoteUsageCmd.Flags().StringVar(&remoteUsageRepo, "repo", "",
+		"With --by-credential: only what the team spent on this repository (forge slug, e.g. owner/repo)")
 	remoteLimitsCmd.Flags().StringVar(&remoteLimitsData, "data", "", "Override JSON (literal or @file)")
 
 	for _, c := range []*cobra.Command{remoteMemoryDocsCmd, remoteMemoryDocCmd, remoteMemoryExportCmd, remoteMemoryImportCmd} {

--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -279,6 +279,53 @@ Metering is best effort throughout, like the org bucket: a missing counter,
 an unattributable route or a store failure leave the observation on the
 floor rather than turn a finished run into a failed one.
 
+### The repository dimension
+
+The meter also keys on the **repository** a run targeted — `repo_id`, the
+forge slug (`owner/repo`, `group/sub/project`) the launch surfaces already
+stamp on the run as `ProjectPath` and the studio already groups runs by, not
+a second identity derived from a clone URL. It is what makes "one busy
+repository is eating the shared subscription" a question with an answer.
+
+```sh
+# What this team spent on one repository this month
+iterion remote usage --by-credential --repo SocialGouv/iterion
+
+# The same repository across every tenant and credential (super-admin)
+iterion remote api GET "/api/admin/credentials/usage?repo=SocialGouv/iterion"
+# ?fingerprint= and ?repo= are REFUSED together (400): one credential across
+# repositories and one repository across credentials are different questions,
+# and answering whichever the code checked first returns a figure nobody
+# asked for.
+```
+
+Four properties are worth knowing, because each is a way to misread the
+numbers:
+
+- **Every listing that predates the dimension sums the repositories back
+  together**, so `--by-credential` without `--repo` reports exactly what it
+  always did. The alternative — one row per repository — would have made a
+  credential appear several times with no total anywhere.
+- **A row with no repository is not "all repositories".** Local runs, CLI
+  runs and non-webhook cloud launches target none, and neither does any row
+  written before this existed. `--repo` therefore never reaches them: a
+  repository's bill must not quietly include the deployment's unattributed
+  runs. The document id omits an empty repo entirely, which is what lets
+  those rows keep accumulating instead of restarting from zero at the deploy.
+- **A repository's spend spans tenants.** Two teams can serve one repo with
+  their own credentials, so the admin view sums both; the team view returns
+  only that team's share.
+- **A run whose repository cannot be read meters without one.** Same rule as
+  the route attribution: charged to the credential, attributed to nobody —
+  never guessed.
+
+Enforcement is a separate promise. This is the accounting subject a per-repo
+quota needs; the quota itself, and the budget FLOORS that would reserve
+capacity for a workload rather than cap it, are not built — see
+[#950](https://github.com/SocialGouv/iterion/issues/950), whose finding is
+that every budget mechanism in iterion today is a ceiling and none is a
+floor.
+
 ## Reading usage
 
 Both views share the same JSON shape

--- a/pkg/credusage/counter_conformance_test.go
+++ b/pkg/credusage/counter_conformance_test.go
@@ -186,6 +186,95 @@ func runCounterConformance(t *testing.T, c Counter) {
 	if rows, _ := c.List(ctx, sept, "team-a"); len(rows) != 4 {
 		t.Fatalf("List(team-a) = %d rows after the invalid spends, want 4", len(rows))
 	}
+
+	// --- the repository dimension ---
+	//
+	// A repo-attributed spend is its own stored row. The listings that
+	// predate the dimension therefore have to SUM the repositories back
+	// together, or every figure an operator reads would drop on the day
+	// their runs started naming a repo — a reporting outage that looks
+	// exactly like a quiet month.
+	const repoA, repoB = "SocialGouv/iterion", "SocialGouv/other"
+	repoKey := func(repo string) Key {
+		return Key{Fingerprint: "fp-team", Provider: "anthropic", Tier: TierTeam, TenantID: "team-a", RepoID: repo}
+	}
+	add(repoKey(repoA), NatureMetered, "claude_code", 1.0, 100, 20, sept)
+	add(repoKey(repoB), NatureMetered, "claw", 0.5, 50, 10, sept)
+
+	// The unattributed row is untouched: Usage addresses ONE row, and its
+	// key names no repository.
+	if own, _ := c.Usage(ctx, sept, teamKey); own.CostUSD != 2.0 || own.Runs != 2 {
+		t.Fatalf("the repo-less row moved to $%.2f / %d runs when repo spend was recorded beside it", own.CostUSD, own.Runs)
+	}
+	if withRepo, _ := c.Usage(ctx, sept, repoKey(repoA)); withRepo.CostUSD != 1.0 || withRepo.RepoID != repoA {
+		t.Fatalf("Usage(repo row) = $%.2f repo=%q, want $1.00 on %q", withRepo.CostUSD, withRepo.RepoID, repoA)
+	}
+
+	rows, err = c.List(ctx, sept, "team-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("List(team-a) = %d rows, want the same 4 — repositories are summed into their credential, not listed beside it", len(rows))
+	}
+	var teamRow *MonthlyUsage
+	for i := range rows {
+		if rows[i].Fingerprint == "fp-team" && rows[i].Tier == TierTeam {
+			teamRow = &rows[i]
+		}
+	}
+	if teamRow == nil {
+		t.Fatal("List(team-a) lost the fp-team/team row")
+	}
+	if teamRow.CostUSD != 3.5 {
+		t.Fatalf("summed fp-team = $%.2f, want $3.50 ($2.00 unattributed + $1.00 + $0.50)", teamRow.CostUSD)
+	}
+	if teamRow.Runs != 4 || teamRow.InputTokens != 1650 || teamRow.OutputTokens != 330 {
+		t.Fatalf("summed fp-team = %d runs / %d in / %d out, want 4 / 1650 / 330", teamRow.Runs, teamRow.InputTokens, teamRow.OutputTokens)
+	}
+	if teamRow.RepoID != "" {
+		t.Fatalf("a summed row named repo %q — it is the total of several, so naming one of them is a wrong answer", teamRow.RepoID)
+	}
+	if len(teamRow.Backends) != 2 || teamRow.Backends[0] != "claude_code" || teamRow.Backends[1] != "claw" {
+		t.Fatalf("summed backends = %v, want [claude_code claw] — the union, sorted", teamRow.Backends)
+	}
+
+	// The new query: one repository's month, rows kept apart.
+	byRepo, err := c.ListByRepo(ctx, sept, repoA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byRepo) != 1 || byRepo[0].CostUSD != 1.0 || byRepo[0].RepoID != repoA {
+		t.Fatalf("ListByRepo(%q) = %+v, want one $1.00 row carrying the repo", repoA, byRepo)
+	}
+	// An empty repo returns NOTHING rather than every unattributed row: a
+	// caller asking a repository's spend must never be handed the
+	// deployment's.
+	if n, err := c.ListByRepo(ctx, sept, ""); err != nil || len(n) != 0 {
+		t.Fatalf("ListByRepo(\"\") = %v, %v; want nothing", n, err)
+	}
+	if n, _ := c.ListByRepo(ctx, sept, "SocialGouv/never-ran"); len(n) != 0 {
+		t.Fatalf("ListByRepo(unknown repo) = %v, want nothing", n)
+	}
+
+	// A second credential on the same repository joins it there, which is
+	// what makes the row a REPO's bill rather than a credential's.
+	add(Key{Fingerprint: "fp-plat", Provider: "openai", Tier: TierPlatform, TenantID: "team-a", RepoID: repoA},
+		NatureEstimate, "codex", 0.25, 10, 2, sept)
+	if byRepo, _ = c.ListByRepo(ctx, sept, repoA); len(byRepo) != 2 {
+		t.Fatalf("ListByRepo(%q) = %d rows, want 2 (both credentials that served it)", repoA, len(byRepo))
+	}
+
+	// Order is deterministic: the summed sequence is what a client diffs
+	// between two polls, and a map iteration would reshuffle ties.
+	first, _ := c.List(ctx, sept, "team-a")
+	second, _ := c.List(ctx, sept, "team-a")
+	for i := range first {
+		if first[i].Fingerprint != second[i].Fingerprint || first[i].Tier != second[i].Tier {
+			t.Fatalf("two identical List calls disagreed at %d: %s/%s vs %s/%s",
+				i, first[i].Fingerprint, first[i].Tier, second[i].Fingerprint, second[i].Tier)
+		}
+	}
 }
 
 func TestMemoryCounter_Conformance(t *testing.T) {

--- a/pkg/credusage/credusage.go
+++ b/pkg/credusage/credusage.go
@@ -31,6 +31,7 @@ package credusage
 import (
 	"context"
 	"math"
+	"sort"
 	"strings"
 	"time"
 )
@@ -89,6 +90,20 @@ type Key struct {
 	// TenantID is the team the run belonged to. Empty for a run with no
 	// tenant (local/CLI), which still meters.
 	TenantID string
+	// RepoID is the forge slug the run targeted ("owner/repo",
+	// "group/sub/project") — store.Run.ProjectPath, the same identifier the
+	// studio already groups runs by rather than a second one invented here.
+	//
+	// Empty for a run that targets no repository (local, CLI, a non-repo
+	// cloud launch) AND for every row written before this dimension existed:
+	// docID leaves an empty repo out entirely, so those documents keep the
+	// id they had and their month is not split in two by a deploy.
+	//
+	// One tenant's spend on one credential is therefore several rows. The
+	// listings that existed before this field SUM over them, so every figure
+	// an operator reads keeps its exact meaning; ListByRepo is the query the
+	// new dimension adds.
+	RepoID string
 }
 
 // Valid reports whether the key names something meterable. A credential with
@@ -107,6 +122,11 @@ type MonthlyUsage struct {
 	Provider    string `json:"provider"`
 	Tier        Tier   `json:"tier"`
 	TenantID    string `json:"tenant_id,omitempty"`
+	// RepoID is the repository this row is attributed to. Set only by
+	// ListByRepo: every other listing sums a credential's repositories
+	// together, and reporting one of them there would name a repo whose
+	// figure is not the row's.
+	RepoID string `json:"repo_id,omitempty"`
 	// Nature qualifies CostUSD. Read it before comparing two rows: an
 	// estimate is not an invoice.
 	Nature Nature `json:"nature"`
@@ -174,6 +194,17 @@ type Counter interface {
 	// (a run is metered where it ran), so "what did the deployment's own
 	// credentials cost this month" cannot be asked by tenant.
 	ListByTier(ctx context.Context, when time.Time, tier Tier) ([]MonthlyUsage, error)
+	// ListByRepo returns every credential-month attributed to one
+	// repository, across tenants and credentials — the figure a per-repo
+	// quota is enforced and reported against.
+	//
+	// Alone among the listings it does NOT sum a credential's repositories
+	// together (it is already scoped to one), so its rows carry RepoID.
+	// Spend that named no repository is unreachable here by construction:
+	// an empty repoID returns nothing rather than "everything unattributed",
+	// because a caller asking for a repo's spend must never be handed the
+	// deployment's.
+	ListByRepo(ctx context.Context, when time.Time, repoID string) ([]MonthlyUsage, error)
 }
 
 // RetentionDays bounds how long credential-month documents are retained
@@ -191,13 +222,83 @@ func monthStart(when time.Time) time.Time {
 	return time.Date(u.Year(), u.Month(), 1, 0, 0, 0, 0, time.UTC)
 }
 
-// docID is the document id for one (credential, tier, tenant, month).
+// docID is the document id for one (credential, tier, tenant, repo, month).
 //
 // The tier is part of the identity, not a label: the same key lent through
 // the pool and used directly by its owner is two different economic facts,
 // and merging them would report the donor's loan as the borrower's spend.
+//
+// An EMPTY repo adds no segment at all, so the id is byte-identical to the
+// one this function returned before repositories were an accounting
+// dimension. Appending an unconditional `|` would have re-identified every
+// stored document: each credential-month would restart from zero at the
+// deploy, and the figure the operator reads would drop to near nothing while
+// the real spend continued — a reporting outage dressed as a quiet month.
 func docID(k Key, when time.Time) string {
-	return "cred|" + k.Fingerprint + "|" + k.Provider + "|" + string(k.Tier) + "|" + k.TenantID + "|" + monthKey(when)
+	id := "cred|" + k.Fingerprint + "|" + k.Provider + "|" + string(k.Tier) + "|" + k.TenantID
+	if k.RepoID != "" {
+		id += "|" + k.RepoID
+	}
+	return id + "|" + monthKey(when)
+}
+
+// aggregateRepos sums a credential-month's per-repository rows back into one
+// row per (fingerprint, provider, tier, tenant), with RepoID cleared.
+//
+// Every listing that predates the repo dimension runs through this, which is
+// what makes the dimension additive: a caller that never heard of
+// repositories reads the same number it read before, whether the spend was
+// attributed to one repo, to five, or to none. The rows keep their first-seen
+// order; the caller sorts.
+func aggregateRepos(rows []MonthlyUsage) []MonthlyUsage {
+	if len(rows) == 0 {
+		return rows
+	}
+	type groupKey struct {
+		fp       string
+		provider string
+		tenant   string
+		tier     Tier
+	}
+	order := make([]groupKey, 0, len(rows))
+	byKey := make(map[groupKey]*MonthlyUsage, len(rows))
+	backends := make(map[groupKey]map[string]bool, len(rows))
+	for _, r := range rows {
+		gk := groupKey{fp: r.Fingerprint, provider: r.Provider, tenant: r.TenantID, tier: r.Tier}
+		acc, ok := byKey[gk]
+		if !ok {
+			merged := r
+			merged.RepoID = ""
+			merged.Backends = nil
+			byKey[gk] = &merged
+			backends[gk] = map[string]bool{}
+			order = append(order, gk)
+			acc = &merged
+		} else {
+			acc.CostUSD += r.CostUSD
+			acc.InputTokens += r.InputTokens
+			acc.OutputTokens += r.OutputTokens
+			acc.AggregateTokens += r.AggregateTokens
+			acc.Runs += r.Runs
+		}
+		for _, b := range r.Backends {
+			backends[gk][b] = true
+		}
+	}
+	out := make([]MonthlyUsage, 0, len(order))
+	for _, gk := range order {
+		row := *byKey[gk]
+		if len(backends[gk]) > 0 {
+			names := make([]string, 0, len(backends[gk]))
+			for b := range backends[gk] {
+				names = append(names, b)
+			}
+			sort.Strings(names)
+			row.Backends = names
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 // CostToMillis converts a USD amount to integer thousandths so the Mongo

--- a/pkg/credusage/memory.go
+++ b/pkg/credusage/memory.go
@@ -62,7 +62,7 @@ func (c *MemoryCounter) AddSpend(_ context.Context, when time.Time, s Spend) err
 func (c *MemoryCounter) Usage(_ context.Context, when time.Time, k Key) (MonthlyUsage, error) {
 	out := MonthlyUsage{
 		Month: monthKey(when), Fingerprint: k.Fingerprint,
-		Provider: k.Provider, Tier: k.Tier, TenantID: k.TenantID,
+		Provider: k.Provider, Tier: k.Tier, TenantID: k.TenantID, RepoID: k.RepoID,
 	}
 	if !k.Valid() {
 		return out, nil
@@ -76,35 +76,63 @@ func (c *MemoryCounter) Usage(_ context.Context, when time.Time, k Key) (Monthly
 }
 
 func (c *MemoryCounter) List(_ context.Context, when time.Time, tenantID string) ([]MonthlyUsage, error) {
-	return c.list(when, func(r *memRow) bool { return r.key.TenantID == tenantID }), nil
+	return c.summed(when, func(r *memRow) bool { return r.key.TenantID == tenantID }), nil
 }
 
 func (c *MemoryCounter) ListByFingerprint(_ context.Context, when time.Time, fingerprint string) ([]MonthlyUsage, error) {
 	if fingerprint == "" {
 		return nil, nil
 	}
-	return c.list(when, func(r *memRow) bool { return r.key.Fingerprint == fingerprint }), nil
+	return c.summed(when, func(r *memRow) bool { return r.key.Fingerprint == fingerprint }), nil
 }
 
 func (c *MemoryCounter) ListByTier(_ context.Context, when time.Time, tier Tier) ([]MonthlyUsage, error) {
 	if tier == "" {
 		return nil, nil
 	}
-	return c.list(when, func(r *memRow) bool { return r.key.Tier == tier }), nil
+	return c.summed(when, func(r *memRow) bool { return r.key.Tier == tier }), nil
+}
+
+// ListByRepo keeps the per-repository rows apart — it is the one listing
+// scoped to a single repo, so summing them would collapse the very dimension
+// asked for.
+func (c *MemoryCounter) ListByRepo(_ context.Context, when time.Time, repoID string) ([]MonthlyUsage, error) {
+	if repoID == "" {
+		return nil, nil
+	}
+	rows := c.list(when, func(r *memRow) bool { return r.key.RepoID == repoID })
+	sortUsage(rows)
+	return rows, nil
+}
+
+// summed is the shape every listing older than the repo dimension takes: the
+// rows a credential accumulated across repositories, added back together.
+func (c *MemoryCounter) summed(when time.Time, keep func(*memRow) bool) []MonthlyUsage {
+	rows := aggregateRepos(c.list(when, keep))
+	sortUsage(rows)
+	return rows
 }
 
 func (c *MemoryCounter) list(when time.Time, keep func(*memRow) bool) []MonthlyUsage {
 	month := monthKey(when)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var out []MonthlyUsage
-	for _, r := range c.rows {
+	// Deterministic before anything downstream groups or sorts: Go's map
+	// order is randomised, and aggregateRepos keeps first-seen order — so an
+	// unordered scan would make the aggregated sequence differ run to run
+	// wherever two rows tie, and the conformance suite compares sequences.
+	ids := make([]string, 0, len(c.rows))
+	for id, r := range c.rows {
 		if r.month != month || !keep(r) {
 			continue
 		}
-		out = append(out, r.view())
+		ids = append(ids, id)
 	}
-	sortUsage(out)
+	sort.Strings(ids)
+	out := make([]MonthlyUsage, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, c.rows[id].view())
+	}
 	return out
 }
 
@@ -120,6 +148,7 @@ func (r *memRow) view() MonthlyUsage {
 		Provider:        r.key.Provider,
 		Tier:            r.key.Tier,
 		TenantID:        r.key.TenantID,
+		RepoID:          r.key.RepoID,
 		Nature:          r.nature,
 		CostUSD:         millisToCost(r.costUSDMillis),
 		InputTokens:     r.inputTokens,

--- a/pkg/credusage/mongo.go
+++ b/pkg/credusage/mongo.go
@@ -39,6 +39,13 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 		// it served, so this cannot be asked by tenant.
 		{Keys: bson.D{{Key: "tier", Value: 1}, {Key: "month", Value: 1}},
 			Options: options.Index().SetName("credusage_tier_month")},
+		// One repository's month, across credentials and tenants — what a
+		// per-repo quota is checked against, so it is a lookup on the hot
+		// path rather than a reporting convenience. Sparse: the documents
+		// that name no repository are the majority and are never an answer
+		// here.
+		{Keys: bson.D{{Key: "repo_id", Value: 1}, {Key: "month", Value: 1}},
+			Options: options.Index().SetName("credusage_repo_month").SetSparse(true)},
 		{Keys: bson.D{{Key: "month_start", Value: 1}},
 			Options: options.Index().SetName("credusage_ttl").
 				SetExpireAfterSeconds(int32(RetentionDays * 24 * 60 * 60))},
@@ -49,11 +56,16 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 }
 
 type usageDoc struct {
-	Month         string `bson:"month"`
-	Fingerprint   string `bson:"fingerprint"`
-	Provider      string `bson:"provider"`
-	Tier          string `bson:"tier"`
-	TenantID      string `bson:"tenant_id"`
+	Month       string `bson:"month"`
+	Fingerprint string `bson:"fingerprint"`
+	Provider    string `bson:"provider"`
+	Tier        string `bson:"tier"`
+	TenantID    string `bson:"tenant_id"`
+	// Absent on every document written before repositories became an
+	// accounting dimension, and on any run that targets none — which is why
+	// docID omits an empty repo rather than encoding it: those documents keep
+	// their id and go on accumulating.
+	RepoID        string `bson:"repo_id,omitempty"`
 	Nature        string `bson:"nature"`
 	CostUSDMillis int64  `bson:"cost_usd_millis"`
 	InputTokens   int64  `bson:"input_tokens"`
@@ -74,6 +86,7 @@ func (d usageDoc) view() MonthlyUsage {
 		Provider:        d.Provider,
 		Tier:            Tier(d.Tier),
 		TenantID:        d.TenantID,
+		RepoID:          d.RepoID,
 		Nature:          Nature(d.Nature),
 		CostUSD:         millisToCost(d.CostUSDMillis),
 		InputTokens:     d.InputTokens,
@@ -110,6 +123,7 @@ func (c *MongoCounter) AddSpend(ctx context.Context, when time.Time, s Spend) er
 			"provider":    s.Provider,
 			"tier":        string(s.Tier),
 			"tenant_id":   s.TenantID,
+			"repo_id":     s.RepoID,
 			// Nature is a property of the CREDENTIAL, not of a call: it
 			// cannot change within a month for one fingerprint+tier, so
 			// the first writer settles it and later ones leave it alone.
@@ -130,7 +144,7 @@ func (c *MongoCounter) AddSpend(ctx context.Context, when time.Time, s Spend) er
 func (c *MongoCounter) Usage(ctx context.Context, when time.Time, k Key) (MonthlyUsage, error) {
 	out := MonthlyUsage{
 		Month: monthKey(when), Fingerprint: k.Fingerprint,
-		Provider: k.Provider, Tier: k.Tier, TenantID: k.TenantID,
+		Provider: k.Provider, Tier: k.Tier, TenantID: k.TenantID, RepoID: k.RepoID,
 	}
 	if !k.Valid() {
 		return out, nil
@@ -147,25 +161,57 @@ func (c *MongoCounter) Usage(ctx context.Context, when time.Time, k Key) (Monthl
 }
 
 func (c *MongoCounter) List(ctx context.Context, when time.Time, tenantID string) ([]MonthlyUsage, error) {
-	return c.find(ctx, bson.M{"tenant_id": tenantID, "month": monthKey(when)})
+	return c.summed(ctx, bson.M{"tenant_id": tenantID, "month": monthKey(when)})
 }
 
 func (c *MongoCounter) ListByFingerprint(ctx context.Context, when time.Time, fingerprint string) ([]MonthlyUsage, error) {
 	if fingerprint == "" {
 		return nil, nil
 	}
-	return c.find(ctx, bson.M{"fingerprint": fingerprint, "month": monthKey(when)})
+	return c.summed(ctx, bson.M{"fingerprint": fingerprint, "month": monthKey(when)})
 }
 
 func (c *MongoCounter) ListByTier(ctx context.Context, when time.Time, tier Tier) ([]MonthlyUsage, error) {
 	if tier == "" {
 		return nil, nil
 	}
-	return c.find(ctx, bson.M{"tier": string(tier), "month": monthKey(when)})
+	return c.summed(ctx, bson.M{"tier": string(tier), "month": monthKey(when)})
+}
+
+// ListByRepo keeps the per-repository rows apart — it is the one listing
+// scoped to a single repo, so summing them would collapse the very dimension
+// asked for.
+func (c *MongoCounter) ListByRepo(ctx context.Context, when time.Time, repoID string) ([]MonthlyUsage, error) {
+	if repoID == "" {
+		return nil, nil
+	}
+	rows, err := c.find(ctx, bson.M{"repo_id": repoID, "month": monthKey(when)})
+	if err != nil {
+		return nil, err
+	}
+	sortUsage(rows)
+	return rows, nil
+}
+
+// summed is the shape every listing older than the repo dimension takes: the
+// rows a credential accumulated across repositories, added back together.
+func (c *MongoCounter) summed(ctx context.Context, filter bson.M) ([]MonthlyUsage, error) {
+	rows, err := c.find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	rows = aggregateRepos(rows)
+	sortUsage(rows)
+	return rows, nil
 }
 
 func (c *MongoCounter) find(ctx context.Context, filter bson.M) ([]MonthlyUsage, error) {
-	cur, err := c.col.Find(ctx, filter)
+	// Ordered by _id, which the memory twin mirrors by sorting its own ids:
+	// aggregateRepos keeps first-seen order, so an undefined scan order would
+	// make the summed sequence differ between the twins — and between two
+	// calls — wherever two rows tie on cost. The conformance suite compares
+	// sequences, so "usually the same" is a flake waiting for a busy month.
+	cur, err := c.col.Find(ctx, filter, options.Find().SetSort(bson.D{{Key: "_id", Value: 1}}))
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, nil
@@ -181,9 +227,8 @@ func (c *MongoCounter) find(ctx context.Context, filter bson.M) ([]MonthlyUsage,
 	for _, d := range docs {
 		out = append(out, d.view())
 	}
-	// Sorted in Go, not in Mongo: the order is biggest-spend-first over
-	// cost_usd_millis, and both twins must produce the identical sequence
-	// for the conformance suite to mean anything.
-	sortUsage(out)
+	// The caller sorts: the presentation order is biggest-spend-first over
+	// cost_usd_millis, and after summing a credential's repositories the
+	// totals — not the individual rows — are what has to be ranked.
 	return out, nil
 }

--- a/pkg/runner/loop_cred_spend.go
+++ b/pkg/runner/loop_cred_spend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/credusage"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // The per-CREDENTIAL half of an attempt's metering (#641), beside
@@ -46,6 +47,7 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 	}
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	repoID := r.repoForSpend(bg, msg)
 	for route, totals := range routes {
 		slot := credentialSlotForRoute(creds, route.backend, route.model)
 		if slot == "" {
@@ -72,6 +74,7 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 				Provider:    slot,
 				Tier:        credentialTier(creds, slot),
 				TenantID:    msg.TenantID,
+				RepoID:      repoID,
 			},
 			Nature:          credentialNature(slot),
 			Backend:         route.backend,
@@ -84,6 +87,33 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 			r.cfg.Logger.Warn("runner: credential spend record for %s (run %s): %v", fp, msg.RunID, err)
 		}
 	}
+}
+
+// repoForSpend names the repository this attempt's spend is attributed to,
+// or "" when iterion cannot say.
+//
+// The value is store.Run.ProjectPath — the forge slug the launch surfaces
+// already stamp and the studio already groups runs by, not a second identity
+// derived here from a clone URL. Read from the run document rather than added
+// to the queue message on purpose: the RunMessage schema is the contract
+// between a server and runner pods that deploy independently, and widening it
+// for an accounting field would couple this to a rollout order for no gain.
+//
+// Best-effort like everything on this path, and SILENT about a miss: a run
+// that legitimately targets no repository is the common case, so a warning
+// here would fire on most local and non-webhook runs. An attempt whose repo
+// cannot be read meters without one — charged to the credential, attributed
+// to nobody — which is the same rule the route attribution follows: never
+// guess a subject.
+func (r *Runner) repoForSpend(ctx context.Context, msg *queue.RunMessage) string {
+	if r.cfg.Store == nil || msg == nil || msg.RunID == "" {
+		return ""
+	}
+	run, err := r.cfg.Store.LoadRun(store.WithIdentity(ctx, msg.TenantID, msg.OwnerID), msg.RunID)
+	if err != nil || run == nil {
+		return ""
+	}
+	return strings.TrimSpace(run.ProjectPath)
 }
 
 // credentialNature says what a credential's dollar figure MEANS.

--- a/pkg/server/cred_usage_repo_test.go
+++ b/pkg/server/cred_usage_repo_test.go
@@ -1,0 +1,152 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/credusage"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func seedRepoSpend(t *testing.T, c credusage.Counter, when time.Time, fp, tenant, repo string, cost float64) {
+	t.Helper()
+	if err := c.AddSpend(context.Background(), when, credusage.Spend{
+		Key: credusage.Key{
+			Fingerprint: fp, Provider: "anthropic", Tier: credusage.TierTeam,
+			TenantID: tenant, RepoID: repo,
+		},
+		Nature:  credusage.NatureMetered,
+		Backend: "claw",
+		CostUSD: cost, InputTokens: 100, OutputTokens: 10,
+	}); err != nil {
+		t.Fatalf("seed %s/%s: %v", fp, repo, err)
+	}
+}
+
+// #950 — the repository is an accounting dimension, which is only useful if
+// asking for one repository's spend answers about THAT repository. Two ways
+// to get it wrong, both silent, both pinned here:
+//
+//   - the team route forwarding a cross-tenant listing, so a team reads
+//     another team's spend on a repo they happen to share;
+//   - the listings that predate the dimension reporting only the
+//     unattributed rows, so every figure drops the day runs start naming a
+//     repo.
+func TestCredentialUsage_RepoDimension(t *testing.T) {
+	const repo = "SocialGouv/iterion"
+	newSrv := func(t *testing.T) (*Server, credusage.Counter, time.Time) {
+		t.Helper()
+		counter := credusage.NewMemoryCounter()
+		return &Server{credUsage: counter, logger: iterlog.Nop()}, counter, time.Now().UTC()
+	}
+	teamReq := func(teamID, query string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/teams/"+teamID+"/credentials/usage"+query, nil)
+		r.SetPathValue("id", teamID)
+		return r.WithContext(store.WithTenant(auth.WithIdentity(r.Context(),
+			auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: teamID}), teamID))
+	}
+	decode := func(t *testing.T, w *httptest.ResponseRecorder) credentialUsageListView {
+		t.Helper()
+		if w.Code != http.StatusOK {
+			t.Fatalf("usage: %d %s", w.Code, w.Body.String())
+		}
+		var body credentialUsageListView
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v (%s)", err, w.Body.String())
+		}
+		return body
+	}
+
+	t.Run("a team's repo view never carries another team's spend", func(t *testing.T) {
+		srv, counter, now := newSrv(t)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", repo, 2.0)
+		// The SAME repository, served by another team's credential. The
+		// counter answers across tenants on purpose; the team route must not.
+		seedRepoSpend(t, counter, now, "fp-b", "team-b", repo, 99.0)
+
+		w := httptest.NewRecorder()
+		srv.handleTeamCredentialUsage(w, teamReq("team-a", "?repo="+repo))
+		body := decode(t, w)
+		if len(body.Credentials) != 1 {
+			t.Fatalf("credentials = %+v, want only team-a's row", body.Credentials)
+		}
+		if body.Credentials[0].Fingerprint != "fp-a" {
+			t.Fatalf("row fingerprint = %q, want fp-a", body.Credentials[0].Fingerprint)
+		}
+		if body.MeteredUSD != 2.0 {
+			t.Fatalf("metered = $%.2f, want $2.00 — $101.00 would mean team-b's spend leaked", body.MeteredUSD)
+		}
+		if body.Credentials[0].RepoID != repo {
+			t.Fatalf("repo_id = %q, want %q — a ?repo= answer names the repo it is about", body.Credentials[0].RepoID, repo)
+		}
+	})
+
+	t.Run("the unfiltered view sums the repositories back in", func(t *testing.T) {
+		srv, counter, now := newSrv(t)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", repo, 2.0)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", "SocialGouv/other", 1.0)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", "", 0.5) // a run that named none
+
+		w := httptest.NewRecorder()
+		srv.handleTeamCredentialUsage(w, teamReq("team-a", ""))
+		body := decode(t, w)
+		if len(body.Credentials) != 1 {
+			t.Fatalf("credentials = %+v, want ONE row — repositories are summed into their credential", body.Credentials)
+		}
+		if body.MeteredUSD != 3.5 {
+			t.Fatalf("metered = $%.2f, want $3.50 — an unfiltered view that reported only the unattributed row would say $0.50", body.MeteredUSD)
+		}
+		if body.Credentials[0].RepoID != "" {
+			t.Fatalf("a summed row named repo %q; it is the total of three", body.Credentials[0].RepoID)
+		}
+	})
+
+	t.Run("an unknown repo is an empty bill, not everyone's", func(t *testing.T) {
+		srv, counter, now := newSrv(t)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", repo, 2.0)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", "", 7.0)
+
+		w := httptest.NewRecorder()
+		srv.handleTeamCredentialUsage(w, teamReq("team-a", "?repo=SocialGouv/never-ran"))
+		body := decode(t, w)
+		if len(body.Credentials) != 0 || body.MeteredUSD != 0 {
+			t.Fatalf("unknown repo = %+v ($%.2f), want an empty bill", body.Credentials, body.MeteredUSD)
+		}
+	})
+
+	t.Run("admin refuses ?fingerprint= and ?repo= together", func(t *testing.T) {
+		srv, counter, now := newSrv(t)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", repo, 2.0)
+
+		r := httptest.NewRequest("GET", "/api/admin/credentials/usage?fingerprint=fp-a&repo="+repo, nil)
+		r = r.WithContext(auth.WithIdentity(r.Context(), auth.Identity{UserID: "root", IsSuperAdmin: true}))
+		w := httptest.NewRecorder()
+		srv.handleAdminCredentialUsage(w, r)
+		// Answering one of the two would return a number that is not the one
+		// asked for — the failure `?tier=org` had on this very endpoint.
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("fingerprint+repo = %d %s, want 400", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("admin ?repo= spans the tenants that served it", func(t *testing.T) {
+		srv, counter, now := newSrv(t)
+		seedRepoSpend(t, counter, now, "fp-a", "team-a", repo, 2.0)
+		seedRepoSpend(t, counter, now, "fp-b", "team-b", repo, 3.0)
+
+		r := httptest.NewRequest("GET", "/api/admin/credentials/usage?repo="+repo, nil)
+		r = r.WithContext(auth.WithIdentity(r.Context(), auth.Identity{UserID: "root", IsSuperAdmin: true}))
+		w := httptest.NewRecorder()
+		srv.handleAdminCredentialUsage(w, r)
+		body := decode(t, w)
+		if len(body.Credentials) != 2 || body.MeteredUSD != 5.0 {
+			t.Fatalf("admin repo view = %+v ($%.2f), want both tenants' rows totalling $5.00", body.Credentials, body.MeteredUSD)
+		}
+	})
+}

--- a/pkg/server/cred_usage_routes.go
+++ b/pkg/server/cred_usage_routes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
@@ -25,13 +26,18 @@ func (s *Server) registerCredUsageRoutes() {
 // never be summed, and a client that only reads cost_usd would do exactly
 // that — so the API states it rather than leaving it to a doc nobody opens.
 type credentialUsageView struct {
-	Month       string  `json:"month"`
-	Fingerprint string  `json:"fingerprint"`
-	Provider    string  `json:"provider"`
-	Tier        string  `json:"tier"`
-	TenantID    string  `json:"tenant_id,omitempty"`
-	Nature      string  `json:"nature"`
-	CostUSD     float64 `json:"cost_usd"`
+	Month       string `json:"month"`
+	Fingerprint string `json:"fingerprint"`
+	Provider    string `json:"provider"`
+	Tier        string `json:"tier"`
+	TenantID    string `json:"tenant_id,omitempty"`
+	// RepoID is the repository this row is attributed to, present ONLY on a
+	// `?repo=` answer. Every other listing sums a credential's repositories
+	// together, and naming one of them on a total would be a wrong answer
+	// rather than a partial one.
+	RepoID  string  `json:"repo_id,omitempty"`
+	Nature  string  `json:"nature"`
+	CostUSD float64 `json:"cost_usd"`
 	// InputTokens / OutputTokens are a MEASURED split and stay zero when
 	// none was observed; AggregateTokens holds a CLI delegate's
 	// unsplittable total. A per-direction ratio is only meaningful when
@@ -58,7 +64,7 @@ func toCredentialUsageList(month string, rows []credusage.MonthlyUsage) credenti
 	for _, r := range rows {
 		out.Credentials = append(out.Credentials, credentialUsageView{
 			Month: r.Month, Fingerprint: r.Fingerprint, Provider: r.Provider,
-			Tier: string(r.Tier), TenantID: r.TenantID, Nature: string(r.Nature),
+			Tier: string(r.Tier), TenantID: r.TenantID, RepoID: r.RepoID, Nature: string(r.Nature),
 			CostUSD: r.CostUSD, InputTokens: r.InputTokens, OutputTokens: r.OutputTokens,
 			AggregateTokens: r.AggregateTokens,
 			Runs:            r.Runs, Backends: r.Backends,
@@ -107,7 +113,23 @@ func (s *Server) handleTeamCredentialUsage(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	now := time.Now().UTC()
-	rows, err := s.credUsage.List(r.Context(), now, teamID)
+	var (
+		rows []credusage.MonthlyUsage
+		err  error
+	)
+	if repo := strings.TrimSpace(r.URL.Query().Get("repo")); repo != "" {
+		// ListByRepo spans TENANTS by design — a repository can be served by
+		// several teams' credentials — so this route, which answers for one
+		// team, must narrow it. Filtering here rather than asking the counter
+		// for a tenant-scoped variant keeps the store surface small; the cost
+		// is that forgetting this line leaks another team's spend, which is
+		// why oneTenant is named and tested rather than inlined.
+		var all []credusage.MonthlyUsage
+		all, err = s.credUsage.ListByRepo(r.Context(), now, repo)
+		rows = oneTenant(all, teamID)
+	} else {
+		rows, err = s.credUsage.List(r.Context(), now, teamID)
+	}
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -115,10 +137,23 @@ func (s *Server) handleTeamCredentialUsage(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, toCredentialUsageList(now.Format("2006-01"), rows))
 }
 
+// oneTenant keeps only the rows belonging to a tenant. The cross-tenant
+// listings are super-admin answers; a team route that forwarded one would
+// report another team's spend under this team's heading.
+func oneTenant(rows []credusage.MonthlyUsage, tenantID string) []credusage.MonthlyUsage {
+	out := make([]credusage.MonthlyUsage, 0, len(rows))
+	for _, row := range rows {
+		if row.TenantID == tenantID {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
 // handleAdminCredentialUsage is the platform view: one credential across
-// every tenant it served (`?fingerprint=`), or the platform tier's own
-// month. Super-admin, because a fingerprint spans tenants and the answer
-// names them.
+// every tenant it served (`?fingerprint=`), one repository across every
+// credential that served IT (`?repo=`), or the platform tier's own month.
+// Super-admin, because both cross-tenant answers name the tenants.
 func (s *Server) handleAdminCredentialUsage(w http.ResponseWriter, r *http.Request) {
 	if s.credUsage == nil {
 		httpError(w, http.StatusNotFound, "per-credential usage is not enabled on this instance")
@@ -129,9 +164,21 @@ func (s *Server) handleAdminCredentialUsage(w http.ResponseWriter, r *http.Reque
 		rows []credusage.MonthlyUsage
 		err  error
 	)
-	if fp := r.URL.Query().Get("fingerprint"); fp != "" {
+	fp := strings.TrimSpace(r.URL.Query().Get("fingerprint"))
+	repo := strings.TrimSpace(r.URL.Query().Get("repo"))
+	switch {
+	case fp != "" && repo != "":
+		// Refused rather than served by whichever the code checks first: the
+		// caller asked a question this endpoint does not answer, and picking
+		// one of the two silently returns a number that is not what was
+		// asked for — the same failure `?tier=org` used to have here.
+		httpError(w, http.StatusBadRequest, "give ?fingerprint= or ?repo=, not both — one credential across repositories and one repository across credentials are different questions")
+		return
+	case repo != "":
+		rows, err = s.credUsage.ListByRepo(r.Context(), now, repo)
+	case fp != "":
 		rows, err = s.credUsage.ListByFingerprint(r.Context(), now, fp)
-	} else {
+	default:
 		// By TIER, not by tenant: a platform credential is metered under
 		// each tenant it served, so no single tenant holds its month.
 		tier, terr := tierOrPlatform(r.URL.Query().Get("tier"))


### PR DESCRIPTION
Refs #950 — the fourth point of its "shape of an answer", and the only one
that needs no product decision.

> **There is no repo dimension in any meter.** `credusage.Key` is
> `{fingerprint, provider, tier, tenant} × month`; `orgusage` counts per org.
> A run knows its repository — the forge integration, `pr_url`, the trigger —
> and nothing carries it into accounting. "A quota per repo" has no subject to
> attach to.

It has one now.

## The identity, and where it comes from

`store.Run.ProjectPath` — the forge slug (`owner/repo`, `group/sub/project`)
every launch surface already stamps and the studio already groups runs by. Not
a second identity derived here from a clone URL.

The runner reads it **from the run document**, not from a new `RunMessage`
field: that schema is the contract between a server and runner pods that
deploy independently — the coupling behind the v14 queue-schema outage — and
widening it for an accounting field would buy a rollout order for nothing. One
store read per attempt, on a path that is already best-effort.

## Two properties keep it additive

**An empty repo adds no segment to the document id.** Encoding it
unconditionally would have re-identified every stored document: each
credential-month restarts from zero at the deploy, and the figure an operator
reads drops to near nothing while the real spend continues — a reporting
outage that looks exactly like a quiet month. Pre-existing rows, and every run
that targets no repository, keep the id they had.

**Every listing that predates the dimension sums the repositories back
together**, so `--by-credential` reports exactly what it always did. The
alternative — one row per repository — makes a credential appear several times
with no total anywhere.

## What the dimension adds

`ListByRepo`: one repository across every credential and tenant that served
it, rows kept apart (it is already scoped to one repo, so summing would
collapse the very dimension asked for).

```sh
iterion remote usage --by-credential --repo SocialGouv/iterion
iterion remote api GET "/api/admin/credentials/usage?repo=SocialGouv/iterion"
```

Three refusals, each one a wrong answer avoided rather than a feature missing:

- **an empty repo returns nothing**, not every unattributed row — a caller
  asking a repository's bill must never be handed the deployment's;
- **the team route narrows the cross-tenant answer to its own tenant** (two
  teams can serve one repo with their own credentials);
- **`?fingerprint=` and `?repo=` together are refused `400`** rather than
  served by whichever the code checks first — one credential across
  repositories and one repository across credentials are different questions.
  This is the failure `?tier=org` had on this very endpoint.

## Verification

- **Both store twins through the conformance suite against a real `mongo:8.0`
  replica set**, not only the memory one — `TestMongoCounter_Conformance` PASS,
  not SKIP. A store-twin change is unverified until it ran there.
- **Both new benches were checked to BITE.** Neutering the tenant filter turns
  the cross-tenant case red; neutering the summing turns both the conformance
  suite and the API case red. A bench that cannot go red is not a bench.
- `task check`: EXIT=0, 144 packages, 0 FAIL, golangci 0 issues.
- `task openapi:check`: no drift.

## Deliberately not in this PR

The **quota** itself, and the budget **floors** #950 is really about. Both need
a product decision on what a "workload" is (a bot? a role? a label?) and what a
"capacity source" is. #950's own finding stands: every budget mechanism in
iterion today is a ceiling, none is a floor — this PR does not change that, it
gives the floor a subject to be expressed against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)