### PR TITLE
fix(golden-master): the seal declines per SET, never per directory

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2615,6 +2615,26 @@ tool oracle_run:
         return code == 0 and bool(out.strip())
 
 
+    def holdout_committed_entries(gm_dir):
+        """The NAMES under mutants/holdout/ that git tracks.
+
+        The directory holds two kinds at once: the set this run drew, which is
+        fresh and untracked, and a set an earlier run committed for a LATER gate.
+        They are told apart by tracking, because that is exactly what makes the
+        difference the seal cares about — moving a tracked file leaves an
+        uncommitted deletion, moving an untracked one leaves nothing.
+        """
+        code, out = run("git ls-files -- mutants/holdout", gm_dir, timeout=60)
+        if code != 0:
+            return set()
+        names = set()
+        for line in out.splitlines():
+            parts = line.strip().split("/")
+            if len(parts) >= 3 and parts[0] == "mutants" and parts[1] == "holdout":
+                names.add(parts[2])
+        return names
+
+
     def seal_holdout(gm_dir, sealed_dir):
         """Move the held-out set OUT of the worktree, once, at the first gate.
 
@@ -2642,12 +2662,25 @@ tool oracle_run:
         rather than letting the next gate report 0/0 for a set that was drawn.
         """
         src = os.path.join(gm_dir, "mutants", "holdout")
-        if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
-                and not seal_committed_opted_in(gm_dir):
-            return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
-        os.makedirs(sealed_dir, exist_ok=True)
+        # Declined PER SET, never per directory. Both reasons above are properties
+        # of ONE entry — a tracked file moved leaves an uncommitted deletion, a
+        # committed set scored here burns its single scoring — so a committed
+        # successor waiting for its gate must not stop THIS run's own fresh set
+        # from sealing. A directory-wide decline made the two indistinguishable:
+        # the next run's set stayed readable in the tree, the sealed pile read
+        # empty, and the gate's held-out term passed 0 == 0 on a set that was
+        # drawn and never hidden — the overfitting this function exists to make
+        # mechanical, reintroduced by the guard meant to protect it.
+        keep = set() if seal_committed_opted_in(gm_dir) else holdout_committed_entries(gm_dir)
+        movable = [n for n in sorted(os.listdir(src))
+                   if n not in keep] if os.path.isdir(src) else []
+        # Only when something actually moves: an empty sealed directory reads as a
+        # pile that exists, and "nothing was sealed" must stay distinguishable from
+        # "a pile is here but empty".
+        if movable:
+            os.makedirs(sealed_dir, exist_ok=True)
         if os.path.isdir(src):
-            for name in sorted(os.listdir(src)):
+            for name in movable:
                 target = os.path.join(sealed_dir, name)
                 if not os.path.exists(target):
                     shutil.move(os.path.join(src, name), target)
@@ -2655,7 +2688,7 @@ tool oracle_run:
                 os.rmdir(src)
             except OSError:
                 pass
-        return bool(os.listdir(sealed_dir))
+        return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
 
 
 
@@ -4895,6 +4928,28 @@ tool oracle_run:
                    os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                    os.path.isdir(sealed2)],
                   [False, True, False])
