### PR TITLE
fix(runner): a per-credential spend never disappears without a line

### DIFF
--- a/pkg/runner/cred_spend_silence_test.go
+++ b/pkg/runner/cred_spend_silence_test.go
@@ -1,0 +1,106 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/credusage"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// spendProbe wires a runner whose log is capturable and whose counter is
+// observable, plus an emitter carrying one real claude_code delegate route.
+func spendProbe(t *testing.T, counter credusage.Counter) (*Runner, *metricsEmitter, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelWarn, &buf), CredUsage: counter}}
+	usage := newMetricsEmitter(nil, nil)
+	usage.observe(store.Event{Type: store.EventLLMRequest, NodeID: "n",
+		Data: map[string]any{"model": "anthropic/claude-opus-5"}})
+	usage.observe(store.Event{Type: store.EventDelegateFinished, NodeID: "n",
+		Data: map[string]any{"backend": delegate.BackendClaudeCode, "tokens": float64(36051), "cost_usd": 2.4}})
+	return r, usage, &buf
+}
+
+// #1087 — a credential whose slot resolves but carries NO fingerprint had its
+// spend dropped by a bare `continue`. Its sibling decline one line above (no
+// slot at all) warns; this one said nothing, so a run that really spent money
+// left no trace anywhere: the counter did not move and the log did not mention
+// it. Measured in production as a per-credential row frozen on every field —
+// runs, cost and tokens — while runs kept completing.
+func TestRecordCredentialSpend_UnfingerprintedSlotIsNotSilent(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	r, usage, logbuf := spendProbe(t, counter)
+
+	// A resolved claude_code forfait with NO fingerprint stamped: exactly the
+	// shape `creds.Fingerprint(slot) == ""` describes.
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: "/tmp/oauth"},
+		Fingerprints:         map[string]string{delegate.BackendClaudeCode: ""},
+	})
+
+	now := time.Now().UTC()
+	r.recordCredentialSpend(ctx, &queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, usage, now)
+
+	rows, err := counter.List(ctx, now, "team-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("an unfingerprinted slot must not be metered (it would merge every unstamped credential): %+v", rows)
+	}
+	got := logbuf.String()
+	if !strings.Contains(got, "run-1") {
+		t.Errorf("the dropped spend named no run in the log — a run that spent $2.40 vanished silently.\nlog: %q", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "fingerprint") {
+		t.Errorf("the log does not say the credential had no fingerprint, so nobody can diagnose it.\nlog: %q", got)
+	}
+}
+
+// The three function-level guards return before any route is examined. Each
+// skips the whole attempt's per-credential metering; none said anything.
+func TestRecordCredentialSpend_EarlyDeclinesAreLogged(t *testing.T) {
+	fullCreds := secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: "/tmp/oauth"},
+		Fingerprints:         map[string]string{delegate.BackendClaudeCode: "fp-1"},
+	}
+
+	t.Run("no counter wired", func(t *testing.T) {
+		_, usage, logbuf := spendProbe(t, nil)
+		r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelWarn, logbuf)}}
+		r.recordCredentialSpend(secrets.WithCredentials(context.Background(), fullCreds),
+			&queue.RunMessage{RunID: "run-2", TenantID: "t"}, usage, time.Now().UTC())
+		if !strings.Contains(logbuf.String(), "run-2") {
+			t.Errorf("a runner with no credential counter meters nothing and says nothing.\nlog: %q", logbuf.String())
+		}
+	})
+
+	t.Run("no credentials on the context", func(t *testing.T) {
+		r, usage, logbuf := spendProbe(t, credusage.NewMemoryCounter())
+		r.recordCredentialSpend(context.Background(),
+			&queue.RunMessage{RunID: "run-3", TenantID: "t"}, usage, time.Now().UTC())
+		if !strings.Contains(logbuf.String(), "run-3") {
+			t.Errorf("a spend with no credentials in context vanished silently.\nlog: %q", logbuf.String())
+		}
+	})
+
+	t.Run("no routes observed", func(t *testing.T) {
+		r, _, logbuf := spendProbe(t, credusage.NewMemoryCounter())
+		empty := newMetricsEmitter(nil, nil)
+		r.recordCredentialSpend(secrets.WithCredentials(context.Background(), fullCreds),
+			&queue.RunMessage{RunID: "run-4", TenantID: "t"}, empty, time.Now().UTC())
+		// A run that consumed nothing is the ordinary case and must stay
+		// quiet — the guard is only worth a line when there WAS spend.
+		if strings.Contains(logbuf.String(), "run-4") {
+			t.Errorf("a run with no observed route is not an anomaly and must not warn.\nlog: %q", logbuf.String())
+		}
+	})
+}

