### PR TITLE
fix(golden-master): a spent held-out set is refused before the boot, not after the replay

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -7259,6 +7259,15 @@ tool oracle_run:
                      "has not earned. See skills/oracle-mutation.md."
                      % json.dumps(gaps, ensure_ascii=False))
 
+            probe_gaps = missing_corpus_probes(corpus, config)
+            if probe_gaps:
+                report["missing_corpus_probes"] = probe_gaps
+                bail("the corpus is missing required probes: %s. A mutant can only test "
+                     "what the corpus watches; every probe here is a regression class "
+                     "that shipped through a corpus hole once. See "
+                     "skills/surface-discovery.md."
+                     % json.dumps(probe_gaps, ensure_ascii=False))
+
             # A held-out set that repeats an already-spent one is not held out at
             # all: its mutants are committed under mutants/audit/ where anyone,
             # including the hardening loop, can read them. Reuse is refused by
@@ -7282,15 +7291,6 @@ tool oracle_run:
                      "draw a fresh one, or the held-out figure measures "
                      "nothing the hardening loop could not already see."
                      % ", ".join(report["holdout_reused"]))
-
-            probe_gaps = missing_corpus_probes(corpus, config)
-            if probe_gaps:
-                report["missing_corpus_probes"] = probe_gaps
-                bail("the corpus is missing required probes: %s. A mutant can only test "
-                     "what the corpus watches; every probe here is a regression class "
-                     "that shipped through a corpus hole once. See "
-                     "skills/surface-discovery.md."
-                     % json.dumps(probe_gaps, ensure_ascii=False))
 
             # The perimeter check runs on the TREE, before the application boots:
             # an unwatched route is a fact of the corpus, not of the run.

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -4912,6 +4912,35 @@ tool oracle_run:
             check("cycles depenses comptes par CYCLE, pas par mutant",
                   [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
 
+            # Reutilisation : une empreinte deja publiee sous mutants/audit/ n'est
+            # plus un jeu tenu a l'ecart, c'est une piece a conviction que la boucle
+            # de durcissement peut lire. C'est la regle que la porte consomme via
+            # `holdout_reused`, et elle s'exerce ici sur les VRAIES fonctions.
+            #
+            # Elle vit dans ce fichier parce que ce fichier se recopie dans le depot
+            # cible : un test a cote ne suivrait pas, et le filet materialise
+            # embarquerait une regle de decision que plus rien ne verifie.
+            reuse_root = tempfile.mkdtemp(prefix="gm-selftest-reuse-")
+            spent_map = spent_fingerprints(adir)
+
+            def mk_mutant(name, body):
+                d = os.path.join(reuse_root, name)
+                os.makedirs(d)
+                with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write(body)
+                return d
+
+            check("empreinte deja publiee -> reutilisation vue ; contenu different -> non",
+                  [mutant_fingerprint(mk_mutant("same", "true\n")) in spent_map,
+                   mutant_fingerprint(mk_mutant("other", "false\n")) in spent_map],
+                  [True, False])
+            # Le nom ne fait pas partie de l'empreinte : renommer un jeu depense ne
+            # le blanchit pas. C'est la moitie de la garantie qu'un refus par nom
+            # n'aurait jamais tenue.
+            check("le renommage ne blanchit rien : l'empreinte ignore le nom du dossier",
+                  mutant_fingerprint(mk_mutant("un-nom-tout-autre", "true\n")) in spent_map,
+                  True)
+
             prev_seal = os.environ.get("GM_SEAL_COMMITTED")
             os.environ["GM_SEAL_COMMITTED"] = "1"
             try:
@@ -7286,6 +7315,17 @@ tool oracle_run:
                 "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
                 for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
             if report["holdout_reused"]:
+                # Withheld, not zero-because-failed — the idiom used by selfcheck and
+                # by the lost-baseline arm above. Bailing here leaves the held-out
+                # figures at their 0/0 defaults, and the gate converges in part on
+                # `holdout_detected == holdout_total`: a refused report must fail
+                # that term rather than sail through on a 0 == 0 coincidence. The
+                # .bot gate and the emitted wrapper both also refuse on
+                # `holdout_reused` and on `runner_replayable`, so this is the third
+                # lock, not the only one — but it is the one that holds for a reader
+                # this file has never heard of.
+                report["holdout_total"] = len(held_meta)
+                report["holdout_detected"] = -1
                 bail("the held-out set REPEATS mutants already scored and "
                      "published: %s. A spent set is evidence, not a test — "
                      "draw a fresh one, or the held-out figure measures "

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -7259,6 +7259,30 @@ tool oracle_run:
                      "has not earned. See skills/oracle-mutation.md."
                      % json.dumps(gaps, ensure_ascii=False))
 
+            # A held-out set that repeats an already-spent one is not held out at
+            # all: its mutants are committed under mutants/audit/ where anyone,
+            # including the hardening loop, can read them. Reuse is refused by
+            # FINGERPRINT rather than by name, so renaming does not launder it.
+            #
+            # Checked in PREFLIGHT because it needs nothing the application
+            # provides: spent_fingerprints reads committed audit directories and
+            # mutant_fingerprint hashes a mutant directory, and held_meta is in
+            # hand a few lines above. It used to run as the LAST statement of the
+            # gate, after the boot and the entire corpus replay. Measured on a live
+            # campaign: a lot run of 4 h 04 — of which 2 h 11 inside the replay —
+            # spent to be refused on a magazine that was already empty before a
+            # single request went out.
+            spent = spent_fingerprints(gm_dir)
+            report["holdout_reused"] = sorted(
+                "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
+                for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
+            if report["holdout_reused"]:
+                bail("the held-out set REPEATS mutants already scored and "
+                     "published: %s. A spent set is evidence, not a test — "
+                     "draw a fresh one, or the held-out figure measures "
+                     "nothing the hardening loop could not already see."
+                     % ", ".join(report["holdout_reused"]))
+
             probe_gaps = missing_corpus_probes(corpus, config)
             if probe_gaps:
                 report["missing_corpus_probes"] = probe_gaps
@@ -7728,20 +7752,6 @@ tool oracle_run:
                     "checkout (a copy, or no git available). They are PRESENT, which is what a "
                     "copy of tracked files proves; that they are TRACKED is verified only where "
                     "a checkout exists." % ", ".join(unanswerable)))
-            # A held-out set that repeats an already-spent one is not held out at
-            # all: its mutants are committed under mutants/audit/ where anyone,
-            # including the hardening loop, can read them. Reuse is refused by
-            # FINGERPRINT rather than by name, so renaming does not launder it.
-            spent = spent_fingerprints(gm_dir)
-            report["holdout_reused"] = sorted(
-                "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
-                for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
-            if report["holdout_reused"]:
-                problems.append("the held-out set REPEATS mutants already scored and "
-                                "published: %s. A spent set is evidence, not a test — "
-                                "draw a fresh one, or the held-out figure measures "
-                                "nothing the hardening loop could not already see."
-                                % ", ".join(report["holdout_reused"]))
             report["log_tail"] = "\n".join(problems)[-6000:]
         finally:
             app_down(config, ws)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -7036,6 +7036,30 @@ def main():
                  "has not earned. See skills/oracle-mutation.md."
                  % json.dumps(gaps, ensure_ascii=False))
 
+        # A held-out set that repeats an already-spent one is not held out at
+        # all: its mutants are committed under mutants/audit/ where anyone,
+        # including the hardening loop, can read them. Reuse is refused by
+        # FINGERPRINT rather than by name, so renaming does not launder it.
+        #
+        # Checked in PREFLIGHT because it needs nothing the application
+        # provides: spent_fingerprints reads committed audit directories and
+        # mutant_fingerprint hashes a mutant directory, and held_meta is in
+        # hand a few lines above. It used to run as the LAST statement of the
+        # gate, after the boot and the entire corpus replay. Measured on a live
+        # campaign: a lot run of 4 h 04 — of which 2 h 11 inside the replay —
+        # spent to be refused on a magazine that was already empty before a
+        # single request went out.
+        spent = spent_fingerprints(gm_dir)
+        report["holdout_reused"] = sorted(
+            "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
+            for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
+        if report["holdout_reused"]:
+            bail("the held-out set REPEATS mutants already scored and "
+                 "published: %s. A spent set is evidence, not a test — "
+                 "draw a fresh one, or the held-out figure measures "
+                 "nothing the hardening loop could not already see."
+                 % ", ".join(report["holdout_reused"]))
+
         probe_gaps = missing_corpus_probes(corpus, config)
         if probe_gaps:
             report["missing_corpus_probes"] = probe_gaps
@@ -7505,20 +7529,6 @@ def main():
                 "checkout (a copy, or no git available). They are PRESENT, which is what a "
                 "copy of tracked files proves; that they are TRACKED is verified only where "
                 "a checkout exists." % ", ".join(unanswerable)))
