### PR TITLE
feat(dsl): a property registry the parser is held to, and E012 names the remedy (lot 1a of #1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,7 @@ Other top-level directories: `studio/` (React/Vite frontend), `examples/` (.bot 
   - `types/` — Shared enums (transports, field types, session/router/await/interaction modes)
   - `expr/` — Expression evaluator for `compute` nodes and `when` conditions
   - `workflowfile/` — Workflow source-file loading + hash computation (used by `iterion resume` change detection)
+  - `spec/` — The declarative **property registry** (a leaf): every kind's accepted properties with value shape and one-line doc. Held to the parser by a black-box conformance test in BOTH directions (a property added to one side without the other fails CI) and to the EBNF's `*_prop` productions. Feeds E012's remedy (closest name, the block a name belongs to, the kind's list — `parser.unknownProperty`, the one choke point), and renders `docs/references/dsl-properties.md`, the grammar's tables and the skills' property section (`iterion dsl spec --write` / `task dsl:gen`; `task dsl:check` fails on a stale rendering). The parser's `isKeywordToken` is derived from the lexer's keyword table for the same reason: the hand-kept copy drifted twice
 - `pkg/backend/` — Execution stack (LLM + tools)
   - `model/` — Executor registry (`ClawExecutor`), schema validation, event hooks
   - `delegate/` — Backend interface and CLI delegates (`claude_code`, `codex`, `pi`, `kimi`, `grok`); `claw` implements the same interface in-process under `model/`
@@ -1711,6 +1712,7 @@ above is the standing baseline, not an open-work list).
 
 ```
 iterion validate <file.bot>            # Parse and validate workflow
+iterion dsl spec [--region reference|skill|'table <kind>'] [--write]  # Render the DSL property registry, or regenerate the committed reference/tables/skill sections (task dsl:gen)
 iterion import <workflow.js> [--out] [--name] [--dry-run]  # Lossy Claude-Code workflow-script → draft .bot (goja AST, zero execution; see docs/import.md)
 iterion run <file.bot> [flags]         # Execute workflow (--var, --recipe, --timeout, --store-dir, --merge-into, --branch-name, --compress, --fallback, --max-cost-usd, --max-tokens, --max-duration, --max-iterations, --max-parallel-branches)
 iterion inspect [--run-id] [--events]   # View run state and events

--- a/SKILL.md
+++ b/SKILL.md
@@ -182,6 +182,56 @@ shipped bots, so they are written here:
 - **A typed refusal is `fail <name>:`** with an UPPER_SNAKE `code:` — the bare
   `-> fail` target carries no code.
 
+## Property reference
+
+What each kind accepts, from the parser's own registry — the one list an
+unknown property is checked against, so a name that is not here draws E012
+with the closest accepted name in its `fix:` line.
+
+<!-- dsl-spec:begin skill -->
+Generated from the parser's property registry (`iterion dsl spec --write`). Forms: `str` quoted string · `id` bare name · `str|id` either · `int` `num` `bool` literals · `a|b` one of · `[id]` `[str]` `[tool]` `[skill]` inline lists · `map` `{K: "v"}` or an indented block · `with{}` a `with { k: "v" }` map · `{kind}` an indented block described under that kind.
+
+- `prompt` — entries `indented text lines`
+- `schema` — entries `field: string | bool | int | float | json | string[] | file [enum: "a", "b"]`
+- `cursor` — description str · values {cursor.values} · bands {cursor.bands}
+- `cursor.values` (`values:` in cursor) — entries `name: "prompt fragment"`
+- `cursor.bands` (`bands:` in cursor) — entries `"lo..hi": "prompt fragment"`
+- `supervisor` — watches [id] · model str · system id · cooldown str · max_evals int · monitors [str]
+- `mcp_server` — transport stdio|http|sse · command str · args [str] · url str · auth {auth}
+- `auth` (`auth:` in mcp_server) — type str · auth_url str · token_url str · revoke_url str · client_id str · scopes [str]
+- `group` — entries `node declarations and edges (src -> dst)`
+- `use` — entries `use g as p with { param: "value" }`
+- `vars` (`vars:` in the file, workflow) — entries `name: type [enum: "a", "b"] [= default]`
+- `presets` (`presets:` in the file) — entries `name: (indented) var: literal`
+- `attachments` (`attachments:` in the file, workflow) — entries `name: file | image`
+- `attachment` (`attachments:` in attachments) — description str · accept_mime [str] · required bool
+- `secrets` (`secrets:` in the file) — entries `name: "value"`
+- `secret` (`secrets:` in secrets) — value str · as value|file · mount_path str · env str|id · optional bool · hosts [str] · description str
+- `agent` / `judge` — description str · model str · backend str · provider str · command str · input id · output id · publish id · artifact_labels [tool] · system id · user id · session fresh|inherit|inherit_if_available|fork|artifacts_only|persist · tools [tool] · tool_policy [tool] · capabilities [tool] · skills [skill] · tool_max_steps int · max_tokens int · reasoning_effort low|medium|high|xhigh|max|ultracode · timeout str · readonly bool · full_access bool · images [str] · interaction none|human|llm|llm_or_human|review|async · interaction_prompt id · interaction_model str · await wait_all|best_effort · compress on|ultra|off · auto_memory on|off · permission off|ask|deny · needs id|[id] · fallbacks {fallback} · mcp {mcp} · compaction {compaction} · memory {memory} · sandbox none|auto|{sandbox} · cursors {cursors}
+- `router` — description str · mode fan_out_all|fan_out_each|condition|round_robin|llm · model str · backend str · provider str · system id · user id · multi bool · reasoning_effort low|medium|high|xhigh|max|ultracode · over str · as id · key id · depends_on id · needs id|[id]
+- `human` — description str · input id · output id · publish id · artifact_labels [tool] · instructions id · system id · model str · interaction none|human|llm|llm_or_human|review|async · interaction_prompt id · interaction_model str · min_answers int · await wait_all|best_effort · review_url str · posture human_required|agent_verdict_ok · merge_strategy squash|merge · merge_into str|id · max_turns int
+- `tool` — description str · command str · script str · language js|node|py|python|python3|sh|bash · input id · output id · publish id · artifact_labels [tool] · await wait_all|best_effort · sandbox none|auto|{sandbox} · compress on|ultra|off · permission id · needs id|[id] · parallel_safe bool · goal str · postcondition str · policy required|recover|best_effort · recovery {recovery}
+- `recovery` (`recovery:` in tool) — max_repair_attempts int · max_agent_attempts int · model str · agent_tools [tool]
+- `compute` — description str · input id · output id · publish id · artifact_labels [tool] · await wait_all|best_effort · expr {expr}
+- `expr` (`expr:` in compute) — entries `field: "expression"`
+- `subbot` — description str · source str · with with{} · output id · needs id|[id] · isolated bool
+- `emit` — description str · event str · with with{}
+- `wait` — description str · event str · timeout str · output id
+- `await_answers` — description str · from str|id · timeout str
+- `fail` — description str · code str|id · message str · resumable bool
+- `workflow` — entry id · vars {vars} · attachments {attachments} · budget {budget} · resources {resources} · mcp {mcp} · compaction {compaction} · sandbox none|auto|{sandbox} · worktree auto|none · default_backend str · compress on|ultra|off · auto_memory on|off · loop_budget_guard on|off · repo_devbox on|off · workspace_checkpoint on|off · permission off|ask|deny · allow [str] · ask [str] · deny [str] · tool_policy [tool] · capabilities [tool] · skills [skill] · interaction none|human|llm|llm_or_human|review|async
+- `budget` (`budget:` in workflow) — max_parallel_branches int · max_duration str · max_cost_usd num · max_tokens int · warn_tokens int · max_iterations int
+- `resources` (`resources:` in workflow) — entries `name: <int> | ["member-a", "member-b"]`
+- `compaction` (`compaction:` in workflow, agent, judge) — threshold num · preserve_recent int
+- `memory` (`memory:` in agent, judge) — enabled bool · scope str · autoload [str] · read bool · write bool · pre_compact_inject bool · project_root bool · visibility str
+- `mcp` (`mcp:` in workflow, agent, judge) — autoload_project bool · inherit bool · servers [id] · disable [id]
+- `sandbox` (`sandbox:` in workflow, agent, judge, tool) — mode none|auto|inline · image str · build {sandbox.build} · user str · workspace_folder str · host_state auto|none · post_create str · env map · mounts [str|id] · network {sandbox.network}
+- `sandbox.build` (`build:` in sandbox) — dockerfile str · context str · args map
+- `sandbox.network` (`network:` in sandbox) — mode open|allowlist|denylist · preset str|id · inherit replace|append · rules [str|id]
+- `cursors` (`cursors:` in agent, judge) — enabled bool — entries `cursor_name: ident | number | "string"`
+- `fallback` (`fallbacks:` in agent, judge) — backend str · model str · provider str · on [id] · metered bool · action skip · when str
+<!-- dsl-spec:end -->
+
 ## Validate in a loop, against the right build
 
 Write, then `iterion validate --json <file>`: every finding carries its

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -504,6 +504,17 @@ tasks:
       - task: studio:check
       - task: pi-ext:check
       - task: brand:check
+      - task: dsl:check
+
+  dsl:gen:
+    desc: Regenerate the DSL property reference + the grammar tables + the skills' property section from the parser's registry (pkg/dsl/spec)
+    cmds:
+      - go run -mod=vendor ./cmd/iterion dsl spec --write
+
+  dsl:check:
+    desc: Fail if a committed rendering of the DSL property registry is stale, or if the registry and the parser disagree
+    cmds:
+      - go test -count=1 -run 'TestGeneratedDSLDocsAreFresh|TestRegistryMatchesTheParser|TestEBNF' ./pkg/dsl/spec/
 
   brand:gen:
     desc: Regenerate every committed copy of the brand assets (favicons, app icon, docs logo, pkg/brand, studio mark) from assets/brand/

--- a/bots/sec-audit-source/skills/reviewer-isolation.md
+++ b/bots/sec-audit-source/skills/reviewer-isolation.md
@@ -30,7 +30,7 @@ projection, we make that injected text statically unreachable.
 
 The reviewer's input schema is `review_isolation_input`:
 
-```
+```iter fragment
 schema review_isolation_input:
   file:     string    # path to the file (workspace-relative)
   line:     json      # [start, end] line range from the finding

--- a/bots/whats-next/iterion-bot-catalog-static.md
+++ b/bots/whats-next/iterion-bot-catalog-static.md
@@ -418,7 +418,7 @@ node picks where its LLM call runs:
 **comma-separated, ordered chain** declares fallbacks that the runtime
 walks transparently when a provider fails *beyond its retry budget*:
 
-```yaml
+```iter fragment
 agent reviewer:
   backend: "claude_code"
   provider: "zai,anthropic"        # try z.ai; on hard failure, fall through to Anthropic

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -1671,7 +1671,7 @@ node picks where its LLM call runs:
 **comma-separated, ordered chain** declares fallbacks that the runtime
 walks transparently when a provider fails *beyond its retry budget*:
 
-```yaml
+```iter fragment
 agent reviewer:
   backend: "claude_code"
   provider: "zai,anthropic"        # try z.ai; on hard failure, fall through to Anthropic

--- a/bots/whats-next/skills/iterion-dsl-quickref.md
+++ b/bots/whats-next/skills/iterion-dsl-quickref.md
@@ -138,7 +138,7 @@ agent w:
   model:   "openai/gpt-5.5"     # claw with openai/* prefix
   reasoning_effort: high        # low | medium | high | xhigh | max | ultracode
                                 # ultracode = xhigh + multi-agent orchestration prerogative;
-                                # reliable only on claude-opus-4-8 (else warns C089, runs as xhigh)
+                                # reliable on Opus 4.8 and the Claude 5 family only (else warns C089, runs as xhigh)
   input:   request_schema
   output:  result_schema
   system:  w_system
@@ -203,7 +203,7 @@ Backend rules:
   when a CLI forfait's window shuts. Named entries, declaration order =
   try order:
 
-  ```
+  ```iter fragment
   agent implement:
     backend: "claude_code"
     model: "claude-opus-5"
@@ -246,6 +246,57 @@ Session-mode notes:
 - `persist` — resume **this** node's last conversation on
   re-entry (ADR-089). Trunk-only (C243); CLI backends with a
   packed StateRef. Not inherit-from-parent.
+
+## Property reference (generated)
+
+Every kind and what it accepts, rendered from the parser's property registry
+(`iterion dsl spec --write`; a conformance test holds the registry to the
+parser). A name absent from a kind's line is refused with E012 and the
+closest accepted name.
+
+<!-- dsl-spec:begin skill -->
+Generated from the parser's property registry (`iterion dsl spec --write`). Forms: `str` quoted string · `id` bare name · `str|id` either · `int` `num` `bool` literals · `a|b` one of · `[id]` `[str]` `[tool]` `[skill]` inline lists · `map` `{K: "v"}` or an indented block · `with{}` a `with { k: "v" }` map · `{kind}` an indented block described under that kind.
+
+- `prompt` — entries `indented text lines`
+- `schema` — entries `field: string | bool | int | float | json | string[] | file [enum: "a", "b"]`
+- `cursor` — description str · values {cursor.values} · bands {cursor.bands}
+- `cursor.values` (`values:` in cursor) — entries `name: "prompt fragment"`
+- `cursor.bands` (`bands:` in cursor) — entries `"lo..hi": "prompt fragment"`
+- `supervisor` — watches [id] · model str · system id · cooldown str · max_evals int · monitors [str]
+- `mcp_server` — transport stdio|http|sse · command str · args [str] · url str · auth {auth}
+- `auth` (`auth:` in mcp_server) — type str · auth_url str · token_url str · revoke_url str · client_id str · scopes [str]
+- `group` — entries `node declarations and edges (src -> dst)`
+- `use` — entries `use g as p with { param: "value" }`
+- `vars` (`vars:` in the file, workflow) — entries `name: type [enum: "a", "b"] [= default]`
+- `presets` (`presets:` in the file) — entries `name: (indented) var: literal`
+- `attachments` (`attachments:` in the file, workflow) — entries `name: file | image`
+- `attachment` (`attachments:` in attachments) — description str · accept_mime [str] · required bool
+- `secrets` (`secrets:` in the file) — entries `name: "value"`
+- `secret` (`secrets:` in secrets) — value str · as value|file · mount_path str · env str|id · optional bool · hosts [str] · description str
+- `agent` / `judge` — description str · model str · backend str · provider str · command str · input id · output id · publish id · artifact_labels [tool] · system id · user id · session fresh|inherit|inherit_if_available|fork|artifacts_only|persist · tools [tool] · tool_policy [tool] · capabilities [tool] · skills [skill] · tool_max_steps int · max_tokens int · reasoning_effort low|medium|high|xhigh|max|ultracode · timeout str · readonly bool · full_access bool · images [str] · interaction none|human|llm|llm_or_human|review|async · interaction_prompt id · interaction_model str · await wait_all|best_effort · compress on|ultra|off · auto_memory on|off · permission off|ask|deny · needs id|[id] · fallbacks {fallback} · mcp {mcp} · compaction {compaction} · memory {memory} · sandbox none|auto|{sandbox} · cursors {cursors}
+- `router` — description str · mode fan_out_all|fan_out_each|condition|round_robin|llm · model str · backend str · provider str · system id · user id · multi bool · reasoning_effort low|medium|high|xhigh|max|ultracode · over str · as id · key id · depends_on id · needs id|[id]
+- `human` — description str · input id · output id · publish id · artifact_labels [tool] · instructions id · system id · model str · interaction none|human|llm|llm_or_human|review|async · interaction_prompt id · interaction_model str · min_answers int · await wait_all|best_effort · review_url str · posture human_required|agent_verdict_ok · merge_strategy squash|merge · merge_into str|id · max_turns int
+- `tool` — description str · command str · script str · language js|node|py|python|python3|sh|bash · input id · output id · publish id · artifact_labels [tool] · await wait_all|best_effort · sandbox none|auto|{sandbox} · compress on|ultra|off · permission id · needs id|[id] · parallel_safe bool · goal str · postcondition str · policy required|recover|best_effort · recovery {recovery}
+- `recovery` (`recovery:` in tool) — max_repair_attempts int · max_agent_attempts int · model str · agent_tools [tool]
+- `compute` — description str · input id · output id · publish id · artifact_labels [tool] · await wait_all|best_effort · expr {expr}
+- `expr` (`expr:` in compute) — entries `field: "expression"`
+- `subbot` — description str · source str · with with{} · output id · needs id|[id] · isolated bool
+- `emit` — description str · event str · with with{}
+- `wait` — description str · event str · timeout str · output id
+- `await_answers` — description str · from str|id · timeout str
+- `fail` — description str · code str|id · message str · resumable bool
+- `workflow` — entry id · vars {vars} · attachments {attachments} · budget {budget} · resources {resources} · mcp {mcp} · compaction {compaction} · sandbox none|auto|{sandbox} · worktree auto|none · default_backend str · compress on|ultra|off · auto_memory on|off · loop_budget_guard on|off · repo_devbox on|off · workspace_checkpoint on|off · permission off|ask|deny · allow [str] · ask [str] · deny [str] · tool_policy [tool] · capabilities [tool] · skills [skill] · interaction none|human|llm|llm_or_human|review|async
+- `budget` (`budget:` in workflow) — max_parallel_branches int · max_duration str · max_cost_usd num · max_tokens int · warn_tokens int · max_iterations int
+- `resources` (`resources:` in workflow) — entries `name: <int> | ["member-a", "member-b"]`
+- `compaction` (`compaction:` in workflow, agent, judge) — threshold num · preserve_recent int
+- `memory` (`memory:` in agent, judge) — enabled bool · scope str · autoload [str] · read bool · write bool · pre_compact_inject bool · project_root bool · visibility str
+- `mcp` (`mcp:` in workflow, agent, judge) — autoload_project bool · inherit bool · servers [id] · disable [id]
+- `sandbox` (`sandbox:` in workflow, agent, judge, tool) — mode none|auto|inline · image str · build {sandbox.build} · user str · workspace_folder str · host_state auto|none · post_create str · env map · mounts [str|id] · network {sandbox.network}
+- `sandbox.build` (`build:` in sandbox) — dockerfile str · context str · args map
+- `sandbox.network` (`network:` in sandbox) — mode open|allowlist|denylist · preset str|id · inherit replace|append · rules [str|id]
+- `cursors` (`cursors:` in agent, judge) — enabled bool — entries `cursor_name: ident | number | "string"`
+- `fallback` (`fallbacks:` in agent, judge) — backend str · model str · provider str · on [id] · metered bool · action skip · when str
+<!-- dsl-spec:end -->
 
 ## Edges
 
@@ -582,13 +633,13 @@ workflow isolated:
     user: "1000:1000"
     network:
       mode: allowlist                 # open (default) | allowlist | denylist
-      preset: default                 # LLM + npm/pypi/golang + git hosts
-      inherit: false                  # add to (not replace) the preset
+      preset: "iterion-default"       # LLM + npm/pypi/golang + git hosts (the one built-in preset)
+      inherit: append                 # node rules compose with the workflow's: omit = merge, or replace / append
       rules: ["registry.example.com", "!evil.site"]   # host globs, inline; `!` denies
 ```
 
 Sandbox top-level modes: `auto`, `none`, or the block form
-above. `network.preset: default` already covers LLM
+above. `network.preset: "iterion-default"` already covers LLM
 endpoints, npm/pypi/golang/cargo, github/gitlab/bitbucket
 and the Nix cache — only add `rules:` for private hosts.
 