+            # LE MELANGE, qui est l'etat normal des que le rite laisse un
+            # successeur : un jeu COMMITE qui attend sa porte, et le jeu FRAIS de
+            # ce run. Le renoncement se fait PAR JEU, jamais par repertoire --
+            # sinon le successeur empeche le jeu du run de se cacher, la pile
+            # scellee lit vide, et le terme held-out de la porte passe sur 0 == 0
+            # avec un jeu reste lisible par la boucle de durcissement.
+            repo3 = os.path.join(sroot, "mixed")
+            gmd3m = mk_holdout(repo3)            # t01, qui sera COMMITE
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "successor")):
+                fixture_git(repo3, *args)
+            fresh = os.path.join(gmd3m, "mutants", "holdout", "t02")
+            os.makedirs(fresh)                   # t02, FRAIS et non suivi
+            with open(os.path.join(fresh, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write("true\n")
+            sealed_mix = os.path.join(sroot, "sealed-mixed")
+            check("melange : le frais se scelle, le committe reste en place",
+                  [seal_holdout(gmd3m, sealed_mix),
+                   os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t01")),
+                   os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t02")),
+                   sorted(os.listdir(sealed_mix)) if os.path.isdir(sealed_mix) else []],
+                  [True, True, False, ["t02"]])
+
             # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
             # sont pas la meme, et aucune n'est un echec : ce sont des etats que
             # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2392,6 +2392,26 @@ def holdout_committed_in_tree(gm_dir):
     return code == 0 and bool(out.strip())
 
 
+def holdout_committed_entries(gm_dir):
+    """The NAMES under mutants/holdout/ that git tracks.
+
+    The directory holds two kinds at once: the set this run drew, which is
+    fresh and untracked, and a set an earlier run committed for a LATER gate.
+    They are told apart by tracking, because that is exactly what makes the
+    difference the seal cares about — moving a tracked file leaves an
+    uncommitted deletion, moving an untracked one leaves nothing.
+    """
+    code, out = run("git ls-files -- mutants/holdout", gm_dir, timeout=60)
+    if code != 0:
+        return set()
+    names = set()
+    for line in out.splitlines():
+        parts = line.strip().split("/")
+        if len(parts) >= 3 and parts[0] == "mutants" and parts[1] == "holdout":
+            names.add(parts[2])
+    return names
+
+
 def seal_holdout(gm_dir, sealed_dir):
     """Move the held-out set OUT of the worktree, once, at the first gate.
 
@@ -2419,12 +2439,25 @@ def seal_holdout(gm_dir, sealed_dir):
     rather than letting the next gate report 0/0 for a set that was drawn.
     """
     src = os.path.join(gm_dir, "mutants", "holdout")
-    if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
-            and not seal_committed_opted_in(gm_dir):
-        return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
-    os.makedirs(sealed_dir, exist_ok=True)
+    # Declined PER SET, never per directory. Both reasons above are properties
+    # of ONE entry — a tracked file moved leaves an uncommitted deletion, a
+    # committed set scored here burns its single scoring — so a committed
+    # successor waiting for its gate must not stop THIS run's own fresh set
+    # from sealing. A directory-wide decline made the two indistinguishable:
+    # the next run's set stayed readable in the tree, the sealed pile read
+    # empty, and the gate's held-out term passed 0 == 0 on a set that was
+    # drawn and never hidden — the overfitting this function exists to make
+    # mechanical, reintroduced by the guard meant to protect it.
+    keep = set() if seal_committed_opted_in(gm_dir) else holdout_committed_entries(gm_dir)
+    movable = [n for n in sorted(os.listdir(src))
+               if n not in keep] if os.path.isdir(src) else []
+    # Only when something actually moves: an empty sealed directory reads as a
+    # pile that exists, and "nothing was sealed" must stay distinguishable from
+    # "a pile is here but empty".
+    if movable:
+        os.makedirs(sealed_dir, exist_ok=True)
     if os.path.isdir(src):
-        for name in sorted(os.listdir(src)):
+        for name in movable:
             target = os.path.join(sealed_dir, name)
             if not os.path.exists(target):
                 shutil.move(os.path.join(src, name), target)
@@ -2432,7 +2465,7 @@ def seal_holdout(gm_dir, sealed_dir):
             os.rmdir(src)
         except OSError:
             pass
-    return bool(os.listdir(sealed_dir))
+    return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
 
 
 
@@ -4672,6 +4705,28 @@ def _selftest():
                os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                os.path.isdir(sealed2)],
               [False, True, False])
+        # LE MELANGE, qui est l'etat normal des que le rite laisse un
+        # successeur : un jeu COMMITE qui attend sa porte, et le jeu FRAIS de
+        # ce run. Le renoncement se fait PAR JEU, jamais par repertoire --
+        # sinon le successeur empeche le jeu du run de se cacher, la pile
+        # scellee lit vide, et le terme held-out de la porte passe sur 0 == 0
+        # avec un jeu reste lisible par la boucle de durcissement.
+        repo3 = os.path.join(sroot, "mixed")
+        gmd3m = mk_holdout(repo3)            # t01, qui sera COMMITE
+        for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "successor")):
+            fixture_git(repo3, *args)
+        fresh = os.path.join(gmd3m, "mutants", "holdout", "t02")
+        os.makedirs(fresh)                   # t02, FRAIS et non suivi
+        with open(os.path.join(fresh, "apply.sh"), "w", encoding="utf-8") as f:
+            f.write("true\n")
+        sealed_mix = os.path.join(sroot, "sealed-mixed")
+        check("melange : le frais se scelle, le committe reste en place",
+              [seal_holdout(gmd3m, sealed_mix),
+               os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t01")),
+               os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t02")),
+               sorted(os.listdir(sealed_mix)) if os.path.isdir(sealed_mix) else []],
+              [True, True, False, ["t02"]])
+
         # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
         # sont pas la meme, et aucune n'est un echec : ce sont des etats que
         # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice

