### PR TITLE
feat(runs): a run says which tier paid for it, and says it again after a resume

### DIFF
--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -366,6 +366,24 @@ asking "which key paid for this, and why not the other one". The cheapest way
 to get one on demand is to `resume` a run parked on a usage window: a resume
 re-resolves credentials, so it both proves the wiring and unblocks the run.
 
+**The run itself now carries which TIER paid** (`credential_tiers` on
+`GET /api/runs/{id}`, shown as a `paid by …` badge on the run header). It is
+stamped with `cred_fingerprints`, as one unit, at launch and at **every
+resume** — a resume can be funded by a different tier than the launch, so a
+field that recorded only the first answer would send you to the wrong door.
+It survives log rotation, which the lines above do not:
+
+```json
+{ "cred_fingerprints": ["1cf39b47…"], "credential_tiers": ["oauth-forfait"] }
+```
+
+It is **plural** because a run is: one attempt can spend a team forfait on
+its implementer and the platform's codex key on its plan review, and naming
+one of them "the tier" would be wrong about the other. It carries no slot
+names — for the (slot, tier, fingerprint) triple, the GRANTED line above
+remains the place to look, and the two cannot drift because they are computed
+by the same function.
+
 ### Two connections of the same account are two meters
 
 A Claude `credentials.json` carries no account or subscription id, so

--- a/openapi.json
+++ b/openapi.json
@@ -2167,6 +2167,12 @@
             },
             "type": "array"
           },