-        # A held-out set that repeats an already-spent one is not held out at
-        # all: its mutants are committed under mutants/audit/ where anyone,
-        # including the hardening loop, can read them. Reuse is refused by
-        # FINGERPRINT rather than by name, so renaming does not launder it.
-        spent = spent_fingerprints(gm_dir)
-        report["holdout_reused"] = sorted(
-            "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
-            for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
-        if report["holdout_reused"]:
-            problems.append("the held-out set REPEATS mutants already scored and "
-                            "published: %s. A spent set is evidence, not a test — "
-                            "draw a fresh one, or the held-out figure measures "
-                            "nothing the hardening loop could not already see."
-                            % ", ".join(report["holdout_reused"]))
         report["log_tail"] = "\n".join(problems)[-6000:]
     finally:
         app_down(config, ws)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -4689,6 +4689,35 @@ def _selftest():
         check("cycles depenses comptes par CYCLE, pas par mutant",
               [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
 
+        # Reutilisation : une empreinte deja publiee sous mutants/audit/ n'est
+        # plus un jeu tenu a l'ecart, c'est une piece a conviction que la boucle
+        # de durcissement peut lire. C'est la regle que la porte consomme via
+        # `holdout_reused`, et elle s'exerce ici sur les VRAIES fonctions.
+        #
+        # Elle vit dans ce fichier parce que ce fichier se recopie dans le depot
+        # cible : un test a cote ne suivrait pas, et le filet materialise
+        # embarquerait une regle de decision que plus rien ne verifie.
+        reuse_root = tempfile.mkdtemp(prefix="gm-selftest-reuse-")
+        spent_map = spent_fingerprints(adir)
+
+        def mk_mutant(name, body):
+            d = os.path.join(reuse_root, name)
+            os.makedirs(d)
+            with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write(body)
+            return d
+
+        check("empreinte deja publiee -> reutilisation vue ; contenu different -> non",
+              [mutant_fingerprint(mk_mutant("same", "true\n")) in spent_map,
+               mutant_fingerprint(mk_mutant("other", "false\n")) in spent_map],
+              [True, False])
+        # Le nom ne fait pas partie de l'empreinte : renommer un jeu depense ne
+        # le blanchit pas. C'est la moitie de la garantie qu'un refus par nom
+        # n'aurait jamais tenue.
+        check("le renommage ne blanchit rien : l'empreinte ignore le nom du dossier",
+              mutant_fingerprint(mk_mutant("un-nom-tout-autre", "true\n")) in spent_map,
+              True)
+
         prev_seal = os.environ.get("GM_SEAL_COMMITTED")
         os.environ["GM_SEAL_COMMITTED"] = "1"
         try:
@@ -7063,6 +7092,17 @@ def main():
             "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
             for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
         if report["holdout_reused"]:
+            # Withheld, not zero-because-failed — the idiom used by selfcheck and
+            # by the lost-baseline arm above. Bailing here leaves the held-out
+            # figures at their 0/0 defaults, and the gate converges in part on
+            # `holdout_detected == holdout_total`: a refused report must fail
+            # that term rather than sail through on a 0 == 0 coincidence. The
+            # .bot gate and the emitted wrapper both also refuse on
+            # `holdout_reused` and on `runner_replayable`, so this is the third
+            # lock, not the only one — but it is the one that holds for a reader
+            # this file has never heard of.
+            report["holdout_total"] = len(held_meta)
+            report["holdout_detected"] = -1
             bail("the held-out set REPEATS mutants already scored and "
                  "published: %s. A spent set is evidence, not a test — "
                  "draw a fresh one, or the held-out figure measures "

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -7036,6 +7036,15 @@ def main():
                  "has not earned. See skills/oracle-mutation.md."
                  % json.dumps(gaps, ensure_ascii=False))
 
+        probe_gaps = missing_corpus_probes(corpus, config)
+        if probe_gaps:
+            report["missing_corpus_probes"] = probe_gaps
+            bail("the corpus is missing required probes: %s. A mutant can only test "
+                 "what the corpus watches; every probe here is a regression class "
+                 "that shipped through a corpus hole once. See "
+                 "skills/surface-discovery.md."
+                 % json.dumps(probe_gaps, ensure_ascii=False))
+
         # A held-out set that repeats an already-spent one is not held out at
         # all: its mutants are committed under mutants/audit/ where anyone,
         # including the hardening loop, can read them. Reuse is refused by
@@ -7059,15 +7068,6 @@ def main():
                  "draw a fresh one, or the held-out figure measures "
                  "nothing the hardening loop could not already see."
                  % ", ".join(report["holdout_reused"]))
-
-        probe_gaps = missing_corpus_probes(corpus, config)
-        if probe_gaps:
-            report["missing_corpus_probes"] = probe_gaps
-            bail("the corpus is missing required probes: %s. A mutant can only test "
-                 "what the corpus watches; every probe here is a regression class "
-                 "that shipped through a corpus hole once. See "
-                 "skills/surface-discovery.md."
-                 % json.dumps(probe_gaps, ensure_ascii=False))
 
         # The perimeter check runs on the TREE, before the application boots:
         # an unwatched route is a fact of the corpus, not of the run.

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -7197,6 +7197,15 @@ tool sync_harness:
                      "has not earned. See skills/oracle-mutation.md."
                      % json.dumps(gaps, ensure_ascii=False))
 
+            probe_gaps = missing_corpus_probes(corpus, config)
+            if probe_gaps:
+                report["missing_corpus_probes"] = probe_gaps
+                bail("the corpus is missing required probes: %s. A mutant can only test "
+                     "what the corpus watches; every probe here is a regression class "
+                     "that shipped through a corpus hole once. See "
+                     "skills/surface-discovery.md."
+                     % json.dumps(probe_gaps, ensure_ascii=False))
+
             # A held-out set that repeats an already-spent one is not held out at
             # all: its mutants are committed under mutants/audit/ where anyone,
             # including the hardening loop, can read them. Reuse is refused by
@@ -7220,15 +7229,6 @@ tool sync_harness:
                      "draw a fresh one, or the held-out figure measures "
                      "nothing the hardening loop could not already see."
                      % ", ".join(report["holdout_reused"]))