--- a/bots/golden-master/sync-harness.bot
+++ b/bots/golden-master/sync-harness.bot
@@ -2553,6 +2553,26 @@ tool sync_harness:
         return code == 0 and bool(out.strip())
 
 
+    def holdout_committed_entries(gm_dir):
+        """The NAMES under mutants/holdout/ that git tracks.
+
+        The directory holds two kinds at once: the set this run drew, which is
+        fresh and untracked, and a set an earlier run committed for a LATER gate.
+        They are told apart by tracking, because that is exactly what makes the
+        difference the seal cares about — moving a tracked file leaves an
+        uncommitted deletion, moving an untracked one leaves nothing.
+        """
+        code, out = run("git ls-files -- mutants/holdout", gm_dir, timeout=60)
+        if code != 0:
+            return set()
+        names = set()
+        for line in out.splitlines():
+            parts = line.strip().split("/")
+            if len(parts) >= 3 and parts[0] == "mutants" and parts[1] == "holdout":
+                names.add(parts[2])
+        return names
+
+
     def seal_holdout(gm_dir, sealed_dir):
         """Move the held-out set OUT of the worktree, once, at the first gate.
 
@@ -2580,12 +2600,25 @@ tool sync_harness:
         rather than letting the next gate report 0/0 for a set that was drawn.
         """
         src = os.path.join(gm_dir, "mutants", "holdout")
-        if os.path.isdir(src) and holdout_committed_in_tree(gm_dir) \
-                and not seal_committed_opted_in(gm_dir):
-            return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
-        os.makedirs(sealed_dir, exist_ok=True)
+        # Declined PER SET, never per directory. Both reasons above are properties
+        # of ONE entry — a tracked file moved leaves an uncommitted deletion, a
+        # committed set scored here burns its single scoring — so a committed
+        # successor waiting for its gate must not stop THIS run's own fresh set
+        # from sealing. A directory-wide decline made the two indistinguishable:
+        # the next run's set stayed readable in the tree, the sealed pile read
+        # empty, and the gate's held-out term passed 0 == 0 on a set that was
+        # drawn and never hidden — the overfitting this function exists to make
+        # mechanical, reintroduced by the guard meant to protect it.
+        keep = set() if seal_committed_opted_in(gm_dir) else holdout_committed_entries(gm_dir)
+        movable = [n for n in sorted(os.listdir(src))
+                   if n not in keep] if os.path.isdir(src) else []
+        # Only when something actually moves: an empty sealed directory reads as a
+        # pile that exists, and "nothing was sealed" must stay distinguishable from
+        # "a pile is here but empty".
+        if movable:
+            os.makedirs(sealed_dir, exist_ok=True)
         if os.path.isdir(src):
-            for name in sorted(os.listdir(src)):
+            for name in movable:
                 target = os.path.join(sealed_dir, name)
                 if not os.path.exists(target):
                     shutil.move(os.path.join(src, name), target)
@@ -2593,7 +2626,7 @@ tool sync_harness:
                 os.rmdir(src)
             except OSError:
                 pass
-        return bool(os.listdir(sealed_dir))
+        return bool(os.path.isdir(sealed_dir) and os.listdir(sealed_dir))
 
 
 
@@ -4833,6 +4866,28 @@ tool sync_harness:
                    os.path.isdir(os.path.join(gmd2, "mutants", "holdout", "t01")),
                    os.path.isdir(sealed2)],
                   [False, True, False])
