### PR TITLE
fix(runtime): a convergence its whole fan-out failed lost every incoming mapping

### DIFF
--- a/docs/routers.md
+++ b/docs/routers.md
@@ -278,11 +278,15 @@ command deliberately keeps an unresolved reference visible, so there it stays
 `{{input.<key>}}`.
 
 Precedence is the ordinary one: a live edge, and a loop back-edge, both
-outrank the floor on a shared key. Two exclusive alternatives from one dead
-source (`a -> collect when ok` and `a -> collect else`, with `a` never run)
-are genuinely undecided: where they agree the value applies, and where they
-disagree the key is left unset with a warning naming the node, both edges and
-the key — never picked by declaration order.
+outrank the floor on a shared key.
+
+**A key two floor edges disagree on is left unset**, with a warning naming the
+node, both edges and the key — never picked by declaration order. The two need
+not share a source: the node that would have chosen between them is often
+further back (`head -> x when ok` / `head -> y else`, then `x -> collect` and
+`y -> collect`, with `head` never run), and the alternatives then arrive from
+two different nodes. Where they agree, the value is theirs whichever would
+have fired.
 
 **Only the branch that actually ran contributes.** What reaches the collector
 this way is read from what the invocation DID — the nodes its branches entered

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -284,6 +284,13 @@ are genuinely undecided: where they agree the value applies, and where they
 disagree the key is left unset with a warning naming the node, both edges and
 the key — never picked by declaration order.
 
+**Only the branch that actually ran contributes.** What reaches the collector
+this way is read from what the invocation DID — the nodes its branches entered
+and the edges they recorded firing — never from the graph alone. A route
+routing turned down is not walked, so an `else` nobody took cannot arrive
+through a node that never executed; and a node that ran two invocations ago
+still has an output on the run, which is not evidence it ran in this one.
+
 **Which node is the collector.** A node that declares `await:` is the collector for the branches that reach it. Without the annotation, the engine elects the first node (breadth-first from the router's targets) that has more than one distinct predecessor, bounded back-edges excluded. For the router's **direct targets** — the branch heads — only predecessors inside the fan-out count (the router itself, or a node it reaches): the mono/dual topology, where a `condition` router reaches the same reviewer directly *or* through a `fan_out_all` router, gives that reviewer two predecessors, and it is still an ordinary branch head, not the collector. Below the heads every predecessor counts, including a trunk edge that bypasses the fan-out (`plan -> collect else` for the no-items case) — that bypass is what makes `collect` the implicit collector of a linear `fan_out_each` template. Declare `await:` on the intended collector rather than relying on the implicit election.
 
 Routers are fan-out sources and do not declare `await:` themselves.

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -267,6 +267,23 @@ Parallel branches — whether from `fan_out_all`, `fan_out_each`, or `llm` multi
 
 One `join_ready` event is emitted per convergence, on the collector, naming the strategy — a second `join_ready`, or a second execution of the collector, is an engine defect, never a mode.
 
+**A branch that produced nothing still carries its `with` mappings.** When a
+branch fails — or when a `fan_out_each` fans over an empty collection, so no
+branch runs at all — the mappings on its edge into the collector are still
+applied, as a floor under every live edge. Most of them never depended on the
+branch: `{{outputs.<parent>.count}}` or `{{vars.x}}` resolves exactly as it
+would have. What reads the dead branch itself (`{{outputs.<branch>}}`) lands
+empty with its key present — an empty string in a prompt, but a `tool` node's
+command deliberately keeps an unresolved reference visible, so there it stays
+`{{input.<key>}}`.
+
+Precedence is the ordinary one: a live edge, and a loop back-edge, both
+outrank the floor on a shared key. Two exclusive alternatives from one dead
+source (`a -> collect when ok` and `a -> collect else`, with `a` never run)
+are genuinely undecided: where they agree the value applies, and where they
+disagree the key is left unset with a warning naming the node, both edges and
+the key — never picked by declaration order.
+
 **Which node is the collector.** A node that declares `await:` is the collector for the branches that reach it. Without the annotation, the engine elects the first node (breadth-first from the router's targets) that has more than one distinct predecessor, bounded back-edges excluded. For the router's **direct targets** — the branch heads — only predecessors inside the fan-out count (the router itself, or a node it reaches): the mono/dual topology, where a `condition` router reaches the same reviewer directly *or* through a `fan_out_all` router, gives that reviewer two predecessors, and it is still an ordinary branch head, not the collector. Below the heads every predecessor counts, including a trunk edge that bypasses the fan-out (`plan -> collect else` for the no-items case) — that bypass is what makes `collect` the implicit collector of a linear `fan_out_each` template. Declare `await:` on the intended collector rather than relying on the implicit election.
 
 Routers are fan-out sources and do not declare `await:` themselves.

--- a/openapi.json
+++ b/openapi.json
@@ -393,6 +393,15 @@
             },
             "type": "object"
           },
+          "settled_incoming": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/IncomingEdge"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
           "start_node_id": {
             "type": "string"
           },
@@ -569,6 +578,15 @@
             "type": "object"
           },
           "selected_incoming": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/IncomingEdge"
+              },
+              "type": "array"
+            },
+            "type": "object"
+          },
+          "settled_incoming": {
             "additionalProperties": {
               "items": {
                 "$ref": "#/components/schemas/IncomingEdge"

--- a/pkg/runtime/artifact_contract.go
+++ b/pkg/runtime/artifact_contract.go
@@ -145,18 +145,21 @@ func (e *Engine) consumedArtifactRefs(nodeID string, rs *runState) []string {
 		tracked = false
 	}
 	overlayForward := tracked && incomingOnlyBounded(selected)
-	floor := settledFloorFor(nodeID, resolveScope{rs: rs})
-	return ir.NodeArtifactRefsForEdges(e.workflow, nodeID, func(edge *ir.Edge) bool {
+	sc := resolveScope{vars: rs.vars, outputs: rs.outputs, artifacts: rs.artifacts, rs: rs}
+	floor := settledFloorFor(nodeID, sc)
+	// Floor edges are answered separately, by the SAME function that decides
+	// what the node's input carries. Letting them through this predicate
+	// would record a dependency on an artifact the conflict rule refused to
+	// apply — and a required dependency is re-validated on resume, so an
+	// artifact nobody consumed can go on to block one.
+	refs := ir.NodeArtifactRefsForEdges(e.workflow, nodeID, func(edge *ir.Edge) bool {
+		if settledFloorEligible(edge, floor) {
+			return false
+		}
 		if edge.From != "" {
 			if _, local := rs.outputs[edge.From]; !local {
 				if _, inherited := rs.inheritedOutputs[edge.From]; !inherited {
-					// An edge the settled floor feeds into the node reaches
-					// it exactly like any other, so its artifact references
-					// belong in the node's contract. Same eligibility rule
-					// as the resolver — ONE function, so the two cannot
-					// drift and leave a join consuming an artifact its
-					// contract never named.
-					return settledFloorEligible(edge, floor, false)
+					return false
 				}
 			}
 		}
@@ -165,6 +168,22 @@ func (e *Engine) consumedArtifactRefs(nodeID string, rs *runState) []string {
 		}
 		return edgeInIncoming(edge, selected)
 	})
+	if len(floor) == 0 {
+		return refs
+	}
+	applied, _ := e.settledFloorMappings(nodeID, sc)
+	seen := make(map[string]bool, len(refs))
+	for _, name := range refs {
+		seen[name] = true
+	}
+	for name := range applied.artifactRefs {
+		if !seen[name] {
+			seen[name] = true
+			refs = append(refs, name)
+		}
+	}
+	sort.Strings(refs)
+	return refs
 }
 
 // ValidateArtifactContracts checks persisted artifact metadata before a

--- a/pkg/runtime/artifact_contract.go
+++ b/pkg/runtime/artifact_contract.go
@@ -145,11 +145,18 @@ func (e *Engine) consumedArtifactRefs(nodeID string, rs *runState) []string {
 		tracked = false
 	}
 	overlayForward := tracked && incomingOnlyBounded(selected)
+	floor := settledFloorFor(nodeID, resolveScope{rs: rs})
 	return ir.NodeArtifactRefsForEdges(e.workflow, nodeID, func(edge *ir.Edge) bool {
 		if edge.From != "" {
 			if _, local := rs.outputs[edge.From]; !local {
 				if _, inherited := rs.inheritedOutputs[edge.From]; !inherited {
-					return false
+					// An edge the settled floor feeds into the node reaches
+					// it exactly like any other, so its artifact references
+					// belong in the node's contract. Same eligibility rule
+					// as the resolver — ONE function, so the two cannot
+					// drift and leave a join consuming an artifact its
+					// contract never named.
+					return settledFloorEligible(edge, floor, false)
 				}
 			}
 		}

--- a/pkg/runtime/artifact_contract_test.go
+++ b/pkg/runtime/artifact_contract_test.go
@@ -1091,7 +1091,7 @@ func TestMaterializeHumanArtifactKeepsIncomingArtifactDependency(t *testing.T) {
 		map[string]map[string]any{"planner": {"ok": true}},
 		map[string]map[string]any{"plan": {"ok": true}},
 		revisions,
-		map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}},
+		incomingState{selected: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/runtime/artifact_contract_test.go
+++ b/pkg/runtime/artifact_contract_test.go
@@ -1091,7 +1091,7 @@ func TestMaterializeHumanArtifactKeepsIncomingArtifactDependency(t *testing.T) {
 		map[string]map[string]any{"planner": {"ok": true}},
 		map[string]map[string]any{"plan": {"ok": true}},
 		revisions,
-		incomingState{selected: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
+		&store.Checkpoint{SelectedIncoming: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -42,6 +42,10 @@ type branchResult struct {
 	// fired into each node it executed (or the join it stopped at).
 	// Concurrent branches must not write the trunk runState map.
 	selectedIncoming map[string][]store.IncomingEdge
+	// settledIncoming is the same privacy for the floor a NESTED fan-out
+	// left on a convergence inside this branch. The trunk's own floor is
+	// never read here — a branch does not execute the trunk's join.
+	settledIncoming map[string][]store.IncomingEdge
 	// costUSD is the branch's cumulative LLM spend for this invocation,
 	// seeded from the durable branch cursor so a resumed pass keeps
 	// growing the same monotonic-max daily-cap ledger entry.
@@ -348,6 +352,11 @@ func initBranchResult(rs *runState, branchID string, cp *store.BranchCheckpoint)
 		artifactRevisions: make(map[string]store.ArtifactRevisionRef),
 		artifactVersions:  branchArtifactVersions,
 		selectedIncoming:  make(map[string][]store.IncomingEdge),
+		// Always allocated: newBranchRunState ALIASES it onto the branch
+		// runState, and a map created lazily on first write would replace
+		// that alias instead of writing through it — the floor would then
+		// never reach the checkpoint.
+		settledIncoming: make(map[string][]store.IncomingEdge),
 	}
 	if cp != nil {
 		result.outputs = copyOutputs(cp.Outputs)
@@ -372,6 +381,9 @@ func initBranchResult(rs *runState, branchID string, cp *store.BranchCheckpoint)
 		}
 		if incoming := cloneIncoming(cp.SelectedIncoming); incoming != nil {
 			result.selectedIncoming = incoming
+		}
+		if settled := cloneIncoming(cp.SettledIncoming); settled != nil {
+			result.settledIncoming = settled
 		}
 		result.costUSD = cp.CostUSD
 	}
@@ -398,6 +410,10 @@ func newBranchRunState(parent *runState, cp *store.BranchCheckpoint, result *bra
 	}
 	local.artifactVersions = result.artifactVersions
 	local.selectedIncoming = result.selectedIncoming
+	// Aliased, not copied: a nested fan-out settling a floor inside this
+	// branch writes through to the result, which is what the branch cursor
+	// persists. Never the parent's map — concurrent branches would race it.
+	local.settledIncoming = result.settledIncoming
 	local.loopCounters = make(map[string]int)
 	local.loopPreviousOutput = make(map[string]map[string]any)
 	local.loopCurrentOutput = make(map[string]map[string]any)
@@ -447,6 +463,7 @@ func branchCheckpointFromState(rs *runState, result *branchResult, currentNodeID
 		LoopCurrentOutput:  copyOutputs(rs.loopCurrentOutput),
 		LoopBudgetMarks:    snapshotLoopBudgetMarks(rs),
 		SelectedIncoming:   cloneIncoming(result.selectedIncoming),
+		SettledIncoming:    cloneIncoming(result.settledIncoming),
 		JoinNodeID:         result.joinNodeID,
 		TerminalNodeID:     result.terminalNodeID,
 		Completed:          completed,

--- a/pkg/runtime/checkpoint.go
+++ b/pkg/runtime/checkpoint.go
@@ -41,6 +41,7 @@ func buildCheckpointWithoutParallel(rs *runState, nodeID string) *store.Checkpoi
 		ArtifactRevisions:      artifactRevisions,
 		ArtifactRevisionsKnown: true,
 		SelectedIncoming:       cloneIncoming(rs.selectedIncoming),
+		SettledIncoming:        cloneIncoming(rs.settledIncoming),
 		Vars:                   rs.vars,
 		NodeAttempts:           serializeNodeAttempts(rs.nodeAttempts),
 		// Persist run-scoped accounting so resume continues from consumed
@@ -354,11 +355,22 @@ func restoreLoopSnapshots(rs *runState, cp *store.Checkpoint) {
 // would have on the first attempt. A missing field (legacy checkpoint)
 // leaves the empty map newRunState allocated: incomingFor then reports
 // untracked and the resolver falls back to source-output presence.
+//
+// It rehydrates the settled floor in the same breath, because the two are
+// only useful together: a run parked ON a convergence node whose fan-out
+// produced nothing restarts from that very node without replaying the
+// fan-out, so a floor left behind here would go missing on the resume
+// after surviving the first attempt.
 func restoreSelectedIncoming(rs *runState, cp *store.Checkpoint) {
-	if cp == nil || len(cp.SelectedIncoming) == 0 {
+	if cp == nil {
 		return
 	}
-	rs.selectedIncoming = cloneIncoming(cp.SelectedIncoming)
+	if len(cp.SelectedIncoming) > 0 {
+		rs.selectedIncoming = cloneIncoming(cp.SelectedIncoming)
+	}
+	if len(cp.SettledIncoming) > 0 {
+		rs.settledIncoming = cloneIncoming(cp.SettledIncoming)
+	}
 }
 
 // restoreNodeAttempts is the inverse of serializeNodeAttempts: it rebuilds

--- a/pkg/runtime/convergence.go
+++ b/pkg/runtime/convergence.go
@@ -14,7 +14,11 @@ import (
 // node's await strategy, merges outputs into the run state, builds the
 // convergence node's input from multi-edge with-mappings, and returns
 // the convergence node ID for the main loop to continue execution.
-func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, results []*branchResult) (string, error) {
+//
+// launched is the set of edges this invocation actually started branches on
+// (a subset of the declared ones under an llm multi-select router) — the
+// provenance of the settled floor recorded for the join.
+func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, results []*branchResult, launched []*ir.Edge) (string, error) {
 	convNode, ok := e.workflow.Nodes[convergenceNodeID]
 	if !ok {
 		return "", &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: convergenceNodeID, Message: fmt.Sprintf("convergence node %q not found", convergenceNodeID)}
@@ -154,7 +158,7 @@ func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, resu
 		e.logger.Warn("failed to emit convergence_ready: %v", err)
 	}
 
-	mergeJoinIncoming(rs, convergenceNodeID, results)
+	e.mergeJoinIncoming(rs, convergenceNodeID, results, launched)
 
 	// Return the convergence node ID — the main loop will execute it normally.
 	return convergenceNodeID, nil

--- a/pkg/runtime/convergence.go
+++ b/pkg/runtime/convergence.go
@@ -15,10 +15,10 @@ import (
 // convergence node's input from multi-edge with-mappings, and returns
 // the convergence node ID for the main loop to continue execution.
 //
-// launched is the set of edges this invocation actually started branches on
-// (a subset of the declared ones under an llm multi-select router) — the
-// provenance of the settled floor recorded for the join.
-func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, results []*branchResult, launched []*ir.Edge) (string, error) {
+// seeds are the nodes this invocation actually entered — the provenance of
+// the settled floor recorded for the join. The caller computes them because
+// the two fan-out shapes differ (see settledSeedsPerEdge / ForTemplate).
+func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, results []*branchResult, seeds []string) (string, error) {
 	convNode, ok := e.workflow.Nodes[convergenceNodeID]
 	if !ok {
 		return "", &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: convergenceNodeID, Message: fmt.Sprintf("convergence node %q not found", convergenceNodeID)}
@@ -158,7 +158,7 @@ func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, resu
 		e.logger.Warn("failed to emit convergence_ready: %v", err)
 	}
 
-	e.mergeJoinIncoming(rs, convergenceNodeID, results, launched)
+	e.mergeJoinIncoming(rs, convergenceNodeID, results, seeds)
 
 	// Return the convergence node ID — the main loop will execute it normally.
 	return convergenceNodeID, nil

--- a/pkg/runtime/convergence_all_failed_incoming_test.go
+++ b/pkg/runtime/convergence_all_failed_incoming_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// #559 — when EVERY branch of a best_effort fan-out fails, the convergence
+// node still executes (that is what best_effort promises) but arrives with
+// none of its incoming `with` mappings.
+//
+// The mappings that matter here do not depend on the failed branches at all:
+// they read a durable parent output or a var, which are still on the run
+// state. A required join input such as `expected_count` therefore goes
+// missing, and shell rendering — which deliberately keeps an unresolved
+// reference as a literal — hands `{{input.expected_count}}` to the command.
+func TestConvergence_allFailedBestEffortKeepsParentSourcedMappings(t *testing.T) {
+	wf := fanOutWorkflow(ir.AwaitBestEffort)
+	// Both branch→join edges carry a mapping sourced from the PARENT's
+	// output, beside the one sourced from the branch itself.
+	for _, e := range wf.Edges {
+		if e.To != "finalize" {
+			continue
+		}
+		e.With = append(e.With, &ir.DataMapping{
+			Key:  "expected_count",
+			Refs: []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"entry", "count"}}},
+			Raw:  "{{outputs.entry.count}}",
+		})
+	}
+
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"summary": "go", "count": 2}, nil
+	})
+	exec.on("agent_a", func(_ map[string]any) (map[string]any, error) {
+		return nil, errors.New("fail A")
+	})
+	exec.on("agent_b", func(_ map[string]any) (map[string]any, error) {
+		return nil, errors.New("fail B")
+	})
+	var finalizeInput map[string]any
+	exec.on("finalize", func(input map[string]any) (map[string]any, error) {
+		finalizeInput = input
+		return map[string]any{}, nil
+	})
+
+	s := tmpStore(t)
+	if err := New(wf, s, exec).Run(context.Background(), "run-559", nil); err != nil {
+		t.Fatalf("run: %v (best_effort tolerates all failures)", err)
+	}
+	if finalizeInput == nil {
+		t.Fatal("the convergence node never ran")
+	}
+	got, ok := finalizeInput["expected_count"]
+	if !ok {
+		t.Fatalf("input = %v — expected_count is missing, so a shell node would be handed the literal {{input.expected_count}}. Its mapping reads the PARENT's output, which every failed branch left untouched.", finalizeInput)
+	}
+	if got != 2 {
+		t.Fatalf("expected_count = %v, want 2 (the parent's own output)", got)
+	}
+}
+
+// The SAME symptom on a sibling site (grep-la-classe): `fan_out_each` whose
+// `over` resolves to an EMPTY array also skips to the convergence after
+// deleting the tracking entry (fan_out_each.go:147). No branch ran, so no
+// source has output, so the same guard drops every incoming mapping —
+// including the ones reading a durable parent output.
+//
+// Probe first, fix second: if this is red too, the fix has to cover both
+// sites or it leaves the class alive.
+func TestConvergence_emptyFanOutEachKeepsParentSourcedMappings(t *testing.T) {
+	wf := fanOutEachWorkflow(false, ir.AwaitWaitAll, 0)
+	for _, e := range wf.Edges {
+		if e.From == "handle" && e.To == "collect" {
+			e.With = []*ir.DataMapping{{
+				Key:  "expected_count",
+				Refs: []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"entry", "count"}}},
+				Raw:  "{{outputs.entry.count}}",
+			}}
+		}
+	}
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{}, "count": 0}, nil
+	})
+	var collectInput map[string]any
+	exec.on("collect", func(input map[string]any) (map[string]any, error) {
+		collectInput = input
+		return map[string]any{}, nil
+	})
+	s := tmpStore(t)
+	if err := New(wf, s, exec).Run(context.Background(), "run-559-empty", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if collectInput == nil {
+		t.Fatal("the convergence node never ran")
+	}
+	if _, ok := collectInput["expected_count"]; !ok {
+		t.Fatalf("input = %v — same class as the all-failed case: an empty fan_out_each leaves the convergence without its parent-sourced mappings", collectInput)
+	}
+}

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -431,6 +431,14 @@ type runState struct {
 	// cannot race this map; the trunk copies the join union at
 	// processConvergence. Re-seeded at resume from Checkpoint.SelectedIncoming.
 	selectedIncoming map[string][]store.IncomingEdge
+	// settledIncoming records, per convergence node, the edges a fan-out
+	// invocation stabilized on whose source produced no output — every
+	// branch failed, or the collection fanned over was empty. Kept apart
+	// from selectedIncoming because a join may be a loop head, whose
+	// selection the back-edge REPLACES on re-entry; the floor is a
+	// forward-pass base that has to survive that. Re-seeded at resume from
+	// Checkpoint.SettledIncoming.
+	settledIncoming map[string][]store.IncomingEdge
 	// parallel is non-nil while the trunk is parked on a fan-out router.
 	// Branch goroutines mutate it only through its mutex-protected helpers;
 	// the trunk clears/replaces it at router invocation boundaries.

--- a/pkg/runtime/engine_resolve.go
+++ b/pkg/runtime/engine_resolve.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -89,6 +90,12 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 			result[k] = v
 		}
 	}