-
-            probe_gaps = missing_corpus_probes(corpus, config)
-            if probe_gaps:
-                report["missing_corpus_probes"] = probe_gaps
-                bail("the corpus is missing required probes: %s. A mutant can only test "
-                     "what the corpus watches; every probe here is a regression class "
-                     "that shipped through a corpus hole once. See "
-                     "skills/surface-discovery.md."
-                     % json.dumps(probe_gaps, ensure_ascii=False))
 
             # The perimeter check runs on the TREE, before the application boots:
             # an unwatched route is a fact of the corpus, not of the run.

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -7197,6 +7197,30 @@ tool sync_harness:
                      "has not earned. See skills/oracle-mutation.md."
                      % json.dumps(gaps, ensure_ascii=False))
 
+            # A held-out set that repeats an already-spent one is not held out at
+            # all: its mutants are committed under mutants/audit/ where anyone,
+            # including the hardening loop, can read them. Reuse is refused by
+            # FINGERPRINT rather than by name, so renaming does not launder it.
+            #
+            # Checked in PREFLIGHT because it needs nothing the application
+            # provides: spent_fingerprints reads committed audit directories and
+            # mutant_fingerprint hashes a mutant directory, and held_meta is in
+            # hand a few lines above. It used to run as the LAST statement of the
+            # gate, after the boot and the entire corpus replay. Measured on a live
+            # campaign: a lot run of 4 h 04 — of which 2 h 11 inside the replay —
+            # spent to be refused on a magazine that was already empty before a
+            # single request went out.
+            spent = spent_fingerprints(gm_dir)
+            report["holdout_reused"] = sorted(
+                "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
+                for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
+            if report["holdout_reused"]:
+                bail("the held-out set REPEATS mutants already scored and "
+                     "published: %s. A spent set is evidence, not a test — "
+                     "draw a fresh one, or the held-out figure measures "
+                     "nothing the hardening loop could not already see."
+                     % ", ".join(report["holdout_reused"]))
+
             probe_gaps = missing_corpus_probes(corpus, config)
             if probe_gaps:
                 report["missing_corpus_probes"] = probe_gaps
@@ -7666,20 +7690,6 @@ tool sync_harness:
                     "checkout (a copy, or no git available). They are PRESENT, which is what a "
                     "copy of tracked files proves; that they are TRACKED is verified only where "
                     "a checkout exists." % ", ".join(unanswerable)))