--- a/cmd/iterion/dsl.go
+++ b/cmd/iterion/dsl.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/spec"
+	"github.com/spf13/cobra"
+)
+
+// dslCmd groups the commands that inspect the .bot language itself rather
+// than a workflow written in it.
+var dslCmd = &cobra.Command{
+	Use:   "dsl",
+	Short: "Inspect the .bot DSL itself (property registry, generated reference)",
+}
+
+var (
+	dslSpecWrite  bool
+	dslSpecRoot   string
+	dslSpecRegion string
+)
+
+// dslSpecCmd renders the property registry (pkg/dsl/spec) — the one source
+// the grammar reference tables and the authoring skills' property section
+// are generated from — or regenerates those committed documents in place.
+// A conformance test holds the registry to the parser; `task dsl:check`
+// fails when a committed rendering is stale.
+var dslSpecCmd = &cobra.Command{
+	Use:   "spec",
+	Short: "Render the DSL property registry, or regenerate the committed docs from it",
+	Long: "Render the property registry every kind of the .bot DSL is described by —\n" +
+		"the full reference (default), the compact `skill` section, or the table of\n" +
+		"one kind (`--region 'table agent'`) — or, with --write, regenerate every\n" +
+		"committed generated region in place (docs/references/dsl-properties.md,\n" +
+		"docs/references/dsl-grammar.md, SKILL.md, the whats-next DSL quickref).\n\n" +
+		"The registry is held to the parser by a conformance test in both\n" +
+		"directions, so what this prints is what the parser accepts.",
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if dslSpecWrite {
+			changed, err := spec.Regenerate(dslSpecRoot)
+			for _, f := range changed {
+				fmt.Fprintf(os.Stderr, "wrote %s\n", f)
+			}
+			if err != nil {
+				return err
+			}
+			if len(changed) == 0 {
+				fmt.Fprintln(os.Stderr, "every generated region is already fresh")
+			}
+			return nil
+		}
+		body, err := spec.Render(dslSpecRegion)
+		if err != nil {
+			return err
+		}
+		_, err = os.Stdout.WriteString(body)
+		return err
+	},
+}
+
+func init() {
+	dslSpecCmd.Flags().BoolVar(&dslSpecWrite, "write", false, "Regenerate every committed generated region in place instead of printing")
+	dslSpecCmd.Flags().StringVar(&dslSpecRoot, "root", ".", "Repository root the --write paths are relative to")
+	dslSpecCmd.Flags().StringVar(&dslSpecRegion, "region", "reference", "What to print: reference, skill, or 'table <kind>'")
+	dslCmd.AddCommand(dslSpecCmd)
+	rootCmd.AddCommand(dslCmd)
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ For the architectural trade-off against prompt-only orchestration, read [why-not
 |---|---|
 | [dsl.md](dsl.md) | Language guide and map of every declaration, node family, edge form, and workflow control. |
 | [references/dsl-grammar.md](references/dsl-grammar.md) | Readable grammar derived from the parser surface. |
+| [references/dsl-properties.md](references/dsl-properties.md) | Every kind's properties, value shapes and meaning — generated from the parser's registry (`task dsl:gen`), held to the parser by a conformance test. |
 | [grammar/iterion_v1.ebnf](grammar/iterion_v1.ebnf) | Formal EBNF counterpart. |
 | [grammar/V1_SCOPE.md](grammar/V1_SCOPE.md) | Living boundary of the additively evolved V1 grammar and AST. |
 | [references/diagnostics.md](references/diagnostics.md) | Authoritative sparse catalogue: DSL C001–C199 plus async C240–C242, and bundle checks C200–C234. |

--- a/docs/adr/051-in-bot-event-driven-primitives.md
+++ b/docs/adr/051-in-bot-event-driven-primitives.md
@@ -43,10 +43,10 @@ wrong for in-run coordination).
 
 ### `emit` node
 
-```
+```iter fragment
 emit ping:
   event: "ready"
-  with: { value: "{{outputs.producer.n}}" }
+  with { value: "{{outputs.producer.n}}" }
 ```
 
 Publishes a **sticky** event named `ready` into the run registry with an
@@ -57,7 +57,7 @@ order-fragile). Non-mutating, no LLM, no shell.
 
 ### `wait` node
 
-```
+```iter fragment
 wait for_ready:
   event: "ready"
   timeout: "30s"          ## MANDATORY — the bornage

--- a/docs/adr/087-cross-backend-model-fallback-chain.md
+++ b/docs/adr/087-cross-backend-model-fallback-chain.md
@@ -116,10 +116,11 @@ already used by `secrets:` and `attachments:`, parsed from `parseLLMProp`'s
 `case TokenIdent:` arm following the tool node's `recovery:` precedent — no
 lexer, token-table or `isKeywordToken` change:
 
-```
+```iter fragment
 agent implement:
   backend: "claude_code"
   model: "claude-opus-5"
+  tools: [read_file, bash]   # explicit: a claw⇄CLI crossing with no list is refused (C176)
   fallbacks:
     api:
       backend: "claw"

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -201,7 +201,7 @@ Known hints:
 chain. The chain is the declarative generalisation of the
 `RESCUE_PROVIDER` escape hatch:
 
-```yaml
+```iter fragment
 agent reviewer:
   backend: "claude_code"
   provider: "${RESCUE_PROVIDER:-zai},anthropic"   # z.ai first, Anthropic on hard failure
@@ -256,7 +256,7 @@ A provider-specific model can be pinned per chain element with a
 `provider:model` token, so a fall-through swaps **both** the credential
 hint and the wire model:
 
-```yaml
+```iter fragment
 agent reviewer:
   backend: "claude_code"
   provider: "zai:glm-5.2,anthropic:claude-opus-4-8"   # glm-5.2 on z.ai, claude-opus-4-8 on Anthropic
@@ -286,7 +286,7 @@ credential — for the case the `provider:` chain cannot serve: a CLI
 backend whose subscription forfait has shut, continuing on a metered API
 through `claw`. See [ADR-087](adr/087-cross-backend-model-fallback-chain.md).
 
-```yaml
+```iter fragment
 agent implement:
   backend: "claude_code"          # forfait
   model: "claude-opus-5"
@@ -370,7 +370,10 @@ values keep the cooldown enabled.
 Two route properties extend the chain beyond backend switches
 ([ADR-091](adr/091-fallback-skip-route-and-plan-peer-review.md)):
 
-```yaml
+```iter fragment
+vars:
+  plan_review_policy: string = "on"   # a route's when: may only read a DECLARED var (C173)
+
 judge plan_review:
   backend: "claw"
   model: "openai/gpt-5.6-sol"
@@ -770,7 +773,7 @@ node. It lifts the sandbox to `danger-full-access` (unrestricted network +
 out-of-workspace writes) — the same posture as `codex exec -s
 danger-full-access`. It is **off by default and opt-in per node** in the workflow:
 
-```
+```iter fragment
 agent make_cover:
   backend: "codex"
   full_access: true    # codex sandbox -> danger-full-access (needed for imagegen / network)
@@ -792,7 +795,7 @@ A codex node can receive **input images** for image-to-image via the node-level
 node's `input`/`vars`/etc. and forwarded to the codex CLI as `-i`. Empty results
 (e.g. an optional reference that doesn't apply this run) are dropped.
 
-```
+```iter fragment
 agent keyframe:
   backend: "codex"
   full_access: true
@@ -877,7 +880,7 @@ xAI is a first-class claw provider. Set `XAI_API_KEY` (or store a BYOK
 key under provider `xai` in cloud mode) and point a node at a Grok
 model:
 
-```yaml
+```iter fragment
 agent planner:
   backend: "claw"
   model: "xai/grok-3"
@@ -988,11 +991,14 @@ new plumbing.
 is a multi-provider agent harness. It is the backend to reach for when you
 need **a model the other backends cannot run**.
 
-```yaml
+```iter fragment
+prompt task:
+  Review the diff for correctness and say what must change.
+
 agent review:
   backend: "pi"
   model: "openai/gpt-5.5"   # or cerebras/…, groq/…, zai/…, github-copilot/…
-  system: "…the task…"
+  system: task              # a prompt declaration, never an inline string
 ```
 
 **Install:** `npm install -g @earendil-works/pi-coding-agent` (Node ≥ 22.19)
@@ -1197,11 +1203,14 @@ Moonshot's **`kimi-code`** takes the prompt as `-p <prompt>`
 kimi -p <prompt> --output-format {text,stream-json} [-m <alias>]
 ```
 
-```yaml
+```iter fragment
+prompt task:
+  Implement the feature described in the issue and run the tests.
+
 agent implement:
   backend: "kimi"
   model: "kimi-code/kimi-for-coding" # complete kimi-code alias is preserved
-  system: "…the task…"
+  system: task
   permission: deny                   # supported on host runs
 ```
 
@@ -1217,12 +1226,15 @@ grok -p <prompt> --output-format json \
      [-m <model>] [--rules <system>] [--reasoning-effort <level>]
 ```
 
-```yaml
+```iter fragment
+prompt task:
+  Implement the feature described in the issue and run the tests.
+
 agent implement:
   backend: "grok"
   model: "grok-4.5"          # or grok-4.5-build, grok-3, …
   # model: "xai/grok-4.5"    # also fine — the xai/ prefix is stripped
-  system: "…the task…"       # delivered as --rules (appended to Grok's native prompt)
+  system: task               # delivered as --rules (appended to Grok's native prompt)
   reasoning_effort: high     # optional; mapped to --reasoning-effort
 ```
 

--- a/docs/cli-permission-seam-spike.md
+++ b/docs/cli-permission-seam-spike.md
@@ -255,11 +255,10 @@ directories, unchanged.
 C176 screens **fallback routes** only. A **primary** backend that cannot enforce
 the gate is not screened at all — this compiles clean today:
 
-```
+```iter fragment
 agent runner:
   backend: "grok"
   model: "grok-4.5"
-  …
 workflow main:
   permission: deny
   deny: ["Bash"]

--- a/docs/cursors.md
+++ b/docs/cursors.md
@@ -20,7 +20,7 @@ band carries a prompt fragment that gets appended to the agent's
 system prompt under a `## Calibration` section when the cursor is
 activated.
 
-```
+```iter fragment
 cursor ambition:
   description: "How aggressively to expand scope beyond the stated request."
   values:
@@ -42,7 +42,7 @@ A cursor declares **either** `values:` (enum) **or** `bands:`
 
 ## Activating cursors on a node
 
-```
+```iter fragment
 agent reviewer:
   model: "anthropic/claude-sonnet-4-6"
   system: review_system
@@ -51,7 +51,7 @@ agent reviewer:
     enabled: true
     ambition: ambitious      # enum lookup
     depth: 0.7               # numeric → matches the 0.67..1.0 band
-    rigor: ${ITERION_RIGOR}  # env-substitution allowed
+    rigor: "${ITERION_RIGOR}" # env-substitution allowed (quoted)
 ```
 
 When `enabled: false` (or the block is absent), no `## Calibration`

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -4,7 +4,7 @@
 
 Source files end in `.bot`; deterministic bundles end in `.botz`.
 
-This page is the language guide. For exact accepted syntax use the [readable grammar](references/dsl-grammar.md), the [formal EBNF](grammar/iterion_v1.ebnf), and the [diagnostic catalogue](references/diagnostics.md). The parser, IR compiler, and validators under [`pkg/dsl/`](../pkg/dsl/) remain the implementation source of truth.
+This page is the language guide. For exact accepted syntax use the [readable grammar](references/dsl-grammar.md), the [property reference](references/dsl-properties.md) (every kind's properties, generated from the parser's own registry), the [formal EBNF](grammar/iterion_v1.ebnf), and the [diagnostic catalogue](references/diagnostics.md). The parser, IR compiler, and validators under [`pkg/dsl/`](../pkg/dsl/) remain the implementation source of truth; an unknown property (E012) names the closest accepted one and the block it belongs to, from that same registry.
 
 A `.bot` file travels through a fixed pipeline before it runs:
 
@@ -962,6 +962,7 @@ Terminal targets `done` and `fail` are reserved and are never declared.
 Run `iterion validate workflow.bot` before execution. Diagnostics occupy sparse ranges: DSL/compiler/runtime consistency checks use C001–C199 plus the async-interaction band C240–C242, C243 (`session: persist` in a fan-out body), C244 (bounded iteration crossing a parallel-branch boundary), and C245 (trunk-only human mode in a parallel branch); bundle checks use C200–C234. The authoritative list is [references/diagnostics.md](references/diagnostics.md).
 
 - [Readable grammar](references/dsl-grammar.md)
+- [Property reference](references/dsl-properties.md) (generated)
 - [Formal EBNF](grammar/iterion_v1.ebnf)
 - [Router semantics](routers.md)
 - [Composition, iteration, resources, and sub-bots](groups-iteration-subbots.md)

--- a/docs/grammar/iterion_v1.ebnf
+++ b/docs/grammar/iterion_v1.ebnf
@@ -127,7 +127,8 @@ supervisor_prop = "watches" ":" ident_list NEWLINE
                 | "model" ":" STRING_LIT NEWLINE
                 | "system" ":" IDENT NEWLINE
                 | "cooldown" ":" STRING_LIT NEWLINE
-                | "max_evals" ":" INT_LIT NEWLINE ;
+                | "max_evals" ":" INT_LIT NEWLINE
+                | "monitors" ":" string_list NEWLINE ;
 
 (* ---------- LLM nodes ---------- *)
 
@@ -142,7 +143,9 @@ fallback_prop   = "backend" ":" STRING_LIT NEWLINE
                 | "model" ":" STRING_LIT NEWLINE
                 | "provider" ":" STRING_LIT NEWLINE
                 | "on" ":" ident_list NEWLINE
-                | "metered" ":" BOOL_LIT NEWLINE ;
+                | "metered" ":" BOOL_LIT NEWLINE
+                | "action" ":" ( "skip" | STRING_LIT ) NEWLINE
+                | "when" ":" STRING_LIT NEWLINE ;
 
 agent_decl = "agent" IDENT ":" NEWLINE INDENT { llm_prop } DEDENT ;
 judge_decl = "judge" IDENT ":" NEWLINE INDENT { llm_prop } DEDENT ;
@@ -354,6 +357,7 @@ workflow_member = vars_decl | attachments_decl | mcp_config_block
                 | "auto_memory" ":" auto_memory_mode NEWLINE
                 | "loop_budget_guard" ":" loop_budget_guard_mode NEWLINE
                 | "repo_devbox" ":" repo_devbox_mode NEWLINE
+                | "workspace_checkpoint" ":" ( "on" | "off" ) NEWLINE
                 | "permission" ":" permission_mode NEWLINE
                 | "allow" ":" string_list NEWLINE
                 | "ask" ":" string_list NEWLINE
@@ -367,6 +371,7 @@ budget_prop = "max_parallel_branches" ":" INT_LIT NEWLINE
             | "max_duration" ":" STRING_LIT NEWLINE
             | "max_cost_usd" ":" NUMBER_LIT NEWLINE
             | "max_tokens" ":" INT_LIT NEWLINE
+            | "warn_tokens" ":" INT_LIT NEWLINE
             | "max_iterations" ":" INT_LIT NEWLINE ;
 
 resources_block = "resources" ":" NEWLINE [ INDENT

--- a/docs/groups-iteration-subbots.md
+++ b/docs/groups-iteration-subbots.md
@@ -25,7 +25,7 @@ the internal edges are rewired, and `{{params.X}}` is substituted from the
 runtime. External edges address an instance's nodes via the dotted reference
 `prefix.node`.
 
-```
+```iter fragment
 group review_block(target, max_fix):
   judge check:
     model: "anthropic/claude-sonnet-4-6"
@@ -90,7 +90,7 @@ boundaries. Bounded retries and human gates can also be inlined directly in a
 `fan_out_each` branch; a subbot is no longer required solely to obtain local
 counters or resumability.
 
-```
+```iter fragment
 subbot run_ticket:
   source: "child.bot"                 # resolved relative to the parent .bot
   with { issue: "{{outputs.plan.id}}" }   # → the child's vars
@@ -98,8 +98,11 @@ subbot run_ticket:
   needs: worktree_slot                # optional resource lease for the child run
   isolated: true                      # child confines writes to its own run/worktree
 
-plan -> run_ticket
-run_ticket -> merge when validated
+workflow w:
+  entry: plan
+  plan -> run_ticket
+  run_ticket -> merge when validated
+  run_ticket -> fail else
 ```
 
 - The child's **terminal-node output** is mapped to `outputs.<subbot>.<field>`,
@@ -166,7 +169,7 @@ on an agent/judge node: the runtime cannot *prove* the child is
 workspace-independent, so you certify it, and the guard then admits the
 parallel fan-out (both `fan_out_each` and static `fan_out_all`).
 
-```
+```iter fragment
 router dispatch:
   mode: fan_out_each
   over: "{{outputs.plan.tickets}}"
@@ -177,8 +180,10 @@ subbot run_ticket:
   with { id: "{{outputs.dispatch.ticket.id}}" }
   isolated: true        # each child writes only to its own run store
 
-dispatch -> run_ticket
-run_ticket -> collect
+workflow w:
+  entry: dispatch
+  dispatch -> run_ticket
+  run_ticket -> collect
 ```
 
 > **Contract — use `isolated:` ONLY when true.** If the child *does* write the
@@ -197,7 +202,7 @@ concurrently. When each replay writes only to a **disjoint, item-keyed target**
 — the replays never race, and `parallel_safe: true` opts the tool out of the
 guard on a `fan_out_each`:
 
-```
+```iter fragment
 router keyframes_dispatch:
   mode: fan_out_each
   over: "{{outputs.prepare.keyframes}}"
@@ -208,8 +213,10 @@ tool generate_keyframe_scene:
   command: "render --scene {{outputs.keyframes_dispatch.keyframe.scene_id}}"
   parallel_safe: true   # each replay writes only to its own scene-keyed path
 
-keyframes_dispatch -> generate_keyframe_scene
-generate_keyframe_scene -> verify   # wait_all
+workflow w:
+  entry: keyframes_dispatch
+  keyframes_dispatch -> generate_keyframe_scene
+  generate_keyframe_scene -> verify   # wait_all
 ```
 
 Unlike `isolated:` (own run store/worktree) the tool still writes to the shared

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -18,7 +18,7 @@ emits `human_input_requested`, writes the question to
 `paused_waiting_human` — a durable, resumable checkpoint (see
 [resume.md](resume.md)).
 
-```
+```iter fragment
 human approval:
   instructions: approval_instructions   # a prompt: block, shown as markdown
   output: approval_decision             # the schema → drives the form widgets
@@ -56,7 +56,7 @@ map on the interaction. The studio renders it read-only above the form,
 under **"What you're reviewing"** — on the run console, the pipeline
 board, and the kanban card alike.
 
-```
+```iter fragment
 agent draft_plan:
   output: plan_out
 
@@ -82,7 +82,7 @@ two things: the reading order (the author's field order wins over
 alphabetical), and the type when the shape is ambiguous — `json` for a
 payload that arrived as a JSON string, `file` for a bare path.
 
-```
+```iter fragment
 schema review_context:
   plan: string
   findings: json

--- a/docs/memory-and-knowledge.md
+++ b/docs/memory-and-knowledge.md
@@ -154,7 +154,7 @@ auto-memory of its own (`~/.claude/projects/<cwd>/memory/`), and claw and pi
 maintain one from a prompt section plus their ordinary file tools.
 `auto_memory:` is the switch for that mechanism.
 
-```
+```iter fragment
 workflow main:
   auto_memory: off          # workflow default
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -44,7 +44,7 @@ scoped `Tool(pattern)` matches an argument:
 
 Rule lists use iterion's inline-array syntax (like `capabilities:`):
 
-```
+```iter fragment
 workflow main:
   permission: ask
   allow: ["Read(**)", "Edit(pkg/**)", "Bash(go test:*)", "Grep", "mcp__github__get_*"]

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -2,6 +2,8 @@
 
 This is the readable inventory of the syntax accepted by the current parser. The machine-oriented counterpart is [`grammar/iterion_v1.ebnf`](../grammar/iterion_v1.ebnf). Parsing success is only the first stage: the IR compiler then checks declarations, types, references, graph structure, mode-specific properties, loops, resources, and capabilities.
 
+The property tables on this page are **generated** from the parser's property registry ([`pkg/dsl/spec`](../../pkg/dsl/spec/spec.go), `task dsl:gen`), which a conformance test holds to the parser in both directions; the complete per-kind reference, blocks included, is [dsl-properties.md](dsl-properties.md).
+
 Notation: `{x}` means zero or more, `[x]` is optional, and `a | b` is an alternative. Indentation is significant; examples use two spaces. `#` comments (`##` is the same comment) and blank lines are ignored between constructs.
 
 ## File declarations
@@ -140,30 +142,49 @@ agent = "agent" IDENT ":" INDENT { llm_property } DEDENT ;
 judge = "judge" IDENT ":" INDENT { llm_property } DEDENT ;
 ```
 
-They share the exact property surface:
+They share the exact property surface (a tool-ref list accepts dotted refs and a trailing `.*`, and a quoted element is the literal name; `reasoning_effort` also takes a quoted runtime value):
 
-| Property | Value |
-|---|---|
-| `description` | string |
-| `model`, `backend`, `provider`, `command` | string |
-| `input`, `output`, `publish`, `system`, `user` | identifier reference |
-| `artifact_labels` | tool-ref-style identifier list; a quoted string is the literal label (`"review-ledger"`) |
-| `session` | `fresh`, `inherit`, `inherit_if_available`, `fork`, `artifacts_only`, `persist` |
-| `tools`, `tool_policy`, `capabilities` | tool-ref list; dotted refs and trailing `.*` are accepted, and a quoted string is the literal name |
-| `skills` | quoted string or dotted-identifier list |
-| `tool_max_steps`, `max_tokens` | integer |
-| `reasoning_effort` | `low`, `medium`, `high`, `xhigh`, `max`, `ultracode`, or quoted runtime value |
-| `timeout` | duration string |
-| `readonly`, `full_access` | boolean |
-| `images` | string list |
-| `interaction` | `none`, `human`, `llm`, `llm_or_human`, `review`, `async` |
-| `interaction_prompt` | prompt identifier |
-| `interaction_model` | string |
-| `await` | `wait_all`, `best_effort` |
-| `compress` | `off`, `on`, `ultra` |
-| `permission` | `off`, `ask`, `deny` |
-| `needs` | one resource identifier or an identifier list |
-| `mcp`, `compaction`, `memory`, `sandbox`, `cursors` | nested blocks described here |
+<!-- dsl-spec:begin table agent -->
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `backend` | string | Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `command` | string | Executable that drives a CLI backend, overriding its default binary |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `system` | ident | Prompt declaration used as the system prompt |
+| `user` | ident | Prompt declaration used as the user message |
+| `session` | one of `fresh`, `inherit`, `inherit_if_available`, `fork`, `artifacts_only`, `persist` | How the node's LLM session relates to the previous node's |
+| `tools` | tool list | Tools the node may call; restricts claw (C135 on a name it lacks), inert on a CLI backend |
+| `tool_policy` | tool list | Tool-policy entries applied on top of tools |
+| `capabilities` | tool list | Board capabilities opened to the node: board.create, board.move, board.read, … (C080/C081) |
+| `skills` | skill list | Skill-library skills mirrored into the run's .claude/skills |
+| `tool_max_steps` | int | Upper bound on tool-call rounds in one execution |
+| `max_tokens` | int | Output-token cap per call |
+| `reasoning_effort` | one of `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime |
+| `timeout` | string | Duration the node may run, e.g. "20m" |
+| `readonly` | bool | Declares the node mutates no workspace file, so it may run beside another branch |
+| `full_access` | bool | Grants the backend its full tool access |
+| `images` | string list | Image paths sent with the prompt |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | How the node asks the operator (ADR-081) |
+| `interaction_prompt` | ident | Prompt the llm interaction mode answers with in the operator's place |
+| `interaction_model` | string | Model the llm interaction mode uses |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `auto_memory` | ident — `on`, `off` | The backend's own auto-memory: on or off (C131/C132) |
+| `permission` | ident — `off`, `ask`, `deny` | Tool-permission gate: off, ask or deny (C110–C112) |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `fallbacks` | block → [fallback](#fallback) | Ordered, NAMED alternative routes taken when the primary fails (ADR-087); a chain with no route is refused |
+| `mcp` | block → [mcp](#mcp) | MCP servers active for the node |
+| `compaction` | block → [compaction](#compaction) | Context-compaction thresholds of the node's session |
+| `memory` | block → [memory](#memory) | iterion's shared-memory tools and scopes for the node |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `cursors` | block → [cursors](#cursors) | Prompt-engineering dials activated on the node (docs/cursors.md) |
+<!-- dsl-spec:end -->
 
 Nested blocks:
 
@@ -187,13 +208,26 @@ router_mode = "fan_out_all" | "fan_out_each" | "condition"
             | "round_robin" | "llm" ;
 ```
 
-| Property | Applies to |
-|---|---|
-| `description: STRING`, `mode: router_mode`, `needs: needs_value` | all routers |
-| `model: STRING`, `backend: STRING`, `provider: STRING`, `system: IDENT`, `user: IDENT`, `multi: BOOL`, `reasoning_effort: effort` | `llm` |
-| `over: STRING`, `as: IDENT`, `key: IDENT`, `depends_on: IDENT` | `fan_out_each` |
+<!-- dsl-spec:begin table router -->
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `mode` | one of `fan_out_all`, `fan_out_each`, `condition`, `round_robin`, `llm` | Routing mode |
+| `model` | string | llm mode only (C023 otherwise): Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `backend` | string | llm mode only (C023 otherwise): Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `system` | ident | llm mode only (C023 otherwise): Prompt declaration used as the system prompt |
+| `user` | ident | llm mode only (C023 otherwise): Prompt declaration used as the user message |
+| `multi` | bool | llm mode only (C023 otherwise): the model may select several outgoing edges |
+| `reasoning_effort` | one of `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | llm mode only (C023 otherwise): Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime |
+| `over` | string | fan_out_each: expression naming the collection to iterate |
+| `as` | ident | fan_out_each: alias each item is bound to ({{each.<as>}}) |
+| `key` | ident | fan_out_each: item field that names each branch |
+| `depends_on` | ident | fan_out_each: item field naming the branch this one waits for (requires key) |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+<!-- dsl-spec:end -->
 
-`fan_out_each` requires `over` and exactly one unconditional outgoing template edge. `depends_on` requires `key`. Routers never accept `await`.
+`description`, `mode` and `needs` apply to every router; the model properties to `llm`; `over`, `as`, `key` and `depends_on` to `fan_out_each`, which requires `over` and exactly one unconditional outgoing template edge. `depends_on` requires `key`. Routers never accept `await`.
 
 ## Human nodes
 
@@ -211,20 +245,28 @@ Accepted properties are `description: STRING`, `input/output/publish: IDENT`, `a
 tool = "tool" IDENT ":" INDENT { tool_property } DEDENT ;
 ```
 
-| Property | Value |
-|---|---|
-| `description`, `command`, `script`, `goal`, `postcondition` | string |
-| `language` | `js`, `py`, `sh`, `bash` |
-| `input`, `output`, `publish` | identifier |
-| `artifact_labels` | tool-ref list; a quoted string is the literal label |
-| `await` | `wait_all`, `best_effort` |
-| `sandbox` | sandbox block |
-| `compress` | `off`, `on`, `ultra` |
-| `permission` | `off`, `ask`, `deny` |
-| `needs` | one identifier or identifier list |
-| `parallel_safe` | boolean |
-| `policy` | `required`, `recover`, `best_effort` |
-| `recovery` | nested block |
+<!-- dsl-spec:begin table tool -->
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `command` | string | Shell command, run through bash -c (exclusive with script) |
+| `script` | string | Inline script run by the interpreter language: names |
+| `language` | ident — `js`, `node`, `py`, `python`, `python3`, `sh`, `bash` | Interpreter for script: |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `permission` | ident | Parsed for symmetry but NOT enforced on a tool node (C112 warns): the command runs directly, the gate is an agent's |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `parallel_safe` | bool | Declares the node safe to run beside a mutating branch |
+| `goal` | string | Verified action: what the command is for, in one line |
+| `postcondition` | string | Verified action: command whose exit code is the truth oracle at every rung |
+| `policy` | ident — `required`, `recover`, `best_effort` | Verified action: required (default), recover or best_effort (C103–C106) |
+| `recovery` | block → [recovery](#recovery) | Verified action: the self-heal ladder's bounds |
+<!-- dsl-spec:end -->
 
 `command` and `script` are mutually exclusive. Recovery accepts `max_repair_attempts: INT`, `max_agent_attempts: INT`, `model: STRING`, and `agent_tools: tool_ref_list`.
 
@@ -277,22 +319,35 @@ Groups are compile-time macros. `use` bindings substitute `{{params.name}}`; exp
 workflow = "workflow" IDENT ":" INDENT { workflow_member } DEDENT ;
 ```
 
-Workflow members may appear in any order:
+Workflow members — the properties below and the edges (`src -> dst …`) — may appear in any order:
 
-| Member | Value |
-|---|---|
-| `vars`, `attachments` | blocks described above |
-| `entry` | plain or dotted node reference |
-| `default_backend` | string |
-| `tool_policy`, `capabilities` | tool-ref list |
-| `skills` | skill-ref list |
-| `mcp`, `budget`, `resources`, `compaction`, `sandbox` | nested blocks |
-| `interaction` | interaction mode |
-| `worktree` | `auto`, `none` |
-| `compress` | `off`, `on`, `ultra` |
-| `permission` | `off`, `ask`, `deny` |
-| `allow`, `ask`, `deny` | string list |
-| edge | graph transition |
+<!-- dsl-spec:begin table workflow -->
+| Property | Value | Meaning |
+|---|---|---|
+| `entry` | ident | Node the run starts at; a dotted name addresses a group instance's node |
+| `vars` | block → [vars](#vars) | Workflow-scoped vars (merged with the file's) |
+| `attachments` | block → [attachments](#attachments) | Workflow-scoped attachments |
+| `budget` | block → [budget](#budget) | Run caps, each overridable by the matching run flag |
+| `resources` | block → [resources](#resources) | Named semaphores and pools nodes lease with needs: |
+| `mcp` | block → [mcp](#mcp) | MCP servers active for the run |
+| `compaction` | block → [compaction](#compaction) | Default compaction thresholds |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `worktree` | ident — `auto`, `none` | auto runs the workflow in a fresh git worktree, finalised into a branch; none runs in place |
+| `default_backend` | string | Backend for nodes that name none |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `auto_memory` | ident — `on`, `off` | The backend's own auto-memory: on or off (C131/C132) |
+| `loop_budget_guard` | ident — `on`, `off` | Decline a loop's back-edge the budget cannot fund: on (default) or off (C133) |
+| `repo_devbox` | ident — `on`, `off` | Load the target repo's devbox.json toolchain: on (default) or off (C134) |
+| `workspace_checkpoint` | ident — `on`, `off` | Mid-run preservation of a copy-based sandbox's workspace as a checkpoint branch pushed to the run's own remote: on (default) or off (C139) |
+| `permission` | ident — `off`, `ask`, `deny` | Tool-permission gate: off, ask or deny (C110–C112) |
+| `allow` | string list | Permission rules always allowed, Tool(pattern) syntax |
+| `ask` | string list | Permission rules that pause for approval |
+| `deny` | string list | Permission rules always blocked |
+| `tool_policy` | tool list | Run-wide tool-policy entries |
+| `capabilities` | tool list | Run-wide board capabilities |
+| `skills` | skill list | Run-wide skill-library skills |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | Default interaction mode for the run's nodes that set none |
+<!-- dsl-spec:end -->
 
 Budget fields are `max_parallel_branches: INT`, `max_duration: STRING`, `max_cost_usd: NUMBER`, `max_tokens: INT`, `warn_tokens: INT` (advisory-only — crossing it emits a `budget_warning`), and `max_iterations: INT`.
 

--- a/docs/references/dsl-properties.md
+++ b/docs/references/dsl-properties.md
@@ -1,0 +1,636 @@
+# Iterion `.bot` property reference
+
+Every declaration kind, node kind and block of the DSL, with the properties
+each accepts, the shape of every value and one line on what it means. This
+page is **generated** from the parser's property registry
+([`pkg/dsl/spec`](../../pkg/dsl/spec/spec.go)) by `iterion dsl spec --write`
+(`task dsl:gen`): the registry is held to the real parser by a conformance
+test in both directions — every property listed here is accepted by the
+parser, every property the parser accepts is listed here — and `task
+dsl:check` fails when this page no longer matches the registry. The same
+registry gives an unknown property its remedy (`iterion validate`'s `fix:`
+line: the closest accepted name, the block a name belongs to, the kind's own
+list) and feeds the property section of the authoring skills.
+
+The readable grammar is [dsl-grammar.md](dsl-grammar.md); the semantics of
+each property live in the [DSL guide](../dsl.md). The value forms:
+
+| Form | Written as |
+|---|---|
+| string | a quoted string: `"…"`, a backtick raw string, or a `\|` block scalar |
+| ident | a bare name: a declared prompt, schema or node, or an accepted word |
+| string\|ident | either of the two |
+| int, number, bool | an unquoted literal (`3`, `0.8`, `true`) |
+| one of … | one of the listed bare words |
+| ident list, string list, tool list, skill list | an inline `[a, b]` list; tool refs may be dotted (`mcp.server.*`), a quoted element is the literal name |
+| map | `{ KEY: "v" }` inline, or an indented `KEY: v` block |
+| with { … } | `with { key: "value", … }` |
+| block → kind | an indented block whose lines are that kind's properties |
+
+<!-- dsl-spec:begin reference -->
+_Generated from the parser's property registry (`pkg/dsl/spec`) by `iterion dsl spec --write`; do not edit by hand. A conformance test holds the registry to the parser in both directions._
+
+### prompt
+
+A named text block, referenced by `system:` / `user:` / `instructions:`; its body is free text with {{…}} references and {{include "file"}} directives. Blank lines in the body are dropped by the lexer; a bare header declares an empty prompt.
+
+A top-level declaration: `prompt <name>:`.
+
+Entries: `indented text lines` — Free text; the first line's indentation is stripped from every line.
+
+### schema
+
+A structured-output shape; a bare header declares an empty schema.
+
+A top-level declaration: `schema <name>:`.
+
+Entries: `field: string | bool | int | float | json | string[] | file [enum: "a", "b"]` — One field per line; `file` is valid only on the output schema of a human node whose interaction collects operator bytes (C129); the enum constraint applies to strings.
+
+### cursor
+
+A prompt-engineering dial: an enum (values:) or a numeric band map (bands:) over [0, 1], each entry carrying a prompt fragment (C083–C086).
+
+A top-level declaration: `cursor <name>:`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `values` | block → [cursor.values](#cursorvalues) | Enum form: one `name: "fragment"` per line, order preserved |
+| `bands` | block → [cursor.bands](#cursorbands) | Numeric form: one `"lo..hi": "fragment"` per line |
+
+### cursor.values
+
+The enum values of a cursor.
+
+A block opened by `values:` inside `cursor`.
+
+Entries: `name: "prompt fragment"` — Order is the position a numeric invocation snaps to.
+
+### cursor.bands
+
+The numeric bands of a cursor.
+
+A block opened by `bands:` inside `cursor`.
+
+Entries: `"lo..hi": "prompt fragment"` — The range is parsed by the compiler (C085 when malformed).
+
+### supervisor
+
+A concurrent LLM watcher of agent nodes that enqueues steering messages the watched node reads at its next turn (docs/supervisors.md); run metadata, not a graph node.
+
+A top-level declaration: `supervisor <name>:`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `watches` | ident list | Agent nodes the supervisor is armed for |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `system` | ident | Prompt declaration used as the system prompt |
+| `cooldown` | string | Minimum delay between two evaluations, e.g. "2m" |
+| `max_evals` | int | Upper bound on evaluations per run |
+| `monitors` | string list | Event patterns armed from the first event (the CLI --monitor grammar) |
+
+### mcp_server
+
+An MCP server the workflow may activate: stdio (command/args) or http/sse (url), optionally OAuth2.
+
+A top-level declaration: `mcp_server <name>:`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `transport` | one of `stdio`, `http`, `sse` | How the server is reached |
+| `command` | string | stdio: the executable |
+| `args` | string list | stdio: its arguments |
+| `url` | string | http / sse: the endpoint |
+| `auth` | block → [auth](#auth) | OAuth2 authorization-code/PKCE settings |
+
+### auth
+
+OAuth2 settings of an MCP server (only authorization-code/PKCE is wired).
+
+A block opened by `auth:` inside `mcp_server`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `type` | string | "oauth2" |
+| `auth_url` | string | Authorization endpoint |
+| `token_url` | string | Token endpoint |
+| `revoke_url` | string | Revocation endpoint (optional) |
+| `client_id` | string | OAuth client id |
+| `scopes` | string list | Scopes requested |
+
+### group
+
+A reusable node cluster with parameters, whose body holds agent/judge/router/human/tool/compute declarations and edges; instantiated by `use`, expanded at compile time (C141 warns on a use of an empty group). Prompts read `{{params.name}}`.
+
+A top-level declaration: `group <name>(<param>, …):`.
+
+Entries: `node declarations and edges (src -> dst)` — Nodes are addressed as <prefix>.<node> once instantiated.
+
+### use
+
+One instance of a group; the with map binds its parameters. No body.
+
+A top-level declaration: `use <group> as <prefix> [with { <param>: "value", … }]`.
+
+Entries: `use g as p with { param: "value" }` — A single line, no indented body.
+
+### vars
+
+Typed run parameters, overridable with --var and presets.
+
+A block opened by `vars:` inside the top level, `workflow`.
+
+Entries: `name: type [enum: "a", "b"] [= default]` — type is string, bool, int, float, json or string[]; the enum constraint applies to strings; a json/string[] default is a quoted JSON text.
+
+### presets
+
+Named bundles of var values selected with --recipe / --preset.
+
+A block opened by `presets:` inside the top level.
+
+Entries: `name: (indented) var: literal` — Each entry is a preset name with one `var: literal` line per value.
+
+### attachments
+
+Operator-supplied files and images the run receives.
+
+A block opened by `attachments:` inside the top level, `workflow`.
+
+Entries: `name: file | image` — An entry may open an indented sub-block; an entry's sub-block is a [attachment](#attachment).
+
+### attachment
+
+The optional sub-block of one attachment.
+
+An entry opened by `attachments:` inside `attachments`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `accept_mime` | string list | MIME types accepted |
+| `required` | bool | The run cannot start without it |
+
+### secrets
+
+Secrets the run resolves by name from the team's or the local store (docs/secrets.md).
+
+A block opened by `secrets:` inside the top level.
+
+Entries: `name: "value"` — The value on the header line is optional: a bare `name:` (with or without a sub-block) resolves the stored secret by name; an entry's sub-block is a [secret](#secret).
+
+### secret
+
+The optional sub-block of one secret.
+
+An entry opened by `secrets:` inside `secrets`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `value` | string | Inline value — prefer the stored secret, resolved by name |
+| `as` | ident — `value`, `file` | How the secret is materialised: value (env/template) or file |
+| `mount_path` | string | as: file — the path inside the sandbox |
+| `env` | string\|ident | Environment variable that receives the value |
+| `optional` | bool | A missing secret does not fail the launch |
+| `hosts` | string list | Hosts the secret may be sent to |
+| `description` | string | Free-text description shown by the studio and the reports |
+
+### agent
+
+An LLM node with tools, structured I/O and any backend.
+
+A node: `agent <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `backend` | string | Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `command` | string | Executable that drives a CLI backend, overriding its default binary |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `system` | ident | Prompt declaration used as the system prompt |
+| `user` | ident | Prompt declaration used as the user message |
+| `session` | one of `fresh`, `inherit`, `inherit_if_available`, `fork`, `artifacts_only`, `persist` | How the node's LLM session relates to the previous node's |
+| `tools` | tool list | Tools the node may call; restricts claw (C135 on a name it lacks), inert on a CLI backend |
+| `tool_policy` | tool list | Tool-policy entries applied on top of tools |
+| `capabilities` | tool list | Board capabilities opened to the node: board.create, board.move, board.read, … (C080/C081) |
+| `skills` | skill list | Skill-library skills mirrored into the run's .claude/skills |
+| `tool_max_steps` | int | Upper bound on tool-call rounds in one execution |
+| `max_tokens` | int | Output-token cap per call |
+| `reasoning_effort` | one of `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime |
+| `timeout` | string | Duration the node may run, e.g. "20m" |
+| `readonly` | bool | Declares the node mutates no workspace file, so it may run beside another branch |
+| `full_access` | bool | Grants the backend its full tool access |
+| `images` | string list | Image paths sent with the prompt |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | How the node asks the operator (ADR-081) |
+| `interaction_prompt` | ident | Prompt the llm interaction mode answers with in the operator's place |
+| `interaction_model` | string | Model the llm interaction mode uses |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `auto_memory` | ident — `on`, `off` | The backend's own auto-memory: on or off (C131/C132) |
+| `permission` | ident — `off`, `ask`, `deny` | Tool-permission gate: off, ask or deny (C110–C112) |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `fallbacks` | block → [fallback](#fallback) | Ordered, NAMED alternative routes taken when the primary fails (ADR-087); a chain with no route is refused |
+| `mcp` | block → [mcp](#mcp) | MCP servers active for the node |
+| `compaction` | block → [compaction](#compaction) | Context-compaction thresholds of the node's session |
+| `memory` | block → [memory](#memory) | iterion's shared-memory tools and scopes for the node |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `cursors` | block → [cursors](#cursors) | Prompt-engineering dials activated on the node (docs/cursors.md) |
+
+### judge
+
+An LLM node producing verdicts; same surface as an agent, typically without tools.
+
+A node: `judge <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `backend` | string | Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `command` | string | Executable that drives a CLI backend, overriding its default binary |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `system` | ident | Prompt declaration used as the system prompt |
+| `user` | ident | Prompt declaration used as the user message |
+| `session` | one of `fresh`, `inherit`, `inherit_if_available`, `fork`, `artifacts_only`, `persist` | How the node's LLM session relates to the previous node's |
+| `tools` | tool list | Tools the node may call; restricts claw (C135 on a name it lacks), inert on a CLI backend |
+| `tool_policy` | tool list | Tool-policy entries applied on top of tools |
+| `capabilities` | tool list | Board capabilities opened to the node: board.create, board.move, board.read, … (C080/C081) |
+| `skills` | skill list | Skill-library skills mirrored into the run's .claude/skills |
+| `tool_max_steps` | int | Upper bound on tool-call rounds in one execution |
+| `max_tokens` | int | Output-token cap per call |
+| `reasoning_effort` | one of `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime |
+| `timeout` | string | Duration the node may run, e.g. "20m" |
+| `readonly` | bool | Declares the node mutates no workspace file, so it may run beside another branch |
+| `full_access` | bool | Grants the backend its full tool access |
+| `images` | string list | Image paths sent with the prompt |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | How the node asks the operator (ADR-081) |
+| `interaction_prompt` | ident | Prompt the llm interaction mode answers with in the operator's place |
+| `interaction_model` | string | Model the llm interaction mode uses |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `auto_memory` | ident — `on`, `off` | The backend's own auto-memory: on or off (C131/C132) |
+| `permission` | ident — `off`, `ask`, `deny` | Tool-permission gate: off, ask or deny (C110–C112) |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `fallbacks` | block → [fallback](#fallback) | Ordered, NAMED alternative routes taken when the primary fails (ADR-087); a chain with no route is refused |
+| `mcp` | block → [mcp](#mcp) | MCP servers active for the node |
+| `compaction` | block → [compaction](#compaction) | Context-compaction thresholds of the node's session |
+| `memory` | block → [memory](#memory) | iterion's shared-memory tools and scopes for the node |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `cursors` | block → [cursors](#cursors) | Prompt-engineering dials activated on the node (docs/cursors.md) |
+
+### router
+
+A routing node: fan_out_all, fan_out_each, condition, round_robin or llm (docs/routers.md). Never takes await.
+
+A node: `router <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `mode` | one of `fan_out_all`, `fan_out_each`, `condition`, `round_robin`, `llm` | Routing mode |
+| `model` | string | llm mode only (C023 otherwise): Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `backend` | string | llm mode only (C023 otherwise): Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `system` | ident | llm mode only (C023 otherwise): Prompt declaration used as the system prompt |
+| `user` | ident | llm mode only (C023 otherwise): Prompt declaration used as the user message |
+| `multi` | bool | llm mode only (C023 otherwise): the model may select several outgoing edges |
+| `reasoning_effort` | one of `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | llm mode only (C023 otherwise): Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime |
+| `over` | string | fan_out_each: expression naming the collection to iterate |
+| `as` | ident | fan_out_each: alias each item is bound to ({{each.<as>}}) |
+| `key` | ident | fan_out_each: item field that names each branch |
+| `depends_on` | ident | fan_out_each: item field naming the branch this one waits for (requires key) |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+
+### human
+
+A pause point the operator answers (interaction human, the default), an LLM answers (llm / llm_or_human), or a review gate (review).
+
+A node: `human <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `instructions` | ident | Prompt shown to the operator as the question |
+| `system` | ident | Prompt declaration used as the system prompt |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | How the node asks the operator (ADR-081) |
+| `interaction_prompt` | ident | Prompt the llm interaction mode answers with in the operator's place |
+| `interaction_model` | string | Model the llm interaction mode uses |
+| `min_answers` | int | Answers required before the node resumes |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `review_url` | string | review: the PR/MR the gate reviews (a {{…}} reference is accepted) |
+| `posture` | string\|ident — `human_required`, `agent_verdict_ok` | review: who may merge — human_required (default) or agent_verdict_ok; not validated at compile, another word reads as the default |
+| `merge_strategy` | string\|ident — `squash`, `merge` | review: squash (default) or merge; not validated at compile |
+| `merge_into` | string\|ident | review: current (default), none or a branch name |
+| `max_turns` | int | review: conversation turns before the gate escalates |
+
+### tool
+
+Direct shell execution, no LLM: `command:` runs through bash -c, `script:` through the interpreter `language:` names; with `output:` the command prints schema-shaped JSON on stdout. A Verified Action adds goal + postcondition + policy + recovery (ADR-044).
+
+A node: `tool <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `command` | string | Shell command, run through bash -c (exclusive with script) |
+| `script` | string | Inline script run by the interpreter language: names |
+| `language` | ident — `js`, `node`, `py`, `python`, `python3`, `sh`, `bash` | Interpreter for script: |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `permission` | ident | Parsed for symmetry but NOT enforced on a tool node (C112 warns): the command runs directly, the gate is an agent's |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `parallel_safe` | bool | Declares the node safe to run beside a mutating branch |
+| `goal` | string | Verified action: what the command is for, in one line |
+| `postcondition` | string | Verified action: command whose exit code is the truth oracle at every rung |
+| `policy` | ident — `required`, `recover`, `best_effort` | Verified action: required (default), recover or best_effort (C103–C106) |
+| `recovery` | block → [recovery](#recovery) | Verified action: the self-heal ladder's bounds |
+
+### recovery
+
+Bounds of a Verified Action's recovery ladder (idempotent-skip → recipe → self-repair → agent → policy).
+
+A block opened by `recovery:` inside `tool`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `max_repair_attempts` | int | Self-repair rungs before the agent rung |
+| `max_agent_attempts` | int | Agent rungs before the policy decides |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `agent_tools` | tool list | Tools the recovery agent may call |
+
+### compute
+
+A deterministic expression node: each expr entry is evaluated by the bounded expression language into an output field.
+
+A node: `compute <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `input` | ident | Schema the node's input is validated against |
+| `output` | ident | Schema the node's structured output must match |
+| `publish` | ident | Artifact name the output is published under (read back as {{artifacts.<name>}}) |
+| `artifact_labels` | tool list | Labels stamped on the published artifact; a quoted element is the literal label |
+| `await` | one of `wait_all`, `best_effort` | Convergence rule when several incoming branches reach the node |
+| `expr` | block → [expr](#expr) | One `field: "expression"` per output field |
+
+### expr
+
+The expressions of a compute node.
+
+A block opened by `expr:` inside `compute`.
+
+Entries: `field: "expression"` — An expression over vars, input, outputs, artifacts, loop and run — not a {{template}}.
+
+### subbot
+
+Runs another .bot as a nested child run; its outputs read back as {{outputs.<subbot>.<field>}} (C119).
+
+A node: `subbot <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `source` | string | Path of the child .bot, relative to this file |
+| `with` | with { … } | Child vars; {{…}} references are allowed in the values |
+| `output` | ident | Schema the node's structured output must match |
+| `needs` | ident \| ident list | Resource(s) leased from the workflow's resources: block for the node's duration |
+| `isolated` | bool | Asserts the child runs in its own workspace |
+
+### emit
+
+Publishes a named run-scoped event with an immutable payload (ADR-051).
+
+A node: `emit <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `event` | string | Event name |
+| `with` | with { … } | Payload fields |
+
+### wait
+
+Blocks its branch until the named event fires; the timeout is mandatory (ADR-051, C196–C198).
+
+A node: `wait <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `event` | string | Event name awaited |
+| `timeout` | string | Duration after which the wait fails, e.g. "30s" (mandatory) |
+| `output` | ident | Schema the node's structured output must match |
+
+### await_answers
+
+Parks its branch until every pending ask_user_async question of `from:` (or the whole run) is answered; output {answers: […]} (ADR-081, C241/C242).
+
+A node: `await_answers <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `from` | string\|ident | Node whose async questions are awaited; omit for the whole run |
+| `timeout` | string | Duration after which the node fails, e.g. "30m" (mandatory) |
+
+### fail
+
+A named terminal failure with a typed code and a message (C247 checks the UPPER_SNAKE code, C248 refuses a reserved one).
+
+A node: `fail <name>:` at the top level or inside a `group`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `description` | string | Free-text description shown by the studio and the reports |
+| `code` | string\|ident | Error code, UPPER_SNAKE (bare or quoted) |
+| `message` | string | Message; {{…}} references are rendered |
+| `resumable` | bool | Leaves the run failed_resumable instead of failed |
+
+### workflow
+
+The graph: entry, edges (`src -> dst [when …|else] [as loop(N)] [with {…}]`), and the run-wide settings; a bare header declares an empty workflow (C008).
+
+A top-level declaration: `workflow <name>:`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `entry` | ident | Node the run starts at; a dotted name addresses a group instance's node |
+| `vars` | block → [vars](#vars) | Workflow-scoped vars (merged with the file's) |
+| `attachments` | block → [attachments](#attachments) | Workflow-scoped attachments |
+| `budget` | block → [budget](#budget) | Run caps, each overridable by the matching run flag |
+| `resources` | block → [resources](#resources) | Named semaphores and pools nodes lease with needs: |
+| `mcp` | block → [mcp](#mcp) | MCP servers active for the run |
+| `compaction` | block → [compaction](#compaction) | Default compaction thresholds |
+| `sandbox` | one of `none`, `auto`, or a block → [sandbox](#sandbox) | Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044) |
+| `worktree` | ident — `auto`, `none` | auto runs the workflow in a fresh git worktree, finalised into a branch; none runs in place |
+| `default_backend` | string | Backend for nodes that name none |
+| `compress` | ident — `on`, `ultra`, `off` | Command-output compression: on, ultra or off (C102) |
+| `auto_memory` | ident — `on`, `off` | The backend's own auto-memory: on or off (C131/C132) |
+| `loop_budget_guard` | ident — `on`, `off` | Decline a loop's back-edge the budget cannot fund: on (default) or off (C133) |
+| `repo_devbox` | ident — `on`, `off` | Load the target repo's devbox.json toolchain: on (default) or off (C134) |
+| `workspace_checkpoint` | ident — `on`, `off` | Mid-run preservation of a copy-based sandbox's workspace as a checkpoint branch pushed to the run's own remote: on (default) or off (C139) |
+| `permission` | ident — `off`, `ask`, `deny` | Tool-permission gate: off, ask or deny (C110–C112) |
+| `allow` | string list | Permission rules always allowed, Tool(pattern) syntax |
+| `ask` | string list | Permission rules that pause for approval |
+| `deny` | string list | Permission rules always blocked |
+| `tool_policy` | tool list | Run-wide tool-policy entries |
+| `capabilities` | tool list | Run-wide board capabilities |
+| `skills` | skill list | Run-wide skill-library skills |
+| `interaction` | one of `none`, `human`, `llm`, `llm_or_human`, `review`, `async` | Default interaction mode for the run's nodes that set none |
+
+### budget
+
+Run caps; a zero or absent cap is the engine default, and each is overridable per run without editing the .bot.
+
+A block opened by `budget:` inside `workflow`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `max_parallel_branches` | int | Concurrent branches (0 = engine default) |
+| `max_duration` | string | Wall-clock cap, e.g. "4h" |
+| `max_cost_usd` | number | Spend cap in USD |
+| `max_tokens` | int | Total token cap |
+| `warn_tokens` | int | Advisory: crossing it emits budget_warning |
+| `max_iterations` | int | Total node executions; also the fuel of an unbounded loop (C097) |
+
+### resources
+
+Named resources nodes lease with needs:.
+
+A block opened by `resources:` inside `workflow`.
+
+Entries: `name: <int> | ["member-a", "member-b"]` — A count is a semaphore; a quoted list is a pool whose members are leased one at a time.
+
+### compaction
+
+When and how a session's context is compacted.
+
+A block opened by `compaction:` inside `workflow`, `agent`, `judge`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `threshold` | number | Context fraction (0–1) that triggers compaction |
+| `preserve_recent` | int | Recent messages kept verbatim |
+
+### memory
+
+iterion's shared-memory tools for a node (docs/memory-and-knowledge.md); distinct from auto_memory.
+
+A block opened by `memory:` inside `agent`, `judge`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `enabled` | bool | Open the memory tools to the node |
+| `scope` | string | Memory scope the tools read and write |
+| `autoload` | string list | Documents injected at node start |
+| `read` | bool | Allow memory_read |
+| `write` | bool | Allow memory_write |
+| `pre_compact_inject` | bool | Re-inject memory before a compaction |
+| `project_root` | bool | Key the space on the repository root rather than the working directory (legacy; exclusive with visibility) |
+| `visibility` | string | Who sees the space: bot, project, cross_project, user, org or global (C170) |
+
+### mcp
+
+Which MCP servers are active; an empty block wires nothing (C135 stays an error).
+
+A block opened by `mcp:` inside `workflow`, `agent`, `judge`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `autoload_project` | bool | Workflow scope: load the repository's .mcp.json servers (default true) |
+| `inherit` | bool | Node scope: inherit the workflow's active servers (default true) |
+| `servers` | ident list | mcp_server declarations activated |
+| `disable` | ident list | Servers removed from the ambient set |
+
+### sandbox
+
+Per-run container isolation (docs/sandbox.md): the short form names a mode, the block form is inline and needs image: or build: (C044).
+
+A block opened by `sandbox:` inside `workflow`, `agent`, `judge`, `tool`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `mode` | one of `none`, `auto`, `inline` | none, auto (devcontainer.json or the published slim image) or inline |
+| `image` | string | Container image (exclusive with build) |
+| `build` | block → [sandbox.build](#sandboxbuild) | Dockerfile build, local docker only (V2-6) |
+| `user` | string | Container user |
+| `workspace_folder` | string | Mount point of the workspace inside the container |
+| `host_state` | ident — `auto`, `none` | Mount ~/.iterion and ~/.claude into the container: auto or none |
+| `post_create` | string | Command run once after the container starts |
+| `env` | map | Environment variables |
+| `mounts` | string\|ident list | Extra bind mounts |
+| `network` | block → [sandbox.network](#sandboxnetwork) | Egress policy (open by default) |
+
+### sandbox.build
+
+A Dockerfile build of the sandbox image (docker driver only).
+
+A block opened by `build:` inside `sandbox`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `dockerfile` | string | Dockerfile path |
+| `context` | string | Build context |
+| `args` | map | Build arguments |
+
+### sandbox.network
+
+Network egress of the sandbox, enforced by a CONNECT proxy on the host.
+
+A block opened by `network:` inside `sandbox`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `mode` | one of `open`, `allowlist`, `denylist` | open (no proxy), allowlist or denylist |
+| `preset` | string\|ident | Rule preset, e.g. "iterion-default" |
+| `inherit` | ident — `replace`, `append` | How a node's rules compose with the workflow's: omit to merge (the default), or replace / append (C044 on another word) |
+| `rules` | string\|ident list | Hosts and globs; a leading ! negates |
+
+### cursors
+
+Cursor activation on a node: the reserved enabled: key plus one setting per declared cursor.
+
+A block opened by `cursors:` inside `agent`, `judge`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `enabled` | bool | Gate for the whole block (an explicit block opts in) |
+
+Entries: `cursor_name: ident | number | "string"` — A value name, a position in [0, 1], or a quoted string for ${VAR} substitution.
+
+### fallback
+
+One named route of a fallbacks: chain (ADR-087/ADR-091), tried in declaration order.
+
+An entry opened by `fallbacks:` inside `agent`, `judge`.
+
+| Property | Value | Meaning |
+|---|---|---|
+| `backend` | string | Execution backend: claw, claude_code, codex, pi, kimi or grok |
+| `model` | string | Model id the backend serves, e.g. "anthropic/claude-opus-5"; empty takes the backend's default |
+| `provider` | string | Provider hint for credential resolution, e.g. "anthropic" |
+| `on` | ident list over `usage_window`, `auth`, `unavailable`, `transient_exhausted`, `any` | Failure classes that take this route (default usage_window, unavailable; never any or auth by default) |
+| `metered` | bool | The route spends a metered API key (credential hint) |
+| `action` | ident — `skip` | skip: complete the node with a zero-value output stamped _skipped instead of failing |
+| `when` | string | Expression over vars that gates the route |
+
+<!-- dsl-spec:end -->

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -296,14 +296,13 @@ ephemeral port). The container receives the proxy URL via standard
 need the stricter security-first posture opt in by declaring an
 explicit `network:` block:
 
-```yaml
+```iter fragment:workflow
 sandbox:
   image: "ghcr.io/socialgouv/iterion-sandbox-full:edge"
   network:
     mode: allowlist
-    preset: iterion-default
-    rules:
-      - "internal.acme.dev"
+    preset: "iterion-default"        # quoted: the lexer reads a bare kebab-case name as two words
+    rules: ["internal.acme.dev"]     # an inline list, never `- item` lines
 ```
 
 The shipped **`iterion-default`** preset is the recommended

--- a/docs/skills-library.md
+++ b/docs/skills-library.md
@@ -52,7 +52,7 @@ No sealing: a skill is public guidance text, not a secret.
 
 Add a `skills:` list to an `agent`/`judge` node, or a workflow-level default:
 
-```
+```iter fragment
 agent draft:
   model: "anthropic/claude-sonnet-4-6"
   skills: ["changelog-writer", "semver-bump"]

--- a/docs/supervisors.md
+++ b/docs/supervisors.md
@@ -56,7 +56,7 @@ Declare the supervisor inline in the workflow it watches — a top-level
 arms it only while a watched node is active. Multiple supervisors are
 allowed (each watching a different node set).
 
-```
+```iter fragment
 supervisor watchdog:
   watches: [implement, fix]            # agent node(s) to steer (omit = whole run)
   model: "anthropic/claude-opus-5"  # optional pin; resolution below

--- a/pkg/bundle/loader.go
+++ b/pkg/bundle/loader.go
@@ -77,6 +77,15 @@ func Open(path, cacheRoot string) (*Bundle, func() error, error) {
 			return nil, nil, err
 		}
 	}
+	// The extracted bundle's prompts/ live under this root, and a prompt's
+	// {{include}} resolves only beside an ABSOLUTELY named file (C055
+	// otherwise): the root is made absolute here, once, so no caller's
+	// relative spelling of it can reach that refusal.
+	absRoot, err := filepath.Abs(cacheRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("bundle: resolve cache root %s: %w", cacheRoot, err)
+	}
+	cacheRoot = absRoot
 	if err := os.MkdirAll(cacheRoot, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("bundle: mkdir cache %s: %w", cacheRoot, err)
 	}

--- a/pkg/bundle/open_cache_root_test.go
+++ b/pkg/bundle/open_cache_root_test.go
@@ -1,0 +1,33 @@
+package bundle
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A relative cache root is made absolute by Open itself: the extracted
+// bundle's prompts/ sit under it, and a prompt's {{include}} resolves only
+// beside an absolutely named file, so a caller's relative spelling of the
+// root must not be what a bundle prompt's Span.File inherits.
+func TestOpenAbsolutisesARelativeCacheRoot(t *testing.T) {
+	path := fixtureBundleWithSkillsPrompts(t)
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	b, cleanup, err := Open(path, "cache")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer cleanup()
+	for what, dir := range map[string]string{"Dir": b.Dir, "PromptsDir": b.PromptsDir, "IterPath": b.IterPath} {
+		if dir == "" {
+			t.Fatalf("%s is empty", what)
+		}
+		if !filepath.IsAbs(dir) {
+			t.Errorf("%s = %q is not absolute", what, dir)
+		}
+		if !strings.HasPrefix(dir, filepath.Join(cwd, "cache")) {
+			t.Errorf("%s = %q is not under the cache root %q", what, dir, filepath.Join(cwd, "cache"))
+		}
+	}
+}

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -925,7 +925,7 @@ type SandboxNetworkBlock struct {
 	Mode    string   // "allowlist" | "denylist" | "open" | ""
 	Preset  string   // "iterion-default" or named preset
 	Rules   []string // glob patterns + "!exclusions"
-	Inherit string   // "merge" | "replace" | "append" — node scope only
+	Inherit string   // "" (merge, the default) | "replace" | "append" — node scope only; the word merge is not a value
 	Span    Span
 }
 

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -259,6 +259,16 @@ func (c *compiler) compileSandboxBlock(blk *ast.SandboxBlock, scope, name string
 	}
 	switch blk.Mode {
 	case "", "none", "auto", "inline":
+	case "open", "allowlist", "denylist":
+		// A network mode written on the sandbox: the one name the two
+		// blocks share, so the mistake is naming the right block — an
+		// author who wrote `mode: allowlist` under `sandbox:` (or whose
+		// `network:` body sat de-indented after a blank line) meant the
+		// network's.
+		c.errorfAt(DiagInvalidSandboxMode, name, "",
+			"%s %q has invalid sandbox mode %q: that is a network: mode — write it as `network:` + `mode: %s` under `sandbox:` (the sandbox's own modes are \"none\", \"auto\" and \"inline\")",
+			scope, name, blk.Mode, blk.Mode)
+		return nil
 	default:
 		c.errorfAt(DiagInvalidSandboxMode, name, "",
 			"%s %q has invalid sandbox mode %q (want \"\", \"none\", \"auto\", or \"inline\")",
@@ -293,6 +303,26 @@ func (c *compiler) compileSandboxBlock(blk *ast.SandboxBlock, scope, name string
 		spec.Mounts = append([]string(nil), blk.Mounts...)
 	}
 	if blk.Network != nil {
+		// The driver refuses these at prepare time (pkg/sandbox Spec.Validate),
+		// long after `iterion validate` said OK: refuse them here, where the
+		// author is. The inherit modes are the sandbox package's: merge is the
+		// empty value, never a word.
+		switch blk.Network.Mode {
+		case "", "open", "allowlist", "denylist":
+		default:
+			c.errorfAt(DiagInvalidSandboxMode, name, "",
+				"%s %q has invalid sandbox.network mode %q (want \"open\", \"allowlist\" or \"denylist\")",
+				scope, name, blk.Network.Mode)
+			return nil
+		}
+		switch blk.Network.Inherit {
+		case "", "replace", "append":
+		default:
+			c.errorfAt(DiagInvalidSandboxMode, name, "",
+				"%s %q has invalid sandbox.network inherit %q (want \"replace\" or \"append\"; omit it to merge, the default)",
+				scope, name, blk.Network.Inherit)
+			return nil
+		}
 		spec.Network = &SandboxNetwork{
 			Mode:    blk.Network.Mode,
 			Preset:  blk.Network.Preset,

--- a/pkg/dsl/ir/diag_catalog_test.go
+++ b/pkg/dsl/ir/diag_catalog_test.go
@@ -119,7 +119,9 @@ func TestParseDiagnosticsCarryHint(t *testing.T) {
 	if d.Code != parser.DiagUnknownProperty {
 		t.Fatalf("code = %s, want %s", d.Code, parser.DiagUnknownProperty)
 	}
-	if d.Hint == "" || d.Hint != parser.HintFor(d.Code) {
-		t.Errorf("hint = %q, want the catalogued one", d.Hint)
+	// E012's hint is the registry's remedy (pkg/dsl/spec) — at least the
+	// kind's own property list — not the catalogue's generic line.
+	if d.Hint == "" || !strings.Contains(d.Hint, "agent accepts:") {
+		t.Errorf("hint = %q, want the registry's remedy naming what an agent accepts", d.Hint)
 	}
 }

--- a/pkg/dsl/ir/sandbox.go
+++ b/pkg/dsl/ir/sandbox.go
@@ -69,7 +69,7 @@ type SandboxNetwork struct {
 	Mode    string   // "allowlist" | "denylist" | "open" | ""
 	Preset  string   // "iterion-default" or named preset
 	Rules   []string // glob patterns + "!exclusions"
-	Inherit string   // "merge" (default) | "replace" | "append" — node scope only
+	Inherit string   // "" (merge, the default) | "replace" | "append" — node scope only; the word merge is not a value
 }
 
 // IsActive reports whether the spec requests an active sandbox mode

--- a/pkg/dsl/ir/sandbox_network_compile_test.go
+++ b/pkg/dsl/ir/sandbox_network_compile_test.go
@@ -1,0 +1,46 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// A network block's mode and inherit are refused at compile (C044) with the
+// accepted words named — not at the driver's prepare, after `iterion
+// validate` said OK. `merge` is the inherit DEFAULT, spelled by omission; the
+// word itself is not a value.
+func TestSandboxNetworkModeAndInheritAreCheckedAtCompile(t *testing.T) {
+	compile := func(network string) []string {
+		src := "agent a:\n  model: \"m\"\nworkflow w:\n  entry: a\n  sandbox:\n    image: \"img\"\n    network:\n" + network + "  a -> done\n"
+		pr := parser.Parse("net.bot", src)
+		if len(pr.Diagnostics) != 0 {
+			t.Fatalf("parse: %v", pr.Diagnostics)
+		}
+		res := Compile(pr.File)
+		var out []string
+		for _, d := range res.Diagnostics {
+			if d.Severity == SeverityError {
+				out = append(out, string(d.Code)+": "+d.Message)
+			}
+		}
+		return out
+	}
+	if errs := compile("      mode: allowlist\n      inherit: append\n"); len(errs) != 0 {
+		t.Fatalf("a valid network block drew %v", errs)
+	}
+	if errs := compile("      mode: allowlist\n"); len(errs) != 0 {
+		t.Fatalf("an omitted inherit (merge) drew %v", errs)
+	}
+	for _, c := range []struct{ body, want string }{
+		{"      mode: allowlist\n      inherit: merge\n", "invalid sandbox.network inherit \"merge\""},
+		{"      mode: allowlist\n      inherit: false\n", "invalid sandbox.network inherit \"false\""},
+		{"      mode: blocklist\n", "invalid sandbox.network mode \"blocklist\""},
+	} {
+		errs := compile(c.body)
+		if len(errs) != 1 || !strings.HasPrefix(errs[0], "C044: ") || !strings.Contains(errs[0], c.want) {
+			t.Errorf("%q: want one C044 containing %q, got %v", c.body, c.want, errs)
+		}
+	}
+}

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -518,14 +518,18 @@ func (p *parser) unknownProperty(kind string, t Token, name string) {
 }
 
 // skipIndentedBlock drops the indented block that follows a refused header,
-// so its lines are not reported one by one as strays of the parent.
+// so its lines are not reported one by one as strays of the parent. A
+// lexer diagnosis met on the way (a tab, an unclosed quote) is still
+// reported: it is the author's mistake, not cascade noise, and dropped with
+// the block it would only resurface after the header is fixed.
 func (p *parser) skipIndentedBlock() {
 	if p.peek().Type != TokenIndent {
 		return
 	}
 	depth := 0
 	for {
-		switch p.next().Type {
+		t := p.next()
+		switch t.Type {
 		case TokenIndent:
 			depth++
 		case TokenDedent:
@@ -533,6 +537,8 @@ func (p *parser) skipIndentedBlock() {
 			if depth == 0 {
 				return
 			}
+		case TokenError:
+			p.lexerError(t)
 		case TokenEOF:
 			return
 		}
@@ -547,4 +553,27 @@ func (p *parser) enterBlock(host string) func() {
 	prev := p.blockHost
 	p.blockHost = host
 	return func() { p.blockHost = prev }
+}
+
+// skipUnknownProperty drops what an unknown property brought: the rest of
+// its line and, when the property was a misspelt block header, the indented
+// body under it — which would otherwise spill into the enclosing kind's
+// property switch one stray line at a time, each with a diagnostic of its
+// own and the compile errors that follow (a `sandbx:` block's `user:` read
+// as the agent's prompt reference). Every E012 site recovers through it.
+func (p *parser) skipUnknownProperty() {
+	p.skipToNewline()
+	p.skipNewlines()
+	p.skipIndentedBlock()
+}
+
+// declHeaderAhead reports whether the tokens at the cursor read as a
+// declaration header — `<keyword> <name>:` — without consuming them.
+func (p *parser) declHeaderAhead() bool {
+	at := p.lex.ti
+	kw := p.next()
+	name := p.next()
+	isHeader := kw.Type != TokenEOF && tokenAsIdent(name) != "" && p.peek().Type == TokenColon
+	p.lex.ti = at
+	return isHeader
 }

--- a/pkg/dsl/parser/parser.go
+++ b/pkg/dsl/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+	"github.com/SocialGouv/iterion/pkg/dsl/spec"
 )
 
 // ParseResult is the output of Parse.
@@ -25,6 +26,11 @@ type parser struct {
 	lex   *Lexer
 	file  string
 	diags []Diagnostic
+	// blockHost is the kind whose body the block being parsed sits in — what
+	// an "outdent it" remedy must name when the block has several possible
+	// hosts (an mcp: block under a workflow is not an agent's). Set by
+	// enterBlock, "" at the top level.
+	blockHost string
 }
 
 // ---- helpers ----
@@ -498,4 +504,47 @@ func (p *parser) parseDeclHeader(kind string) (start Token, name string, ok bool
 		return start, name, false
 	}
 	return start, name, true
+}
+
+// unknownProperty reports a property the kind does not accept, with the
+// remedy the registry can name (spec.UnknownPropertyHint): the closest
+// accepted names, the block or the enclosing kind the name belongs to, and
+// the kind's own list — so the author does not have to open the reference.
+// kind is the registry's name for the kind, which is also the word the
+// message uses; the conformance test in pkg/dsl/spec holds the two sets of
+// names together.
+func (p *parser) unknownProperty(kind string, t Token, name string) {
+	p.addErrorHint(DiagUnknownProperty, t, "unknown "+kind+" property '"+name+"'", spec.UnknownPropertyHintIn(kind, p.blockHost, name))
+}
+
+// skipIndentedBlock drops the indented block that follows a refused header,
+// so its lines are not reported one by one as strays of the parent.
+func (p *parser) skipIndentedBlock() {
+	if p.peek().Type != TokenIndent {
+		return
+	}
+	depth := 0
+	for {
+		switch p.next().Type {
+		case TokenIndent:
+			depth++
+		case TokenDedent:
+			depth--
+			if depth == 0 {
+				return
+			}
+		case TokenEOF:
+			return
+		}
+	}
+}
+
+// enterBlock records the kind whose body the block about to be parsed sits
+// in, for the remedy an unknown property carries, and returns the restore
+// for the caller to defer: blocks nest (a network: inside a sandbox: inside
+// a workflow), so the previous host comes back when the inner block ends.
+func (p *parser) enterBlock(host string) func() {
+	prev := p.blockHost
+	p.blockHost = host
+	return func() { p.blockHost = prev }
 }

--- a/pkg/dsl/parser/parser_decls.go
+++ b/pkg/dsl/parser/parser_decls.go
@@ -249,7 +249,7 @@ func (p *parser) parseAttachmentField() *ast.AttachmentField {
 		case "required":
 			af.Required = p.parseBool()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown attachment property '"+propName+"'")
+			p.unknownProperty("attachment", t, propName)
 			p.skipToNewline()
 		}
 		p.skipNewlines()
@@ -354,7 +354,7 @@ func (p *parser) parseSecretField() *ast.SecretField {
 		case "description":
 			sf.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown secret property '"+propName+"'")
+			p.unknownProperty("secret", t, propName)
 			p.skipToNewline()
 		}
 		p.skipNewlines()
@@ -633,7 +633,7 @@ func (p *parser) parseCursorDecl() *ast.CursorDecl {
 		case "bands":
 			cd.Bands = p.parseCursorBands()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown cursor property '"+propName+"'")
+			p.unknownProperty("cursor", t, propName)
 			p.skipToNewline()
 		}
 	}
@@ -776,7 +776,7 @@ func (p *parser) parseSupervisorDecl() *ast.SupervisorDecl {
 			sd.Monitors = p.parseStringList()
 			p.skipNewlines()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown supervisor property '"+propName+"'")
+			p.unknownProperty("supervisor", t, propName)
 			p.skipToNewline()
 		}
 	}

--- a/pkg/dsl/parser/parser_decls.go
+++ b/pkg/dsl/parser/parser_decls.go
@@ -250,7 +250,7 @@ func (p *parser) parseAttachmentField() *ast.AttachmentField {
 			af.Required = p.parseBool()
 		default:
 			p.unknownProperty("attachment", t, propName)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -355,7 +355,7 @@ func (p *parser) parseSecretField() *ast.SecretField {
 			sf.Description = p.expectString()
 		default:
 			p.unknownProperty("secret", t, propName)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -634,7 +634,7 @@ func (p *parser) parseCursorDecl() *ast.CursorDecl {
 			cd.Bands = p.parseCursorBands()
 		default:
 			p.unknownProperty("cursor", t, propName)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return cd
@@ -777,7 +777,7 @@ func (p *parser) parseSupervisorDecl() *ast.SupervisorDecl {
 			p.skipNewlines()
 		default:
 			p.unknownProperty("supervisor", t, propName)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return sd

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -251,42 +251,24 @@ func tokenAsIdent(t Token) string {
 	return ""
 }
 
-func isKeywordToken(tt TokenType) bool {
-	switch tt {
-	case TokenVars, TokenPresets, TokenMCPServer, TokenPrompt, TokenSchema, TokenAgent, TokenJudge,
-		TokenRouter, TokenHuman, TokenTool, TokenCompute, TokenWorkflow,
-		TokenJoin,
-		TokenEntry, TokenMCP, TokenBudget, TokenTransport, TokenServers,
-		TokenDisable, TokenAutoloadProject, TokenModel, TokenInput, TokenOutput,
-		TokenPublish, TokenSystem, TokenUser, TokenSession, TokenTools, TokenToolPolicy,
-		TokenCapabilities, TokenSkills, TokenArtifactLabels, TokenToolMaxSteps, TokenReasoningEffort, TokenMode, TokenStrategy, TokenRequire,
-		TokenInstructions, TokenCommand, TokenScript, TokenLanguage, TokenArgs, TokenURL,
-		TokenAuth, TokenReadonly, TokenFullAccess, TokenImages,
-		TokenDefaultBackend,
-		TokenInteraction, TokenInteractionPrompt, TokenInteractionModel,
-		TokenBackend, TokenProvider, TokenAwait, TokenWhen, TokenNot, TokenAs,
-		TokenWith, TokenEnum, TokenFresh, TokenInherit, TokenArtifactsOnly,
-		TokenFork, TokenPersist,
-		TokenFanOutAll, TokenCondition, TokenRoundRobin, TokenLLM, TokenMulti,
-		TokenWaitAll, TokenBestEffort,
-		TokenTrue, TokenFalse,
-		TokenTypeString, TokenTypeBool, TokenTypeInt, TokenTypeFloat,
-		TokenTypeJSON, TokenTypeStringArray,
-		TokenMaxParallelBranches, TokenMaxDuration, TokenMaxCostUSD,
-		TokenMaxTokens, TokenMaxIterations, TokenWarnTokens,
-		TokenCompaction, TokenThreshold, TokenPreserveRecent,
-		TokenMemory, TokenEnabled, TokenScope, TokenAutoload, TokenRead, TokenWrite, TokenPreCompactInject,
-		TokenWorktree,
-		TokenCompress, TokenAutoMemory,
-		TokenPermission, TokenAllow, TokenAsk, TokenDeny,
-		TokenSandbox,
-		TokenCursor, TokenCursors, TokenValues, TokenBands,
-		TokenGroup, TokenUse, TokenSubbot,
-		TokenAttachments, TokenTypeFile, TokenTypeImage,
-		// secrets / sandbox-host-state / forge keywords usable as identifiers in name positions
-		TokenSecrets, TokenInheritIfAvailable, TokenProjectRoot, TokenVisibility,
-		TokenDone, TokenFail:
-		return true
+// keywordTokens is every token type the lexer's keyword table produces — the
+// set isKeywordToken reads. Derived from the table rather than listed again
+// so a keyword added to the lexer is a valid identifier in a name position
+// (a node called `emit`, a field called `key`) from the same commit: the
+// hand-kept copy of this set drifted twice, refusing a dozen names each
+// time (`agent emit:` broke a shipped bot), and read those words as
+// "unexpected token" inside the blocks that match properties by value.
+var keywordTokens = func() map[TokenType]bool {
+	m := make(map[TokenType]bool, len(keywords))
+	for _, tt := range keywords {
+		m[tt] = true
 	}
-	return false
+	return m
+}()
+
+// isKeywordToken reports whether tt is a keyword — usable as an identifier
+// wherever a name is expected (tokenAsIdent), and a property name where a
+// block matches properties by their spelling.
+func isKeywordToken(tt TokenType) bool {
+	return keywordTokens[tt]
 }

--- a/pkg/dsl/parser/parser_keyword_class_test.go
+++ b/pkg/dsl/parser/parser_keyword_class_test.go
@@ -1,0 +1,46 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// Every keyword the lexer knows is a valid name for a declaration, a var or
+// a schema field — not the dozen the hand-kept list happened to contain when
+// it was last extended. The set is derived from the lexer's own table now;
+// this test walks that table so a keyword added tomorrow cannot leave the
+// class open again (`agent emit:` broke a shipped bot the last time it did).
+func TestEveryKeywordIsAValidName(t *testing.T) {
+	for _, kw := range parser.Keywords() {
+		if kw == "done" || kw == "fail" {
+			continue // the reserved terminal targets, refused by name on purpose (E011)
+		}
+		t.Run(kw, func(t *testing.T) {
+			src := "agent " + kw + ":\n  model: \"m\"\nvars:\n  " + kw + ": string\nschema s:\n  " + kw + ": string\n"
+			res := parser.Parse("kw.bot", src)
+			for _, d := range res.Diagnostics {
+				t.Errorf("keyword %q as a name: %v", kw, d)
+			}
+			if len(res.File.Agents) != 1 || res.File.Agents[0].Name != kw {
+				t.Fatalf("agent named %q not parsed", kw)
+			}
+			if res.File.Vars == nil || len(res.File.Vars.Fields) != 1 || res.File.Vars.Fields[0].Name != kw {
+				t.Fatalf("var named %q not parsed", kw)
+			}
+			if len(res.File.Schemas) != 1 || len(res.File.Schemas[0].Fields) != 1 || res.File.Schemas[0].Fields[0].Name != kw {
+				t.Fatalf("schema field named %q not parsed", kw)
+			}
+		})
+	}
+}
+
+// Inside a block that matches properties by their spelling, a keyword that is
+// not one of its properties is an unknown PROPERTY (E012, with the remedy),
+// not an "unexpected token".
+func TestKeywordInAValueMatchedBlockIsAnUnknownProperty(t *testing.T) {
+	res := parser.Parse("kw.bot", "workflow w:\n  sandbox:\n    needs: 1\n")
+	if len(res.Diagnostics) != 1 || res.Diagnostics[0].Code != parser.DiagUnknownProperty {
+		t.Fatalf("want one E012, got %v", res.Diagnostics)
+	}
+}

--- a/pkg/dsl/parser/parser_mcp.go
+++ b/pkg/dsl/parser/parser_mcp.go
@@ -64,7 +64,7 @@ func (p *parser) parseMCPServerProp(md *ast.MCPServerDecl, propTok Token) {
 		md.Auth = p.parseMCPAuthBlock(propTok)
 	default:
 		p.unknownProperty("mcp_server", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -102,7 +102,7 @@ func (p *parser) parseMCPAuthBlock(authTok Token) *ast.MCPAuthDecl {
 		if t.Type != TokenIdent {
 			p.unknownProperty("auth", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 			continue
 		}
 		propTok := p.next()
@@ -122,7 +122,7 @@ func (p *parser) parseMCPAuthBlock(authTok Token) *ast.MCPAuthDecl {
 			auth.Scopes = p.parseStringList()
 		default:
 			p.unknownProperty("auth", propTok, propTok.Value)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -186,7 +186,7 @@ func (p *parser) parseMCPConfigProp(cfg *ast.MCPConfigDecl, propTok Token) {
 		cfg.Disable = p.parseIdentList()
 	default:
 		p.unknownProperty("mcp", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }

--- a/pkg/dsl/parser/parser_mcp.go
+++ b/pkg/dsl/parser/parser_mcp.go
@@ -63,7 +63,7 @@ func (p *parser) parseMCPServerProp(md *ast.MCPServerDecl, propTok Token) {
 	case TokenAuth:
 		md.Auth = p.parseMCPAuthBlock(propTok)
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown mcp_server property '"+propTok.Value+"'")
+		p.unknownProperty("mcp_server", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -100,7 +100,7 @@ func (p *parser) parseMCPAuthBlock(authTok Token) *ast.MCPAuthDecl {
 			break
 		}
 		if t.Type != TokenIdent {
-			p.addError(DiagUnknownProperty, t, "unknown auth property '"+t.Value+"'")
+			p.unknownProperty("auth", t, t.Value)
 			p.next()
 			p.skipToNewline()
 			continue
@@ -121,7 +121,7 @@ func (p *parser) parseMCPAuthBlock(authTok Token) *ast.MCPAuthDecl {
 		case "scopes":
 			auth.Scopes = p.parseStringList()
 		default:
-			p.addError(DiagUnknownProperty, propTok, "unknown auth property '"+propTok.Value+"'")
+			p.unknownProperty("auth", propTok, propTok.Value)
 			p.skipToNewline()
 		}
 		p.skipNewlines()
@@ -145,7 +145,8 @@ func (p *parser) parseMCPTransport() ast.MCPTransport {
 	}
 }
 
-func (p *parser) parseMCPConfigBlock() *ast.MCPConfigDecl {
+func (p *parser) parseMCPConfigBlock(host string) *ast.MCPConfigDecl {
+	defer p.enterBlock(host)()
 	start := p.next() // consume "mcp"
 	cfg := &ast.MCPConfigDecl{Span: ast.Span{Start: p.pos(start)}}
 	switch p.parseBlockBody() {
@@ -184,7 +185,7 @@ func (p *parser) parseMCPConfigProp(cfg *ast.MCPConfigDecl, propTok Token) {
 		p.expect(TokenColon)
 		cfg.Disable = p.parseIdentList()
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown mcp property '"+propTok.Value+"'")
+		p.unknownProperty("mcp", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -94,9 +94,9 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 			p.expect(TokenColon)
 			d.Description = p.expectString()
 		case "fallbacks":
-			d.Fallbacks = p.parseFallbacksBlock(propTok)
+			d.Fallbacks = p.parseFallbacksBlock(propTok, kind)
 		default:
-			p.addError(DiagUnknownProperty, propTok, "unknown "+kind+" property '"+propTok.Value+"'")
+			p.unknownProperty(kind, propTok, propTok.Value)
 			p.skipToNewline()
 		}
 	case TokenReadonly:
@@ -114,7 +114,7 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 		d.Images = p.parseStringList()
 	case TokenMCP:
 		p.backup()
-		d.MCP = p.parseMCPConfigBlock()
+		d.MCP = p.parseMCPConfigBlock(kind)
 	case TokenBackend:
 		p.expect(TokenColon)
 		d.Backend = p.expectString()
@@ -150,18 +150,18 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 		d.Await = p.parseAwaitMode()
 	case TokenCompaction:
 		p.backup()
-		d.Compaction = p.parseCompactionBlock()
+		d.Compaction = p.parseCompactionBlock(kind)
 	case TokenMemory:
 		p.backup()
-		d.Memory = p.parseMemoryBlock()
+		d.Memory = p.parseMemoryBlock(kind)
 	case TokenSandbox:
 		p.backup()
-		d.Sandbox = p.parseSandboxBlock()
+		d.Sandbox = p.parseSandboxBlock(kind)
 	case TokenCursors:
 		p.backup()
 		d.Cursors = p.parseCursorsBlock()
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown "+kind+" property '"+propTok.Value+"'")
+		p.unknownProperty(kind, propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -279,12 +279,12 @@ func (p *parser) parseRouterDecl() *ast.RouterDecl {
 				p.expect(TokenColon)
 				rd.Description = p.expectString()
 			} else {
-				p.addError(DiagUnknownProperty, t, "unknown router property '"+t.Value+"'")
+				p.unknownProperty("router", t, t.Value)
 				p.next()
 				p.skipToNewline()
 			}
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown router property '"+t.Value+"'")
+			p.unknownProperty("router", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}
@@ -414,11 +414,11 @@ func (p *parser) parseHumanProp(hd *ast.HumanDecl, propTok Token) {
 			p.expect(TokenColon)
 			hd.MaxTurns = p.expectInt()
 		default:
-			p.addError(DiagUnknownProperty, propTok, "unknown human property '"+propTok.Value+"'")
+			p.unknownProperty("human", propTok, propTok.Value)
 			p.skipToNewline()
 		}
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown human property '"+propTok.Value+"'")
+		p.unknownProperty("human", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -501,7 +501,7 @@ func (p *parser) parseToolNodeProp(td *ast.ToolNodeDecl, propTok Token) {
 		td.Await = p.parseAwaitMode()
 	case TokenSandbox:
 		p.backup()
-		td.Sandbox = p.parseSandboxBlock()
+		td.Sandbox = p.parseSandboxBlock("tool")
 	case TokenCompress:
 		p.expect(TokenColon)
 		td.Compress = p.expectIdent()
@@ -536,11 +536,11 @@ func (p *parser) parseToolNodeProp(td *ast.ToolNodeDecl, propTok Token) {
 				td.ParallelSafe = *v
 			}
 		default:
-			p.addError(DiagUnknownProperty, propTok, "unknown tool property '"+propTok.Value+"'")
+			p.unknownProperty("tool", propTok, propTok.Value)
 			p.skipToNewline()
 		}
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown tool property '"+propTok.Value+"'")
+		p.unknownProperty("tool", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -591,7 +591,7 @@ func (p *parser) parseRecoveryBlock(propTok Token) *ast.RecoveryBlock {
 		case "agent_tools":
 			rb.AgentTools = p.parseToolList()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown recovery property '"+name+"'")
+			p.unknownProperty("recovery", t, name)
 			p.skipToNewline()
 		}
 		p.skipNewlines()
@@ -616,7 +616,8 @@ func (p *parser) parseRecoveryBlock(propTok Token) *ast.RecoveryBlock {
 // Reached from parseLLMProp's TokenIdent arm, so `fallbacks` stays a
 // plain identifier — making it a reserved keyword would break any bot
 // with a node, prompt or schema of that name.
-func (p *parser) parseFallbacksBlock(propTok Token) []*ast.FallbackDecl {
+func (p *parser) parseFallbacksBlock(propTok Token, host string) []*ast.FallbackDecl {
+	defer p.enterBlock(host)()
 	switch p.parseBlockBody() {
 	case headerFailed:
 		return nil
@@ -712,7 +713,7 @@ func (p *parser) parseFallbackEntry() *ast.FallbackDecl {
 			// A quoted expr over vars, like a compute `expr:` value.
 			fd.When = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown fallback property '"+propName+"'")
+			p.unknownProperty("fallback", t, propName)
 			p.skipToNewline()
 		}
 		fd.Span.End = p.pos(t)
@@ -777,11 +778,11 @@ func (p *parser) parseComputeProp(cd *ast.ComputeDecl, propTok Token) {
 			p.expect(TokenColon)
 			cd.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, propTok, "unknown compute property '"+propTok.Value+"'")
+			p.unknownProperty("compute", propTok, propTok.Value)
 			p.skipToNewline()
 		}
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown compute property '"+propTok.Value+"'")
+		p.unknownProperty("compute", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -999,7 +1000,7 @@ func (p *parser) parseSubbotDecl() *ast.SubbotDecl {
 			p.expect(TokenColon)
 			sd.Needs = p.parseNeedsList()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown subbot property '"+t.Value+"'")
+			p.unknownProperty("subbot", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}
@@ -1042,7 +1043,7 @@ func (p *parser) parseEmitDecl() *ast.EmitDecl {
 			p.expect(TokenColon)
 			ed.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown emit property '"+t.Value+"'")
+			p.unknownProperty("emit", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}
@@ -1089,7 +1090,7 @@ func (p *parser) parseWaitDecl() *ast.WaitDecl {
 			p.expect(TokenColon)
 			wd.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown wait property '"+t.Value+"'")
+			p.unknownProperty("wait", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}
@@ -1148,7 +1149,7 @@ func (p *parser) parseFailDecl() *ast.FailDecl {
 			p.expect(TokenColon)
 			fd.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown fail property '"+t.Value+"'")
+			p.unknownProperty("fail", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}
@@ -1191,7 +1192,7 @@ func (p *parser) parseAwaitAnswersDecl() *ast.AwaitAnswersDecl {
 			p.expect(TokenColon)
 			ad.Description = p.expectString()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown await_answers property '"+t.Value+"'")
+			p.unknownProperty("await_answers", t, t.Value)
 			p.next()
 			p.skipToNewline()
 		}

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -97,7 +97,7 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 			d.Fallbacks = p.parseFallbacksBlock(propTok, kind)
 		default:
 			p.unknownProperty(kind, propTok, propTok.Value)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	case TokenReadonly:
 		p.expect(TokenColon)
@@ -162,7 +162,7 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 		d.Cursors = p.parseCursorsBlock()
 	default:
 		p.unknownProperty(kind, propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -281,12 +281,12 @@ func (p *parser) parseRouterDecl() *ast.RouterDecl {
 			} else {
 				p.unknownProperty("router", t, t.Value)
 				p.next()
-				p.skipToNewline()
+				p.skipUnknownProperty()
 			}
 		default:
 			p.unknownProperty("router", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -415,11 +415,11 @@ func (p *parser) parseHumanProp(hd *ast.HumanDecl, propTok Token) {
 			hd.MaxTurns = p.expectInt()
 		default:
 			p.unknownProperty("human", propTok, propTok.Value)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	default:
 		p.unknownProperty("human", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -537,11 +537,11 @@ func (p *parser) parseToolNodeProp(td *ast.ToolNodeDecl, propTok Token) {
 			}
 		default:
 			p.unknownProperty("tool", propTok, propTok.Value)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	default:
 		p.unknownProperty("tool", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -592,7 +592,7 @@ func (p *parser) parseRecoveryBlock(propTok Token) *ast.RecoveryBlock {
 			rb.AgentTools = p.parseToolList()
 		default:
 			p.unknownProperty("recovery", t, name)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -714,7 +714,7 @@ func (p *parser) parseFallbackEntry() *ast.FallbackDecl {
 			fd.When = p.expectString()
 		default:
 			p.unknownProperty("fallback", t, propName)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		fd.Span.End = p.pos(t)
 		p.skipNewlines()
@@ -779,11 +779,11 @@ func (p *parser) parseComputeProp(cd *ast.ComputeDecl, propTok Token) {
 			cd.Description = p.expectString()
 		default:
 			p.unknownProperty("compute", propTok, propTok.Value)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	default:
 		p.unknownProperty("compute", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -912,6 +912,18 @@ func (p *parser) parseGroupDecl() *ast.GroupDecl {
 		case TokenComment:
 			p.next()
 		default:
+			if isTopLevelKeyword(t.Type) && p.declHeaderAhead() {
+				// A declaration a group cannot hold (an emit, a prompt, a
+				// workflow…): say so, rather than read its keyword as the
+				// source of an edge and ask for the arrow; its body goes
+				// with it. A node NAMED like a keyword is still an edge
+				// endpoint — that shape has no `<name>:` after the keyword.
+				p.addErrorHint(DiagUnexpectedToken, t, "'"+t.Value+"' cannot be declared inside a group — a group holds agent, judge, router, human, tool and compute declarations, and edges",
+					"Move the `"+t.Value+"` declaration to the top level, outside the group.")
+				p.next()
+				p.skipUnknownProperty()
+				continue
+			}
 			if t.Type == TokenIdent || isKeywordToken(t.Type) {
 				if e := p.parseEdge(); e != nil {
 					gd.Edges = append(gd.Edges, e)
@@ -1002,7 +1014,7 @@ func (p *parser) parseSubbotDecl() *ast.SubbotDecl {
 		default:
 			p.unknownProperty("subbot", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return sd
@@ -1045,7 +1057,7 @@ func (p *parser) parseEmitDecl() *ast.EmitDecl {
 		default:
 			p.unknownProperty("emit", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return ed
@@ -1092,7 +1104,7 @@ func (p *parser) parseWaitDecl() *ast.WaitDecl {
 		default:
 			p.unknownProperty("wait", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return wd
@@ -1151,7 +1163,7 @@ func (p *parser) parseFailDecl() *ast.FailDecl {
 		default:
 			p.unknownProperty("fail", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return fd
@@ -1194,7 +1206,7 @@ func (p *parser) parseAwaitAnswersDecl() *ast.AwaitAnswersDecl {
 		default:
 			p.unknownProperty("await_answers", t, t.Value)
 			p.next()
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 	}
 	return ad

--- a/pkg/dsl/parser/parser_recovery_test.go
+++ b/pkg/dsl/parser/parser_recovery_test.go
@@ -1,0 +1,102 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// A misspelt block header anywhere — a node body, a nested block — draws ONE
+// diagnostic, and its indented body goes with it: the body's lines are not
+// re-read as the enclosing kind's properties (an E003 per line, then a C003
+// at compile for a `user:` taken as the agent's prompt reference), and the
+// members after it still parse.
+func TestAMisspeltBlockHeaderDropsItsBodyEverywhere(t *testing.T) {
+	cases := []struct {
+		name, src, hint string
+		check           func(t *testing.T, res *ParseResult)
+	}{
+		{"agent body", "agent a:\n  model: \"m\"\n  sandbx:\n    image: \"i\"\n    user: \"u\"\n  system: s\n", "Did you mean `sandbox`?",
+			func(t *testing.T, res *ParseResult) {
+				if got := res.File.Agents[0].System; got != "s" {
+					t.Errorf("the member after the block did not parse: system = %q", got)
+				}
+			}},
+		{"tool body", "tool t:\n  command: \"c\"\n  recovry:\n    max_repair_attempts: 2\n  description: \"d\"\n", "Did you mean `recovery`?",
+			func(t *testing.T, res *ParseResult) {
+				if got := res.File.Tools[0].Description; got != "d" {
+					t.Errorf("the member after the block did not parse: description = %q", got)
+				}
+			}},
+		{"router body (peeked site)", "router r:\n  mode: condition\n  bogus:\n    x: 1\n    y: 2\n  description: \"d\"\n", "router accepts:",
+			func(t *testing.T, res *ParseResult) {
+				if got := res.File.Routers[0].Description; got != "d" {
+					t.Errorf("the member after the block did not parse: description = %q", got)
+				}
+			}},
+		{"nested block", "workflow w:\n  entry: a\n  sandbox:\n    image: \"i\"\n    netwrk:\n      mode: allowlist\n    user: \"u\"\n", "Did you mean `network`?",
+			func(t *testing.T, res *ParseResult) {
+				if got := res.File.Workflows[0].Sandbox.User; got != "u" {
+					t.Errorf("the member after the nested block did not parse: user = %q", got)
+				}
+			}},
+		{"secret entry", "secrets:\n  s:\n    valu:\n      x: 1\n    optional: true\n", "Did you mean `value`?",
+			func(t *testing.T, res *ParseResult) {
+				if !res.File.Secrets.Fields[0].Optional {
+					t.Errorf("the member after the block did not parse: optional is false")
+				}
+			}},
+	}
+	for _, c := range cases {
+		res := Parse("t.bot", c.src)
+		if len(res.Diagnostics) != 1 {
+			t.Errorf("%s: want exactly one diagnostic, got %v", c.name, res.Diagnostics)
+			continue
+		}
+		d := res.Diagnostics[0]
+		if d.Code != DiagUnknownProperty || !strings.Contains(d.Hint, c.hint) {
+			t.Errorf("%s: got %s %q (hint %q)", c.name, d.Code, d.Message, d.Hint)
+		}
+		c.check(t, res)
+	}
+}
+
+// A lexer diagnosis inside a dropped body is still reported: the tab is the
+// author's mistake, and swallowing it would only make it resurface after the
+// header is fixed.
+func TestALexerErrorInsideADroppedBodyIsStillReported(t *testing.T) {
+	res := Parse("t.bot", "agent a:\n  model: \"m\"\n  sandbx:\n    image: \"i\"\n\tuser: \"u\"\n  system: s\n")
+	var codes []string
+	for _, d := range res.Diagnostics {
+		codes = append(codes, string(d.Code))
+	}
+	if strings.Join(codes, ",") != "E012,E003" {
+		t.Fatalf("want E012 (the header) then E003 (the tab), got %v", res.Diagnostics)
+	}
+	if got := res.File.Agents[0].System; got != "s" {
+		t.Fatalf("the member after the block did not parse: system = %q", got)
+	}
+}
+
+// A declaration a group cannot hold is refused by name, not read as the
+// source of an edge that lacks its arrow — while a node NAMED like a keyword
+// is still a valid edge endpoint.
+func TestADeclarationAGroupCannotHoldIsRefusedByName(t *testing.T) {
+	res := Parse("g.bot", "group g:\n  emit e:\n    event: \"x\"\n  agent a:\n    model: \"m\"\n")
+	if len(res.Diagnostics) != 1 {
+		t.Fatalf("want one diagnostic, got %v", res.Diagnostics)
+	}
+	d := res.Diagnostics[0]
+	if d.Code != DiagUnexpectedToken || !strings.Contains(d.Message, "'emit' cannot be declared inside a group") {
+		t.Fatalf("got %s %q", d.Code, d.Message)
+	}
+	if !strings.Contains(d.Hint, "Move the `emit` declaration to the top level") {
+		t.Fatalf("the remedy is the catalogue's, not this site's: %q", d.Hint)
+	}
+	if len(res.File.Groups) != 1 || len(res.File.Groups[0].Agents) != 1 {
+		t.Fatalf("the member after the refused declaration did not parse: %+v", res.File.Groups)
+	}
+	res = Parse("g.bot", "group g:\n  agent emit:\n    model: \"m\"\n  emit -> done\n")
+	if len(res.Diagnostics) != 0 || len(res.File.Groups[0].Edges) != 1 {
+		t.Fatalf("an edge from a node named `emit` must still parse: %v, %d edges", res.Diagnostics, len(res.File.Groups[0].Edges))
+	}
+}

--- a/pkg/dsl/parser/parser_sandbox.go
+++ b/pkg/dsl/parser/parser_sandbox.go
@@ -113,7 +113,7 @@ func (p *parser) parseSandboxProp(sb *ast.SandboxBlock, propTok Token) {
 		sb.Build = p.parseSandboxBuildBody(propTok, colon)
 	default:
 		p.unknownProperty("sandbox", propTok, name)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -158,7 +158,7 @@ func (p *parser) parseSandboxBuildBody(startTok, colon Token) *ast.SandboxBuildB
 			bb.Args = p.parseStringMapBlock()
 		default:
 			p.unknownProperty("sandbox.build", t, name)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}
@@ -213,7 +213,7 @@ func (p *parser) parseSandboxNetworkBody(startTok, colon Token) *ast.SandboxNetw
 			nb.Rules = p.parseStringOrIdentList()
 		default:
 			p.unknownProperty("sandbox.network", t, name)
-			p.skipToNewline()
+			p.skipUnknownProperty()
 		}
 		p.skipNewlines()
 	}

--- a/pkg/dsl/parser/parser_sandbox.go
+++ b/pkg/dsl/parser/parser_sandbox.go
@@ -25,7 +25,8 @@ import (
 // presence of body fields when not declared explicitly: the parser
 // sets Mode="inline" so the IR compiler routes it through the
 // driver-spec converter rather than the devcontainer.json reader.
-func (p *parser) parseSandboxBlock() *ast.SandboxBlock {
+func (p *parser) parseSandboxBlock(host string) *ast.SandboxBlock {
+	defer p.enterBlock(host)()
 	start := p.next() // consume "sandbox"
 	colon, _ := p.expect(TokenColon)
 
@@ -111,7 +112,7 @@ func (p *parser) parseSandboxProp(sb *ast.SandboxBlock, propTok Token) {
 		// `image:` (enforced at IR compile time, not the parser).
 		sb.Build = p.parseSandboxBuildBody(propTok, colon)
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown sandbox property '"+name+"'")
+		p.unknownProperty("sandbox", propTok, name)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -156,7 +157,7 @@ func (p *parser) parseSandboxBuildBody(startTok, colon Token) *ast.SandboxBuildB
 		case "args":
 			bb.Args = p.parseStringMapBlock()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown sandbox.build property '"+name+"'")
+			p.unknownProperty("sandbox.build", t, name)
 			p.skipToNewline()
 		}
 		p.skipNewlines()
@@ -211,7 +212,7 @@ func (p *parser) parseSandboxNetworkBody(startTok, colon Token) *ast.SandboxNetw
 		case "rules":
 			nb.Rules = p.parseStringOrIdentList()
 		default:
-			p.addError(DiagUnknownProperty, t, "unknown sandbox.network property '"+name+"'")
+			p.unknownProperty("sandbox.network", t, name)
 			p.skipToNewline()
 		}
 		p.skipNewlines()

--- a/pkg/dsl/parser/parser_unknown_property_test.go
+++ b/pkg/dsl/parser/parser_unknown_property_test.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// An unknown property arrives with the registry's remedy in its hint: the
+// closest accepted name, the block the name belongs to, or the kind's list.
+func TestUnknownPropertyCarriesTheRegistryRemedy(t *testing.T) {
+	cases := []struct {
+		name, src, msg, hint string
+	}{
+		{"typo on a tool", "tool t:\n  comand: \"x\"\n", "unknown tool property 'comand'", "Did you mean `command`?"},
+		{"network property on the sandbox", "workflow w:\n  entry: a\n  sandbox:\n    rules: [\"a\"]\n", "unknown sandbox property 'rules'", "indent it under `network:`"},
+		{"workflow property inside budget", "workflow w:\n  budget:\n    entry: a\n", "unknown budget property 'entry'", "belongs to the enclosing `workflow`"},
+		{"another kind's property", "compute c:\n  command: \"x\"\n", "unknown compute property 'command'", "compute does not take it"},
+		{"agent list", "agent a:\n  zzz: 1\n", "unknown agent property 'zzz'", "agent accepts: description, model"},
+		// A block with several hosts names the host it is IN, never another:
+		// an mcp: block under a workflow is not an agent's.
+		{"agent property in a workflow's mcp", "workflow w:\n  entry: a\n  mcp:\n    model: \"x\"\n", "unknown mcp property 'model'", "`model` is a property of agent/fallback/human/judge/"},
+		{"agent property in an agent's mcp", "agent a:\n  mcp:\n    model: \"x\"\n", "unknown mcp property 'model'", "belongs to the enclosing `agent`"},
+		{"workflow property in an agent's mcp", "agent a:\n  mcp:\n    entry: x\n", "unknown mcp property 'entry'", "`entry` is a property of workflow"},
+		{"tool property in a tool's sandbox", "tool t:\n  command: \"x\"\n  sandbox:\n    goal: \"g\"\n", "unknown sandbox property 'goal'", "belongs to the enclosing `tool`"},
+		// A nested single-host block names its own host even under another.
+		{"sandbox property in a network under a workflow", "workflow w:\n  entry: a\n  sandbox:\n    image: \"i\"\n    network:\n      image: \"x\"\n", "unknown sandbox.network property 'image'", "belongs to the enclosing `sandbox`"},
+	}
+	for _, c := range cases {
+		res := Parse("t.bot", c.src)
+		var found bool
+		for _, d := range res.Diagnostics {
+			if d.Code != DiagUnknownProperty {
+				continue
+			}
+			found = true
+			if d.Message != c.msg {
+				t.Errorf("%s: message %q, want %q", c.name, d.Message, c.msg)
+			}
+			if !strings.Contains(d.Hint, c.hint) {
+				t.Errorf("%s: hint %q does not contain %q", c.name, d.Hint, c.hint)
+			}
+			if strings.Contains(d.Hint, "enclosing") && !strings.Contains(c.hint, "enclosing") {
+				t.Errorf("%s: hint %q names an enclosing kind it cannot know", c.name, d.Hint)
+			}
+		}
+		if !found {
+			t.Errorf("%s: no E012 in %v", c.name, res.Diagnostics)
+		}
+	}
+}
+
+// A `name:` line the workflow does not know is an unknown PROPERTY (E012,
+// with the remedy), not an edge that lacks its arrow — and its indented body,
+// when it has one, is dropped whole rather than reported line by line. The
+// edges around it still parse.
+func TestUnknownWorkflowPropertyIsE012NotAMissingArrow(t *testing.T) {
+	src := "agent a:\n  model: \"m\"\nworkflow w:\n  entry: a\n  budjet:\n    max_cost_usd: 1\n  a -> done\n"
+	res := Parse("t.bot", src)
+	if len(res.Diagnostics) != 1 {
+		t.Fatalf("want exactly one diagnostic, got %v", res.Diagnostics)
+	}
+	d := res.Diagnostics[0]
+	if d.Code != DiagUnknownProperty || d.Message != "unknown workflow property 'budjet'" {
+		t.Fatalf("got %s %q", d.Code, d.Message)
+	}
+	if !strings.Contains(d.Hint, "Did you mean `budget`?") {
+		t.Fatalf("hint %q lacks the suggestion", d.Hint)
+	}
+	if d.Line != 5 {
+		t.Fatalf("positioned at line %d, want 5", d.Line)
+	}
+	wf := res.File.Workflows[0]
+	if len(wf.Edges) != 1 || wf.Entry != "a" {
+		t.Fatalf("the surrounding members did not parse: entry %q, %d edges", wf.Entry, len(wf.Edges))
+	}
+}
+
+// An edge line is still an edge — the colon peek must not swallow it.
+func TestEdgesStillParseAfterTheColonPeek(t *testing.T) {
+	src := "workflow w:\n  entry: a\n  a -> b when ok\n  a -> done else\n  b -> a as fix(3)\n"
+	res := Parse("t.bot", src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	if got := len(res.File.Workflows[0].Edges); got != 3 {
+		t.Fatalf("want 3 edges, got %d", got)
+	}
+}

--- a/pkg/dsl/parser/parser_workflow.go
+++ b/pkg/dsl/parser/parser_workflow.go
@@ -42,7 +42,7 @@ func (p *parser) parseWorkflowDecl() *ast.WorkflowDecl {
 			wd.Attachments = p.parseAttachmentsBlock()
 
 		case TokenMCP:
-			wd.MCP = p.parseMCPConfigBlock()
+			wd.MCP = p.parseMCPConfigBlock("workflow")
 
 		case TokenEntry:
 			p.next() // consume "entry"
@@ -59,7 +59,7 @@ func (p *parser) parseWorkflowDecl() *ast.WorkflowDecl {
 			wd.Resources = p.parseResourcesBlock()
 
 		case TokenCompaction:
-			wd.Compaction = p.parseCompactionBlock()
+			wd.Compaction = p.parseCompactionBlock("workflow")
 
 		case TokenWorktree:
 			p.next() // consume "worktree"
@@ -122,7 +122,7 @@ func (p *parser) parseWorkflowDecl() *ast.WorkflowDecl {
 			p.skipNewlines()
 
 		case TokenSandbox:
-			wd.Sandbox = p.parseSandboxBlock()
+			wd.Sandbox = p.parseSandboxBlock("workflow")
 			p.skipNewlines()
 
 		case TokenDefaultBackend:
@@ -160,8 +160,20 @@ func (p *parser) parseWorkflowDecl() *ast.WorkflowDecl {
 			p.next() // skip workflow-level comments
 
 		default:
-			// Must be an edge: IDENT -> IDENT ...
+			// Must be an edge: IDENT -> IDENT ... — unless a colon follows the
+			// name: then it is a property the workflow does not have, and the
+			// author is told so (with the registry's remedy) rather than
+			// "expected ->", which is the edge parser's reading of it.
 			if t.Type == TokenIdent || isKeywordToken(t.Type) {
+				p.next()
+				if p.peek().Type == TokenColon {
+					p.unknownProperty("workflow", t, t.Value)
+					p.skipToNewline()
+					p.skipNewlines()
+					p.skipIndentedBlock() // a misspelt block header: its body is not a run of strays
+					continue
+				}
+				p.backup()
 				edge := p.parseEdge()
 				if edge != nil {
 					wd.Edges = append(wd.Edges, edge)
@@ -221,7 +233,7 @@ func (p *parser) parseBudgetProp(bb *ast.BudgetBlock, propTok Token) {
 		p.expect(TokenColon)
 		bb.MaxIterations = p.expectInt()
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown budget property '"+propTok.Value+"'")
+		p.unknownProperty("budget", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -283,7 +295,8 @@ func (p *parser) parseResourceProp(rb *ast.ResourcesBlock, propTok Token) {
 	p.skipNewlines()
 }
 
-func (p *parser) parseCompactionBlock() *ast.CompactionBlock {
+func (p *parser) parseCompactionBlock(host string) *ast.CompactionBlock {
+	defer p.enterBlock(host)()
 	start := p.next() // consume "compaction"
 	cb := &ast.CompactionBlock{Span: ast.Span{Start: p.pos(start)}}
 	switch p.parseBlockBody() {
@@ -309,7 +322,8 @@ func (p *parser) parseCompactionBlock() *ast.CompactionBlock {
 
 // parseMemoryBlock parses a `memory:` sub-block on an agent or
 // judge node. All fields are optional; IR compile applies defaults.
-func (p *parser) parseMemoryBlock() *ast.MemoryBlock {
+func (p *parser) parseMemoryBlock(host string) *ast.MemoryBlock {
+	defer p.enterBlock(host)()
 	start := p.next() // consume "memory"
 	mb := &ast.MemoryBlock{Span: ast.Span{Start: p.pos(start)}}
 	switch p.parseBlockBody() {
@@ -345,7 +359,7 @@ func (p *parser) parseCompactionProp(cb *ast.CompactionBlock, propTok Token) {
 		v := p.expectInt()
 		cb.PreserveRecent = &v
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown compaction property '"+propTok.Value+"'")
+		p.unknownProperty("compaction", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()
@@ -391,7 +405,7 @@ func (p *parser) parseMemoryProp(mb *ast.MemoryBlock, propTok Token) {
 		v := p.expectString()
 		mb.Visibility = &v
 	default:
-		p.addError(DiagUnknownProperty, propTok, "unknown memory property '"+propTok.Value+"'")
+		p.unknownProperty("memory", propTok, propTok.Value)
 		p.skipToNewline()
 	}
 	p.skipNewlines()

--- a/pkg/dsl/parser/parser_workflow.go
+++ b/pkg/dsl/parser/parser_workflow.go
@@ -168,9 +168,7 @@ func (p *parser) parseWorkflowDecl() *ast.WorkflowDecl {
 				p.next()
 				if p.peek().Type == TokenColon {
 					p.unknownProperty("workflow", t, t.Value)
-					p.skipToNewline()
-					p.skipNewlines()
-					p.skipIndentedBlock() // a misspelt block header: its body is not a run of strays
+					p.skipUnknownProperty() // a misspelt block header: its body is not a run of strays
 					continue
 				}
 				p.backup()
@@ -234,7 +232,7 @@ func (p *parser) parseBudgetProp(bb *ast.BudgetBlock, propTok Token) {
 		bb.MaxIterations = p.expectInt()
 	default:
 		p.unknownProperty("budget", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -360,7 +358,7 @@ func (p *parser) parseCompactionProp(cb *ast.CompactionBlock, propTok Token) {
 		cb.PreserveRecent = &v
 	default:
 		p.unknownProperty("compaction", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }
@@ -406,7 +404,7 @@ func (p *parser) parseMemoryProp(mb *ast.MemoryBlock, propTok Token) {
 		mb.Visibility = &v
 	default:
 		p.unknownProperty("memory", propTok, propTok.Value)
-		p.skipToNewline()
+		p.skipUnknownProperty()
 	}
 	p.skipNewlines()
 }

--- a/pkg/dsl/parser/token.go
+++ b/pkg/dsl/parser/token.go
@@ -1,6 +1,9 @@
 package parser
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // TokenType identifies the kind of a lexical token.
 type TokenType int
@@ -515,4 +518,17 @@ type Token struct {
 	// reports THAT — never "expected X, got Error" with a token-shape hint
 	// about a cause that is a character.
 	Code DiagCode
+}
+
+// Keywords returns every keyword the lexer tokenises, sorted — the candidate
+// names the registry's conformance probe (pkg/dsl/spec) feeds the parser,
+// since a property matched by token TYPE is only reachable by the word the
+// lexer maps to that type.
+func Keywords() []string {
+	out := make([]string, 0, len(keywords))
+	for k := range keywords {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/dsl/spec/conformance_test.go
+++ b/pkg/dsl/spec/conformance_test.go
@@ -1,0 +1,238 @@
+package spec_test
+
+import (
+	"fmt"
+	goast "go/ast"
+	goparser "go/parser"
+	"go/token"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/dsl/spec"
+)
+
+// probes puts `<name>: 1` in the body of each kind that has a fixed property
+// table, as the minimal document the parser reads. The value is irrelevant:
+// E012 is decided on the NAME, before the value is read, so an accepted name
+// draws at most a value error while a refused one draws E012 — the one
+// signal this test reads, from the REAL parser, which is what makes the
+// registry unable to drift from it: a property added to the parser without
+// its registry line fails here, and so does a registry line the parser does
+// not honour.
+var probes = map[string]string{
+	"agent":           "agent x:\n  %s: 1\n",
+	"judge":           "judge x:\n  %s: 1\n",
+	"router":          "router x:\n  %s: 1\n",
+	"human":           "human x:\n  %s: 1\n",
+	"tool":            "tool x:\n  %s: 1\n",
+	"compute":         "compute x:\n  %s: 1\n",
+	"subbot":          "subbot x:\n  %s: 1\n",
+	"emit":            "emit x:\n  %s: 1\n",
+	"wait":            "wait x:\n  %s: 1\n",
+	"await_answers":   "await_answers x:\n  %s: 1\n",
+	"fail":            "fail x:\n  %s: 1\n",
+	"workflow":        "workflow w:\n  %s: 1\n",
+	"supervisor":      "supervisor s:\n  %s: 1\n",
+	"cursor":          "cursor c:\n  %s: 1\n",
+	"mcp_server":      "mcp_server m:\n  %s: 1\n",
+	"auth":            "mcp_server m:\n  auth:\n    %s: 1\n",
+	"mcp":             "workflow w:\n  mcp:\n    %s: 1\n",
+	"budget":          "workflow w:\n  budget:\n    %s: 1\n",
+	"compaction":      "workflow w:\n  compaction:\n    %s: 1\n",
+	"memory":          "agent a:\n  memory:\n    %s: 1\n",
+	"sandbox":         "workflow w:\n  sandbox:\n    %s: 1\n",
+	"sandbox.build":   "workflow w:\n  sandbox:\n    build:\n      %s: 1\n",
+	"sandbox.network": "workflow w:\n  sandbox:\n    network:\n      %s: 1\n",
+	"recovery":        "tool t:\n  recovery:\n    %s: 1\n",
+	"fallback":        "agent a:\n  fallbacks:\n    r:\n      %s: 1\n",
+	"attachment":      "attachments:\n  a: file\n    %s: 1\n",
+	"secret":          "secrets:\n  s:\n    %s: 1\n",
+	"cursors":         "agent a:\n  cursors:\n    %s: 1\n",
+}
+
+// freeEntryProbes is one arbitrary entry name in each block whose body is
+// author-named entries; the parser must take it without a diagnostic.
+var freeEntryProbes = map[string]string{
+	"vars":          "vars:\n  zz_probe: string\n",
+	"presets":       "presets:\n  zz_probe:\n    a: 1\n",
+	"attachments":   "attachments:\n  zz_probe: file\n",
+	"secrets":       "secrets:\n  zz_probe: \"v\"\n",
+	"resources":     "workflow w:\n  resources:\n    zz_probe: 1\n",
+	"expr":          "compute c:\n  expr:\n    zz_probe: \"1\"\n",
+	"cursors":       "agent a:\n  cursors:\n    zz_probe: 1\n",
+	"cursor.values": "cursor c:\n  values:\n    zz_probe: \"f\"\n",
+	"cursor.bands":  "cursor c:\n  bands:\n    \"0..1\": \"f\"\n",
+	"schema":        "schema s:\n  zz_probe: string\n",
+}
+
+func parserAccepts(tmpl, name string) bool {
+	res := parser.Parse("probe.bot", fmt.Sprintf(tmpl, name))
+	for _, d := range res.Diagnostics {
+		if d.Code == parser.DiagUnknownProperty {
+			return false
+		}
+	}
+	return true
+}
+
+// candidateNames is every name the parser could accept as a property: the
+// lexer's keywords (a property matched by token type is reachable only by
+// its keyword) and every identifier-shaped string literal in the parser's
+// sources (a property matched by `case "name":` or `t.Value == "name"`),
+// plus the registry's own names. A superset costs nothing — a name nobody
+// accepts and nobody lists is consistent.
+func candidateNames(t *testing.T) []string {
+	t.Helper()
+	set := map[string]bool{}
+	for _, k := range parser.Keywords() {
+		set[k] = true
+	}
+	for _, k := range spec.Kinds {
+		for _, n := range k.Names() {
+			set[n] = true
+		}
+	}
+	files, err := filepath.Glob(filepath.Join("..", "parser", "*.go"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("parser sources: %v (%d files)", err, len(files))
+	}
+	ident := regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+	fset := token.NewFileSet()
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		af, err := goparser.ParseFile(fset, f, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		goast.Inspect(af, func(n goast.Node) bool {
+			lit, ok := n.(*goast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			if s, err := strconv.Unquote(lit.Value); err == nil && ident.MatchString(s) {
+				set[s] = true
+			}
+			return true
+		})
+	}
+	out := make([]string, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestRegistryMatchesTheParser holds the registry to the parser in both
+// directions, kind by kind, over every candidate name.
+func TestRegistryMatchesTheParser(t *testing.T) {
+	names := candidateNames(t)
+	if len(names) < 100 {
+		t.Fatalf("only %d candidate names — the sweep is not reading the parser", len(names))
+	}
+	for kind, tmpl := range probes {
+		k, ok := spec.Lookup(kind)
+		if !ok {
+			t.Errorf("probe %q names a kind the registry does not have", kind)
+			continue
+		}
+		free := k.Entries != nil // any name is an entry: only the listed ones are checked
+		for _, name := range names {
+			accepted := parserAccepts(tmpl, name)
+			listed := k.Has(name)
+			switch {
+			case listed && !accepted:
+				t.Errorf("%s: the registry lists %q but the parser refuses it", kind, name)
+			case accepted && !listed && !free:
+				t.Errorf("%s: the parser accepts %q but the registry does not list it", kind, name)
+			}
+		}
+	}
+}
+
+// TestEveryFixedTableHasAProbe: a kind added to the registry with properties
+// but no probe would be a table nothing holds to the parser.
+func TestEveryFixedTableHasAProbe(t *testing.T) {
+	for _, k := range spec.Kinds {
+		if len(k.Properties) == 0 {
+			continue
+		}
+		if _, ok := probes[k.Name]; !ok {
+			t.Errorf("kind %q has a property table but no probe document", k.Name)
+		}
+	}
+}
+
+// TestFreeEntryBlocksTakeAnyName: the registry says these blocks are made of
+// author-named entries; the parser must take an arbitrary one cleanly.
+func TestFreeEntryBlocksTakeAnyName(t *testing.T) {
+	for kind, doc := range freeEntryProbes {
+		k, ok := spec.Lookup(kind)
+		if !ok {
+			t.Errorf("probe %q names a kind the registry does not have", kind)
+			continue
+		}
+		if k.Entries == nil {
+			t.Errorf("%s: probed as free entries but the registry declares no Entries", kind)
+		}
+		res := parser.Parse("probe.bot", doc)
+		if len(res.Diagnostics) > 0 {
+			t.Errorf("%s: an arbitrary entry drew %v", kind, res.Diagnostics)
+		}
+	}
+	for _, k := range spec.Kinds {
+		if k.Entries == nil || k.Name == "prompt" || k.Name == "group" || k.Name == "use" {
+			continue
+		}
+		if _, ok := freeEntryProbes[k.Name]; !ok {
+			t.Errorf("kind %q declares free entries but has no probe", k.Name)
+		}
+	}
+}
+
+// TestBlocksNameTheirHostsAndOpeners: a block's Hosts must be kinds the
+// registry knows, and its Body references must resolve, or the hints built
+// on them point at nothing.
+func TestBlocksNameTheirHostsAndOpeners(t *testing.T) {
+	for _, k := range spec.Kinds {
+		for _, h := range k.Hosts {
+			if h == "file" {
+				continue
+			}
+			if _, ok := spec.Lookup(h); !ok {
+				t.Errorf("%s: host %q is not a registered kind", k.Name, h)
+			}
+		}
+		if (k.Role == spec.BlockRole || k.Role == spec.Entry) && (k.Opener == "" || len(k.Hosts) == 0) {
+			t.Errorf("%s: a block or entry needs an opener and at least one host", k.Name)
+		}
+		for _, p := range k.Properties {
+			if p.Form == spec.Block || p.Form == spec.BlockOrIdent {
+				body, ok := spec.Lookup(p.Body)
+				if !ok {
+					t.Errorf("%s.%s: body kind %q is not registered", k.Name, p.Name, p.Body)
+					continue
+				}
+				hosted := false
+				for _, h := range body.Hosts {
+					if h == k.Name {
+						hosted = true
+					}
+				}
+				if !hosted {
+					t.Errorf("%s.%s: body kind %q does not list %q among its hosts", k.Name, p.Name, p.Body, k.Name)
+				}
+			}
+			if p.Form == spec.Enum && len(p.Values) == 0 {
+				t.Errorf("%s.%s: an enum needs values", k.Name, p.Name)
+			}
+		}
+	}
+}

--- a/pkg/dsl/spec/conformance_test.go
+++ b/pkg/dsl/spec/conformance_test.go
@@ -157,6 +157,91 @@ func TestRegistryMatchesTheParser(t *testing.T) {
 	}
 }
 
+// sampleValues writes the property line (or lines) with a WELL-FORMED value
+// of the property's declared form — EVERY listed value when the form names
+// some, since each is rendered to authors as accepted — so the parser's
+// acceptance is proven on a clean document rather than inferred from the
+// absence of E012 alone: a listed property whose form was wrong, a listed
+// value the parser refuses, or a name refused through another code, draws a
+// diagnostic here. Continuation lines are indented relative to the property.
+func sampleValues(p spec.Property) []string {
+	each := func(values []string) []string {
+		out := make([]string, 0, len(values))
+		for _, v := range values {
+			out = append(out, p.Name+": "+v)
+		}
+		return out
+	}
+	switch p.Form {
+	case spec.String:
+		return []string{p.Name + `: "x"`}
+	case spec.Ident, spec.StringOrIdent:
+		if len(p.Values) > 0 {
+			return each(p.Values)
+		}
+		return []string{p.Name + ": x"}
+	case spec.Int, spec.Number:
+		return []string{p.Name + ": 1"}
+	case spec.Bool:
+		return []string{p.Name + ": true", p.Name + ": false"}
+	case spec.Enum, spec.BlockOrIdent:
+		return each(p.Values)
+	case spec.IdentList, spec.ToolList, spec.MixedList:
+		if len(p.Values) > 0 {
+			return []string{p.Name + ": [" + strings.Join(p.Values, ", ") + "]"}
+		}
+		return []string{p.Name + ": [a]"}
+	case spec.StringList, spec.SkillList:
+		return []string{p.Name + `: ["a"]`}
+	case spec.IdentOrList:
+		return []string{p.Name + ": a", p.Name + ": [a, b]"}
+	case spec.Map:
+		return []string{p.Name + `: { A: "v" }`}
+	case spec.WithMap:
+		return []string{p.Name + ` { k: "v" }`}
+	case spec.Block:
+		switch p.Body {
+		case "expr":
+			return []string{"expr:\n  f: \"1\""}
+		case "cursor.values":
+			return []string{"values:\n  a: \"f\""}
+		case "cursor.bands":
+			return []string{"bands:\n  \"0..1\": \"f\""}
+		case "fallback":
+			return []string{"fallbacks:\n  r:\n    backend: \"claw\""}
+		}
+		return []string{p.Name + ":"} // an empty block: the bare header
+	}
+	return []string{p.Name + ": 1"}
+}
+
+// TestEveryListedPropertyParsesCleanWithItsForm proves the other half of
+// "listed ⇒ accepted": with a value of its declared form — each listed value
+// in turn — every property of every kind parses with NO diagnostic at all,
+// not merely without E012.
+func TestEveryListedPropertyParsesCleanWithItsForm(t *testing.T) {
+	n := 0
+	for kind, tmpl := range probes {
+		k, _ := spec.Lookup(kind)
+		line := strings.Replace(tmpl, "%s: 1", "%s", 1)
+		at := strings.Index(line, "%s")
+		indent := line[strings.LastIndex(line[:at], "\n")+1 : at]
+		for _, p := range k.Properties {
+			for _, sample := range sampleValues(p) {
+				n++
+				value := strings.ReplaceAll(sample, "\n", "\n"+indent)
+				doc := fmt.Sprintf(line, value)
+				if res := parser.Parse("probe.bot", doc); len(res.Diagnostics) > 0 {
+					t.Errorf("%s.%s (%s): %q drew %v", kind, p.Name, p.Form, doc, res.Diagnostics)
+				}
+			}
+		}
+	}
+	if n < 300 {
+		t.Fatalf("only %d documents probed — the sweep is not covering the registry", n)
+	}
+}
+
 // TestEveryFixedTableHasAProbe: a kind added to the registry with properties
 // but no probe would be a table nothing holds to the parser.
 func TestEveryFixedTableHasAProbe(t *testing.T) {

--- a/pkg/dsl/spec/docs_fresh_test.go
+++ b/pkg/dsl/spec/docs_fresh_test.go
@@ -1,0 +1,41 @@
+package spec_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/spec"
+)
+
+// The committed renderings of the registry — the property reference, the
+// grammar's tables, the skills' property section — must be what the
+// registry renders today. Regenerate with `task dsl:gen` (`iterion dsl spec
+// --write`) and commit the result.
+func TestGeneratedDSLDocsAreFresh(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	stale, err := spec.Stale(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stale) > 0 {
+		t.Fatalf("stale generated regions in %v — run `task dsl:gen` and commit", stale)
+	}
+}
+
+// Every region kind renders, and an unknown one is refused rather than
+// spliced as nothing.
+func TestRenderRefusesAnUnknownRegion(t *testing.T) {
+	for _, what := range []string{"reference", "skill", "table agent", "table sandbox.network"} {
+		if _, err := spec.Render(what); err != nil {
+			t.Errorf("Render(%q): %v", what, err)
+		}
+	}
+	for _, what := range []string{"table nokind", "tables", ""} {
+		if _, err := spec.Render(what); err == nil {
+			t.Errorf("Render(%q) accepted", what)
+		}
+	}
+	if _, err := spec.Splice("no region here"); err == nil {
+		t.Error("Splice accepted a document without a region")
+	}
+}

--- a/pkg/dsl/spec/ebnf_test.go
+++ b/pkg/dsl/spec/ebnf_test.go
@@ -1,0 +1,168 @@
+package spec_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/spec"
+)
+
+// ebnfProductions maps a registry kind to the EBNF production that lists
+// its properties (docs/grammar/iterion_v1.ebnf). The EBNF stays
+// hand-written — its structure is more than property lists — but each of
+// these productions must name exactly the properties the registry does,
+// or the machine-readable grammar teaches a surface the parser does not
+// have.
+var ebnfProductions = map[string]string{
+	"agent":           "llm_prop",
+	"judge":           "llm_prop",
+	"router":          "router_prop",
+	"human":           "human_prop",
+	"tool":            "tool_prop",
+	"recovery":        "recovery_prop",
+	"compute":         "compute_prop",
+	"emit":            "emit_prop",
+	"wait":            "wait_prop",
+	"await_answers":   "await_answers_prop",
+	"fail":            "fail_prop",
+	"subbot":          "subbot_prop",
+	"workflow":        "workflow_member",
+	"budget":          "budget_prop",
+	"compaction":      "compaction_prop",
+	"memory":          "memory_prop",
+	"mcp":             "mcp_config_prop",
+	"sandbox":         "sandbox_prop",
+	"sandbox.build":   "sandbox_build_prop",
+	"sandbox.network": "sandbox_network_prop",
+	"mcp_server":      "mcp_server_prop",
+	"auth":            "mcp_auth_prop",
+	"cursor":          "cursor_prop",
+	"supervisor":      "supervisor_prop",
+	"attachment":      "attachment_prop",
+	"secret":          "secret_prop",
+	"fallback":        "fallback_prop",
+}
+
+var (
+	productionRe = regexp.MustCompile(`(?m)^([a-z_]+)\s*=`)
+	quotedRe     = regexp.MustCompile(`^"([a-z_]+)"`)
+)
+
+// loadProductions reads the EBNF into name → body (the text between `=`
+// and the terminating `;`, comments stripped).
+func loadProductions(t *testing.T) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "docs", "grammar", "iterion_v1.ebnf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for _, l := range strings.Split(string(raw), "\n") {
+		if i := strings.Index(l, "(*"); i >= 0 && strings.Contains(l, "*)") {
+			l = l[:i] + l[strings.Index(l, "*)")+2:]
+		}
+		lines = append(lines, l)
+	}
+	text := strings.Join(lines, "\n")
+	out := map[string]string{}
+	locs := productionRe.FindAllStringSubmatchIndex(text, -1)
+	for i, loc := range locs {
+		end := len(text)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+		body := text[loc[1]:end]
+		if j := strings.LastIndex(body, ";"); j >= 0 {
+			body = body[:j]
+		}
+		out[text[loc[2]:loc[3]]] = strings.TrimSpace(body)
+	}
+	if len(out) < 50 {
+		t.Fatalf("only %d productions read from the EBNF", len(out))
+	}
+	return out
+}
+
+// alternatives splits a production body on its top-level `|`.
+func alternatives(body string) []string {
+	var out []string
+	depth, inQuote := 0, false
+	start := 0
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		switch {
+		case inQuote:
+			if c == '"' {
+				inQuote = false
+			}
+		case c == '"':
+			inQuote = true
+		case c == '(' || c == '[' || c == '{':
+			depth++
+		case c == ')' || c == ']' || c == '}':
+			depth--
+		case c == '|' && depth == 0:
+			out = append(out, strings.TrimSpace(body[start:i]))
+			start = i + 1
+		}
+	}
+	return append(out, strings.TrimSpace(body[start:]))
+}
+
+// propertyNames lists the property each alternative of a production opens
+// with: its leading quoted word, or, for an alternative that is another
+// production, that production's leading quoted word (a block such as
+// mcp_auth_block = "auth" ":" …). An alternative opening with neither (an
+// edge) is not a property.
+func propertyNames(prods map[string]string, name string) []string {
+	var out []string
+	for _, alt := range alternatives(prods[name]) {
+		if m := quotedRe.FindStringSubmatch(alt); m != nil {
+			out = append(out, m[1])
+			continue
+		}
+		ref := strings.Fields(alt)
+		if len(ref) == 0 {
+			continue
+		}
+		if body, ok := prods[ref[0]]; ok {
+			if m := quotedRe.FindStringSubmatch(strings.TrimSpace(body)); m != nil {
+				out = append(out, m[1])
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestEBNFPropertyProductionsMatchTheRegistry(t *testing.T) {
+	prods := loadProductions(t)
+	for kind, prod := range ebnfProductions {
+		k, ok := spec.Lookup(kind)
+		if !ok {
+			t.Errorf("%s: not a registered kind", kind)
+			continue
+		}
+		if _, ok := prods[prod]; !ok {
+			t.Errorf("%s: production %q not found in the EBNF", kind, prod)
+			continue
+		}
+		got := propertyNames(prods, prod)
+		want := append([]string(nil), k.Names()...)
+		sort.Strings(want)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("%s: EBNF production %s lists %v, the registry %v", kind, prod, got, want)
+		}
+	}
+	for _, k := range spec.Kinds {
+		if len(k.Properties) > 0 && k.Name != "cursors" {
+			if _, ok := ebnfProductions[k.Name]; !ok {
+				t.Errorf("kind %q has a property table but no EBNF production mapped", k.Name)
+			}
+		}
+	}
+}

--- a/pkg/dsl/spec/render.go
+++ b/pkg/dsl/spec/render.go
@@ -1,0 +1,334 @@
+package spec
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// The generated regions. A committed document carries
+//
+//	<!-- dsl-spec:begin <what> -->
+//	…
+//	<!-- dsl-spec:end -->
+//
+// and Splice rewrites what lies between the two markers from the registry:
+// `reference` is the whole property reference, `table <kind>` one kind's
+// table, `skill` the compact section the authoring skills carry. `iterion
+// dsl spec --write` (task dsl:gen) regenerates every file in Files;
+// TestGeneratedDSLDocsAreFresh (task dsl:check) fails when a committed
+// region differs from what the registry renders — the same freshness
+// contract as the pi extension's embedded asset.
+const (
+	beginPrefix = "<!-- dsl-spec:begin "
+	endMarker   = "<!-- dsl-spec:end -->"
+)
+
+var regionRe = regexp.MustCompile(`(?s)<!-- dsl-spec:begin ([a-z]+(?: [a-z_.]+)?) -->\n.*?<!-- dsl-spec:end -->`)
+
+// Files are the repository-relative documents that carry generated regions.
+var Files = []string{
+	"docs/references/dsl-properties.md",
+	"docs/references/dsl-grammar.md",
+	"SKILL.md",
+	"bots/whats-next/skills/iterion-dsl-quickref.md",
+}
+
+// Splice rewrites every generated region of doc from the registry. A
+// region naming something the registry cannot render is an error, not a
+// silent no-op — and so is a region the pattern cannot take whole: a
+// `begin` without its `end` (or with CRLF line ends) would otherwise be
+// left as it is and reported fresh, and in a document with several regions
+// the pattern would run from that `begin` to the NEXT region's `end` and
+// the rewrite would delete the hand-written text between them. Every
+// marker must belong to exactly one matched region.
+func Splice(doc string) (string, error) {
+	begins, ends := strings.Count(doc, beginPrefix), strings.Count(doc, endMarker)
+	if n := len(regionRe.FindAllString(doc, -1)); n != begins || n != ends {
+		return "", fmt.Errorf("dsl-spec regions are unbalanced or unrecognised: %d matched, %d begin marker(s), %d end marker(s) — each `%s<what> -->` needs its own `%s` on a later line, LF line ends, and what must be reference, skill or table <kind>", n, begins, ends, beginPrefix, endMarker)
+	}
+	var firstErr error
+	out := regionRe.ReplaceAllStringFunc(doc, func(m string) string {
+		sub := regionRe.FindStringSubmatch(m)
+		body, err := Render(sub[1])
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return m
+		}
+		return beginPrefix + sub[1] + " -->\n" + body + endMarker
+	})
+	if firstErr != nil {
+		return "", firstErr
+	}
+	if !strings.Contains(doc, beginPrefix) {
+		return "", fmt.Errorf("the document carries no dsl-spec region")
+	}
+	return out, nil
+}
+
+// Render produces the body of one region kind: "reference", "table <kind>"
+// or "skill".
+func Render(what string) (string, error) {
+	switch {
+	case what == "reference":
+		return Reference(), nil
+	case what == "skill":
+		return SkillSection(), nil
+	case strings.HasPrefix(what, "table "):
+		kind := strings.TrimPrefix(what, "table ")
+		k, ok := Lookup(kind)
+		if !ok {
+			return "", fmt.Errorf("dsl-spec region: unknown kind %q", kind)
+		}
+		return Table(k), nil
+	}
+	return "", fmt.Errorf("dsl-spec region: unknown region %q", what)
+}
+
+// Regenerate rewrites every generated region of the documents under root and
+// returns the files it changed. Every document is read and spliced before
+// any is written, so a document that cannot be regenerated leaves the tree
+// as it was rather than half rewritten.
+func Regenerate(root string) ([]string, error) {
+	type pending struct {
+		rel, path, body string
+	}
+	var todo []pending
+	for _, rel := range Files {
+		path := filepath.Join(root, rel)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		fresh, err := Splice(string(raw))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", rel, err)
+		}
+		if fresh != string(raw) {
+			todo = append(todo, pending{rel, path, fresh})
+		}
+	}
+	var changed []string
+	for _, p := range todo {
+		if err := os.WriteFile(p.path, []byte(p.body), 0o644); err != nil {
+			return changed, err
+		}
+		changed = append(changed, p.rel)
+	}
+	return changed, nil
+}
+
+// Stale returns the files under root whose generated regions differ from
+// what the registry renders.
+func Stale(root string) ([]string, error) {
+	var stale []string
+	for _, rel := range Files {
+		raw, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			return stale, err
+		}
+		fresh, err := Splice(string(raw))
+		if err != nil {
+			return stale, fmt.Errorf("%s: %w", rel, err)
+		}
+		if fresh != string(raw) {
+			stale = append(stale, rel)
+		}
+	}
+	return stale, nil
+}
+
+// Reference renders every kind: a heading, its doc, where it lives, its
+// table or its entry shape.
+func Reference() string {
+	var b strings.Builder
+	b.WriteString("_Generated from the parser's property registry (`pkg/dsl/spec`) by `iterion dsl spec --write`; do not edit by hand. A conformance test holds the registry to the parser in both directions._\n\n")
+	for _, k := range Kinds {
+		fmt.Fprintf(&b, "### %s\n\n", k.Name)
+		b.WriteString(k.Doc + "\n\n")
+		if line := whereLine(k); line != "" {
+			b.WriteString(line + "\n\n")
+		}
+		if len(k.Properties) > 0 {
+			b.WriteString(Table(k))
+			b.WriteString("\n")
+		}
+		if k.Entries != nil {
+			fmt.Fprintf(&b, "Entries: `%s` — %s", k.Entries.Shape, k.Entries.Doc)
+			if k.Entries.Body != "" {
+				fmt.Fprintf(&b, "; an entry's sub-block is a [%s](#%s)", k.Entries.Body, anchor(k.Entries.Body))
+			}
+			b.WriteString(".\n\n")
+		}
+	}
+	return b.String()
+}
+
+func whereLine(k Kind) string {
+	switch k.Role {
+	case Declaration:
+		if k.Header != "" {
+			return "A top-level declaration: `" + k.Header + "`."
+		}
+		return "A top-level declaration: `" + k.Name + " <name>:`."
+	case Node:
+		return "A node: `" + k.Name + " <name>:` at the top level or inside a `group`."
+	case BlockRole, Entry:
+		hosts := make([]string, 0, len(k.Hosts))
+		for _, h := range k.Hosts {
+			if h == "file" {
+				hosts = append(hosts, "the top level")
+			} else {
+				hosts = append(hosts, "`"+h+"`")
+			}
+		}
+		what := "A block"
+		if k.Role == Entry {
+			what = "An entry"
+		}
+		return fmt.Sprintf("%s opened by `%s:` inside %s.", what, k.Opener, strings.Join(hosts, ", "))
+	}
+	return ""
+}
+
+// Table renders one kind's property table.
+func Table(k Kind) string {
+	var b strings.Builder
+	b.WriteString("| Property | Value | Meaning |\n|---|---|---|\n")
+	for _, p := range k.Properties {
+		fmt.Fprintf(&b, "| `%s` | %s | %s |\n", p.Name, valueCell(p), escapePipes(p.Doc))
+	}
+	return b.String()
+}
+
+func valueCell(p Property) string {
+	switch p.Form {
+	case Enum:
+		return "one of " + codes(p.Values)
+	case Block:
+		return fmt.Sprintf("block → [%s](#%s)", p.Body, anchor(p.Body))
+	case BlockOrIdent:
+		return fmt.Sprintf("one of %s, or a block → [%s](#%s)", codes(p.Values), p.Body, anchor(p.Body))
+	case Ident, StringOrIdent:
+		if len(p.Values) > 0 {
+			return escapePipes(string(p.Form)) + " — " + codes(p.Values)
+		}
+	case IdentList:
+		if len(p.Values) > 0 {
+			return string(p.Form) + " over " + codes(p.Values)
+		}
+	}
+	return escapePipes(string(p.Form))
+}
+
+func codes(values []string) string {
+	q := make([]string, 0, len(values))
+	for _, v := range values {
+		q = append(q, "`"+v+"`")
+	}
+	return strings.Join(q, ", ")
+}
+
+func escapePipes(s string) string { return strings.ReplaceAll(s, "|", "\\|") }
+
+// anchor is the GitHub-style heading anchor of a kind name.
+func anchor(name string) string { return strings.ReplaceAll(name, ".", "") }
+
+// SkillSection renders the compact property list the authoring skills carry:
+// one line per kind, each property with a short form code. Kept terse on
+// purpose — it is read by an agent before every draft, so every byte is paid
+// on every draft.
+func SkillSection() string {
+	var b strings.Builder
+	b.WriteString("Generated from the parser's property registry (`iterion dsl spec --write`). Forms: `str` quoted string · `id` bare name · `str|id` either · `int` `num` `bool` literals · `a|b` one of · `[id]` `[str]` `[tool]` `[skill]` inline lists · `map` `{K: \"v\"}` or an indented block · `with{}` a `with { k: \"v\" }` map · `{kind}` an indented block described under that kind.\n\n")
+	seen := map[string]bool{}
+	for _, k := range Kinds {
+		if seen[k.Name] {
+			continue
+		}
+		label := "`" + k.Name + "`"
+		if k.Name == "agent" {
+			label = "`agent` / `judge`"
+			seen["judge"] = true
+		}
+		where := ""
+		if k.Role == BlockRole || k.Role == Entry {
+			where = " (`" + k.Opener + ":` in " + strings.Join(hostNames(k), ", ") + ")"
+		}
+		fmt.Fprintf(&b, "- %s%s", label, where)
+		if len(k.Properties) > 0 {
+			parts := make([]string, 0, len(k.Properties))
+			for _, p := range k.Properties {
+				parts = append(parts, p.Name+" "+shortForm(p))
+			}
+			b.WriteString(" — " + strings.Join(parts, " · "))
+		}
+		if k.Entries != nil {
+			fmt.Fprintf(&b, " — entries `%s`", k.Entries.Shape)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func hostNames(k Kind) []string {
+	out := make([]string, 0, len(k.Hosts))
+	for _, h := range k.Hosts {
+		if h == "file" {
+			out = append(out, "the file")
+		} else {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func shortForm(p Property) string {
+	switch p.Form {
+	case String:
+		return "str"
+	case Ident:
+		if len(p.Values) > 0 {
+			return strings.Join(p.Values, "|")
+		}
+		return "id"
+	case StringOrIdent:
+		if len(p.Values) > 0 {
+			return strings.Join(p.Values, "|")
+		}
+		return "str|id"
+	case Int:
+		return "int"
+	case Number:
+		return "num"
+	case Bool:
+		return "bool"
+	case Enum:
+		return strings.Join(p.Values, "|")
+	case IdentList:
+		return "[id]"
+	case StringList:
+		return "[str]"
+	case ToolList:
+		return "[tool]"
+	case SkillList:
+		return "[skill]"
+	case MixedList:
+		return "[str|id]"
+	case IdentOrList:
+		return "id|[id]"
+	case Map:
+		return "map"
+	case WithMap:
+		return "with{}"
+	case Block:
+		return "{" + p.Body + "}"
+	case BlockOrIdent:
+		return strings.Join(p.Values, "|") + "|{" + p.Body + "}"
+	}
+	return string(p.Form)
+}

--- a/pkg/dsl/spec/render_test.go
+++ b/pkg/dsl/spec/render_test.go
@@ -1,0 +1,70 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A region the pattern cannot take whole is an ERROR, never a fresh no-op:
+// a begin marker without its end left the document untouched and reported
+// fresh, and with two regions the pattern ran from the first begin to the
+// second end and the rewrite deleted the prose between them.
+func TestSpliceRefusesUnbalancedRegions(t *testing.T) {
+	good := "intro\n<!-- dsl-spec:begin skill -->\nstale\n<!-- dsl-spec:end -->\nmiddle prose\n<!-- dsl-spec:begin table budget -->\nstale\n<!-- dsl-spec:end -->\nend\n"
+	out, err := Splice(good)
+	if err != nil {
+		t.Fatalf("balanced document refused: %v", err)
+	}
+	if !strings.Contains(out, "middle prose") || !strings.Contains(out, "max_cost_usd") || strings.Contains(out, "stale") {
+		t.Fatalf("balanced document not spliced as expected:\n%s", out)
+	}
+	cases := map[string]string{
+		"single region, no end":    "<!-- dsl-spec:begin skill -->\nTOTAL GARBAGE\n",
+		"first end missing of two": "<!-- dsl-spec:begin skill -->\nx\nmiddle prose\n<!-- dsl-spec:begin table budget -->\ny\n<!-- dsl-spec:end -->\n",
+		"end without begin":        "prose\n<!-- dsl-spec:end -->\n",
+		"crlf line ends":           "<!-- dsl-spec:begin skill -->\r\nx\r\n<!-- dsl-spec:end -->\r\n",
+		"double space in header":   "<!-- dsl-spec:begin  skill -->\nx\n<!-- dsl-spec:end -->\n",
+		"unknown region":           "<!-- dsl-spec:begin tables -->\nx\n<!-- dsl-spec:end -->\n",
+	}
+	for name, doc := range cases {
+		if out, err := Splice(doc); err == nil {
+			t.Errorf("%s: accepted, produced %q", name, out)
+		}
+	}
+}
+
+// Regenerate leaves every file as it was when one of them cannot be spliced.
+func TestRegenerateIsAllOrNothing(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, body string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i, rel := range Files {
+		body := "<!-- dsl-spec:begin skill -->\nstale\n<!-- dsl-spec:end -->\n"
+		if i == len(Files)-1 {
+			body = "<!-- dsl-spec:begin skill -->\nno end marker\n" // the last file is broken
+		}
+		write(rel, body)
+	}
+	changed, err := Regenerate(root)
+	if err == nil {
+		t.Fatal("a broken document did not fail Regenerate")
+	}
+	if len(changed) != 0 {
+		t.Fatalf("files were rewritten before the failure: %v", changed)
+	}
+	for _, rel := range Files[:len(Files)-1] {
+		raw, _ := os.ReadFile(filepath.Join(root, rel))
+		if !strings.Contains(string(raw), "stale") {
+			t.Errorf("%s was rewritten although another document failed", rel)
+		}
+	}
+}

--- a/pkg/dsl/spec/spec.go
+++ b/pkg/dsl/spec/spec.go
@@ -1,0 +1,518 @@
+// Package spec is the declarative registry of the `.bot` DSL's property
+// surface: for every declaration kind, node kind and anonymous block, the
+// properties it accepts, each with the shape of its value and one line of
+// doc. It is a LEAF (no iterion import): the parser reads it to explain an
+// unknown property (the closest accepted names, the block a name belongs
+// to, the kind's full list), the renderers turn it into the grammar
+// reference and the skill's property section, and a conformance test holds
+// it to the parser in BOTH directions — every property listed here is
+// accepted by the parser, every property the parser accepts is listed here
+// — so a property added to one side without the other fails CI instead of
+// drifting for months (the three canonical examples of the DSL quickref did
+// not parse until #1010's lot 0 rewrote them).
+//
+// The registry DESCRIBES the parser; it does not drive it (a generic parser
+// loop over it is lot 1b of #1010, an option). What parses is decided by
+// the parser's switch arms; this is the copy that cannot drift because the
+// test reads both.
+package spec
+
+import "sort"
+
+// Form is the shape of a property's value as the parser reads it.
+type Form string
+
+const (
+	String        Form = "string"             // a quoted string: "…", `…` or a `|` block scalar
+	Ident         Form = "ident"              // a bare identifier (a name or a reference)
+	StringOrIdent Form = "string|ident"       // a quoted string or a bare identifier
+	Int           Form = "int"                // an unquoted integer
+	Number        Form = "number"             // an unquoted integer or float
+	Bool          Form = "bool"               // true or false
+	Enum          Form = "enum"               // one of Property.Values, bare
+	IdentList     Form = "ident list"         // [a, b]
+	StringList    Form = "string list"        // ["a", "b"]
+	ToolList      Form = "tool list"          // [bash, mcp.server.*, "quoted-literal"]
+	SkillList     Form = "skill list"         // ["kebab-name", dotted.ident]
+	MixedList     Form = "string|ident list"  // ["!**.evil.site", github.com]
+	IdentOrList   Form = "ident | ident list" // godot or [godot, blender]
+	Map           Form = "map"                // { KEY: "v" } inline, or an indented `KEY: v` block
+	WithMap       Form = "with { … }"         // with { key: "value", … }
+	Block         Form = "block"              // an indented block whose body is the kind named in Property.Body
+	BlockOrIdent  Form = "ident | block"      // a bare mode on the header line, or an indented block
+)
+
+// Property is one `name: value` line a kind accepts.
+type Property struct {
+	Name string
+	Form Form
+	// Values are the accepted bare values of an Enum. For an Ident or a
+	// StringOrIdent they are the values a COMPILE check accepts (the parser
+	// takes any word; the compiler names the code), listed for the reader.
+	Values []string
+	// Body names the kind whose properties fill a Block / BlockOrIdent.
+	Body string
+	Doc  string
+}
+
+// Role says what a kind is in the grammar.
+type Role string
+
+const (
+	Declaration Role = "declaration" // `kind name:` at the top level (prompt, schema, cursor, …)
+	Node        Role = "node"        // a graph node declaration (agent, tool, …)
+	BlockRole   Role = "block"       // an anonymous block opened by a keyword or a property (budget:, mcp:, …)
+	Entry       Role = "entry"       // an author-named entry inside a block (an attachment, a secret, a fallback route)
+)
+
+// Entries describes the author-named entries a block's body is made of,
+// when its body is not (only) a fixed property table.
+type Entries struct {
+	Shape string // the entry line, e.g. `name: type [enum: "a", "b"] [= default]`
+	Doc   string
+	Body  string // the kind describing an entry's own sub-block, if it has one
+}
+
+// Kind is one declaration kind, node kind or block of the grammar.
+type Kind struct {
+	Name string // the name the parser's diagnostics use: "agent", "sandbox.network", …
+	Role Role
+	// Opener is, for a block or an entry, the keyword or property that opens
+	// it inside its host: "network" for sandbox.network, "fallbacks" for a
+	// fallback route.
+	Opener string
+	// Hosts are the kinds whose body may contain this one; "file" is the top
+	// level. Empty for a top-level declaration.
+	Hosts []string
+	// Header is the declaration line when it is not the default
+	// `<kind> <name>:` (a group carries parameters, a use has no body).
+	Header     string
+	Doc        string
+	Properties []Property
+	Entries    *Entries
+}
+
+// Names returns the kind's property names in declaration order.
+func (k Kind) Names() []string {
+	out := make([]string, 0, len(k.Properties))
+	for _, p := range k.Properties {
+		out = append(out, p.Name)
+	}
+	return out
+}
+
+// Property returns the kind's property of that name.
+func (k Kind) Property(name string) (Property, bool) {
+	for _, p := range k.Properties {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return Property{}, false
+}
+
+// Has reports whether the kind accepts a property of that name.
+func (k Kind) Has(name string) bool {
+	_, ok := k.Property(name)
+	return ok
+}
+
+// Lookup returns the kind of that name.
+func Lookup(name string) (Kind, bool) {
+	for _, k := range Kinds {
+		if k.Name == name {
+			return k, true
+		}
+	}
+	return Kind{}, false
+}
+
+// Owners returns, sorted, the names of the kinds that accept a property of
+// that name.
+func Owners(name string) []string {
+	var out []string
+	for _, k := range Kinds {
+		if k.Has(name) {
+			out = append(out, k.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HostedBy returns the kinds whose Hosts include host, in registry order.
+func HostedBy(host string) []Kind {
+	var out []Kind
+	for _, k := range Kinds {
+		for _, h := range k.Hosts {
+			if h == host {
+				out = append(out, k)
+				break
+			}
+		}
+	}
+	return out
+}
+
+func prop(name string, form Form, doc string) Property {
+	return Property{Name: name, Form: form, Doc: doc}
+}
+
+func enum(name, doc string, values ...string) Property {
+	return Property{Name: name, Form: Enum, Values: values, Doc: doc}
+}
+
+// checked is an Ident the parser takes as any word and a later check — the
+// compiler's, or the runtime's — narrows to values (the doc names the
+// diagnostic when there is one).
+func checked(name, doc string, values ...string) Property {
+	return Property{Name: name, Form: Ident, Values: values, Doc: doc}
+}
+
+func block(name, body, doc string) Property {
+	return Property{Name: name, Form: Block, Body: body, Doc: doc}
+}
+
+// Properties shared by every node kind that produces or consumes data.
+var (
+	pInput          = prop("input", Ident, "Schema the node's input is validated against")
+	pOutput         = prop("output", Ident, "Schema the node's structured output must match")
+	pPublish        = prop("publish", Ident, "Artifact name the output is published under (read back as {{artifacts.<name>}})")
+	pArtifactLabels = prop("artifact_labels", ToolList, "Labels stamped on the published artifact; a quoted element is the literal label")
+	pAwait          = enum("await", "Convergence rule when several incoming branches reach the node", "wait_all", "best_effort")
+	pDescription    = prop("description", String, "Free-text description shown by the studio and the reports")
+	pNeeds          = prop("needs", IdentOrList, "Resource(s) leased from the workflow's resources: block for the node's duration")
+	pModel          = prop("model", String, "Model id the backend serves, e.g. \"anthropic/claude-opus-5\"; empty takes the backend's default")
+	pBackend        = prop("backend", String, "Execution backend: claw, claude_code, codex, pi, kimi or grok")
+	pProvider       = prop("provider", String, "Provider hint for credential resolution, e.g. \"anthropic\"")
+	pSystem         = prop("system", Ident, "Prompt declaration used as the system prompt")
+	pUser           = prop("user", Ident, "Prompt declaration used as the user message")
+	pTimeout        = prop("timeout", String, "Duration the node may run, e.g. \"20m\"")
+	pCompress       = checked("compress", "Command-output compression: on, ultra or off (C102)", "on", "ultra", "off")
+	pPermission     = checked("permission", "Tool-permission gate: off, ask or deny (C110–C112)", "off", "ask", "deny")
+	pAutoMemory     = checked("auto_memory", "The backend's own auto-memory: on or off (C131/C132)", "on", "off")
+	pInteraction    = enum("interaction", "How the node asks the operator (ADR-081)", "none", "human", "llm", "llm_or_human", "review", "async")
+	pInteractionP   = prop("interaction_prompt", Ident, "Prompt the llm interaction mode answers with in the operator's place")
+	pInteractionM   = prop("interaction_model", String, "Model the llm interaction mode uses")
+	pReasoning      = Property{Name: "reasoning_effort", Form: Enum, Values: []string{"low", "medium", "high", "xhigh", "max", "ultracode"},
+		Doc: "Reasoning effort; ultracode is xhigh plus multi-agent orchestration, reliable on Opus 4.8 and the Claude 5 family (Opus 5, Fable 5.1) only (C089 warns elsewhere); a quoted string is env-substituted at runtime"}
+	pSandbox = Property{Name: "sandbox", Form: BlockOrIdent, Body: "sandbox", Values: []string{"none", "auto"},
+		Doc: "Sandbox for this scope: a bare mode (none, auto) or an indented block — the inline form, which needs image: or build: (C044)"}
+)
+
+// llmOnly marks a router property C023 refuses outside mode: llm.
+func llmOnly(p Property) Property {
+	p.Doc = "llm mode only (C023 otherwise): " + p.Doc
+	return p
+}
+
+// llmProperties is the surface agents and judges share (one parser arm
+// serves both).
+var llmProperties = []Property{
+	pDescription,
+	pModel, pBackend, pProvider,
+	prop("command", String, "Executable that drives a CLI backend, overriding its default binary"),
+	pInput, pOutput, pPublish, pArtifactLabels,
+	pSystem, pUser,
+	enum("session", "How the node's LLM session relates to the previous node's", "fresh", "inherit", "inherit_if_available", "fork", "artifacts_only", "persist"),
+	prop("tools", ToolList, "Tools the node may call; restricts claw (C135 on a name it lacks), inert on a CLI backend"),
+	prop("tool_policy", ToolList, "Tool-policy entries applied on top of tools"),
+	prop("capabilities", ToolList, "Board capabilities opened to the node: board.create, board.move, board.read, … (C080/C081)"),
+	prop("skills", SkillList, "Skill-library skills mirrored into the run's .claude/skills"),
+	prop("tool_max_steps", Int, "Upper bound on tool-call rounds in one execution"),
+	prop("max_tokens", Int, "Output-token cap per call"),
+	pReasoning,
+	pTimeout,
+	prop("readonly", Bool, "Declares the node mutates no workspace file, so it may run beside another branch"),
+	prop("full_access", Bool, "Grants the backend its full tool access"),
+	prop("images", StringList, "Image paths sent with the prompt"),
+	pInteraction, pInteractionP, pInteractionM,
+	pAwait,
+	pCompress, pAutoMemory, pPermission,
+	pNeeds,
+	block("fallbacks", "fallback", "Ordered, NAMED alternative routes taken when the primary fails (ADR-087); a chain with no route is refused"),
+	block("mcp", "mcp", "MCP servers active for the node"),
+	block("compaction", "compaction", "Context-compaction thresholds of the node's session"),
+	block("memory", "memory", "iterion's shared-memory tools and scopes for the node"),
+	pSandbox,
+	block("cursors", "cursors", "Prompt-engineering dials activated on the node (docs/cursors.md)"),
+}
+
+// Kinds is the registry, in the order the reference renders them.
+var Kinds = []Kind{
+	// ---- top-level declarations ----
+	{Name: "prompt", Role: Declaration, Doc: "A named text block, referenced by `system:` / `user:` / `instructions:`; its body is free text with {{…}} references and {{include \"file\"}} directives. Blank lines in the body are dropped by the lexer; a bare header declares an empty prompt.",
+		Entries: &Entries{Shape: "indented text lines", Doc: "Free text; the first line's indentation is stripped from every line"}},
+	{Name: "schema", Role: Declaration, Doc: "A structured-output shape; a bare header declares an empty schema.",
+		Entries: &Entries{Shape: `field: string | bool | int | float | json | string[] | file [enum: "a", "b"]`, Doc: "One field per line; `file` is valid only on the output schema of a human node whose interaction collects operator bytes (C129); the enum constraint applies to strings"}},
+	{Name: "cursor", Role: Declaration, Doc: "A prompt-engineering dial: an enum (values:) or a numeric band map (bands:) over [0, 1], each entry carrying a prompt fragment (C083–C086).",
+		Properties: []Property{
+			pDescription,
+			block("values", "cursor.values", "Enum form: one `name: \"fragment\"` per line, order preserved"),
+			block("bands", "cursor.bands", "Numeric form: one `\"lo..hi\": \"fragment\"` per line"),
+		}},
+	{Name: "cursor.values", Role: BlockRole, Opener: "values", Hosts: []string{"cursor"}, Doc: "The enum values of a cursor.",
+		Entries: &Entries{Shape: `name: "prompt fragment"`, Doc: "Order is the position a numeric invocation snaps to"}},
+	{Name: "cursor.bands", Role: BlockRole, Opener: "bands", Hosts: []string{"cursor"}, Doc: "The numeric bands of a cursor.",
+		Entries: &Entries{Shape: `"lo..hi": "prompt fragment"`, Doc: "The range is parsed by the compiler (C085 when malformed)"}},
+	{Name: "supervisor", Role: Declaration, Doc: "A concurrent LLM watcher of agent nodes that enqueues steering messages the watched node reads at its next turn (docs/supervisors.md); run metadata, not a graph node.",
+		Properties: []Property{
+			prop("watches", IdentList, "Agent nodes the supervisor is armed for"),
+			pModel,
+			pSystem,
+			prop("cooldown", String, "Minimum delay between two evaluations, e.g. \"2m\""),
+			prop("max_evals", Int, "Upper bound on evaluations per run"),
+			prop("monitors", StringList, "Event patterns armed from the first event (the CLI --monitor grammar)"),
+		}},
+	{Name: "mcp_server", Role: Declaration, Doc: "An MCP server the workflow may activate: stdio (command/args) or http/sse (url), optionally OAuth2.",
+		Properties: []Property{
+			enum("transport", "How the server is reached", "stdio", "http", "sse"),
+			prop("command", String, "stdio: the executable"),
+			prop("args", StringList, "stdio: its arguments"),
+			prop("url", String, "http / sse: the endpoint"),
+			block("auth", "auth", "OAuth2 authorization-code/PKCE settings"),
+		}},
+	{Name: "auth", Role: BlockRole, Opener: "auth", Hosts: []string{"mcp_server"}, Doc: "OAuth2 settings of an MCP server (only authorization-code/PKCE is wired).",
+		Properties: []Property{
+			prop("type", String, "\"oauth2\""),
+			prop("auth_url", String, "Authorization endpoint"),
+			prop("token_url", String, "Token endpoint"),
+			prop("revoke_url", String, "Revocation endpoint (optional)"),
+			prop("client_id", String, "OAuth client id"),
+			prop("scopes", StringList, "Scopes requested"),
+		}},
+	{Name: "group", Role: Declaration, Header: "group <name>(<param>, …):", Doc: "A reusable node cluster with parameters, whose body holds agent/judge/router/human/tool/compute declarations and edges; instantiated by `use`, expanded at compile time (C141 warns on a use of an empty group). Prompts read `{{params.name}}`.",
+		Entries: &Entries{Shape: "node declarations and edges (src -> dst)", Doc: "Nodes are addressed as <prefix>.<node> once instantiated"}},
+	{Name: "use", Role: Declaration, Header: "use <group> as <prefix> [with { <param>: \"value\", … }]", Doc: "One instance of a group; the with map binds its parameters. No body.",
+		Entries: &Entries{Shape: `use g as p with { param: "value" }`, Doc: "A single line, no indented body"}},
+
+	// ---- top-level blocks ----
+	{Name: "vars", Role: BlockRole, Opener: "vars", Hosts: []string{"file", "workflow"}, Doc: "Typed run parameters, overridable with --var and presets.",
+		Entries: &Entries{Shape: `name: type [enum: "a", "b"] [= default]`, Doc: "type is string, bool, int, float, json or string[]; the enum constraint applies to strings; a json/string[] default is a quoted JSON text"}},
+	{Name: "presets", Role: BlockRole, Opener: "presets", Hosts: []string{"file"}, Doc: "Named bundles of var values selected with --recipe / --preset.",
+		Entries: &Entries{Shape: "name: (indented) var: literal", Doc: "Each entry is a preset name with one `var: literal` line per value"}},
+	{Name: "attachments", Role: BlockRole, Opener: "attachments", Hosts: []string{"file", "workflow"}, Doc: "Operator-supplied files and images the run receives.",
+		Entries: &Entries{Shape: "name: file | image", Body: "attachment", Doc: "An entry may open an indented sub-block"}},
+	{Name: "attachment", Role: Entry, Opener: "attachments", Hosts: []string{"attachments"}, Doc: "The optional sub-block of one attachment.",
+		Properties: []Property{
+			pDescription,
+			prop("accept_mime", StringList, "MIME types accepted"),
+			prop("required", Bool, "The run cannot start without it"),
+		}},
+	{Name: "secrets", Role: BlockRole, Opener: "secrets", Hosts: []string{"file"}, Doc: "Secrets the run resolves by name from the team's or the local store (docs/secrets.md).",
+		Entries: &Entries{Shape: `name: "value"`, Body: "secret", Doc: "The value on the header line is optional: a bare `name:` (with or without a sub-block) resolves the stored secret by name"}},
+	{Name: "secret", Role: Entry, Opener: "secrets", Hosts: []string{"secrets"}, Doc: "The optional sub-block of one secret.",
+		Properties: []Property{
+			prop("value", String, "Inline value — prefer the stored secret, resolved by name"),
+			checked("as", "How the secret is materialised: value (env/template) or file", "value", "file"),
+			prop("mount_path", String, "as: file — the path inside the sandbox"),
+			prop("env", StringOrIdent, "Environment variable that receives the value"),
+			prop("optional", Bool, "A missing secret does not fail the launch"),
+			prop("hosts", StringList, "Hosts the secret may be sent to"),
+			pDescription,
+		}},
+
+	// ---- nodes ----
+	{Name: "agent", Role: Node, Doc: "An LLM node with tools, structured I/O and any backend.", Properties: llmProperties},
+	{Name: "judge", Role: Node, Doc: "An LLM node producing verdicts; same surface as an agent, typically without tools.", Properties: llmProperties},
+	{Name: "router", Role: Node, Doc: "A routing node: fan_out_all, fan_out_each, condition, round_robin or llm (docs/routers.md). Never takes await.",
+		Properties: []Property{
+			pDescription,
+			enum("mode", "Routing mode", "fan_out_all", "fan_out_each", "condition", "round_robin", "llm"),
+			llmOnly(pModel), llmOnly(pBackend), pProvider, llmOnly(pSystem), llmOnly(pUser),
+			prop("multi", Bool, "llm mode only (C023 otherwise): the model may select several outgoing edges"),
+			llmOnly(pReasoning),
+			prop("over", String, "fan_out_each: expression naming the collection to iterate"),
+			prop("as", Ident, "fan_out_each: alias each item is bound to ({{each.<as>}})"),
+			prop("key", Ident, "fan_out_each: item field that names each branch"),
+			prop("depends_on", Ident, "fan_out_each: item field naming the branch this one waits for (requires key)"),
+			pNeeds,
+		}},
+	{Name: "human", Role: Node, Doc: "A pause point the operator answers (interaction human, the default), an LLM answers (llm / llm_or_human), or a review gate (review).",
+		Properties: []Property{
+			pDescription,
+			pInput, pOutput, pPublish, pArtifactLabels,
+			prop("instructions", Ident, "Prompt shown to the operator as the question"),
+			pSystem, pModel,
+			pInteraction, pInteractionP, pInteractionM,
+			prop("min_answers", Int, "Answers required before the node resumes"),
+			pAwait,
+			prop("review_url", String, "review: the PR/MR the gate reviews (a {{…}} reference is accepted)"),
+			Property{Name: "posture", Form: StringOrIdent, Values: []string{"human_required", "agent_verdict_ok"},
+				Doc: "review: who may merge — human_required (default) or agent_verdict_ok; not validated at compile, another word reads as the default"},
+			Property{Name: "merge_strategy", Form: StringOrIdent, Values: []string{"squash", "merge"},
+				Doc: "review: squash (default) or merge; not validated at compile"},
+			prop("merge_into", StringOrIdent, "review: current (default), none or a branch name"),
+			prop("max_turns", Int, "review: conversation turns before the gate escalates"),
+		}},
+	{Name: "tool", Role: Node, Doc: "Direct shell execution, no LLM: `command:` runs through bash -c, `script:` through the interpreter `language:` names; with `output:` the command prints schema-shaped JSON on stdout. A Verified Action adds goal + postcondition + policy + recovery (ADR-044).",
+		Properties: []Property{
+			pDescription,
+			prop("command", String, "Shell command, run through bash -c (exclusive with script)"),
+			prop("script", String, "Inline script run by the interpreter language: names"),
+			checked("language", "Interpreter for script:", "js", "node", "py", "python", "python3", "sh", "bash"),
+			pInput, pOutput, pPublish, pArtifactLabels,
+			pAwait,
+			pSandbox,
+			pCompress,
+			prop("permission", Ident, "Parsed for symmetry but NOT enforced on a tool node (C112 warns): the command runs directly, the gate is an agent's"),
+			pNeeds,
+			prop("parallel_safe", Bool, "Declares the node safe to run beside a mutating branch"),
+			prop("goal", String, "Verified action: what the command is for, in one line"),
+			prop("postcondition", String, "Verified action: command whose exit code is the truth oracle at every rung"),
+			checked("policy", "Verified action: required (default), recover or best_effort (C103–C106)", "required", "recover", "best_effort"),
+			block("recovery", "recovery", "Verified action: the self-heal ladder's bounds"),
+		}},
+	{Name: "recovery", Role: BlockRole, Opener: "recovery", Hosts: []string{"tool"}, Doc: "Bounds of a Verified Action's recovery ladder (idempotent-skip → recipe → self-repair → agent → policy).",
+		Properties: []Property{
+			prop("max_repair_attempts", Int, "Self-repair rungs before the agent rung"),
+			prop("max_agent_attempts", Int, "Agent rungs before the policy decides"),
+			pModel,
+			prop("agent_tools", ToolList, "Tools the recovery agent may call"),
+		}},
+	{Name: "compute", Role: Node, Doc: "A deterministic expression node: each expr entry is evaluated by the bounded expression language into an output field.",
+		Properties: []Property{
+			pDescription,
+			pInput, pOutput, pPublish, pArtifactLabels,
+			pAwait,
+			block("expr", "expr", "One `field: \"expression\"` per output field"),
+		}},
+	{Name: "expr", Role: BlockRole, Opener: "expr", Hosts: []string{"compute"}, Doc: "The expressions of a compute node.",
+		Entries: &Entries{Shape: `field: "expression"`, Doc: "An expression over vars, input, outputs, artifacts, loop and run — not a {{template}}"}},
+	{Name: "subbot", Role: Node, Doc: "Runs another .bot as a nested child run; its outputs read back as {{outputs.<subbot>.<field>}} (C119).",
+		Properties: []Property{
+			pDescription,
+			prop("source", String, "Path of the child .bot, relative to this file"),
+			prop("with", WithMap, "Child vars; {{…}} references are allowed in the values"),
+			pOutput,
+			pNeeds,
+			prop("isolated", Bool, "Asserts the child runs in its own workspace"),
+		}},
+	{Name: "emit", Role: Node, Doc: "Publishes a named run-scoped event with an immutable payload (ADR-051).",
+		Properties: []Property{
+			pDescription,
+			prop("event", String, "Event name"),
+			prop("with", WithMap, "Payload fields"),
+		}},
+	{Name: "wait", Role: Node, Doc: "Blocks its branch until the named event fires; the timeout is mandatory (ADR-051, C196–C198).",
+		Properties: []Property{
+			pDescription,
+			prop("event", String, "Event name awaited"),
+			prop("timeout", String, "Duration after which the wait fails, e.g. \"30s\" (mandatory)"),
+			pOutput,
+		}},
+	{Name: "await_answers", Role: Node, Doc: "Parks its branch until every pending ask_user_async question of `from:` (or the whole run) is answered; output {answers: […]} (ADR-081, C241/C242).",
+		Properties: []Property{
+			pDescription,
+			prop("from", StringOrIdent, "Node whose async questions are awaited; omit for the whole run"),
+			prop("timeout", String, "Duration after which the node fails, e.g. \"30m\" (mandatory)"),
+		}},
+	{Name: "fail", Role: Node, Doc: "A named terminal failure with a typed code and a message (C247 checks the UPPER_SNAKE code, C248 refuses a reserved one).",
+		Properties: []Property{
+			pDescription,
+			prop("code", StringOrIdent, "Error code, UPPER_SNAKE (bare or quoted)"),
+			prop("message", String, "Message; {{…}} references are rendered"),
+			prop("resumable", Bool, "Leaves the run failed_resumable instead of failed"),
+		}},
+
+	// ---- workflow and its blocks ----
+	{Name: "workflow", Role: Declaration, Doc: "The graph: entry, edges (`src -> dst [when …|else] [as loop(N)] [with {…}]`), and the run-wide settings; a bare header declares an empty workflow (C008).",
+		Properties: []Property{
+			prop("entry", Ident, "Node the run starts at; a dotted name addresses a group instance's node"),
+			block("vars", "vars", "Workflow-scoped vars (merged with the file's)"),
+			block("attachments", "attachments", "Workflow-scoped attachments"),
+			block("budget", "budget", "Run caps, each overridable by the matching run flag"),
+			block("resources", "resources", "Named semaphores and pools nodes lease with needs:"),
+			block("mcp", "mcp", "MCP servers active for the run"),
+			block("compaction", "compaction", "Default compaction thresholds"),
+			pSandbox,
+			checked("worktree", "auto runs the workflow in a fresh git worktree, finalised into a branch; none runs in place", "auto", "none"),
+			prop("default_backend", String, "Backend for nodes that name none"),
+			pCompress, pAutoMemory,
+			checked("loop_budget_guard", "Decline a loop's back-edge the budget cannot fund: on (default) or off (C133)", "on", "off"),
+			checked("repo_devbox", "Load the target repo's devbox.json toolchain: on (default) or off (C134)", "on", "off"),
+			checked("workspace_checkpoint", "Mid-run preservation of a copy-based sandbox's workspace as a checkpoint branch pushed to the run's own remote: on (default) or off (C139)", "on", "off"),
+			pPermission,
+			prop("allow", StringList, "Permission rules always allowed, Tool(pattern) syntax"),
+			prop("ask", StringList, "Permission rules that pause for approval"),
+			prop("deny", StringList, "Permission rules always blocked"),
+			prop("tool_policy", ToolList, "Run-wide tool-policy entries"),
+			prop("capabilities", ToolList, "Run-wide board capabilities"),
+			prop("skills", SkillList, "Run-wide skill-library skills"),
+			enum("interaction", "Default interaction mode for the run's nodes that set none", "none", "human", "llm", "llm_or_human", "review", "async"),
+		}},
+	{Name: "budget", Role: BlockRole, Opener: "budget", Hosts: []string{"workflow"}, Doc: "Run caps; a zero or absent cap is the engine default, and each is overridable per run without editing the .bot.",
+		Properties: []Property{
+			prop("max_parallel_branches", Int, "Concurrent branches (0 = engine default)"),
+			prop("max_duration", String, "Wall-clock cap, e.g. \"4h\""),
+			prop("max_cost_usd", Number, "Spend cap in USD"),
+			prop("max_tokens", Int, "Total token cap"),
+			prop("warn_tokens", Int, "Advisory: crossing it emits budget_warning"),
+			prop("max_iterations", Int, "Total node executions; also the fuel of an unbounded loop (C097)"),
+		}},
+	{Name: "resources", Role: BlockRole, Opener: "resources", Hosts: []string{"workflow"}, Doc: "Named resources nodes lease with needs:.",
+		Entries: &Entries{Shape: `name: <int> | ["member-a", "member-b"]`, Doc: "A count is a semaphore; a quoted list is a pool whose members are leased one at a time"}},
+	{Name: "compaction", Role: BlockRole, Opener: "compaction", Hosts: []string{"workflow", "agent", "judge"}, Doc: "When and how a session's context is compacted.",
+		Properties: []Property{
+			prop("threshold", Number, "Context fraction (0–1) that triggers compaction"),
+			prop("preserve_recent", Int, "Recent messages kept verbatim"),
+		}},
+	{Name: "memory", Role: BlockRole, Opener: "memory", Hosts: []string{"agent", "judge"}, Doc: "iterion's shared-memory tools for a node (docs/memory-and-knowledge.md); distinct from auto_memory.",
+		Properties: []Property{
+			prop("enabled", Bool, "Open the memory tools to the node"),
+			prop("scope", String, "Memory scope the tools read and write"),
+			prop("autoload", StringList, "Documents injected at node start"),
+			prop("read", Bool, "Allow memory_read"),
+			prop("write", Bool, "Allow memory_write"),
+			prop("pre_compact_inject", Bool, "Re-inject memory before a compaction"),
+			prop("project_root", Bool, "Key the space on the repository root rather than the working directory (legacy; exclusive with visibility)"),
+			prop("visibility", String, "Who sees the space: bot, project, cross_project, user, org or global (C170)"),
+		}},
+	{Name: "mcp", Role: BlockRole, Opener: "mcp", Hosts: []string{"workflow", "agent", "judge"}, Doc: "Which MCP servers are active; an empty block wires nothing (C135 stays an error).",
+		Properties: []Property{
+			prop("autoload_project", Bool, "Workflow scope: load the repository's .mcp.json servers (default true)"),
+			prop("inherit", Bool, "Node scope: inherit the workflow's active servers (default true)"),
+			prop("servers", IdentList, "mcp_server declarations activated"),
+			prop("disable", IdentList, "Servers removed from the ambient set"),
+		}},
+	{Name: "sandbox", Role: BlockRole, Opener: "sandbox", Hosts: []string{"workflow", "agent", "judge", "tool"}, Doc: "Per-run container isolation (docs/sandbox.md): the short form names a mode, the block form is inline and needs image: or build: (C044).",
+		Properties: []Property{
+			enum("mode", "none, auto (devcontainer.json or the published slim image) or inline", "none", "auto", "inline"),
+			prop("image", String, "Container image (exclusive with build)"),
+			block("build", "sandbox.build", "Dockerfile build, local docker only (V2-6)"),
+			prop("user", String, "Container user"),
+			prop("workspace_folder", String, "Mount point of the workspace inside the container"),
+			checked("host_state", "Mount ~/.iterion and ~/.claude into the container: auto or none", "auto", "none"),
+			prop("post_create", String, "Command run once after the container starts"),
+			prop("env", Map, "Environment variables"),
+			prop("mounts", MixedList, "Extra bind mounts"),
+			block("network", "sandbox.network", "Egress policy (open by default)"),
+		}},
+	{Name: "sandbox.build", Role: BlockRole, Opener: "build", Hosts: []string{"sandbox"}, Doc: "A Dockerfile build of the sandbox image (docker driver only).",
+		Properties: []Property{
+			prop("dockerfile", String, "Dockerfile path"),
+			prop("context", String, "Build context"),
+			prop("args", Map, "Build arguments"),
+		}},
+	{Name: "sandbox.network", Role: BlockRole, Opener: "network", Hosts: []string{"sandbox"}, Doc: "Network egress of the sandbox, enforced by a CONNECT proxy on the host.",
+		Properties: []Property{
+			enum("mode", "open (no proxy), allowlist or denylist", "open", "allowlist", "denylist"),
+			prop("preset", StringOrIdent, "Rule preset, e.g. \"iterion-default\""),
+			checked("inherit", "How a node's rules compose with the workflow's: omit to merge (the default), or replace / append (C044 on another word)", "replace", "append"),
+			prop("rules", MixedList, "Hosts and globs; a leading ! negates"),
+		}},
+	{Name: "cursors", Role: BlockRole, Opener: "cursors", Hosts: []string{"agent", "judge"}, Doc: "Cursor activation on a node: the reserved enabled: key plus one setting per declared cursor.",
+		Properties: []Property{
+			prop("enabled", Bool, "Gate for the whole block (an explicit block opts in)"),
+		},
+		Entries: &Entries{Shape: `cursor_name: ident | number | "string"`, Doc: "A value name, a position in [0, 1], or a quoted string for ${VAR} substitution"}},
+	{Name: "fallback", Role: Entry, Opener: "fallbacks", Hosts: []string{"agent", "judge"}, Doc: "One named route of a fallbacks: chain (ADR-087/ADR-091), tried in declaration order.",
+		Properties: []Property{
+			pBackend, pModel, pProvider,
+			Property{Name: "on", Form: IdentList, Values: []string{"usage_window", "auth", "unavailable", "transient_exhausted", "any"},
+				Doc: "Failure classes that take this route (default usage_window, unavailable; never any or auth by default)"},
+			prop("metered", Bool, "The route spends a metered API key (credential hint)"),
+			checked("action", "skip: complete the node with a zero-value output stamped _skipped instead of failing", "skip"),
+			prop("when", String, "Expression over vars that gates the route"),
+		}},
+}

--- a/pkg/dsl/spec/suggest.go
+++ b/pkg/dsl/spec/suggest.go
@@ -1,0 +1,169 @@
+package spec
+
+import (
+	"sort"
+	"strings"
+)
+
+// Suggest returns the kind's property names closest to name — at most
+// three, nearest first — or nothing when none is close: an edit distance of
+// one for a short name, two from five characters on, and a name that is a
+// prefix of the other (a truncated `max_cost` for `max_cost_usd`).
+func Suggest(kind, name string) []string {
+	k, ok := Lookup(kind)
+	if !ok {
+		return nil
+	}
+	type cand struct {
+		name string
+		dist int
+	}
+	var out []cand
+	for _, p := range k.Properties {
+		if p.Name == name {
+			return nil
+		}
+		d := levenshtein(name, p.Name)
+		limit := 1
+		if len(name) >= 5 {
+			limit = 2
+		}
+		prefixed := len(name) >= 3 && (strings.HasPrefix(p.Name, name) || strings.HasPrefix(name, p.Name))
+		if d <= limit || prefixed {
+			out = append(out, cand{p.Name, d})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].dist != out[j].dist {
+			return out[i].dist < out[j].dist
+		}
+		return out[i].name < out[j].name
+	})
+	if len(out) > 3 {
+		out = out[:3]
+	}
+	names := make([]string, 0, len(out))
+	for _, c := range out {
+		names = append(names, c.name)
+	}
+	return names
+}
+
+// UnknownPropertyHint is UnknownPropertyHintIn for a caller that does not
+// know which host the block sits in.
+func UnknownPropertyHint(kind, name string) string {
+	return UnknownPropertyHintIn(kind, "", name)
+}
+
+// UnknownPropertyHintIn is the one-line remedy the parser attaches to an
+// "unknown <kind> property" diagnostic: the closest accepted names when
+// there are any; otherwise the block of this kind the name belongs to (a
+// `mode:` written on the sandbox is the network's), or the enclosing kind
+// it belongs to (an `entry:` written inside `budget:` is the workflow's);
+// and always the kind's own list, so the author does not open the
+// reference. host is the kind whose body the block sits in, when the
+// caller knows it: an `mcp:` block lives under a workflow OR an agent, and
+// "outdent it to the agent's level" is a lie under a workflow — so with an
+// unknown host the enclosing-kind remedy is given only for a block with one
+// possible host. Empty for a kind the registry does not know.
+func UnknownPropertyHintIn(kind, host, name string) string {
+	k, ok := Lookup(kind)
+	if !ok {
+		return ""
+	}
+	var parts []string
+	switch {
+	case len(Suggest(kind, name)) > 0:
+		parts = append(parts, "Did you mean "+quoteList(Suggest(kind, name), " or ")+"?")
+	case len(childOwners(k, name)) > 0:
+		c := childOwners(k, name)
+		parts = append(parts, "`"+name+"` is a property of the `"+c[0].Opener+":` block — indent it under `"+c[0].Opener+":`.")
+	case enclosingOwner(k, host, name) != "":
+		h := enclosingOwner(k, host, name)
+		parts = append(parts, "`"+name+"` belongs to the enclosing `"+h+"`, not to `"+kind+"` — outdent it to the "+h+"'s level.")
+	case len(Owners(name)) > 0:
+		parts = append(parts, "`"+name+"` is a property of "+strings.Join(Owners(name), "/")+"; "+kind+" does not take it.")
+	}
+	if len(k.Properties) > 0 {
+		parts = append(parts, kind+" accepts: "+strings.Join(k.Names(), ", ")+".")
+	} else if k.Entries != nil {
+		parts = append(parts, kind+" takes entries of the form `"+k.Entries.Shape+"`.")
+	}
+	return strings.Join(parts, " ")
+}
+
+// childOwners returns the kinds hosted by k that accept name.
+func childOwners(k Kind, name string) []Kind {
+	var out []Kind
+	for _, c := range HostedBy(k.Name) {
+		if c.Has(name) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// enclosingOwner returns the host of k that accepts name — the host the
+// block actually sits in when the caller named one that k lists, else k's
+// only host; "" when the host is unknown among several (a guess would be a
+// false claim) or accepts no such property.
+func enclosingOwner(k Kind, host, name string) string {
+	candidates := k.Hosts
+	switch {
+	case host != "" && hostOf(k, host):
+		candidates = []string{host}
+	case len(k.Hosts) != 1:
+		return ""
+	}
+	for _, h := range candidates {
+		if hk, ok := Lookup(h); ok && hk.Has(name) {
+			return h
+		}
+	}
+	return ""
+}
+
+func hostOf(k Kind, host string) bool {
+	for _, h := range k.Hosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
+func quoteList(names []string, sep string) string {
+	q := make([]string, 0, len(names))
+	for _, n := range names {
+		q = append(q, "`"+n+"`")
+	}
+	return strings.Join(q, sep)
+}
+
+// levenshtein is the edit distance between two short ASCII-ish strings.
+func levenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+	prev := make([]int, len(rb)+1)
+	cur := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev, cur = cur, prev
+	}
+	return prev[len(rb)]
+}

--- a/pkg/dsl/spec/suggest_test.go
+++ b/pkg/dsl/spec/suggest_test.go
@@ -1,0 +1,104 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSuggestFindsTheClosestNames(t *testing.T) {
+	cases := []struct {
+		kind, name string
+		want       []string
+	}{
+		{"tool", "comand", []string{"command"}},
+		{"budget", "max_cost", []string{"max_cost_usd"}},
+		{"agent", "modle", []string{"model"}},
+		{"workflow", "budjet", []string{"budget"}},
+		{"agent", "toolz", []string{"tools"}},
+		{"agent", "model", nil}, // an exact match is not a suggestion
+		{"agent", "zzzzzzzz", nil},
+		{"nokind", "model", nil},
+	}
+	for _, c := range cases {
+		got := Suggest(c.kind, c.name)
+		if strings.Join(got, ",") != strings.Join(c.want, ",") {
+			t.Errorf("Suggest(%q, %q) = %v, want %v", c.kind, c.name, got, c.want)
+		}
+	}
+}
+
+func TestUnknownPropertyHintNamesTheRemedy(t *testing.T) {
+	cases := []struct {
+		kind, name string
+		wants      []string
+	}{
+		// a typo: the closest accepted name
+		{"tool", "comand", []string{"Did you mean `command`?", "tool accepts: description, command"}},
+		// a child block's property written on its host: indent it
+		{"sandbox", "rules", []string{"`rules` is a property of the `network:` block", "indent it under `network:`"}},
+		{"sandbox", "preset", []string{"`network:` block"}},
+		{"tool", "max_repair_attempts", []string{"`recovery:` block"}},
+		// the host's property written inside its child: outdent it
+		{"budget", "entry", []string{"belongs to the enclosing `workflow`", "outdent"}},
+		{"sandbox.network", "image", []string{"belongs to the enclosing `sandbox`"}},
+		// another kind's property: named, with the kind's own list
+		{"compute", "command", []string{"`command` is a property of agent/judge/mcp_server/tool", "compute does not take it", "compute accepts: description, input, output"}},
+		{"tool", "readonly", []string{"`readonly` is a property of agent/judge"}},
+		// nothing close: the list alone
+		{"emit", "zzzz", []string{"emit accepts: description, event, with."}},
+	}
+	for _, c := range cases {
+		got := UnknownPropertyHint(c.kind, c.name)
+		for _, w := range c.wants {
+			if !strings.Contains(got, w) {
+				t.Errorf("UnknownPropertyHint(%q, %q) = %q, want it to contain %q", c.kind, c.name, got, w)
+			}
+		}
+	}
+	if got := UnknownPropertyHint("nokind", "x"); got != "" {
+		t.Errorf("an unknown kind must yield no hint, got %q", got)
+	}
+}
+
+// A block with several possible hosts names the enclosing kind only when the
+// caller says which one the block sits in: "outdent it to the agent's level"
+// is a false claim under a workflow.
+func TestEnclosingKindRemedyNeedsTheRealHost(t *testing.T) {
+	cases := []struct {
+		host, name    string
+		want, wantNot string
+	}{
+		{"agent", "model", "belongs to the enclosing `agent`", ""},
+		{"judge", "model", "belongs to the enclosing `judge`", "`agent`"},
+		{"workflow", "model", "`model` is a property of agent/fallback/human/judge/", "enclosing"},
+		{"", "model", "`model` is a property of agent/fallback/human/judge/", "enclosing"},
+		{"agent", "entry", "`entry` is a property of workflow", "enclosing"},
+		{"workflow", "entry", "belongs to the enclosing `workflow`", ""},
+	}
+	for _, c := range cases {
+		got := UnknownPropertyHintIn("mcp", c.host, c.name)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("mcp in %q, %q: %q lacks %q", c.host, c.name, got, c.want)
+		}
+		if c.wantNot != "" && strings.Contains(got, c.wantNot) {
+			t.Errorf("mcp in %q, %q: %q must not contain %q", c.host, c.name, got, c.wantNot)
+		}
+	}
+	// A single-host block keeps its remedy with no host named.
+	if got := UnknownPropertyHint("budget", "entry"); !strings.Contains(got, "belongs to the enclosing `workflow`") {
+		t.Errorf("budget: %q", got)
+	}
+}
+
+func TestOwnersAndHostedBy(t *testing.T) {
+	if got := strings.Join(Owners("threshold"), ","); got != "compaction" {
+		t.Errorf("Owners(threshold) = %q", got)
+	}
+	var names []string
+	for _, k := range HostedBy("sandbox") {
+		names = append(names, k.Name)
+	}
+	if got := strings.Join(names, ","); got != "sandbox.build,sandbox.network" {
+		t.Errorf("HostedBy(sandbox) = %q", got)
+	}
+}

--- a/pkg/sandbox/spec.go
+++ b/pkg/sandbox/spec.go
@@ -264,7 +264,7 @@ func (s *Spec) Validate() error {
 			return fmt.Errorf("sandbox.network: invalid mode %q (want allowlist, denylist, or open)", s.Network.Mode)
 		}
 		if !s.Network.Inherit.IsValid() {
-			return fmt.Errorf("sandbox.network: invalid inherit %q (want merge, replace, or append)", s.Network.Inherit)
+			return fmt.Errorf("sandbox.network: invalid inherit %q (want replace or append; omit it to merge, the default)", s.Network.Inherit)
 		}
 	}
 	if s.WorkspaceFolder != "" && !strings.HasPrefix(s.WorkspaceFolder, "/") {


### PR DESCRIPTION
Lot 1a of #1010 — closes #1084.

## What

The `.bot` property surface lived in five hand-written copies: the parser's switch arms, `docs/grammar/iterion_v1.ebnf`, `docs/references/dsl-grammar.md`, the root `SKILL.md` and the whats-next quickref. They drifted (lot 0 found the quickref's three canonical examples did not parse), and an unknown property was refused with E012 and a pointer to a table.

- **`pkg/dsl/spec`** — a declarative registry (a leaf): every declaration kind, node kind and block, with the properties it accepts, each value's shape and one line of doc. It DESCRIBES the parser; it does not drive it (a generic parser loop is lot 1b, an option).
- **Held to the parser by a black-box conformance test in both directions.** Candidate names = the lexer's keywords ∪ every identifier-shaped string literal in the parser's sources ∪ the registry's names; for each kind, a minimal document `<kind> x:\n  <name>: 1` (nested for blocks) is parsed and "accepted" means no E012. Listed⇒accepted and accepted⇒listed; free-entry blocks are probed with an arbitrary name; hosts, openers and block bodies must resolve. A second test holds the EBNF's `*_prop` productions to the registry — on its first run it found **four drifts** in the hand-written grammar (`monitors`, `action`/`when`, `workspace_checkpoint`, `warn_tokens`), now fixed.
- **E012 names the remedy**, through one choke point (`parser.unknownProperty`, the 31 former sites): the closest accepted name (`Did you mean \`command\`?`), the block a name belongs to (`\`rules\` is a property of the \`network:\` block — indent it under \`network:\``), the enclosing kind it belongs to (`\`entry\` belongs to the enclosing \`workflow\` — outdent it`), the kinds that do take it, and always the kind's own list. A `name:` line the `workflow` body does not know is now E012 with that remedy instead of the edge parser's "expected ->", and its misspelt block's indented body is dropped whole rather than reported line by line.
- **`isKeywordToken` is derived from the lexer's keyword table.** The probe's first run found the hand-kept list had drifted by 14 keywords (`emit`, `wait`, `needs`, `key`, `over`, `else`, `resources`, `supervisor`, `await_answers`, `depends_on`, `fan_out_each`, `loop_budget_guard`, `repo_devbox`, `workspace_checkpoint`): `agent emit:` or a schema field named `key` were refused, and those words drew "unexpected token" instead of E012 inside the blocks that match properties by spelling. A test now walks the whole table.
- **Generated renderings, checked fresh in CI** (`task dsl:check`, in `task check`): `docs/references/dsl-properties.md` (new, the complete per-kind reference), the four property tables of `dsl-grammar.md`, and a compact property section in `SKILL.md` and the whats-next quickref, all between `<!-- dsl-spec:begin … -->` markers. `iterion dsl spec --write` (`task dsl:gen`) regenerates them; `--region reference|skill|'table <kind>'` prints one.
- **Fences**: 30 documentation fences carrying DSL without the `iter` tag are now compiled by `TestDocsIterFencesCompile`; 11 did not parse or compile (a YAML-style `with:`, an unquoted `${VAR}`, three inline `system: "…"` strings, a fallback chain C176 would refuse, a route reading an undeclared var, edges outside a `workflow`, an `…` line) and were corrected.
- Two carries from #1067's review: `bundle.Open` absolutises its `cacheRoot` (Q4), and C044 names a network mode written on the sandbox (`open|allowlist|denylist` → "write it as `network:` + `mode:`", Q2).

## Deferred, on purpose

JSON Schema rendering (the registry keeps what it needs; the document such a schema would validate is lot 5's YAML twin). The template gallery and the F20 re-probe are the next ticket of lot 1. C135 already carried did-you-mean (`toolcatalog.Suggest`).

## Verification

`task check` green locally (lint 0 issues; `go test ./...` — the only red was `TestPiRPCLiveMCPStdioBridge`, a known TempDir-cleanup flake, green on rerun). One local adversarial round (two reviewers, code and written assertions) before this PR; findings and dispositions in the first comment.