+
+	// Settled floor: the mappings of a fan-out invocation that stabilized
+	// without any branch producing output. Applied here, under both passes
+	// below, so any live edge — and the back-edge overlay applied last —
+	// wins on a shared key (#559, #1113).
+	e.applySettledFloor(nodeID, sc, result)
 
 	// applyEdge merges one edge's with-mappings into result. A not-yet-run
 	// source never contributes (the mapping is left to a later-firing
@@ -213,6 +220,118 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 	}
 
 	return result
+}
+
+// applySettledFloor merges the with-mappings of the edges a fan-out
+// invocation settled on whose source never produced output — every branch
+// failed under best_effort, or the collection fanned over was empty. Those
+// edges are dropped by every ordinary rule (no output, and the join is left
+// untracked), so without this the node executes with NO incoming mapping at
+// all — including the ones that read a durable parent output or a var and
+// never depended on the dead branch. A tool node is then handed the literal
+// `{{input.x}}` in its command, since shell rendering deliberately keeps an
+// unresolved reference visible (#559, #1113).
+//
+// What it does NOT do: make a mapping that reads the dead branch resolvable.
+// `{{outputs.agent_a}}` still lands nil. That is a narrower promise than it
+// looks — a nil renders empty in a prompt but stays a literal in a shell
+// command, so this reduces the leak without closing it.
+//
+// Two invariants keep it from reopening #484:
+//
+//   - Only an OUTPUT-LESS source contributes (settledFloorEligible). An edge
+//     whose source ran is left to the passes below, where routing's recorded
+//     selection still decides between exclusive siblings.
+//   - It is a FLOOR — applied before both passes, so a live edge and the
+//     back-edge overlay both win on a shared key.
+//
+// Membership is tested against the CURRENT workflow edges, which is what
+// revalidates a floor rehydrated by `resume --force` against an edited .bot:
+// per-edge, not per-node, so an identity that matches no current edge
+// contributes nothing and a wholly stale floor contributes nothing at all
+// (R25212d).
+func (e *Engine) applySettledFloor(nodeID string, sc resolveScope, result map[string]any) {
+	floor := settledFloorFor(nodeID, sc)
+	if len(floor) == 0 || e.workflow == nil {
+		return
+	}
+	// Resolve per SOURCE before writing anything: two floor edges from one
+	// source are exclusive alternatives (`when` / `else`) that routing never
+	// got to decide between, because the source never ran. Where they agree
+	// the value is theirs whichever would have fired; where they disagree,
+	// picking by declaration order is precisely the guess #484 removed.
+	type floorValue struct {
+		value    any
+		decided  bool
+		fromEdge string
+	}
+	sources := make([]string, 0, 2)
+	bySource := make(map[string]map[string]*floorValue)
+	for _, edge := range e.workflow.Edges {
+		if edge == nil || edge.To != nodeID || len(edge.With) == 0 {
+			continue
+		}
+		_, hasOutput := sc.outputs[edge.From]
+		if !settledFloorEligible(edge, floor, hasOutput) {
+			continue
+		}
+		bucket, seen := bySource[edge.From]
+		if !seen {
+			bucket = make(map[string]*floorValue, len(edge.With))
+			bySource[edge.From] = bucket
+			sources = append(sources, edge.From)
+		}
+		// The source produced nothing, so `{{input.*}}` on this edge has no
+		// namespace to read: an explicit empty map, never the caller's
+		// runInputs, which would silently promote a run-level payload into
+		// the source-output namespace (#479). warnMissingEdgeInput is
+		// deliberately skipped — it would fire on every field of a node that
+		// never ran, and say "not on the source node's output" about a source
+		// that has no output at all.
+		edgeScope := sc
+		edgeScope.runInputs = map[string]any{}
+		for _, dm := range edge.With {
+			val := e.resolveMapping(dm, edgeScope)
+			prev, dup := bucket[dm.Key]
+			if !dup {
+				bucket[dm.Key] = &floorValue{value: val, decided: true, fromEdge: edgeLabel(edge)}
+				continue
+			}
+			if prev.decided && !reflect.DeepEqual(prev.value, val) {
+				prev.decided = false
+				e.logger.Warn("runtime: node %s: incoming edges %s and %s are exclusive alternatives from %s, neither ran, and they disagree on %q (%v vs %v) — leaving it unset rather than picking by declaration order",
+					nodeID, prev.fromEdge, edgeLabel(edge), edge.From, dm.Key, prev.value, val)
+			}
+		}
+	}
+	for _, from := range sources {
+		for key, v := range bySource[from] {
+			if v.decided {
+				result[key] = v.value
+			}
+		}
+	}
+}
+
+// edgeLabel renders an edge's routing shape for a diagnostic: `a -> b`,
+// `a -> b when ok`, `a -> b else`. Enough to tell two alternatives apart in
+// a log line, which is the whole point of naming them.
+func edgeLabel(edge *ir.Edge) string {
+	if edge == nil {
+		return "<nil edge>"
+	}
+	label := edge.From + " -> " + edge.To
+	switch {
+	case edge.IsElse:
+		return label + " else"
+	case edge.ExpressionSrc != "":
+		return label + " when " + edge.ExpressionSrc
+	case edge.Condition != "" && edge.Negated:
+		return label + " when not " + edge.Condition
+	case edge.Condition != "":
+		return label + " when " + edge.Condition
+	}
+	return label
 }
 
 // warnMissingEdgeInput logs when a with-mapping {{input.x}} names a

--- a/pkg/runtime/engine_resolve.go
+++ b/pkg/runtime/engine_resolve.go
@@ -253,8 +253,8 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 func (e *Engine) applySettledFloor(nodeID string, sc resolveScope, result map[string]any) {
 	applied, conflicts := e.settledFloorMappings(nodeID, sc)
 	for _, c := range conflicts {
-		e.logger.Warn("runtime: node %s: incoming edges %s and %s are exclusive alternatives from %s, neither ran, and they disagree on %q (%v vs %v) — leaving it unset rather than picking by declaration order",
-			nodeID, c.firstEdge, c.secondEdge, c.from, c.key, c.first, c.second)
+		e.logger.Warn("runtime: node %s: incoming edges %s and %s both settled without running and disagree on %q (%v vs %v) — leaving it unset rather than picking by declaration order",
+			nodeID, c.firstEdge, c.secondEdge, c.key, c.first, c.second)
 	}
 	for _, key := range applied.order {
 		result[key] = applied.values[key]
@@ -270,9 +270,9 @@ type settledFloorContribution struct {
 	artifactRefs map[string]bool
 }
 
-// settledFloorConflict is one key two undecided alternatives disagreed on.
+// settledFloorConflict is one key two undecided floor edges disagreed on.
 type settledFloorConflict struct {
-	from, key             string
+	key                   string
 	firstEdge, secondEdge string
 	first, second         any
 }
@@ -283,11 +283,14 @@ type settledFloorConflict struct {
 // carry must not appear among the artifacts the node is recorded to depend
 // on, or a later resume is refused over a value nobody consumed.
 //
-// Resolution is grouped per SOURCE, because two floor edges from one source
-// are exclusive alternatives (`when` / `else`) that routing never got to
-// decide between — the source never ran. Where they agree, the value is
-// theirs whichever would have fired; where they disagree, picking by
-// declaration order is precisely the guess #484 removed.
+// A disagreement is judged per KEY across the WHOLE floor, not per source.
+// Two floor edges are alternatives whenever the node that would have chosen
+// between them never ran, and that node is not always their common source:
+// `head -> x when ok` / `head -> y else` with `x -> join` / `y -> join` puts
+// two mutually exclusive mappings on the join from two DIFFERENT sources.
+// Bucketing by source let declaration order settle exactly the case the rule
+// exists to refuse. Where the alternatives agree, the value is theirs
+// whichever would have fired; where they disagree, the key is left unset.
 func (e *Engine) settledFloorMappings(nodeID string, sc resolveScope) (settledFloorContribution, []settledFloorConflict) {
 	out := settledFloorContribution{values: map[string]any{}, artifactRefs: map[string]bool{}}
 	floor := settledFloorFor(nodeID, sc)
@@ -302,9 +305,8 @@ func (e *Engine) settledFloorMappings(nodeID string, sc resolveScope) (settledFl
 		fromEdge string
 	}
 	var conflicts []settledFloorConflict
-	sources := make([]string, 0, 2)
-	keyOrder := make(map[string][]string)
-	bySource := make(map[string]map[string]*floorValue)
+	var keyOrder []string
+	byKey := make(map[string]*floorValue)
 	for _, edge := range e.workflow.Edges {
 		if edge == nil || edge.To != nodeID || len(edge.With) == 0 {
 			continue
@@ -312,61 +314,60 @@ func (e *Engine) settledFloorMappings(nodeID string, sc resolveScope) (settledFl
 		if !settledFloorEligible(edge, floor) {
 			continue
 		}
-		bucket, seen := bySource[edge.From]
-		if !seen {
-			bucket = make(map[string]*floorValue, len(edge.With))
-			bySource[edge.From] = bucket
-			sources = append(sources, edge.From)
-		}
 		// The source produced nothing, so `{{input.*}}` on this edge has no
 		// namespace to read: an explicit empty map, never the caller's
 		// runInputs, which would silently promote a run-level payload into
-		// the source-output namespace (#479). warnMissingEdgeInput is
-		// deliberately skipped — it would fire on every field of a node that
-		// never ran, and say "not on the source node's output" about a source
-		// that has no output at all.
+		// the source-output namespace (#479). Every floor edge therefore
+		// resolves in the SAME scope, which is what makes the template
+		// short-circuit below sound across sources too. warnMissingEdgeInput
+		// is deliberately skipped — it would fire on every field of a node
+		// that never ran, and say "not on the source node's output" about a
+		// source that has no output at all.
 		edgeScope := sc
 		edgeScope.runInputs = map[string]any{}
 		for _, dm := range edge.With {
-			prev, dup := bucket[dm.Key]
+			prev, dup := byKey[dm.Key]
 			if dup && prev.raw == dm.Raw {
-				// The same template on both alternatives IS the same
-				// mapping, whatever it resolves to. Resolving it twice and
-				// comparing would report a false disagreement for any
-				// namespace that moves between the two reads —
-				// `{{run.elapsed_seconds}}` differs on every lookup.
+				// The same template IS the same mapping, whatever it
+				// resolves to. Resolving it twice and comparing would report
+				// a false disagreement for any namespace that moves between
+				// the two reads — `{{run.elapsed_seconds}}` differs on every
+				// lookup.
 				continue
 			}
 			val := e.resolveMapping(dm, edgeScope)
 			if !dup {
-				bucket[dm.Key] = &floorValue{value: val, raw: dm.Raw, refs: dm.Refs, decided: true, fromEdge: edgeLabel(edge)}
-				keyOrder[edge.From] = append(keyOrder[edge.From], dm.Key)
+				byKey[dm.Key] = &floorValue{value: val, raw: dm.Raw, refs: dm.Refs, decided: true, fromEdge: edgeLabel(edge)}
+				keyOrder = append(keyOrder, dm.Key)
 				continue
 			}
-			if prev.decided && !reflect.DeepEqual(prev.value, val) {
+			if !prev.decided {
+				continue
+			}
+			if !reflect.DeepEqual(prev.value, val) {
 				prev.decided = false
 				conflicts = append(conflicts, settledFloorConflict{
-					from: edge.From, key: dm.Key,
+					key:       dm.Key,
 					firstEdge: prev.fromEdge, secondEdge: edgeLabel(edge),
 					first: prev.value, second: val,
 				})
-			}
-		}
-	}
-	for _, from := range sources {
-		for _, key := range keyOrder[from] {
-			v := bySource[from][key]
-			if v == nil || !v.decided {
 				continue
 			}
-			if _, dup := out.values[key]; !dup {
-				out.order = append(out.order, key)
-			}
-			out.values[key] = v.value
-			for _, ref := range v.refs {
-				if ref != nil && ref.Kind == ir.RefArtifacts && len(ref.Path) > 0 {
-					out.artifactRefs[ref.Path[0]] = true
-				}
+			// They agree on the value by two different templates: both were
+			// genuinely read, so both sets of references were consumed.
+			prev.refs = append(prev.refs, dm.Refs...)
+		}
+	}
+	for _, key := range keyOrder {
+		v := byKey[key]
+		if v == nil || !v.decided {
+			continue
+		}
+		out.order = append(out.order, key)
+		out.values[key] = v.value
+		for _, ref := range v.refs {
+			if ref != nil && ref.Kind == ir.RefArtifacts && len(ref.Path) > 0 {
+				out.artifactRefs[ref.Path[0]] = true
 			}
 		}
 	}

--- a/pkg/runtime/engine_resolve.go
+++ b/pkg/runtime/engine_resolve.go
@@ -251,28 +251,65 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 // contributes nothing and a wholly stale floor contributes nothing at all
 // (R25212d).
 func (e *Engine) applySettledFloor(nodeID string, sc resolveScope, result map[string]any) {
+	applied, conflicts := e.settledFloorMappings(nodeID, sc)
+	for _, c := range conflicts {
+		e.logger.Warn("runtime: node %s: incoming edges %s and %s are exclusive alternatives from %s, neither ran, and they disagree on %q (%v vs %v) — leaving it unset rather than picking by declaration order",
+			nodeID, c.firstEdge, c.secondEdge, c.from, c.key, c.first, c.second)
+	}
+	for _, key := range applied.order {
+		result[key] = applied.values[key]
+	}
+}
+
+// settledFloorContribution is what a node's floor actually hands it: the
+// resolved value per key, in a deterministic order, and the artifact
+// references those surviving mappings carry.
+type settledFloorContribution struct {
+	values       map[string]any
+	order        []string
+	artifactRefs map[string]bool
+}
+
+// settledFloorConflict is one key two undecided alternatives disagreed on.
+type settledFloorConflict struct {
+	from, key             string
+	firstEdge, secondEdge string
+	first, second         any
+}
+
+// settledFloorMappings resolves a node's floor into the keys it contributes
+// and the disagreements it refuses to arbitrate. THE single answer, read by
+// the resolver AND by the artifact contract: a key the node's input does not
+// carry must not appear among the artifacts the node is recorded to depend
+// on, or a later resume is refused over a value nobody consumed.
+//
+// Resolution is grouped per SOURCE, because two floor edges from one source
+// are exclusive alternatives (`when` / `else`) that routing never got to
+// decide between — the source never ran. Where they agree, the value is
+// theirs whichever would have fired; where they disagree, picking by
+// declaration order is precisely the guess #484 removed.
+func (e *Engine) settledFloorMappings(nodeID string, sc resolveScope) (settledFloorContribution, []settledFloorConflict) {
+	out := settledFloorContribution{values: map[string]any{}, artifactRefs: map[string]bool{}}
 	floor := settledFloorFor(nodeID, sc)
 	if len(floor) == 0 || e.workflow == nil {
-		return
+		return out, nil
 	}
-	// Resolve per SOURCE before writing anything: two floor edges from one
-	// source are exclusive alternatives (`when` / `else`) that routing never
-	// got to decide between, because the source never ran. Where they agree
-	// the value is theirs whichever would have fired; where they disagree,
-	// picking by declaration order is precisely the guess #484 removed.
 	type floorValue struct {
 		value    any
+		raw      string
+		refs     []*ir.Ref
 		decided  bool
 		fromEdge string
 	}
+	var conflicts []settledFloorConflict
 	sources := make([]string, 0, 2)
+	keyOrder := make(map[string][]string)
 	bySource := make(map[string]map[string]*floorValue)
 	for _, edge := range e.workflow.Edges {
 		if edge == nil || edge.To != nodeID || len(edge.With) == 0 {
 			continue
 		}
-		_, hasOutput := sc.outputs[edge.From]
-		if !settledFloorEligible(edge, floor, hasOutput) {
+		if !settledFloorEligible(edge, floor) {
 			continue
 		}
 		bucket, seen := bySource[edge.From]
@@ -291,26 +328,49 @@ func (e *Engine) applySettledFloor(nodeID string, sc resolveScope, result map[st
 		edgeScope := sc
 		edgeScope.runInputs = map[string]any{}
 		for _, dm := range edge.With {
-			val := e.resolveMapping(dm, edgeScope)
 			prev, dup := bucket[dm.Key]
+			if dup && prev.raw == dm.Raw {
+				// The same template on both alternatives IS the same
+				// mapping, whatever it resolves to. Resolving it twice and
+				// comparing would report a false disagreement for any
+				// namespace that moves between the two reads —
+				// `{{run.elapsed_seconds}}` differs on every lookup.
+				continue
+			}
+			val := e.resolveMapping(dm, edgeScope)
 			if !dup {
-				bucket[dm.Key] = &floorValue{value: val, decided: true, fromEdge: edgeLabel(edge)}
+				bucket[dm.Key] = &floorValue{value: val, raw: dm.Raw, refs: dm.Refs, decided: true, fromEdge: edgeLabel(edge)}
+				keyOrder[edge.From] = append(keyOrder[edge.From], dm.Key)
 				continue
 			}
 			if prev.decided && !reflect.DeepEqual(prev.value, val) {
 				prev.decided = false
-				e.logger.Warn("runtime: node %s: incoming edges %s and %s are exclusive alternatives from %s, neither ran, and they disagree on %q (%v vs %v) — leaving it unset rather than picking by declaration order",
-					nodeID, prev.fromEdge, edgeLabel(edge), edge.From, dm.Key, prev.value, val)
+				conflicts = append(conflicts, settledFloorConflict{
+					from: edge.From, key: dm.Key,
+					firstEdge: prev.fromEdge, secondEdge: edgeLabel(edge),
+					first: prev.value, second: val,
+				})
 			}
 		}
 	}
 	for _, from := range sources {
-		for key, v := range bySource[from] {
-			if v.decided {
-				result[key] = v.value
+		for _, key := range keyOrder[from] {
+			v := bySource[from][key]
+			if v == nil || !v.decided {
+				continue
+			}
+			if _, dup := out.values[key]; !dup {
+				out.order = append(out.order, key)
+			}
+			out.values[key] = v.value
+			for _, ref := range v.refs {
+				if ref != nil && ref.Kind == ir.RefArtifacts && len(ref.Path) > 0 {
+					out.artifactRefs[ref.Path[0]] = true
+				}
 			}
 		}
 	}
+	return out, conflicts
 }
 
 // edgeLabel renders an edge's routing shape for a diagnostic: `a -> b`,

--- a/pkg/runtime/fan_out.go
+++ b/pkg/runtime/fan_out.go
@@ -445,7 +445,7 @@ func (e *Engine) resolveConvergence(rs *runState, routerNodeID string, results [
 		}
 	}
 
-	return e.processConvergence(rs, convergenceNodeID, results, plan.edges)
+	return e.processConvergence(rs, convergenceNodeID, results, settledSeedsPerEdge(routerNodeID, plan.edges, results))
 }
 
 // allTerminatedAtDone reports whether every branch finished cleanly at

--- a/pkg/runtime/fan_out.go
+++ b/pkg/runtime/fan_out.go
@@ -445,7 +445,7 @@ func (e *Engine) resolveConvergence(rs *runState, routerNodeID string, results [
 		}
 	}
 
-	return e.processConvergence(rs, convergenceNodeID, results)
+	return e.processConvergence(rs, convergenceNodeID, results, plan.edges)
 }
 
 // allTerminatedAtDone reports whether every branch finished cleanly at

--- a/pkg/runtime/fan_out_each.go
+++ b/pkg/runtime/fan_out_each.go
@@ -152,7 +152,7 @@ func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID 
 		// parent output or a var would go missing too (#1113, the twin of
 		// #559's all-failed case). Settle the floor on the edges this
 		// invocation WOULD have fired.
-		rs.setSettledFloor(convergence, settledEdgesInto(e.workflow, []*ir.Edge{tmplEdge}, convergence))
+		rs.setSettledFloor(convergence, settledEdgesInto(e.workflow, []*ir.Edge{tmplEdge}, convergence, evidenceFromBranches(nil)))
 		return convergence, nil
 	}
 

--- a/pkg/runtime/fan_out_each.go
+++ b/pkg/runtime/fan_out_each.go
@@ -152,7 +152,7 @@ func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID 
 		// parent output or a var would go missing too (#1113, the twin of
 		// #559's all-failed case). Settle the floor on the edges this
 		// invocation WOULD have fired.
-		rs.setSettledFloor(convergence, settledEdgesInto(e.workflow, []*ir.Edge{tmplEdge}, convergence, evidenceFromBranches(nil)))
+		rs.setSettledFloor(convergence, settledEdgesInto(e.workflow, settledSeedsForTemplate(tmplEdge, nil), convergence, evidenceFromBranches(nil)))
 		return convergence, nil
 	}
 
@@ -368,7 +368,7 @@ func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID 
 		}
 	}
 
-	next, err := e.processConvergence(rs, convergenceNodeID, results, []*ir.Edge{tmplEdge})
+	next, err := e.processConvergence(rs, convergenceNodeID, results, settledSeedsForTemplate(tmplEdge, results))
 	if err == nil {
 		rs.parallel = nil
 	}

--- a/pkg/runtime/fan_out_each.go
+++ b/pkg/runtime/fan_out_each.go
@@ -147,6 +147,12 @@ func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID 
 		if rs.selectedIncoming != nil {
 			delete(rs.selectedIncoming, convergence)
 		}
+		// The untracked fallback keeps only edges whose source produced
+		// output, and no branch ran at all — so a mapping reading a durable
+		// parent output or a var would go missing too (#1113, the twin of
+		// #559's all-failed case). Settle the floor on the edges this
+		// invocation WOULD have fired.
+		rs.setSettledFloor(convergence, settledEdgesInto(e.workflow, []*ir.Edge{tmplEdge}, convergence))
 		return convergence, nil
 	}
 
@@ -362,7 +368,7 @@ func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID 
 		}
 	}
 
-	next, err := e.processConvergence(rs, convergenceNodeID, results)
+	next, err := e.processConvergence(rs, convergenceNodeID, results, []*ir.Edge{tmplEdge})
 	if err == nil {
 		rs.parallel = nil
 	}

--- a/pkg/runtime/incoming.go
+++ b/pkg/runtime/incoming.go
@@ -366,16 +366,6 @@ func (rs *runState) setSettledFloor(joinNodeID string, settled []store.IncomingE
 	rs.settledIncoming[joinNodeID] = settled
 }
 
-// incomingState is the PAIR of per-node edge sets a node's input and its
-// artifact contract are both built from. They travel together because either
-// one alone answers half the question: the selection says which live edges
-// fired, the floor says what a stabilized fan-out left behind. A contract
-// built from the selection alone omits exactly what the floor supplied.
-type incomingState struct {
-	selected map[string][]store.IncomingEdge
-	settled  map[string][]store.IncomingEdge
-}
-
 // settledFloorFor returns the floor recorded for nodeID, if any.
 func settledFloorFor(nodeID string, sc resolveScope) []store.IncomingEdge {
 	if sc.rs == nil {

--- a/pkg/runtime/incoming.go
+++ b/pkg/runtime/incoming.go
@@ -163,8 +163,9 @@ func cloneIncoming(m map[string][]store.IncomingEdge) map[string][]store.Incomin
 // mergeJoinIncoming unions the selected incoming edges that successful
 // fan-out branches recorded for the convergence node, and writes that
 // set onto the trunk runState so the join execution applies exactly those
-// mappings.
-func mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult) {
+// mappings. launched is the set of edges this invocation actually started
+// branches on — the provenance of the settled floor recorded alongside.
+func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult, launched []*ir.Edge) {
 	if rs == nil || joinNodeID == "" {
 		return
 	}
@@ -183,6 +184,10 @@ func mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult)
 			union = append(union, in)
 		}
 	}
+	// Record what this invocation settled on, whichever way it went: a
+	// fresh invocation owns the floor for its join, so one that produced
+	// output must not leave the previous one's floor standing.
+	rs.setSettledFloor(joinNodeID, settledEdgesInto(e.workflow, launched, joinNodeID))
 	if len(union) == 0 {
 		// No successful branch recorded an edge into the join (every
 		// branch failed under best_effort, or the join came from the
@@ -199,4 +204,113 @@ func mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult)
 		rs.selectedIncoming = make(map[string][]store.IncomingEdge)
 	}
 	rs.selectedIncoming[joinNodeID] = union
+}
+
+// ---------------------------------------------------------------------------
+// Settled floor — the edges a stabilized fan-out left with no output behind
+// ---------------------------------------------------------------------------
+
+// settledEdgesInto returns the edges into joinNodeID that a fan-out
+// invocation would have fired, found by walking forward from the nodes it
+// actually entered.
+//
+// Provenance is the LAUNCHED edges, never the declared ones: an llm router
+// in multi-select mode starts a subset of what the graph declares, so
+// reading the declaration would sweep in the very foreign edge the floor
+// exists to exclude.
+//
+// Bounded-iteration edges are out of both the walk and the result. A
+// back-edge is a per-iteration overlay applied last, not part of a
+// stabilized forward pass (Rae4900).
+func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string) []store.IncomingEdge {
+	if wf == nil || joinNodeID == "" || len(launched) == 0 {
+		return nil
+	}
+	reachable := make(map[string]bool, len(launched))
+	frontier := make([]string, 0, len(launched))
+	push := func(id string) {
+		if id == "" || reachable[id] {
+			return
+		}
+		reachable[id] = true
+		frontier = append(frontier, id)
+	}
+	for _, edge := range launched {
+		if edge == nil || edge.IsBoundedIteration() {
+			continue
+		}
+		push(edge.To)
+	}
+	// Forward closure, stopping AT the join: expanding past it could
+	// re-enter through an unrelated downstream cycle and claim edges this
+	// invocation never owned.
+	for len(frontier) > 0 {
+		node := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		if node == joinNodeID {
+			continue
+		}
+		for _, edge := range wf.Edges {
+			if edge == nil || edge.From != node || edge.IsBoundedIteration() {
+				continue
+			}
+			push(edge.To)
+		}
+	}
+	var settled []store.IncomingEdge
+	for _, edge := range wf.Edges {
+		if edge == nil || edge.To != joinNodeID || edge.IsBoundedIteration() {
+			continue
+		}
+		if edge.From == "" || !reachable[edge.From] {
+			continue
+		}
+		settled = append(settled, incomingFromEdge(edge))
+	}
+	return settled
+}
+
+// setSettledFloor stores — or clears — the settled floor for a convergence
+// node. Kept apart from selectedIncoming because a join may be a loop head
+// (TestValidateLoopAfterJoin_Allowed): selectEdgeRS REPLACES the selection
+// on re-entry, so a floor living there would vanish on the second visit.
+func (rs *runState) setSettledFloor(joinNodeID string, settled []store.IncomingEdge) {
+	if rs == nil || joinNodeID == "" {
+		return
+	}
+	if len(settled) == 0 {
+		delete(rs.settledIncoming, joinNodeID)
+		return
+	}
+	if rs.settledIncoming == nil {
+		rs.settledIncoming = make(map[string][]store.IncomingEdge)
+	}
+	rs.settledIncoming[joinNodeID] = settled
+}
+
+// settledFloorFor returns the floor recorded for nodeID, if any.
+func settledFloorFor(nodeID string, sc resolveScope) []store.IncomingEdge {
+	if sc.rs == nil {
+		return nil
+	}
+	return sc.rs.settledIncoming[nodeID]
+}
+
+// settledFloorEligible reports whether edge draws its with-mappings from
+// the floor recorded for its destination. THE shared eligibility rule:
+// buildNodeInputRS and consumedArtifactRefs both consult it, so an edge
+// that feeds the join can never sit outside the join's artifact contract.
+//
+// Only an output-less source qualifies. An edge whose source ran is left
+// to the ordinary passes, where routing's recorded selection still decides
+// between exclusive siblings — without that clause a `when`/`else` pair
+// downstream of a live node would both contribute again (#484).
+func settledFloorEligible(edge *ir.Edge, floor []store.IncomingEdge, hasOutput bool) bool {
+	if edge == nil || len(floor) == 0 || hasOutput || edge.From == "" {
+		return false
+	}
+	if edge.IsBoundedIteration() {
+		return false
+	}
+	return edgeInIncoming(edge, floor)
 }

