### PR TITLE
fix(golden-master): a held-out set of zero is not a proof, and the gate now says so

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -7888,7 +7888,27 @@ compute oracle_gate:
     ## defect was an unproved class went green while every docstring in the
     ## harness claimed the gate checked it. A proof obligation nothing refuses is
     ## a waiver with extra steps.
-    converged: "outputs.oracle_run.stable && outputs.oracle_run.noop_silent && outputs.oracle_run.revert_clean && outputs.oracle_run.collateral == 0 && length(outputs.oracle_run.unstable_controls) == 0 && length(outputs.oracle_run.uncontrolled) == 0 && length(outputs.oracle_run.blind_lanes) == 0 && length(outputs.oracle_run.missing_archetypes) == 0 && length(outputs.oracle_run.duplicate_groups_unproven) == 0 && outputs.oracle_run.corpus_distinct >= vars.min_corpus && outputs.oracle_run.runner_replayable && length(outputs.oracle_run.holdout_reused) == 0 && outputs.oracle_run.score_pct >= vars.mutation_floor && outputs.oracle_run.holdout_detected == outputs.oracle_run.holdout_total"
+    ##
+    ## `holdout_total > 0` is the FLOOR under the held-out term, and it is a
+    ## TERM rather than a nicety because `holdout_detected == holdout_total` is
+    ## satisfied by `0 == 0`: an EMPTY held-out set passes the gate's strongest
+    ## clause by having nothing to say. The harness distinguishes three ways to
+    ## arrive there and writes a field for each — `holdout_spent_unreplaced`,
+    ## `holdout_awaiting_gate`, `holdout_sealed_uncommitted` — and none of the
+    ## three is read by anything: they are not declared in `schema
+    ## oracle_output`, so C031 makes a term over them impossible to write at
+    ## all. Measured on a live campaign and recorded in the harness's own
+    ## comment: thirteen spent cycles, no set redrawn, every landing reporting
+    ## `held-out detected 0/0` through a clause that was vacuously true.
+    ##
+    ## The floor sits HERE, on the rite's own convergence gate, because the rite
+    ## is who OWES the next set — drawing, sealing and scoring them is its
+    ## whole job. It is deliberately absent from RUNNER_VERDICT_PY, which a
+    ## lot's verify runs: a lot cannot discharge a debt only a rite can pay, and
+    ## a floor there would refuse trees whose defect is somewhere else entirely.
+    ## That asymmetry is stated on the runner's `ok`, where it is visible to
+    ## whoever reads the weaker of the two gates.
+    converged: "outputs.oracle_run.stable && outputs.oracle_run.noop_silent && outputs.oracle_run.revert_clean && outputs.oracle_run.collateral == 0 && length(outputs.oracle_run.unstable_controls) == 0 && length(outputs.oracle_run.uncontrolled) == 0 && length(outputs.oracle_run.blind_lanes) == 0 && length(outputs.oracle_run.missing_archetypes) == 0 && length(outputs.oracle_run.duplicate_groups_unproven) == 0 && outputs.oracle_run.corpus_distinct >= vars.min_corpus && outputs.oracle_run.runner_replayable && length(outputs.oracle_run.holdout_reused) == 0 && outputs.oracle_run.score_pct >= vars.mutation_floor && outputs.oracle_run.holdout_total > 0 && outputs.oracle_run.holdout_detected == outputs.oracle_run.holdout_total"
     fail_log: "outputs.oracle_run.log_tail"
 
 ## emit_runner — one entry point for CI and for humans, plus the report a
@@ -7946,6 +7966,23 @@ tool emit_runner:
         # the standalone entry point is what CI and humans run.
         "    and r.get(\"runner_replayable\") and not r.get(\"holdout_reused\")\n"
         "    and r.get(\"holdout_detected\")==r.get(\"holdout_total\"))\n"
+        # THE ONE TERM THIS VERDICT DOES NOT CARRY, stated so it is a decision
+        # and not an oversight: the graph gate also requires `holdout_total > 0`
+        # — the floor that stops `0 == 0` from satisfying the line above — and
+        # this one does not. The split follows who can DISCHARGE the debt. A
+        # rite draws, seals and scores held-out sets, so an empty one is its own
+        # failure and its gate refuses. This entry point is what a lot's verify
+        # and CI run, on a net they did not build: a floor here would turn every
+        # later lot red for a set only a rite can redraw, refusing trees whose
+        # defect is somewhere else entirely. The state is not silent, it is
+        # reported below by name.
+        #
+        # That makes this verdict knowingly weaker than the graph gate on
+        # exactly one term. The parity check in bots/ compares the two on the
+        # FIELDS they read, and `holdout_total` is read here, so it cannot see
+        # this difference: the bench that pins it is the one asserting the floor
+        # is in the conjunction.
+        #
         # A notice is never fatal, but it must never be silent either: the one
         # that matters here says the held-out figure is 0/0 because the set was
         # spent and published, and a CI job reading only an exit code would

