### PR TITLE
fix(sec-audit): the deep scanner reports what it did, and its timeout escalates

### DIFF
--- a/bots/sec-audit-source/main.bot
+++ b/bots/sec-audit-source/main.bot
@@ -2662,7 +2662,12 @@ unset _cb
 # would stall the whole node until the run timeout. 2400s is ~2x a legit
 # large-repo process; on timeout (124) the retry below re-runs it (network
 # back by then). This catches the hang case the exit-only retry cannot.
-_dsproc() { ( cd "$DSW" && CLAUDE_CODE_EXECUTABLE="$CLAUDE_BIN" timeout 2400 deepsec process --concurrency "$CONC" $PROC_ARGS $AGENT_ARGS ); }
+#
+# -k is not optional. Bare timeout sends SIGTERM ONLY, and the node process
+# deepsec runs under ignores it. Measured 2026-09-10 on this node: a 240s
+# bound returned after 27 minutes 39. Without the kill-after escalation the
+# bound is advisory — a limit that reads as enforced and is not.
+_dsproc() { ( cd "$DSW" && CLAUDE_CODE_EXECUTABLE="$CLAUDE_BIN" timeout -k 60 2400 deepsec process --concurrency "$CONC" $PROC_ARGS $AGENT_ARGS ); }
 # deepsec process drives its OWN claude LLM calls (outside iterion network
 # retry). A transient blip (rate-limit / quota / network) here drops the
 # whole deepsec contribution and silently thins the audit. Retry once after a
@@ -2694,7 +2699,49 @@ if [ -n "$ERRS" ] && [ "$FCNT" = "0" ]; then
   ERRS="$ERRS export_unusable"
 fi
 