--- a/pkg/runtime/incoming.go
+++ b/pkg/runtime/incoming.go
@@ -74,6 +74,22 @@ func (rs *runState) setIncoming(edge *ir.Edge) {
 		rs.selectedIncoming = make(map[string][]store.IncomingEdge)
 	}
 	recordIncoming(rs.selectedIncoming, edge, true)
+	if edge != nil && !edge.IsBoundedIteration() {
+		// A FORWARD arrival: routing picked a path into this node that is not
+		// the fan-out that settled its floor, so that floor belongs to an
+		// earlier visit. Keeping it would feed the node with-mappings from
+		// edges this visit's routing did not select, through a path that
+		// bypasses the tracked/selected filter — the #484 shape. This is the
+		// ONE place a forward selection replaces a node's incoming set; the
+		// fan-out writes the join's selection directly (mergeJoinIncoming),
+		// so the fed visit and its resume are untouched.
+		//
+		// A bounded-iteration edge is excluded deliberately: a loop head
+		// re-entered by its own back-edge is the SAME visit continuing, and
+		// its dead branches are still dead — dropping the floor there would
+		// make their mappings vanish from iteration 2 on.
+		delete(rs.settledIncoming, edge.To)
+	}
 }
 
 // incomingFor returns the selected incoming edges recorded for this visit
@@ -163,9 +179,9 @@ func cloneIncoming(m map[string][]store.IncomingEdge) map[string][]store.Incomin
 // mergeJoinIncoming unions the selected incoming edges that successful
 // fan-out branches recorded for the convergence node, and writes that
 // set onto the trunk runState so the join execution applies exactly those