+            # LE MELANGE, qui est l'etat normal des que le rite laisse un
+            # successeur : un jeu COMMITE qui attend sa porte, et le jeu FRAIS de
+            # ce run. Le renoncement se fait PAR JEU, jamais par repertoire --
+            # sinon le successeur empeche le jeu du run de se cacher, la pile
+            # scellee lit vide, et le terme held-out de la porte passe sur 0 == 0
+            # avec un jeu reste lisible par la boucle de durcissement.
+            repo3 = os.path.join(sroot, "mixed")
+            gmd3m = mk_holdout(repo3)            # t01, qui sera COMMITE
+            for args in (("init", "-q"), ("add", "-A"), ("commit", "-qm", "successor")):
+                fixture_git(repo3, *args)
+            fresh = os.path.join(gmd3m, "mutants", "holdout", "t02")
+            os.makedirs(fresh)                   # t02, FRAIS et non suivi
+            with open(os.path.join(fresh, "apply.sh"), "w", encoding="utf-8") as f:
+                f.write("true\n")
+            sealed_mix = os.path.join(sroot, "sealed-mixed")
+            check("melange : le frais se scelle, le committe reste en place",
+                  [seal_holdout(gmd3m, sealed_mix),
+                   os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t01")),
+                   os.path.isdir(os.path.join(gmd3m, "mutants", "holdout", "t02")),
+                   sorted(os.listdir(sealed_mix)) if os.path.isdir(sealed_mix) else []],
+                  [True, True, False, ["t02"]])
+
             # Les deux dettes qu'une figure held-out 0/0 peut porter. Elles ne
             # sont pas la meme, et aucune n'est un echec : ce sont des etats que
             # le rapport doit rendre LISIBLES A UNE MACHINE — une chaine de notice


### PR DESCRIPTION
## What the seal is for

`seal_holdout` relocates the held-out set out of the worktree so the hardening loop cannot read it. That seal was a sentence in a skill and nothing enforced it — on the first real run the campaign simply executed the held-out mutants itself, learned which escaped, and hardened against them. Relocating them makes it mechanical.

A **committed** set is deliberately exempt: it awaits its own gate. Moving tracked files would leave uncommitted deletions a finalize refuses to merge, and would burn that set's single scoring on a gate that does not own it.

## The defect

Both of those reasons are properties of **one entry**. The test was not:

```python
def holdout_committed_in_tree(gm_dir):
    code, out = run("git ls-files -- mutants/holdout", gm_dir)   # the WHOLE directory
    return code == 0 and bool(out.strip())
```

Any committed entry declined the move for **everything**.

That stays theoretical only while nothing ever commits a successor. The moment one does — which is the entire point of a set a LATER gate must score, and exactly what this bundle's own docstring instructs the caller to do — the next run's freshly drawn set stops sealing:

- it stays **readable in the tree**, where the hardening loop can consult it;
- `load_mutants(..., sealed_dir=...)` reads an empty pile;
- `holdout_total` and `holdout_detected` are both `0`;
- the "sealed set is missing" bail cannot fire, because the directory still exists;
- and `oracle_gate.converged`'s `holdout_detected == holdout_total` term passes **`0 == 0`**.

So the guard written to make the seal mechanical reintroduces, one cycle later, the precise overfitting it exists to prevent — **silently, behind a green gate**. A loud late failure becomes a quiet wrong answer, which is the worst trade this bundle can make.

## The fix

Declined **per set**: an entry git tracks is left where it is, an untracked one seals. `GM_SEAL_COMMITTED=1` still widens the consuming gate to everything, unchanged.

The sealed directory is created only when something actually moves, so *"nothing was sealed"* stays distinguishable from *"an empty pile is here"*. The existing selftest pinned that distinction and caught the first attempt changing it — the bench did its job before the reviewer had to.

## Falsification

Restoring the directory-wide decline reddens the new selftest case:

```
melange : le frais se scelle, le committe reste en place
  attendu : [True, True, False, ["t02"]]
  obtenu  : [False, True, True, []]
```

Read across: nothing sealed, the committed set still there (correct), and **`t02` — the run's own fresh set — still readable in the tree**, with the pile empty. That is the hazard, printed.

## Verification

`GM_MODE=selftest` — **320 checks** (319 + the mixed-directory case). `go test ./bots/` — 689 pass, including the byte-identity test over the three harness bodies. `golangci-lint run ./bots/...` — 0 issues. The bodies were regenerated with `sync-harness.py`, never edited by hand.

## Relation to #1137

#1137 tells a rite to leave a committed successor. Reviewing it is what surfaced this: the instruction is unsafe *until this lands*, because the successor it creates is exactly the committed entry that blocks the next rite's seal. This PR is the prerequisite; #1137 should rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
