### PR TITLE
chore(docker): pin codex to a version the offered models can be driven with

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1113,13 +1113,38 @@ tasks:
 
   # --- Docker image plumbing (plan §F T-39) -----------------------
   docker:pin-llm-clis:
-    desc: Refresh docker/llm-clis/package.json to the latest stable claude-code + codex versions
+    desc: Refresh every pinned CLI in docker/llm-clis/package.json to its latest stable version
     cmds:
       - |
-        CLAUDE_VERSION=$(npm view @anthropic-ai/claude-code version)
-        CODEX_VERSION=$(npm view @openai/codex version)
-        echo "claude=$CLAUDE_VERSION codex=$CODEX_VERSION"
-        printf '{\n  "name": "iterion-llm-clis",\n  "private": true,\n  "description": "Pinned npm dependencies for the LLM CLIs baked into the iterion container image. Refresh via `task docker:pin-llm-clis` (T-39).",\n  "dependencies": {\n    "@anthropic-ai/claude-code": "%s",\n    "@openai/codex": "%s"\n  }\n}\n' "$CLAUDE_VERSION" "$CODEX_VERSION" > docker/llm-clis/package.json
+        # Edits the file IN PLACE, one dependency at a time. It used to reprint
+        # a hardcoded template naming two CLIs; a third was pinned later and the
+        # template was never updated, so the documented refresh path silently
+        # DELETED @earendil-works/pi-coding-agent. Reading the file instead of
+        # restating its contents removes that drift entirely.
+        python3 - <<'PY'
+        import json, subprocess, sys
+
+        path = "docker/llm-clis/package.json"
+        with open(path, encoding="utf-8") as fh:
+            doc = json.load(fh)
+
+        deps = doc.get("dependencies") or {}
+        if not deps:
+            sys.exit("%s declares no dependencies — refusing to rewrite it" % path)
+
+        for name in sorted(deps):
+            out = subprocess.run(["npm", "view", name, "version"],
+                                 capture_output=True, text=True)
+            version = out.stdout.strip()
+            if out.returncode != 0 or not version:
+                sys.exit("npm view %s failed: %s" % (name, out.stderr.strip() or "no version"))
+            print("%s %s -> %s" % (name, deps[name], version))
+            deps[name] = version
+
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(doc, fh, indent=2)
+            fh.write("\n")
+        PY
         echo "Updated docker/llm-clis/package.json — review and commit."
 
   docker:build:

--- a/docker/llm-clis/package.json
+++ b/docker/llm-clis/package.json
@@ -5,6 +5,6 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "2.1.175",
     "@earendil-works/pi-coding-agent": "0.84.3",
-    "@openai/codex": "0.139.0"
+    "@openai/codex": "0.154.0"
   }
 }


### PR DESCRIPTION
## The refusal

A claw node asking for a recent OpenAI model is refused outright:

```
openai: API error 400: The 'gpt-6-astra' model requires a newer version of Codex
```

The runner bakes `@openai/codex` **0.139.0**; the model is gated at **≥ 0.153**.

And the refusal is not graceful: the run failed and was **auto-resumed ten times in eighty seconds** against the same deterministic 400, one sandbox pod per attempt. (That retry behaviour is a separate defect — a typed "model unavailable for this version" ought to be terminal, not resumable — and is not addressed here.)

Pinning **0.154.0** (npm latest) makes the model reachable.

Nothing else moves. The `claude-code` and `pi` pins are deliberate: the changelog records 2.1.175 being chosen over 2.1.128 for a StructuredOutput emission bug.

## The refresh path this file documents was itself broken

`task docker:pin-llm-clis` reprinted a **hardcoded template naming two CLIs**. A third, `@earendil-works/pi-coding-agent`, was pinned later and the template was never updated — so the documented way to refresh the pins **silently deleted a CLI from the image**.

It now reads the file and updates each dependency in place. There is no longer a second statement of the contents that can drift from the first, which is why this needs no guard test: the class is removed rather than watched.

**Verified against the real artifact** — running the task body:

```
@anthropic-ai/claude-code 2.1.175 -> 2.1.267
@earendil-works/pi-coding-agent 0.84.3 -> 0.85.1
@openai/codex 0.154.0 -> 0.154.0
```

All three survive, each reported old → new. Under the old template, the middle line would not exist and the dependency would be gone.

## Rollout note

This changes the **runner image**, so it lands only once the runner digest is bumped where it is pinned by digest.