-// mappings. launched is the set of edges this invocation actually started
-// branches on — the provenance of the settled floor recorded alongside.
-func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult, launched []*ir.Edge) {
+// mappings. seeds are the nodes this invocation actually entered — the
+// provenance of the settled floor recorded alongside.
+func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*branchResult, seeds []string) {
 	if rs == nil || joinNodeID == "" {
 		return
 	}
@@ -187,7 +203,7 @@ func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*b
 	// Record what this invocation settled on, whichever way it went: a
 	// fresh invocation owns the floor for its join, so one that produced
 	// output must not leave the previous one's floor standing.
-	rs.setSettledFloor(joinNodeID, settledEdgesInto(e.workflow, launched, joinNodeID, evidenceFromBranches(results)))
+	rs.setSettledFloor(joinNodeID, settledEdgesInto(e.workflow, seeds, joinNodeID, evidenceFromBranches(results)))
 	if len(union) == 0 {
 		// No successful branch recorded an edge into the join (every
 		// branch failed under best_effort, or the join came from the
@@ -225,12 +241,6 @@ type invocationEvidence struct {
 	ran map[string]bool
 	// chosen holds, per destination, the edges that actually fired into it.
 	chosen map[string][]store.IncomingEdge
-	// entered holds the nodes the branches actually STARTED at. On a resume
-	// that is the durable cursor's start node, which can differ from what
-	// the current graph's template edge names: an edited `fan_out_each`
-	// re-executes the node the cursor recorded, so reading the template
-	// would walk a branch this invocation is not running.
-	entered []string
 }
 
 // evidenceFromBranches gathers what the branches of one invocation recorded.
@@ -239,7 +249,6 @@ type invocationEvidence struct {
 // and the caller's declared edges are then the only provenance available.
 func evidenceFromBranches(results []*branchResult) invocationEvidence {
 	ev := invocationEvidence{ran: map[string]bool{}, chosen: map[string][]store.IncomingEdge{}}
-	seenStart := map[string]bool{}
 	for _, r := range results {
 		if r == nil {
 			continue
@@ -250,25 +259,84 @@ func evidenceFromBranches(results []*branchResult) invocationEvidence {
 		for dst, edges := range r.selectedIncoming {
 			ev.chosen[dst] = append(ev.chosen[dst], edges...)
 		}
-		// Synthetic results — a DAG item skipped because its dependency
-		// failed — carry no start node. They contribute nothing here, and
-		// their siblings supply the provenance.
-		if r.startNodeID != "" && !seenStart[r.startNodeID] {
-			seenStart[r.startNodeID] = true
-			ev.entered = append(ev.entered, r.startNodeID)
-		}
 	}
 	return ev
+}
+
+// settledSeedsPerEdge returns the node the walk starts from FOR EACH launched
+// edge: the start node the branch that edge launched actually reported, or
+// the edge's own target when that branch never started.
+//
+// Per edge, never per invocation. A `fan_out_all` gives every branch its own
+// target, so one sibling reporting a start node says nothing about a sibling
+// that bailed before execBranch — a slot acquired on an already-cancelled
+// fan-out, a resume-turn error, a panic caught before the start all yield a
+// result with an empty start node. Reading the invocation as a whole dropped
+// that branch's subgraph from the floor entirely, which is the very mapping
+// loss this exists to prevent.
+func settledSeedsPerEdge(routerNodeID string, launched []*ir.Edge, results []*branchResult) []string {
+	started := make(map[string]string, len(results))
+	for _, r := range results {
+		if r != nil && r.startNodeID != "" {
+			started[r.branchID] = r.startNodeID
+		}
+	}
+	var seeds []string
+	seen := map[string]bool{}
+	push := func(id string) {
+		if id != "" && !seen[id] {
+			seen[id] = true
+			seeds = append(seeds, id)
+		}
+	}
+	for _, edge := range launched {
+		if edge == nil || edge.IsBoundedIteration() {
+			continue
+		}
+		if start, ok := started[fmt.Sprintf("branch_%s_%s", routerNodeID, edge.To)]; ok {
+			push(start)
+			continue
+		}
+		push(edge.To)
+	}
+	return seeds
+}
+
+// settledSeedsForTemplate is the `fan_out_each` shape, where every item
+// replays the SAME template subgraph: one branch's recorded start node speaks
+// for all of them, and it OUTRANKS the template edge because a resumed cursor
+// names the node the branch is really running even when an edit re-pointed
+// the template. Only an invocation where NO branch started at all falls back
+// on the declaration.
+func settledSeedsForTemplate(tmplEdge *ir.Edge, results []*branchResult) []string {
+	var seeds []string
+	seen := map[string]bool{}
+	for _, r := range results {
+		if r != nil && r.startNodeID != "" && !seen[r.startNodeID] {
+			seen[r.startNodeID] = true
+			seeds = append(seeds, r.startNodeID)
+		}
+	}
+	if len(seeds) > 0 {
+		return seeds
+	}
+	if tmplEdge != nil && !tmplEdge.IsBoundedIteration() {
+		return []string{tmplEdge.To}
+	}
+	return nil
 }
 
 // settledEdgesInto returns the edges into joinNodeID that a fan-out
 // invocation would have fired, found by walking forward from the nodes it
 // actually entered.
 //
-// Provenance is the LAUNCHED edges, never the declared ones: an llm router
-// in multi-select mode starts a subset of what the graph declares, so
-// reading the declaration would sweep in the very foreign edge the floor
-// exists to exclude.
+// seeds are the nodes this invocation actually entered, computed by the
+// caller because the two fan-out shapes differ: `fan_out_all` gives each
+// branch its own target (settledSeedsPerEdge), `fan_out_each` replays one
+// template for every item (settledSeedsForTemplate). They come from the
+// LAUNCHED edges, never the declared ones — an llm router in multi-select
+// mode starts a subset of what the graph declares, so reading the declaration
+// would sweep in the very foreign edge the floor exists to exclude.
 //
 // The walk is ROUTING-AWARE, which is what keeps it from resurrecting a
 // rejected route: leaving a node the invocation executed, it follows only the
@@ -279,12 +347,12 @@ func evidenceFromBranches(results []*branchResult) invocationEvidence {
 // Bounded-iteration edges are out of both the walk and the result. A
 // back-edge is a per-iteration overlay applied last, not part of a
 // stabilized forward pass (Rae4900).
-func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string, ev invocationEvidence) []store.IncomingEdge {
-	if wf == nil || joinNodeID == "" || len(launched) == 0 {
+func settledEdgesInto(wf *ir.Workflow, seeds []string, joinNodeID string, ev invocationEvidence) []store.IncomingEdge {
+	if wf == nil || joinNodeID == "" || len(seeds) == 0 {
 		return nil
 	}
-	reachable := make(map[string]bool, len(launched))
-	frontier := make([]string, 0, len(launched))
+	reachable := make(map[string]bool, len(seeds))
+	frontier := make([]string, 0, len(seeds))
 	push := func(id string) {
 		if id == "" || reachable[id] {
 			return
@@ -292,20 +360,8 @@ func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string, e
 		reachable[id] = true
 		frontier = append(frontier, id)
 	}
-	// The nodes the branches REPORTED starting at outrank the declared ones.
-	// On a resume they are the durable cursors, and an edited template would
-	// otherwise send the walk down a branch this invocation is not running.
-	if len(ev.entered) > 0 {
-		for _, id := range ev.entered {
-			push(id)
-		}
-	} else {
-		for _, edge := range launched {
-			if edge == nil || edge.IsBoundedIteration() {
-				continue
-			}
-			push(edge.To)
-		}
+	for _, id := range seeds {
+		push(id)
 	}
 	// Forward closure, stopping AT the join: expanding past it could
 	// re-enter through an unrelated downstream cycle and claim edges this

--- a/pkg/runtime/incoming.go
+++ b/pkg/runtime/incoming.go
@@ -187,7 +187,7 @@ func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*b
 	// Record what this invocation settled on, whichever way it went: a
 	// fresh invocation owns the floor for its join, so one that produced
 	// output must not leave the previous one's floor standing.
-	rs.setSettledFloor(joinNodeID, settledEdgesInto(e.workflow, launched, joinNodeID))
+	rs.setSettledFloor(joinNodeID, settledEdgesInto(e.workflow, launched, joinNodeID, evidenceFromBranches(results)))
 	if len(union) == 0 {
 		// No successful branch recorded an edge into the join (every
 		// branch failed under best_effort, or the join came from the
@@ -210,6 +210,57 @@ func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*b
 // Settled floor — the edges a stabilized fan-out left with no output behind
 // ---------------------------------------------------------------------------
 
+// invocationEvidence is what a fan-out invocation actually DID: the nodes it
+// executed to completion, and the edges that fired into each node it entered.
+//
+// It is read from the branch results, the FAILED ones included, because the
+// trunk is not a witness of this: processConvergence merges only successful
+// branches' outputs and never removes what an earlier invocation left behind,
+// so "absent from rs.outputs" conflates "never ran", "ran and failed" and
+// "ran two invocations ago". Anchoring the floor on the trunk made the walk
+// resurrect a route routing had rejected, and made a partial failure lose the
+// mapping it was supposed to keep.
+type invocationEvidence struct {
+	// ran holds the nodes that produced output IN THIS INVOCATION.
+	ran map[string]bool
+	// chosen holds, per destination, the edges that actually fired into it.
+	chosen map[string][]store.IncomingEdge
+	// entered holds the nodes the branches actually STARTED at. On a resume
+	// that is the durable cursor's start node, which can differ from what
+	// the current graph's template edge names: an edited `fan_out_each`
+	// re-executes the node the cursor recorded, so reading the template
+	// would walk a branch this invocation is not running.
+	entered []string
+}
+
+// evidenceFromBranches gathers what the branches of one invocation recorded.
+// An invocation that launched nothing (an empty `fan_out_each`) yields empty
+// evidence, which is the truthful answer: no node ran, no route was rejected,
+// and the caller's declared edges are then the only provenance available.
+func evidenceFromBranches(results []*branchResult) invocationEvidence {
+	ev := invocationEvidence{ran: map[string]bool{}, chosen: map[string][]store.IncomingEdge{}}
+	seenStart := map[string]bool{}
+	for _, r := range results {
+		if r == nil {
+			continue
+		}
+		for nodeID := range r.outputs {
+			ev.ran[nodeID] = true
+		}
+		for dst, edges := range r.selectedIncoming {
+			ev.chosen[dst] = append(ev.chosen[dst], edges...)
+		}
+		// Synthetic results — a DAG item skipped because its dependency
+		// failed — carry no start node. They contribute nothing here, and
+		// their siblings supply the provenance.
+		if r.startNodeID != "" && !seenStart[r.startNodeID] {
+			seenStart[r.startNodeID] = true
+			ev.entered = append(ev.entered, r.startNodeID)
+		}
+	}
+	return ev
+}
+
 // settledEdgesInto returns the edges into joinNodeID that a fan-out
 // invocation would have fired, found by walking forward from the nodes it
 // actually entered.
@@ -219,10 +270,16 @@ func (e *Engine) mergeJoinIncoming(rs *runState, joinNodeID string, results []*b
 // reading the declaration would sweep in the very foreign edge the floor
 // exists to exclude.
 //
+// The walk is ROUTING-AWARE, which is what keeps it from resurrecting a
+// rejected route: leaving a node the invocation executed, it follows only the
+// edge that node's branch recorded as firing. Leaving a node that did NOT run
+// it follows every forward edge — that is the whole point, since the node
+// that would have carried the mapping is precisely the one that died.
+//
 // Bounded-iteration edges are out of both the walk and the result. A
 // back-edge is a per-iteration overlay applied last, not part of a
 // stabilized forward pass (Rae4900).
-func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string) []store.IncomingEdge {
+func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string, ev invocationEvidence) []store.IncomingEdge {
 	if wf == nil || joinNodeID == "" || len(launched) == 0 {
 		return nil
 	}
@@ -235,11 +292,20 @@ func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string) [
 		reachable[id] = true
 		frontier = append(frontier, id)
 	}
-	for _, edge := range launched {
-		if edge == nil || edge.IsBoundedIteration() {
-			continue
+	// The nodes the branches REPORTED starting at outrank the declared ones.
+	// On a resume they are the durable cursors, and an edited template would
+	// otherwise send the walk down a branch this invocation is not running.
+	if len(ev.entered) > 0 {
+		for _, id := range ev.entered {
+			push(id)
 		}
-		push(edge.To)
+	} else {
+		for _, edge := range launched {
+			if edge == nil || edge.IsBoundedIteration() {
+				continue
+			}
+			push(edge.To)
+		}
 	}
 	// Forward closure, stopping AT the join: expanding past it could
 	// re-enter through an unrelated downstream cycle and claim edges this
@@ -254,6 +320,12 @@ func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string) [
 			if edge == nil || edge.From != node || edge.IsBoundedIteration() {
 				continue
 			}
+			if ev.ran[node] && !edgeInIncoming(edge, ev.chosen[edge.To]) {
+				// This node ran and routing did not take this edge.
+				// Walking it anyway is how an unselected `else` used to
+				// reach the join through a node that never executed (#484).
+				continue
+			}
 			push(edge.To)
 		}
 	}
@@ -263,6 +335,12 @@ func settledEdgesInto(wf *ir.Workflow, launched []*ir.Edge, joinNodeID string) [
 			continue
 		}
 		if edge.From == "" || !reachable[edge.From] {
+			continue
+		}
+		if ev.ran[edge.From] {
+			// The source executed: its edges are live, and which of them
+			// contributes is routing's recorded selection to apply, not the
+			// floor's to guess.
 			continue
 		}
 		settled = append(settled, incomingFromEdge(edge))
@@ -288,6 +366,16 @@ func (rs *runState) setSettledFloor(joinNodeID string, settled []store.IncomingE
 	rs.settledIncoming[joinNodeID] = settled
 }
 
+// incomingState is the PAIR of per-node edge sets a node's input and its
+// artifact contract are both built from. They travel together because either
+// one alone answers half the question: the selection says which live edges
+// fired, the floor says what a stabilized fan-out left behind. A contract
+// built from the selection alone omits exactly what the floor supplied.
+type incomingState struct {
+	selected map[string][]store.IncomingEdge
+	settled  map[string][]store.IncomingEdge
+}
+
 // settledFloorFor returns the floor recorded for nodeID, if any.
 func settledFloorFor(nodeID string, sc resolveScope) []store.IncomingEdge {
 	if sc.rs == nil {
@@ -301,12 +389,14 @@ func settledFloorFor(nodeID string, sc resolveScope) []store.IncomingEdge {
 // buildNodeInputRS and consumedArtifactRefs both consult it, so an edge
 // that feeds the join can never sit outside the join's artifact contract.
 //
-// Only an output-less source qualifies. An edge whose source ran is left
-// to the ordinary passes, where routing's recorded selection still decides
-// between exclusive siblings — without that clause a `when`/`else` pair
-// downstream of a live node would both contribute again (#484).
-func settledFloorEligible(edge *ir.Edge, floor []store.IncomingEdge, hasOutput bool) bool {
-	if edge == nil || len(floor) == 0 || hasOutput || edge.From == "" {
+// Membership is the whole rule. What keeps an edge out of a floor lives at
+// the moment it is SETTLED (settledEdgesInto): a source that ran contributes
+// through routing's recorded selection instead, and a route routing rejected
+// is never walked. Re-deciding that here against the trunk's outputs is what
+// made a partial failure lose its mapping — a stale output from an earlier
+// invocation reads exactly like a live one.
+func settledFloorEligible(edge *ir.Edge, floor []store.IncomingEdge) bool {
+	if edge == nil || len(floor) == 0 || edge.From == "" {
 		return false
 	}
 	if edge.IsBoundedIteration() {

--- a/pkg/runtime/incoming_test.go
+++ b/pkg/runtime/incoming_test.go
@@ -298,16 +298,22 @@ func TestSelectedIncoming_StaleRecordFallsBack(t *testing.T) {
 	}
 }
 
+// An empty union still leaves the join UNTRACKED: an empty recorded set
+// would mark it tracked and filter every mapping away, and a foreign edge
+// whose source did run must still reach it through the untracked fallback.
+// What the mappings of the dead branches now ride instead is the settled
+// floor, asserted separately (settled_floor_test.go).
 func TestMergeJoinIncoming_EmptyUnionLeavesUntracked(t *testing.T) {
+	eng := New(fanOutWorkflow(ir.AwaitBestEffort), tmpStore(t), newStubExecutor())
 	rs := &runState{selectedIncoming: map[string][]store.IncomingEdge{
 		"join": {{From: "stale", To: "join"}},
 	}}
-	mergeJoinIncoming(rs, "join", []*branchResult{
+	eng.mergeJoinIncoming(rs, "join", []*branchResult{
 		{err: fmt.Errorf("failed"), selectedIncoming: map[string][]store.IncomingEdge{
 			"join": {{From: "a", To: "join"}},
 		}},
 		{err: fmt.Errorf("failed too")},
-	})
+	}, nil)
 	if _, tracked := rs.selectedIncoming["join"]; tracked {
 		t.Fatalf("empty union left join tracked: %#v", rs.selectedIncoming["join"])
 	}

--- a/pkg/runtime/parallel_checkpoint.go
+++ b/pkg/runtime/parallel_checkpoint.go
@@ -325,6 +325,7 @@ func newParallelInvocation(routerNodeID, invocationKey string, starts map[string
 			LoopCurrentOutput:  make(map[string]map[string]any),
 			LoopBudgetMarks:    make(map[string]map[string]float64),
 			SelectedIncoming:   make(map[string][]store.IncomingEdge),
+			SettledIncoming:    make(map[string][]store.IncomingEdge),
 		}
 	}
 	return &parallelExecutionState{cp: cp}
@@ -659,6 +660,7 @@ func cloneBranchCheckpoint(src *store.BranchCheckpoint) *store.BranchCheckpoint 
 		LoopCurrentOutput:  copyOutputs(src.LoopCurrentOutput),
 		LoopBudgetMarks:    cloneNestedFloatMap(src.LoopBudgetMarks),
 		SelectedIncoming:   cloneIncoming(src.SelectedIncoming),
+		SettledIncoming:    cloneIncoming(src.SettledIncoming),
 		JoinNodeID:         src.JoinNodeID,
 		TerminalNodeID:     src.TerminalNodeID,
 		Completed:          src.Completed,

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -919,8 +919,7 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 	artifactRevisions := artifactState.revisions
 	artifacts := artifactState.artifacts
 	artifactOwners := artifactState.owners
-	artifactVersions, err := e.materializeHumanArtifact(ctx, runID, humanNodeID, answers, artifactVersions, outputs, artifacts, artifactRevisions,
-		incomingState{selected: cp.SelectedIncoming, settled: cp.SettledIncoming})
+	artifactVersions, err := e.materializeHumanArtifact(ctx, runID, humanNodeID, answers, artifactVersions, outputs, artifacts, artifactRevisions, cp)
 	if err != nil {
 		return err
 	}
@@ -1194,7 +1193,7 @@ func (e *Engine) recordHumanAnswers(ctx context.Context, r *store.Run, cp *store
 // artifact_written emit is best-effort: the artifact is durably written, so
 // emit failures are logged rather than propagated to keep the resume path
 // from aborting on observability hiccups.
-func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeID string, answers map[string]any, artifactVersions map[string]int, outputs, artifacts map[string]map[string]any, artifactRevisions map[string]store.ArtifactRevisionRef, incoming incomingState) (map[string]int, error) {
+func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeID string, answers map[string]any, artifactVersions map[string]int, outputs, artifacts map[string]map[string]any, artifactRevisions map[string]store.ArtifactRevisionRef, cp *store.Checkpoint) (map[string]int, error) {
 	humanNode, ok := e.workflow.Nodes[humanNodeID]
 	if !ok {
 		return nil, &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: humanNodeID, Message: fmt.Sprintf("runtime: human node %q not found in workflow", humanNodeID)}
@@ -1205,11 +1204,29 @@ func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeI
 	if artifactRevisions == nil {
 		artifactRevisions = make(map[string]store.ArtifactRevisionRef)
 	}
+	if cp == nil {
+		cp = &store.Checkpoint{}
+	}
+	// The contract is computed from a state built BY HAND here, and the
+	// artifact refs it records now depend on how the settled floor RESOLVES
+	// — a conflict between two alternatives is decided on values, not on
+	// edge identities alone. So this state has to carry the same namespaces
+	// the node's input was built from, or the two callers of
+	// settledFloorMappings hand it different worlds and it answers them
+	// differently: two mappings disagreeing only through `{{vars.x}}` would
+	// read nil == nil here, agree, and record as REQUIRED an artifact the
+	// collector never consumed — which a later resume can refuse over.
+	// Sharing a function is not sharing an answer; both callers now read the
+	// same checkpoint.
 	contractState := &runState{
 		outputs: outputs, artifacts: artifacts, artifactVersions: artifactVersions,
-		artifactRevisions: artifactRevisions,
-		selectedIncoming:  cloneIncoming(incoming.selected),
-		settledIncoming:   cloneIncoming(incoming.settled),
+		artifactRevisions:  artifactRevisions,
+		selectedIncoming:   cloneIncoming(cp.SelectedIncoming),
+		settledIncoming:    cloneIncoming(cp.SettledIncoming),
+		vars:               cp.Vars,
+		loopCounters:       cp.LoopCounters,
+		loopPreviousOutput: cp.LoopPreviousOutput,
+		loopCurrentOutput:  cp.LoopCurrentOutput,
 	}
 	if pub := nodePublish(humanNode); pub != "" {
 		version := artifactVersions[humanNodeID]

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -919,7 +919,8 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 	artifactRevisions := artifactState.revisions
 	artifacts := artifactState.artifacts
 	artifactOwners := artifactState.owners
-	artifactVersions, err := e.materializeHumanArtifact(ctx, runID, humanNodeID, answers, artifactVersions, outputs, artifacts, artifactRevisions, cp.SelectedIncoming)
+	artifactVersions, err := e.materializeHumanArtifact(ctx, runID, humanNodeID, answers, artifactVersions, outputs, artifacts, artifactRevisions,
+		incomingState{selected: cp.SelectedIncoming, settled: cp.SettledIncoming})
 	if err != nil {
 		return err
 	}
@@ -1193,7 +1194,7 @@ func (e *Engine) recordHumanAnswers(ctx context.Context, r *store.Run, cp *store
 // artifact_written emit is best-effort: the artifact is durably written, so
 // emit failures are logged rather than propagated to keep the resume path
 // from aborting on observability hiccups.
-func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeID string, answers map[string]any, artifactVersions map[string]int, outputs, artifacts map[string]map[string]any, artifactRevisions map[string]store.ArtifactRevisionRef, selectedIncoming map[string][]store.IncomingEdge) (map[string]int, error) {
+func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeID string, answers map[string]any, artifactVersions map[string]int, outputs, artifacts map[string]map[string]any, artifactRevisions map[string]store.ArtifactRevisionRef, incoming incomingState) (map[string]int, error) {
 	humanNode, ok := e.workflow.Nodes[humanNodeID]
 	if !ok {
 		return nil, &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: humanNodeID, Message: fmt.Sprintf("runtime: human node %q not found in workflow", humanNodeID)}
@@ -1206,7 +1207,9 @@ func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeI
 	}
 	contractState := &runState{
 		outputs: outputs, artifacts: artifacts, artifactVersions: artifactVersions,
-		artifactRevisions: artifactRevisions, selectedIncoming: cloneIncoming(selectedIncoming),
+		artifactRevisions: artifactRevisions,
+		selectedIncoming:  cloneIncoming(incoming.selected),
+		settledIncoming:   cloneIncoming(incoming.settled),
 	}
 	if pub := nodePublish(humanNode); pub != "" {
 		version := artifactVersions[humanNodeID]

--- a/pkg/runtime/settled_floor_test.go
+++ b/pkg/runtime/settled_floor_test.go
@@ -1,0 +1,685 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The settled floor is what a convergence node falls back on when the
+// fan-out that fed it stabilized without a single branch producing output
+// (#559, #1113). These tests fence what it must NOT do, which is the half
+// that decides whether the fix is safe:
+//
+//   - it never applies an edge whose source RAN (that is routing's
+//     selection to make — #484);
+//   - it never applies an edge outside the invocation that settled;
+//   - it never outranks a live edge or a back-edge overlay.
+//
+// A negative test here only bites if it names an edge that CLEARS the
+// ordinary filters, so relaxing the floor is what turns it red. An edge
+// edgeInIncoming already rejects would stay green through any mutation and
+// prove nothing.
+
+// settledRef builds a with-mapping reading {{outputs.<node>.<field>}}.
+func settledRef(key, node, field string) *ir.DataMapping {
+	raw := "{{outputs." + node + "." + field + "}}"
+	return &ir.DataMapping{
+		Key:  key,
+		Refs: []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{node, field}, Raw: raw}},
+		Raw:  raw,
+	}
+}
+
+// settledLiteral builds a with-mapping carrying a constant.
+func settledLiteral(key, value string) *ir.DataMapping {
+	return &ir.DataMapping{Key: key, Raw: value}
+}
+
+// settledSame compares a resolved mapping against its expected value while
+// tolerating the int → float64 widening a JSON checkpoint round-trip
+// applies to every number, so a resume assertion is about the floor rather
+// than about the encoding.
+func settledSame(got, want any) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	return fmt.Sprint(got) == fmt.Sprint(want)
+}
+
+// settledEntryOutput is the parent output every workflow below hands its
+// fan-out: values that survive any branch failure, which is exactly why a
+// mapping reading them has no business going missing.
+func settledEntryOutput() map[string]any {
+	return map[string]any{"summary": "go", "count": 2, "stale_count": 99, "note": "n"}
+}
+
+// ---------------------------------------------------------------------------
+// Provenance: the floor is the invocation's own edges, nobody else's
+// ---------------------------------------------------------------------------
+
+// A node outside the fan-out, never reached, must stay out of the floor —
+// even though it clears every ordinary filter the way the settled edges do
+// (no output, join left untracked). Relaxing the floor to "any edge whose
+// source has no output" is precisely what this catches.
+func TestSettledFloor_ForeignEdgeIsNotSettled(t *testing.T) {
+	wf := fanOutWorkflow(ir.AwaitBestEffort)
+	for _, e := range wf.Edges {
+		if e.To == "finalize" {
+			e.With = append(e.With, settledRef("expected_count", "entry", "count"))
+		}
+	}
+	wf.Nodes["outsider"] = &ir.AgentNode{BaseNode: ir.BaseNode{ID: "outsider"}}
+	// Declared LAST, so declaration order would hand it the win on the
+	// shared key if it were ever applied.
+	wf.Edges = append(wf.Edges, &ir.Edge{From: "outsider", To: "finalize", With: []*ir.DataMapping{
+		settledRef("expected_count", "entry", "stale_count"),
+		settledRef("only_outsider", "entry", "stale_count"),
+	}})
+
+	got := runSettledFanOut(t, wf, "run-559-foreign", map[string]func() (map[string]any, error){
+		"agent_a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"agent_b": func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "finalize")
+
+	if got["expected_count"] != 2 {
+		t.Fatalf("expected_count = %v, want 2 (the fan-out's own edges) — %v means the outsider's edge was settled too", got["expected_count"], got["expected_count"])
+	}
+	if v, ok := got["only_outsider"]; ok {
+		t.Fatalf("only_outsider = %v: an edge from outside the stabilized invocation reached the join", v)
+	}
+}
+
+// The walk has to reach past the node the branch STARTED at: a branch that
+// dies on its first node never runs the node that actually carries the edge
+// into the join, so a floor derived from the branch's start node alone (or
+// from what the branch recorded before failing) finds nothing.
+func TestSettledFloor_WalksPastTheBranchStartNode(t *testing.T) {
+	wf := settledLongBranchWorkflow()
+	got := runSettledFanOut(t, wf, "run-559-long", map[string]func() (map[string]any, error){
+		"a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"b": func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "join")
+
+	if got["expected_count"] != 2 {
+		t.Fatalf("input = %v — the edge into the join is carried by a2/b2, two hops past the launched edge; a floor anchored on the branch start node misses it", got)
+	}
+}
+
+// settledEdgesInto reads the edges the invocation LAUNCHED, never the ones
+// the graph declares: an llm router in multi-select mode starts a subset,
+// and the unlaunched sibling's downstream edge is a foreign edge.
+func TestSettledEdgesInto_OnlyWalksTheLaunchedEdges(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_provenance", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"c":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "c"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "router", To: "c"},
+			{From: "a", To: "join"},
+			{From: "b", To: "join"},
+			{From: "c", To: "join"},
+			{From: "join", To: "a", LoopName: "retry"},
+			{From: "join", To: "join", LoopName: "retry"},
+		},
+	}
+	launched := []*ir.Edge{wf.Edges[0], wf.Edges[1]}
+	got := settledEdgesInto(wf, launched, "join")
+
+	froms := map[string]bool{}
+	for _, in := range got {
+		froms[in.From] = true
+		if in.LoopName != "" || in.ForeachName != "" {
+			t.Fatalf("a bounded-iteration edge entered the floor: %+v — a back-edge is a per-iteration overlay, not a stabilized forward pass", in)
+		}
+	}
+	if !froms["a"] || !froms["b"] {
+		t.Fatalf("floor = %+v, want the launched branches' edges into the join", got)
+	}
+	if froms["c"] {
+		t.Fatalf("floor = %+v: the unlaunched branch's edge was settled — provenance read the DECLARED edges, not the launched ones", got)
+	}
+	if froms["join"] {
+		t.Fatalf("floor = %+v: the walk expanded past the join and came back through the cycle", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #484: an edge whose source RAN is routing's call, never the floor's
+// ---------------------------------------------------------------------------
+
+// The unselected `else` of a live source clears the source-has-output guard
+// — only routing's recorded selection keeps it out. The floor must not
+// reopen that door, which is why it admits output-less sources alone.
+func TestSettledFloor_LiveSourceExclusiveSiblingsStayFiltered(t *testing.T) {
+	got := runSettledFanOut(t, settledLiveGateWorkflow(), "run-559-live-gate", map[string]func() (map[string]any, error){
+		"a":    func() (map[string]any, error) { return map[string]any{"done": true}, nil },
+		"gate": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+		"b":    func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "finalize")
+
+	if v, ok := got["escalate"]; ok {
+		t.Fatalf("escalate = %v: the unselected else of a node that RAN reached the join through the floor (#484)", v)
+	}
+	if got["verdict"] != "from-when" {
+		t.Fatalf("verdict = %v, want %q — routing chose the `when` edge", got["verdict"], "from-when")
+	}
+}
+
+// The dead half of a partially-failed fan-out has the same claim as a
+// wholly-failed one: its mapping reads a durable parent output the failure
+// never touched.
+func TestSettledFloor_PartialFailureKeepsTheDeadBranchesMapping(t *testing.T) {
+	got := runSettledFanOut(t, settledLiveGateWorkflow(), "run-559-partial", map[string]func() (map[string]any, error){
+		"a":    func() (map[string]any, error) { return map[string]any{"done": true}, nil },
+		"gate": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+		"b":    func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "finalize")
+
+	if got["note"] != "n" {
+		t.Fatalf("note = %v, want %q — the failed branch's edge reads the PARENT's output, which its failure left untouched", got["note"], "n")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Two alternatives from one dead source: undecided, not decided by order
+// ---------------------------------------------------------------------------
+
+func TestSettledFloor_UndecidedAlternativesLeaveTheKeyUnset(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_alternatives", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router":   &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"finalize": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "finalize"}, AwaitMode: ir.AwaitBestEffort},
+			"done":     &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "finalize", Condition: "ok", With: []*ir.DataMapping{
+				settledLiteral("verdict", "from-when"),
+				settledRef("shared", "entry", "note"),
+			}},
+			{From: "a", To: "finalize", IsElse: true, With: []*ir.DataMapping{
+				settledLiteral("verdict", "from-else"),
+				settledRef("shared", "entry", "note"),
+			}},
+			{From: "b", To: "finalize", With: []*ir.DataMapping{settledRef("expected_count", "entry", "count")}},
+			{From: "finalize", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+
+	var logBuf bytes.Buffer
+	got := runSettledFanOutOpts(t, wf, "run-559-undecided", map[string]func() (map[string]any, error){
+		"a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"b": func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "finalize", WithLogger(log.New(log.LevelWarn, &logBuf)))
+
+	if v, ok := got["verdict"]; ok {
+		t.Fatalf("verdict = %v: two exclusive alternatives from a source that never ran disagree, and declaration order picked one — that is the guess #484 removed", v)
+	}
+	if got["shared"] != "n" {
+		t.Fatalf("shared = %v, want %q — the alternatives AGREE on it, so it holds whichever would have fired", got["shared"], "n")
+	}
+	if got["expected_count"] != 2 {
+		t.Fatalf("expected_count = %v, want 2 — a disagreement on one key must not drop the other edges", got["expected_count"])
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`disagree on "verdict"`)) {
+		t.Fatalf("the dropped key was silent; log:\n%s", logBuf.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lifetime: a join may be a loop head, whose selection the back-edge replaces
+// ---------------------------------------------------------------------------
+
+func TestSettledFloor_SurvivesLoopReentryAndYieldsToTheBackEdge(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_loop_head", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"gate":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "join", With: []*ir.DataMapping{
+				settledRef("expected_count", "entry", "count"),
+				settledRef("note", "entry", "note"),
+			}},
+			{From: "b", To: "join", With: []*ir.DataMapping{
+				settledRef("expected_count", "entry", "count"),
+				settledRef("note", "entry", "note"),
+			}},
+			{From: "join", To: "gate"},
+			{From: "gate", To: "join", LoopName: "retry", Condition: "again", With: []*ir.DataMapping{
+				settledRef("expected_count", "gate", "bumped"),
+			}},
+			{From: "gate", To: "done", IsElse: true},
+		},
+		Loops: map[string]*ir.Loop{
+			"retry": {Name: "retry", MaxIterations: 3, Entries: map[string]bool{"join": true}, Body: map[string]bool{"join": true, "gate": true}},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Foreaches: map[string]*ir.Foreach{},
+	}
+
+	var visits []map[string]any
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	exec.on("a", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail A") })
+	exec.on("b", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail B") })
+	exec.on("join", func(input map[string]any) (map[string]any, error) {
+		visits = append(visits, input)
+		return map[string]any{}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"again": len(visits) < 2, "bumped": 7}, nil
+	})
+
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), "run-559-loop", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(visits) < 2 {
+		t.Fatalf("the join ran %d time(s), want 2 — the loop never re-entered", len(visits))
+	}
+	if visits[1]["note"] != "n" {
+		t.Fatalf("second visit = %v — the floor vanished on re-entry: selectEdgeRS REPLACES the selection at a loop head, which is why the floor cannot live there (Rae4900)", visits[1])
+	}
+	if visits[1]["expected_count"] != 7 {
+		t.Fatalf("expected_count = %v on re-entry, want 7 — the back-edge carries the value for the NEXT iteration and must outrank the floor", visits[1]["expected_count"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The artifact contract sees exactly what the resolver applies
+// ---------------------------------------------------------------------------
+
+// An edge the floor feeds into the join reaches it like any other, so a
+// {{artifacts.*}} reference on it is a dependency of the join. The two
+// guards used to be separate copies; one shared eligibility rule is what
+// keeps a join from consuming an artifact its contract never named.
+func TestSettledFloor_ArtifactDependencyEntersTheJoinsContract(t *testing.T) {
+	settled := &ir.Edge{From: "dead", To: "join", With: []*ir.DataMapping{{
+		Key: "reviewed_plan", Raw: "{{artifacts.plan}}",
+		Refs: []*ir.Ref{{Kind: ir.RefArtifacts, Path: []string{"plan"}}},
+	}}}
+	foreign := &ir.Edge{From: "outsider", To: "join", With: []*ir.DataMapping{{
+		Key: "stray", Raw: "{{artifacts.notes}}",
+		Refs: []*ir.Ref{{Kind: ir.RefArtifacts, Path: []string{"notes"}}},
+	}}}
+	join := &ir.ToolNode{BaseNode: ir.BaseNode{ID: "join"}, Publish: "report"}
+	eng := &Engine{workflow: &ir.Workflow{Nodes: map[string]ir.Node{
+		"planner":  &ir.ToolNode{BaseNode: ir.BaseNode{ID: "planner"}, Publish: "plan"},
+		"noter":    &ir.ToolNode{BaseNode: ir.BaseNode{ID: "noter"}, Publish: "notes"},
+		"dead":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "dead"}},
+		"outsider": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "outsider"}},
+		"join":     join,
+	}, Edges: []*ir.Edge{settled, foreign}}}
+	rs := &runState{
+		outputs:          map[string]map[string]any{},
+		artifacts:        map[string]map[string]any{"plan": {"ok": true}, "notes": {"ok": true}},
+		artifactVersions: map[string]int{"planner": 1, "noter": 1},
+		artifactRevisions: map[string]store.ArtifactRevisionRef{
+			"plan":  {NodeID: "planner", Version: 0},
+			"notes": {NodeID: "noter", Version: 0},
+		},
+		settledIncoming: map[string][]store.IncomingEdge{"join": {incomingFromEdge(settled)}},
+	}
+
+	contract := eng.artifactContractFor("join", join, 0, rs)
+	if len(contract.Dependencies) != 1 || contract.Dependencies[0].LogicalRef != "plan" {
+		t.Fatalf("contract dependencies = %+v, want exactly the settled edge's artifact (%q); the foreign edge's %q must stay out", contract.Dependencies, "plan", "notes")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1113: an empty fan_out_each, under either await mode
+// ---------------------------------------------------------------------------
+
+// The repro pins wait_all; the deletion the floor replaces is taken before
+// the await mode is ever consulted, so best_effort has to answer the same.
+func TestSettledFloor_EmptyFanOutEachUnderBestEffort(t *testing.T) {
+	wf := fanOutEachWorkflow(false, ir.AwaitBestEffort, 0)
+	settledAttachCollectMapping(wf)
+	got := runSettledFanOutEach(t, wf, "run-1113-best-effort", map[string]any{"items": []any{}, "count": 0})
+	if !settledSame(got["expected_count"], 0) {
+		t.Fatalf("input = %v — an empty fan_out_each drops its parent-sourced mappings under best_effort too", got)
+	}
+}
+
+// A DAG item whose dependency failed gets a SYNTHETIC branch result with no
+// start node recorded, so a floor derived from what the branches reported
+// would find nothing to walk from.
+func TestSettledFloor_EmptyFanOutEachSkippedDagItem(t *testing.T) {
+	wf := fanOutEachWorkflow(true, ir.AwaitBestEffort, 0)
+	settledAttachCollectMapping(wf)
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B", "A")}, "count": 2}, nil
+	})
+	exec.on("handle", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("A fails, B is skipped") })
+	var got map[string]any
+	exec.on("collect", func(input map[string]any) (map[string]any, error) {
+		got = input
+		return map[string]any{}, nil
+	})
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), "run-1113-dag", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("the convergence node never ran")
+	}
+	if !settledSame(got["expected_count"], 2) {
+		t.Fatalf("input = %v — a skipped DAG item carries no start node, so provenance cannot be read off the branch results", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Persistence: the failure that creates the floor is what parks the run
+// ---------------------------------------------------------------------------
+
+// The join itself failing is the ordinary way this run ends up parked, and
+// the resume restarts AT the join without replaying the fan-out. A floor
+// that lived only in memory would be gone exactly there.
+func TestSettledFloor_SurvivesAResumeAtTheJoin(t *testing.T) {
+	s := tmpStore(t)
+	seen, _ := runSettledUntilParked(t, s, "run-559-resume", settledResumeWorkflow())
+
+	r, err := s.LoadRun(context.Background(), "run-559-resume")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want failed_resumable", r.Status)
+	}
+	if len(r.Checkpoint.SettledIncoming["finalize"]) == 0 {
+		t.Fatalf("the checkpoint carries no settled floor for the join: %+v", r.Checkpoint.SelectedIncoming)
+	}
+
+	// A NEW engine, so nothing rides in-process state across the resume.
+	if err := New(settledResumeWorkflow(), s, seen.exec).Resume(context.Background(), "run-559-resume", nil); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if len(seen.inputs) != 2 {
+		t.Fatalf("the join ran %d time(s), want 2", len(seen.inputs))
+	}
+	if !settledSame(seen.inputs[1]["from_a"], 2) || !settledSame(seen.inputs[1]["from_b"], "n") {
+		t.Fatalf("input after resume = %v — the floor did not survive the checkpoint", seen.inputs[1])
+	}
+}
+
+// `resume --force` re-executes against an edited .bot. The floor carries
+// enough provenance to be revalidated EDGE BY EDGE: what still matches
+// applies, what does not is dropped, and nothing is admitted that the
+// invocation never settled. A per-node boolean would have let all three
+// cases through.
+func TestSettledFloor_RevalidatesPerEdgeAgainstAnEditedGraph(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		edit  func(*ir.Workflow)
+		wantA any
+		wantB any
+	}{
+		{
+			name:  "one source renamed: its edge alone is dropped",
+			edit:  func(wf *ir.Workflow) { renameSettledNode(wf, "agent_b", "agent_c") },
+			wantA: 2, wantB: nil,
+		},
+		{
+			name: "every source renamed: the floor empties, with no implicit fallback",
+			edit: func(wf *ir.Workflow) {
+				renameSettledNode(wf, "agent_a", "agent_x")
+				renameSettledNode(wf, "agent_b", "agent_y")
+			},
+			wantA: nil, wantB: nil,
+		},
+		{
+			name: "an edge added by the edit is not settled retroactively",
+			edit: func(wf *ir.Workflow) {
+				wf.Nodes["newcomer"] = &ir.AgentNode{BaseNode: ir.BaseNode{ID: "newcomer"}}
+				wf.Edges = append(wf.Edges, &ir.Edge{From: "newcomer", To: "finalize", With: []*ir.DataMapping{
+					settledRef("from_new", "entry", "stale_count"),
+				}})
+			},
+			wantA: 2, wantB: "n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tmpStore(t)
+			seen, _ := runSettledUntilParked(t, s, "run-559-force", settledResumeWorkflow())
+
+			edited := settledResumeWorkflow()
+			tc.edit(edited)
+			if err := New(edited, s, seen.exec).Resume(context.Background(), "run-559-force", nil); err != nil {
+				t.Fatalf("Resume: %v", err)
+			}
+			got := seen.inputs[len(seen.inputs)-1]
+			if !settledSame(got["from_a"], tc.wantA) {
+				t.Fatalf("from_a = %v, want %v (input %v)", got["from_a"], tc.wantA, got)
+			}
+			if !settledSame(got["from_b"], tc.wantB) {
+				t.Fatalf("from_b = %v, want %v (input %v)", got["from_b"], tc.wantB, got)
+			}
+			if _, present := got["from_new"]; present {
+				t.Fatalf("input = %v: an edge the edit ADDED was applied as if the invocation had settled it — a floor revalidated per NODE admits every new edge into that node, which is why it has to be per EDGE", got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// settledResumeWorkflow gives each dead branch a key of its own, so an
+// edge-by-edge revalidation is observable one edge at a time.
+func settledResumeWorkflow() *ir.Workflow {
+	wf := fanOutWorkflow(ir.AwaitBestEffort)
+	for _, e := range wf.Edges {
+		switch {
+		case e.From == "agent_a" && e.To == "finalize":
+			e.With = append(e.With, settledRef("from_a", "entry", "count"))
+		case e.From == "agent_b" && e.To == "finalize":
+			e.With = append(e.With, settledRef("from_b", "entry", "note"))
+		}
+	}
+	return wf
+}
+
+// renameSettledNode rewrites a node id and every edge that names it — the
+// shape a `.bot` edit takes, and what makes a rehydrated floor identity
+// match nothing on the current graph.
+func renameSettledNode(wf *ir.Workflow, from, to string) {
+	if node, ok := wf.Nodes[from]; ok {
+		delete(wf.Nodes, from)
+		wf.Nodes[to] = node
+	}
+	for _, e := range wf.Edges {
+		if e.From == from {
+			e.From = to
+		}
+		if e.To == from {
+			e.To = to
+		}
+	}
+}
+
+// settledAttachCollectMapping puts a parent-sourced mapping on the
+// fan_out_each template's edge into the convergence — the mapping that has
+// nothing to do with the items and must survive an empty collection.
+func settledAttachCollectMapping(wf *ir.Workflow) {
+	for _, e := range wf.Edges {
+		if e.From == "handle" && e.To == "collect" {
+			e.With = []*ir.DataMapping{settledRef("expected_count", "entry", "count")}
+		}
+	}
+}
+
+func runSettledFanOutEach(t *testing.T, wf *ir.Workflow, runID string, entryOut map[string]any) map[string]any {
+	t.Helper()
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return entryOut, nil })
+	var got map[string]any
+	exec.on("collect", func(input map[string]any) (map[string]any, error) {
+		got = input
+		return map[string]any{}, nil
+	})
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), runID, nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got == nil {
+		t.Fatal("the convergence node never ran")
+	}
+	return got
+}
+
+type settledJoinProbe struct {
+	inputs []map[string]any
+	exec   *stubExecutor
+}
+
+// runSettledUntilParked runs wf until the join fails and the run parks
+// failed_resumable, and hands back the probe so the caller can resume with
+// a fresh engine.
+func runSettledUntilParked(t *testing.T, s store.RunStore, runID string, wf *ir.Workflow) (*settledJoinProbe, error) {
+	t.Helper()
+	probe := &settledJoinProbe{exec: newStubExecutor()}
+	probe.exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	probe.exec.on("agent_a", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail A") })
+	probe.exec.on("agent_b", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail B") })
+	probe.exec.on("finalize", func(input map[string]any) (map[string]any, error) {
+		probe.inputs = append(probe.inputs, input)
+		if len(probe.inputs) == 1 {
+			return nil, errors.New("transient")
+		}
+		return map[string]any{}, nil
+	})
+	err := New(wf, s, probe.exec).Run(context.Background(), runID, nil)
+	if err == nil {
+		t.Fatal("expected the join to fail the first pass")
+	}
+	return probe, err
+}
+
+// settledLongBranchWorkflow puts a second node between the launched edge and
+// the edge that reaches the join, so a floor derived from the branch's start
+// node alone comes up empty.
+func settledLongBranchWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name: "settled_long_branch", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"a2":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a2"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"b2":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b2"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "a2"},
+			{From: "b", To: "b2"},
+			{From: "a2", To: "join", With: []*ir.DataMapping{settledRef("expected_count", "entry", "count")}},
+			{From: "b2", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+}
+
+// settledLiveGateWorkflow has one branch that RUNS through a conditional
+// gate and one that dies, so the same join sees both an edge routing chose
+// between and an edge nobody could choose.
+func settledLiveGateWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name: "settled_live_gate", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router":   &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"gate":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"b":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"finalize": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "finalize"}, AwaitMode: ir.AwaitBestEffort},
+			"done":     &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "gate"},
+			{From: "gate", To: "finalize", Condition: "ok", With: []*ir.DataMapping{settledLiteral("verdict", "from-when")}},
+			// The unselected branch carries a key of its OWN beside the
+			// shared one. Without it the disagreement rule would mask a
+			// dropped has-output clause: two alternatives that collide on
+			// every key leave nothing for the floor to leak.
+			{From: "gate", To: "finalize", IsElse: true, With: []*ir.DataMapping{
+				settledLiteral("verdict", "from-else"),
+				settledLiteral("escalate", "yes"),
+			}},
+			{From: "b", To: "finalize", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "finalize", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+}
+
+func runSettledFanOut(t *testing.T, wf *ir.Workflow, runID string, behaviour map[string]func() (map[string]any, error), capture string) map[string]any {
+	t.Helper()
+	return runSettledFanOutOpts(t, wf, runID, behaviour, capture)
+}
+
+// runSettledFanOutOpts runs wf with a stub `entry` producing the shared
+// parent output, the per-node behaviour given, and returns the input the
+// capture node was handed.
+func runSettledFanOutOpts(t *testing.T, wf *ir.Workflow, runID string, behaviour map[string]func() (map[string]any, error), capture string, opts ...EngineOption) map[string]any {
+	t.Helper()
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	for id, fn := range behaviour {
+		exec.on(id, func(_ map[string]any) (map[string]any, error) { return fn() })
+	}
+	var got map[string]any
+	exec.on(capture, func(input map[string]any) (map[string]any, error) {
+		got = input
+		return map[string]any{}, nil
+	})
+	if err := New(wf, tmpStore(t), exec, opts...).Run(context.Background(), runID, nil); err != nil {
+		t.Fatalf("run: %v (best_effort tolerates branch failures)", err)
+	}
+	if got == nil {
+		t.Fatalf("the convergence node %q never ran", capture)
+	}
+	return got
+}

--- a/pkg/runtime/settled_floor_test.go
+++ b/pkg/runtime/settled_floor_test.go
@@ -656,6 +656,56 @@ func TestSettledFloor_ArtifactDependencyEntersTheJoinsContract(t *testing.T) {
 	}
 }
 
+// The node that would have chosen between two alternatives is not always
+// their common source. A conditional head that never ran leaves BOTH of its
+// mutually exclusive successors reachable and output-less, so they reach the
+// join as two distinct sources — and a disagreement judged per source never
+// sees them meet.
+func TestSettledFloor_AlternativesFromTwoDeadSourcesAreStillUndecided(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_cross_source", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"head":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "head"}},
+			"x":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "x"}},
+			"y":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "y"}},
+			"other":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "other"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "head"},
+			{From: "router", To: "other"},
+			{From: "head", To: "x", Condition: "ok"},
+			{From: "head", To: "y", IsElse: true},
+			{From: "x", To: "join", With: []*ir.DataMapping{settledLiteral("verdict", "from-x")}},
+			{From: "y", To: "join", With: []*ir.DataMapping{settledLiteral("verdict", "from-y")}},
+			{From: "other", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+
+	var logBuf bytes.Buffer
+	got := runSettledFanOutOpts(t, wf, "run-559-cross-source", map[string]func() (map[string]any, error){
+		"head":  func() (map[string]any, error) { return nil, errors.New("head fails") },
+		"other": func() (map[string]any, error) { return nil, errors.New("other fails") },
+	}, "join", WithLogger(log.New(log.LevelWarn, &logBuf)))
+
+	if v, ok := got["verdict"]; ok {
+		t.Fatalf("verdict = %v — `x` and `y` are mutually exclusive and neither ran, so declaration order settled it; judging the disagreement per SOURCE never puts them in the same bucket", v)
+	}
+	if got["note"] != "n" {
+		t.Fatalf("note = %v, want %q — refusing one disagreement must not cost the other sources' keys", got["note"], "n")
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte(`disagree on "verdict"`)) {
+		t.Fatalf("the dropped key was silent; log:\n%s", logBuf.String())
+	}
+}
+
 // A key the conflict rule refused to apply is not a dependency: the node
 // never received it. Recording it anyway makes a later resume re-validate an
 // artifact nobody consumed, and refuse over its absence.

--- a/pkg/runtime/settled_floor_test.go
+++ b/pkg/runtime/settled_floor_test.go
@@ -161,7 +161,9 @@ func TestSettledEdgesInto_EachExclusionHasItsOwnWitness(t *testing.T) {
 			{From: "looper", To: "join", LoopName: "retry"},
 		},
 	}
+	// The seeds a `fan_out_all` produces: each launched edge's own target.
 	launched := []*ir.Edge{wf.Edges[0], wf.Edges[1], wf.Edges[3]}
+	seeds := settledSeedsPerEdge("router", launched, nil)
 	// `live` ran and routed to `taken`, which ran too. Everything else in
 	// this invocation produced nothing — which is what puts `a` and `b` in
 	// the floor and keeps `taken` out.
@@ -172,7 +174,7 @@ func TestSettledEdgesInto_EachExclusionHasItsOwnWitness(t *testing.T) {
 			"join":  {incomingFromEdge(wf.Edges[10])},
 		},
 	}
-	got := settledEdgesInto(wf, launched, "join", ev)
+	got := settledEdgesInto(wf, seeds, "join", ev)
 
 	froms := map[string]bool{}
 	for _, in := range got {
@@ -217,14 +219,110 @@ func TestSettledEdgesInto_RecordedStartNodesOutrankTheDeclaredTemplate(t *testin
 			{From: "new_handle", To: "collect", With: []*ir.DataMapping{settledLiteral("route", "new")}},
 		},
 	}
-	ev := invocationEvidence{
-		ran: map[string]bool{}, chosen: map[string][]store.IncomingEdge{},
-		entered: []string{"old_handle"},
-	}
-	got := settledEdgesInto(wf, []*ir.Edge{wf.Edges[0]}, "collect", ev)
+	ev := invocationEvidence{ran: map[string]bool{}, chosen: map[string][]store.IncomingEdge{}}
+	got := settledEdgesInto(wf, settledSeedsForTemplate(wf.Edges[0], []*branchResult{
+		{branchID: "branch_dispatch_0", startNodeID: "old_handle"},
+	}), "collect", ev)
 
 	if len(got) != 1 || got[0].From != "old_handle" {
 		t.Fatalf("floor = %+v, want old_handle -> collect — the cursor says the branch is running `old_handle`, so that is the branch whose edges settled", got)
+	}
+}
+
+// A `fan_out_all` branch can bail BEFORE execBranch — a slot acquired on an
+// already-cancelled fan-out, a resume-turn error, a panic caught before the
+// start — and then reports no start node at all. Every branch there has its
+// OWN target, so a sibling that did start says nothing about it: reading the
+// invocation as a whole drops its entire subgraph from the floor.
+func TestSettledSeedsPerEdge_ABranchThatNeverStartedKeepsItsOwnSeed(t *testing.T) {
+	launched := []*ir.Edge{
+		{From: "router", To: "a"},
+		{From: "router", To: "b"},
+		{From: "router", To: "resumed"},
+	}
+	seeds := settledSeedsPerEdge("router", launched, []*branchResult{
+		{branchID: "branch_router_a", startNodeID: "a"},
+		// Bailed before execBranch: a result, but no start node.
+		{branchID: "branch_router_b"},
+		// A durable cursor that re-anchored the branch elsewhere.
+		{branchID: "branch_router_resumed", startNodeID: "elsewhere"},
+	})
+
+	want := map[string]bool{"a": true, "b": true, "elsewhere": true}
+	got := map[string]bool{}
+	for _, s := range seeds {
+		got[s] = true
+	}
+	for id := range want {
+		if !got[id] {
+			t.Fatalf("seeds = %v, missing %q — each launched edge answers for ITSELF: its branch's recorded start node, or its own target when that branch never started", seeds, id)
+		}
+	}
+	if got["resumed"] {
+		t.Fatalf("seeds = %v — a branch that DID report a start node must not also seed the declared target", seeds)
+	}
+}
+
+// The floor belongs to the fan-out visit that settled it. A later visit
+// arriving through a bypass edge is a different visit, and routing chose that
+// path: feeding it the dead branches' mappings is the #484 shape through a
+// door that skips the tracked/selected filter.
+func TestSettledFloor_AForwardArrivalDropsAnEarlierVisitsFloor(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_bypass", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"gate":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"bypass": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "bypass"}},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "b", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "gate"},
+			{From: "gate", To: "bypass", Condition: "again"},
+			{From: "gate", To: "done", IsElse: true},
+			// A FORWARD edge back into the collector, bypassing the fan-out.
+			{From: "bypass", To: "join"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+
+	var visits []map[string]any
+	pass := 0
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	exec.on("a", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail A") })
+	exec.on("b", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail B") })
+	exec.on("join", func(input map[string]any) (map[string]any, error) {
+		visits = append(visits, input)
+		return map[string]any{}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		pass++
+		return map[string]any{"again": pass < 2}, nil
+	})
+	exec.on("bypass", func(_ map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), "run-559-bypass", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(visits) < 2 {
+		t.Fatalf("the join ran %d time(s), want 2 — the bypass never fired", len(visits))
+	}
+	if visits[0]["note"] != "n" {
+		t.Fatalf("first visit = %v — the fan-out's own visit must get its floor", visits[0])
+	}
+	if v, present := visits[1]["note"]; present {
+		t.Fatalf("second visit note = %v — this visit arrived through the bypass edge routing selected, so the earlier fan-out's floor is not its input (#484)", v)
 	}
 }
 

--- a/pkg/runtime/settled_floor_test.go
+++ b/pkg/runtime/settled_floor_test.go
@@ -112,48 +112,119 @@ func TestSettledFloor_WalksPastTheBranchStartNode(t *testing.T) {
 	}
 }
 
-// settledEdgesInto reads the edges the invocation LAUNCHED, never the ones
-// the graph declares: an llm router in multi-select mode starts a subset,
-// and the unlaunched sibling's downstream edge is a foreign edge.
-func TestSettledEdgesInto_OnlyWalksTheLaunchedEdges(t *testing.T) {
+// Every exclusion the walk performs gets a source that is reachable ONLY
+// through it, so removing that exclusion changes the result. A node the walk
+// would reach anyway proves nothing about the guard that was supposed to
+// block it.
+func TestSettledEdgesInto_EachExclusionHasItsOwnWitness(t *testing.T) {
+	node := func(id string) ir.Node { return &ir.AgentNode{BaseNode: ir.BaseNode{ID: id}} }
 	wf := &ir.Workflow{
 		Name: "settled_provenance", Entry: "entry",
 		Nodes: map[string]ir.Node{
 			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
-			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
-			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
-			"c":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "c"}},
-			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}},
+			"a":      node("a"), "b": node("b"), "unlaunched": node("unlaunched"),
+			"live": node("live"), "taken": node("taken"), "rejected": node("rejected"),
+			"behind_bounded": node("behind_bounded"), "looper": node("looper"),
+			"after": node("after"), "past_the_join": node("past_the_join"),
+			"join": node("join"),
 		},
 		Edges: []*ir.Edge{
 			{From: "router", To: "a"},
 			{From: "router", To: "b"},
-			{From: "router", To: "c"},
+			{From: "router", To: "unlaunched"},
+			{From: "router", To: "live"},
 			{From: "a", To: "join"},
 			{From: "b", To: "join"},
-			{From: "c", To: "join"},
-			{From: "join", To: "a", LoopName: "retry"},
-			{From: "join", To: "join", LoopName: "retry"},
+			// Witness 1 — provenance: reachable only from the branch this
+			// invocation did NOT launch.
+			{From: "unlaunched", To: "join"},
+			// Witness 2 — routing: `live` ran and took `taken`; `rejected`
+			// is reachable only through the edge routing turned down.
+			{From: "live", To: "taken", Condition: "ok"},
+			{From: "live", To: "rejected", IsElse: true},
+			{From: "rejected", To: "join"},
+			{From: "taken", To: "join"},
+			// Witness 3 — bounded edges are not walked: `behind_bounded` sits
+			// behind one, and its own edge into the join is ordinary.
+			{From: "a", To: "behind_bounded", LoopName: "inner"},
+			{From: "behind_bounded", To: "join"},
+			// Witness 4 — the walk stops AT the join: `past_the_join` is
+			// reachable only by continuing through it.
+			{From: "join", To: "after"},
+			{From: "after", To: "past_the_join"},
+			{From: "past_the_join", To: "join"},
+			// Witness 5 — a bounded edge INTO the join is never collected.
+			// Its source has to be reachable by an ORDINARY edge, or the
+			// stop-at-join guard excludes it first and the collect filter
+			// is never asked.
+			{From: "b", To: "looper"},
+			{From: "looper", To: "join", LoopName: "retry"},
 		},
 	}
-	launched := []*ir.Edge{wf.Edges[0], wf.Edges[1]}
-	got := settledEdgesInto(wf, launched, "join")
+	launched := []*ir.Edge{wf.Edges[0], wf.Edges[1], wf.Edges[3]}
+	// `live` ran and routed to `taken`, which ran too. Everything else in
+	// this invocation produced nothing — which is what puts `a` and `b` in
+	// the floor and keeps `taken` out.
+	ev := invocationEvidence{
+		ran: map[string]bool{"live": true, "taken": true},
+		chosen: map[string][]store.IncomingEdge{
+			"taken": {incomingFromEdge(wf.Edges[7])},
+			"join":  {incomingFromEdge(wf.Edges[10])},
+		},
+	}
+	got := settledEdgesInto(wf, launched, "join", ev)
 
 	froms := map[string]bool{}
 	for _, in := range got {
 		froms[in.From] = true
-		if in.LoopName != "" || in.ForeachName != "" {
-			t.Fatalf("a bounded-iteration edge entered the floor: %+v — a back-edge is a per-iteration overlay, not a stabilized forward pass", in)
+	}
+	for _, tc := range []struct{ from, why string }{
+		{"unlaunched", "provenance read the DECLARED edges instead of the launched ones"},
+		{"rejected", "the walk crossed an edge routing turned down, so a node that never ran reached the join (#484)"},
+		{"behind_bounded", "the walk crossed a bounded-iteration edge, which is a per-iteration overlay and not a stabilized forward pass (Rae4900)"},
+		{"past_the_join", "the walk expanded PAST the join and came back into it from downstream"},
+		{"looper", "a bounded-iteration edge into the join was collected"},
+		{"after", "the walk expanded past the join through its own outgoing edge"},
+		{"taken", "a source that RAN was collected; its edges are routing's recorded selection to apply"},
+	} {
+		if froms[tc.from] {
+			t.Errorf("floor contains %s -> join: %s (floor = %+v)", tc.from, tc.why, got)
 		}
 	}
 	if !froms["a"] || !froms["b"] {
-		t.Fatalf("floor = %+v, want the launched branches' edges into the join", got)
+		t.Fatalf("floor = %+v, want the launched branches' own edges into the join", got)
 	}
-	if froms["c"] {
-		t.Fatalf("floor = %+v: the unlaunched branch's edge was settled — provenance read the DECLARED edges, not the launched ones", got)
+}
+
+// A resumed branch re-executes the node its durable cursor recorded, not the
+// one the current graph's template edge names. An edited `fan_out_each`
+// therefore runs the OLD start node while the declaration points at a new
+// one, and provenance read from the declaration walks a branch this
+// invocation is not running.
+func TestSettledEdgesInto_RecordedStartNodesOutrankTheDeclaredTemplate(t *testing.T) {
+	node := func(id string) ir.Node { return &ir.AgentNode{BaseNode: ir.BaseNode{ID: id}} }
+	wf := &ir.Workflow{
+		Name: "settled_edited_template", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"dispatch":   &ir.RouterNode{BaseNode: ir.BaseNode{ID: "dispatch"}, RouterMode: ir.RouterFanOutEach},
+			"old_handle": node("old_handle"), "new_handle": node("new_handle"),
+			"collect": node("collect"),
+		},
+		Edges: []*ir.Edge{
+			// The edit re-pointed the template; both collector edges remain.
+			{From: "dispatch", To: "new_handle"},
+			{From: "old_handle", To: "collect", With: []*ir.DataMapping{settledLiteral("route", "old")}},
+			{From: "new_handle", To: "collect", With: []*ir.DataMapping{settledLiteral("route", "new")}},
+		},
 	}
-	if froms["join"] {
-		t.Fatalf("floor = %+v: the walk expanded past the join and came back through the cycle", got)
+	ev := invocationEvidence{
+		ran: map[string]bool{}, chosen: map[string][]store.IncomingEdge{},
+		entered: []string{"old_handle"},
+	}
+	got := settledEdgesInto(wf, []*ir.Edge{wf.Edges[0]}, "collect", ev)
+
+	if len(got) != 1 || got[0].From != "old_handle" {
+		t.Fatalf("floor = %+v, want old_handle -> collect — the cursor says the branch is running `old_handle`, so that is the branch whose edges settled", got)
 	}
 }
 
@@ -176,6 +247,121 @@ func TestSettledFloor_LiveSourceExclusiveSiblingsStayFiltered(t *testing.T) {
 	}
 	if got["verdict"] != "from-when" {
 		t.Fatalf("verdict = %v, want %q — routing chose the `when` edge", got["verdict"], "from-when")
+	}
+}
+
+// The walk follows the graph, so it will happily cross an edge ROUTING
+// TURNED DOWN and reach the join through a node that never executed. That
+// node produced no output, so an eligibility rule reading output-presence
+// admits it — #484 reopened through the back door.
+func TestSettledFloor_NeverWalksThroughARejectedRoute(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_rejected_route", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router":   &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"gate":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"unchosen": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "unchosen"}},
+			"b":        &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"join":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"done":     &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "gate"},
+			{From: "gate", To: "join", Condition: "ok", With: []*ir.DataMapping{settledLiteral("verdict", "from-when")}},
+			{From: "gate", To: "unchosen", IsElse: true},
+			{From: "unchosen", To: "join", With: []*ir.DataMapping{settledLiteral("escalate", "yes")}},
+			{From: "b", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+
+	got := runSettledFanOut(t, wf, "run-559-rejected-route", map[string]func() (map[string]any, error){
+		"a":    func() (map[string]any, error) { return map[string]any{"done": true}, nil },
+		"gate": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+		"unchosen": func() (map[string]any, error) {
+			t.Error("`unchosen` must never execute — routing took the `when ok` edge")
+			return nil, errors.New("unreachable")
+		},
+		"b": func() (map[string]any, error) { return nil, errors.New("fail B") },
+	}, "join")
+
+	if v, ok := got["escalate"]; ok {
+		t.Fatalf("escalate = %v — the floor walked THROUGH the edge routing turned down and applied the mapping of a node that never ran (#484)", v)
+	}
+	if got["verdict"] != "from-when" || got["note"] != "n" {
+		t.Fatalf("input = %v — pruning the rejected route must not cost the routes that WERE taken", got)
+	}
+}
+
+// "Absent from the trunk's outputs" is not "never ran": processConvergence
+// merges only the successful branches and never removes what an EARLIER
+// invocation left for a branch that failed this time. Anchoring the floor on
+// the trunk therefore rejects the very branch it exists to serve, while the
+// ordinary pass rejects it too for not being in this visit's selection.
+func TestSettledFloor_StaleOutputFromAnEarlierInvocationIsNotEvidenceItRan(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "settled_stale_output", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"gate":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			{From: "a", To: "join"},
+			{From: "b", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "gate"},
+			{From: "gate", To: "router", LoopName: "retry", Condition: "again"},
+			{From: "gate", To: "done", IsElse: true},
+		},
+		Loops: map[string]*ir.Loop{
+			"retry": {Name: "retry", MaxIterations: 3, Entries: map[string]bool{"router": true}, Body: map[string]bool{"router": true, "a": true, "b": true, "join": true, "gate": true}},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Foreaches: map[string]*ir.Foreach{},
+	}
+
+	var visits []map[string]any
+	pass := 0
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	exec.on("a", func(_ map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+	exec.on("b", func(_ map[string]any) (map[string]any, error) {
+		if pass == 0 {
+			return map[string]any{"ok": true}, nil
+		}
+		return nil, errors.New("b fails on the second invocation")
+	})
+	exec.on("join", func(input map[string]any) (map[string]any, error) {
+		visits = append(visits, input)
+		return map[string]any{}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		pass++
+		return map[string]any{"again": pass < 2}, nil
+	})
+
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), "run-559-stale", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(visits) < 2 {
+		t.Fatalf("the join ran %d time(s), want 2 — the fan-out was not re-invoked", len(visits))
+	}
+	if visits[1]["note"] != "n" {
+		t.Fatalf("second visit = %v — `b` failed THIS invocation, but its output from the previous one made it look alive, so its parent-sourced mapping was dropped by both the floor and the ordinary pass", visits[1])
 	}
 }
 
@@ -317,6 +503,118 @@ func TestSettledFloor_SurvivesLoopReentryAndYieldsToTheBackEdge(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// It is a FLOOR, and it resolves in the edge's own namespace
+// ---------------------------------------------------------------------------
+
+// A live edge and a floor edge writing the same key: the floor is applied
+// before both merge passes, so the live value wins. Moving the floor between
+// the passes would leave every other assertion in this file green.
+func TestSettledFloor_LiveEdgeOutranksTheFloorOnASharedKey(t *testing.T) {
+	wf := settledSharedKeyWorkflow()
+	got := runSettledFanOut(t, wf, "run-559-collision", map[string]func() (map[string]any, error){
+		"a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"b": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+	}, "join")
+
+	if got["shared"] != "from-live" {
+		t.Fatalf("shared = %v, want %q — the floor outranked a live edge; it is a base under both passes, not one more edge in them", got["shared"], "from-live")
+	}
+}
+
+// `{{input.x}}` on an edge is the SOURCE NODE'S output, and a source that
+// never ran has none. Resolving a floor edge against the caller's scope would
+// silently promote the run-level launch payload into that namespace — the
+// coincidence #479 removed.
+func TestSettledFloor_InputRefsDoNotFallBackToTheRunPayload(t *testing.T) {
+	wf := settledSharedKeyWorkflow()
+	for _, e := range wf.Edges {
+		if e.From == "a" && e.To == "join" {
+			e.With = append(e.With, &ir.DataMapping{
+				Key:  "sneaked",
+				Refs: []*ir.Ref{{Kind: ir.RefInput, Path: []string{"leak"}, Raw: "{{input.leak}}"}},
+				Raw:  "{{input.leak}}",
+			})
+		}
+	}
+	wf.Vars["leak"] = &ir.Var{Name: "leak", Type: ir.VarString}
+
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) { return settledEntryOutput(), nil })
+	exec.on("a", func(_ map[string]any) (map[string]any, error) { return nil, errors.New("fail A") })
+	exec.on("b", func(_ map[string]any) (map[string]any, error) { return map[string]any{"ok": true}, nil })
+	var got map[string]any
+	exec.on("join", func(input map[string]any) (map[string]any, error) {
+		got = input
+		return map[string]any{}, nil
+	})
+	if err := New(wf, tmpStore(t), exec).Run(context.Background(), "run-559-ns", map[string]any{"leak": "run-level payload"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	v, present := got["sneaked"]
+	if !present {
+		t.Fatalf("input = %v — the key must exist with an empty value, not vanish", got)
+	}
+	if v != nil {
+		t.Fatalf("sneaked = %#v — {{input.leak}} on a floor edge read the RUN-LEVEL payload; that namespace is the source node's output, and this source produced none (#479)", v)
+	}
+}
+
+// A reference that resolves to nil is still a VALID mapping: the field
+// exists, its value is empty. Dropping the key is what leaves
+// `{{input.<key>}}` unresolved in a downstream prompt.
+func TestSettledFloor_KeepsTheKeyOfANilValuedMapping(t *testing.T) {
+	wf := settledSharedKeyWorkflow()
+	for _, e := range wf.Edges {
+		if e.From == "a" && e.To == "join" {
+			e.With = append(e.With, settledRef("dead_branch_review", "a", "review"))
+		}
+	}
+	got := runSettledFanOut(t, wf, "run-559-nil-key", map[string]func() (map[string]any, error){
+		"a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"b": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+	}, "join")
+
+	v, present := got["dead_branch_review"]
+	if !present {
+		t.Fatalf("input = %v — a mapping reading the dead branch must keep its key with an empty value; dropping it is what surfaces template syntax to the model", got)
+	}
+	if v != nil {
+		t.Fatalf("dead_branch_review = %#v, want nil — the branch produced nothing", v)
+	}
+}
+
+// A nested fan-out settles its floor on the BRANCH runState, which is aliased
+// onto the branch result and persisted on the branch cursor. A lazily created
+// map would replace the alias instead of writing through it, and the floor
+// would never reach the checkpoint.
+func TestSettledFloor_BranchCursorCarriesANestedFloor(t *testing.T) {
+	parent := &runState{
+		outputs:           map[string]map[string]any{"entry": {"ok": true}},
+		artifacts:         map[string]map[string]any{},
+		artifactOwners:    map[string]string{},
+		artifactRevisions: map[string]store.ArtifactRevisionRef{},
+		artifactVersions:  map[string]int{},
+		loopCounters:      map[string]int{},
+	}
+	result := initBranchResult(parent, "branch-x", nil)
+	local := newBranchRunState(parent, nil, result)
+
+	local.setSettledFloor("inner_join", []store.IncomingEdge{{From: "dead", To: "inner_join"}})
+	if len(result.settledIncoming["inner_join"]) != 1 {
+		t.Fatalf("branch result floor = %+v — setSettledFloor replaced the alias instead of writing through it", result.settledIncoming)
+	}
+
+	cp := branchCheckpointFromState(local, result, "inner_join", false)
+	if len(cp.SettledIncoming["inner_join"]) != 1 {
+		t.Fatalf("branch cursor = %+v — a nested floor does not survive a branch pause", cp.SettledIncoming)
+	}
+	revived := initBranchResult(parent, "branch-x", cp)
+	if len(revived.settledIncoming["inner_join"]) != 1 || revived.settledIncoming["inner_join"][0].From != "dead" {
+		t.Fatalf("revived branch floor = %+v — the cursor was written but never read back", revived.settledIncoming)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // The artifact contract sees exactly what the resolver applies
 // ---------------------------------------------------------------------------
 
@@ -355,6 +653,121 @@ func TestSettledFloor_ArtifactDependencyEntersTheJoinsContract(t *testing.T) {
 	contract := eng.artifactContractFor("join", join, 0, rs)
 	if len(contract.Dependencies) != 1 || contract.Dependencies[0].LogicalRef != "plan" {
 		t.Fatalf("contract dependencies = %+v, want exactly the settled edge's artifact (%q); the foreign edge's %q must stay out", contract.Dependencies, "plan", "notes")
+	}
+}
+
+// A key the conflict rule refused to apply is not a dependency: the node
+// never received it. Recording it anyway makes a later resume re-validate an
+// artifact nobody consumed, and refuse over its absence.
+func TestSettledFloor_ADiscardedKeyIsNotADependency(t *testing.T) {
+	whenEdge := &ir.Edge{From: "dead", To: "join", Condition: "ok", With: []*ir.DataMapping{{
+		Key: "choice", Raw: "{{artifacts.plan}}",
+		Refs: []*ir.Ref{{Kind: ir.RefArtifacts, Path: []string{"plan"}}},
+	}}}
+	elseEdge := &ir.Edge{From: "dead", To: "join", IsElse: true, With: []*ir.DataMapping{{
+		Key: "choice", Raw: "{{artifacts.notes}}",
+		Refs: []*ir.Ref{{Kind: ir.RefArtifacts, Path: []string{"notes"}}},
+	}}}
+	join := &ir.ToolNode{BaseNode: ir.BaseNode{ID: "join"}, Publish: "report"}
+	eng := New(&ir.Workflow{Nodes: map[string]ir.Node{
+		"planner": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "planner"}, Publish: "plan"},
+		"noter":   &ir.ToolNode{BaseNode: ir.BaseNode{ID: "noter"}, Publish: "notes"},
+		"dead":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "dead"}},
+		"join":    join,
+	}, Edges: []*ir.Edge{whenEdge, elseEdge}}, tmpStore(t), newStubExecutor())
+	rs := &runState{
+		outputs: map[string]map[string]any{},
+		// Distinct bodies, or the two alternatives would genuinely AGREE and
+		// the key would rightly be applied — the fixture has to make them
+		// disagree for the discard to be what is under test.
+		artifacts:        map[string]map[string]any{"plan": {"title": "ship"}, "notes": {"title": "park"}},
+		artifactVersions: map[string]int{"planner": 1, "noter": 1},
+		artifactRevisions: map[string]store.ArtifactRevisionRef{
+			"plan":  {NodeID: "planner", Version: 0},
+			"notes": {NodeID: "noter", Version: 0},
+		},
+		settledIncoming: map[string][]store.IncomingEdge{
+			"join": {incomingFromEdge(whenEdge), incomingFromEdge(elseEdge)},
+		},
+	}
+
+	if got := eng.buildNodeInputRS("join", rs.scope()); len(got) != 0 {
+		t.Fatalf("input = %v — the two alternatives disagree on `choice`, so it must be unset", got)
+	}
+	contract := eng.artifactContractFor("join", join, 0, rs)
+	if len(contract.Dependencies) != 0 {
+		t.Fatalf("contract dependencies = %+v — `choice` never reached the node's input, so neither artifact is a dependency; a required one is re-validated on resume and can refuse it", contract.Dependencies)
+	}
+}
+
+// A human collector resumes through its own path, which rebuilds the contract
+// state by hand. Handing it the selection alone publishes an approval whose
+// contract omits the artifact the floor actually fed it.
+func TestSettledFloor_HumanCollectorPublishesItsFloorDependency(t *testing.T) {
+	ctx := context.Background()
+	s := tmpStore(t)
+	if _, err := s.CreateRun(ctx, "human-floor", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	human := &ir.HumanNode{BaseNode: ir.BaseNode{ID: "approve"}, Publish: "approval"}
+	// `dead` never ran: the branch that would have carried this edge failed,
+	// which is exactly why the edge is on the floor rather than the selection.
+	edge := &ir.Edge{From: "dead", To: "approve", With: []*ir.DataMapping{{
+		Key: "plan", Raw: "{{artifacts.plan}}",
+		Refs: []*ir.Ref{{Kind: ir.RefArtifacts, Path: []string{"plan"}}},
+	}}}
+	eng := New(&ir.Workflow{Nodes: map[string]ir.Node{
+		"planner": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "planner"}, Publish: "plan"},
+		"dead":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "dead"}},
+		"approve": human,
+	}, Edges: []*ir.Edge{edge}}, s, newStubExecutor())
+
+	if _, err := eng.materializeHumanArtifact(
+		ctx, "human-floor", "approve", map[string]any{"approved": true},
+		map[string]int{"planner": 1},
+		map[string]map[string]any{"planner": {"ok": true}},
+		map[string]map[string]any{"plan": {"ok": true}},
+		map[string]store.ArtifactRevisionRef{"plan": {NodeID: "planner", Version: 0}},
+		incomingState{settled: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := s.LoadArtifact(ctx, "human-floor", "approve", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Contract == nil || len(artifact.Contract.Dependencies) != 1 || artifact.Contract.Dependencies[0].NodeID != "planner" {
+		t.Fatalf("human artifact contract = %+v — the collector consumed {{artifacts.plan}} through the floor, so its published approval depends on it", artifact.Contract)
+	}
+}
+
+// Two alternatives carrying the SAME template agree by construction. Reading
+// a moving namespace twice and comparing the two reads invents a
+// disagreement, and the key is dropped from a node that should have had it.
+func TestSettledFloor_IdenticalTemplatesDoNotDisagreeOverAMovingClock(t *testing.T) {
+	elapsed := func(key string) *ir.DataMapping {
+		return &ir.DataMapping{
+			Key:  key,
+			Refs: []*ir.Ref{{Kind: ir.RefRun, Path: []string{"elapsed_seconds"}, Raw: "{{run.elapsed_seconds}}"}},
+			Raw:  "{{run.elapsed_seconds}}",
+		}
+	}
+	wf := settledSharedKeyWorkflow()
+	for _, e := range wf.Edges {
+		if e.From == "a" && e.To == "join" {
+			e.With = []*ir.DataMapping{elapsed("started_at"), settledLiteral("shared", "from-floor")}
+		}
+	}
+	// The same source's `else` alternative carries the identical mapping.
+	wf.Edges = append(wf.Edges, &ir.Edge{From: "a", To: "join", IsElse: true, With: []*ir.DataMapping{elapsed("started_at")}})
+
+	got := runSettledFanOut(t, wf, "run-559-clock", map[string]func() (map[string]any, error){
+		"a": func() (map[string]any, error) { return nil, errors.New("fail A") },
+		"b": func() (map[string]any, error) { return map[string]any{"ok": true}, nil },
+	}, "join")
+
+	if _, present := got["started_at"]; !present {
+		t.Fatalf("input = %v — both alternatives carry the IDENTICAL template, so they cannot disagree; only resolving it twice against a clock that moves makes them look like they do", got)
 	}
 }
 
@@ -611,6 +1024,35 @@ func settledLongBranchWorkflow() *ir.Workflow {
 			{From: "b", To: "b2"},
 			{From: "a2", To: "join", With: []*ir.DataMapping{settledRef("expected_count", "entry", "count")}},
 			{From: "b2", To: "join", With: []*ir.DataMapping{settledRef("note", "entry", "note")}},
+			{From: "join", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},
+		Vars: map[string]*ir.Var{}, Loops: map[string]*ir.Loop{},
+	}
+}
+
+// settledSharedKeyWorkflow has one dead branch and one live branch whose
+// edges into the join write the SAME key, so precedence between the floor and
+// the ordinary passes is observable.
+func settledSharedKeyWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name: "settled_shared_key", Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":  &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"a":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitBestEffort},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "router"},
+			{From: "router", To: "a"},
+			{From: "router", To: "b"},
+			// Declared FIRST, so a floor applied in edge order rather than as
+			// a base would still lose here; it is the PASS order that decides.
+			{From: "a", To: "join", With: []*ir.DataMapping{settledLiteral("shared", "from-floor")}},
+			{From: "b", To: "join", With: []*ir.DataMapping{settledLiteral("shared", "from-live")}},
 			{From: "join", To: "done"},
 		},
 		Schemas: map[string]*ir.Schema{}, Prompts: map[string]*ir.Prompt{},

--- a/pkg/runtime/settled_floor_test.go
+++ b/pkg/runtime/settled_floor_test.go
@@ -778,7 +778,7 @@ func TestSettledFloor_HumanCollectorPublishesItsFloorDependency(t *testing.T) {
 		map[string]map[string]any{"planner": {"ok": true}},
 		map[string]map[string]any{"plan": {"ok": true}},
 		map[string]store.ArtifactRevisionRef{"plan": {NodeID: "planner", Version: 0}},
-		incomingState{settled: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
+		&store.Checkpoint{SettledIncoming: map[string][]store.IncomingEdge{"approve": {incomingFromEdge(edge)}}},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -788,6 +788,67 @@ func TestSettledFloor_HumanCollectorPublishesItsFloorDependency(t *testing.T) {
 	}
 	if artifact.Contract == nil || len(artifact.Contract.Dependencies) != 1 || artifact.Contract.Dependencies[0].NodeID != "planner" {
 		t.Fatalf("human artifact contract = %+v — the collector consumed {{artifacts.plan}} through the floor, so its published approval depends on it", artifact.Contract)
+	}
+}
+
+// The contract for a human collector is computed from a state built BY HAND
+// on the resume path, and the floor's artifact refs now depend on how it
+// RESOLVES. Hand that state fewer namespaces than the node's input was built
+// from and the shared function answers the two callers differently: two
+// alternatives that disagree through `{{vars.*}}` read nil == nil, agree, and
+// record as REQUIRED an artifact the collector never consumed.
+func TestSettledFloor_HumanContractResolvesInTheSameNamespacesAsTheInput(t *testing.T) {
+	ctx := context.Background()
+	s := tmpStore(t)
+	if _, err := s.CreateRun(ctx, "human-vars", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	human := &ir.HumanNode{BaseNode: ir.BaseNode{ID: "approve"}, Publish: "approval"}
+	// The two alternatives differ ONLY through the var they read; the two
+	// artifacts have identical bodies, so a path that cannot see vars finds
+	// them equal and calls it agreement.
+	alt := func(varName, artifactName string, isElse bool) *ir.Edge {
+		raw := "{{vars." + varName + "}}/{{artifacts." + artifactName + "}}"
+		return &ir.Edge{From: "dead", To: "approve", IsElse: isElse, Condition: map[bool]string{true: "", false: "ok"}[isElse], With: []*ir.DataMapping{{
+			Key: "choice", Raw: raw,
+			Refs: []*ir.Ref{
+				{Kind: ir.RefVars, Path: []string{varName}},
+				{Kind: ir.RefArtifacts, Path: []string{artifactName}},
+			},
+		}}}
+	}
+	whenEdge, elseEdge := alt("a_pick", "plan", false), alt("b_pick", "notes", true)
+	eng := New(&ir.Workflow{Nodes: map[string]ir.Node{
+		"planner": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "planner"}, Publish: "plan"},
+		"noter":   &ir.ToolNode{BaseNode: ir.BaseNode{ID: "noter"}, Publish: "notes"},
+		"dead":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "dead"}},
+		"approve": human,
+	}, Edges: []*ir.Edge{whenEdge, elseEdge}}, s, newStubExecutor())
+
+	if _, err := eng.materializeHumanArtifact(
+		ctx, "human-vars", "approve", map[string]any{"approved": true},
+		map[string]int{"planner": 1, "noter": 1},
+		map[string]map[string]any{},
+		map[string]map[string]any{"plan": {"same": true}, "notes": {"same": true}},
+		map[string]store.ArtifactRevisionRef{
+			"plan":  {NodeID: "planner", Version: 0},
+			"notes": {NodeID: "noter", Version: 0},
+		},
+		&store.Checkpoint{
+			Vars: map[string]any{"a_pick": "A", "b_pick": "B"},
+			SettledIncoming: map[string][]store.IncomingEdge{
+				"approve": {incomingFromEdge(whenEdge), incomingFromEdge(elseEdge)},
+			},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+	artifact, err := s.LoadArtifact(ctx, "human-vars", "approve", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact.Contract != nil && len(artifact.Contract.Dependencies) != 0 {
+		t.Fatalf("contract dependencies = %+v — the two alternatives disagree through {{vars.*}}, so `choice` never reached the collector; a contract blind to vars reads them as equal and records an artifact nobody consumed, which a later resume can refuse over", artifact.Contract.Dependencies)
 	}
 }
 

--- a/pkg/runview/fork.go
+++ b/pkg/runview/fork.go
@@ -236,6 +236,13 @@ func (s *Service) Fork(ctx context.Context, spec ForkSpec) (*ForkResult, error) 
 		Vars:                   copyVars(parent.Checkpoint),
 		BackendName:            turn.Backend,
 		BackendSessionID:       turn.SessionID,
+		// The anchor re-executes first, so it needs the incoming state an
+		// ordinary resume would rebuild it from: which edges fired into it,
+		// and the floor a stabilized fan-out left it. Only the anchor's own
+		// entries travel — the child never re-runs what sat below it, so
+		// carrying more could only resurrect a selection nothing remakes.
+		SelectedIncoming: copySelectedIncomingFor(parent.Checkpoint, spec.NodeID),
+		SettledIncoming:  copySettledIncomingFor(parent.Checkpoint, spec.NodeID),
 	}
 	// Claw rehydration: when the turn checkpoint has a MessagesRef
 	// (i.e. the parent was running on the claw backend), load the
@@ -574,6 +581,33 @@ func copyForkArtifacts(ctx context.Context, runStore store.RunStore, parentRunID
 		}
 	}
 	return nil
+}
+
+// copySelectedIncomingFor / copySettledIncomingFor carry ONE node's incoming
+// state into the child checkpoint: the edges routing selected for it, and the
+// floor a stabilized fan-out left it. A nil result is the honest answer when
+// the parent recorded nothing — the resolver then falls back to source-output
+// presence, exactly as it would on the parent.
+func copySelectedIncomingFor(cp *store.Checkpoint, nodeID string) map[string][]store.IncomingEdge {
+	if cp == nil {
+		return nil
+	}
+	return copyIncomingFor(cp.SelectedIncoming, nodeID)
+}
+
+func copySettledIncomingFor(cp *store.Checkpoint, nodeID string) map[string][]store.IncomingEdge {
+	if cp == nil {
+		return nil
+	}
+	return copyIncomingFor(cp.SettledIncoming, nodeID)
+}
+
+func copyIncomingFor(src map[string][]store.IncomingEdge, nodeID string) map[string][]store.IncomingEdge {
+	edges := src[nodeID]
+	if len(edges) == 0 {
+		return nil
+	}
+	return map[string][]store.IncomingEdge{nodeID: append([]store.IncomingEdge(nil), edges...)}
 }
 
 func copyVars(cp *store.Checkpoint) map[string]any {

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -631,8 +631,9 @@ func retireOutputCorrections(run *store.Run, invalidated []string, retiredAt tim
 //     read {{loop.<name>.previous_output}} on its first re-execution.
 //   - SelectedIncoming and SettledIncoming of the PIVOT: the last visit's
 //     selected edges — and the floor a stabilized fan-out left it — are what
-//     the re-execution should rebuild from. Downstream keys are cleared with
-//     the dropped nodes. A graph edit that invalidates the pivot's
+//     the re-execution should rebuild from. Every INVALIDATED node below it
+//     is cleared, including the ones that never produced an output and so
+//     never appear in `dropped`. A graph edit that invalidates the pivot's
 //     identities is handled at resolve time (untracked fallback for the
 //     selection, per-edge revalidation for the floor).
 func applyRewind(cp *store.Checkpoint, wf *ir.Workflow, nodeID string, dropped, invalidated []string) {
@@ -643,7 +644,16 @@ func applyRewind(cp *store.Checkpoint, wf *ir.Workflow, nodeID string, dropped, 
 	if cp.ArtifactVersions == nil {
 		cp.ArtifactVersions = map[string]int{}
 	}
-	for _, id := range dropped {
+	// `invalidated`, not `dropped`, and never the pivot. `dropped` is the
+	// REPORTING set — it is filtered on "has an output" and it always
+	// contains the pivot, so using it here did the exact opposite of what
+	// the contract above promises: it erased the pivot's own incoming state
+	// (which the re-execution rebuilds from) while leaving behind the state
+	// of every downstream node the run never reached.
+	for _, id := range invalidated {
+		if id == nodeID {
+			continue
+		}
 		delete(cp.SelectedIncoming, id)
 		delete(cp.SettledIncoming, id)
 	}

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -629,10 +629,12 @@ func retireOutputCorrections(run *store.Run, invalidated []string, retiredAt tim
 //     stays exhausted; grant more with resume's --max-iterations.
 //   - LoopPreviousOutput / LoopCurrentOutput: the pivot may legitimately
 //     read {{loop.<name>.previous_output}} on its first re-execution.
-//   - SelectedIncoming of the PIVOT: the last visit's selected edges are
-//     what the re-execution should rebuild from. Downstream keys are
-//     cleared with the dropped nodes. A graph edit that invalidates the
-//     pivot's identities is handled at resolve time (untracked fallback).
+//   - SelectedIncoming and SettledIncoming of the PIVOT: the last visit's
+//     selected edges — and the floor a stabilized fan-out left it — are what
+//     the re-execution should rebuild from. Downstream keys are cleared with
+//     the dropped nodes. A graph edit that invalidates the pivot's
+//     identities is handled at resolve time (untracked fallback for the
+//     selection, per-edge revalidation for the floor).
 func applyRewind(cp *store.Checkpoint, wf *ir.Workflow, nodeID string, dropped, invalidated []string) {
 	cp.NodeID = nodeID
 	// From this point the checkpoint's (possibly empty) revision map is an
@@ -643,6 +645,7 @@ func applyRewind(cp *store.Checkpoint, wf *ir.Workflow, nodeID string, dropped, 
 	}
 	for _, id := range dropped {
 		delete(cp.SelectedIncoming, id)
+		delete(cp.SettledIncoming, id)
 	}
 	if !cp.ArtifactsKnown {
 		cp.Artifacts = make(map[string]map[string]any)

--- a/pkg/runview/settled_floor_test.go
+++ b/pkg/runview/settled_floor_test.go
@@ -1,0 +1,135 @@
+package runview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Two ways for a run to re-execute a node — rewind and fork — both rebuild
+// its input from the incoming state the checkpoint carries: the edges routing
+// selected, and the floor a stabilized fan-out left behind. Both used to lose
+// it, in opposite directions.
+
+// applyRewind must keep the PIVOT's incoming state (the re-execution rebuilds
+// from it) and clear every INVALIDATED node below, including the ones that
+// never produced an output — those are absent from `dropped`, which is
+// filtered on output presence and always contains the pivot.
+func TestApplyRewind_KeepsThePivotAndClearsEveryInvalidatedNode(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID: "collect",
+		SelectedIncoming: map[string][]store.IncomingEdge{
+			"collect":     {{From: "work", To: "collect"}},
+			"downstream":  {{From: "collect", To: "downstream"}},
+			"never_ran":   {{From: "downstream", To: "never_ran"}},
+			"upstream":    {{From: "entry", To: "upstream"}},
+			"unaffected2": {{From: "entry", To: "unaffected2"}},
+		},
+		SettledIncoming: map[string][]store.IncomingEdge{
+			"collect":   {{From: "dead", To: "collect"}},
+			"never_ran": {{From: "dead2", To: "never_ran"}},
+		},
+		ArtifactsKnown: true, ArtifactRevisionsKnown: true,
+	}
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{}, Edges: []*ir.Edge{}}
+
+	// `never_ran` produced no output, so it is invalidated but NOT dropped.
+	applyRewind(cp, wf, "collect",
+		[]string{"collect", "downstream"},
+		[]string{"collect", "downstream", "never_ran"})
+
+	if len(cp.SelectedIncoming["collect"]) != 1 || len(cp.SettledIncoming["collect"]) != 1 {
+		t.Fatalf("the pivot lost its incoming state: selected=%+v settled=%+v — the re-execution rebuilds its input from exactly this",
+			cp.SelectedIncoming["collect"], cp.SettledIncoming["collect"])
+	}
+	for _, id := range []string{"downstream", "never_ran"} {
+		if _, present := cp.SelectedIncoming[id]; present {
+			t.Errorf("invalidated node %q kept its selection: a node the run never reached is absent from `dropped`, which is why cleanup reads `invalidated`", id)
+		}
+		if _, present := cp.SettledIncoming[id]; present {
+			t.Errorf("invalidated node %q kept its settled floor", id)
+		}
+	}
+	if len(cp.SelectedIncoming["upstream"]) != 1 || len(cp.SelectedIncoming["unaffected2"]) != 1 {
+		t.Fatalf("a node outside the rewind lost its selection: %+v", cp.SelectedIncoming)
+	}
+}
+
+// A fork re-executes its anchor first, so the anchor needs the same incoming
+// state an ordinary resume would give it. The synthetic checkpoint used to
+// carry outputs, vars and artifact state and neither incoming map, so a
+// forked collector lost mappings a plain resume keeps.
+func TestFork_CarriesTheAnchorsIncomingState(t *testing.T) {
+	dir := t.TempDir()
+	logger := iterlog.Nop()
+	st, err := store.New(dir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	ctx := context.Background()
+	const parentID = "run-fork-incoming"
+	if _, err := st.CreateRun(ctx, parentID, "wf", nil); err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	parent, err := st.LoadRun(ctx, parentID)
+	if err != nil {
+		t.Fatalf("load parent: %v", err)
+	}
+	parent.Checkpoint = &store.Checkpoint{
+		NodeID:                 "collect",
+		Outputs:                map[string]map[string]any{"entry": {"count": 2}},
+		Vars:                   map[string]any{},
+		ArtifactsKnown:         true,
+		ArtifactRevisionsKnown: true,
+		SelectedIncoming: map[string][]store.IncomingEdge{
+			"collect":   {{From: "work", To: "collect"}},
+			"elsewhere": {{From: "x", To: "elsewhere"}},
+		},
+		SettledIncoming: map[string][]store.IncomingEdge{
+			"collect":   {{From: "dead", To: "collect"}},
+			"elsewhere": {{From: "y", To: "elsewhere"}},
+		},
+	}
+	parent.Status = store.RunStatusCancelled
+	if err := st.SaveRun(ctx, parent); err != nil {
+		t.Fatalf("save parent: %v", err)
+	}
+	if err := st.WriteTurn(ctx, &store.TurnCheckpoint{
+		RunID: parentID, NodeID: "collect", LoopIter: 0, TurnIndex: 0,
+		Backend: "claw", FinishReason: "tool_use", WrittenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write turn: %v", err)
+	}
+
+	svc, err := NewService(dir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	result, err := svc.Fork(ctx, ForkSpec{RunID: parentID, NodeID: "collect", TurnIndex: 0})
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	child, err := st.LoadRun(ctx, result.NewRunID)
+	if err != nil {
+		t.Fatalf("load child: %v", err)
+	}
+	if child.Checkpoint == nil {
+		t.Fatal("the child carries no checkpoint")
+	}
+	if len(child.Checkpoint.SelectedIncoming["collect"]) != 1 || child.Checkpoint.SelectedIncoming["collect"][0].From != "work" {
+		t.Fatalf("child selected incoming = %+v — the anchor re-executes first and rebuilds its input from this", child.Checkpoint.SelectedIncoming)
+	}
+	if len(child.Checkpoint.SettledIncoming["collect"]) != 1 || child.Checkpoint.SettledIncoming["collect"][0].From != "dead" {
+		t.Fatalf("child settled floor = %+v — a forked collector must keep what a plain resume keeps", child.Checkpoint.SettledIncoming)
+	}
+	if _, present := child.Checkpoint.SelectedIncoming["elsewhere"]; present {
+		t.Fatalf("child carried a node other than the anchor: %+v — nothing below the anchor re-executes, so nothing below it should travel", child.Checkpoint.SelectedIncoming)
+	}
+	if _, present := child.Checkpoint.SettledIncoming["elsewhere"]; present {
+		t.Fatalf("child carried a floor other than the anchor's: %+v", child.Checkpoint.SettledIncoming)
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -1424,7 +1424,19 @@ type Checkpoint struct {
 	// existed — the resolver then falls back to "every incoming edge
 	// whose source has produced output".
 	SelectedIncoming map[string][]IncomingEdge `json:"selected_incoming,omitempty" bson:"selected_incoming,omitempty"`
-	Vars             map[string]any            `json:"vars" bson:"vars"` // resolved workflow variables
+	// SettledIncoming records, per convergence node, the incoming edges a
+	// fan-out invocation stabilized on whose source produced no output —
+	// every branch failed, or the collection fanned over was empty. It has
+	// to survive the checkpoint because that failure is exactly what parks
+	// the run: a resume restarts AT the convergence node without replaying
+	// the fan-out, so a volatile marker would be gone at the one moment it
+	// is needed. Kept apart from SelectedIncoming, which a loop head's
+	// back-edge replaces on re-entry. Each edge is revalidated against the
+	// current graph at resolve time, so a `resume --force` against an
+	// edited .bot drops the identities that no longer match rather than
+	// the whole set.
+	SettledIncoming map[string][]IncomingEdge `json:"settled_incoming,omitempty" bson:"settled_incoming,omitempty"`
+	Vars            map[string]any            `json:"vars" bson:"vars"` // resolved workflow variables
 	// InteractionQuestions embeds the questions from the interaction record
 	// so that resume is self-sufficient even if the interaction file is deleted.
 	InteractionQuestions map[string]any `json:"interaction_questions,omitempty" bson:"interaction_questions,omitempty"`
@@ -1554,10 +1566,13 @@ type BranchCheckpoint struct {
 	LoopCurrentOutput  map[string]map[string]any      `json:"loop_current_output,omitempty" bson:"loop_current_output,omitempty"`
 	LoopBudgetMarks    map[string]map[string]float64  `json:"loop_budget_marks,omitempty" bson:"loop_budget_marks,omitempty"`
 	SelectedIncoming   map[string][]IncomingEdge      `json:"selected_incoming,omitempty" bson:"selected_incoming,omitempty"`
-	JoinNodeID         string                         `json:"join_node_id,omitempty" bson:"join_node_id,omitempty"`
-	TerminalNodeID     string                         `json:"terminal_node_id,omitempty" bson:"terminal_node_id,omitempty"`
-	Completed          bool                           `json:"completed,omitempty" bson:"completed,omitempty"`
-	TerminatedAtDone   bool                           `json:"terminated_at_done,omitempty" bson:"terminated_at_done,omitempty"`
+	// SettledIncoming is the branch-private twin of Checkpoint.SettledIncoming:
+	// the floor a NESTED fan-out left on a convergence inside this branch.
+	SettledIncoming  map[string][]IncomingEdge `json:"settled_incoming,omitempty" bson:"settled_incoming,omitempty"`
+	JoinNodeID       string                    `json:"join_node_id,omitempty" bson:"join_node_id,omitempty"`
+	TerminalNodeID   string                    `json:"terminal_node_id,omitempty" bson:"terminal_node_id,omitempty"`
+	Completed        bool                      `json:"completed,omitempty" bson:"completed,omitempty"`
+	TerminatedAtDone bool                      `json:"terminated_at_done,omitempty" bson:"terminated_at_done,omitempty"`
 	// CostUSD is this branch's cumulative LLM spend for the current
 	// invocation. The daily spend cap records per-branch spend under a
 	// monotonic-max ledger key, so a resumed branch must restart its

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -223,6 +223,13 @@ func testParallelCheckpointRoundTrip(t *testing.T, s store.RunStore) {
 			"historic": {NodeID: "planner", Version: 0, ValueFromRevision: true},
 		},
 		ArtifactRevisionsKnown: true,
+		// The floor a stabilized fan-out left on a convergence node. It
+		// rides the checkpoint precisely because the failure that creates
+		// it is what parks the run, so a store that drops it resumes the
+		// join with none of its incoming mappings (#559).
+		SettledIncoming: map[string][]store.IncomingEdge{
+			"collect": {{From: "work", To: "collect"}, {From: "review", To: "collect", IsElse: true}},
+		},
 		Parallel: &store.ParallelCheckpoint{
 			RouterNodeID:                "dispatch",
 			InvocationKey:               "dispatch@outer=2",
@@ -286,6 +293,10 @@ func testParallelCheckpointRoundTrip(t *testing.T, s store.RunStore) {
 	}
 	if !r.Checkpoint.ArtifactRevisions["historic"].ValueFromRevision {
 		t.Fatalf("historical artifact value reference was lost in store round-trip: %+v", r.Checkpoint.ArtifactRevisions)
+	}
+	settled := r.Checkpoint.SettledIncoming["collect"]
+	if len(settled) != 2 || settled[0].From != "work" || settled[1].From != "review" || !settled[1].IsElse {
+		t.Fatalf("settled floor after round-trip = %+v — a join whose fan-out produced nothing resumes with no incoming mapping at all when this is lost", settled)
 	}
 	got := r.Checkpoint.Parallel
 	branch := got.Branches["branch_dispatch_0"]

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5754,6 +5754,9 @@ export interface components {
             selected_incoming?: {
                 [key: string]: components["schemas"]["IncomingEdge"][];
             };
+            settled_incoming?: {
+                [key: string]: components["schemas"]["IncomingEdge"][];
+            };
             start_node_id: string;
             terminal_node_id?: string;
             terminated_at_done?: boolean;
@@ -5838,6 +5841,9 @@ export interface components {
                 [key: string]: number;
             };
             selected_incoming?: {
+                [key: string]: components["schemas"]["IncomingEdge"][];
+            };
+            settled_incoming?: {
                 [key: string]: components["schemas"]["IncomingEdge"][];
             };
             vars: {


### PR DESCRIPTION
Closes #559. Closes #1113.

When a fan-out stabilizes without a single branch producing output — every
branch failed under `best_effort` (#559), or a `fan_out_each` fanned over an
empty collection (#1113, the twin site) — the convergence node ran with **no**
incoming `with` mapping at all. Not just the ones reading the dead branches:
also the ones reading a durable parent output or a var, which the failure
never touched. A `tool` node was then handed the literal `{{input.x}}` in its
command, since shell rendering deliberately keeps an unresolved reference
visible.

Both sites deleted the join's tracking entry to fall back on "every edge whose
source produced output" — and no source had, so the fallback kept nothing.

## The fix

A **settled floor**: the edges into the join that the invocation settled on,
applied under both merge passes so a live edge and a loop back-edge still win
on a shared key.

What makes it safe is where the provenance is read from. Not the graph — **what
the invocation DID**: the nodes its branches entered, the nodes that produced
output, the edges they recorded firing, the failed branches included. Leaving a
node that executed, the walk follows only the edge that node's branch recorded;
leaving one that did not, it follows every forward edge, which is the whole
point, since the node that would have carried the mapping is the one that died.

It rides the checkpoint, because the failure that creates it is what parks the
run: a resume restarts AT the join without replaying the fan-out. Each edge is
revalidated against the current graph at resolve time, per edge rather than per
node, so `resume --force` against an edited `.bot` drops the identities that no
longer match instead of the whole set.

**What it does not promise**: a mapping reading the dead branch still lands
empty, and an empty value is a literal again in a `tool` command. The leak is
reduced, not closed.

## Adversarial review

The first commit was reviewed by a cross-family model with repo access, which
returned **10 findings, 5 high**, with reproductions it executed and seven
mutations that left the submitted tests green. Verdict: *block this merge*. The
second commit is that review's disposition. All ten are adopted — none was
refuted.

| | finding | disposition |
|---|---|---|
| **F1** high | the walk crossed a route routing REJECTED and reached the join through a node that never ran — #484 through the back door | fixed at the choke point; reproduced independently before adopting |
| **F6** medium | a node that ran two invocations ago still has an output, which is not evidence it ran in this one — a partial failure lost its mapping twice over | same choke point |
| **F3** high | a resumed branch runs the node its cursor names; an edited `fan_out_each` template sent the walk down a branch nobody is running | recorded start nodes outrank the declared ones |
| **F8** medium | a key two undecided alternatives disagreed on still reached the artifact contract as a **required** dependency — re-validated on resume, so an artifact nobody consumed could refuse one | one shared `settledFloorMappings` answers the input and the contract |
| **F9** medium | two alternatives carrying the identical template were resolved twice and compared, so `{{run.elapsed_seconds}}` invented a disagreement | identical template = agreement by construction |
| **F7** medium | a human collector rebuilds its contract state by hand and got the selection alone, publishing an approval missing what the floor fed it | both maps travel together as `incomingState` |
| **F2** high | **pre-existing**: `applyRewind` cleared the PIVOT's incoming state (against its own documented contract) and kept every downstream node that never produced an output | reads `invalidated` minus the pivot |
| **F5** high | **pre-existing**: a fork's synthetic checkpoint carried neither incoming map, so a forked collector lost what a plain resume keeps | the anchor's own entries travel |
| **F4** high | an older replica's whole-document `SaveRun` drops any field it does not know — true of every field ever added, `SelectedIncoming` included | filed as its own class: #1118 |
| **F10** medium | seven submitted assertions did not detect the guard they named | rewritten around witnesses reachable only through the guard |

F2 and F5 are defects `SelectedIncoming` already had and the floor faithfully
copied. Fixed here rather than filed, so the class leaves in one piece.

## Verification

Every guard was checked by **mutation** — removed, and the test that names it
confirmed to redden. Three tests were inert when first written, including one I
caught myself and two the review caught: each is rewritten around a witness
reachable **only** through the guard under test, since a node the walk would
reach anyway proves nothing about the guard meant to block it.

- `devbox run -- task check` — exit 0
- `-race` on `pkg/runtime`, `pkg/runview`, `pkg/store` — green
- Mongo conformance against a real `mongo:8.0` replica set — 28 s (a skipped
  run is 0.8 s), and the new conformance row was confirmed to redden when the
  bson tag is broken
- OpenAPI + `schema.ts` regenerated

Also filed from this work: **#1116** — a re-invoked fan-out exposes the
previous invocation's outputs for a branch that failed this time, reproduced
and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