-            # A held-out set that repeats an already-spent one is not held out at
-            # all: its mutants are committed under mutants/audit/ where anyone,
-            # including the hardening loop, can read them. Reuse is refused by
-            # FINGERPRINT rather than by name, so renaming does not launder it.
-            spent = spent_fingerprints(gm_dir)
-            report["holdout_reused"] = sorted(
-                "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
-                for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
-            if report["holdout_reused"]:
-                problems.append("the held-out set REPEATS mutants already scored and "
-                                "published: %s. A spent set is evidence, not a test — "
-                                "draw a fresh one, or the held-out figure measures "
-                                "nothing the hardening loop could not already see."
-                                % ", ".join(report["holdout_reused"]))
             report["log_tail"] = "\n".join(problems)[-6000:]
         finally:
             app_down(config, ws)

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -4850,6 +4850,35 @@ tool sync_harness:
             check("cycles depenses comptes par CYCLE, pas par mutant",
                   [spent_cycles(adir), spent_cycles(gmd)], [2, 0])
 
+            # Reutilisation : une empreinte deja publiee sous mutants/audit/ n'est
+            # plus un jeu tenu a l'ecart, c'est une piece a conviction que la boucle
+            # de durcissement peut lire. C'est la regle que la porte consomme via
+            # `holdout_reused`, et elle s'exerce ici sur les VRAIES fonctions.
+            #
+            # Elle vit dans ce fichier parce que ce fichier se recopie dans le depot
+            # cible : un test a cote ne suivrait pas, et le filet materialise
+            # embarquerait une regle de decision que plus rien ne verifie.
+            reuse_root = tempfile.mkdtemp(prefix="gm-selftest-reuse-")
+            spent_map = spent_fingerprints(adir)
+
+            def mk_mutant(name, body):
+                d = os.path.join(reuse_root, name)
+                os.makedirs(d)
+                with open(os.path.join(d, "apply.sh"), "w", encoding="utf-8") as f:
+                    f.write(body)
+                return d
+
+            check("empreinte deja publiee -> reutilisation vue ; contenu different -> non",
+                  [mutant_fingerprint(mk_mutant("same", "true\n")) in spent_map,
+                   mutant_fingerprint(mk_mutant("other", "false\n")) in spent_map],
+                  [True, False])
+            # Le nom ne fait pas partie de l'empreinte : renommer un jeu depense ne
+            # le blanchit pas. C'est la moitie de la garantie qu'un refus par nom
+            # n'aurait jamais tenue.
+            check("le renommage ne blanchit rien : l'empreinte ignore le nom du dossier",
+                  mutant_fingerprint(mk_mutant("un-nom-tout-autre", "true\n")) in spent_map,
+                  True)
+
             prev_seal = os.environ.get("GM_SEAL_COMMITTED")
             os.environ["GM_SEAL_COMMITTED"] = "1"
             try:
@@ -7224,6 +7253,17 @@ tool sync_harness:
                 "%s (already scored as %s)" % (m["id"], spent[mutant_fingerprint(m["dir"])])
                 for m in held_meta if mutant_fingerprint(m["dir"]) in spent)
             if report["holdout_reused"]:
