### PR TITLE
fix(credusage): a usage listing that hides its filter reads as a frozen meter

### DIFF
--- a/cmd/iterion/remote_gov.go
+++ b/cmd/iterion/remote_gov.go
@@ -62,6 +62,14 @@ var remoteUsageByCredential bool
 // bill must never quietly include the deployment's unattributed runs.
 var remoteUsageRepo string
 
+// remoteUsageMonth reads a PAST month of that ledger. The endpoint keys its
+// rows by month and only the current one was reachable from here, so
+// answering "what did this key cost in August" meant querying the raw API —
+// and a hand-written `?month=` was silently ignored, which is how a probe
+// came to read September's numbers as August's and call a live counter
+// frozen (#1087).
+var remoteUsageMonth string
+
 var remoteUsageCmd = &cobra.Command{
 	Use:   "usage",
 	Short: "Org monthly usage (alias of `orgs usage`); --by-credential for the per-credential ledger",
@@ -73,9 +81,16 @@ var remoteUsageCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				path := "/api/teams/" + team + "/credentials/usage"
+				q := url.Values{}
 				if repo := strings.TrimSpace(remoteUsageRepo); repo != "" {
-					path += "?repo=" + url.QueryEscape(repo)
+					q.Set("repo", repo)
+				}
+				if month := strings.TrimSpace(remoteUsageMonth); month != "" {
+					q.Set("month", month)
+				}
+				path := "/api/teams/" + team + "/credentials/usage"
+				if len(q) > 0 {
+					path += "?" + q.Encode()
 				}
 				return cli.RemoteGetPrint(cmd.Context(), c, p, path)
 			})(cmd, args)
@@ -229,6 +244,8 @@ func init() {
 		"Per-credential ledger for the team instead of the org bucket (each amount typed metered|estimate)")
 	remoteUsageCmd.Flags().StringVar(&remoteUsageRepo, "repo", "",
 		"With --by-credential: only what the team spent on this repository (forge slug, e.g. owner/repo)")
