### PR TITLE
fix(review-pr): the merge step no longer pins a gpt review to the Claude wire

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -1208,12 +1208,19 @@ agent converge:
   ## declares `publish:` — without this the hand-off resolves to nothing, and
   ## a missing seed is indistinguishable from "this PR was never reviewed".
   publish: review_findings
-  backend: "claude_code"
+  ## Overridable like every other route here, because this node is on
+  ## EVERY path: `mono_family` picks which reviewer judges, never who
+  ## merges. Pinned to one backend, it made the gpt family a half
+  ## promise — the review ran, then the merge died on the Anthropic
+  ## weekly cap, so a deployment whose Claude window is spent could not
+  ## review at all despite having a second family credentialed.
+  backend: "${ITERION_VIBE_BACKEND_EMIT:-claude_code}"
   ## Dedicated env (NOT ITERION_VIBE_MODEL_CLAUDE, which pins the
   ## REVIEWER): in mono the merge is near-mechanical — dedupe is a
   ## no-op, then threshold, cap, report — so it defaults to a cheaper
   ## model than the judging pass. Flip back per deployment with
-  ## ITERION_VIBE_MODEL_EMIT=claude-opus-5.
+  ## ITERION_VIBE_MODEL_EMIT=claude-opus-5, or off the wire entirely
+  ## with ITERION_VIBE_BACKEND_EMIT=claw ITERION_VIBE_MODEL_EMIT=openai/gpt-5.6-sol.
   model: "${ITERION_VIBE_MODEL_EMIT:-claude-sonnet-5}"
   reasoning_effort: "${ITERION_VIBE_EFFORT_EMIT:-medium}"
   output: emit_output

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -8,6 +8,63 @@ pr_url` it also posts an inline forge review and an optional deterministic
 commit-status gate. Never edits or commits. See
 [bots/review-pr/](../../bots/review-pr/).
 
+## 2026-09-11 — the gpt family carried a whole review for the first time, and named what still pinned it to Claude (runs 01a092b2 + 01a092c3, PR #1150)
+
+- Status: **validated** — `revi/review` posted `success` from a run in which
+  Claude never executed.
+- Versions: bot review-pr 0.9.0 · engine v3.140.0 (deployment) · reviewer
+  `claw` + `openai/gpt-5.6-sol`.
+- Method: `runs launch --bot review-pr --var mono_family=gpt --var
+  review_mode=mono --var pr_url=… --var post_to_board=false`, with
+  `--model-overrides '[{"selector":"judge",…},{"selector":"agent",…}]'` moving
+  every LLM node onto claw. Occasion: the deployment's Anthropic seven-day
+  window crossed the 95% hard cap at ~20:30Z, and every claude_code run on the
+  repo — 4 reviews and 2 fixer runs — parked `failed_resumable`, so no PR could
+  satisfy its required check.
+- Result: converged, `finished` in ~5m30. `gpt_ran=true`, `claude_ran=false`.
+  Verdict: 0 findings, and a summary naming the five changed areas by file plus
+  the tests it ran — including which broader suite it could NOT finish inside
+  its 30s limit. Not a façade: the honest gap is reported rather than absorbed.
+
+### What blocked it, in the order the run met it
+
+1. **`mono_family` switches the REVIEWER, never the graph.** `agent converge`
+   carried a hardcoded `backend: "claude_code"`, so the gpt review completed and
+   the merge step then died on the cap. A family switch that still requires the
+   other family is a half promise — the shape CLAUDE.md's parity doctrine calls
+   a defect. Fixed here: `${ITERION_VIBE_BACKEND_EMIT:-claude_code}`, the form
+   its own siblings already use.
+2. **The admission pre-flight refused the whole run.** `AnthropicWireReachable`
+   exists precisely to spare a run pinned off that wire (#668, a fully pinned
+   rite frozen five days) and it does read the launch's overrides — but it is
+   STATIC: the untaken `reviewer_claude*` nodes and `converge` were enough to
+   make the wire "reachable", whatever `mono_family` would route at run time.
+   Covered by two KIND selectors (`judge`, `agent`) rather than by naming
+   sites — the routers are `condition`/`fan_out_all`, so those two cover every
+   LLM node by construction.
+3. **A CLI launch gets no checkout.** `POST /api/runs` accepts `repo_url` /
+   `repo_ref` / `connection_id` (`pkg/server/runs_launch.go`), and the webhook
+   path sets them; `iterion remote runs launch` exposes none of the three. The
+   reviewer opened on `fatal: not a git repository` and re-derived the diff
+   through the forge API. It recovered and still reviewed well, but the local
+   checkout the node is written for was never there.
+
+### Lessons for next run
+
+- To run Revi off the Anthropic wire, overriding the reviewer is not enough:
+  override by KIND so the pre-flight sees no anthropic route at all. The
+  per-run form needs no bot edit and is the mechanism the pre-flight was
+  built to read.
+- `resume` cannot carry `--model-overrides`; only a fresh launch can. A run
+  parked by the cap therefore cannot be re-aimed at another family in place —
+  worth knowing before spending a reviewer pass twice.
+- A run parked on a usage window will be re-driven when the window reopens.
+  Cancel a superseded one, or a second verdict lands on the same gate days
+  later.
+- Verify the binary before trusting a local `validate`: a v3.69 CLI reported
+  `E002` on a bot the v3.140 build compiles cleanly, on the UNMODIFIED file —
+  the control that separated "my edit broke it" from "my tool is stale".
+
 ## 2026-09-09 — forge-native ticket context: the first `covered` verdict, and the [high] the feature found in itself (run 01a085b8, PR #1017)
 
 - Status: **validated locally**; the cloud half arrives on its own once 0.9.0 is baked.


### PR DESCRIPTION
`mono_family` picks which reviewer **judges**. It never moved who **merges**.

`agent converge` sits on every path — it is the node that dedupes, thresholds,
caps and reports, whichever family reviewed — and it carried a hardcoded
`backend: "claude_code"`. So selecting the gpt family bought a review that ran
to completion and then died at the aggregation step. A family switch that still
requires the other family is the half-wired shape the parity doctrine in
CLAUDE.md calls a defect, not a staging decision.

## Measured, not hypothesised

Tonight the deployment's Anthropic seven-day window crossed its 95% hard cap at
~20:30Z. Every `claude_code` run on this repo parked `failed_resumable` — four
reviews and two fixer runs — so **no open PR could satisfy its required check**,
despite a second family being credentialed and idle.

Run `01a092c3` then reviewed #1150 end to end with every LLM node overridden
onto `claw` + `openai/gpt-5.6-sol`: `gpt_ran=true`, `claude_ran=false`,
`revi/review` posted `success`, 0 findings, with a summary naming the five
changed areas by file and reporting honestly which broader test suite it could
not finish inside its 30s limit.

That run is the proof `converge` works on claw. This change is only what makes
the same route reachable **without a per-run override** — the default is
unchanged (`${ITERION_VIBE_BACKEND_EMIT:-claude_code}`), in the form its own
siblings (`ITERION_VIBE_BACKEND_GPT`) already use.

## Scope, counted rather than assumed

Four catalog bots declare `mono_family`:

| bot | pinned `claude_code` nodes | verdict |
|---|---|---|
| `review-pr` | `reviewer_claude`, `reviewer_claude_glance`, **`converge`** | the first two are family-NAMED and correct by design; `converge` is the defect, fixed here |
| `evolve` | `judge review_claude` | family-named — correct by design, untouched |
| `branch-improve-loop` | `plan`, `plan_revise`, `verify_build`, `review`, `finalize_mr` | same shape, NOT family-named — **unproven**, reported not swept |
| `feature-dev` | `plan`, `plan_revise`, `campaign`, `verify_build`, `review`, `finalize_mr` | same shape, NOT family-named — **unproven**, reported not swept |

The last two are named in the bilan rather than changed blind: I have not run
either off the Claude wire, and a sweep on an unmeasured assumption is how a
guard that matches nothing gets to look like one that works.

## Also in this PR

The dogfood bilan the repo requires for a live run
(`docs/bot-runs/review-pr.md`), including the two frictions this change does
**not** fix:

- **The admission pre-flight is static.** `AnthropicWireReachable` exists
  precisely to spare a run pinned off that wire (#668 — a fully pinned rite
  frozen five days) and it does read the launch's overrides, but the *untaken*
  `reviewer_claude*` nodes are enough to make the wire "reachable" whatever
  `mono_family` routes at run time. The working recipe is to override by KIND
  (`judge` + `agent`), which covers every LLM node by construction here since
  both routers are `condition`/`fan_out_all`.
- **A CLI launch gets no checkout.** `POST /api/runs` accepts `repo_url` /
  `repo_ref` / `connection_id` and the webhook path sets them;
  `iterion remote runs launch` exposes none of the three, so the reviewer opens
  on `fatal: not a git repository` and re-derives the diff through the forge
  API. Followed up separately.

`go test ./bots/...` green. `iterion validate bots/review-pr/main.bot` → OK
(with a build of this tree: a stale v3.69 CLI reports a spurious `E002` on the
**unmodified** file, which is the control that separates a bad edit from a stale
tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
