### PR TITLE
fix(runs): a credential with no fingerprint still names the tier that paid

### DIFF
--- a/pkg/server/cloudpublisher/credential_tiers_test.go
+++ b/pkg/server/cloudpublisher/credential_tiers_test.go
@@ -3,6 +3,7 @@ package cloudpublisher
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/credpool"
@@ -108,6 +109,51 @@ func TestCredentialTiers_platformThenPoolAfterTheKeyIsWithdrawn(t *testing.T) {
 	}
 	if len(r.CredFingerprints) != len(resumed.fingerprints) {
 		t.Fatalf("applyTo left the fingerprints behind: %v vs %v", r.CredFingerprints, resumed.fingerprints)
+	}
+}
+
+// A credential with no fingerprint still PAID (Revi, #1105). The
+// fingerprint harvest skips it by construction — setOAuthFingerprint
+// refuses an empty stamp, so an unstamped forfait never enters the map the
+// harvest walks — and a tier collected from that map would have gone silent
+// on exactly the odd credential an operator is most likely to be chasing,
+// while the GRANTED log line still named its tier as `<unstamped>`.
+func TestCredentialTiers_anUnstampedCredentialStillNamesItsTier(t *testing.T) {
+	ctx := context.Background()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	// The platform's own forfait, sealed WITHOUT a fingerprint — the shape a
+	// record created before fingerprinting shipped still has.
+	oauth := secrets.NewMemoryOAuthStore()
+	blob := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-platform-unstamped"}}`)
+	sealed, err := secrets.SealOAuthPayload(sealer, secrets.PlatformOwnerKey, secrets.OAuthKindClaudeCode, blob)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if err := oauth.Upsert(ctx, secrets.OAuthRecord{
+		UserID: secrets.PlatformOwnerKey, Kind: secrets.OAuthKindClaudeCode,
+		SealedPayload: sealed, Fingerprint: "", CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	p := &Publisher{
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer,
+		oauthForfait: oauth, logger: iterlog.New(iterlog.LevelError, nil),
+	}
+	creds, err := p.resolveAndSealCredentials(store.WithTenant(ctx, poolTeam), "run-unstamped",
+		poolOrg, poolTeam, "requester", "docs-refresh", nil, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The premise: nothing to count, because there is no audit identity.
+	if len(creds.fingerprints) != 0 {
+		t.Fatalf("fingerprints = %v, want none — the record carries no stamp", creds.fingerprints)
+	}
+	// The answer that must survive it anyway.
+	if got := creds.tiers; len(got) != 1 || got[0] != store.CredentialTierPlatform {
+		t.Fatalf("tiers = %v, want [platform] — a credential with no fingerprint still paid for the run", got)
 	}
 }
 

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -762,28 +762,46 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	// the facade was refused the only credential its model could use.
 	// Unpinned or unresolvable routes keep everything (fail open toward
 	// protection: that run takes whatever the process holds).
-	// The tiers ride the SAME walk, deliberately: a tier collected outside
-	// this filter would name a credential the run holds but cannot spend,
-	// which is the misattribution the filter exists to prevent. Deduplicated
-	// because a tier is a fact about the run, not a per-slot count.
 	spend := spendableProviders(wf, modelOverrides, runFallbacks)
 	seen := map[string]bool{}
-	tiers := map[string]bool{}
 	for prov, fp := range apiKeyFPs {
 		if fp != "" && !seen[fp] && spend.allows(strings.ToLower(string(prov))) {
 			seen[fp] = true
 			res.fingerprints = append(res.fingerprints, fp)
-			tiers[credentialTierForSlot(bundle, res.grant, string(prov), credpool.SourceAPIKey, store.CredentialTierBYOK)] = true
 		}
 	}
 	for kind, fp := range bundle.OAuthFingerprints {
 		if fp != "" && !seen[fp] && spend.allows(providerOfOAuthKind(kind)) {
 			seen[fp] = true
 			res.fingerprints = append(res.fingerprints, fp)
-			tiers[credentialTierForSlot(bundle, res.grant, kind, credpool.SourceOAuth, store.CredentialTierOAuthForfait)] = true
 		}
 	}
 	sort.Strings(res.fingerprints)
+
+	// Which TIERS funded the run — the same spendable narrowing, but walked
+	// over the slots the bundle actually SEALED rather than over the
+	// fingerprint maps. That is the source logGrantedCredentials reads, so
+	// the field and the line an operator greps answer identically.
+	//
+	// It cannot ride the harvest above, which is keyed on a fingerprint and
+	// skips a credential that has none: setOAuthFingerprint refuses an empty
+	// stamp outright, so an unstamped forfait never even enters the map. A
+	// credential with no audit identity still PAID, and a run funded only by
+	// one reported no tier at all — an empty answer where the log line says
+	// `<unstamped>`, which is exactly the confident silence this field exists
+	// to remove. Deduplicated: a tier is a fact about the run, not a
+	// per-slot count.
+	tiers := map[string]bool{}
+	for prov := range bundle.APIKeys {
+		if spend.allows(strings.ToLower(string(prov))) {
+			tiers[credentialTierForSlot(bundle, res.grant, string(prov), credpool.SourceAPIKey, store.CredentialTierBYOK)] = true
+		}
+	}
+	for kind := range bundle.OAuthCredentials {
+		if spend.allows(providerOfOAuthKind(kind)) {
+			tiers[credentialTierForSlot(bundle, res.grant, kind, credpool.SourceOAuth, store.CredentialTierOAuthForfait)] = true
+		}
+	}
 	for tier := range tiers {
 		res.tiers = append(res.tiers, tier)
 	}
@@ -906,6 +924,12 @@ func (c credResolution) applyTo(r *store.Run) {
 	r.CredFingerprints = s.Fingerprints
 	r.CredentialTiers = s.Tiers
 	r.SkippedCredReopensAt = s.SkippedReopensAt
+	// Both stores clear this on a stamp — "a re-resolution is a fresh
+	// attempt, it counts until it proves idle". At launch the document is
+	// new and the marker is already nil, so this changes nothing today; it
+	// is here so the in-memory twin cannot answer differently from the
+	// persisted one if it is ever applied to a loaded run.
+	r.LLMIdleSince = nil
 }
 
 // spendable answers "may a run with these routes spend a credential of


### PR DESCRIPTION
Follow-up to #1105, from the two non-blocking questions Revi raised on it.

## The gap it closes

#1105 collected the credential tiers **inside the fingerprint harvest**. That
walk is keyed on an audit identity and skips a credential that has none —
`setOAuthFingerprint` refuses an empty stamp outright, so an unstamped forfait
never even enters the map it reads.

So a run funded only by such a credential reported **no tier at all**: an empty
answer where the GRANTED log line says `<unstamped>`. That is the confident
silence the field was added to remove, arriving on exactly the odd credential
an operator is most likely to be chasing.

## The change

The tiers get their own walk, over the slots the bundle actually **sealed** —
the same source `logGrantedCredentials` reads. The field and the line now
answer identically *by construction* rather than by coincidence, which is the
property #1105's PR claimed and did not fully have.

The fingerprint harvest is deliberately **untouched**: requiring a stamp is
right there, since a credential with no identity is one the per-key
concurrency meter cannot count. Two questions, two walks.

Also mirrors `SetRunCredStamp`'s `LLMIdleSince` clear in `applyTo` — a no-op
at launch, where the document is new; there so the in-memory twin cannot
answer differently from the persisted one if it is ever applied to a loaded
run.

## Verification

`devbox run -- task check` → exit 0.

The new test reproduces Revi's case literally — a platform forfait sealed with
`Fingerprint: ""`, driven through the real resolution — and it goes red on the
code merged in #1105:

```
tiers = [], want [platform] — a credential with no fingerprint still paid for the run
```

Refs #991, #1105