--- a/bots/golden_master_gate_holdout_floor_test.go
+++ b/bots/golden_master_gate_holdout_floor_test.go
@@ -1,0 +1,135 @@
+package bots
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/expr"
+)
+
+// `holdout_detected == holdout_total` is the gate's strongest clause and it is
+// satisfied by `0 == 0`. A rite whose held-out set is empty therefore converges
+// on a term that measured nothing — the "no-op confirmed as a success" this bot
+// exists to refuse in other people's deliveries.
+//
+// The harness already distinguishes three ways to reach an empty set and writes
+// a field for each (`holdout_spent_unreplaced`, `holdout_awaiting_gate`,
+// `holdout_sealed_uncommitted`). None is declared in `schema oracle_output`, so
+// C031 makes a graph term over any of them impossible to write: they were
+// computed and unwired, which is how thirteen spent cycles each landed
+// reporting `held-out detected 0/0`.
+//
+// These checks drive the REAL conjunction — parsed out of main.bot and
+// evaluated by the engine's own expression evaluator — rather than matching its
+// text. A bench that greps for a spelling certifies the spelling: it stays green
+// against any rewrite that keeps the words and loses the meaning, and goes red
+// against a rename that changes nothing.
+func TestGoldenMasterGateRefusesAVacuousHeldOutTerm(t *testing.T) {
+	ast := convergedAST(t)
+
+	// Every other term satisfied, so the only thing under test is the held-out
+	// pair. Figures taken from a rite that really converged (7 drawn, 7 seen).
+	if ok := evalConverged(t, ast, convergedReport(7, 7)); !ok {
+		t.Fatalf("the conjunction refuses a rite that converged for real (held-out 7/7): " +
+			"the floor is refusing legitimate runs, not vacuous ones")
+	}
+
+	if ok := evalConverged(t, ast, convergedReport(0, 0)); ok {
+		t.Errorf("the conjunction ACCEPTS a rite whose held-out set is EMPTY (0/0): " +
+			"`holdout_detected == holdout_total` is true by having nothing to compare, so the gate's " +
+			"strongest term certifies a measurement that never happened. Add " +
+			"`outputs.oracle_run.holdout_total > 0` to `converged`.")
+	}
+}
+
+// The floor must be what does the work. Removing that one term has to hand the
+// vacuous report a green — otherwise the check above passes for some unrelated
+// reason and would keep passing the day the floor is deleted.
+func TestGoldenMasterHeldOutFloorIsWhatRefusesTheVacuousReport(t *testing.T) {
+	const floor = " && outputs.oracle_run.holdout_total > 0"
+	src := convergedExpr(t, readHarnessFile(t, "golden-master/main.bot"))
+	if !strings.Contains(src, floor) {
+		t.Fatalf("the floor term is not in the conjunction, so this falsification has nothing to remove: %s", src)
+	}
+	without, err := expr.Parse(exprSrc(t, strings.Replace(src, floor, "", 1)))
+	if err != nil {
+		t.Fatalf("parsing the conjunction without its floor: %v", err)
+	}
+	if ok := evalConverged(t, without, convergedReport(0, 0)); !ok {
+		t.Errorf("with the floor removed, the vacuous 0/0 report is STILL refused: " +
+			"something else in the conjunction is doing the refusing, and the previous test would stay " +
+			"green if the floor were deleted. Find what refuses, and pin that instead.")
+	}
+}
+
+// convergedReport is a report that satisfies every term of the conjunction but
+// the held-out pair, which the caller sets.
+func convergedReport(detected, total int64) map[string]any {
+	return map[string]any{
+		"stable":                    true,
+		"noop_silent":               true,
+		"revert_clean":              true,
+		"collateral":                int64(0),
+		"unstable_controls":         []any{},
+		"uncontrolled":              []any{},
+		"blind_lanes":               []any{},
+		"missing_archetypes":        []any{},
+		"duplicate_groups_unproven": []any{},
+		"corpus_distinct":           int64(42),
+		"runner_replayable":         true,
+		"holdout_reused":            []any{},
+		"score_pct":                 int64(100),
+		"holdout_detected":          detected,
+		"holdout_total":             total,
+	}
+}
+
+// convergedAST parses the conjunction main.bot actually ships.
+func convergedAST(t *testing.T) *expr.AST {
+	t.Helper()
+	ast, err := expr.Parse(exprSrc(t, convergedExpr(t, readHarnessFile(t, "golden-master/main.bot"))))
+	if err != nil {
+		t.Fatalf("the shipped `converged:` conjunction does not parse: %v", err)
+	}
+	return ast
+}
+
+// exprSrc strips the `converged:` key and the surrounding quotes off the line,
+// leaving the expression source the engine compiles.
+func exprSrc(t *testing.T, line string) string {
+	t.Helper()
+	i := strings.Index(line, `"`)
+	j := strings.LastIndex(line, `"`)
+	if i < 0 || j <= i {
+		t.Fatalf("the conjunction line carries no quoted expression: %q", line)
+	}
+	return line[i+1 : j]
+}
+
+// evalConverged resolves `outputs.oracle_run.<field>` against the report and
+// `vars.<name>` against the bot's declared defaults — the two namespaces the
+// conjunction reads. An unknown path returns nil, which the evaluator treats as
+// absent, so a term reading a field this fixture forgot fails loudly here rather
+// than passing on a default.
+func evalConverged(t *testing.T, ast *expr.AST, report map[string]any) bool {
+	t.Helper()
+	vars := map[string]any{"mutation_floor": int64(90), "min_corpus": int64(25)}
+	ok, err := ast.EvalBool(&expr.Context{
+		Outputs: func(path []string) any {
+			if len(path) != 2 || path[0] != "oracle_run" {
+				return nil
+			}
+			return report[path[1]]
+		},
+		Vars: func(path []string) any {
+			if len(path) != 1 {
+				return nil
+			}
+			return vars[path[0]]
+		},
+	})
+	if err != nil {
+		t.Fatalf("evaluating the conjunction: %v", err)
+	}
+	return ok
+}