+          "credential_tiers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "current_run_start": {
             "format": "date-time",
             "type": "string"

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -102,6 +102,20 @@ type RunHeader struct {
 	// an operator can audit a key's occupancy from the run list instead of
 	// the server logs. Empty for local runs and runs that sealed nothing.
 	CredFingerprints []string `json:"cred_fingerprints,omitempty"`
+	// CredentialTiers names which resolution tiers FUNDED the run
+	// (store.CredentialTier*: byok, oauth-forfait, org, pool, platform),
+	// stamped with the fingerprints above and re-stamped at every resume.
+	// It answers "who paid for this run", which until now lived only in a
+	// publisher INFO line and stopped being answerable once the logs
+	// rotated — and it decides who to talk to when a run is refused: a
+	// donor whose window shut, an org whose budget is spent, or the
+	// deployment's own fallback.
+	//
+	// Plural: one attempt can spend two tiers, and the pair (tiers,
+	// fingerprints) is deliberately not a per-slot map — the publisher's
+	// GRANTED log line stays the place where slot, tier and fingerprint are
+	// read together.
+	CredentialTiers []string `json:"credential_tiers,omitempty"`
 	// LLMIdleSince is set while the run executes no model-calling node —
 	// it then holds none of its credentials' concurrency slots.
 	LLMIdleSince *time.Time `json:"llm_idle_since,omitempty"`
@@ -1520,6 +1534,7 @@ func headerFromRun(r *store.Run) RunHeader {
 		Inputs:               r.Inputs,
 		PermissionMode:       r.PermissionMode,
 		CredFingerprints:     r.CredFingerprints,
+		CredentialTiers:      r.CredentialTiers,
 		LLMIdleSince:         r.LLMIdleSince,
 		SkippedCredReopensAt: r.SkippedCredReopensAt,
 		ModelOverrides:       r.ModelOverrides,

--- a/pkg/server/cloudpublisher/credential_tiers_test.go
+++ b/pkg/server/cloudpublisher/credential_tiers_test.go
@@ -1,0 +1,181 @@
+package cloudpublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #991 — a run records WHICH tier funded it, so "who paid for this?" stays
+// answerable once the publisher's GRANTED log line has rotated away.
+//
+// The scenario is the one the ticket asks for, and it is the reason the
+// field is re-stamped rather than written once: the same run, resolved
+// twice, is funded by two different tiers. Nothing here hands the publisher
+// a tier — if the stamp is not wired to the real resolution, the assertions
+// read an empty list.
+func TestCredentialTiers_platformThenPoolAfterTheKeyIsWithdrawn(t *testing.T) {
+	ctx := context.Background()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+
+	// The deployment's own fallback forfait, and a donor's pledge that is
+	// NOT yet lending — the pool is consulted before the platform, so a
+	// live pledge would win and the first half would prove nothing.
+	oauth := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, oauth, sealer, secrets.PlatformOwnerKey, "sk-ant-platform")
+	seedOAuth(t, oauth, sealer, "donor", "sk-ant-donated")
+
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-1", OrgID: poolOrg, Enabled: true}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	pledge := credpool.Pledge{
+		ID: credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), PoolID: "pool-1",
+		UserID: "donor", Credential: credpool.Credential{Source: credpool.SourceOAuth, Ref: "claude_code"},
+		Enabled: false, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: 5},
+	}
+	if err := pledges.Upsert(ctx, pledge); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	rs := secrets.NewMemoryRunSecretsStore()
+	p := &Publisher{
+		runSecrets: rs,
+		sealer:     sealer,
+		// No apiKeys and no tenant forfait: this tenant brought nothing,
+		// which is the only condition under which the shared tiers serve.
+		oauthForfait: oauth,
+		credPool: credpool.NewBroker(credpool.BrokerConfig{
+			Pools: pools, Pledges: pledges, Leases: credpool.NewMemoryLeaseStore(),
+			Ledger: credpool.NewMemoryLedger(), OAuth: oauth, Sealer: sealer, Logger: testLogger(),
+		}),
+		logger: iterlog.New(iterlog.LevelError, nil),
+	}
+	tctx := store.WithTenant(ctx, poolTeam)
+
+	// 1. The launch. Every tenant tier abstained and no pledge is lending,
+	//    so the deployment's own fallback pays.
+	launch, err := p.resolveAndSealCredentials(tctx, "run-991", poolOrg, poolTeam, "requester", "docs-refresh", nil, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolve (launch): %v", err)
+	}
+	if got := launch.tiers; len(got) != 1 || got[0] != store.CredentialTierPlatform {
+		t.Fatalf("launch tiers = %v, want [platform]", got)
+	}
+	if s := launch.stamp(); len(s.Tiers) != 1 || s.Tiers[0] != store.CredentialTierPlatform {
+		t.Fatalf("launch stamp tiers = %v, want the resolution's own answer", s.Tiers)
+	}
+
+	// 2. The platform forfait is withdrawn and the donor starts lending —
+	//    the ordinary way a long-lived run's funding changes under it.
+	rec, err := oauth.Get(ctx, secrets.PlatformOwnerKey, secrets.OAuthKindClaudeCode)
+	if err != nil {
+		t.Fatalf("read the platform record back: %v", err)
+	}
+	if err := oauth.Delete(ctx, rec.ID); err != nil {
+		t.Fatalf("withdraw the platform forfait: %v", err)
+	}
+	pledge.Enabled = true
+	if err := pledges.Upsert(ctx, pledge); err != nil {
+		t.Fatalf("enable the pledge: %v", err)
+	}
+
+	// 3. The resume, same run. A field written only at launch would still
+	//    say "platform" here and send an operator to the wrong door.
+	resumed, err := p.resolveAndSealCredentials(tctx, "run-991", poolOrg, poolTeam, "requester", "docs-refresh", nil, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolve (resume): %v", err)
+	}
+	if got := resumed.tiers; len(got) != 1 || got[0] != store.CredentialTierPool {
+		t.Fatalf("resumed tiers = %v, want [pool] — the platform key is gone and a donor is paying", got)
+	}
+
+	// And the launch path writes it onto the in-memory document as one unit
+	// with the fingerprints, the way the resume path writes it through
+	// SetRunCredStamp.
+	var r store.Run
+	resumed.applyTo(&r)
+	if len(r.CredentialTiers) != 1 || r.CredentialTiers[0] != store.CredentialTierPool {
+		t.Fatalf("Run.CredentialTiers = %v after applyTo, want [pool]", r.CredentialTiers)
+	}
+	if len(r.CredFingerprints) != len(resumed.fingerprints) {
+		t.Fatalf("applyTo left the fingerprints behind: %v vs %v", r.CredFingerprints, resumed.fingerprints)
+	}
+}
+
+// credentialTierForSlot is the ONE place the tier is decided, read by both
+// the GRANTED log line and the run stamp. Its own bench, because a helper
+// two callers share is the one whose drift is invisible.
+func TestCredentialTierForSlot_everyTier(t *testing.T) {
+	const slot = "claude_code"
+	poolGrant := &credpool.Grant{Credential: credpool.Credential{Source: credpool.SourceOAuth, Ref: slot}}
+	cases := []struct {
+		name   string
+		bundle secrets.RunBundle
+		grant  *credpool.Grant
+		own    string
+		want   string
+	}{
+		{"nothing claimed it — the tenant's own subscription", secrets.RunBundle{}, nil, store.CredentialTierOAuthForfait, store.CredentialTierOAuthForfait},
+		{"nothing claimed it — the tenant's own key", secrets.RunBundle{}, nil, store.CredentialTierBYOK, store.CredentialTierBYOK},
+		{"the org lent it", secrets.RunBundle{OrgSourced: map[string]bool{slot: true}}, nil, store.CredentialTierOAuthForfait, store.CredentialTierOrg},
+		{"the deployment's fallback", secrets.RunBundle{PlatformSourced: map[string]bool{slot: true}}, nil, store.CredentialTierOAuthForfait, store.CredentialTierPlatform},
+		{"a donor lent it", secrets.RunBundle{}, poolGrant, store.CredentialTierOAuthForfait, store.CredentialTierPool},
+		// The pool wins over the provenance maps: a lent credential is the
+		// donor's spend whatever slot it filled.
+		{"a donor lent it, platform map set too", secrets.RunBundle{PlatformSourced: map[string]bool{slot: true}}, poolGrant, store.CredentialTierOAuthForfait, store.CredentialTierPool},
+		// A grant for ANOTHER slot must not colour this one.
+		{"a grant naming another slot", secrets.RunBundle{}, &credpool.Grant{Credential: credpool.Credential{Source: credpool.SourceOAuth, Ref: "codex"}}, store.CredentialTierOAuthForfait, store.CredentialTierOAuthForfait},
+		// Same ref, different source: an API-key grant does not claim the
+		// OAuth slot of the same name.
+		{"a grant of the other source", secrets.RunBundle{}, &credpool.Grant{Credential: credpool.Credential{Source: credpool.SourceAPIKey, Ref: slot}}, store.CredentialTierOAuthForfait, store.CredentialTierOAuthForfait},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := credentialTierForSlot(tc.bundle, tc.grant, slot, credpool.SourceOAuth, tc.own); got != tc.want {
+				t.Fatalf("tier = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A resolution that sealed nothing names no tier: an empty list is "iterion
+// cannot say", and a default would be a confident wrong answer about who
+// paid — the failure the per-credential meter exists to remove.
+func TestCredentialTiers_nothingSealedNamesNoTier(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	// Drop the pool so nothing at all can serve.
+	f.pub.credPool = nil
+	_, creds := f.mustResolveEmpty(t)
+	if len(creds.tiers) != 0 {
+		t.Fatalf("tiers = %v on a resolution that sealed nothing, want none", creds.tiers)
+	}
+	if s := creds.stamp(); len(s.Tiers) != 0 {
+		t.Fatalf("stamp tiers = %v, want none", s.Tiers)
+	}
+	var r store.Run
+	r.CredentialTiers = []string{store.CredentialTierPlatform}
+	creds.applyTo(&r)
+	if len(r.CredentialTiers) != 0 {
+		t.Fatalf("applyTo left a stale tier in place: %v — a re-resolution replaces wholesale", r.CredentialTiers)
+	}
+}
+
+// mustResolveEmpty runs the resolution and returns it whatever it sealed.
+func (f *poolFixture) mustResolveEmpty(t *testing.T) (secrets.RunBundle, credResolution) {
+	t.Helper()
+	ctx := store.WithTenant(context.Background(), poolTeam)
+	creds, err := f.pub.resolveAndSealCredentials(ctx, "run-empty", poolOrg, poolTeam, "requester", "docs-refresh", nil, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolveAndSealCredentials: %v", err)
+	}
+	return secrets.RunBundle{}, creds
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -762,21 +762,32 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	// the facade was refused the only credential its model could use.
 	// Unpinned or unresolvable routes keep everything (fail open toward
 	// protection: that run takes whatever the process holds).
+	// The tiers ride the SAME walk, deliberately: a tier collected outside
+	// this filter would name a credential the run holds but cannot spend,
+	// which is the misattribution the filter exists to prevent. Deduplicated
+	// because a tier is a fact about the run, not a per-slot count.
 	spend := spendableProviders(wf, modelOverrides, runFallbacks)
 	seen := map[string]bool{}
+	tiers := map[string]bool{}
 	for prov, fp := range apiKeyFPs {
 		if fp != "" && !seen[fp] && spend.allows(strings.ToLower(string(prov))) {
 			seen[fp] = true
 			res.fingerprints = append(res.fingerprints, fp)
+			tiers[credentialTierForSlot(bundle, res.grant, string(prov), credpool.SourceAPIKey, store.CredentialTierBYOK)] = true
 		}
 	}
 	for kind, fp := range bundle.OAuthFingerprints {
 		if fp != "" && !seen[fp] && spend.allows(providerOfOAuthKind(kind)) {
 			seen[fp] = true
 			res.fingerprints = append(res.fingerprints, fp)
+			tiers[credentialTierForSlot(bundle, res.grant, kind, credpool.SourceOAuth, store.CredentialTierOAuthForfait)] = true
 		}
 	}
 	sort.Strings(res.fingerprints)
+	for tier := range tiers {
+		res.tiers = append(res.tiers, tier)
+	}
+	sort.Strings(res.tiers)
 
 	// The moment "no LLM credential" becomes definitive: every tier
 	// abstained, and the runner will either spend its pod's ambient env or
@@ -860,6 +871,12 @@ type credResolution struct {
 	// The caller stamps them on the run document so the per-key
 	// concurrency meter can count alive runs by credential.
 	fingerprints []string
+	// tiers names which resolution tiers funded the credentials above
+	// (store.CredentialTier*), sorted and deduplicated. Plural because one
+	// run is: a team forfait can serve the implementer while the platform's
+	// codex key serves the plan review, and naming one of them "the tier"
+	// would be wrong about the other.
+	tiers []string
 	// skippedReopensAt is when the earliest credential the walk passed
 	// over (refused window, reached cap) reopens; zero when none was.
 	// Stamped on the run document next to the fingerprints, so a run that
@@ -870,12 +887,25 @@ type credResolution struct {
 
 // stamp is the run-document form of the resolution.
 func (c credResolution) stamp() store.RunCredStamp {
-	s := store.RunCredStamp{Fingerprints: c.fingerprints}
+	s := store.RunCredStamp{Fingerprints: c.fingerprints, Tiers: c.tiers}
 	if !c.skippedReopensAt.IsZero() {
 		at := c.skippedReopensAt.UTC()
 		s.SkippedReopensAt = &at
 	}
 	return s
+}
+
+// applyTo writes the resolution onto an IN-MEMORY run document — the launch
+// path's counterpart to RunStore.SetRunCredStamp, which the resume path
+// takes. Both go through stamp(), so a fact added to the resolution cannot
+// reach one path and silently miss the other; that unit is the whole promise
+// of RunCredStamp, and assigning the fields one by one here is what would
+// break it.
+func (c credResolution) applyTo(r *store.Run) {
+	s := c.stamp()
+	r.CredFingerprints = s.Fingerprints
+	r.CredentialTiers = s.Tiers
+	r.SkippedCredReopensAt = s.SkippedReopensAt
 }
 
 // spendable answers "may a run with these routes spend a credential of
@@ -1698,15 +1728,7 @@ func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.
 		if _, ok := bundle.APIKeys[prov]; !ok {
 			continue
 		}
-		tier := "byok"
-		switch {
-		case grant != nil && grant.Source == credpool.SourceAPIKey && grant.Ref == string(prov):
-			tier = "pool"
-		case bundle.PlatformSourced[string(prov)]:
-			tier = "platform"
-		case bundle.OrgSourced[string(prov)]:
-			tier = "org"
-		}
+		tier := credentialTierForSlot(bundle, grant, string(prov), credpool.SourceAPIKey, store.CredentialTierBYOK)
 		fp := apiKeyFPs[prov]
 		if fp == "" {
 			fp = "<unstamped>"
@@ -1721,15 +1743,7 @@ func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.
 		if _, ok := bundle.OAuthCredentials[kind]; !ok {
 			continue
 		}
-		tier := "oauth-forfait"
-		switch {
-		case grant != nil && grant.Ref == kind && grant.Source == credpool.SourceOAuth:
-			tier = "pool"
-		case bundle.PlatformSourced[kind]:
-			tier = "platform"
-		case bundle.OrgSourced[kind]:
-			tier = "org"
-		}
+		tier := credentialTierForSlot(bundle, grant, kind, credpool.SourceOAuth, store.CredentialTierOAuthForfait)
 		fp := bundle.OAuthFingerprints[kind]
 		if fp == "" {
 			fp = "<unstamped>"
@@ -1740,6 +1754,30 @@ func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.
 		return
 	}
 	logger.Info("cloudpublisher: credentials GRANTED for run=%s — %s", runID, strings.Join(parts, ", "))
+}
+
+// credentialTierForSlot names which resolution tier filled one slot, in the
+// publisher's own five-tier vocabulary (store.CredentialTier*).
+//
+// ONE function for the GRANTED log line and for the run document's
+// CredentialTiers stamp. They answer the same question — the line is what an
+// operator greps while the logs live, the stamp is what still answers once
+// they have rotated — and two copies of this switch would disagree about the
+// same run the day a sixth tier lands.
+//
+// own is the tier a slot falls to when no shared tier claimed it: the
+// tenant's own key (byok) or the subscription it connected itself
+// (oauth-forfait).
+func credentialTierForSlot(bundle secrets.RunBundle, grant *credpool.Grant, slot string, poolSource credpool.CredentialSource, own string) string {
+	switch {
+	case grant != nil && grant.Source == poolSource && grant.Ref == slot:
+		return store.CredentialTierPool
+	case bundle.PlatformSourced[slot]:
+		return store.CredentialTierPlatform
+	case bundle.OrgSourced[slot]:
+		return store.CredentialTierOrg
+	}
+	return own
 }
 
 // SubmitLaunch persists the run as queued in Mongo, then publishes
@@ -1878,8 +1916,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	// exist yet (the launch's one persist comes later), and a patch here
 	// would be a warn-and-lose no-op that leaves the ceiling blind to
 	// every launched run.
-	r.CredFingerprints = creds.fingerprints
-	r.SkippedCredReopensAt = creds.stamp().SkippedReopensAt
+	creds.applyTo(r)
 
 	// A run served by the pool may not spend more than what remains of its
 	// donor's allowance. This is the enforcement: the engine stops the run

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -696,7 +696,11 @@ func (s *Store) CountActiveRunsByTenant(ctx context.Context, tenantID string) (i
 // patch: the caller stamps a run it just persisted. Granular $set/$unset
 // so a status transition racing this write is never disturbed.
 func (s *Store) SetRunCredStamp(ctx context.Context, id string, stamp store.RunCredStamp) error {
-	set := bson.M{"cred_fingerprints": stamp.Fingerprints, "updated_at": time.Now().UTC()}
+	set := bson.M{
+		"cred_fingerprints": stamp.Fingerprints,
+		"credential_tiers":  stamp.Tiers,
+		"updated_at":        time.Now().UTC(),
+	}
 	// A re-stamp is a fresh attempt: it counts until it proves idle.
 	unset := bson.M{"llm_idle_since": ""}
 	if stamp.SkippedReopensAt != nil {

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -217,6 +217,33 @@ const (
 	BotSourceTierBaked = "baked"
 )
 
+// The credential-resolution tiers a run can be FUNDED by, persisted on
+// Run.CredentialTiers. Same rule as the bot tiers above: the vocabulary
+// lives beside the field, so the publisher that computes it and the log
+// line an operator already greps cannot drift apart.
+//
+// These are the publisher's own five tiers, not credusage.Tier's four —
+// that package merges a tenant's key and its subscription into "team",
+// because it meters money and the two spend the same tenant's budget.
+// Here they stay apart, because the question is who to TALK to when a run
+// is refused, and a dead API key and a shut forfait window are two
+// different conversations.
+const (
+	// CredentialTierBYOK — an API key the run's own tenant stored.
+	CredentialTierBYOK = "byok"
+	// CredentialTierOAuthForfait — a subscription the run's own tenant or
+	// its user connected.
+	CredentialTierOAuthForfait = "oauth-forfait"
+	// CredentialTierOrg — the parent org's shared credential, lent to the
+	// teams its CredentialAudience admits.
+	CredentialTierOrg = "org"
+	// CredentialTierPool — a contributor's credential lent through the
+	// mutualised pool: the spend is the DONOR's.
+	CredentialTierPool = "pool"
+	// CredentialTierPlatform — the deployment's own DB-backed fallback.
+	CredentialTierPlatform = "platform"
+)
+
 // Run is the top-level metadata for a single workflow invocation.
 //
 // bson tags mirror the json tags exactly (same snake_case names) so a
@@ -508,6 +535,8 @@ type RunCredStamp struct {
 	// Fingerprints replaces Run.CredFingerprints wholesale; nil or empty
 	// clears it (a re-resolution that sealed nothing holds no slot).
 	Fingerprints []string
+	// Tiers replaces Run.CredentialTiers wholesale, on the same terms.
+	Tiers []string
 	// SkippedReopensAt replaces Run.SkippedCredReopensAt; nil clears it.
 	SkippedReopensAt *time.Time
 }
@@ -542,6 +571,20 @@ type Run struct {
 	// concurrency meter (secrets.ApiKey.MaxConcurrentRuns) counts alive
 	// runs through this field.
 	CredFingerprints []string `json:"cred_fingerprints,omitempty" bson:"cred_fingerprints,omitempty"`
+	// CredentialTiers names which resolution tiers funded this run
+	// (CredentialTier* above), sorted and deduplicated. Stamped with
+	// CredFingerprints, as one unit, at launch and at every resume —
+	// a resume can be funded by a different tier than the launch, and a
+	// field recording only the first answer would be worse than none.
+	//
+	// PLURAL because a run is: one attempt can spend a team forfait on its
+	// implementer and the platform's codex key on its plan review, and a
+	// single "the tier" would have to pick one and be wrong about the
+	// other. It carries no slot names — CredFingerprints does not either,
+	// and the pair answers the operator's question ("who funded this, who
+	// do I talk to") without becoming a second copy of the publisher's
+	// GRANTED log line.
+	CredentialTiers []string `json:"credential_tiers,omitempty" bson:"credential_tiers,omitempty"`
 	// SkippedCredReopensAt is the earliest instant a credential the
 	// resolution PASSED OVER reopens — a refused window's reset, a reached
 	// cap's reset — or nil when nothing usable was skipped. Stamped with

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -1008,6 +1008,7 @@ func (s *FilesystemRunStore) SetRunCredStamp(ctx context.Context, runID string, 
 		return err
 	}
 	r.CredFingerprints = stamp.Fingerprints
+	r.CredentialTiers = stamp.Tiers
 	r.SkippedCredReopensAt = stamp.SkippedReopensAt
 	r.LLMIdleSince = nil
 	return s.SaveRun(ctx, r)

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -2826,6 +2826,46 @@ func testCredFingerprintMeter(t *testing.T, s store.RunStore) {
 		t.Fatalf("a re-stamp that skipped nothing must clear SkippedCredReopensAt, got %v (%v)", got.SkippedCredReopensAt, err)
 	}
 
+	// Which TIERS funded the run ride the same stamp, and are replaced
+	// wholesale by it (#991). A resume can be funded by a different tier
+	// than the launch — the platform key withdrawn, a pool pledge taking
+	// over — so a stamp that appended, or that left the launch's answer in
+	// place, would report a payer that no longer pays.
+	if err := s.SetRunCredStamp(ctx, "fp_run1", store.RunCredStamp{
+		Fingerprints: []string{"fp-zai"},
+		Tiers:        []string{store.CredentialTierOAuthForfait, store.CredentialTierPlatform},
+	}); err != nil {
+		t.Fatalf("stamp with tiers: %v", err)
+	}
+	if got, err = s.LoadRun(ctx, "fp_run1"); err != nil {
+		t.Fatalf("LoadRun fp_run1: %v", err)
+	}
+	if len(got.CredentialTiers) != 2 ||
+		got.CredentialTiers[0] != store.CredentialTierOAuthForfait ||
+		got.CredentialTiers[1] != store.CredentialTierPlatform {
+		t.Fatalf("CredentialTiers = %v, want [oauth-forfait platform] — a run funded by two tiers reports both",
+			got.CredentialTiers)
+	}
+	if err := s.SetRunCredStamp(ctx, "fp_run1", store.RunCredStamp{
+		Fingerprints: []string{"fp-zai"},
+		Tiers:        []string{store.CredentialTierPool},
+	}); err != nil {
+		t.Fatalf("re-stamp with a different tier: %v", err)
+	}
+	if got, err = s.LoadRun(ctx, "fp_run1"); err != nil {
+		t.Fatalf("LoadRun fp_run1: %v", err)
+	}
+	if len(got.CredentialTiers) != 1 || got.CredentialTiers[0] != store.CredentialTierPool {
+		t.Fatalf("CredentialTiers after re-stamp = %v, want [pool] alone — the previous resolution's tiers must not survive it",
+			got.CredentialTiers)
+	}
+	if err := s.SetRunCredStamp(ctx, "fp_run1", store.RunCredStamp{Fingerprints: []string{"fp-zai"}}); err != nil {
+		t.Fatalf("re-stamp with no tier: %v", err)
+	}
+	if got, err = s.LoadRun(ctx, "fp_run1"); err != nil || len(got.CredentialTiers) != 0 {
+		t.Fatalf("a resolution that sealed nothing must clear CredentialTiers, got %v (%v)", got.CredentialTiers, err)
+	}
+
 	// The model-idle marker: a running run executing no model-calling node
 	// holds its key's slot for nobody. Only fp_run1 (running) carries
 	// fp-zai at this point (fp_run2 was re-stamped to fp-anthropic).

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -360,6 +360,11 @@ export interface RunHeader {
   // identities the key/connection views show — never secrets); what the
   // per-key concurrency ceiling counts. Absent for local runs.
   cred_fingerprints?: string[];
+  // Which resolution tiers FUNDED the run — byok, oauth-forfait, org, pool
+  // or platform — stamped with the fingerprints above and re-read at every
+  // resume, so it names who is paying now rather than who paid at launch.
+  // Plural: one attempt can spend two tiers. Absent for local runs.
+  credential_tiers?: string[];
   // Set while the run executes no model-calling node: it then holds none
   // of its credentials' concurrency slots.
   llm_idle_since?: string;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -6326,6 +6326,7 @@ export interface components {
             /** Format: date-time */
             created_at: string;
             cred_fingerprints?: string[];
+            credential_tiers?: string[];
             /** Format: date-time */
             current_run_start?: string;
             deployment?: components["schemas"]["DeploymentReport"];

--- a/studio/src/components/Runs/RunHeader.tsx
+++ b/studio/src/components/Runs/RunHeader.tsx
@@ -292,6 +292,23 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
               </span>
             </Tooltip>
           )}
+          {run.credential_tiers && run.credential_tiers.length > 0 && (
+            <Tooltip
+              content={
+                `Which tier funded this run — re-read at every resume, so it names who is paying NOW.` +
+                (run.credential_tiers.length > 1
+                  ? " Two tiers: one attempt can spend a team forfait on one node and a shared credential on another."
+                  : "")
+              }
+            >
+              <span
+                className="inline-flex items-center gap-1 rounded border border-border-default px-1.5 py-0.5 text-micro text-fg-subtle"
+                data-testid="run-credential-tiers"
+              >
+                paid by {run.credential_tiers.join(" · ")}
+              </span>
+            </Tooltip>
+          )}
           {active && (
             <LiveDot
               tone="live"


### PR DESCRIPTION
Closes #991.

## The gap

`run.bot_source_tier` answers *"which bundle served this launch"*. Nothing
answered the question an operator asks at least as often — **"who paid for
this run?"** — even though the publisher computes it: it walks five tiers
(BYOK → OAuth-forfait → org → pool → platform) and names the winner in one
INFO line. Answering for one run meant grepping the publisher log by run id;
answering for a run whose logs had rotated meant not answering at all.

That matters more than observability usually does: a run's own error names
neither the credential, nor the window, nor the tier. With five tiers, "which
one funded this" is what decides **who to talk to** when a run is refused — a
donor whose window shut, an org whose budget is spent, or the deployment's own
fallback are three different conversations.

## The shape, and why plural

`Run.CredentialTiers` rides `RunCredStamp` — the unit a credential resolution
already leaves on the document. That is what makes it re-stamped at every
resume *for free*, which the ticket asks for and which matters: a resume can
be funded by a different tier than the launch, and a field recording only the
first answer would be worse than none.

It is **plural** because a run is. One attempt can spend a team forfait on its
implementer and the platform's codex key on its plan review; a single "the
tier" would have to pick one and be silently wrong about the other — the same
shape `aggregate_tokens` was introduced for in #992. It carries no slot names:
`cred_fingerprints` does not either, and for the (slot, tier, fingerprint)
triple the GRANTED line remains the place to look.

## Three things done deliberately

- **`credentialTierForSlot` is now the ONE place the tier is decided**, read
  by the GRANTED log line and by the stamp. Two copies of that switch would
  disagree about the same run the day a sixth tier lands.
- **The tiers ride the same `spend.allows` walk as the fingerprints.** A tier
  collected outside that filter would name a credential the run holds but
  cannot spend — the misattribution the filter exists to prevent.
- **`credResolution.applyTo` replaces the launch path's field-by-field
  assignment.** Both paths now go through `stamp()`, so a fact added to the
  resolution cannot reach the launch and miss the resume. That unit is the
  whole promise of `RunCredStamp`, and assigning fields one by one is exactly
  what breaks it.

## Verification

`devbox run -- task check` → exit 0, plus `tsc --noEmit` on the studio.

**The Mongo conformance was run against a real replica set**, not skipped:
`pkg/store/mongo` took **45.2s** (a skip is 0.004s), every tree in the CI job
green. A store-twin change is unverified until it has.

The new tests were run against the previous behaviour and go red with the
production symptom, so the bench bites:

```
launch tiers = [], want [platform]
launch stamp tiers = [], want the resolution's own answer
```

The headline test is the ticket's own scenario, end to end through the real
resolution: a run funded by the platform tier, the platform forfait then
**actually deleted** from the store and a donor's pledge enabled, the same run
resolved again → `[pool]`.

## Not in scope

The publisher's five-name vocabulary (`byok` / `oauth-forfait` / …) stays
distinct from `credusage.Tier`'s four, which merges the first two into `team`.
That package meters money, where a tenant's key and its subscription spend the
same budget; this field answers who to talk to, where a dead key and a shut
forfait window are different conversations.
