### PR TITLE
fix(sec-audit): the deep scanner's retry resumes instead of starting over

### DIFF
--- a/bots/sec-audit-source/main.bot
+++ b/bots/sec-audit-source/main.bot
@@ -2690,13 +2690,56 @@ unset _cb
 # deepsec runs under ignores it. Measured 2026-09-10 on this node: a 240s
 # bound returned after 27 minutes 39. Without the kill-after escalation the
 # bound is advisory — a limit that reads as enforced and is not.
-_dsproc() { ( cd "$DSW" && CLAUDE_CODE_EXECUTABLE="$CLAUDE_BIN" timeout -k 60 2400 deepsec process --concurrency "$CONC" $PROC_ARGS $AGENT_ARGS ); }
+# The optional first argument is a deepsec run id. Passing it RESUMES that
+# run, so the retry re-investigates only the batches the first attempt did not
+# finish; without it the retry opens a fresh run and pays for the whole pass a
+# second time, under the same bound that just expired. Two explicit branches
+# rather than a brace-plus-alternate parameter form, which the DSL expands at
+# LAUNCH with the server environment instead of leaving to the shell.
+_dsproc() {
+  _rid="$1"
+  if [ -n "$_rid" ]; then
+    ( cd "$DSW" && CLAUDE_CODE_EXECUTABLE="$CLAUDE_BIN" timeout -k 60 2400 deepsec process --run-id "$_rid" --concurrency "$CONC" $PROC_ARGS $AGENT_ARGS )
+  else
+    ( cd "$DSW" && CLAUDE_CODE_EXECUTABLE="$CLAUDE_BIN" timeout -k 60 2400 deepsec process --concurrency "$CONC" $PROC_ARGS $AGENT_ARGS )
+  fi
+}
+
+# deepsec prints "Processing complete. Run: <id>" BEFORE it exits 1 on errored
+# batches, so the id is readable from a FAILED attempt -- which is the only
+# time it is wanted. Strips the ANSI colouring the CLI wraps it in. Empty when
+# the line never appeared, which is the honest input to "start fresh".
+_dsrunid() {
+  grep -a "Processing complete" "$LOG_DIR/process.log" 2>/dev/null | tail -1 \
+    | tr -d "\033" | sed -e "s/.*Run: //" -e "s/\[[0-9;]*m//g" -e "s/[^A-Za-z0-9_.-].*//"
+}
+
+# A quota wall does not heal in twenty seconds. Retrying one buys a second
+# full pass that cannot succeed and spends the remaining wall-clock proving
+# it. deepsec names this failure itself rather than leaving it to be inferred
+# from a provider message: "Stopped: <source> exhausted" (quota-message.ts).
+_dsquota() { grep -qa "Stopped:.*exhausted" "$LOG_DIR/process.log" 2>/dev/null; }
+
 # deepsec process drives its OWN claude LLM calls (outside iterion network
-# retry). A transient blip (rate-limit / quota / network) here drops the
-# whole deepsec contribution and silently thins the audit. Retry once after a
-# short backoff; degrade-with-report only if BOTH attempts fail. Diagnosed: a
-# real run lost all deepsec findings to one such blip.
-_dsproc >"$LOG_DIR/process.log" 2>&1 || { echo "[deepsec] process failed; retrying once after 20s (transient LLM blip)" >>"$LOG_DIR/process.log"; sleep 20; _dsproc >>"$LOG_DIR/process.log" 2>&1; } || ERRS="$ERRS process"
+# retry). A transient blip (rate-limit / network) here drops the whole deepsec
+# contribution and silently thins the audit. Retry once after a short backoff;
+# degrade-with-report only if BOTH attempts fail. Diagnosed: a real run lost
+# all deepsec findings to one such blip.
+if _dsproc "" >"$LOG_DIR/process.log" 2>&1; then
+  :
+elif _dsquota; then
+  echo "[deepsec] quota exhausted: no retry, a quota wall does not clear in 20s. What was investigated before it stays exported." >>"$LOG_DIR/process.log"
+  ERRS="$ERRS process"
+else
+  _RID=$(_dsrunid)
+  if [ -n "$_RID" ]; then
+    echo "[deepsec] process failed; resuming run $_RID in 20s (batches already investigated are not redone)" >>"$LOG_DIR/process.log"
+  else
+    echo "[deepsec] process failed; no run id in the log, the retry starts a fresh pass" >>"$LOG_DIR/process.log"
+  fi
+  sleep 20
+  _dsproc "$_RID" >>"$LOG_DIR/process.log" 2>&1 || ERRS="$ERRS process"
+fi
 
 ( cd "$DSW" && deepsec export --format json --out "$OUT_JSON" ) >"$LOG_DIR/export.log" 2>&1 || ERRS="$ERRS export"
 