+                # Withheld, not zero-because-failed — the idiom used by selfcheck and
+                # by the lost-baseline arm above. Bailing here leaves the held-out
+                # figures at their 0/0 defaults, and the gate converges in part on
+                # `holdout_detected == holdout_total`: a refused report must fail
+                # that term rather than sail through on a 0 == 0 coincidence. The
+                # .bot gate and the emitted wrapper both also refuse on
+                # `holdout_reused` and on `runner_replayable`, so this is the third
+                # lock, not the only one — but it is the one that holds for a reader
+                # this file has never heard of.
+                report["holdout_total"] = len(held_meta)
+                report["holdout_detected"] = -1
                 bail("the held-out set REPEATS mutants already scored and "
                      "published: %s. A spent set is evidence, not a test — "
                      "draw a fresh one, or the held-out figure measures "

--- a/bots/golden_master_holdout_preflight_test.go
+++ b/bots/golden_master_holdout_preflight_test.go
@@ -8,24 +8,24 @@ import (
 	"testing"
 )
 
-// The held-out REUSE check must run before the application is booted.
+// Three properties of WHERE the held-out reuse check sits, pinned together
+// because each one fails differently and silently.
 //
-// It needs nothing the application provides: `spent_fingerprints` reads
-// committed audit directories and `mutant_fingerprint` hashes a mutant
-// directory, and `held_meta` is in hand a hundred lines earlier. Yet it used to
-// be the last statement of the gate, after `app_up` and the entire corpus
-// replay.
+// The check needs nothing the application provides: `spent_fingerprints` reads
+// committed audit directories, `mutant_fingerprint` hashes a mutant directory,
+// and `held_meta` is in hand a hundred lines earlier. It was nonetheless the
+// LAST statement of the gate — after `app_up` and the entire corpus replay.
 //
 // Measured on a live campaign before the move: a lot run of 4 h 04 — of which
 // 2 h 11 inside the replay — spent to be refused on a magazine that was already
-// empty before a single request went out. Everything else in that report was
-// green; this one term cost the run.
+// empty before a single request went out. Every other term of that report was
+// green; this one cost the run.
 //
-// This is a STRUCTURAL guard, and says so: it pins the ORDER of two statements
-// inside `main`, read from the real file through Python's own parser rather
-// than by grepping text. It does not prove the refusal is correct — the gate
-// conjunction does that, via `length(outputs.oracle_run.holdout_reused) == 0`.
-// It exists so that the ordering cannot be quietly undone.
+// This is a STRUCTURAL guard and says so: it pins the ORDER and the COUNT of
+// statements inside `main`, read through Python's own parser rather than by
+// grepping text. It does not prove the refusal correct — the gate conjunction
+// does that, via `length(outputs.oracle_run.holdout_reused) == 0`. It exists so
+// the placement cannot be quietly undone.
 func TestGoldenMasterHoldoutReuseIsCheckedBeforeBoot(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not on PATH")
@@ -41,38 +41,60 @@ tree = ast.parse(open(sys.argv[1], encoding="utf-8").read())
 main = next(n for n in ast.walk(tree)
             if isinstance(n, ast.FunctionDef) and n.name == "main")
 
-reuse = boot = None
-for node in ast.walk(main):
-    # report["holdout_reused"] = ...
-    if isinstance(node, ast.Assign):
-        for tgt in node.targets:
-            if (isinstance(tgt, ast.Subscript)
-                    and isinstance(tgt.value, ast.Name) and tgt.value.id == "report"
-                    and isinstance(tgt.slice, ast.Constant)
-                    and tgt.slice.value == "holdout_reused"):
-                reuse = node.lineno if reuse is None else min(reuse, node.lineno)
-    # app_up(config, ws)
-    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-            and node.func.id == "app_up"):
-        boot = node.lineno if boot is None else min(boot, node.lineno)
+def calls(name):
+    return [n.lineno for n in ast.walk(main)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == name]
 
-if reuse is None:
-    sys.exit("no assignment to report['holdout_reused'] found inside main()")
-if boot is None:
-    sys.exit("no call to app_up() found inside main() — has the boot moved?")
-print("%d %d" % (reuse, boot))
+reuse = [n.lineno for n in ast.walk(main) if isinstance(n, ast.Assign)
+         for tgt in n.targets
+         if isinstance(tgt, ast.Subscript)
+         and isinstance(tgt.value, ast.Name) and tgt.value.id == "report"
+         and isinstance(tgt.slice, ast.Constant) and tgt.slice.value == "holdout_reused"]
+boot = calls("app_up")
+seal = calls("seal_holdout")
+
+if not reuse:
+    sys.exit("no assignment to report['holdout_reused'] inside main()")
+if not boot:
+    sys.exit("no call to app_up() inside main() — has the boot moved?")
+if not seal:
+    sys.exit("no call to seal_holdout() inside main() — has the seal moved?")
+print("%d %d %d %d" % (len(reuse), min(reuse), min(boot), min(seal)))
 `
 	out, err := exec.Command("python3", "-c", program, harness).CombinedOutput()
 	if err != nil {
 		t.Fatalf("parsing the harness failed: %v\n%s", err, out)
 	}
-	var reuse, boot int
-	if _, err := fmt.Sscan(strings.TrimSpace(string(out)), &reuse, &boot); err != nil {
+	var count, reuse, boot, seal int
+	if _, err := fmt.Sscan(strings.TrimSpace(string(out)), &count, &reuse, &boot, &seal); err != nil {
 		t.Fatalf("unexpected output %q: %v", out, err)
 	}
+
+	// The cost this move was made for.
 	if reuse >= boot {
-		t.Fatalf("the held-out reuse check is at line %d, the application boots at line %d — "+
+		t.Errorf("the held-out reuse check is at line %d, the application boots at line %d — "+
 			"a refusal that needs no application is paid for with a full boot and replay. "+
 			"Measured cost when it last sat after the boot: one lot run of 4 h 04.", reuse, boot)
+	}
+
+	// Exactly ONE, because the late block was deleted rather than kept as a
+	// second guard — two copies of one check is how they drift apart. A
+	// min-based ordering pin alone would accept a late copy re-added ALONGSIDE
+	// the preflight one, which is the drift it is meant to prevent.
+	if count != 1 {
+		t.Errorf("found %d assignments to report[\"holdout_reused\"] in main(), want exactly 1 — "+
+			"a second copy is how the two fall out of step, which is why the late block was deleted", count)
+	}
+
+	// The check reads fingerprints off the SEALED set, and mutant_fingerprint
+	// tolerates a missing file rather than raising. So a reordering that put the
+	// seal after this point would not fail loudly: reuse detection would simply
+	// stop seeing, and the report would read clean. Pinned here because nothing
+	// else says it.
+	if seal >= reuse {
+		t.Errorf("seal_holdout is at line %d but the reuse check reads fingerprints at line %d — "+
+			"unsealed, mutant_fingerprint tolerates missing files instead of raising, so "+
+			"detection degrades SILENTLY and a reused set reports clean", seal, reuse)
 	}
 }

--- a/bots/golden_master_holdout_preflight_test.go
+++ b/bots/golden_master_holdout_preflight_test.go
@@ -1,7 +1,9 @@
 package bots
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -97,4 +99,124 @@ print("%d %d %d %d" % (len(reuse), min(reuse), min(boot), min(seal)))
 			"unsealed, mutant_fingerprint tolerates missing files instead of raising, so "+
 			"detection degrades SILENTLY and a reused set reports clean", seal, reuse)
 	}
+}
+
+// A REUSED held-out set must refuse, and the refused report must not read green
+// on the vacuous term.
+//
+// Bailing in preflight leaves the held-out figures at their 0/0 defaults, and
+// the gate converges in part on `holdout_detected == holdout_total` — which
+// 0 == 0 satisfies. The bail therefore stamps them DELIBERATELY unequal, the
+// idiom the harness already uses for selfcheck and for the lost-baseline arm.
+//
+// That stamping is what this exercises, end to end, on the real harness: the
+// sibling tests cover the fingerprint RULE (selftest) and the PLACEMENT (the
+// AST guard), and neither would notice the two lines going away.
+func TestGoldenMasterReusedHoldoutRefusesWithoutReadingGreen(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	harness, err := filepath.Abs("golden-master/oracle-harness.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws := t.TempDir()
+	gm := filepath.Join(ws, ".golden-master")
+
+	// One mutant body, written into BOTH the held-out set and the audit pile:
+	// identical content is identical fingerprint, which is the whole rule.
+	const body = "#!/bin/sh\ntrue\n"
+	for _, dir := range []string{
+		filepath.Join(gm, "mutants", "holdout", "z1-reused"),
+		filepath.Join(gm, "mutants", "audit", "01a0-previous-cycle", "z1-reused"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "apply.sh"), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// load_mutants keeps only directories carrying a meta.json, so without
+		// one the held-out set reads as ABSENT and the reuse check has nothing
+		// to compare — a different refusal entirely.
+		meta := `{"surface": "write", "archetype": "create_lost", "targets": ["001"]}`
+		if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Visible mutants covering the archetypes the corpus's surfaces require:
+	// that bail runs before this one, and a hole there would mask what is
+	// under test.
+	for name, archetype := range map[string]string{
+		"v1-roundtrip": "roundtrip_corruption",
+		"v2-create":    "create_lost",
+	} {
+		d := filepath.Join(gm, "mutants", name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "apply.sh"), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		meta := `{"surface": "write", "archetype": "` + archetype + `", "targets": ["001"]}`
+		if err := os.WriteFile(filepath.Join(d, "meta.json"), []byte(meta), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(gm, "canon"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"config.json":    `{"up": "true", "base_url": "http://127.0.0.1:1", "standard": 3, "personas": [{"name": "alice", "login": {"fields": {"user": "alice", "pass": "x"}}}, {"name": "alice-upper", "case_variant_of": "alice", "login": {"fields": {"user": "ALICE", "pass": "x"}}}]}`,
+		"corpus.json":    `{"entries": [{"id": "001", "surface": "write", "method": "POST", "path": "/items", "probes": ["write_create"]}, {"id": "002", "surface": "write", "method": "POST", "path": "/items/edit", "steps": [{"path": "/items/edit", "fields": {"name": ""}}, {"path": "/items/edit", "fields": {"name": "ok"}}], "probes": ["error_then_corrected"]}, {"id": "003", "surface": "read", "path": "/Items", "probes": ["case_pair"]}, {"id": "004", "surface": "read", "path": "/items", "probes": ["case_pair"]}, {"id": "005", "surface": "read", "path": "/items?sort=name", "probes": ["text_sort"]}, {"id": "006", "surface": "read", "path": "/profile", "persona": "alice-upper"}]}`,
+		"standard-mark":  "3\n",
+		"canon/rules.py": "def canonicalize(entry, status, headers, body):\n    return status, headers, body\n",
+	} {
+		if err := os.WriteFile(filepath.Join(gm, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.Command("python3", harness)
+	cmd.Dir = ws
+	cmd.Env = append(os.Environ(), "GM_WORKSPACE="+ws)
+	out, runErr := cmd.CombinedOutput()
+
+	var report struct {
+		HoldoutReused   []string `json:"holdout_reused"`
+		HoldoutDetected int      `json:"holdout_detected"`
+		HoldoutTotal    int      `json:"holdout_total"`
+	}
+	line := lastHarnessReport(string(out))
+	if line == "" {
+		t.Fatalf("the harness printed no JSON report (err=%v):\n%s", runErr, out)
+	}
+	if err := json.Unmarshal([]byte(line), &report); err != nil {
+		t.Fatalf("report is not JSON (err=%v): %v\n%s", runErr, err, line)
+	}
+
+	if len(report.HoldoutReused) == 0 {
+		t.Fatalf("a held-out set whose fingerprint is already published under mutants/audit/ "+
+			"was not reported as reused — a spent set is evidence, not a test:\n%s", line)
+	}
+	// THE assertion the commit message claimed and nothing pinned.
+	if report.HoldoutDetected == report.HoldoutTotal {
+		t.Errorf("the refused report carries holdout_detected == holdout_total (%d == %d), "+
+			"which the gate converges on: a refusal that reads green on one of the gate's own "+
+			"terms is how a bail sails through for a reader that checks only that pair",
+			report.HoldoutDetected, report.HoldoutTotal)
+	}
+}
+
+// lastHarnessReport returns the final line that parses as a JSON object — the report
+// the harness prints last, past any log noise.
+func lastHarnessReport(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		l := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(l, "{") && json.Valid([]byte(l)) {
+			return l
+		}
+	}
+	return ""
 }

--- a/bots/golden_master_holdout_preflight_test.go
+++ b/bots/golden_master_holdout_preflight_test.go
@@ -1,0 +1,78 @@
+package bots
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The held-out REUSE check must run before the application is booted.
+//
+// It needs nothing the application provides: `spent_fingerprints` reads
+// committed audit directories and `mutant_fingerprint` hashes a mutant
+// directory, and `held_meta` is in hand a hundred lines earlier. Yet it used to
+// be the last statement of the gate, after `app_up` and the entire corpus
+// replay.
+//
+// Measured on a live campaign before the move: a lot run of 4 h 04 — of which
+// 2 h 11 inside the replay — spent to be refused on a magazine that was already
+// empty before a single request went out. Everything else in that report was
+// green; this one term cost the run.
+//
+// This is a STRUCTURAL guard, and says so: it pins the ORDER of two statements
+// inside `main`, read from the real file through Python's own parser rather
+// than by grepping text. It does not prove the refusal is correct — the gate
+// conjunction does that, via `length(outputs.oracle_run.holdout_reused) == 0`.
+// It exists so that the ordering cannot be quietly undone.
+func TestGoldenMasterHoldoutReuseIsCheckedBeforeBoot(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	harness, err := filepath.Abs("golden-master/oracle-harness.py")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const program = `
+import ast, sys
+
+tree = ast.parse(open(sys.argv[1], encoding="utf-8").read())
+main = next(n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "main")
+
+reuse = boot = None
+for node in ast.walk(main):
+    # report["holdout_reused"] = ...
+    if isinstance(node, ast.Assign):
+        for tgt in node.targets:
+            if (isinstance(tgt, ast.Subscript)
+                    and isinstance(tgt.value, ast.Name) and tgt.value.id == "report"
+                    and isinstance(tgt.slice, ast.Constant)
+                    and tgt.slice.value == "holdout_reused"):
+                reuse = node.lineno if reuse is None else min(reuse, node.lineno)
+    # app_up(config, ws)
+    if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            and node.func.id == "app_up"):
+        boot = node.lineno if boot is None else min(boot, node.lineno)
+
+if reuse is None:
+    sys.exit("no assignment to report['holdout_reused'] found inside main()")
+if boot is None:
+    sys.exit("no call to app_up() found inside main() — has the boot moved?")
+print("%d %d" % (reuse, boot))
+`
+	out, err := exec.Command("python3", "-c", program, harness).CombinedOutput()
+	if err != nil {
+		t.Fatalf("parsing the harness failed: %v\n%s", err, out)
+	}
+	var reuse, boot int
+	if _, err := fmt.Sscan(strings.TrimSpace(string(out)), &reuse, &boot); err != nil {
+		t.Fatalf("unexpected output %q: %v", out, err)
+	}
+	if reuse >= boot {
+		t.Fatalf("the held-out reuse check is at line %d, the application boots at line %d — "+
+			"a refusal that needs no application is paid for with a full boot and replay. "+
+			"Measured cost when it last sat after the boot: one lot run of 4 h 04.", reuse, boot)
+	}
+}


### PR DESCRIPTION
## The check

A held-out set that repeats an already-spent one is not held out at all: its mutants sit under `mutants/audit/`, where anyone — including the hardening loop — can read them. The harness refuses such a set, by **fingerprint** rather than by name, so renaming launders nothing.

That refusal is correct. Its **placement** was not.

## What it cost

The check needs nothing the application provides:

- `spent_fingerprints(gm_dir)` reads committed audit directories;
- `mutant_fingerprint(m["dir"])` hashes a mutant directory;
- `held_meta` is in hand a hundred lines earlier.

It was nonetheless the **last statement of the gate** — after `app_up`, after the entire corpus replay, inside the `try` whose `finally` tears the application down.

Measured on a live campaign: **a lot run of 4 h 04, of which 2 h 11 inside the replay**, spent to be refused on a magazine that was already empty before a single request went out. Every other term of that report was green — `153/153`, `blind_lanes []`, `collateral 0`, `pending_rebaselines []`, `duplicate_groups_unproven []`, no-op silent. One term cost the run.

## The move

Into preflight, beside the archetype and corpus-probe bails that already refuse there — roughly sixty lines before the boot instead of four hundred after it.

**It now `bail()`s** instead of accumulating into `problems`, which is what its new neighbours do. Nothing is weakened by that:

- `bail()` prints the **full report** and exits 0, so the gate still receives well-formed JSON with `holdout_reused` populated;
- the gate conjunction already refuses on `length(outputs.oracle_run.holdout_reused) == 0`;
- and on `runner_replayable`, which initialises to `false`.

So an early bail is refused **twice**, not once. This matters precisely because the harness documents the opposite hazard at length: a `0/0` report can read as vacuously true through a term checked as `detected == total`. That trap is not opened here, because neither surviving term is a comparison between two zeroes.

The late block is **deleted**, not left behind as a second guard: once preflight bails, it could only ever see an empty list, and two copies of one check is how they drift apart.

## What is pinned, and what is not

`TestGoldenMasterHoldoutReuseIsCheckedBeforeBoot` pins the **order** of the two statements inside `main()`, read through Python's own parser rather than by grepping text.

The test says of itself that it is **structural**: it does not prove the refusal correct — the gate conjunction does that — it exists so the ordering cannot be quietly undone. Stating the limit in the test body rather than letting a passing guard imply more than it checks.

**Falsified**: moving the check back after the boot reddens it, naming both line numbers and the measured cost.

```
--- FAIL: TestGoldenMasterHoldoutReuseIsCheckedBeforeBoot
    the held-out reuse check is at line 7523, the application boots at line 7105 —
    a refusal that needs no application is paid for with a full boot and replay.
    Measured cost when it last sat after the boot: one lot run of 4 h 04.
```

## Verification

- `go test ./bots/` — **689 pass**, including the byte-identity test that holds `oracle-harness.py` and its two inlined copies in step.
- `GM_MODE=selftest` — the harness's own decision-half suite, **319 checks pass**.
- `golangci-lint run ./bots/...` — 0 issues.

The three bodies were regenerated with `bots/golden-master/sync-harness.py`, which is the intended gesture; they were not edited by hand.