-ERR_JSON=$(printf "%s" "$ERRS" | python3 -c "import json,sys; e=sys.stdin.read().strip().split(); print(json.dumps([\"step failed: \"+x for x in e]))")
+# The envelope carries the LOG, not just the name of the step that failed.
+# Every log this node writes lives under LOG_DIR inside the sandbox, and the
+# pod is destroyed when the run ends: an operator reading "step failed:
+# process" afterwards has no way to learn why. Measured 2026-09-10: four
+# consecutive launches reported a failed step and nothing else, and the cause
+# (an unauthenticated agent answering "Not logged in") was only found once the
+# tail travelled in the envelope.
+#
+# The file name is NOT derived from the token alone. A token may be more
+# specific than its log (a preflight_unreachable token against preflight.log),
+# so several names are tried; and when none answers, the message says which
+# ones were tried and what the directory actually holds. A diagnostic that
+# fails must name what it saw, never just "unreadable".
+ERR_JSON=$(printf "%s" "$ERRS" | LOG_DIR="$LOG_DIR" python3 -c "
+import json, os, sys
+e = sys.stdin.read().strip().split()
+out = [\"step failed: \" + x for x in e]
+log_dir = os.environ.get(\"LOG_DIR\", \"\")
+try:
+    present = sorted(os.listdir(log_dir))
+except OSError as ex:
+    present = [\"<listdir failed: \" + type(ex).__name__ + \">\"]
+for step in e:
+    names = [step + \".log\", step.split(\"_\")[0] + \".log\"]
+    for n in names:
+        try:
+            body = open(os.path.join(log_dir, n), errors=\"replace\").read()[-1500:]
+        except OSError:
+            continue
+        out.append(\"log tail \" + step + \" (\" + n + \"): \" + body)
+        break
+    else:
+        out.append(\"log tail \" + step + \": none of \" + \",\".join(names)
+                   + \" — \" + log_dir + \" holds: \" + \",\".join(present))
+# env.log carries the credential and transport verdicts this node writes at
+# startup. They are what tells a degraded pass from a broken one, and they die
+# with the pod unless they travel here.
+try:
+    out.append(\"env.log: \" + open(os.path.join(log_dir, \"env.log\"), errors=\"replace\").read()[-1500:])
+except OSError as ex:
+    out.append(\"env.log: unreadable (\" + type(ex).__name__ + \")\")
+print(json.dumps(out))
+")
 printf "{\"scanner\":\"deepsec\",\"subscanners\":[\"deepsec\"],\"json_paths\":%s,\"finding_count\":%s,\"errors\":%s}\n" "$PATHS_JSON" "$FCNT" "$ERR_JSON"
 '`
   output: scanner_output

--- a/bots/sec_audit_deepsec_report_test.go
+++ b/bots/sec_audit_deepsec_report_test.go
@@ -1,0 +1,160 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every log the deep scanner writes lives under LOG_DIR inside the sandbox,
+// and the pod is destroyed when the run ends. An operator reading
+// "step failed: process" afterwards has no way to learn why.
+//
+// Measured 2026-09-10: four consecutive launches reported a failed step and
+// nothing else. The cause — an unauthenticated agent answering "Not logged
+// in" — was only found once the log tail travelled in the node's envelope.
+//
+// So the envelope must carry the LOG, and this exercises the real reporter
+// against a fixture directory rather than asserting on its source text: the
+// property is what the script produces, not how it is spelled.
+func TestDeepsecEnvelopeCarriesTheLogNotJustTheStepName(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	script := deepsecErrReporter(t)
+
+	logDir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(logDir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("preflight.log", "PREFLIGHT DETAIL\nNot logged in · Please run /login\n")
+	write("env.log", "[deepsec] token exported\n[preflight] ok=no\n")
+
+	run := func(t *testing.T, tokens string) []string {
+		t.Helper()
+		f := filepath.Join(t.TempDir(), "report.py")
+		if err := os.WriteFile(f, []byte(script), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command("python3", f)
+		cmd.Stdin = strings.NewReader(tokens)
+		cmd.Env = append(os.Environ(), "LOG_DIR="+logDir)
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("reporter failed: %v (out %q)", err, out)
+		}
+		var lines []string
+		if err := json.Unmarshal(out, &lines); err != nil {
+			t.Fatalf("reporter output is not a JSON array: %v (%q)", err, out)
+		}
+		return lines
+	}
+
+	joined := func(lines []string) string { return strings.Join(lines, "\n") }
+
+	t.Run("a token more specific than its log still finds it", func(t *testing.T) {
+		// The token names the failure; the file is named after the STEP. A
+		// reporter that derives one from the other reports "unreadable" on
+		// exactly the failure it exists to explain — measured on three runs.
+		got := joined(run(t, "preflight_unreachable"))
+		if !strings.Contains(got, "Not logged in") {
+			t.Errorf("the preflight log did not travel: %s", got)
+		}
+		if !strings.Contains(got, "preflight.log") {
+			t.Errorf("the envelope does not name the file it read: %s", got)
+		}
+	})
+
+	t.Run("a missing log names what was tried AND what is there", func(t *testing.T) {
+		got := joined(run(t, "process"))
+		if strings.Contains(got, "unreadable (") && !strings.Contains(got, "holds:") {
+			t.Errorf("the reporter said only that it failed: %s", got)
+		}
+		for _, want := range []string{"process.log", "holds:", "preflight.log"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("the message does not mention %q, so the reader cannot tell a wrong name "+
+					"from an absent log: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("env.log travels whatever failed", func(t *testing.T) {
+		// The credential and transport verdicts are written there at startup;
+		// they are what tells a degraded pass from a broken one.
+		got := joined(run(t, "export"))
+		if !strings.Contains(got, "token exported") || !strings.Contains(got, "ok=no") {
+			t.Errorf("env.log did not travel: %s", got)
+		}
+	})
+}
+
+// TestDeepsecTimeoutEscalates pins the kill-after. Bare `timeout` sends
+// SIGTERM only and the node process under deepsec ignores it: measured
+// 2026-09-10, a 240s bound returned after 27 minutes 39. A bound without -k
+// is advisory while reading as enforced.
+func TestDeepsecTimeoutEscalates(t *testing.T) {
+	body := deepsecCommand(t)
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.Contains(line, "timeout ") || !strings.Contains(line, "deepsec ") {
+			continue
+		}
+		if !strings.Contains(line, "timeout -k ") {
+			t.Errorf("a deepsec invocation is bounded by a bare `timeout`, which only sends SIGTERM — "+
+				"the process ignores it and the bound is advisory. Use `timeout -k <grace> <limit>`: %s",
+				strings.TrimSpace(line))
+		}
+	}
+}
+
+// deepsecCommand returns the shell body of the deep-scanner node.
+func deepsecCommand(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("sec-audit-source/main.bot")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, blk := range commandBackticks(string(raw)) {
+		if strings.Contains(blk, "deepsec export --format json") {
+			return blk
+		}
+	}
+	t.Fatal("no deepsec command block found")
+	return ""
+}
+
+// deepsecErrReporter extracts the embedded python that builds the errors[]
+// array, with the shell-level escaping of its double quotes undone — which is
+// exactly what the shell hands to python3 -c.
+func deepsecErrReporter(t *testing.T) string {
+	t.Helper()
+	body := deepsecCommand(t)
+	const marker = `python3 -c "`
+	i := strings.Index(body, `ERR_JSON=$(`)
+	if i < 0 {
+		t.Fatal("no ERR_JSON assignment in the deepsec command")
+	}
+	j := strings.Index(body[i:], marker)
+	if j < 0 {
+		t.Fatal("the ERR_JSON assignment embeds no python3 -c body")
+	}
+	start := i + j + len(marker)
+	// The terminator is the closing quote of `python3 -c "…"`, which sits at
+	// the start of its own line. Searching for a bare `")` cuts the body at
+	// the first ESCAPED quote before a paren — and python then dies on a
+	// syntax error with empty stdout, which reads as "the reporter is broken"
+	// rather than "the test mis-parsed it".
+	end := strings.Index(body[start:], "\n\")")
+	if end < 0 {
+		t.Fatal("the errors[] reporter is not the multi-line python this test can exercise. If it was " +
+			"reverted to the one-liner that emits step NAMES only, the log tail no longer travels in the " +
+			"envelope and the failure it explains is unreadable once the pod is gone. If it was merely " +
+			"reshaped, re-point this extraction at the new form.")
+	}
+	return strings.ReplaceAll(body[start:start+end], `\"`, `"`)
+}


### PR DESCRIPTION
Two defects, both measured on real runs, both of the same family: **a failure that leaves no readable trace**.

## 1. The envelope carried the step's NAME and nothing else

Every log this node writes lives under `LOG_DIR` **inside the sandbox**, and the pod is destroyed with the run. So `step failed: process`, read afterwards, is unreadable.

Measured 2026-09-10: **four consecutive launches** reported a failed step and nothing more. The cause — an unauthenticated agent answering `Not logged in · Please run /login` — was found only once the tail travelled in the envelope.

Now the envelope carries the log. Three details are deliberate:

- **the file name is not derived from the token alone.** A token can be more specific than its log, so several names are tried;
- **when none answers, the message names what was tried and what the directory holds.** The first version of this very reporter said `unreadable (FileNotFoundError)` on the one failure it existed to explain — a diagnostic that fails must name what it saw;
- **`env.log` travels too.** The credential and transport verdicts written at startup are what distinguishes a degraded pass from a broken one.

## 2. `timeout` without `-k` never escalates

`timeout 2400` sends **SIGTERM only**, and the node process deepsec runs under ignores it. Measured on this node: a **240 s** bound returned after **27 minutes 39**. A bound without `-k` is advisory while reading as enforced.

## Tests

They run the **real reporter** against a fixture log directory rather than asserting on source text — the property is what the script produces, not how it is spelled.

| face | assertion |
|---|---|
| token more specific than its log | the tail still travels, and the envelope names the file it read |
| log absent | the message names what was tried **and** what the directory holds |
| whatever failed | `env.log` travels |
| every deepsec invocation | bounded by `timeout -k` |

**Verified to bite.** Restoring the bare `timeout` fails the escalation test. Restoring the step-names-only one-liner fails the envelope test with a message that states the loss rather than a parser complaint.

`go test ./bots/` → 693 passed.