--- a/bots/sec_audit_deepsec_retry_test.go
+++ b/bots/sec_audit_deepsec_retry_test.go
@@ -1,0 +1,172 @@
+package bots
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The deep scanner drives its own LLM calls, outside iterion's network retry,
+// so the node retries the pass once itself. That retry used to open a FRESH
+// deepsec run: every batch the first attempt had already investigated was
+// paid for again, under the same bound that had just expired — and when the
+// first attempt died on a provider quota, the retry spent the remaining
+// wall-clock proving the wall was still there.
+//
+// deepsec answers both: `--run-id` resumes a run, and it names a quota stop
+// itself ("Stopped: <source> exhausted"). These tests run the REAL retry
+// block from the shipped .bot against a stub CLI that records its argv,
+// because the property is which invocations the node actually makes.
+
+// deepsecRetryBlock returns the shipped text from the _dsproc definition
+// through the end of the retry decision, verbatim. Reading it out of the .bot
+// rather than restating it here is the point: a test that carries its own
+// copy of the logic certifies the copy.
+func deepsecRetryBlock(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("sec-audit-source/main.bot")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for _, blk := range commandBackticks(string(raw)) {
+		start := strings.Index(blk, "_dsproc() {")
+		if start < 0 {
+			continue
+		}
+		const endMarker = "_dsproc \"$_RID\" >>\"$LOG_DIR/process.log\" 2>&1 || ERRS=\"$ERRS process\""
+		end := strings.Index(blk, endMarker)
+		if end < 0 {
+			t.Fatal("the deepsec command body defines _dsproc but never calls it with a resumed run id: the retry would restart the pass from scratch")
+		}
+		rest := blk[end+len(endMarker):]
+		closing := strings.Index(rest, "fi")
+		if closing < 0 {
+			t.Fatal("the retry block is not closed")
+		}
+		return blk[start : end+len(endMarker)+closing+len("fi")]
+	}
+	t.Fatal("no command body defines _dsproc")
+	return ""
+}
+
+// stubDeepsec writes a fake `deepsec` (and an instant `sleep`) onto PATH. The
+// fake appends its argv to calls.log and replays the scenario's stdout, so an
+// assertion can read exactly which invocations the node made.
+func stubDeepsec(t *testing.T, dir, stdout string, exitCode int) {
+	t.Helper()
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + filepath.Join(dir, "calls.log") + "\n" +
+		"printf '%b' " + shellQuote(stdout) + "\n" +
+		"exit " + itoa(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(bin, "deepsec"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	// The retry sleeps 20s before resuming. The property under test is which
+	// invocation happens, not how long the node waits for it.
+	if err := os.WriteFile(filepath.Join(bin, "sleep"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write sleep stub: %v", err)
+	}
+}
+
+// runRetryBlock executes the shipped block with the stub on PATH and returns
+// the recorded invocations plus the ERRS the block ended with.
+func runRetryBlock(t *testing.T, stdout string, exitCode int) ([]string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	stubDeepsec(t, dir, stdout, exitCode)
+
+	logDir := filepath.Join(dir, "logs")
+	dsw := filepath.Join(dir, "ws")
+	for _, d := range []string{logDir, dsw} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	harness := "set -u\n" +
+		"LOG_DIR=" + logDir + "\n" +
+		"DSW=" + dsw + "\n" +
+		"CLAUDE_BIN=/bin/true\nCONC=4\nPROC_ARGS=\nAGENT_ARGS=\nERRS=\n" +
+		deepsecRetryBlock(t) + "\n" +
+		"printf 'ERRS=%s\\n' \"$ERRS\"\n"
+
+	cmd := exec.Command("bash", "-c", harness)
+	cmd.Env = append(os.Environ(), "PATH="+filepath.Join(dir, "bin")+":"+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("harness failed: %v\n%s", err, out)
+	}
+
+	calls, _ := os.ReadFile(filepath.Join(dir, "calls.log"))
+	var invocations []string
+	for _, line := range strings.Split(strings.TrimSpace(string(calls)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			invocations = append(invocations, line)
+		}
+	}
+	return invocations, strings.TrimSpace(string(out))
+}
+
+// A clean pass runs deepsec exactly once, and never names a run id: there is
+// nothing to resume.
+func TestDeepsecRetry_CleanPassRunsOnce(t *testing.T) {
+	calls, out := runRetryBlock(t, "Processing complete. Run: run_abc123\\n", 0)
+	if len(calls) != 1 {
+		t.Fatalf("a clean pass must invoke deepsec once, got %d: %v", len(calls), calls)
+	}
+	if strings.Contains(calls[0], "--run-id") {
+		t.Fatalf("a first attempt has no run to resume, yet it passed one: %s", calls[0])
+	}
+	if !strings.Contains(out, "ERRS=") || strings.Contains(out, "ERRS= process") {
+		t.Fatalf("a clean pass must record no error, got %q", out)
+	}
+}
+
+// The case the change exists for: one batch errored, deepsec exited 1, and the
+// run id it printed BEFORE exiting is handed back so the retry resumes instead
+// of re-investigating every finished batch.
+func TestDeepsecRetry_ResumesTheRunItAlreadyStarted(t *testing.T) {
+	stdout := "\\033[32mProcessing complete.\\033[0m Run: \\033[1mrun_abc123\\033[0m\\n" +
+		"  Analyses: 120\\n  Findings: 87\\n" +
+		"\\033[31m3 batch(es) errored — exiting 1 (agent failure, not a clean review).\\033[0m\\n"
+	calls, _ := runRetryBlock(t, stdout, 1)
+	if len(calls) != 2 {
+		t.Fatalf("a transient failure must be retried exactly once, got %d invocation(s): %v", len(calls), calls)
+	}
+	if !strings.Contains(calls[1], "--run-id run_abc123") {
+		t.Fatalf("the retry must RESUME run_abc123, or every finished batch is investigated and paid for twice; got: %s", calls[1])
+	}
+}
+
+// A quota wall is not retried: the second pass cannot succeed, and it would
+// spend the node's remaining wall-clock establishing that.
+func TestDeepsecRetry_DoesNotRetryAQuotaWall(t *testing.T) {
+	stdout := "Processing complete. Run: run_abc123\\n" +
+		"\\033[31m✘ Stopped: ChatGPT subscription exhausted\\033[0m\\n" +
+		"  Your direct OpenAI account is out of credits/quota.\\n"
+	calls, out := runRetryBlock(t, stdout, 1)
+	if len(calls) != 1 {
+		t.Fatalf("a quota wall must not be retried — a second full pass cannot succeed; got %d invocation(s): %v", len(calls), calls)
+	}
+	if !strings.Contains(out, "ERRS= process") {
+		t.Fatalf("a quota stop must still be reported as a failed step, got %q", out)
+	}
+}
+
+// When the id is unreadable the node says so and starts fresh, rather than
+// passing an empty --run-id that deepsec would reject.
+func TestDeepsecRetry_StartsFreshWhenNoRunIdWasPrinted(t *testing.T) {
+	calls, _ := runRetryBlock(t, "deepsec: command failed before it started\\n", 1)
+	if len(calls) != 2 {
+		t.Fatalf("a failure with no readable run id is still retried once, got %d: %v", len(calls), calls)
+	}
+	if strings.Contains(calls[1], "--run-id") {
+		t.Fatalf("with no id to resume the retry must start fresh, not pass an empty one: %s", calls[1])
+	}
+}


### PR DESCRIPTION
## What breaks today

`deepsec process` exits 1 **as soon as one batch errored** (`commands/process.ts`: *"batch(es) errored — exiting 1 (agent failure, not a clean review)"*). The node's single retry is therefore reached far more often than "the pass crashed" suggests — and it opened a **fresh** run every time.

Every batch the first attempt had already investigated was re-investigated and paid for again, under the same `timeout -k 60 2400` bound that had just expired. On a large repository that is the difference between finishing and timing out twice.

The second half is a retry that could never work: a provider quota wall does not clear in twenty seconds. Retrying one spends the node's whole remaining wall-clock establishing that the wall is still there.

## What this does

- **The retry resumes.** deepsec prints `Processing complete. Run: <id>` *before* it exits on errored batches, so the id is readable precisely when it is wanted. `_dsproc` takes it and passes `--run-id`.
- **A quota wall is not retried.** deepsec names this stop itself — `Stopped: <source> exhausted` (`quota-message.ts`) — rather than leaving it to be inferred from a provider message. The node reads its own scanner's verdict and skips the retry. The step is still reported as failed.
- With no readable id the node **says so** and starts fresh, rather than passing an empty `--run-id` that deepsec would reject.

`_dsproc` is written as two explicit branches rather than a brace-plus-alternate parameter form: the DSL expands that form at **launch**, with the server environment, instead of leaving it to the shell at runtime.

## Falsification

The tests run the **real** retry block out of the shipped `.bot` against a stub CLI that records its argv — the property is which invocations the node makes, and a test carrying its own copy of the logic would certify the copy.

Verified to bite, per guard:

| mutation | tests that fail |
|---|---|
| quota pattern blanked | `DoesNotRetryAQuotaWall` only |
| `--run-id` dropped | `ResumesTheRunItAlreadyStarted` only |
| whole change reverted | all four, naming the loss |

`go test ./bots/` — 712 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)