### PR DESCRIPTION
## The defect

`oracle_gate.converged` ends on `outputs.oracle_run.holdout_detected == outputs.oracle_run.holdout_total`. That is the gate's strongest clause — the held-out set is the one the hardening loop never sees — and **`0 == 0` satisfies it**. A rite whose held-out set is empty converges on a term that measured nothing.

## It was already known, and already unwired

The harness distinguishes **three** ways to reach an empty set and writes a field for each:

| field | the state it names |
|---|---|
| `holdout_spent_unreplaced` | this cycle's set was scored and published; nobody drew the next one |
| `holdout_awaiting_gate` | a set is committed and waits for a gate to opt in |
| `holdout_sealed_uncommitted` | the set was sealed out of the tree and dies with the workspace |

Its own comment says why they are separate: conflating them *"is how a vacuous 0 == 0 slips through the conjunction wearing a green coat"*.

**None of the three is read by anything.** They are not declared in `schema oracle_output` either, so C031 makes a graph term over them impossible to write at all. Computed and unwired — the same shape as `duplicate_groups_unproven` before it, which the file's own comment calls *a waiver with extra steps*.

The cost is recorded in that comment: **thirteen spent cycles, no set redrawn, every landing reporting `held-out detected 0/0`** through a clause that was vacuously true.

## The change

One term on the field that *is* declared:

```
&& outputs.oracle_run.holdout_total > 0
```

Checked against a rite that really converged — `holdout_total: 7`, `holdout_detected: 7`, `score_pct: 100` — which passes unchanged. The floor refuses the vacuous report and nothing else.

## What it deliberately does NOT do

The floor is on the graph gate and **not** on `RUNNER_VERDICT_PY`. The split follows who can discharge the debt:

- a **rite** draws, seals and scores held-out sets, so an empty one is its own failure;
- the **standalone runner** is what a lot's verify and CI execute, on a net they did not build. A floor there would turn every later lot red for a set only a rite can redraw — refusing trees whose defect is somewhere else entirely.

That asymmetry is written on the runner's `ok`, beside the verdict it weakens, because the parity check compares the two gates on the **fields** they read and `holdout_total` is read by both: it structurally cannot see this difference. A divergence no bench can catch has to be a sentence someone reads.

## The benches

Both drive the **real** conjunction — parsed out of `main.bot` and evaluated by the engine's own expression evaluator — instead of matching its text. A bench that greps for a spelling certifies the spelling: it survives any rewrite that keeps the words and loses the meaning.

1. `TestGoldenMasterGateRefusesAVacuousHeldOutTerm` — the 7/7 report converges, the 0/0 report does not.
2. `TestGoldenMasterHeldOutFloorIsWhatRefusesTheVacuousReport` — **falsifies the first**: it removes the floor term and asserts the vacuous report then goes green. Without it, a bench passing for some unrelated reason would outlive the term it claims to pin.

Verified by mutation on the shipped file, not on a copy: deleting the floor from `main.bot` turns bench 1 red with its own diagnostic. `go test ./bots/` green (127 s).

## Relation to the open work

- **#1149** (`the seal declines per SET, never per directory`) fixes a *route* to the empty set. This is the floor underneath it, and each is verifiable without the other.
- Answers finding **R214391** on **#1137** at the class level: that finding's suggested fix is exactly this term. Its specific mechanism dies with #1149; the floor is what survives both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)