+	remoteUsageCmd.Flags().StringVar(&remoteUsageMonth, "month", "",
+		"With --by-credential: which month to read (YYYY-MM; default: the current one)")
 	remoteLimitsCmd.Flags().StringVar(&remoteLimitsData, "data", "", "Override JSON (literal or @file)")
 
 	for _, c := range []*cobra.Command{remoteMemoryDocsCmd, remoteMemoryDocCmd, remoteMemoryExportCmd, remoteMemoryImportCmd} {

--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -269,11 +269,36 @@ definitive for that attempt, so it has to be visible.
 iterion remote usage --by-credential
 # GET /api/teams/{id}/credentials/usage
 
+# A past month, on either route
+iterion remote usage --by-credential --month 2026-08
+iterion remote api GET "/api/admin/credentials/usage?month=2026-08"
+
 # The platform tier across every tenant it served (super-admin)
 iterion remote api GET /api/admin/credentials/usage
 # ?tier=team|pool|platform — or ?fingerprint=<fp> for one credential,
 # whose rows live under each tenant that drew on it.
 ```
+
+**The admin route answers for ONE tier, and the default is `platform`.** A
+team forfait's spend is metered on a `team` row and is therefore absent from
+the unfiltered listing — by design, since no tenant view can show the
+platform tier and that is the question this route exists for. Every response
+now carries a `scope` object naming what was applied (`tier`, `fingerprint`,
+`repo`, `team_id`), because a listing that does not say what it left out
+reads as "everything", and a credential missing from "everything" reads as a
+credential that spent nothing:
+
+```json
+{ "month": "2026-09", "scope": { "tier": "platform" }, "credentials": [ … ] }
+```
+
+Both routes take `?month=YYYY-MM`, and **refuse a value they cannot parse**
+(400) rather than fall back to the current month — the response is labelled
+with a month, so serving another one under that label is a wrong answer, not
+a partial one. Two readings of this endpoint made without either property
+were what opened #1087 against a counter that was recording normally: a
+`?month=` the server ignored returned the current month twice, and the
+platform-tier default hid the team row the run had actually charged.
 
 Metering is best effort throughout, like the org bucket: a missing counter,
 an unattributable route or a store failure leave the observation on the

--- a/pkg/server/cred_usage_routes.go
+++ b/pkg/server/cred_usage_routes.go
@@ -49,9 +49,32 @@ type credentialUsageView struct {
 	Backends        []string `json:"backends,omitempty"`
 }
 
+// credentialUsageScope names what a listing was filtered on.
+//
+// A listing that does not say what it left out reads as "everything", and a
+// credential absent from it reads as a credential that spent nothing. The
+// admin route's ABSENT `?tier=` answers for the platform tier alone, so a
+// team forfait's spend — metered on a team row — is invisible there. A
+// production probe read exactly that as a frozen meter and opened a defect
+// against a counter that was recording normally (#1087).
+type credentialUsageScope struct {
+	// Tier is the tier filter the admin listing applied, including the one
+	// it defaulted to on its own.
+	Tier string `json:"tier,omitempty"`
+	// Fingerprint / Repo name the narrower questions, each exclusive of Tier.
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Repo        string `json:"repo,omitempty"`
+	// TeamID is set by the team route, whose rows are one tenant's slice of
+	// each credential rather than the whole of it.
+	TeamID string `json:"team_id,omitempty"`
+}
+
 // credentialUsageListView is the response envelope.
 type credentialUsageListView struct {
-	Month       string                `json:"month"`
+	Month string `json:"month"`
+	// Scope is always present: an answer states the question it answers,
+	// not only its result.
+	Scope       credentialUsageScope  `json:"scope"`
 	Credentials []credentialUsageView `json:"credentials"`
 	// MeteredUSD / EstimatedUSD are the two totals, kept apart for the
 	// reason nature exists: one is an invoice, the other is not.
@@ -59,8 +82,8 @@ type credentialUsageListView struct {
 	EstimatedUSD float64 `json:"estimated_usd"`
 }
 
-func toCredentialUsageList(month string, rows []credusage.MonthlyUsage) credentialUsageListView {
-	out := credentialUsageListView{Month: month, Credentials: make([]credentialUsageView, 0, len(rows))}
+func toCredentialUsageList(month string, scope credentialUsageScope, rows []credusage.MonthlyUsage) credentialUsageListView {
+	out := credentialUsageListView{Month: month, Scope: scope, Credentials: make([]credentialUsageView, 0, len(rows))}
 	for _, r := range rows {
 		out.Credentials = append(out.Credentials, credentialUsageView{
 			Month: r.Month, Fingerprint: r.Fingerprint, Provider: r.Provider,
@@ -98,6 +121,27 @@ func tierOrPlatform(raw string) (credusage.Tier, error) {
 	}
 }
 
+// monthFromQuery reads the optional `?month=YYYY-MM` these listings key on,
+// defaulting to the current month.
+//
+// A value it cannot parse is an ERROR, for the reason an unknown `?tier=`
+// is: the response carries a `month` field, so serving the current month to
+// a caller who asked for another is a wrong answer wearing the right label.
+// Measured — a probe asking for `2026-08` was served September, byte for
+// byte, and the identical numbers read as a counter that had stopped
+// (#1087).
+func monthFromQuery(raw string, now time.Time) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return now, nil
+	}
+	when, err := time.Parse("2006-01", raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unknown month %q (want YYYY-MM)", raw)
+	}
+	return when.UTC(), nil
+}
+
 // handleTeamCredentialUsage lists what each credential cost THIS team this
 // month. A platform or lent credential appears with the team's own slice of
 // it — the whole of it is the admin view's answer.
@@ -112,12 +156,18 @@ func (s *Server) handleTeamCredentialUsage(w http.ResponseWriter, r *http.Reques
 		httpError(w, http.StatusForbidden, "not a member of this team")
 		return
 	}
-	now := time.Now().UTC()
+	when, merr := monthFromQuery(r.URL.Query().Get("month"), time.Now().UTC())
+	if merr != nil {
+		httpError(w, http.StatusBadRequest, "%s", merr.Error())
+		return
+	}
+	scope := credentialUsageScope{TeamID: teamID}
 	var (
 		rows []credusage.MonthlyUsage
 		err  error
 	)
 	if repo := strings.TrimSpace(r.URL.Query().Get("repo")); repo != "" {
+		scope.Repo = repo
 		// ListByRepo spans TENANTS by design — a repository can be served by
 		// several teams' credentials — so this route, which answers for one
 		// team, must narrow it. Filtering here rather than asking the counter
@@ -125,16 +175,16 @@ func (s *Server) handleTeamCredentialUsage(w http.ResponseWriter, r *http.Reques
 		// is that forgetting this line leaks another team's spend, which is
 		// why oneTenant is named and tested rather than inlined.
 		var all []credusage.MonthlyUsage
-		all, err = s.credUsage.ListByRepo(r.Context(), now, repo)
+		all, err = s.credUsage.ListByRepo(r.Context(), when, repo)
 		rows = oneTenant(all, teamID)
 	} else {
-		rows, err = s.credUsage.List(r.Context(), now, teamID)
+		rows, err = s.credUsage.List(r.Context(), when, teamID)
 	}
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
-	writeJSON(w, toCredentialUsageList(now.Format("2006-01"), rows))
+	writeJSON(w, toCredentialUsageList(when.Format("2006-01"), scope, rows))
 }
 
 // oneTenant keeps only the rows belonging to a tenant. The cross-tenant
@@ -159,10 +209,15 @@ func (s *Server) handleAdminCredentialUsage(w http.ResponseWriter, r *http.Reque
 		httpError(w, http.StatusNotFound, "per-credential usage is not enabled on this instance")
 		return
 	}
-	now := time.Now().UTC()
+	when, merr := monthFromQuery(r.URL.Query().Get("month"), time.Now().UTC())
+	if merr != nil {
+		httpError(w, http.StatusBadRequest, "%s", merr.Error())
+		return
+	}
 	var (
-		rows []credusage.MonthlyUsage
-		err  error
+		rows  []credusage.MonthlyUsage
+		err   error
+		scope credentialUsageScope
 	)
 	fp := strings.TrimSpace(r.URL.Query().Get("fingerprint"))
 	repo := strings.TrimSpace(r.URL.Query().Get("repo"))
@@ -175,9 +230,11 @@ func (s *Server) handleAdminCredentialUsage(w http.ResponseWriter, r *http.Reque
 		httpError(w, http.StatusBadRequest, "give ?fingerprint= or ?repo=, not both — one credential across repositories and one repository across credentials are different questions")
 		return
 	case repo != "":
-		rows, err = s.credUsage.ListByRepo(r.Context(), now, repo)
+		scope.Repo = repo
+		rows, err = s.credUsage.ListByRepo(r.Context(), when, repo)
 	case fp != "":
-		rows, err = s.credUsage.ListByFingerprint(r.Context(), now, fp)
+		scope.Fingerprint = fp
+		rows, err = s.credUsage.ListByFingerprint(r.Context(), when, fp)
 	default:
 		// By TIER, not by tenant: a platform credential is metered under
 		// each tenant it served, so no single tenant holds its month.
@@ -186,11 +243,15 @@ func (s *Server) handleAdminCredentialUsage(w http.ResponseWriter, r *http.Reque
 			httpError(w, http.StatusBadRequest, "%s", terr.Error())
 			return
 		}
-		rows, err = s.credUsage.ListByTier(r.Context(), now, tier)
+		// Echoed even — especially — when the caller named no tier: this
+		// listing is one tier's, and the default is the one a reader is
+		// least likely to have in mind.
+		scope.Tier = string(tier)
+		rows, err = s.credUsage.ListByTier(r.Context(), when, tier)
 	}
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
-	writeJSON(w, toCredentialUsageList(now.Format("2006-01"), rows))
+	writeJSON(w, toCredentialUsageList(when.Format("2006-01"), scope, rows))
 }

--- a/pkg/server/cred_usage_routes_test.go
+++ b/pkg/server/cred_usage_routes_test.go
@@ -124,6 +124,146 @@ func TestCredentialUsage_NotEnabled(t *testing.T) {
 	}
 }
 
+// #1087 — the reading that opened a defect against a healthy counter. The
+// admin listing filters on the PLATFORM tier when the caller names none, so
+// a team forfait's spend is absent from it by design; nothing in the answer
+// said so, and two identical reads around a run that spent $2.40 on that
+// team forfait read as a meter that had stopped recording.
+//
+// The fix is not a different default — it is an answer that states its own
+// question.
+func TestAdminCredentialUsage_SaysWhichTierItAnswered(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	now := time.Now().UTC()
+	seedCredUsage(t, counter, now, "fp-plat", "openai", credusage.TierPlatform, "team-a", credusage.NatureMetered, "codex", 2.0)
+	seedCredUsage(t, counter, now, "fp-team", "claude_code", credusage.TierTeam, "team-a", credusage.NatureEstimate, "claude_code", 2.40)
+
+	srv := &Server{credUsage: counter, logger: iterlog.Nop()}
+	body := adminCredUsage(t, srv, "")
+	if body.Scope.Tier != string(credusage.TierPlatform) {
+		t.Fatalf("scope.tier = %q on an unfiltered listing, want the platform default named — a listing that hides its filter reads as 'everything', and a credential missing from it reads as one that spent nothing",
+			body.Scope.Tier)
+	}
+	// The row the probe was looking for, and the reason it was not there.
+	for _, c := range body.Credentials {
+		if c.Fingerprint == "fp-team" {
+			t.Fatalf("the team row leaked into the platform listing: %+v", c)
+		}
+	}
+	if team := adminCredUsage(t, srv, "?tier=team"); team.Scope.Tier != string(credusage.TierTeam) {
+		t.Fatalf("scope.tier = %q for ?tier=team", team.Scope.Tier)
+	}
+	if fp := adminCredUsage(t, srv, "?fingerprint=fp-team"); fp.Scope.Fingerprint != "fp-team" || fp.Scope.Tier != "" {
+		t.Fatalf("scope = %+v for ?fingerprint=, want the fingerprint named and no tier claimed", fp.Scope)
+	}
+}
+
+// A month the caller did not ask for, wearing the label of the month they
+// did, is the shape of #1087's probe: `?month=2026-08` was served September
+// byte for byte, and the numbers being identical is what read as "frozen".
+func TestCredentialUsage_AnswersTheMonthAsked(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	past := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	seedCredUsage(t, counter, now, "fp-sep", "anthropic", credusage.TierTeam, "team-a", credusage.NatureMetered, "claw", 5.0)
+	seedCredUsage(t, counter, past, "fp-aug", "anthropic", credusage.TierTeam, "team-a", credusage.NatureMetered, "claw", 3.0)
+
+	srv := &Server{credUsage: counter, logger: iterlog.Nop()}
+	aug := teamCredUsage(t, srv, "team-a", "?month=2026-08")
+	if aug.Month != "2026-08" {
+		t.Fatalf("month = %q, want the month asked for", aug.Month)
+	}
+	if len(aug.Credentials) != 1 || aug.Credentials[0].Fingerprint != "fp-aug" {
+		t.Fatalf("?month=2026-08 = %+v, want August's single row — serving another month under this label is a wrong answer, not a partial one",
+			aug.Credentials)
+	}
+	// And the same question on the admin route, which had the identical bug.
+	if a := adminCredUsage(t, srv, "?tier=team&month=2026-08"); len(a.Credentials) != 1 || a.Credentials[0].Fingerprint != "fp-aug" {
+		t.Fatalf("admin ?month=2026-08 = %+v, want August's row", a.Credentials)
+	}
+}
+
+// A month it cannot parse is refused, for the reason an unknown ?tier= is:
+// falling back to now would answer a question nobody asked.
+func TestCredentialUsage_MalformedMonthIsRefused(t *testing.T) {
+	counter := credusage.NewMemoryCounter()
+	srv := &Server{credUsage: counter, logger: iterlog.Nop()}
+	for _, raw := range []string{"august", "2026", "2026-13", "2026-08-03"} {
+		for _, call := range []struct {
+			name string
+			code int
+		}{
+			{"team", teamCredUsageStatus(t, srv, "team-a", "?month="+raw)},
+			{"admin", adminCredUsageStatus(t, srv, "?month="+raw)},
+		} {
+			if call.code != http.StatusBadRequest {
+				t.Errorf("%s route, month=%q: status %d, want 400", call.name, raw, call.code)
+			}
+		}
+	}
+	// The current month stays the default when none is named.
+	if body := teamCredUsage(t, srv, "team-a", ""); body.Month != time.Now().UTC().Format("2006-01") {
+		t.Errorf("default month = %q, want the current one", body.Month)
+	}
+}
+
+func adminCredUsage(t *testing.T, srv *Server, query string) credentialUsageListView {
+	t.Helper()
+	w := adminCredUsageRec(srv, query)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admin usage%s: %d %s", query, w.Code, w.Body.String())
+	}
+	var body credentialUsageListView
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body
+}
+
+func adminCredUsageStatus(t *testing.T, srv *Server, query string) int {
+	t.Helper()
+	return adminCredUsageRec(srv, query).Code
+}
+
+func adminCredUsageRec(srv *Server, query string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest("GET", "/api/admin/credentials/usage"+query, nil)
+	r = r.WithContext(auth.WithIdentity(r.Context(), auth.Identity{UserID: "root", IsSuperAdmin: true}))
+	w := httptest.NewRecorder()
+	srv.handleAdminCredentialUsage(w, r)
+	return w
+}
+
+func teamCredUsage(t *testing.T, srv *Server, teamID, query string) credentialUsageListView {
+	t.Helper()
+	w := teamCredUsageRec(srv, teamID, query)
+	if w.Code != http.StatusOK {
+		t.Fatalf("team usage%s: %d %s", query, w.Code, w.Body.String())
+	}
+	var body credentialUsageListView
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Scope.TeamID != teamID {
+		t.Fatalf("scope.team_id = %q, want %q — these rows are one tenant's slice of each credential, not the whole of it", body.Scope.TeamID, teamID)
+	}
+	return body
+}
+
+func teamCredUsageStatus(t *testing.T, srv *Server, teamID, query string) int {
+	t.Helper()
+	return teamCredUsageRec(srv, teamID, query).Code
+}
+
+func teamCredUsageRec(srv *Server, teamID, query string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest("GET", "/api/teams/"+teamID+"/credentials/usage"+query, nil)
+	r.SetPathValue("id", teamID)
+	r = r.WithContext(store.WithTenant(auth.WithIdentity(r.Context(),
+		auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: teamID}), teamID))
+	w := httptest.NewRecorder()
+	srv.handleTeamCredentialUsage(w, r)
+	return w
+}
+
 // The admin per-credential view filters by tier. The switch behind it is
 // CLOSED, and its old fallthrough was silent: an unknown value answered
 // with the platform tier's numbers, so `?tier=org` did not report "I do not


### PR DESCRIPTION
## What this fixes

`GET /api/admin/credentials/usage` answers for **one tier**, defaulting to
`platform` when the caller names none. That default is right — no tenant
view can show the platform tier, which is the question the route exists for
— but nothing in the response said which tier had been applied.

Both routes also labelled every answer with a `month` derived from
`time.Now()` while reading no `?month=` at all, so a caller asking for
`2026-08` was served September under an August-shaped question.

Together they make a listing that reads as "everything" while being one
slice of it, and a credential absent from "everything" reads as a
credential that spent nothing.

## How it was found

By making that exact mistake in production. Two reads of the unfiltered
admin listing around a $2.40 run showed identical numbers, and I filed
#1087: *the per-credential counter is frozen*. The run was served by its
tenant's own **team** forfait and metered on a `team` row — invisible on a
`platform` listing. The meter was recording normally.

```
?tier=team → 1cf39b473b9a5941 claude_code tenant=3a29c5ee runs=411 aggregate_tokens=64670
```

`aggregate_tokens` only exists since #1052 (merged 2026-09-09 21:38Z), so a
non-zero value there was written by a runner build carrying it — i.e. after
this deployment's runner digest went live at 10:52Z the same morning.

## The change

- Every response carries a `scope` object naming what was applied —
  `tier`, `fingerprint`, `repo`, `team_id` — **including the tier the
  route defaulted to on its own**.
- `?month=YYYY-MM` is read by both routes, and a value they cannot parse
  is **refused with 400** rather than silently answered with the current
  month. Same rule the file already applies to an unknown `?tier=`: a
  wrong answer is worse than a missing feature.
- `iterion remote usage --by-credential --month 2026-08` reaches it from
  the CLI, which could only ever ask for the current month.

The platform default is deliberately **unchanged**: changing it would move
the wrong-answer surface rather than remove it. The fix is an answer that
states its own question.

## Verification

`devbox run -- task check` → exit 0.

The three new tests were run against the previous behaviour and each fails
with the production symptom, so the bench bites rather than merely passing:

```
scope.tier = "" on an unfiltered listing, want the platform default named
month = "2026-09", want the month asked for
team route, month="august": status 200, want 400
```

Refs #1087
