### PR TITLE
fix(docs): the docs site has not built since the browser-security page landed

### DIFF
--- a/docs/browser-security.md
+++ b/docs/browser-security.md
@@ -200,7 +200,7 @@ The Monaco editor used to be fetched at runtime from `cdn.jsdelivr.net`
 third-party executable code in the surface that edits LLM keys, OAuth forfaits
 and forge tokens, and told the CDN who was using a `gouv.fr` deployment.
 
-It is now bundled ([studio/src/lib/monaco.ts](../studio/src/lib/monaco.ts)) —
+It is now bundled ([studio/src/lib/monaco.tsx](../studio/src/lib/monaco.tsx)) —
 **import `Editor`/`DiffEditor` from there, never from `@monaco-editor/react`.**
 The same rule already governs the fonts (`@fontsource-variable/*`, self-hosted
 so the desktop app and sandboxed runs work offline). `script-src 'self'` is now


### PR DESCRIPTION
`main`'s documentation build has been red for an hour, on six consecutive
commits, and nothing said so.

## The failure

```
❌ 1 broken link(s):
   https://github.com/SocialGouv/iterion/blob/main/studio/src/lib/monaco.ts  ←  browser-security.html
```

`docs/scripts/check-links.mjs` resolves this site's github blob links against
the real tree — the check that exists precisely because VitePress's own
dead-link pass does not cover them. The module is `studio/src/lib/monaco.tsx`
(it exports the `Editor` / `DiffEditor` the sentence is about); `monaco.ts` is
not a path in the tree. One character, and `pnpm -C docs build` exits 1.

## Why it slid

Red since `d01f80707` (08:54Z), the commit that added
[docs/browser-security.md](https://github.com/SocialGouv/iterion/blob/main/docs/browser-security.md).
`docs` is **not a required check**, so the merge queue never looked at it, and
each following merge inherited a red `main` without having caused it — mine
included, which is how I found it.

Worth a separate thought: a workflow whose only job is to publish, failing
silently for six commits, is the shape of a check that should either be
required or be alerting. Not changed here.

## Verified

Ran the real build both ways rather than reasoning about the path:

- without the fix — exit **1**, naming this exact link;
- with it — exit **0**, `build complete`, no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)