--- a/pkg/runner/loop_cred_spend.go
+++ b/pkg/runner/loop_cred_spend.go
@@ -34,15 +34,33 @@ import (
 // floor rather than fail a finished run. Detached context (5s) for the same
 // reason recordOrgSpend detaches — a cancelled run still spent.
 func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessage, usage *metricsEmitter, at time.Time) {
-	if r.cfg.CredUsage == nil || usage == nil {
-		return
-	}
-	creds, ok := secrets.CredentialsFromContext(ctx)
-	if !ok {
+	if usage == nil {
 		return
 	}
 	routes := usage.RouteTotals()
 	if len(routes) == 0 {
+		// A run that consumed nothing. Ordinary, and the only decline here
+		// that is not worth a line.
+		return
+	}
+	// Past this point the attempt DID spend, so every decline below drops a
+	// real observation — and says which one. Silence here is what let a
+	// production counter sit frozen on EVERY field, runs and cost included,
+	// while runs kept completing: nothing in the counter and nothing in the
+	// log, so the meter read as "no spend" rather than "not recorded" (#1087).
+	if r.cfg.CredUsage == nil {
+		if r.cfg.Logger != nil {
+			r.cfg.Logger.Warn("runner: run %s spent on %d route(s) but this runner has no per-credential counter wired — nothing metered per credential",
+				msg.RunID, len(routes))
+		}
+		return
+	}
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok {
+		if r.cfg.Logger != nil {
+			r.cfg.Logger.Warn("runner: run %s spent on %d route(s) but its context carries no credentials — nothing metered per credential",
+				msg.RunID, len(routes))
+		}
 		return
 	}
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -56,7 +74,7 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 			// a debug line is silent on a production runner. Once per route.
 			if r.cfg.Logger != nil && usage.noteDeclinedRoute(route) {
 				r.cfg.Logger.Warn("runner: run %s spent %d tokens ($%.4f) on %s/%s with no credential iterion can name (wire %q) — not metered per credential",
-					msg.RunID, totals.inputTokens+totals.outputTokens, totals.costUSD,
+					msg.RunID, totals.tokens(), totals.costUSD,
 					route.backend, route.model, wireForRoute(route.backend, route.model))
 			}
 			continue
@@ -66,6 +84,15 @@ func (r *Runner) recordCredentialSpend(ctx context.Context, msg *queue.RunMessag
 			// A slot with no fingerprint names a SLOT, not an account:
 			// counting it would merge every unstamped credential of that
 			// provider into one bucket.
+			//
+			// Declined like its sibling above, and said out loud for the same
+			// reason: the drop leaves NOTHING in the counter, so silence here
+			// is indistinguishable from a run that spent nothing.
+			if r.cfg.Logger != nil && usage.noteDeclinedRoute(route) {
+				r.cfg.Logger.Warn("runner: run %s spent %d tokens ($%.4f) on %s/%s but its %s credential carries no fingerprint — not metered per credential",
+					msg.RunID, totals.tokens(), totals.costUSD,
+					route.backend, route.model, slot)
+			}
 			continue
 		}
 		spend := credusage.Spend{

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -110,6 +110,13 @@ type routeTotals struct {
 	aggregateTokens int64
 }
 
+// tokens is everything the route consumed. The three counters are disjoint —
+// a delegate that cannot split its total fills only aggregateTokens — so a sum
+// that omits it reports 0 for every claude_code route.
+func (t routeTotals) tokens() int64 {
+	return t.inputTokens + t.outputTokens + t.aggregateTokens
+}
+
 func newMetricsEmitter(inner model.EventEmitter, reg *metrics.Registry) *metricsEmitter {
 	return &metricsEmitter{
 		inner:          inner,


### PR DESCRIPTION
Refs #1087.

## The silence, measured

On ovh-prod a run spent **$2.40 / 36 051 tokens** on a named `claude_code` forfait (the runner log names the credential and tenant), finished cleanly — and the credential's monthly row did not move on **any** field:

```
runs      = 94        (unchanged)   input     = 3007491  (unchanged)
cost      = 337.406   (unchanged)   aggregate = 0        (unchanged)
```

`runs` is incremented on every `AddSpend`, even for a zero-token spend. Frozen `runs` means `AddSpend` was never called — and there was **nothing in the runner log either**: zero declined-route warnings, zero write errors, across 6h and 93 credential activations.

## Four declines, one of them the likely culprit

`recordCredentialSpend` had four ways to drop an attempt's metering without a word. The one that matters sits **one line below** a sibling that already warns:

```go
if slot == "" {
    ... Logger.Warn("... with no credential iterion can name ...")   // loud
    continue
}
fp := creds.Fingerprint(slot)
if fp == "" {
    // A slot with no fingerprint names a SLOT, not an account: ...
    continue                                                          // mute
}
```

The comment explains *why* it declines; nobody learns *that* it declined. And because the drop leaves nothing in the counter either, the meter reads **"this key spent nothing"** rather than **"this was not recorded"** — precisely the misreading `pkg/credusage` exists to remove.

Each decline now names the run, what it spent, and which condition dropped it. The one ordinary case stays quiet: a run with **no observed route** consumed nothing and is not an anomaly (asserted as such — the test fails if it starts warning).

## A regression #1052 introduced, caught on the way

The sibling warning summed `inputTokens + outputTokens`. Since #1052 moved a delegate's unsplittable total into `aggregateTokens`, that warning reported **"spent 0 tokens"** for exactly the claude_code routes it was written for. `routeTotals.tokens()` sums all three; the counters are disjoint by construction.

## Honest about what this does and does not do

It makes the production symptom **diagnosable**; it does not by itself explain it. I could not determine from outside which of the four guards fires. The next run that declines will name it in the log — which is the point.

## Evidence

- Tests seen **red first**, each showing `log: ""` — the literal silence.
- `task check` — exit 0, zero FAIL lines.
