### PR TITLE
docs(tenancy): what a repo does NOT carry when it changes team

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,7 +369,13 @@ the hours this one spent.
   caps, the shared-credential audience, and the **team lifecycle**
   (`iterion remote teams update|status|delete|add-member` — rename, suspend,
   delete an empty team, and place an account that already exists instead of
-  emailing it an invitation). Plus its original subject: plugging tracker
+  emailing it an invitation). Read *Moving a repo to another team* before
+  splitting a tenant: the provisioner rebuilds the managed forge secret and its
+  `forge_token` binding on the target, and **nothing else keyed on `Team.ID`
+  follows** — an operator secret, a `tracker_token` binding, a config-share, a
+  schedule, `sync_issues_enabled`. The launch that needed one fails mute, since
+  a missing binding reads exactly like a feature nobody configured. Plus its
+  original subject: plugging tracker
   tickets (Jira Cloud/DC, GitHub/GitLab issues) into a Revi review so it
   verifies the PR delivers what the ticket asks: the team wiring (team
   secret → `tracker_token` binding with `allowed_hosts` → per-repo

--- a/docs/ticket-context.md
+++ b/docs/ticket-context.md
@@ -177,3 +177,41 @@ which is why `orgs add-member` exists as its org-admin twin, and why the two
 are a pair. Without it the round trip was merely moved one level up: a user
 with no org at all stayed reachable only by email. For an account that does
 not exist **yet**, the email invitation remains the path.
+
+### Moving a repo to another team — what does NOT follow it
+
+There is no transfer route: a repo changes team by `DELETE
+/api/teams/<src>/forge/repo-bots/<iid>` then `POST` on the target, which
+recreates the webhook and the managed forge secret. That much is automatic —
+the `forge_github_*` / `forge_gitlab_*` secret and its `forge_token` binding
+are rebuilt on the target team by the provisioner.
+
+**Everything else keyed on `Team.ID` stays behind**, and the launch that needs
+it fails with no diagnostic, because a missing binding is indistinguishable
+from a feature that was never configured. Measured on a real migration: a repo
+kept its `tracker_api_base` / `tracker_user` launch vars — replayed with care —
+while the `tracker_token` binding they address stayed on the source team, so
+ticket conformance went quiet.
+
+Walk the class before calling a move done:
+
+| Endpoint | Follows the repo? |
+|---|---|
+| `/forge/repo-bots` | yes — that is the move |
+| `/secrets` (`forge_*` managed) | yes, rebuilt by the provisioner |
+| `/bots/{bot}/bindings` (`forge_token`) | yes, rebuilt |
+| `/secrets` (operator-owned) | **no** |
+| `/bots/{bot}/bindings` (`tracker_token`, …) | **no** |
+| `/config-shares` · `/schedules` | **no** |
+| `/plugin-sources` · `/bot-sources` · `/api-keys` | **no** |
+| `sync_issues_enabled` | **no** — not a provisioning field, re-`PATCH` it |
+
+Recreating an operator secret on the target is only correct if it is the SAME
+credential: compare the `fingerprint` (and `last4`) the API returns against the
+source's before trusting the new binding — a lookalike token authenticates
+until it silently does not.
+
+And a source team emptied of repos is not necessarily inert: it may still own
+the schedules, config-shares and connections of the bots that were never
+repo-scoped. Check `/schedules` and `/config-shares` before treating it as a
+shell.


### PR DESCRIPTION
Écrit après avoir scindé un tenant réel (18 dépôts, 13 équipes) et découvert
la moitié manquante en vérifiant, pas en lisant.

## Le piège

Déplacer une intégration *a l'air* de suffire : le provisioner recrée le
webhook, le secret managé `forge_*` et sa liaison `forge_token` sur l'équipe
cible. Le dépôt est re-reviewé, tout paraît sain.

Tout le reste, scopé par `Team.ID`, reste derrière — et cet échec est **muet** :
une liaison absente est indistinguable d'une fonctionnalité que personne n'a
configurée.

Mesuré : un dépôt est parti avec ses `launch_vars` `tracker_api_base` /
`tracker_user` rejouées champ par champ, pendant que la liaison
`tracker_token` qu'elles adressent restait sur l'équipe source. La conformité
aux tickets s'est simplement tue.

## Ce que la PR ajoute

- la liste endpoint par endpoint de ce qui suit le dépôt et de ce qui ne suit
  pas (`/secrets` opérateur, `/bots/{bot}/bindings`, `/config-shares`,
  `/schedules`, `/plugin-sources`, `sync_issues_enabled`) ;
- le contrôle d'**empreinte** qui distingue un secret recréé d'un homonyme —
  un token qui ressemble authentifie jusqu'au moment où il n'authentifie plus ;
- l'avertissement qu'une équipe source vidée de ses dépôts n'est pas forcément
  inerte : elle peut encore porter les schedules et config-shares des bots qui
  n'étaient pas liés à un dépôt. Ce n'est pas une coquille à supprimer.

Le pointeur d'index dans `CLAUDE.md` est mis à jour en conséquence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
